### PR TITLE
Add many Nix/NixOS packages.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -41,7 +41,8 @@ Distro packaging links:
   - IF AVAILABLE
 - Alpine: https://pkgs.alpinelinux.org/packages
   - IF AVAILABLE
-
+- NixOS/nixpkgs: https://search.nixos.org/packages
+  - OPTIONAL
 
 
 <!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,7 @@ Guidelines for rosdep rules
     * Ubuntu and Debian are top priority.
     * Fedora and Gentoo have packaging jobs and should be filled in if they are available.
     * OSX is also nice to have.
+    * NixOS is not required, but may be added if desired
     * If specific versions are called out, there should be coverage of all versions currently targeted by supported ROS distros.
      * If there's a new distro in prerelease adding a rule for it is fine.
        However please don't target 'sid' as it's a rolling target and when the keys change our database gets out of date.
@@ -134,6 +135,11 @@ Work has been proposed to add a separate installer for AUR packages [ros-infrast
 
 * FreeBSD project pkg repository: main or quarterly
 * A database of FreeBSD packages is available at https://freshports.org
+
+#### NixOS/nixpkgs
+
+* [NixOS unstable channel](https://github.com/NixOS/nixpkgs/tree/nixos-unstable), search available at https://search.nixos.org/packages
+* [nix-ros-overlay](https://github.com/lopsided98/nix-ros-overlay)
 
 #### pip
 

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2,9 +2,11 @@ ace:
   arch: [ace]
   debian: [libace-dev]
   gentoo: [dev-libs/ace]
+  nixos: [ace]
   ubuntu: [libace-dev]
 ack:
   debian: [ack]
+  nixos: [ack]
   ubuntu:
     '*': [ack]
     xenial: null
@@ -13,23 +15,27 @@ ack-grep:
   debian: [ack-grep]
   fedora: [ack]
   gentoo: [sys-apps/ack]
+  nixos: [ack]
   ubuntu: [ack-grep]
 acl:
   arch: [acl]
   debian: [acl, libacl1-dev]
   fedora: [acl, libacl-devel]
   gentoo: [sys-apps/acl]
+  nixos: [acl]
   rhel: [acl, libacl-devel]
   ubuntu: [acl, libacl1-dev]
 acpi:
   debian: [acpi]
   fedora: [acpi]
   gentoo: [sys-power/acpi]
+  nixos: [acpi]
   ubuntu: [acpi]
 acpitool:
   debian: [acpitool]
   fedora: [acpitool]
   gentoo: [sys-power/acpitool]
+  nixos: [acpitool]
   ubuntu:
     precise: [acpitool]
     trusty: [acpitool]
@@ -41,29 +47,34 @@ alsa-oss:
   debian: [alsa-oss]
   fedora: [alsa-oss]
   gentoo: [media-libs/alsa-oss]
+  nixos: [alsaOss]
   ubuntu: [alsa-oss]
 alsa-utils:
   arch: [alsa-utils]
   debian: [alsa-utils]
   fedora: [alsa-utils]
   gentoo: [media-sound/alsa-utils]
+  nixos: [alsaUtils]
   ubuntu: [alsa-utils]
 ant:
   arch: [apache-ant]
   debian: [ant]
   fedora: [ant]
   gentoo: [dev-java/ant]
+  nixos: [ant]
   ubuntu: [ant]
 antlr:
   arch: [antlr]
   debian: [antlr, libantlr-dev]
   fedora: [antlr3-C, antlr-C++]
   gentoo: [dev-java/antlr]
+  nixos: [antlr]
   ubuntu: [antlr, libantlr-dev]
 apache2:
   debian: [apache2]
   fedora: [httpd]
   gentoo: [www-servers/apache]
+  nixos: [apacheHttpd]
   ubuntu: [apache2]
 apache2-mpm-prefork:
   debian:
@@ -84,6 +95,7 @@ apr:
   freebsd: [builtin]
   gentoo: [dev-libs/apr, dev-libs/apr-util]
   macports: [apr, apr-util]
+  nixos: [apr]
   openembedded: [apr@openembedded-core]
   opensuse: [libapr1, libapr-util1]
   rhel: [apr-devel, apr-util]
@@ -97,6 +109,7 @@ apt-transport-https:
 aravis:
   debian: [libaravis-0.6-0]
   gentoo: [media-video/aravis]
+  nixos: [aravis]
   ubuntu:
     '*': [libaravis-0.6-0]
     bionic: null
@@ -104,6 +117,7 @@ aravis:
 aravis-dev:
   debian: [libaravis-dev]
   gentoo: [media-video/aravis]
+  nixos: [aravis]
   ubuntu:
     '*': [libaravis-dev]
     bionic: null
@@ -113,6 +127,7 @@ arduino-core:
   debian: [arduino-core]
   fedora: [arduino-core]
   gentoo: [dev-embedded/arduino]
+  nixos: [arduino]
   ubuntu: [arduino-core]
 arista:
   arch: [arista-transcoder]
@@ -125,6 +140,7 @@ armadillo:
   debian: [libarmadillo-dev]
   fedora: [armadillo-devel]
   gentoo: [sci-libs/armadillo]
+  nixos: [armadillo]
   ubuntu: [libarmadillo-dev]
 asio:
   alpine: [asio-dev]
@@ -132,6 +148,7 @@ asio:
   debian: [libasio-dev]
   fedora: [asio-devel]
   gentoo: [dev-cpp/asio]
+  nixos: [asio]
   openembedded: [asio@meta-oe]
   osx:
     homebrew:
@@ -146,6 +163,7 @@ assimp:
   freebsd: [assimp]
   gentoo: [media-libs/assimp]
   macports: [assimp]
+  nixos: [assimp]
   openembedded: [assimp@openembedded-core]
   opensuse: [libassimp3]
   rhel: [assimp-devel]
@@ -163,6 +181,7 @@ assimp-dev:
   fedora: [assimp-devel]
   freebsd: [assimp]
   gentoo: [media-libs/assimp]
+  nixos: [assimp]
   openembedded: [assimp@openembedded-core]
   opensuse: [libassimp3]
   rhel: [assimp-devel]
@@ -178,6 +197,7 @@ at-spi2-core:
   debian: [at-spi2-core]
   fedora: [at-spi2-core]
   gentoo: [at-spi2-core]
+  nixos: [at-spi2-core]
   ubuntu: [at-spi2-core]
 atlas:
   arch: [atlas-lapack]
@@ -193,6 +213,7 @@ autoconf:
   freebsd: [autoconf213, autoconf268]
   gentoo: [sys-devel/autoconf]
   macports: [autoconf]
+  nixos: [autoconf]
   openembedded: [autoconf@openembedded-core]
   opensuse: [autoconf]
   rhel: [autoconf]
@@ -204,6 +225,7 @@ automake:
   freebsd: [automake14, automake111]
   gentoo: [sys-devel/automake]
   macports: [automake]
+  nixos: [automake]
   openembedded: [automake@openembedded-core]
   opensuse: [automake]
   rhel: [automake]
@@ -220,6 +242,7 @@ autossh:
   freebsd: [autossh]
   gentoo: [net-misc/autossh]
   macports: [autossh]
+  nixos: [autossh]
   opensuse: [autossh]
   rhel: [autossh]
   ubuntu: [autossh]
@@ -228,6 +251,7 @@ avahi-daemon:
   debian: [avahi-daemon]
   fedora: [avahi]
   gentoo: [net-dns/avahi]
+  nixos: [avahi]
   openembedded: [avahi@openembedded-core]
   ubuntu: [avahi-daemon]
 avahi-utils:
@@ -235,6 +259,7 @@ avahi-utils:
   debian: [avahi-utils]
   fedora: [avahi-tools]
   gentoo: [net-dns/avahi]
+  nixos: [avahi]
   ubuntu: [avahi-utils]
 avr-libc:
   arch: [avr-libc]
@@ -247,17 +272,20 @@ avrdude:
   debian: [avrdude]
   fedora: [avrdude]
   gentoo: [dev-embedded/avrdude]
+  nixos: [avrdude]
   ubuntu: [avrdude]
 awscli:
   arch: [aws-cli]
   debian: [awscli]
   fedora: [awscli]
   gentoo: [dev-python/awscli]
+  nixos: [awscli]
   ubuntu: [awscli]
 babeltrace:
   debian: [babeltrace]
   fedora: [babeltrace]
   gentoo: [dev-util/babeltrace]
+  nixos: [babeltrace]
   ubuntu: [babeltrace]
 bazaar:
   arch: [bzr]
@@ -266,6 +294,7 @@ bazaar:
   freebsd: [bazaar]
   gentoo: [dev-vcs/bzr]
   macports: [bazaar]
+  nixos: [breezy]
   opensuse: [bzr]
   ubuntu: [bzr]
 beep:
@@ -273,6 +302,7 @@ beep:
   debian: [beep]
   fedora: [beep]
   gentoo: [app-misc/beep]
+  nixos: [beep]
   ubuntu: [beep]
 benchmark:
   debian:
@@ -289,6 +319,7 @@ binutils:
   debian: [binutils-dev]
   fedora: [binutils-devel]
   gentoo: [sys-devel/binutils]
+  nixos: [binutils]
   openembedded: [binutils@openembedded-core]
   ubuntu: [binutils-dev]
 bison:
@@ -297,6 +328,7 @@ bison:
   fedora: [bison]
   gentoo: [sys-devel/bison]
   macports: [bison]
+  nixos: [bison]
   openembedded: [bison@openembedded-core]
   rhel: [bison]
   ubuntu: [bison]
@@ -305,12 +337,14 @@ blender:
   debian: [blender]
   fedora: [blender]
   gentoo: [media-gfx/blender]
+  nixos: [blender]
   ubuntu: [blender]
 bluez:
   arch: [bluez]
   debian: [bluez]
   fedora: [bluez-libs]
   gentoo: [net-wireless/bluez]
+  nixos: [bluez]
   openembedded: [bluez5@openembedded-core]
   rhel: [bluez-libs]
   ubuntu: [bluez]
@@ -339,6 +373,7 @@ boost:
   freebsd: [py27-boost-libs]
   gentoo: ['dev-libs/boost[python]']
   macports: [boost]
+  nixos: [boost]
   openembedded: [boost@openembedded-core]
   opensuse: [boost-devel]
   rhel: [boost-devel, 'boost-python%{python3_pkgversion}-devel']
@@ -356,6 +391,7 @@ box2d-dev:
   arch: [box2d]
   debian: [libbox2d-dev]
   fedora: [Box2D-devel]
+  nixos: [box2d]
   ubuntu: [libbox2d-dev]
 bullet:
   alpine: [bullet-dev]
@@ -364,6 +400,7 @@ bullet:
   fedora: [bullet-devel]
   gentoo: [sci-physics/bullet]
   macports: [bullet]
+  nixos: [bullet]
   openembedded: [bullet@meta-ros-common]
   opensuse: [libbullet]
   rhel: [bullet-devel]
@@ -385,6 +422,7 @@ bzip2:
   freebsd: [bzip2]
   gentoo: [app-arch/bzip2]
   macports: [bzip2]
+  nixos: [bzip2]
   openembedded: [bzip2@openembedded-core]
   opensuse: [libbz2-devel]
   rhel: [bzip2-devel]
@@ -398,11 +436,13 @@ ca-certificates:
   fedora: [ca-certificates]
   freebsd: [ca_root_nss]
   gentoo: [app-misc/ca-certificates]
+  nixos: [cacert]
   openembedded: [ca-certificates@openembedded-core]
   ubuntu: [ca-certificates]
 can-utils:
   debian: [can-utils]
   fedora: [can-utils]
+  nixos: [can-utils]
   ubuntu: [can-utils]
 castxml:
   arch: [castxml]
@@ -413,22 +453,26 @@ castxml:
 cccc:
   debian: [cccc]
   gentoo: [dev-util/cccc]
+  nixos: [cccc]
   ubuntu: [cccc]
 cdk:
   debian: [libcdk5]
   fedora: [cdk]
   gentoo: [dev-libs/cdk]
+  nixos: [cdk]
   ubuntu: [libcdk5]
 cdk-dev:
   debian: [libcdk5-dev]
   fedora: [cdk-devel]
   gentoo: [dev-libs/cdk]
+  nixos: [cdk]
   ubuntu: [libcdk5-dev]
 cgal:
   arch: [cgal]
   debian: [libcgal-dev]
   fedora: [CGAL-devel]
   gentoo: [sci-mathematics/cgal]
+  nixos: [cgal_5]
   ubuntu: [libcgal-dev]
 cgal-qt5-dev:
   arch: [cgal]
@@ -439,23 +483,27 @@ cgal-qt5-dev:
 checkinstall:
   arch: [checkinstall]
   debian: [checkinstall]
+  nixos: [checkinstall]
   ubuntu: [checkinstall]
 chromium-browser:
   debian: [chromium]
   fedora: [chromium]
   gentoo: [www-client/chromium]
+  nixos: [chromium]
   ubuntu: [chromium-browser]
 chrony:
   arch: [chrony]
   debian: [chrony]
   fedora: [chrony]
   gentoo: [net-misc/chrony]
+  nixos: [chrony]
   opensuse: [chrony]
   ubuntu: [chrony]
 clang:
   debian: [clang]
   fedora: [clang]
   gentoo: [sys-devel/clang]
+  nixos: [clang]
   ubuntu: [clang]
 clang-format:
   alpine: [clang]
@@ -465,6 +513,7 @@ clang-format:
     stretch: [clang-format]
   fedora: [clang]
   gentoo: [sys-devel/clang]
+  nixos: [clang]
   osx:
     homebrew:
       packages: [clang-format]
@@ -478,6 +527,7 @@ clang-tidy:
     stretch: [clang-tidy]
   fedora: [clang-tools-extra]
   gentoo: [sys-devel/clang]
+  nixos: [clang]
   osx:
     homebrew:
       packages: [llvm]
@@ -495,6 +545,7 @@ cmake:
   freebsd: [cmake]
   gentoo: [dev-util/cmake]
   macports: [cmake]
+  nixos: [cmake]
   openembedded: [cmake@openembedded-core]
   opensuse: [cmake]
   rhel: [cmake3]
@@ -585,6 +636,7 @@ coreutils:
   debian: [coreutils]
   fedora: [coreutils]
   gentoo: [sys-apps/coreutils]
+  nixos: [coreutils]
   openembedded: [coreutils@openembedded-core]
   ubuntu: [coreutils]
 couchdb:
@@ -592,6 +644,7 @@ couchdb:
   debian: [couchdb]
   fedora: [couchdb]
   gentoo: [dev-db/couchdb]
+  nixos: [couchdb]
   ubuntu: [couchdb]
 cppad:
   debian: [cppad]
@@ -604,6 +657,7 @@ cppcheck:
   debian: [cppcheck]
   fedora: [cppcheck]
   gentoo: [dev-util/cppcheck]
+  nixos: [cppcheck]
   openembedded: [cppcheck@meta-ros-common]
   osx:
     homebrew:
@@ -618,6 +672,7 @@ cppunit:
   freebsd: [cppunit]
   gentoo: [dev-util/cppunit]
   macports: [cppunit]
+  nixos: [cppunit]
   openembedded: [cppunit@meta-oe]
   opensuse: [libcppunit-devel]
   rhel: [cppunit-devel]
@@ -641,6 +696,7 @@ curl:
   freebsd: [curl]
   gentoo: [net-misc/curl]
   macports: [curl]
+  nixos: [curl]
   openembedded: [curl@openembedded-core]
   opensuse: [libcurl-devel, curl]
   rhel: [libcurl-devel, curl]
@@ -657,23 +713,27 @@ cvs:
   debian: [cvs]
   fedora: [cvs]
   gentoo: [dev-vcs/cvs]
+  nixos: [cvs]
   ubuntu: [cvs]
 cwiid:
   arch: [cwiid]
   debian: [libcwiid1]
   gentoo: [app-misc/cwiid]
+  nixos: [cwiid]
   opensuse: [libcwiid1]
   ubuntu: [libcwiid1]
 cwiid-dev:
   arch: [cwiid]
   debian: [libcwiid-dev]
   gentoo: [app-misc/cwiid]
+  nixos: [cwiid]
   opensuse: [libcwiid-devel]
   ubuntu: [libcwiid-dev]
 daemontools:
   arch: [daemontools]
   debian: [daemontools]
   gentoo: [virtual/daemontools]
+  nixos: [daemontools]
   openembedded: [daemontools@meta-oe]
   ubuntu: [daemontools]
 debhelper:
@@ -687,6 +747,7 @@ devilspie2:
   arch: [devilspie2]
   debian: [devilspie2]
   gentoo: [x11-misc/devilspie2]
+  nixos: [devilspie2]
   ubuntu: [devilspie2]
 devscripts:
   debian: [devscripts]
@@ -697,16 +758,19 @@ dfu-util:
   debian: [dfu-util]
   fedora: [dfu-util]
   gentoo: [app-mobilephone/dfu-util]
+  nixos: [dfu-util]
   ubuntu: [dfu-util]
 disper:
   debian: [disper]
   fedora: [disper]
+  nixos: [disper]
   ubuntu: [disper]
 dkms:
   arch: [dkms]
   debian: [dkms]
   fedora: [dkms]
   gentoo: [sys-kernel/dkms]
+  nixos: []
   openembedded: []
   opensuse: [dkms]
   rhel: [dkms]
@@ -715,11 +779,13 @@ dnsmasq:
   debian: [dnsmasq]
   fedora: [dnsmasq]
   gentoo: [net-dns/dnsmasq]
+  nixos: [dnsmasq]
   openembedded: [dnsmasq@meta-networking]
   ubuntu: [dnsmasq]
 docker-compose:
   debian: [docker-compose]
   fedora: [docker-compose]
+  nixos: [docker-compose]
   ubuntu: [docker-compose]
 docker.io:
   debian:
@@ -736,6 +802,7 @@ doxygen:
   freebsd: [doxygen]
   gentoo: [app-doc/doxygen]
   macports: [doxygen]
+  nixos: [doxygen]
   openembedded: [doxygen@meta-oe]
   rhel: [doxygen]
   ubuntu: [doxygen]
@@ -744,11 +811,13 @@ dpkg:
   debian: [dpkg]
   fedora: [dpkg]
   gentoo: [app-arch/dpkg]
+  nixos: [dpkg]
   openembedded: [dpkg@openembedded-core]
   ubuntu: [dpkg]
 dpkg-dev:
   debian: [dpkg-dev]
   fedora: [dpkg-dev]
+  nixos: [dpkg]
   ubuntu: [dpkg-dev]
 dvipng:
   arch: [texlive-bin]
@@ -773,6 +842,7 @@ eclipse:
 ed:
   debian: [ed]
   fedora: [ed]
+  nixos: [ed]
   ubuntu: [ed]
 eigen:
   alpine: [eigen-dev]
@@ -787,6 +857,7 @@ eigen:
   freebsd: [eigen]
   gentoo: [dev-cpp/eigen]
   macports: [eigen3]
+  nixos: [eigen]
   openembedded: [libeigen@meta-oe]
   opensuse: [libeigen3-devel]
   rhel: [eigen3-devel]
@@ -802,6 +873,7 @@ eigen2:
   fedora: [eigen2-devel]
   freebsd: [eigen2]
   gentoo: ['dev-cpp/eigen:2']
+  nixos: [eigen2]
   opensuse: [libeigen2-devel]
   ubuntu: [libeigen2-dev]
 emacs:
@@ -810,6 +882,7 @@ emacs:
   fedora: [emacs]
   freebsd: [emacs]
   gentoo: [virtual/emacs]
+  nixos: [emacs]
   openembedded: [emacs@meta-oe]
   ubuntu: [emacs]
 embree:
@@ -817,6 +890,7 @@ embree:
   debian:
     bullseye: [libembree-dev]
   fedora: [embree]
+  nixos: [embree]
   ubuntu:
     '*': [libembree-dev]
     bionic: null
@@ -825,16 +899,19 @@ enblend:
   debian: [enblend]
   fedora: [enblend]
   gentoo: [media-gfx/enblend]
+  nixos: [enblend-enfuse]
   ubuntu: [enblend]
 enet:
   debian: [libenet-dev]
   fedora: [enet-devel]
   gentoo: [net-libs/enet]
+  nixos: [enet]
   ubuntu: [libenet-dev]
 espeak:
   debian: [espeak]
   fedora: [espeak]
   gentoo: [app-accessibility/espeak]
+  nixos: [espeak]
   ubuntu: [espeak]
 exfat-fuse:
   debian: [exfat-fuse]
@@ -844,16 +921,19 @@ exfat-utils:
   arch: [exfat-utils]
   debian: [exfat-utils]
   gentoo: [sys-fs/exfat-utils]
+  nixos: [exfat-utils]
   ubuntu: [exfat-utils]
 f2c:
   arch: [f2c]
   debian: [f2c, libf2c2, libf2c2-dev]
   fedora: [f2c, f2c-libs]
   gentoo: [dev-lang/f2c]
+  nixos: [libf2c]
   ubuntu: [f2c, libf2c2, libf2c2-dev]
 fakeroot:
   debian: [fakeroot]
   gentoo: [sys-apps/fakeroot]
+  nixos: [fakeroot]
   ubuntu: [fakeroot]
 fcgi:
   arch: [fcgi, mod_fcgid, spawn-fcgi]
@@ -882,6 +962,7 @@ ffmpeg:
   freebsd: [ffmpeg]
   gentoo: [virtual/ffmpeg]
   macports: [ffmpeg]
+  nixos: [ffmpeg]
   openembedded: [ffmpeg@openembedded-core]
   opensuse: [ffmpeg]
   slackware: [ffmpeg]
@@ -899,18 +980,21 @@ ffmpeg2theora:
 file:
   debian: [file]
   fedora: [file]
+  nixos: [file]
   ubuntu: [file]
 filezilla:
   arch: [filezilla]
   debian: [filezilla]
   fedora: [filezilla]
   gentoo: [net-ftp/filezilla]
+  nixos: [filezilla]
   ubuntu: [filezilla]
 flac:
   arch: [flac]
   debian: [flac]
   fedora: [flac]
   gentoo: [media-libs/flac]
+  nixos: [flac]
   openembedded: [flac@openembedded-core]
   ubuntu: [flac]
 flawfinder:
@@ -925,6 +1009,7 @@ flex:
   fedora: [flex]
   gentoo: [sys-devel/flex]
   macports: [flex]
+  nixos: [flex]
   openembedded: [flex@openembedded-core]
   ubuntu: [flex]
 fltk:  # Consider using the libfltk-dev and fluid (fltk runtime) keys instead.
@@ -934,6 +1019,7 @@ fltk:  # Consider using the libfltk-dev and fluid (fltk runtime) keys instead.
   freebsd: [fltk]
   gentoo: [=x11-libs/fltk-1*]
   macports: [fltk]
+  nixos: [fltk]
   opensuse: [fltk-devel]
   slackware: [fltk]
   ubuntu:
@@ -960,6 +1046,7 @@ fluid:
   freebsd: [fltk]
   gentoo: [=x11-libs/fltk-1*]
   macports: [fltk]
+  nixos: [fltk]
   opensuse: [fltk-devel]
   ubuntu: [fluid]
 fmt:
@@ -967,6 +1054,7 @@ fmt:
   debian: [libfmt-dev]
   fedora: [fmt-devel]
   gentoo: [dev-libs/libfmt]
+  nixos: [fmt]
   ubuntu: [libfmt-dev]
 fonts-noto:
   alpine: [font-noto]
@@ -987,6 +1075,7 @@ freeimage:
   fedora: [freeimage-devel]
   gentoo: [media-libs/freeimage]
   macports: [freeimage]
+  nixos: [freeimage]
   rhel: [freeimage-devel]
   ubuntu: [libfreeimage-dev]
 freetype:
@@ -994,17 +1083,21 @@ freetype:
   fedora: [freetype]
   gentoo: [media-libs/freetype]
   macports: [freetype]
+  nixos: [freetype]
 fsharp:
   debian: [fsharp]
   gentoo: [dev-lang/fsharp]
+  nixos: [fsharp]
   ubuntu: [fsharp]
 fswebcam:
+  nixos: [fswebcam]
   ubuntu: [fswebcam]
 ftdi-eeprom:
   arch: [libftdi]
   debian: [ftdi-eeprom]
   fedora: [libftdi-devel, libftdi-c++-devel]
   gentoo: [dev-embedded/ftdi_eeprom]
+  nixos: [libftdi]
   openembedded: [libftdi@meta-oe]
   rhel: [libftdi-devel, libftdi-c++-devel]
   ubuntu: [ftdi-eeprom]
@@ -1026,6 +1119,7 @@ g++-static:
   debian: [g++]
   fedora: [gcc-c++, glibc-devel, glibc-static, libstdc++-devel, libstdc++-static]
   gentoo: [sys-devel/gcc]
+  nixos: []
   openembedded: []
   rhel: [gcc-c++, glibc-devel, glibc-static, libstdc++-devel, libstdc++-static]
   ubuntu: [g++]
@@ -1038,6 +1132,7 @@ gawk:
   debian: [gawk]
   fedora: [gawk]
   gentoo: [sys-apps/gawk]
+  nixos: [gawk]
   openembedded: [gawk@openembedded-core]
   ubuntu: [gawk]
 gazebo:
@@ -1048,6 +1143,7 @@ gazebo:
     stretch: [gazebo9]
   fedora: [gazebo]
   gentoo: [sci-electronics/gazebo]
+  nixos: [gazebo]
   slackware: [gazebo]
   ubuntu:
     artful: [gazebo9]
@@ -1069,6 +1165,7 @@ gazebo11:
   debian:
     buster: [gazebo11]
   gentoo: [=sci-electronics/gazebo-11*]
+  nixos: [gazebo_11]
   ubuntu:
     focal: [gazebo11]
 gazebo5:
@@ -1082,6 +1179,7 @@ gazebo7:
     jessie: [gazebo7]
     stretch: [gazebo7]
   gentoo: [=sci-electronics/gazebo-7*]
+  nixos: [gazebo_7]
   slackware: [gazebo]
   ubuntu: [gazebo7]
 gazebo9:
@@ -1092,6 +1190,7 @@ gazebo9:
     '30': [gazebo]
     '31': [gazebo]
   gentoo: [sci-electronics/gazebo]
+  nixos: [gazebo_9]
   openembedded: []
   ubuntu:
     artful: [gazebo9]
@@ -1136,6 +1235,7 @@ gdal-bin:
   debian: [gdal-bin]
   fedora: [gdal]
   gentoo: [sci-libs/gdal]
+  nixos: [gdal]
   ubuntu: [gdal-bin]
 geographiclib:
   debian:
@@ -1144,11 +1244,13 @@ geographiclib:
     stretch: [libgeographic-dev]
     wheezy: [libgeographiclib-dev]
   fedora: [GeographicLib-devel]
+  nixos: [geographiclib]
   openembedded: [geographiclib@meta-ros-common]
   ubuntu: [libgeographic-dev]
 geographiclib-tools:
   debian: [geographiclib-tools]
   fedora: [GeographicLib]
+  nixos: [geographiclib]
   openembedded: [geographiclib@meta-ros-common]
   ubuntu: [geographiclib-tools]
 geos:
@@ -1156,12 +1258,14 @@ geos:
   debian: [libgeos-dev]
   fedora: [geos-devel]
   gentoo: [sci-libs/geos]
+  nixos: [geos]
   ubuntu: [libgeos-dev]
 gettext-base:
   arch: [gettext]
   debian: [gettext-base]
   fedora: [gettext]
   gentoo: [sys-devel/gettext]
+  nixos: [gettext]
   ubuntu: [gettext-base]
 gforth:
   arch: [gforth]
@@ -1169,29 +1273,34 @@ gforth:
   fedora: [gforth]
   gentoo: [dev-lang/gforth]
   macports: [gforth]
+  nixos: [gforth]
   ubuntu: [gforth]
 gfortran:
   arch: [gcc-fortran]
   debian: [gfortran]
   fedora: [gcc-gfortran]
   gentoo: ['sys-devel/gcc[fortran]']
+  nixos: [gfortran]
   ubuntu: [gfortran]
 ghc:
   arch: [ghc]
   debian: [ghc]
   fedora: [ghc]
   gentoo: ['dev-lang/ghc']
+  nixos: [ghc]
   ubuntu: [ghc]
 gifsicle:
   arch: [gifsicle]
   debian: [gifsicle]
   fedora: [gifsicle]
   gentoo: [media-gfx/gifsicle]
+  nixos: [gifsicle]
   ubuntu: [gifsicle]
 gimp:
   debian: [gimp]
   fedora: [gimp]
   gentoo: [media-gfx/gimp]
+  nixos: [gimp]
   ubuntu: [gimp]
 git:
   alpine: [git]
@@ -1201,6 +1310,7 @@ git:
   freebsd: [git]
   gentoo: [dev-vcs/git]
   macports: [git-core]
+  nixos: [git]
   openembedded: [git@openembedded-core]
   opensuse: [git-core]
   rhel: [git]
@@ -1209,6 +1319,7 @@ gitg:
   debian: [gitg]
   fedora: [gitg]
   gentoo: [dev-vcs/gitg]
+  nixos: [gitg]
   ubuntu: [gitg]
 gitk:
   debian: [gitk]
@@ -1217,27 +1328,32 @@ gitk:
 gksu:
   debian: [gksu]
   gentoo: [x11-libs/gksu]
+  nixos: [gksu]
   ubuntu: [gksu]
 glc:
   arch: [glc]
   gentoo: [media-libs/quesoglc]
+  nixos: [quesoglc]
 glut:
   arch: [freeglut]
   debian: [freeglut3-dev]
   fedora: [freeglut-devel]
   gentoo: [media-libs/freeglut]
   macports: [freeglut]
+  nixos: [freeglut]
   openembedded: [freeglut@meta-oe]
   rhel: [freeglut-devel]
   ubuntu: [freeglut3-dev]
 gnat:
   debian: [gnat]
+  nixos: [gnat]
   ubuntu: [gnat]
 gnuplot:
   arch: [gnuplot]
   debian: [gnuplot]
   fedora: [gnuplot]
   gentoo: [sci-visualization/gnuplot]
+  nixos: [gnuplot]
   openembedded: [gnuplot@meta-oe]
   ubuntu: [gnuplot]
 gnuplot-x11:
@@ -1246,6 +1362,7 @@ gnuplot-x11:
 golang-go:
   debian: [golang-go]
   gentoo: [dev-lang/go]
+  nixos: [go]
   ubuntu: [golang-go]
 google-mock:
   alpine: [gmock]
@@ -1254,6 +1371,7 @@ google-mock:
   fedora: [gmock-devel]
   freebsd: [googlemock]
   gentoo: [dev-cpp/gtest]
+  nixos: [gmock]
   openembedded: [gtest@meta-oe]
   opensuse: [gmock-devel]
   rhel: [gmock-devel]
@@ -1262,6 +1380,7 @@ gpac:
   debian: [gpac]
   fedora: [gpac]
   gentoo: [media-video/gpac]
+  nixos: [gpac]
   osx:
     homebrew:
       packages: [gpac]
@@ -1279,6 +1398,7 @@ gperftools:
   debian: [google-perftools, libgoogle-perftools-dev]
   fedora: [gperftools, gperftools-devel]
   gentoo: [dev-util/gperf]
+  nixos: [gperftools]
   ubuntu: [google-perftools, libgoogle-perftools-dev]
 gpg-agent:
   debian:
@@ -1292,6 +1412,7 @@ gphoto2:
   debian: [gphoto2]
   fedora: [gphoto2]
   gentoo: [media-gfx/gphoto2]
+  nixos: [gphoto2]
   ubuntu: [gphoto2]
 gprbuild:
   debian: [gprbuild]
@@ -1300,6 +1421,7 @@ gpsd:
   debian: [gpsd]
   fedora: [gpsd]
   gentoo: [sci-geosciences/gpsd]
+  nixos: [gpsd]
   ubuntu: [gpsd]
 gradle:
   arch: [gradle]
@@ -1309,6 +1431,7 @@ gradle:
     stretch: [gradle]
   fedora: [gradle]
   gentoo: [dev-java/gradle-bin]
+  nixos: [gradle]
   ubuntu: [gradle]
 graphicsmagick:
   arch: [graphicsmagick]
@@ -1316,6 +1439,7 @@ graphicsmagick:
   fedora: [GraphicsMagick-c++-devel]
   gentoo: [virtual/imagemagick-tools]
   macports: [GraphicsMagick]
+  nixos: [graphicsmagick]
   openembedded: [graphicsmagick@meta-ros2]
   rhel: [GraphicsMagick-c++-devel]
   ubuntu: [libgraphicsmagick++1-dev, graphicsmagick-libmagick-dev-compat]
@@ -1326,6 +1450,7 @@ graphviz:
   freebsd: [graphviz]
   gentoo: [media-gfx/graphviz]
   macports: [graphviz]
+  nixos: [graphviz]
   openembedded: [graphviz@meta-ros-common]
   opensuse: [graphviz]
   rhel: [graphviz]
@@ -1334,11 +1459,13 @@ graphviz:
 graphviz-dev:
   debian: [libgraphviz-dev]
   fedora: [graphviz-devel]
+  nixos: [graphviz]
   rhel: [graphviz-devel]
   ubuntu: [libgraphviz-dev]
 gringo:
   debian: [gringo]
   fedora: [gringo]
+  nixos: [gringo]
   ubuntu: [gringo]
 gstreamer0.10-gconf:
   debian:
@@ -1389,12 +1516,14 @@ gstreamer1.0:
   debian: [gstreamer1.0-tools, libgstreamer1.0-0, gir1.2-gstreamer-1.0]
   fedora: [gstreamer1]
   gentoo: ['media-libs/gstreamer:1.0']
+  nixos: [gst_all_1.gstreamer]
   openembedded: [gstreamer1.0@openembedded-core]
   rhel: [gstreamer1]
   ubuntu: [gstreamer1.0-tools, libgstreamer1.0-0, gir1.2-gstreamer-1.0]
 gstreamer1.0-alsa:
   debian: [gstreamer1.0-alsa]
   fedora: [gstreamer1-plugins-base]
+  nixos: [gst_all_1.gst-plugins-base]
   openembedded: [gstreamer1.0-plugins-base@openembedded-core]
   rhel: [gstreamer1-plugins-base]
   ubuntu: [gstreamer1.0-alsa]
@@ -1404,6 +1533,7 @@ gstreamer1.0-gl:
     '*': [gstreamer1.0-gl]
     stretch: null
   fedora: [gstreamer1-plugins-base]
+  nixos: [gst_all_1.gst-plugins-base]
   ubuntu:
     '*': [gstreamer1.0-gl]
     xenial: null
@@ -1412,6 +1542,7 @@ gstreamer1.0-libav:
   debian: [gstreamer1.0-libav]
   fedora: [gstreamer1-libav]
   gentoo: ['media-plugins/gst-plugins-libav:1.0']
+  nixos: [gst_all_1.gst-libav]
   openembedded: [gstreamer1.0-libav@openembedded-core]
   ubuntu: [gstreamer1.0-libav]
 gstreamer1.0-plugins-bad:
@@ -1419,6 +1550,7 @@ gstreamer1.0-plugins-bad:
   debian: [gstreamer1.0-plugins-bad]
   fedora: [gstreamer1-plugins-bad-free]
   gentoo: ['media-libs/gst-plugins-bad:1.0']
+  nixos: [gst_all_1.gst-plugins-bad]
   openembedded: [gstreamer1.0-plugins-bad@openembedded-core]
   ubuntu: [gstreamer1.0-plugins-bad]
 gstreamer1.0-plugins-base:
@@ -1426,6 +1558,7 @@ gstreamer1.0-plugins-base:
   debian: [gstreamer1.0-plugins-base, libgstreamer-plugins-base1.0-0, gir1.2-gst-plugins-base-1.0]
   fedora: [gstreamer1-plugins-base]
   gentoo: ['media-libs/gst-plugins-base:1.0']
+  nixos: [gst_all_1.gst-plugins-base]
   openembedded: [gstreamer1.0-plugins-base@openembedded-core]
   ubuntu: [gstreamer1.0-plugins-base, libgstreamer-plugins-base1.0-0, gir1.2-gst-plugins-base-1.0]
 gstreamer1.0-plugins-good:
@@ -1433,6 +1566,7 @@ gstreamer1.0-plugins-good:
   debian: [gstreamer1.0-plugins-good]
   fedora: [gstreamer1-plugins-good]
   gentoo: ['media-libs/gst-plugins-good:1.0']
+  nixos: [gst_all_1.gst-plugins-good]
   openembedded: [gstreamer1.0-plugins-good@openembedded-core]
   rhel: [gstreamer1-plugins-good]
   ubuntu: [gstreamer1.0-plugins-good, libgstreamer-plugins-good1.0-0]
@@ -1441,6 +1575,7 @@ gstreamer1.0-plugins-ugly:
   debian: [gstreamer1.0-plugins-ugly]
   fedora: [gstreamer1-plugins-ugly]
   gentoo: ['media-libs/gst-plugins-ugly:1.0']
+  nixos: [gst_all_1.gst-plugins-ugly]
   openembedded: [gstreamer1.0-plugins-ugly@openembedded-core]
   ubuntu: [gstreamer1.0-plugins-ugly]
 gstreamer1.0-rtsp:
@@ -1465,6 +1600,7 @@ gtest:
   freebsd: [googletest]
   gentoo: [dev-cpp/gtest]
   macports: [ros-gtest]
+  nixos: [gtest]
   openembedded: [gtest@meta-oe]
   opensuse: [googletest-devel]
   rhel: [gtest-devel]
@@ -1475,6 +1611,7 @@ gtk-doc-tools:
   debian: [gtk-doc-tools]
   fedora: [gtk-doc]
   gentoo: [dev-util/gtk-doc]
+  nixos: [gtk-doc]
   ubuntu: [gtk-doc-tools]
 gtk2:
   arch: [gtk2]
@@ -1483,6 +1620,7 @@ gtk2:
   freebsd: [gtk2]
   gentoo: ['x11-libs/gtk+:2']
   macports: [gtk2]
+  nixos: [gtk2]
   openembedded: [gtk+@openembedded-core]
   opensuse: [gtk2-devel]
   rhel: [gtk2-devel]
@@ -1497,6 +1635,7 @@ gtk3:
   freebsd: [gtk3]
   gentoo: ['x11-libs/gtk+:3']
   macports: [gtk3]
+  nixos: [gtk3]
   openembedded: [gtk+3@openembedded-core]
   opensuse: [gtk3-devel]
   rhel: [gtk3-devel]
@@ -1513,6 +1652,7 @@ gv:
   debian: [gv]
   fedora: [gv]
   gentoo: [app-text/gv]
+  nixos: [gv]
   ubuntu: [gv]
 hddtemp:
   arch: [hddtemp]
@@ -1521,6 +1661,7 @@ hddtemp:
   freebsd: [python27]
   gentoo: [app-admin/hddtemp]
   macports: [python27]
+  nixos: [hddtemp]
   openembedded: [hddtemp@meta-oe]
   opensuse: [hddtemp]
   rhel: [hddtemp]
@@ -1532,6 +1673,7 @@ hdf5:
   fedora: [hdf5-devel]
   gentoo: [sci-libs/hdf5]
   macports: [hdf5]
+  nixos: [hdf5]
   ubuntu: [libhdf5-serial-dev]
 hdf5-tools:
   debian: [hdf5-tools]
@@ -1541,6 +1683,7 @@ hostapd:
   debian: [hostapd]
   fedora: [hostapd]
   gentoo: [net-wireless/hostapd]
+  nixos: [hostapd]
   openembedded: [hostapd@meta-oe]
   ubuntu: [hostapd]
 hostname:
@@ -1548,28 +1691,33 @@ hostname:
   debian: [hostname]
   fedora: [hostname]
   gentoo: [sys-apps/net-tools]
+  nixos: [hostname]
   ubuntu: [hostname]
 htop:
   arch: [htop]
   debian: [htop]
   fedora: [htop]
   gentoo: [sys-process/htop]
+  nixos: [htop]
   ubuntu: [htop]
 hugin-tools:
   debian: [hugin-tools]
   fedora: [hugin-base]
   gentoo: [media-gfx/hugin]
+  nixos: [hugin]
   ubuntu: [hugin-tools]
 i2c-tools:
   debian: [i2c-tools]
   fedora: [i2c-tools]
   gentoo: [sys-apps/i2c-tools]
+  nixos: [i2c-tools]
   opensuse: [i2c-tools]
   ubuntu: [i2c-tools]
 ifstat:
   debian: [ifstat]
   fedora: [ifstat]
   gentoo: [net-analyzer/ifstat]
+  nixos: [ifstat-legacy]
   ubuntu: [ifstat]
 ignition-citadel:
   debian:
@@ -1579,11 +1727,13 @@ ignition-citadel:
 ignition-cmake2:
   debian:
     buster: [libignition-cmake2-dev]
+  nixos: [ignition.cmake2]
   ubuntu:
     focal: [libignition-cmake2-dev]
 ignition-common3:
   debian:
     buster: [libignition-common3-dev]
+  nixos: [ignition.common3]
   ubuntu:
     focal: [libignition-common3-dev]
 ignition-common4:
@@ -1599,6 +1749,7 @@ ignition-edifice:
 ignition-fuel-tools4:
   debian:
     buster: [libignition-fuel-tools4-dev]
+  nixos: [ignition.fuel-tools4]
   ubuntu:
     focal: [libignition-fuel-tools4-dev]
 ignition-fuel-tools6:
@@ -1639,16 +1790,19 @@ ignition-launch4:
 ignition-math6:
   debian:
     buster: [libignition-math6-dev]
+  nixos: [ignition.math6]
   ubuntu:
     focal: [libignition-math6-dev]
 ignition-math6-eigen3:
   debian:
     buster: [libignition-math6-eigen3-dev]
+  nixos: [ignition.math6]
   ubuntu:
     focal: [libignition-math6-eigen3-dev]
 ignition-msgs5:
   debian:
     buster: [libignition-msgs5-dev]
+  nixos: [ignition.msgs5]
   ubuntu:
     focal: [libignition-msgs5-dev]
 ignition-msgs7:
@@ -1694,6 +1848,7 @@ ignition-sensors5:
 ignition-tools:
   debian:
     buster: [libignition-tools-dev]
+  nixos: [ignition.tools]
   ubuntu:
     focal: [libignition-tools-dev]
 ignition-transport10:
@@ -1704,6 +1859,7 @@ ignition-transport10:
 ignition-transport8:
   debian:
     buster: [libignition-transport8-dev]
+  nixos: [ignition.transport8]
   ubuntu:
     focal: [libignition-transport8-dev]
 ignition-utils1:
@@ -1721,6 +1877,7 @@ imagemagick:
   debian: [imagemagick]
   fedora: [ImageMagick]
   gentoo: [virtual/imagemagick-tools]
+  nixos: [imagemagick]
   ubuntu: [imagemagick]
 intltool:
   arch: [intltool]
@@ -1728,18 +1885,21 @@ intltool:
   fedora: [intltool]
   freebsd: [intltool]
   gentoo: [dev-util/intltool]
+  nixos: [intltool]
   opensuse: [intltool]
   ubuntu: [intltool]
 iperf:
   debian: [iperf]
   fedora: [iperf]
   gentoo: [net-misc/iperf]
+  nixos: [iperf]
   ubuntu: [iperf]
 ipmitool:
   arch: [ipmitool]
   debian: [ipmitool]
   fedora: [ipmitool]
   gentoo: [sys-apps/ipmitool]
+  nixos: [ipmitool]
   openembedded: [ipmitool@meta-oe]
   ubuntu: [ipmitool]
 iproute2:
@@ -1747,6 +1907,7 @@ iproute2:
   debian: [iproute2]
   fedora: [iproute]
   gentoo: [sys-apps/iproute2]
+  nixos: [iproute]
   openembedded: [iproute2@openembedded-core]
   opensuse: [iproute2]
   ubuntu: [iproute2]
@@ -1757,12 +1918,14 @@ iputils-ping:
 iwyu:
   debian: [iwyu]
   fedora: [iwyu]
+  nixos: [include-what-you-use]
   ubuntu: [iwyu]
 jack:
   arch: [jack]
   debian: [libjack-jackd2-dev]
   fedora: [jack-audio-connection-kit-devel]
   gentoo: [virtual/jack]
+  nixos: [jack2]
   ubuntu: [libjack-jackd2-dev]
 jasper:
   arch: [jasper]
@@ -1773,6 +1936,7 @@ jasper:
   freebsd: [jasper]
   gentoo: [media-libs/jasper]
   macports: [jasper]
+  nixos: [jasper]
   opensuse: [libjasper-devel]
   rhel: [jasper-devel]
   slackware:
@@ -1803,6 +1967,7 @@ java:
   fedora: [java]
   freebsd: [openjdk6]
   gentoo: [virtual/jdk]
+  nixos: [openjdk]
   rhel: [java]
   ubuntu: [default-jdk]
 joystick:
@@ -1810,6 +1975,7 @@ joystick:
   debian: [joystick]
   fedora: [linuxconsoletools]
   gentoo: [games-util/joystick]
+  nixos: [linuxConsoleTools]
   openembedded: [joystick@meta-ros-common]
   opensuse: [input-utils]
   rhel: [joystick]
@@ -1818,6 +1984,7 @@ jq:
   debian: [jq]
   fedora: [jq]
   gentoo: [app-misc/jq]
+  nixos: [jq]
   ubuntu: [jq]
 julius-voxforge:
   arch: [voxforge-am-julius]
@@ -1828,28 +1995,33 @@ jython:
   debian: [jython]
   fedora: [jython]
   gentoo: [dev-java/jython]
+  nixos: [jython]
   ubuntu: [jython]
 kakasi:
   arch: [kakasi]
   debian: [kakasi]
   fedora: [kakasi]
   gentoo: [app-i18n/kakasi]
+  nixos: [kakasi]
   ubuntu: [kakasi]
 kate:
   debian: [kate]
   fedora: [kate]
   gentoo: [kde-apps/kate]
+  nixos: [kate]
   ubuntu: [kate]
 kgraphviewer:
   arch: [kgraphviewer]
   debian: [kgraphviewer]
   fedora: [kgraphviewer]
   gentoo: [media-gfx/kgraphviewer]
+  nixos: [kgraphviewer]
   ubuntu: [kgraphviewer]
 konsole:
   debian: [konsole]
   fedora: [konsole]
   gentoo: [kde-apps/konsole]
+  nixos: [konsole]
   ubuntu: [konsole]
 language-pack-de:
   fedora: [filesystem]
@@ -1861,6 +2033,7 @@ lcov:
   debian: [lcov]
   fedora: [lcov]
   gentoo: [dev-util/lcov]
+  nixos: [lcov]
   openembedded: [lcov@meta-oe]
   rhel:
     '7': [lcov]
@@ -1869,6 +2042,7 @@ leveldb:
   debian: [libleveldb-dev]
   fedora: [leveldb-devel]
   gentoo: [dev-libs/leveldb]
+  nixos: [leveldb]
   openembedded: [leveldb@meta-oe]
   ubuntu: [libleveldb-dev]
 lib32asound2:
@@ -1916,12 +2090,14 @@ libasound2-dev:
   debian: [libasound2-dev]
   fedora: [alsa-lib]
   gentoo: [media-libs/alsa-lib]
+  nixos: [alsaLib]
   openembedded: [alsa-lib@openembedded-core]
   ubuntu: [libasound2-dev]
 libatomic:
   arch: [gcc-libs]
   debian: [libatomic1]
   fedora: [libatomic]
+  nixos: []
   rhel: [libatomic]
   ubuntu: [libatomic1]
 libav:
@@ -1929,12 +2105,14 @@ libav:
   debian: [libav-tools]
   fedora: []
   gentoo: [virtual/ffmpeg]
+  nixos: [libav]
   ubuntu: [libav-tools]
 libavahi-client-dev:
   arch: [avahi]
   debian: [libavahi-client-dev]
   fedora: [avahi-devel]
   gentoo: [net-dns/avahi]
+  nixos: [avahi]
   rhel: [avahi-devel]
   ubuntu: [libavahi-client-dev]
 libavahi-core-dev:
@@ -1942,6 +2120,7 @@ libavahi-core-dev:
   debian: [libavahi-core-dev]
   fedora: [avahi-devel]
   gentoo: [net-dns/avahi]
+  nixos: [avahi]
   rhel: [avahi-devel]
   ubuntu: [libavahi-core-dev]
 libavdevice-dev:
@@ -1952,11 +2131,13 @@ libb64-dev:
   debian: [libb64-dev]
   fedora: [libb64-devel]
   gentoo: [libb64]
+  nixos: [libb64]
   ubuntu: [libb64-dev]
 libbison-dev:
   debian: [libbison-dev]
   fedora: [bison-devel]
   gentoo: [sys-devel/bison]
+  nixos: [bison]
   rhel: [bison-devel]
   ubuntu:
     precise: [libbison-dev]
@@ -1969,6 +2150,7 @@ libblas-dev:
   debian: [libblas-dev]
   fedora: [blas-devel]
   gentoo: [virtual/blas]
+  nixos: [blas]
   openembedded: [openblas@meta-ros-common]
   rhel: [blas-devel]
   ubuntu: [libblas-dev]
@@ -1977,6 +2159,7 @@ libbluetooth:
   debian: [libbluetooth3]
   fedora: [bluez-libs]
   gentoo: [net-wireless/bluez-libs]
+  nixos: [bluez]
   rhel: [bluez-libs]
   ubuntu: [libbluetooth3]
 libbluetooth-dev:
@@ -1984,6 +2167,7 @@ libbluetooth-dev:
   debian: [libbluetooth-dev]
   fedora: [bluez-libs-devel]
   gentoo: [net-wireless/bluez-libs]
+  nixos: [bluez]
   rhel: [bluez-libs-devel]
   ubuntu: [libbluetooth-dev]
 libboost-atomic:
@@ -1992,6 +2176,7 @@ libboost-atomic:
     stretch: [libboost-atomic1.62.0]
   fedora: [boost-atomic]
   gentoo: [dev-libs/boost]
+  nixos: [boost]
   openembedded: [boost@openembedded-core]
   ubuntu:
     bionic: [libboost-atomic1.65.1]
@@ -2002,6 +2187,7 @@ libboost-atomic-dev:
   debian: [libboost-atomic-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
+  nixos: [boost]
   openembedded: [boost@openembedded-core]
   rhel: [boost-devel]
   ubuntu: [libboost-atomic-dev]
@@ -2011,6 +2197,7 @@ libboost-chrono:
     stretch: [libboost-chrono1.62.0]
   fedora: [boost-chrono]
   gentoo: [dev-libs/boost]
+  nixos: [boost]
   openembedded: [boost@openembedded-core]
   ubuntu:
     bionic: [libboost-chrono1.65.1]
@@ -2021,6 +2208,7 @@ libboost-chrono-dev:
   debian: [libboost-chrono-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
+  nixos: [boost]
   openembedded: [boost@openembedded-core]
   rhel: [boost-devel]
   ubuntu: [libboost-chrono-dev]
@@ -2030,6 +2218,7 @@ libboost-date-time:
     stretch: [libboost-date-time1.62.0]
   fedora: [boost-date-time]
   gentoo: [dev-libs/boost]
+  nixos: [boost]
   openembedded: [boost@openembedded-core]
   ubuntu:
     bionic: [libboost-date-time1.65.1]
@@ -2040,6 +2229,7 @@ libboost-date-time-dev:
   debian: [libboost-date-time-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
+  nixos: [boost]
   openembedded: [boost@openembedded-core]
   rhel: [boost-devel]
   ubuntu: [libboost-date-time-dev]
@@ -2047,6 +2237,7 @@ libboost-dev:
   debian: [libboost-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
+  nixos: [boost]
   openembedded: [boost@openembedded-core]
   rhel: [boost-devel]
   ubuntu: [libboost-dev]
@@ -2056,6 +2247,7 @@ libboost-filesystem:
     stretch: [libboost-filesystem1.62.0]
   fedora: [boost-filesystem]
   gentoo: [dev-libs/boost]
+  nixos: [boost]
   openembedded: [boost@openembedded-core]
   ubuntu:
     bionic: [libboost-filesystem1.65.1]
@@ -2066,6 +2258,7 @@ libboost-filesystem-dev:
   debian: [libboost-filesystem-dev]
   fedora: [boost-devel]
   gentoo: ['dev-libs/boost[python]']
+  nixos: [boost]
   openembedded: [boost@openembedded-core]
   rhel: [boost-devel]
   ubuntu: [libboost-filesystem-dev]
@@ -2075,6 +2268,7 @@ libboost-iostreams:
     stretch: [libboost-iostreams1.62.0]
   fedora: [boost-iostreams]
   gentoo: [dev-libs/boost]
+  nixos: [boost]
   openembedded: [boost@openembedded-core]
   ubuntu:
     bionic: [libboost-iostreams1.65.1]
@@ -2085,6 +2279,7 @@ libboost-iostreams-dev:
   debian: [libboost-iostreams-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
+  nixos: [boost]
   openembedded: [boost@openembedded-core]
   rhel: [boost-devel]
   ubuntu: [libboost-iostreams-dev]
@@ -2094,6 +2289,7 @@ libboost-math:
     stretch: [libboost-math1.62.0]
   fedora: [boost-math]
   gentoo: [dev-libs/boost]
+  nixos: [boost]
   rhel: [boost-math]
   ubuntu:
     bionic: [libboost-math1.65.1]
@@ -2104,6 +2300,7 @@ libboost-math-dev:
   debian: [libboost-math-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
+  nixos: [boost]
   rhel: [boost-devel]
   ubuntu: [libboost-math-dev]
 libboost-program-options:
@@ -2113,6 +2310,7 @@ libboost-program-options:
     stretch: [libboost-program-options1.62.0]
   fedora: [boost-program-options]
   gentoo: [dev-libs/boost]
+  nixos: [boost]
   openembedded: [boost@openembedded-core]
   rhel: [boost-program-options]
   ubuntu:
@@ -2126,6 +2324,7 @@ libboost-program-options-dev:
   debian: [libboost-program-options-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
+  nixos: [boost]
   openembedded: [boost@openembedded-core]
   rhel: [boost-devel]
   ubuntu: [libboost-program-options-dev]
@@ -2137,6 +2336,7 @@ libboost-python:
     stretch: [libboost-python1.62.0]
   fedora: [boost-python3]
   gentoo: ['dev-libs/boost[python]']
+  nixos: [boost]
   openembedded: [boost@openembedded-core]
   rhel:
     '*': [boost-python3]
@@ -2155,6 +2355,7 @@ libboost-python-dev:
     '*': [boost-devel]
     '32': [boost-devel, boost-python3-devel]
   gentoo: ['dev-libs/boost[python]']
+  nixos: [boost]
   openembedded: [boost@openembedded-core]
   rhel:
     '*': [boost-python3-devel]
@@ -2168,6 +2369,7 @@ libboost-random:
     wheezy: [libboost-random1.49.0]
   fedora: [boost-random]
   gentoo: [dev-libs/boost]
+  nixos: [boost]
   openembedded: [boost@openembedded-core]
   ubuntu:
     bionic: [libboost-random1.65.1]
@@ -2181,6 +2383,7 @@ libboost-random-dev:
   debian: [libboost-random-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
+  nixos: [boost]
   openembedded: [boost@openembedded-core]
   rhel: [boost-devel]
   ubuntu: [libboost-random-dev]
@@ -2190,6 +2393,7 @@ libboost-regex:
     stretch: [libboost-regex1.62.0]
   fedora: [boost-regex]
   gentoo: [dev-libs/boost]
+  nixos: [boost]
   openembedded: [boost@openembedded-core]
   ubuntu:
     bionic: [libboost-regex1.65.1]
@@ -2200,6 +2404,7 @@ libboost-regex-dev:
   debian: [libboost-regex-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
+  nixos: [boost]
   openembedded: [boost@openembedded-core]
   rhel: [boost-devel]
   ubuntu: [libboost-regex-dev]
@@ -2209,6 +2414,7 @@ libboost-serialization:
     stretch: [libboost-serialization1.62.0]
   fedora: [boost-serialization]
   gentoo: [dev-libs/boost]
+  nixos: [boost]
   openembedded: [boost@openembedded-core]
   rhel: [boost-serialization]
   ubuntu:
@@ -2220,6 +2426,7 @@ libboost-serialization-dev:
   debian: [libboost-serialization-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
+  nixos: [boost]
   openembedded: [boost@openembedded-core]
   rhel: [boost-devel]
   ubuntu: [libboost-serialization-dev]
@@ -2229,6 +2436,7 @@ libboost-system:
     stretch: [libboost-system1.62.0]
   fedora: [boost-system]
   gentoo: [dev-libs/boost]
+  nixos: [boost]
   openembedded: [boost@openembedded-core]
   rhel: [boost-system]
   ubuntu:
@@ -2242,6 +2450,7 @@ libboost-system-dev:
   debian: [libboost-system-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
+  nixos: [boost]
   openembedded: [boost@openembedded-core]
   rhel: [boost-devel]
   ubuntu: [libboost-system-dev]
@@ -2251,6 +2460,7 @@ libboost-thread:
     stretch: [libboost-thread1.62.0]
   fedora: [boost-thread]
   gentoo: ['dev-libs/boost[threads]']
+  nixos: [boost]
   openembedded: [boost@openembedded-core]
   ubuntu:
     bionic: [libboost-thread1.65.1]
@@ -2263,6 +2473,7 @@ libboost-thread-dev:
   debian: [libboost-thread-dev]
   fedora: [boost-devel]
   gentoo: ['dev-libs/boost[threads]']
+  nixos: [boost]
   openembedded: [boost@openembedded-core]
   rhel: [boost-devel]
   ubuntu: [libboost-thread-dev]
@@ -2272,6 +2483,7 @@ libboost-timer:
     stretch: [libboost-timer1.62.0]
   fedora: [boost-timer]
   gentoo: [dev-libs/boost]
+  nixos: [boost]
   rhel: [boost-timer]
   ubuntu:
     bionic: [libboost-timer1.65.1]
@@ -2282,6 +2494,7 @@ libboost-timer-dev:
   debian: [libboost-timer-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
+  nixos: [boost]
   rhel: [boost-devel]
   ubuntu: [libboost-timer-dev]
 libcairo2-dev:
@@ -2289,6 +2502,7 @@ libcairo2-dev:
   debian: [libcairo2-dev]
   fedora: [cairo-devel]
   gentoo: [x11-libs/cairo]
+  nixos: [cairo]
   openembedded: [cairo@openembedded-core]
   rhel: [cairo-devel]
   ubuntu: [libcairo2-dev]
@@ -2297,23 +2511,28 @@ libcap-dev:
   debian: [libcap-dev]
   fedora: [libcap-devel]
   gentoo: [sys-libs/libcap]
+  nixos: [libcap]
   openembedded: [libcap@openembedded-core]
   ubuntu: [libcap-dev]
 libcap-ng-dev:
   debian: [libcap-ng-dev]
+  nixos: [libcap_ng]
   ubuntu: [libcap-ng-dev]
 libcap-ng0:
   debian: [libcap-ng0]
   gentoo: [sys-libs/libcap-ng]
+  nixos: [libcap_ng]
   ubuntu: [libcap-ng0]
 libcap2:
   debian: [libcap2]
+  nixos: [libcap]
   ubuntu: [libcap2]
 libcap2-bin:
   arch: [libcap]
   debian: [libcap2-bin]
   fedora: [libcap]
   gentoo: [=sys-libs/libcap-2*]
+  nixos: [libcap]
   ubuntu: [libcap2-bin]
 libccd-dev:
   arch: [libccd]
@@ -2327,12 +2546,14 @@ libcdd-dev:
   debian: [libcdd-dev]
   fedora: [cddlib]
   gentoo: [sci-libs/cddlib]
+  nixos: [cddlib]
   ubuntu: [libcdd-dev]
 libcegui-mk2-dev:
   arch: [cegui]
   debian: [libcegui-mk2-dev]
   fedora: [cegui]
   gentoo: [dev-games/cegui]
+  nixos: [cegui]
   ubuntu: [libcegui-mk2-dev]
 libcereal-dev:
   debian: [libcereal-dev]
@@ -2345,6 +2566,7 @@ libceres-dev:
     stretch: [libceres-dev]
   fedora: [ceres-solver-devel]
   gentoo: ['sci-libs/ceres-solver[sparse,lapack]']
+  nixos: [ceres-solver]
   openembedded: [ceres-solver@meta-oe]
   rhel: [ceres-solver-devel]
   ubuntu: [libceres-dev]
@@ -2352,12 +2574,14 @@ libcgroup-dev:
   debian: [libcgroup-dev]
   fedora: [libcgroup-devel]
   gentoo: [dev-libs/libcgroup]
+  nixos: [libcgroup]
   openembedded: [libcgroup@openembedded-core]
   ubuntu: [libcgroup-dev]
 libclang-dev:
   arch: [clang]
   debian: [libclang-dev]
   fedora: [clang-devel]
+  nixos: [clang]
   ubuntu: [libclang-dev]
 libcoin60-dev:
   arch: [coin]
@@ -2384,6 +2608,7 @@ libconfig-dev:
   debian: [libconfig-dev]
   fedora: [libconfig-devel]
   gentoo: ['dev-libs/libconfig[cxx]']
+  nixos: [libconfig]
   rhel: [libconfig-devel]
   ubuntu: [libconfig-dev]
 libconsole-bridge-dev:
@@ -2393,6 +2618,7 @@ libconsole-bridge-dev:
   fedora: [console-bridge-devel]
   freebsd: [ros-console_bridge]
   gentoo: [dev-libs/console_bridge]
+  nixos: [console-bridge]
   openembedded: [console-bridge@meta-ros-common]
   opensuse: [libconsole_bridge0]
   rhel: [console-bridge-devel]
@@ -2413,6 +2639,7 @@ libcunit-dev:
   debian: [libcunit1-dev]
   fedora: [CUnit-devel]
   gentoo: [dev-util/cunit]
+  nixos: [cunit]
   rhel: [CUnit-devel]
   ubuntu: [libcunit1-dev]
 libdbus-dev:
@@ -2420,6 +2647,7 @@ libdbus-dev:
   debian: [libdbus-1-dev]
   fedora: [dbus-devel]
   gentoo: [sys-apps/dbus]
+  nixos: [dbus]
   ubuntu: [libdbus-1-dev]
 libdc1394-dev:
   arch:
@@ -2428,6 +2656,7 @@ libdc1394-dev:
   debian: [libdc1394-22-dev]
   fedora: [libdc1394-devel]
   gentoo: [media-libs/libdc1394]
+  nixos: [libdc1394]
   openembedded: [libdc1394@meta-multimedia]
   osx:
     macports:
@@ -2438,12 +2667,14 @@ libdevil-dev:
   debian: [libdevil-dev]
   fedora: [DevIL-devel]
   gentoo: [media-libs/devil]
+  nixos: [libdevil]
   ubuntu: [libdevil-dev]
 libdlib-dev:
   debian: [libdlib-dev]
   gentoo:
     portage:
       packages: [sci-libs/dlib]
+  nixos: [dlib]
   ubuntu:
     '*': [libdlib-dev]
     trusty: null
@@ -2452,26 +2683,31 @@ libdmtx-dev:
   debian: [libdmtx-dev]
   fedora: [libdmtx-devel]
   gentoo: [media-libs/libdmtx]
+  nixos: [libdmtx]
   ubuntu: [libdmtx-dev]
 libdpkg-dev:
   debian: [libdpkg-dev]
+  nixos: [dpkg]
   ubuntu: [libdpkg-dev]
 libdrm-dev:
   arch: [libdrm]
   debian: [libdrm-dev]
   fedora: [libdrm-devel]
   gentoo: [x11-libs/libdrm]
+  nixos: [libdrm]
   ubuntu: [libdrm-dev]
 libdw-dev:
   arch: [libelf]
   debian: [libdw-dev]
   fedora: [elfutils-devel]
   gentoo: [dev-libs/elfutils]
+  nixos: [elfutils]
   openembedded: [elfutils@openembedded-core]
   ubuntu: [libdw-dev]
 libdxflib-dev:
   debian: [libdxflib-dev]
   fedora: [libdxflib-devel]
+  nixos: [libsForQt5.dxflib]
   ubuntu: [libdxflib-dev]
 libedit:
   arch: [libedit]
@@ -2479,6 +2715,7 @@ libedit:
   fedora: [libedit]
   gentoo: [dev-libs/libedit]
   macports: [libedit]
+  nixos: [libedit]
   rhel: [libedit]
   ubuntu: [libedit2]
 libedit-dev:
@@ -2487,6 +2724,7 @@ libedit-dev:
   fedora: [libedit-devel]
   gentoo: [dev-libs/libedit]
   macports: [libedit]
+  nixos: [libedit]
   rhel: [libedit-devel]
   ubuntu: [libedit-dev]
 libesd0-dev:
@@ -2497,6 +2735,7 @@ libespeak-dev:
   debian: [libespeak-dev]
   fedora: [espeak-devel]
   gentoo: [app-accessibility/espeak]
+  nixos: [espeak]
   ubuntu: [libespeak-dev]
 libestools-dev:
   debian:
@@ -2517,12 +2756,14 @@ libev-dev:
   debian: [libev-dev]
   fedora: [libev-devel]
   gentoo: [dev-libs/libev]
+  nixos: [libev]
   ubuntu: [libev-dev]
 libevdev-dev:
   arch: [libevdev]
   debian: [libevdev-dev]
   fedora: [libevdev-devel]
   gentoo: [dev-libs/libevdev]
+  nixos: [libevdev]
   ubuntu: [libevdev-dev]
 libexpat1-dev:
   arch: [expat]
@@ -2548,6 +2789,7 @@ libffi-dev:
   debian: [libffi-dev]
   fedora: [libffi-devel]
   gentoo: [virtual/libffi]
+  nixos: [libffi]
   openembedded: [libffi@openembedded-core]
   ubuntu: [libffi-dev]
 libfftw3:
@@ -2555,6 +2797,7 @@ libfftw3:
   debian: [libfftw3-3, libfftw3-dev]
   fedora: [fftw, fftw-devel]
   gentoo: ['sci-libs/fftw:3.0']
+  nixos: [fftw, fftwSinglePrec]
   openembedded: [fftw@meta-oe]
   ubuntu: [libfftw3-3, libfftw3-dev]
 libflann:
@@ -2584,6 +2827,7 @@ libflann-dev:
   fedora: [flann-devel]
   gentoo: [sci-libs/flann]
   macports: [flann]
+  nixos: [flann]
   openembedded: [libflann@meta-ros-common]
   ubuntu: [libflann-dev]
 libfltk-dev:
@@ -2597,6 +2841,7 @@ libfltk-dev:
   freebsd: [fltk]
   gentoo: [x11-libs/fltk]
   macports: [fltk]
+  nixos: [fltk]
   openembedded: [fltk@meta-oe]
   opensuse: [fltk-devel]
   rhel: [fltk-devel]
@@ -2629,6 +2874,7 @@ libfreenect-dev:
   arch: [libfreenect]
   debian: [libfreenect-dev]
   fedora: [libfreenect-devel]
+  nixos: [freenect]
   openembedded: [libfreenect@meta-ros-common]
   ubuntu: [libfreenect-dev]
 libfreetype6:
@@ -2636,6 +2882,7 @@ libfreetype6:
   debian: [libfreetype6]
   fedora: [freetype-devel]
   gentoo: [media-libs/freetype]
+  nixos: [freetype]
   openembedded: [freetype@openembedded-core]
   rhel: [freetype]
   ubuntu: [libfreetype6]
@@ -2644,6 +2891,7 @@ libfreetype6-dev:
   debian: [libfreetype6-dev]
   fedora: [freetype-devel]
   gentoo: [media-libs/freetype]
+  nixos: [freetype]
   openembedded: [freetype@openembedded-core]
   rhel: [freetype-devel]
   ubuntu: [libfreetype6-dev]
@@ -2652,6 +2900,7 @@ libftdi-dev:
   debian: [libftdi-dev]
   fedora: [libftdi-devel]
   gentoo: [dev-embedded/libftdi]
+  nixos: [libftdi]
   openembedded: [libftdi@meta-oe]
   rhel: [libftdi-devel]
   ubuntu: [libftdi-dev]
@@ -2660,6 +2909,7 @@ libftdi1-dev:
   debian: [libftdi1-dev]
   fedora: [libftdi-devel]
   gentoo: [dev-embedded/libftdi]
+  nixos: [libftdi1]
   ubuntu: [libftdi1-dev]
 libftdipp-dev:
   debian:
@@ -2688,6 +2938,7 @@ libgazebo11-dev:
   debian:
     buster: [libgazebo11-dev]
   gentoo: [=sci-electronics/gazebo-11*]
+  nixos: [gazebo_11]
   ubuntu:
     focal: [libgazebo11-dev]
 libgazebo5-dev:
@@ -2701,6 +2952,7 @@ libgazebo7-dev:
     jessie: [libgazebo7-dev]
     stretch: [libgazebo7-dev]
   gentoo: [=sci-electronics/gazebo-7*]
+  nixos: [gazebo_7]
   opensuse: [gazebo-devel]
   slackware: [gazebo]
   ubuntu: [libgazebo7-dev]
@@ -2712,6 +2964,7 @@ libgazebo9-dev:
     '30': [gazebo-devel]
     '31': [gazebo-devel]
   gentoo: [sci-electronics/gazebo]
+  nixos: [gazebo_9]
   ubuntu:
     artful: [libgazebo9-dev]
     bionic: [libgazebo9-dev]
@@ -2723,9 +2976,11 @@ libgconf2:
   debian: [libgconf-2-4]
   fedora: [GConf2]
   gentoo: ['gnome-base/gconf:2']
+  nixos: [gnome2.GConf]
   ubuntu: [libgconf-2-4]
 libgdal-dev:
   debian: [libgdal-dev]
+  nixos: [gdal]
   opensuse: [gdal]
   ubuntu: [libgdal-dev]
 libgeographiclib-dev:
@@ -2739,6 +2994,7 @@ libgeos++-dev:
   debian: [libgeos++-dev]
   fedora: [geos-devel]
   gentoo: [sci-libs/geos]
+  nixos: [geos]
   openembedded: [geos@meta-oe]
   rhel: [geos-devel]
   ubuntu: [libgeos++-dev]
@@ -2747,12 +3003,14 @@ libgeotiff-dev:
   debian: [libgeotiff-dev]
   fedora: [libgeotiff]
   gentoo: [sci-libs/libgeotiff]
+  nixos: [libgeotiff]
   ubuntu: [libgeotiff-dev]
 libgflags-dev:
   arch: [gflags]
   debian: [libgflags-dev]
   fedora: [gflags-devel]
   gentoo: [dev-cpp/gflags]
+  nixos: [gflags]
   openembedded: [gflags@meta-oe]
   rhel: [gflags-devel]
   ubuntu: [libgflags-dev]
@@ -2766,12 +3024,14 @@ libgif-dev:
   debian: [libgif-dev]
   fedora: [libgif-devel]
   gentoo: [media-libs/giflib]
+  nixos: [giflib]
   ubuntu: [libgif-dev]
 libglew-dev:
   arch: [glew]
   debian: [libglew-dev]
   fedora: [glew-devel]
   gentoo: [media-libs/glew]
+  nixos: [glew]
   openembedded: [glew@openembedded-core]
   rhel: [glew-devel]
   ubuntu: [libglew-dev]
@@ -2779,6 +3039,7 @@ libglfw3-dev:
   debian: [libglfw3-dev]
   fedora: [glfw-devel]
   gentoo: [media-libs/glfw]
+  nixos: [glfw3]
   openembedded: [glfw@meta-intel-realsense]
   rhel: [glfw-devel]
   ubuntu:
@@ -2789,6 +3050,7 @@ libglib-dev:
   debian: [libglib2.0-dev]
   fedora: [glib2-devel]
   gentoo: [dev-libs/glib]
+  nixos: [glib]
   openembedded: [glib-2.0@openembedded-core]
   ubuntu: [libglib2.0-dev]
 libglm-dev:
@@ -2817,6 +3079,7 @@ libgmock-dev:
   fedora: [gmock-devel]
   freebsd: [googlemock]
   gentoo: [dev-cpp/gtest]
+  nixos: [gmock]
   openembedded: [gtest@meta-oe]
   opensuse: [gmock-devel]
   rhel: [gmock-devel]
@@ -2826,6 +3089,7 @@ libgmp:
   debian: [libgmp-dev]
   fedora: [gmp-devel]
   gentoo: [dev-libs/gmp]
+  nixos: [gmp]
   ubuntu: [libgmp-dev]
 libgomp1:
   debian: [libgomp1]
@@ -2836,6 +3100,7 @@ libgoogle-glog-dev:
   debian: [libgoogle-glog-dev]
   fedora: [glog-devel]
   gentoo: [dev-cpp/glog]
+  nixos: [glog]
   openembedded: [glog@meta-oe]
   rhel: [glog-devel]
   ubuntu: [libgoogle-glog-dev]
@@ -2850,6 +3115,7 @@ libgpgme-dev:
   fedora: [gpgme-devel]
   freebsd: [gpgme]
   gentoo: [app-crypt/gpgme]
+  nixos: [gpgme]
   openembedded: [gpgme@openembedded-core]
   rhel: [gpgme-devel]
   ubuntu:
@@ -2872,6 +3138,7 @@ libgphoto-dev:
   debian: [libgphoto2-dev]
   fedora: [libgphoto2-devel]
   gentoo: [media-gfx/gphoto2]
+  nixos: [libgphoto2]
   openembedded: [libgphoto2@meta-oe]
   rhel: [libgphoto2-devel]
   ubuntu:
@@ -2884,6 +3151,7 @@ libgps:
   debian: [libgps-dev]
   fedora: [gpsd-devel]
   gentoo: [sci-geosciences/gpsd]
+  nixos: [gpsd]
   openembedded: [gpsd@meta-oe]
   opensuse: [gpsd-devel]
   rhel: [gpsd-devel]
@@ -2898,6 +3166,7 @@ libgsl:
   fedora: [gsl-devel]
   gentoo: [sci-libs/gsl]
   macports: [gsl]
+  nixos: [gsl]
   openembedded: [gsl@meta-oe]
   ubuntu:
     '*': [libgsl-dev]
@@ -2929,6 +3198,7 @@ libgstreamer-plugins-base1.0-dev:
   debian: [libgstreamer-plugins-base1.0-dev]
   fedora: [gstreamer1-plugins-base-devel]
   gentoo: ['media-libs/gst-plugins-base:1.0']
+  nixos: [gst_all_1.gst-plugins-base]
   openembedded: [gstreamer1.0-plugins-base@openembedded-core]
   ubuntu: [libgstreamer-plugins-base1.0-dev]
 libgstreamer0.10-0:
@@ -2952,15 +3222,18 @@ libgstreamer1.0-dev:
   debian: [libgstreamer1.0-dev]
   fedora: [gstreamer1-devel]
   gentoo: ['media-libs/gstreamer:1.0']
+  nixos: [gst_all_1.gstreamer]
   openembedded: [gstreamer1.0@openembedded-core]
   ubuntu: [libgstreamer1.0-dev]
 libgstrtspserver-1.0-0:
   debian: [libgstrtspserver-1.0-0]
   fedora: [gstreamer1-rtsp-server]
+  nixos: [gst_all_1.gst-rtsp-server]
   ubuntu: [libgstrtspserver-1.0-0]
 libgstrtspserver-1.0-dev:
   debian: [libgstrtspserver-1.0-dev]
   fedora: [gstreamer1-rtsp-server-devel]
+  nixos: [gst_all_1.gst-rtsp-server]
   ubuntu: [libgstrtspserver-1.0-dev]
 libgtkmm:
   arch: [gtkmm]
@@ -2973,6 +3246,7 @@ libgts:
   debian: [libgts-dev]
   fedora: [gts]
   gentoo: [sci-libs/gts]
+  nixos: [gts]
   ubuntu: [libgts-dev]
 libhal-dev:
   arch:
@@ -2984,26 +3258,31 @@ libhdf5-dev:
   debian: [libhdf5-dev]
   fedora: [hdf5-devel]
   gentoo: [sci-libs/hdf5]
+  nixos: [hdf5]
   openembedded: [hdf5@meta-oe]
   ubuntu: [libhdf5-dev]
 libhidapi-dev:
   debian: [libhidapi-dev]
   fedora: [hidapi-devel]
   gentoo: [dev-libs/hidapi]
+  nixos: [hidapi]
   ubuntu: [libhidapi-dev]
 libi2c-dev:
   arch: [linux-api-headers]
   debian: [libi2c-dev]
   gentoo: [sys-apps/i2c-tools]
+  nixos: [i2c-tools]
   ubuntu: [libi2c-dev]
 libicu-dev:
   debian: [libicu-dev]
   fedora: [libicu-devel]
   gentoo: [dev-libs/icu]
+  nixos: [icu]
   ubuntu: [libicu-dev]
 libignition-common3:
   debian:
     buster: [libignition-common3]
+  nixos: [ignition.common3]
   ubuntu:
     focal: [libignition-common3]
 libignition-common4:
@@ -3014,6 +3293,7 @@ libignition-common4:
 libignition-fuel-tools4:
   debian:
     buster: [libignition-fuel-tools4]
+  nixos: [ignition.fuel-tools4]
   ubuntu:
     focal: [libignition-fuel-tools4]
 libignition-fuel-tools6:
@@ -3054,11 +3334,13 @@ libignition-launch4:
 libignition-math6:
   debian:
     buster: [libignition-math6]
+  nixos: [ignition.math6]
   ubuntu:
     focal: [libignition-math6]
 libignition-msgs5:
   debian:
     buster: [libignition-msgs5]
+  nixos: [ignition.msgs5]
   ubuntu:
     focal: [libignition-msgs5]
 libignition-msgs7:
@@ -3104,6 +3386,7 @@ libignition-transport10:
 libignition-transport8:
   debian:
     buster: [libignition-transport8]
+  nixos: [ignition.transport8]
   ubuntu:
     focal: [libignition-transport8]
 libignition-utils1:
@@ -3121,11 +3404,13 @@ libirrlicht-dev:
   debian: [libirrlicht-dev]
   fedora: [irrlicht-devel]
   gentoo: [dev-games/irrlicht]
+  nixos: [irrlicht]
   ubuntu: [libirrlicht-dev]
 libiw-dev:
   debian: [libiw-dev]
   fedora: [wireless-tools-devel]
   gentoo: [net-wireless/wireless-tools]
+  nixos: [wirelesstools]
   ubuntu: [libiw-dev]
 libjack-dev:
   debian: [libjack-dev]
@@ -3138,6 +3423,7 @@ libjackson-json-java:
 libjansson-dev:
   debian: [libjansson-dev]
   gentoo: [dev-libs/jansson]
+  nixos: [jansson]
   ubuntu: [libjansson-dev]
 libjaxp1.3-java:
   debian: [libjaxp1.3-java]
@@ -3158,6 +3444,7 @@ libjpeg:
   freebsd: [libjpeg-turbo]
   gentoo: [virtual/jpeg]
   macports: [jpeg]
+  nixos: [libjpeg]
   openembedded: [jpeg@openembedded-core]
   opensuse: [libjpeg62-devel]
   rhel: [libjpeg-turbo-devel]
@@ -3187,6 +3474,7 @@ libjson-glib:
   debian: [libjson-glib-dev]
   fedora: [json-glib]
   gentoo: [dev-libs/json-glib]
+  nixos: [json-glib]
   ubuntu: [libjson-glib-dev]
 libjson-java:
   debian: [libjson-java]
@@ -3205,6 +3493,7 @@ libjsoncpp:
   debian: [libjsoncpp1]
   fedora: [jsoncpp]
   gentoo: [dev-libs/jsoncpp]
+  nixos: [jsoncpp]
   openembedded: [jsoncpp@meta-oe]
   rhel: [jsoncpp]
   ubuntu:
@@ -3220,6 +3509,7 @@ libjsoncpp-dev:
   debian: [libjsoncpp-dev]
   fedora: [jsoncpp-devel]
   gentoo: [dev-libs/jsoncpp]
+  nixos: [jsoncpp]
   openembedded: [jsoncpp@meta-oe]
   rhel: [jsoncpp-devel]
   ubuntu: [libjsoncpp-dev]
@@ -3230,12 +3520,14 @@ libkdtree++-dev:
 libkml-dev:
   arch: [libkml]
   debian: [libkml-dev]
+  nixos: [libkml]
   ubuntu: [libkml-dev]
 liblapack-dev:
   arch: [lapack]
   debian: [liblapack-dev]
   fedora: [lapack-devel]
   gentoo: [virtual/lapack]
+  nixos: [liblapack]
   openembedded: [lapack@meta-oe]
   rhel: [lapack-devel]
   ubuntu: [liblapack-dev]
@@ -3259,33 +3551,39 @@ libleptonica-dev:
   debian: [libleptonica-dev]
   fedora: [leptonica-devel]
   gentoo: [media-libs/leptonica]
+  nixos: [leptonica]
   ubuntu: [libleptonica-dev]
 liblinear-dev:
   debian: [liblinear-dev]
   fedora: [liblinear-devel]
   gentoo: [dev-libs/liblinear]
+  nixos: [liblinear]
   ubuntu: [liblinear-dev]
 liblinphone-dev:
   debian: [liblinphone-dev]
   fedora: [linphone-devel]
   gentoo: [net-voip/linphone]
+  nixos: [liblinphone]
   ubuntu: [liblinphone-dev]
 liblttng-ust-dev:
   arch: [lttng-ust]
   debian: [liblttng-ust-dev]
   fedora: [lttng-ust-devel]
   gentoo: [dev-util/lttng-ust]
+  nixos: [lttng-ust]
   rhel: [lttng-ust-devel]
   ubuntu: [liblttng-ust-dev]
 liblzma-dev:
   debian: [liblzma-dev]
   fedora: [lzma-devel]
+  nixos: [lzma]
   ubuntu: [liblzma-dev]
 libmagick:
   arch: [imagemagick]
   debian: [libmagick++-dev]
   fedora: [ImageMagick-c++-devel]
   gentoo: [virtual/imagemagick-tools]
+  nixos: [imagemagick]
   ubuntu: [libmagick++-dev]
 libmarble-dev:
   arch: [kdeedu-marble]
@@ -3297,6 +3595,7 @@ libmicrohttpd:
   debian: [libmicrohttpd-dev]
   fedora: [libmicrohttpd-devel]
   gentoo: [net-libs/libmicrohttpd]
+  nixos: [libmicrohttpd]
   openembedded: [libmicrohttpd@meta-oe]
   rhel: [libmicrohttpd-devel]
   ubuntu: [libmicrohttpd-dev]
@@ -3314,19 +3613,23 @@ libmockito-java:
 libmodbus-dev:
   debian: [libmodbus-dev]
   fedora: [libmodbus-devel]
+  nixos: [libmodbus]
   openembedded: [libmodbus@meta-oe]
   ubuntu: [libmodbus-dev]
 libmodbus5:
   debian: [libmodbus5]
   fedora: [libmodbus]
   gentoo: [dev-libs/libmodbus]
+  nixos: [libmodbus]
   ubuntu: [libmodbus5]
 libmongoc-1.0-0:
   debian: [libmongoc-1.0-0]
   gentoo: [dev-libs/mongo-c-driver]
+  nixos: [mongoc]
   ubuntu: [libmongoc-1.0-0]
 libmongoc-dev:
   debian: [libmongoc-dev]
+  nixos: [mongoc]
   ubuntu: [libmongoc-dev]
 libmongoclient-dev:
   debian: [libmongoclient-dev]
@@ -3349,15 +3652,18 @@ libmp3lame-dev:
 libmpg123-dev:
   debian: [libmpg123-dev]
   fedora: [mpg123-devel]
+  nixos: [mpg123]
   ubuntu: [libmpg123-dev]
 libmpich-dev:
   debian: [libmpich-dev]
   fedora: [mpich-devel]
   gentoo: [sys-cluster/mpich]
+  nixos: [mpich]
   ubuntu: [libmpich-dev]
 libmpich2-dev:
   debian: [libmpich2-dev]
   gentoo: [sys-cluster/mpich2]
+  nixos: [mpich2]
   ubuntu: [libmpich2-dev]
 libmysqlclient-dev:
   arch: [mariadb]
@@ -3391,6 +3697,7 @@ libncurses-dev:
   fedora: [ncurses-devel]
   gentoo: [sys-libs/ncurses]
   macports: [ncurses]
+  nixos: [ncurses]
   openembedded: [ncurses@openembedded-core]
   rhel: [ncurses-devel]
   ubuntu: [libncurses5-dev]
@@ -3406,6 +3713,7 @@ libnl-3:
   debian: [libnl-3-200, libnl-genl-3-200]
   fedora: [libnl3]
   gentoo: ['dev-libs/libnl:3']
+  nixos: [libnl]
   openembedded: [libnl@openembedded-core]
   ubuntu: [libnl-3-200, libnl-genl-3-200]
 libnl-3-dev:
@@ -3413,6 +3721,7 @@ libnl-3-dev:
   debian: [libnl-3-dev, libnl-genl-3-dev]
   fedora: [libnl3-devel]
   gentoo: ['dev-libs/libnl:3']
+  nixos: [libnl]
   openembedded: [libnl@openembedded-core]
   ubuntu: [libnl-3-dev, libnl-genl-3-dev]
 libnl-dev:
@@ -3427,6 +3736,7 @@ libnlopt-cxx-dev:
     stretch: null
   fedora: [NLopt-devel]
   gentoo: [sci-libs/nlopt]
+  nixos: [nlopt]
   ubuntu:
     '*': [libnlopt-cxx-dev]
     bionic: null
@@ -3435,21 +3745,25 @@ libnlopt-dev:
   debian: [libnlopt-dev]
   fedora: [NLopt-devel]
   gentoo: [sci-libs/nlopt]
+  nixos: [nlopt]
   ubuntu: [libnlopt-dev]
 libnlopt0:
   debian: [libnlopt0]
   fedora: [NLopt]
   gentoo: [sci-libs/nlopt]
+  nixos: [nlopt]
   ubuntu: [libnlopt0]
 libnotify:
   debian: [libnotify-dev]
   fedora: [libnotify-devel]
   gentoo: [x11-libs/libnotify]
+  nixos: [libnotify]
   ubuntu: [libnotify-dev]
 libnss3-dev:
   debian: [libnss3-dev]
   fedora: [nss-devel]
   gentoo: [=dev-libs/nss-3*]
+  nixos: [nss]
   ubuntu: [libnss3-dev]
 libogg:
   arch: [libogg]
@@ -3458,6 +3772,7 @@ libogg:
   freebsd: [libogg]
   gentoo: [media-libs/libogg]
   macports: [libogg]
+  nixos: [libogg]
   openembedded: [libogg@openembedded-core]
   opensuse: [libogg-devel]
   rhel: [libogg-devel]
@@ -3474,6 +3789,7 @@ libogre:
   freebsd: [ogre3d]
   gentoo: [dev-games/ogre]
   macports: [ogre]
+  nixos: [ogre1_9]
   openembedded: [ogre@meta-ros-common]
   opensuse: [ogre-devel]
   slackware: [ogre]
@@ -3507,6 +3823,7 @@ libogre-dev:
   freebsd: [ogre3d]
   gentoo: [dev-games/ogre]
   macports: [ogre]
+  nixos: [ogre1_9]
   openembedded: [ogre@meta-ros-common]
   opensuse: [ogre-devel]
   slackware: [ogre]
@@ -3534,6 +3851,7 @@ libois-dev:
   debian: [libois-dev]
   fedora: [ois-devel]
   gentoo: [dev-games/ois]
+  nixos: [ois]
   ubuntu: [libois-dev]
 libomp-dev:
   arch: [openmp]
@@ -3550,11 +3868,13 @@ libopenal-dev:
   debian: [libopenal-dev]
   fedora: [openal-soft-devel]
   gentoo: [media-libs/openal]
+  nixos: [openal]
   rhel: [openal-soft-devel]
   ubuntu: [libopenal-dev]
 libopenblas-dev:
   debian: [libopenblas-dev]
   fedora: [openblas-devel]
+  nixos: [openblas]
   openembedded: [openblas@meta-ros-common]
   rhel: [openblas-devel]
   ubuntu: [libopenblas-dev]
@@ -3572,6 +3892,7 @@ libopencv-dev:
   freebsd: [opencv-core]
   gentoo: [media-libs/opencv]
   macports: [opencv]
+  nixos: [opencv3]
   openembedded: [opencv@meta-oe]
   rhel: [opencv-devel]
   ubuntu: [libopencv-dev]
@@ -3587,6 +3908,7 @@ libopenexr-dev:
   debian: [libopenexr-dev]
   fedora: [OpenEXR-devel]
   gentoo: [media-libs/openexr]
+  nixos: [openexr]
   rhel: [OpenEXR-devel]
   ubuntu: [libopenexr-dev]
 libopenni-dev:
@@ -3616,12 +3938,14 @@ libopenni2-dev:
   debian: [libopenni2-dev]
   fedora: [openni-devel]
   gentoo: [dev-libs/OpenNI2]
+  nixos: [openni2]
   ubuntu: [libopenni2-dev]
 libopenscenegraph:
   arch: [openscenegraph]
   debian: [openscenegraph, libopenscenegraph-dev]
   fedora: [OpenSceneGraph, OpenSceneGraph-devel, OpenThreads, OpenThreads-devel]
   gentoo: [dev-games/openscenegraph]
+  nixos: [openscenegraph]
   ubuntu: [openscenegraph, libopenscenegraph-dev]
 libopensplice67:
   gentoo: [=sci-libs/opensplice-6.7.*]
@@ -3630,6 +3954,7 @@ libopensplice67:
     xenial: [libopensplice67]
 libopensplice69:
   gentoo: [=sci-libs/opensplice-6.9.*]
+  nixos: [opensplice_6_9]
   ubuntu:
     bionic: [libopensplice69]
     xenial: [libopensplice69]
@@ -3641,6 +3966,7 @@ libopenvdb:
     stretch: [libopenvdb3.2]
   fedora: [openvdb]
   gentoo: [media-gfx/openvdb]
+  nixos: [openvdb]
   ubuntu:
     artful: [libopenvdb3.2]
     bionic: [libopenvdb5.0]
@@ -3658,6 +3984,7 @@ libopenvdb-dev:
   debian: [libopenvdb-dev, libilmbase-dev]
   fedora: [openvdb-devel]
   gentoo: [media-gfx/openvdb]
+  nixos: [openvdb]
   ubuntu: [libopenvdb-dev, libilmbase-dev]
 liborocos-bfl:
   debian:
@@ -3678,6 +4005,7 @@ liborocos-kdl:
     'stretch': [liborocos-kdl1.3]
   fedora: [orocos-kdl]
   gentoo: [sci-libs/orocos_kdl]
+  nixos: [orocos-kdl]
   openembedded: [orocos-kdl@meta-ros1-noetic]
   ubuntu:
     '*': [liborocos-kdl1.4]
@@ -3687,6 +4015,7 @@ liborocos-kdl-dev:
   debian: [liborocos-kdl-dev]
   fedora: [orocos-kdl-devel]
   gentoo: [sci-libs/orocos_kdl]
+  nixos: [orocos-kdl]
   openembedded: [orocos-kdl@meta-ros1-noetic]
   ubuntu: [liborocos-kdl-dev]
 libosmesa6-dev:
@@ -3703,6 +4032,7 @@ libpcap:
   fedora: [libpcap-devel]
   gentoo: [net-libs/libpcap]
   macports: [libpcap]
+  nixos: [libpcap]
   openembedded: [libpcap@openembedded-core]
   rhel: [libpcap-devel]
   ubuntu: [libpcap0.8-dev]
@@ -3716,6 +4046,7 @@ libpcl-all:
   freebsd: [libpcl]
   gentoo: [sci-libs/pcl]
   macports: [libpcl]
+  nixos: [pcl]
   openembedded: [pcl@meta-ros-common]
   opensuse: [pcl]
   rhel: [pcl, pcl-tools]
@@ -3742,6 +4073,7 @@ libpcl-all-dev:
   freebsd: [libpcl]
   gentoo: [sci-libs/pcl]
   macports: [libpcl]
+  nixos: [pcl]
   openembedded: [pcl@meta-ros-common]
   opensuse: [pcl]
   rhel: [pcl-devel]
@@ -3769,6 +4101,7 @@ libpcsclite-dev:
   debian: [libpcsclite-dev]
   fedora: [pcsc-lite-devel]
   gentoo: [sys-apps/pcsc-lite]
+  nixos: [pcsclite]
   ubuntu: [libpcsclite-dev]
 libphonon:
   debian: [libphonon4]
@@ -3783,6 +4116,7 @@ libphonon-dev:
 libpng++-dev:
   debian: [libpng++-dev]
   gentoo: [dev-cpp/pngpp]
+  nixos: [pngpp]
   ubuntu: [libpng++-dev]
 libpng-dev:
   arch: [libpng]
@@ -3795,6 +4129,7 @@ libpng-dev:
   freebsd: [png]
   gentoo: [media-libs/libpng]
   macports: [libpng]
+  nixos: [libpng]
   openembedded: [libpng@openembedded-core]
   opensuse: [libpng12-devel]
   rhel: [libpng-devel]
@@ -3817,6 +4152,7 @@ libpng12-dev:
   freebsd: [png]
   gentoo: ['media-libs/libpng:1.2']
   macports: [libpng]
+  nixos: [libpng12]
   opensuse: [libpng12-devel]
   slackware: [libpng]
   ubuntu: [libpng12-dev]
@@ -3828,6 +4164,7 @@ libpoco-dev:
   freebsd: [poco]
   gentoo: [dev-libs/poco]
   macports: [poco]
+  nixos: [poco]
   openembedded: [poco@meta-oe]
   opensuse: [poco-devel]
   rhel: [poco-devel]
@@ -3842,12 +4179,14 @@ libpopt-dev:
   debian: [libpopt-dev]
   fedora: [popt-devel]
   gentoo: [dev-libs/popt]
+  nixos: [popt]
   ubuntu: [libpopt-dev]
 libpq-dev:
   arch: [postgresql-libs]
   debian: [libpq-dev]
   fedora: [libpq-devel]
   gentoo: [dev-db/postgresql]
+  nixos: [postgresql]
   ubuntu: [libpq-dev]
 libpqxx:
   debian:
@@ -3857,6 +4196,7 @@ libpqxx:
     wheezy: [libpqxx-3.1]
   fedora: [libpqxx]
   gentoo: [dev-libs/libpqxx]
+  nixos: [libpqxx]
   ubuntu:
     artful: [libpqxx-4.0v5]
     bionic: [libpqxx-4.0v5]
@@ -3880,9 +4220,11 @@ libpqxx-dev:
   debian: [libpqxx-dev]
   fedora: [libpqxx-devel]
   gentoo: [dev-libs/libpqxx]
+  nixos: [libpqxx]
   ubuntu: [libpqxx-dev]
 libprocps-dev:
   debian: [libprocps-dev]
+  nixos: [procps]
   ubuntu: [libprocps-dev]
 libprocps6:
   debian:
@@ -3898,6 +4240,7 @@ libpulse-dev:
   debian: [libpulse-dev]
   fedora: [pulseaudio-libs-devel]
   gentoo: [media-sound/pulseaudio]
+  nixos: [pulseaudio]
   openembedded: [pulseaudio@openembedded-core]
   ubuntu: [libpulse-dev]
 libqcustomplot-dev:
@@ -3917,6 +4260,7 @@ libqd-dev:
 libqglviewer-dev-qt5:
   debian: [libqglviewer-dev-qt5]
   fedora: [libQGLViewer-qt5-devel]
+  nixos: [libsForQt5.libqglviewer]
   openembedded: [qtbase@meta-qt5]
   ubuntu: [libqglviewer-dev-qt5]
 libqglviewer-qt4:
@@ -3977,6 +4321,7 @@ libqglviewer-qt4-dev:
 libqglviewer2-qt5:
   debian: [libqglviewer2-qt5]
   fedora: [libQGLViewer-qt5]
+  nixos: [libsForQt5.libqglviewer]
   ubuntu: [libqglviewer2-qt5]
 libqhull:
   arch: [qhull]
@@ -3985,6 +4330,7 @@ libqhull:
   freebsd: [qhull]
   gentoo: [media-libs/qhull]
   macports: [qhull]
+  nixos: [qhull]
   openembedded: [qhull@meta-ros-common]
   opensuse: [qhull-devel]
   rhel: [qhull-devel]
@@ -3993,10 +4339,12 @@ libqhull:
 libqrencode:
   debian: [libqrencode3]
   gentoo: [media-gfx/qrencode]
+  nixos: [libqrencode]
   ubuntu: [libqrencode3]
 libqrencode-dev:
   debian: [libqrencode-dev]
   gentoo: [media-gfx/qrencode]
+  nixos: [libqrencode]
   ubuntu: [libqrencode-dev]
 libqt4:
   arch: [qt4]
@@ -4005,6 +4353,7 @@ libqt4:
   freebsd: [qt4-corelib]
   gentoo: ['dev-qt/qtcore:4']
   macports: [qt4-mac]
+  nixos: [qt4]
   opensuse: [libqt4]
   rhel:
     '7': [qt]
@@ -4016,6 +4365,7 @@ libqt4-dev:
   freebsd: [qt4-corelib]
   gentoo: ['dev-qt/qtcore:4']
   macports: [qt4-mac]
+  nixos: [qt4]
   opensuse: [libqt4-devel]
   rhel:
     '7': [qt-devel]
@@ -4025,6 +4375,7 @@ libqt4-opengl:
   debian: [libqt4-opengl]
   fedora: [qt]
   gentoo: ['dev-qt/qtopengl:4']
+  nixos: [qt4]
   rhel:
     '7': [qt]
   ubuntu: [libqt4-opengl]
@@ -4034,6 +4385,7 @@ libqt4-opengl-dev:
   fedora: [qt-devel]
   gentoo: ['dev-qt/qtopengl:4']
   macports: [qt4-mac]
+  nixos: [qt4]
   opensuse: [libqt4-devel]
   rhel:
     '7': [qt-devel]
@@ -4044,12 +4396,14 @@ libqt4-sql-psql:
   fedora: [qt-postgresql]
   gentoo: ['dev-qt/qtsql:4']
   macports: [qt4-mac]
+  nixos: [qt4]
   ubuntu: [libqt4-sql-psql]
 libqt5-concurrent:
   arch: [qt5-base]
   debian: [libqt5concurrent5]
   fedora: [qt5-qtbase]
   gentoo: ['dev-qt/qtconcurrent:5']
+  nixos: [qt5.qtbase]
   openembedded: [qtbase@meta-qt5]
   opensuse: [libQt5Concurrent5]
   slackware: [qt5]
@@ -4061,6 +4415,7 @@ libqt5-core:
   fedora: [qt5-qtbase]
   freebsd: [qt5-core]
   gentoo: ['dev-qt/qtcore:5']
+  nixos: [qt5.qtbase]
   openembedded: [qtbase@meta-qt5]
   opensuse: [libQt5Core5]
   rhel: [qt5-qtbase]
@@ -4076,6 +4431,7 @@ libqt5-gui:
   fedora: [qt5-qtbase-gui]
   freebsd: [qt5-gui]
   gentoo: ['dev-qt/qtgui:5']
+  nixos: [qt5.qtbase]
   openembedded: [qtbase@meta-qt5]
   opensuse: [libQt5Gui5]
   rhel: [qt5-qtbase-gui]
@@ -4083,6 +4439,7 @@ libqt5-gui:
   ubuntu: [libqt5gui5]
 libqt5-multimedia:
   debian: [libqt5multimedia5]
+  nixos: [qt5.qtmultimedia]
   ubuntu: [libqt5multimedia5]
 libqt5-network:
   arch: [qt5-base]
@@ -4090,6 +4447,7 @@ libqt5-network:
   fedora: [qt5-qtbase]
   freebsd: [qt5-network]
   gentoo: ['dev-qt/qtnetwork:5']
+  nixos: [qt5.qtbase]
   openembedded: [qtbase@meta-qt5]
   ubuntu: [libqt5network5]
 libqt5-opengl:
@@ -4099,6 +4457,7 @@ libqt5-opengl:
   fedora: [qt5-qtbase]
   freebsd: [qt5-opengl]
   gentoo: ['dev-qt/qtopengl:5']
+  nixos: [qt5.qtbase]
   openembedded: [qtbase@meta-qt5]
   opensuse: [libQt5OpenGL5]
   rhel: [qt5-qtbase]
@@ -4110,6 +4469,7 @@ libqt5-opengl-dev:
   fedora: [qt5-qtbase-devel]
   freebsd: [qt5-opengl]
   gentoo: ['dev-qt/qtopengl:5']
+  nixos: [qt5.qtbase]
   openembedded: [qtbase@meta-qt5]
   rhel: [qt5-qtbase-devel]
   slackware: [qt5]
@@ -4120,12 +4480,15 @@ libqt5-printsupport:
   fedora: [qt5-qtbase]
   freebsd: [qt5-printsupport]
   gentoo: ['dev-qt/qtprintsupport:5']
+  nixos: [qt5.qtbase]
   ubuntu: [libqt5printsupport5]
 libqt5-qml:
   debian: [libqt5qml5]
+  nixos: [qt5.qtdeclarative]
   ubuntu: [libqt5qml5]
 libqt5-quick:
   debian: [libqt5quick5]
+  nixos: [qt5.qtdeclarative]
   ubuntu: [libqt5quick5]
 libqt5-serialport:
   arch: [qt5-serialport]
@@ -4133,6 +4496,7 @@ libqt5-serialport:
   fedora: [qt5-qtserialport]
   freebsd: [qt5-serialport]
   gentoo: ['dev-qt/qtserialport:5']
+  nixos: [qt5.qtserialport]
   ubuntu: [libqt5serialport5]
 libqt5-sql:
   arch: [qt5-base]
@@ -4143,12 +4507,14 @@ libqt5-sql:
   fedora: [qt5-qtbase]
   freebsd: [qt5-sql]
   gentoo: ['dev-qt/qtsql:5']
+  nixos: [qt5.qtbase]
   ubuntu: [libqt5sql5]
 libqt5-svg-dev:
   debian: [libqt5svg5-dev]
   fedora: [qt5-qtsvg-devel]
   freebsd: [qt5-svg]
   gentoo: ['dev-qt/qtsvg:5']
+  nixos: [qt5.qtsvg]
   openembedded: [qtsvg@meta-qt5]
   ubuntu: [libqt5svg5-dev]
 libqt5-websockets-dev:
@@ -4156,6 +4522,7 @@ libqt5-websockets-dev:
   debian: [libqt5websockets5-dev]
   fedora: [qt5-qtwebsockets]
   gentoo: ['dev-qt/qtwebsockets:5']
+  nixos: [qt5.qtwebsockets]
   openembedded: [qtwebsockets@meta-qt5]
   ubuntu: [libqt5websockets5-dev]
 libqt5-widgets:
@@ -4165,6 +4532,7 @@ libqt5-widgets:
   fedora: [qt5-qtbase]
   freebsd: [qt5-widgets]
   gentoo: ['dev-qt/qtwidgets:5']
+  nixos: [qt5.qtbase]
   openembedded: [qtbase@meta-qt5]
   opensuse: [libQt5Widgets5]
   rhel: [qt5-qtbase]
@@ -4172,11 +4540,13 @@ libqt5-widgets:
   ubuntu: [libqt5widgets5]
 libqt5-xml:
   debian: [libqt5xml5]
+  nixos: [qt5.qtbase]
   ubuntu: [libqt5xml5]
 libqt5multimedia5-plugins:
   arch: [qt5-multimedia]
   debian: [libqt5multimedia5-plugins]
   fedora: [qt5-qtmultimedia]
+  nixos: [qt5.qtmultimedia]
   openembedded: [qtmultimedia@meta-qt5]
   ubuntu: [libqt5multimedia5-plugins]
 libqt5x11extras5-dev:
@@ -4185,6 +4555,7 @@ libqt5x11extras5-dev:
   fedora: [qt5-qtx11extras-devel]
   freebsd: [qt5-x11extras]
   gentoo: ['dev-qt/qtx11extras:5']
+  nixos: [qt5.qtx11extras]
   openembedded: [qtx11extras@meta-qt5]
   ubuntu: [libqt5x11extras5-dev]
 libqtgui4:
@@ -4192,6 +4563,7 @@ libqtgui4:
   debian: [libqtgui4]
   fedora: [qt-x11]
   gentoo: ['dev-qt/qtgui:4']
+  nixos: [qt4]
   rhel:
     '7': [qt-x11]
   ubuntu: [libqtgui4]
@@ -4200,12 +4572,14 @@ libqtwebkit-dev:
   debian: [libqtwebkit-dev]
   fedora: [qtwebkit-devel]
   gentoo: [dev-qt/qtwebkit]
+  nixos: [qt5.qtwebkit]
   ubuntu: [libqtwebkit-dev]
 libqwt-qt5-dev:
   arch: [qwt]
   debian: [libqwt-qt5-dev]
   fedora: [qwt-qt5-devel]
   gentoo: ['x11-libs/qwt:6']
+  nixos: [qwt6]
   openembedded: [qwt-qt5@meta-qt5]
   ubuntu:
     '*': [libqwt-qt5-dev]
@@ -4221,6 +4595,7 @@ libqwt6:
   debian: [libqwt-dev]
   fedora: [qwt-devel]
   gentoo: ['x11-libs/qwt:6']
+  nixos: [qwt6]
   ubuntu: [libqwt-dev]
 libqwtplot3d-qt4-dev:
   arch: [qwtplot3d]
@@ -4240,6 +4615,7 @@ libraw1394:
   debian: [libraw1394-11]
   fedora: [libraw1394]
   gentoo: [sys-libs/libraw1394]
+  nixos: [libraw1394]
   openembedded: [libraw1394@meta-oe]
   ubuntu: [libraw1394-11]
 libraw1394-dev:
@@ -4249,6 +4625,7 @@ libraw1394-dev:
   debian: [libraw1394-dev]
   fedora: [libraw1394-devel]
   gentoo: [sys-libs/libraw1394]
+  nixos: [libraw1394]
   openembedded: [libraw1394@meta-oe]
   rhel: [libraw1394-devel]
   ubuntu: [libraw1394-dev]
@@ -4256,6 +4633,7 @@ librdkafka-dev:
   debian: [librdkafka-dev]
   fedora: [librdkafka-devel]
   gentoo: [dev-libs/librdkafka]
+  nixos: [rdkafka]
   ubuntu: [librdkafka-dev]
 libreadline:
   arch: [readline]
@@ -4263,6 +4641,7 @@ libreadline:
   fedora: [readline]
   gentoo: [sys-libs/readline]
   macports: [readline]
+  nixos: [readline]
   openembedded: [readline@openembedded-core]
   rhel: [readline]
   ubuntu: [libreadline-dev]
@@ -4272,6 +4651,7 @@ libreadline-dev:
   fedora: [readline-devel]
   gentoo: [sys-libs/readline]
   macports: [readline]
+  nixos: [readline]
   openembedded: [readline@openembedded-core]
   ubuntu: [libreadline-dev]
 libreadline-java:
@@ -4289,6 +4669,7 @@ libsensors4-dev:
   debian: [libsensors4-dev]
   fedora: [lm_sensors-devel]
   gentoo: ['sys-apps/lm_sensors:0']
+  nixos: [lm_sensors]
   openembedded: [lmsensors@meta-oe]
   ubuntu: [libsensors4-dev]
 libserial-dev:
@@ -4303,6 +4684,7 @@ libsndfile1-dev:
   debian: [libsndfile1-dev]
   fedora: [libsndfile-devel]
   gentoo: [media-libs/libsndfile]
+  nixos: [libsndfile]
   rhel: [libsndfile-devel]
   ubuntu: [libsndfile1-dev]
 libsoqt4-dev:
@@ -4313,6 +4695,7 @@ libsoqt4-dev:
   ubuntu: [libsoqt4-dev]
 libspatialindex-dev:
   debian: [libspatialindex-dev]
+  nixos: [libspatialindex]
   ubuntu: [libspatialindex-dev]
 libspatialite:
   arch: [libspatialite]
@@ -4321,6 +4704,7 @@ libspatialite:
     jessie: [libspatialite5]
   fedora: [libspatialite]
   gentoo: ['dev-db/spatialite:0']
+  nixos: [libspatialite]
   ubuntu:
     '*': [libsqlite3-mod-spatialite]
     trusty: [libspatialite5]
@@ -4337,6 +4721,7 @@ libsqlite3-dev:
   debian: [libsqlite3-dev]
   fedora: [libsq3-devel]
   gentoo: ['dev-db/sqlite:3']
+  nixos: [sqlite]
   openembedded: [sqlite3@openembedded-core]
   rhel: [libsq3-devel]
   ubuntu: [libsqlite3-dev]
@@ -4349,18 +4734,21 @@ libssh-dev:
   debian: [libssh-dev]
   fedora: [libssh-devel]
   gentoo: [net-libs/libssh]
+  nixos: [libssh]
   ubuntu: [libssh-dev]
 libssh2:
   arch: [libssh2]
   debian: [libssh2-1]
   fedora: [libssh2]
   gentoo: [net-libs/libssh2]
+  nixos: [libssh2]
   ubuntu: [libssh2-1]
 libssh2-dev:
   arch: [libssh2]
   debian: [libssh2-1-dev]
   fedora: [libssh2-devel]
   gentoo: [net-libs/libssh2]
+  nixos: [libssh2]
   ubuntu: [libssh2-1-dev]
 libssl-dev:
   alpine: [libressl-dev]
@@ -4369,6 +4757,7 @@ libssl-dev:
   fedora: [openssl-devel]
   freebsd: [openssl]
   gentoo: [dev-libs/openssl]
+  nixos: [openssl]
   openembedded: [openssl@openembedded-core]
   rhel: [openssl-devel]
   ubuntu: [libssl-dev]
@@ -4384,16 +4773,19 @@ libstdc++6:
   arch: [gcc-libs]
   debian: [libstdc++6]
   fedora: [libstdc++6]
+  nixos: []
   ubuntu: [libstdc++6]
 libsvm-dev:
   debian: [libsvm-dev]
   fedora: [libsvm-devel]
   gentoo: [sci-libs/libsvm]
+  nixos: [libsvm]
   ubuntu: [libsvm-dev]
 libsvm3:
   debian: [libsvm3]
   fedora: [libsvm]
   gentoo: [=sci-libs/libsvm-3*]
+  nixos: [libsvm]
   ubuntu: [libsvm3]
 libsvn-dev:
   debian: [libsvn-dev]
@@ -4404,6 +4796,7 @@ libswscale-dev:
   debian: [libswscale-dev]
   fedora: [ffmpeg-devel]
   gentoo: [virtual/ffmpeg]
+  nixos: [ffmpeg]
   ubuntu: [libswscale-dev]
 libsystemd-dev:
   debian: [libsystemd-dev]
@@ -4416,11 +4809,13 @@ libtclap-dev:
   fedora: [tclap]
   gentoo: [dev-cpp/tclap]
   macports: [tclap]
+  nixos: [tclap]
   ubuntu: [libtclap-dev]
 libtesseract:
   debian: [libtesseract-dev]
   fedora: [tesseract-devel]
   gentoo: [app-text/tesseract]
+  nixos: [tesseract]
   ubuntu: [libtesseract-dev]
 libtheora:
   arch: [libtheora]
@@ -4429,6 +4824,7 @@ libtheora:
   freebsd: [libtheora]
   gentoo: [media-libs/libtheora]
   macports: [libtheora]
+  nixos: [libtheora]
   openembedded: [libtheora@openembedded-core]
   opensuse: [libtheora-devel]
   rhel: [libtheora-devel]
@@ -4447,6 +4843,7 @@ libtiff-dev:
   freebsd: [tiff]
   gentoo: [media-libs/tiff]
   macports: [tiff]
+  nixos: [libtiff]
   opensuse: [libtiff-devel]
   slackware:
     slackpkg:
@@ -4477,6 +4874,7 @@ libtiff4-dev:
   fedora: [libtiff-devel]
   gentoo: ['media-libs/tiff:0']
   macports: [tiff]
+  nixos: [libtiff]
   ubuntu: [libtiff4-dev]
 libtool:
   arch: [libtool]
@@ -4491,6 +4889,7 @@ libtool:
   freebsd: [libtool]
   gentoo: [sys-devel/libtool]
   macports: [libtool]
+  nixos: [libtool]
   openembedded: [libtool@openembedded-core]
   opensuse: [libtool, libltdl3]
   rhel: [libtool, libtool-ltdl-devel]
@@ -4525,6 +4924,7 @@ libturbojpeg:
   fedora: [turbojpeg-devel]
   freebsd: [libjpeg-turbo]
   gentoo: [media-libs/libjpeg-turbo]
+  nixos: [libjpeg_turbo]
   openembedded: [libjpeg-turbo@openembedded-core]
   rhel: [turbojpeg-devel]
   ubuntu:
@@ -4545,6 +4945,7 @@ libudev-dev:
   debian: [libudev-dev]
   fedora: [libudev-devel]
   gentoo: [virtual/libudev]
+  nixos: [libudev]
   openembedded: [udev@openembedded-core]
   rhel: [libudev-devel]
   ubuntu: [libudev-dev]
@@ -4562,6 +4963,7 @@ libunwind:
     wheezy: [libunwind7]
   fedora: [libunwind]
   gentoo: [sys-libs/libunwind]
+  nixos: [libunwind]
   ubuntu:
     '*': [libunwind8]
     precise: [libunwind7]
@@ -4573,6 +4975,7 @@ libunwind-dev:
     wheezy: [libunwind7-dev]
   fedora: [libunwind-devel]
   gentoo: [sys-libs/libunwind]
+  nixos: [libunwind]
   ubuntu:
     '*': [libunwind-dev]
     precise: [libunwind7-dev]
@@ -4586,6 +4989,7 @@ liburdfdom-dev:
   fedora: [urdfdom-devel]
   freebsd: [ros-urdfdom]
   gentoo: [dev-libs/urdfdom]
+  nixos: [urdfdom]
   openembedded: [urdfdom@meta-ros1]
   opensuse: [urdfdom-devel]
   rhel: [urdfdom-devel]
@@ -4597,6 +5001,7 @@ liburdfdom-headers-dev:
   fedora: [urdfdom-headers-devel]
   freebsd: [ros-urdfdom_headers]
   gentoo: [dev-libs/urdfdom_headers]
+  nixos: [urdfdom-headers]
   openembedded: [urdfdom-headers@meta-ros1]
   opensuse: [urdfdom-headers-devel]
   rhel: [urdfdom-headers-devel]
@@ -4608,6 +5013,7 @@ liburdfdom-tools:
   fedora: [urdfdom]
   freebsd: [ros-urdfdom]
   gentoo: [dev-libs/urdfdom]
+  nixos: [urdfdom]
   openembedded: [urdfdom@meta-ros1]
   slackware: [urdfdom]
   ubuntu: [liburdfdom-tools]
@@ -4617,12 +5023,14 @@ libusb:
   fedora: [libusb]
   gentoo: [virtual/libusb]
   macports: [libusb]
+  nixos: [libusb-compat-0_1]
   ubuntu: [libusb-0.1-4]
 libusb-1.0:
   arch: [libusbx]
   debian: [libusb-1.0-0]
   fedora: [libusbx]
   gentoo: ['virtual/libusb:1']
+  nixos: [libusb]
   openembedded: [libusb1@openembedded-core]
   opensuse: [libusb-1_0-0]
   rhel: [libusbx]
@@ -4633,6 +5041,7 @@ libusb-1.0-dev:
   fedora: [libusbx-devel]
   gentoo: ['virtual/libusb:1']
   macports: [libusb]
+  nixos: [libusb1]
   openembedded: [libusb1@openembedded-core]
   opensuse: [libusb-1_0-devel]
   rhel: [libusbx-devel]
@@ -4643,6 +5052,7 @@ libusb-dev:
   fedora: [libusb-devel]
   gentoo: [virtual/libusb]
   macports: [libusb]
+  nixos: [libusb]
   openembedded: [libusb1@openembedded-core]
   rhel: [libusb-devel]
   ubuntu: [libusb-dev]
@@ -4667,6 +5077,7 @@ libuv1-dev:
     jessie: null
   fedora: [libuv-devel]
   gentoo: [dev-libs/libuv]
+  nixos: [libuv]
   ubuntu: [libuv1-dev]
 libuvc-dev:
   debian:
@@ -4682,6 +5093,7 @@ libv4l-dev:
   fedora: [libv4l-devel]
   freebsd: [libv4l]
   gentoo: [media-libs/libv4l]
+  nixos: [libv4l]
   openembedded: [v4l-utils@meta-oe]
   opensuse: [libv4l-devel]
   rhel: [libv4l-devel]
@@ -4695,6 +5107,7 @@ libvlc:
     jessie: [libvlc5, vlc-nox]
   fedora: [vlc-core]
   gentoo: [media-video/vlc]
+  nixos: [vlc]
   openembedded: [vlc@meta-multimedia]
   ubuntu:
     '*': [libvlc5, vlc-bin]
@@ -4710,6 +5123,7 @@ libvlc-dev:
   debian: [libvlc-dev]
   fedora: [libvlc-devel]
   gentoo: [media-video/vlc]
+  nixos: [vlc]
   openembedded: [vlc@meta-multimedia]
   ubuntu: [libvlc-dev]
 libvlccore-dev:
@@ -4720,6 +5134,7 @@ libvpx-dev:
   debian: [libvpx-dev]
   fedora: [libvpx-devel]
   gentoo: [media-libs/libvpx]
+  nixos: [libvpx]
   rhel: [libvpx-devel]
   ubuntu: [libvpx-dev]
 libvtk:
@@ -4733,6 +5148,7 @@ libvtk:
   freebsd: [vtk6]
   gentoo: ['sci-libs/vtk[boost,python,qt5]']
   macports: [vtk-devel]
+  nixos: [vtk]
   opensuse: [vtk-devel]
   ubuntu:
     '*': [libvtk7-dev]
@@ -4791,6 +5207,7 @@ libvtk-qt:
   fedora: [vtk-qt]
   freebsd: [vtk6]
   gentoo: ['sci-libs/vtk[qt5,rendering]']
+  nixos: [vtkWithQt5]
   opensuse: [vtk-qt]
   slackware: [VTK]
   ubuntu:
@@ -4824,6 +5241,7 @@ libwebp-dev:
   fedora: [libwebp-devel]
   freebsd: [webp]
   gentoo: [media-libs/libwebp]
+  nixos: [libwebp]
   openembedded: [libwebp@openembedded-core]
   ubuntu: [libwebp-dev]
 libwebsocketpp-dev:
@@ -4831,6 +5249,7 @@ libwebsocketpp-dev:
   debian: [libwebsocketpp-dev]
   fedora: [websocketpp-devel]
   gentoo: [websocketpp]
+  nixos: [websocketpp]
   ubuntu: [libwebsocketpp-dev]
 libx11:
   alpine: [libx11]
@@ -4839,6 +5258,7 @@ libx11:
   fedora: [libX11]
   gentoo: [x11-libs/libX11]
   macports: [xorg-libX11]
+  nixos: [xorg.libX11]
   ubuntu: [libx11-dev]
 libx11-dev:
   alpine: [libx11-dev]
@@ -4846,6 +5266,7 @@ libx11-dev:
   debian: [libx11-dev]
   fedora: [libX11-devel]
   gentoo: [x11-libs/libX11]
+  nixos: [xorg.libX11]
   openembedded: [libx11@openembedded-core]
   rhel: [libX11-devel]
   ubuntu: [libx11-dev]
@@ -4853,6 +5274,7 @@ libx264-dev:
   debian: [libx264-dev]
   fedora: [x264-devel]
   gentoo: [media-libs/x264]
+  nixos: [x264]
   ubuntu: [libx264-dev]
 libxaw:
   alpine: [libxaw-dev]
@@ -4862,12 +5284,14 @@ libxaw:
   freebsd: [libXaw]
   gentoo: [x11-libs/libXaw]
   macports: [xorg-libXaw]
+  nixos: [xorg.libXaw]
   openembedded: [libxaw@meta-oe]
   opensuse: [xorg-x11-devel]
   rhel: [libXaw-devel]
   ubuntu: [libxaw7-dev]
 libxcursor-dev:
   debian: [libxcursor-dev]
+  nixos: [xorg.libXcursor]
   ubuntu: [libxcursor-dev]
 libxenomai-dev:
   debian:
@@ -4881,6 +5305,7 @@ libxext:
   freebsd: [libXext]
   gentoo: [x11-libs/libXext]
   macports: [xorg-libXext]
+  nixos: [xorg.libXext]
   openembedded: [libxext@openembedded-core]
   opensuse: [xorg-x11-libXext-devel]
   rhel: [libXext-devel]
@@ -4888,12 +5313,14 @@ libxext:
 libxft-dev:
   debian: [libxft-dev]
   gentoo: [x11-libs/libXft]
+  nixos: [xorg.libXft]
   ubuntu: [libxft-dev]
 libxi-dev:
   arch: [libxi]
   debian: [libxi-dev]
   fedora: [libXi-devel]
   gentoo: [x11-libs/libXi]
+  nixos: [xorg.libXi]
   openembedded: [libxi@openembedded-core]
   rhel: [libXi-devel]
   ubuntu: [libxi-dev]
@@ -4902,6 +5329,7 @@ libxinerama-dev:
   debian: [libxinerama-dev]
   fedora: [libXinerama-devel]
   gentoo: [x11-libs/libXinerama]
+  nixos: [xorg.libXinerama]
   ubuntu: [libxinerama-dev]
 libxkbcommon-dev:
   debian: [libxkbcommon-dev]
@@ -4911,6 +5339,7 @@ libxml++-2.6:
   debian: [libxml++2.6-dev]
   fedora: [libxml++, libxml++-devel]
   gentoo: ['dev-cpp/libxmlpp:2.6']
+  nixos: [libxmlxx]
   ubuntu: [libxml++2.6-dev]
 libxml2:
   arch: [libxml2]
@@ -4919,6 +5348,7 @@ libxml2:
   freebsd: [libxml2]
   gentoo: [dev-libs/libxml2]
   macports: [libxml2]
+  nixos: [libxml2]
   openembedded: [libxml2@openembedded-core]
   opensuse: [libxml2-devel]
   rhel: [libxml2-devel]
@@ -4928,6 +5358,7 @@ libxml2-utils:
   debian: [libxml2-utils]
   fedora: [libxml2]
   gentoo: [dev-libs/libxml2]
+  nixos: [libxml2]
   openembedded: [libxml2@openembedded-core]
   osx:
     homebrew:
@@ -4947,6 +5378,7 @@ libxmu-dev:
   debian: [libxmu-dev]
   fedora: [libXmu-devel]
   gentoo: [x11-libs/libXmu]
+  nixos: [xorg.libXmu]
   openembedded: [libxmu@openembedded-core]
   rhel: [libXmu-devel]
   ubuntu: [libxmu-dev]
@@ -4957,6 +5389,7 @@ libxrandr:
   fedora: [libXrandr-devel]
   gentoo: [x11-libs/libXrandr]
   macports: [xorg-libXrandr]
+  nixos: [xorg.libXrandr]
   openembedded: [libxrandr@openembedded-core]
   rhel: [libXrandr-devel]
   ubuntu: [libxrandr-dev]
@@ -4966,18 +5399,21 @@ libxslt:
   fedora: [libxslt-devel]
   gentoo: [dev-libs/libxslt]
   macports: [libxslt]
+  nixos: [libxslt]
   ubuntu: [libxslt1-dev]
 libxss1:
   arch: [libxss]
   debian: [libxss1]
   fedora: [libXScrnSaver]
   gentoo: [x11-libs/libXScrnSaver]
+  nixos: [xorg.libXScrnSaver]
   ubuntu: [libxss1]
 libxt-dev:
   arch: [libxt]
   debian: [libxt-dev]
   fedora: [libXt-devel]
   gentoo: [x11-libs/libXt]
+  nixos: [xorg.libXtst]
   ubuntu: [libxt-dev]
 libxtst-dev:
   arch: [libxtst]
@@ -5006,6 +5442,7 @@ libzmq3-dev:
   debian: [libzmq3-dev]
   fedora: [cppzmq-devel]
   gentoo: [net-libs/cppzmq]
+  nixos: [cppzmq]
   openembedded: [zeromq@meta-oe]
   rhel: [cppzmq-devel]
   ubuntu: [libzmq3-dev]
@@ -5020,6 +5457,7 @@ libzstd-dev:
   debian: [libzstd-dev]
   fedora: [libzstd-devel]
   gentoo: [app-arch/zstd]
+  nixos: [zstd]
   openembedded: [zstd@meta-oe]
   rhel: [libzstd-devel]
   ubuntu:
@@ -5032,11 +5470,13 @@ light-locker:
 lighttpd:
   debian: [lighttpd]
   fedora: [lighttpd]
+  nixos: [lighttpd]
   ubuntu: [lighttpd]
 linphone:
   debian: [linphone]
   fedora: [linphone]
   gentoo: [net-voip/linphone]
+  nixos: [linphone]
   ubuntu: [linphone]
 linux-headers-generic:
   arch: [linux-headers]
@@ -5046,6 +5486,7 @@ linux-headers-generic:
     wheezy: [linux-headers-3.2.0-4-all]
   fedora: [kernel-headers, kernel-devel]
   gentoo: [sys-kernel/linux-headers]
+  nixos: [linuxHeaders]
   openembedded: [linux-libc-headers@openembedded-core]
   rhel: [kernel-headers, kernel-devel]
   ubuntu: [linux-headers-generic]
@@ -5054,18 +5495,21 @@ linux-kernel-headers:
   debian: [linux-libc-dev]
   fedora: [kernel-headers]
   gentoo: [sys-kernel/linux-headers]
+  nixos: [linuxHeaders]
   openembedded: [linux-libc-headers@openembedded-core]
   ubuntu: [linux-libc-dev]
 llvm:
   arch: [llvm]
   debian: [llvm]
   gentoo: [sys-devel/llvm]
+  nixos: [llvm]
   openembedded: [llvm@openembedded-core]
   ubuntu: [llvm]
 llvm-7:
   debian:
     buster: [llvm-7]
     stretch: [llvm-7]
+  nixos: [llvm_7]
   openembedded: [llvm@openembedded-core]
   ubuntu:
     bionic: [llvm-7]
@@ -5074,6 +5518,7 @@ llvm-7-dev:
   debian:
     buster: [llvm-7-dev]
     stretch: [llvm-7-dev]
+  nixos: [llvm_7]
   openembedded: [llvm@openembedded-core]
   ubuntu:
     bionic: [llvm-7-dev]
@@ -5082,6 +5527,7 @@ llvm-dev:
   arch: [llvm]
   debian: [llvm-dev]
   gentoo: [sys-devel/llvm]
+  nixos: [llvm]
   openembedded: [llvm@openembedded-core]
   ubuntu: [llvm-dev]
 lm-sensors:
@@ -5089,12 +5535,14 @@ lm-sensors:
   debian: [lm-sensors]
   fedora: [lm_sensors]
   gentoo: [sys-apps/lm_sensors]
+  nixos: [lm_sensors]
   openembedded: [lmsensors@meta-oe]
   ubuntu: [lm-sensors]
 log4cplus:
   arch: [log4cplus]
   debian: [liblog4cplus-dev]
   fedora: [log4cplus-devel]
+  nixos: [log4cplus]
   openembedded: [log4cplus@openembedded-core]
   rhel: [log4cplus-devel]
   ubuntu: [liblog4cplus-dev]
@@ -5113,6 +5561,7 @@ log4cxx:
   freebsd: [log4cxx]
   gentoo: [dev-libs/log4cxx]
   macports: [ros-log4cxx]
+  nixos: [log4cxx]
   openembedded: [log4cxx@meta-ros-common]
   opensuse: [liblog4cxx-devel]
   rhel: [log4cxx-devel]
@@ -5144,6 +5593,7 @@ lttng-tools:
   debian: [lttng-tools]
   fedora: [lttng-tools]
   gentoo: [dev-util/lttng-tools]
+  nixos: [lttng-tools]
   ubuntu: [lttng-tools]
 lua-dev:
   arch: [lua]
@@ -5151,12 +5601,14 @@ lua-dev:
   fedora: [compat-lua-devel]
   gentoo: [dev-lang/lua]
   macports: [lua51]
+  nixos: [lua]
   ubuntu: [liblua5.1-0-dev]
 lua5.2-dev:
   arch: [lua52]
   debian: [liblua5.2-dev]
   fedora: [lua-devel]
   gentoo: ['dev-lang/lua:5.2']
+  nixos: [lua5]
   openembedded: [lua@meta-oe]
   rhel: [lua-devel]
   ubuntu: [liblua5.2-dev]
@@ -5167,6 +5619,7 @@ lz4:
   fedora: [lz4-devel]
   freebsd: [liblz4]
   gentoo: [app-arch/lz4]
+  nixos: [lz4]
   openembedded: [lz4@openembedded-core]
   opensuse: [lz4]
   rhel: [lz4-devel]
@@ -5177,6 +5630,7 @@ m4:
   debian: [m4]
   fedora: [m4]
   gentoo: [sys-devel/m4]
+  nixos: [m4]
   opensuse: [m4]
   ubuntu: [m4]
 mapnik-utils:
@@ -5186,6 +5640,7 @@ mapnik-utils:
 matio:
   debian: [libmatio-dev]
   fedora: [matio-devel]
+  nixos: [matio]
   ubuntu: [libmatio-dev]
 maven:
   alpine: [maven]
@@ -5193,6 +5648,7 @@ maven:
   debian: [maven]
   fedora: [maven]
   gentoo: [dev-java/maven-bin]
+  nixos: [maven]
   rhel: [maven]
   ubuntu: [maven]
 mayavi:
@@ -5204,6 +5660,7 @@ meld:
   debian: [meld]
   fedora: [meld]
   gentoo: [dev-util/meld]
+  nixos: [meld]
   ubuntu: [meld]
 mercurial:
   arch: [mercurial]
@@ -5212,6 +5669,7 @@ mercurial:
   freebsd: [mercurial]
   gentoo: [dev-vcs/mercurial]
   macports: [mercurial]
+  nixos: [mercurial]
   opensuse: [mercurial]
   ubuntu: [mercurial]
 mesa-common-dev:
@@ -5230,6 +5688,7 @@ meshlab:
   debian: [meshlab]
   fedora: [meshlab]
   gentoo: [media-gfx/meshlab]
+  nixos: [meshlab]
   ubuntu: [meshlab]
 mkdocs:
   debian:
@@ -5243,6 +5702,7 @@ mkdocs:
         packages: [mkdocs]
   fedora: [mkdocs]
   gentoo: [dev-python/mkdocs]
+  nixos: [mkdocs]
   ubuntu:
     artful: [mkdocs]
     bionic: [mkdocs]
@@ -5320,6 +5780,7 @@ mongodb:
   debian: [mongodb]
   fedora: [mongodb]
   gentoo: [dev-db/mongodb]
+  nixos: [mongodb]
   openembedded: [mongodb@meta-oe]
   ubuntu: [mongodb]
 mongodb-dev:
@@ -5328,6 +5789,7 @@ mongodb-dev:
   fedora: [libmongo-client-devel, mongodb-devel]
   gentoo: [dev-db/mongodb]
   macports: [mongodb]
+  nixos: [mongodb]
   openembedded: [mongodb@meta-oe]
   ubuntu:
     '*': [libmongo-client-dev]
@@ -5353,6 +5815,7 @@ mosquitto:
   arch: [mosquitto]
   debian: [mosquitto]
   fedora: [mosquitto]
+  nixos: [mosquitto]
   ubuntu: [mosquitto]
 mosquitto-clients:
   debian: [mosquitto-clients]
@@ -5365,18 +5828,21 @@ mosquitto-dev:
 mosquittopp-dev:
   debian: [libmosquittopp-dev]
   fedora: [mosquitto-devel]
+  nixos: [mosquitto]
   ubuntu: [libmosquittopp-dev]
 mpg123:
   arch: [mpg123]
   debian: [mpg123]
   fedora: [mpg123-devel]
   gentoo: [media-sound/mpg123]
+  nixos: [mpg123]
   ubuntu: [mpg123]
 mplayer:
   arch: [mplayer]
   debian: [mplayer]
   fedora: [mplayer]
   gentoo: [media-video/mplayer]
+  nixos: [mplayer]
   ubuntu: [mplayer]
 mrpt:
   debian: [libmrpt-dev]
@@ -5388,6 +5854,7 @@ msgpack:
   debian: [libmsgpack-dev]
   fedora: [msgpack-devel]
   gentoo: [dev-libs/msgpack]
+  nixos: [msgpack]
   openembedded: [msgpack-c@meta-oe]
   ubuntu: [libmsgpack-dev]
 multistrap:
@@ -5397,6 +5864,7 @@ muparser:
   debian: [libmuparser-dev]
   fedora: [muParser-devel]
   gentoo: [dev-cpp/muParser]
+  nixos: [muparser]
   ubuntu: [libmuparser-dev]
 nasm:
   arch: [nasm]
@@ -5405,6 +5873,7 @@ nasm:
   freebsd: [nasm]
   gentoo: [dev-lang/nasm]
   macports: [nasm]
+  nixos: [nasm]
   opensuse: [nasm]
   rhel: [nasm]
   ubuntu: [nasm]
@@ -5419,12 +5888,14 @@ net-tools:
   debian: [net-tools]
   fedora: [net-tools]
   gentoo: [sys-apps/net-tools]
+  nixos: [nettools]
   ubuntu: [net-tools]
 netcdf:
   debian: [libnetcdf-dev]
   fedora: [netcdf]
   gentoo: [sci-libs/netcdf, sci-libs/netcdf-cxx, sci-libs/netcdf-fortran]
   macports: [netcdf, netcdf-cxx]
+  nixos: [netcdf]
   ubuntu: [libnetcdf-dev]
 netpbm:
   arch: [netpbm]
@@ -5432,6 +5903,7 @@ netpbm:
   fedora: [netpbm-devel]
   gentoo: [media-libs/netpbm]
   macports: [netpbm]
+  nixos: [netpbm]
   opensuse: [netpbm]
   rhel: [netpbm-devel]
   ubuntu: [libnetpbm10-dev]
@@ -5439,12 +5911,14 @@ network-manager:
   debian: [network-manager]
   fedora: [NetworkManager]
   gentoo: [net-misc/networkmanager]
+  nixos: [networkmanager]
   ubuntu: [network-manager]
 ninja-build:
   arch: [ninja]
   debian: [ninja-build]
   fedora: [ninja-build]
   gentoo: [dev-util/ninja]
+  nixos: [ninja]
   ubuntu: [ninja-build]
 nite-dev:
   arch: [primesense-nite]
@@ -5455,6 +5929,7 @@ nkf:
   debian: [nkf]
   fedora: [nkf]
   gentoo: [app-i18n/nkf]
+  nixos: [nkf]
   rhel: [nkf]
   ubuntu: [nkf]
 nlohmann-json-dev:
@@ -5465,6 +5940,7 @@ nlohmann-json-dev:
     sid: [nlohmann-json3-dev]
     stretch: [nlohmann-json-dev]
   gentoo: [dev-cpp/nlohmann_json]
+  nixos: [nlohmann_json]
   ubuntu:
     bionic: [nlohmann-json-dev]
     focal: [nlohmann-json3-dev]
@@ -5475,33 +5951,39 @@ nmap:
   debian: [nmap]
   fedora: [nmap]
   gentoo: [net-analyzer/nmap]
+  nixos: [nmap]
   ubuntu: [nmap]
 nodejs:
   debian: [nodejs]
   fedora: [nodejs]
   gentoo: [net-libs/nodejs]
+  nixos: [nodejs]
   openembedded: [nodejs@meta-oe]
   ubuntu: [nodejs]
 nodejs-legacy:
   debian: [nodejs-legacy]
   fedora: [nodejs]
+  nixos: [nodejs]
   ubuntu: [nodejs-legacy]
 npm:
   debian: [npm]
   fedora: [npm]
   gentoo: ['net-libs/nodejs[npm]']
+  nixos: [nodePackages.npm]
   ubuntu: [npm]
 ntp:
   arch: [ntp]
   debian: [ntp]
   fedora: [ntp]
   gentoo: [net-misc/ntp]
+  nixos: [ntp]
   ubuntu: [ntp]
 ntpdate:
   arch: [ntp]
   debian: [ntpdate]
   fedora: [ntpdate]
   gentoo: [net-misc/ntp]
+  nixos: [ntp]
   ubuntu: [ntpdate]
 nvidia-cg:
   arch: [nvidia-cg-toolkit]
@@ -5532,6 +6014,7 @@ omniidl:
   arch: [omniorb]
   debian: [omniidl, omniorb-idl]
   fedora: [omniORB-devel]
+  nixos: [omniorb]
   ubuntu: [omniidl, omniorb-idl]
 omniorb:
   arch: [omniorb]
@@ -5539,11 +6022,13 @@ omniorb:
   fedora: [omniORB, omniORB-devel, omniORB-servers]
   gentoo: [net-misc/omniORB]
   macports: [omniORB]
+  nixos: [omniorb]
   ubuntu: [omniorb, omniidl, omniorb-idl, omniorb-nameserver, libomniorb4-dev]
 opencl-headers:
   arch: [opencl-headers]
   debian: [opencl-headers]
   fedora: [opencl-headers]
+  nixos: [opencl-headers]
   openembedded: [opencl-headers@meta-oe]
   rhel: [opencl-headers]
   ubuntu: [opencl-headers]
@@ -5552,6 +6037,7 @@ opende:
   debian: [libode-dev]
   fedora: [ode]
   gentoo: [dev-games/ode]
+  nixos: [ode]
   ubuntu: [libode-dev]
 opengl:
   alpine: [mesa-dev]
@@ -5561,6 +6047,7 @@ opengl:
   freebsd: [mesa-libs]
   gentoo: [virtual/opengl]
   macports: [mesa]
+  nixos: [libGL, libGLU]
   openembedded: [mesa@openembedded-core]
   opensuse: [Mesa-devel]
   rhel: [mesa-libGL-devel, mesa-libGLU-devel]
@@ -5581,6 +6068,7 @@ openmpi:
   freebsd: []
   gentoo: [sys-cluster/openmpi]
   macports: [openmpi]
+  nixos: [openmpi]
   ubuntu: []
 openni-dev:
   arch: [openni]
@@ -5592,6 +6080,7 @@ openocd:
   debian: [openocd]
   fedora: [openocd]
   gentoo: [openocd]
+  nixos: [openocd]
   ubuntu: [openocd]
 opensplice:
   gentoo: [sci-libs/opensplice]
@@ -5599,11 +6088,13 @@ openssh-client:
   debian: [openssh-client]
   fedora: [openssh-clients]
   gentoo: [net-misc/openssh]
+  nixos: [openssh]
   ubuntu: [openssh-client]
 openssh-server:
   debian: [openssh-server]
   fedora: [openssh-server]
   gentoo: [net-misc/openssh]
+  nixos: [openssh]
   ubuntu: [openssh-server]
 openssl:
   alpine: [openssl]
@@ -5611,6 +6102,7 @@ openssl:
   debian: [openssl]
   fedora: [openssl]
   gentoo: [dev-libs/openssl]
+  nixos: [openssl]
   openembedded: [openssl@openembedded-core]
   rhel: [openssl]
   ubuntu: [openssl]
@@ -5618,20 +6110,24 @@ optipng:
   debian: [optipng]
   fedora: [optipng]
   gentoo: [media-gfx/optipng]
+  nixos: [optipng]
   ubuntu: [optipng]
 osm2pgsql:
   debian: [osm2pgsql]
   fedora: [osm2pgsql]
   gentoo: [sci-geosciences/osm2pgsql]
+  nixos: [osm2pgsql]
   ubuntu: [osm2pgsql]
 osmium:
   debian: [libosmium-dev]
   fedora: [libosmium-devel]
+  nixos: [libosmium]
   ubuntu: [libosmium-dev]
 pandoc:
   debian: [pandoc]
   fedora: [pandoc]
   gentoo: [app-text/pandoc]
+  nixos: [pandoc]
   rhel: [pandoc]
   ubuntu: [pandoc]
 pcre:
@@ -5641,6 +6137,7 @@ pcre:
   fedora: [pcre-devel]
   gentoo: [dev-libs/libpcre]
   macports: [pcre]
+  nixos: [pcre]
   openembedded: [libpcre@openembedded-core]
   rhel: [pcre-devel]
   ubuntu: [libpcre3-dev]
@@ -5649,6 +6146,7 @@ pcre-dev:
   debian: [libpcre++-dev]
   fedora: [pcre-devel]
   gentoo: [dev-libs/libpcre]
+  nixos: [pcre]
   rhel: [pcre-devel]
   ubuntu: [libpcre++-dev]
 phantomjs:
@@ -5656,6 +6154,7 @@ phantomjs:
     buster: [phantomjs]
     stretch: [phantomjs]
   gentoo: [www-client/phantomjs]
+  nixos: [phantomjs]
   ubuntu: [phantomjs]
 php:
   arch: [php]
@@ -5665,6 +6164,7 @@ php:
     stretch: [php7.0]
   fedora: [php]
   gentoo: [dev-lang/php]
+  nixos: [php]
   ubuntu:
     precise: [php5]
     raring: [php5]
@@ -5690,6 +6190,7 @@ pkg-config:
   freebsd: [pkgconf]
   gentoo: [virtual/pkgconfig]
   macports: [pkgconfig]
+  nixos: [pkg-config]
   openembedded: [pkgconfig@openembedded-core]
   opensuse: [pkg-config]
   rhel: [pkgconfig]
@@ -5703,6 +6204,7 @@ pmount:
   debian: [pmount]
   fedora: [pmount]
   gentoo: [sys-apps/pmount]
+  nixos: [pmount]
   ubuntu: [pmount]
 pocketsphinx-bin:
   debian:
@@ -5711,6 +6213,7 @@ pocketsphinx-bin:
     stretch: [pocketsphinx]
   fedora: [pocketsphinx]
   gentoo: [app-accessibility/pocketsphinx]
+  nixos: [pocketsphinx]
   ubuntu:
     precise: [libsphinxbase1]
     quantal: [libsphinxbase1]
@@ -5739,15 +6242,18 @@ portaudio:
   debian: [libportaudio-dev]
   fedora: [portaudio-devel]
   gentoo: [media-libs/portaudio]
+  nixos: [portaudio]
   ubuntu: [libportaudio-dev]
 portaudio19-dev:
   debian: [portaudio19-dev]
   fedora: [libportaudio-devel]
   gentoo: [=media-libs/portaudio-19*]
+  nixos: [portaudio]
   ubuntu: [portaudio19-dev]
 postgresql:
   debian: [postgresql, postgresql-contrib]
   fedora: [postgresql-server, postgresql-contrib]
+  nixos: [postgresql]
   openembedded: [postgresql@meta-oe]
   ubuntu: [postgresql, postgresql-contrib]
 postgresql-9.x-postgis:
@@ -5794,12 +6300,14 @@ powertop:
   arch: [powertop]
   debian: [powertop]
   fedora: [powertop]
+  nixos: [powertop]
   ubuntu: [powertop]
 procps:
   arch: [procps-ng]
   debian: [procps]
   fedora: [procps-ng]
   gentoo: [sys-process/procps]
+  nixos: [procps]
   openembedded: [procps@openembedded-core]
   ubuntu: [procps]
 proj:
@@ -5808,6 +6316,7 @@ proj:
   fedora: [proj-devel]
   freebsd: [proj]
   gentoo: [sci-libs/proj]
+  nixos: [proj]
   openembedded: [proj@meta-oe]
   opensuse: [proj]
   rhel: [proj-devel]
@@ -5825,6 +6334,7 @@ protobuf:
   freebsd: [protobuf]
   gentoo: [dev-libs/protobuf]
   macports: [protobuf-cpp]
+  nixos: [protobuf]
   openembedded: [protobuf@meta-oe]
   opensuse: [libprotobuf9]
   rhel: [protobuf]
@@ -5851,6 +6361,7 @@ protobuf-dev:
   freebsd: [protobuf]
   gentoo: [dev-libs/protobuf]
   macports: [protobuf-cpp]
+  nixos: [protobuf]
   openembedded: [protobuf@meta-oe]
   opensuse: [protobuf-devel]
   rhel: [protobuf-devel, protobuf-compiler]
@@ -5865,12 +6376,14 @@ pstoedit:
   debian: [pstoedit]
   fedora: [pstoedit]
   gentoo: [media-gfx/pstoedit]
+  nixos: [pstoedit]
   rhel: [pstoedit]
   ubuntu: [pstoedit]
 psutils:
   debian: [psutils]
   fedora: [psutils]
   gentoo: [psutils]
+  nixos: [psutils]
   ubuntu: [psutils]
 pugixml-dev:
   debian: [libpugixml-dev]
@@ -5881,10 +6394,12 @@ pybind11-dev:
   arch: [pybind11]
   debian: [pybind11-dev]
   fedora: [pybind11-devel]
+  nixos: [pybind11]
   ubuntu: [pybind11-dev]
 python-dev:
   debian: [python-dev]
   fedora: [python2-devel]
+  nixos: [pythonPackages.python]
   ubuntu:
     '*': [python-dev]
     'focal': [python2-dev]
@@ -5893,6 +6408,7 @@ qhull-bin:
   debian: [qhull-bin]
   fedora: [qhull]
   gentoo: [media-libs/qhull]
+  nixos: [qhull]
   ubuntu: [qhull-bin]
 qml-module-qtgraphicaleffects:
   debian: [qml-module-qtgraphicaleffects]
@@ -5926,12 +6442,14 @@ qrencode:
   debian: [qrencode]
   fedora: [qrencode]
   gentoo: [media-gfx/qrencode]
+  nixos: [qrencode]
   ubuntu: [qrencode]
 qt4-dev-tools:
   arch: [qt4]
   debian: [qt4-dev-tools]
   fedora: [qt-devel]
   gentoo: ['dev-qt/assistant:4', 'dev-qt/linguist:4', 'dev-qt/pixeltool:4']
+  nixos: [qt4]
   opensuse: [libqt4-devel-doc]
   ubuntu: [qt4-dev-tools]
 qt4-linguist-tools:
@@ -5949,6 +6467,7 @@ qt4-qmake:
   freebsd: [qt4-qmake]
   gentoo: ['dev-qt/qtcore:4']
   macports: [qt4-mac]
+  nixos: [qt4]
   opensuse: [libqt4-devel]
   rhel:
     '7': [qt-devel]
@@ -5956,6 +6475,7 @@ qt4-qmake:
 qt5-image-formats-plugins:
   arch: [qt5-imageformats]
   debian: [qt5-image-formats-plugins]
+  nixos: [qt5.qtimageformats]
   ubuntu: [qt5-image-formats-plugins]
 qt5-qmake:
   alpine: [qt5-qtbase-dev]
@@ -5964,6 +6484,7 @@ qt5-qmake:
   fedora: [qt5-qtbase-devel]
   freebsd: [qt5-qmake]
   gentoo: ['dev-qt/qtcore:5']
+  nixos: [qt5.qtbase]
   openembedded: [qtbase@meta-qt5]
   opensuse: [libqt5-qtbase-common-devel]
   rhel: [qt5-qtbase-devel]
@@ -5976,6 +6497,7 @@ qtbase5-dev:
   fedora: [qt5-qtbase-devel]
   freebsd: [qt5-core]
   gentoo: ['dev-qt/qtcore:5', 'dev-qt/qtwidgets:5', 'dev-qt/qttest:5']
+  nixos: [qt5.qtbase]
   openembedded: [qtbase@meta-qt5]
   opensuse: [libqt5-qtbase-common-devel, libqt5-qtbase-devel]
   rhel: [qt5-qtbase-devel]
@@ -5992,6 +6514,7 @@ qtdeclarative5-dev:
   fedora: [qt5-qtdeclarative-devel]
   freebsd: [qt5-qml, qt5-quick]
   gentoo: ['dev-qt/qtdeclarative:5']
+  nixos: [qt5.qtdeclarative]
   openembedded: [qtdeclarative@meta-qt5]
   ubuntu: [qtdeclarative5-dev]
 qtmobility-dev:
@@ -6006,6 +6529,7 @@ qtmultimedia5-dev:
   fedora: [qt5-qtmultimedia-devel]
   freebsd: [qt5-multimedia]
   gentoo: ['dev-qt/qtmultimedia:5']
+  nixos: [qt5.qtmultimedia]
   openembedded: [qtmultimedia@meta-qt5]
   ubuntu: [qtmultimedia5-dev]
 qtpositioning5-dev:
@@ -6014,6 +6538,7 @@ qtpositioning5-dev:
 qttools5-dev:
   debian: [qttools5-dev]
   fedora: [qt5-qttools-devel]
+  nixos: [qt5.qttools]
   rhel: [qt5-qttools-devel]
   ubuntu: [qttools5-dev]
 qttools5-dev-tools:
@@ -6044,18 +6569,21 @@ rapidjson-dev:
   debian: [rapidjson-dev]
   fedora: [rapidjson]
   gentoo: [dev-libs/rapidjson]
+  nixos: [rapidjson]
   ubuntu: [rapidjson-dev]
 readline-dev:
   arch: [readline]
   debian: [libreadline-dev]
   fedora: [readline-devel]
   gentoo: [sys-libs/readline]
+  nixos: [readline]
   ubuntu: [libreadline-dev]
 recode:
   arch: [recode]
   debian: [recode]
   fedora: [recode-devel]
   gentoo: [app-text/recode]
+  nixos: [recode]
   ubuntu: [recode]
 recordmydesktop:
   arch: [recordmydesktop]
@@ -6068,6 +6596,7 @@ redis-server:
   debian: [redis-server]
   fedora: [redis]
   gentoo: [dev-db/redis]
+  nixos: [redis]
   ubuntu: [redis-server]
 robotino-api2:
   ubuntu: [robotino-api2]
@@ -6081,6 +6610,7 @@ rsync:
   debian: [rsync]
   fedora: [rsync]
   gentoo: [net-misc/rsync]
+  nixos: [rsync]
   openembedded: [rsync@openembedded-core]
   opensuse: [rsync]
   ubuntu: [rsync]
@@ -6089,6 +6619,7 @@ rsyslog:
   fedora: [rsyslog]
   ubuntu: [rsyslog]
 rti-connext-dds-5.3.1:
+  nixos: []
   ubuntu:
     bionic: [rti-connext-dds-5.3.1]
     focal: [rti-connext-dds-5.3.1]
@@ -6096,6 +6627,7 @@ rti-connext-dds-5.3.1:
 rtmidi:
   debian: [librtmidi-dev]
   fedora: [rtmidi-devel]
+  nixos: [rtmidi]
   ubuntu: [librtmidi-dev]
 sbcl:
   alpine: [sbcl]
@@ -6105,6 +6637,7 @@ sbcl:
   freebsd: [sbcl]
   gentoo: [dev-lisp/sbcl]
   macports: [sbcl]
+  nixos: [sbcl]
   opensuse: [sbcl]
   rhel: [sbcl]
   slackware: [sbcl]
@@ -6116,6 +6649,7 @@ scons:
   freebsd: [scons]
   gentoo: [dev-util/scons]
   macports: [scons]
+  nixos: [scons]
   opensuse: [scons]
   ubuntu: [scons]
 screen:
@@ -6123,6 +6657,7 @@ screen:
   debian: [screen]
   fedora: [screen]
   gentoo: [app-misc/screen]
+  nixos: [screen]
   openembedded: [screen@openembedded-core]
   ubuntu: [screen]
 sdformat:
@@ -6130,6 +6665,7 @@ sdformat:
   debian: [libsdformat-dev]
   fedora: [sdformat-devel]
   gentoo: [dev-libs/sdformat]
+  nixos: [sdformat]
   rhel:
     '7': [sdformat-devel]
   ubuntu:
@@ -6154,6 +6690,7 @@ sdl:
   fedora: [SDL-devel]
   gentoo: [media-libs/libsdl]
   macports: [libsdl]
+  nixos: [SDL]
   openembedded: [libsdl@openembedded-core]
   rhel: [SDL-devel]
   ubuntu: [libsdl1.2-dev]
@@ -6162,6 +6699,7 @@ sdl-gfx:
   debian: [libsdl-gfx1.2-dev]
   fedora: [SDL_gfx]
   gentoo: [media-libs/sdl-gfx]
+  nixos: [SDL_gfx]
   ubuntu: [libsdl-gfx1.2-dev]
 sdl-image:
   arch: [sdl_image]
@@ -6170,6 +6708,7 @@ sdl-image:
   freebsd: [sdl_image]
   gentoo: [media-libs/sdl-image]
   macports: [libsdl_image]
+  nixos: [SDL_image]
   openembedded: [libsdl-image@meta-oe]
   opensuse: [SDL_image]
   rhel:
@@ -6181,17 +6720,20 @@ sdl-mixer:
   fedora: [SDL_mixer-devel]
   gentoo: [media-libs/sdl-mixer]
   macports: [libsdl_mixer]
+  nixos: [SDL_mixer]
   ubuntu: [libsdl-mixer1.2-dev]
 sdl-ttf:
   arch: [sdl_ttf]
   debian: [libsdl-ttf2.0-dev]
   fedora: [SDL_ttf]
   gentoo: [media-libs/sdl-ttf]
+  nixos: [SDL_ttf]
   ubuntu: [libsdl-ttf2.0-dev]
 sdl2:
   debian: [libsdl2-dev]
   fedora: [SDL2-devel]
   gentoo: [media-libs/libsdl2]
+  nixos: [SDL2]
   openembedded: [libsdl2@openembedded-core]
   rhel: [SDL2-devel]
   ubuntu: [libsdl2-dev]
@@ -6209,17 +6751,20 @@ sdl2-ttf:
   debian: [libsdl2-ttf-dev]
   fedora: [SDL2_ttf-devel]
   gentoo: [media-libs/sdl2-ttf]
+  nixos: [SDL2_ttf]
   ubuntu: [libsdl2-ttf-dev]
 setserial:
   debian: [setserial]
   fedora: [setserial]
   gentoo: [sys-apps/setserial]
+  nixos: [setserial]
   ubuntu: [setserial]
 sfml-dev:
   arch: [sfml]
   debian: [libsfml-dev]
   fedora: [SFML-devel]
   gentoo: [media-libs/libsfml]
+  nixos: [sfml]
   ubuntu: [libsfml-dev]
 sixad:
   ubuntu: [sixad]
@@ -6233,18 +6778,21 @@ smartmontools:
   debian: [smartmontools]
   fedora: [smartmontools]
   gentoo: [sys-apps/smartmontools]
+  nixos: [smartmontools]
   ubuntu: [smartmontools]
 smbclient:
   arch: [smbclient]
   debian: [smbclient]
   fedora: [samba-client]
   gentoo: [net-fs/samba]
+  nixos: [smbclient]
   ubuntu: [smbclient]
 snappy:
   arch: [snappy]
   debian: [libsnappy-dev]
   fedora: [snappy-devel]
   gentoo: [app-arch/snappy]
+  nixos: [snappy]
   rhel: [snappy-devel]
   ubuntu: [libsnappy-dev]
 socat:
@@ -6252,6 +6800,7 @@ socat:
   debian: [socat]
   fedora: [socat]
   gentoo: [net-misc/socat]
+  nixos: [socat]
   ubuntu: [socat]
 sound-theme-freedesktop:
   debian: [sound-theme-freedesktop]
@@ -6262,18 +6811,21 @@ sox:
   debian: [sox]
   fedora: [sox]
   gentoo: [media-sound/sox]
+  nixos: [sox]
   ubuntu: [sox]
 spacenavd:
   arch: [spacenavd]
   debian: [spacenavd]
   fedora: [spacenavd]
   gentoo: [app-misc/spacenavd]
+  nixos: [spacenavd]
   rhel: [spacenavd]
   ubuntu: [spacenavd]
 sparsehash:
   debian: [libsparsehash-dev]
   fedora: [sparsehash-devel]
   gentoo: [dev-cpp/sparsehash]
+  nixos: [sparsehash]
   ubuntu:
     artful: [libsparsehash-dev]
     bionic: [libsparsehash-dev]
@@ -6291,6 +6843,7 @@ spdlog:
   debian: [libspdlog-dev]
   fedora: [spdlog-devel]
   gentoo: [dev-libs/spdlog]
+  nixos: [spdlog]
   openembedded: [spdlog@meta-oe]
   rhel: [spdlog-devel]
   ubuntu: [libspdlog-dev]
@@ -6303,6 +6856,7 @@ speex:
   debian: [speex]
   fedora: [speex, speex-tools, speexdsp]
   gentoo: [media-libs/speex]
+  nixos: [speex]
   ubuntu:
     precise: [speex]
     trusty: [speex]
@@ -6314,6 +6868,7 @@ sqlite3:
   debian: [sqlite3]
   fedora: [sqlite]
   gentoo: [=dev-db/sqlite-3*]
+  nixos: [sqlite]
   ubuntu: [sqlite3]
 ssh-askpass:
   debian: [ssh-askpass]
@@ -6329,6 +6884,7 @@ sshpass:
   debian: [sshpass]
   fedora: [sshpass]
   gentoo: [net-misc/sshpass]
+  nixos: [sshpass]
   ubuntu: [sshpass]
 stress:
   arch: [stress]
@@ -6336,6 +6892,7 @@ stress:
   fedora: [stress]
   freebsd: [stress]
   gentoo: [app-benchmarks/stress]
+  nixos: [stress]
   ubuntu: [stress]
 subversion:
   arch: [subversion]
@@ -6344,6 +6901,7 @@ subversion:
   freebsd: [subversion]
   gentoo: [dev-vcs/subversion]
   macports: [subversion]
+  nixos: [subversion]
   openembedded: [subversion@openembedded-core]
   opensuse: [subversion]
   ubuntu: [subversion]
@@ -6353,6 +6911,7 @@ suitesparse:
   fedora: [suitesparse-devel]
   gentoo: [sci-libs/suitesparse]
   macports: [SuiteSparse]
+  nixos: [suitesparse]
   openembedded: [suitesparse-cxsparse@meta-ros-common, suitesparse-cholmod@meta-ros-common]
   rhel: [suitesparse-devel]
   ubuntu: [libsuitesparse-dev]
@@ -6447,6 +7006,7 @@ swig:
   debian: [swig]
   fedora: [swig]
   gentoo: [dev-lang/swig]
+  nixos: [swig]
   openembedded: [swig@openembedded-core]
   ubuntu: [swig]
 swig-wx:
@@ -6456,6 +7016,7 @@ sysstat:
   debian: [sysstat]
   fedora: [sysstat]
   gentoo: [app-admin/sysstat]
+  nixos: [sysstat]
   openembedded: [sysstat@openembedded-core]
   ubuntu: [sysstat]
 tango-icon-theme:
@@ -6467,6 +7028,7 @@ tango-icon-theme:
   gentoo: [x11-themes/tango-icon-theme]
   macports: [tango-icon-theme]
   mandrake: [tango-icon-theme]
+  nixos: [tango-icon-theme]
   openembedded: [adwaita-icon-theme@openembedded-core]
   opensuse: [tango-icon-theme]
   rhel:
@@ -6490,6 +7052,7 @@ tar:
   freebsd: [libtar]
   gentoo: [dev-libs/libtar]
   macports: [libtar]
+  nixos: [libtar]
   opensuse: [libtar-devel]
   rhel: [libtar-devel]
   ubuntu: [libtar-dev]
@@ -6499,6 +7062,7 @@ tbb:
   fedora: [tbb-devel]
   gentoo: [dev-cpp/tbb]
   macports: [tbb]
+  nixos: [tbb]
   openembedded: [tbb@meta-oe]
   opensuse: [tbb-devel]
   rhel: [tbb-devel]
@@ -6508,11 +7072,13 @@ tcsh:
   debian: [tcsh]
   fedora: [tcsh]
   gentoo: [app-shells/tcsh]
+  nixos: [tcsh]
   ubuntu: [tcsh]
 terminator:
   debian: [terminator]
   fedora: [terminator]
   gentoo: [x11-terms/terminator]
+  nixos: [terminator]
   ubuntu: [terminator]
 tesseract-ocr:
   debian: [tesseract-ocr]
@@ -6561,12 +7127,14 @@ texmaker:
   debian: [texmaker]
   fedora: [texmaker]
   gentoo: [app-office/texmaker]
+  nixos: [texmaker]
   ubuntu: [texmaker]
 time:
   arch: [time]
   debian: [time]
   fedora: [time]
   gentoo: [sys-process/time]
+  nixos: [time]
   openembedded: [time@openembedded-core]
   ubuntu: [time]
 tinyxml:
@@ -6577,6 +7145,7 @@ tinyxml:
   freebsd: [tinyxml]
   gentoo: [dev-libs/tinyxml]
   macports: [tinyxml]
+  nixos: [tinyxml]
   openembedded: [libtinyxml@meta-oe]
   opensuse: [tinyxml-devel]
   rhel: [tinyxml-devel]
@@ -6589,6 +7158,7 @@ tinyxml2:
   fedora: [tinyxml2-devel]
   freebsd: [tinyxml2]
   gentoo: [dev-libs/tinyxml2]
+  nixos: [tinyxml-2]
   openembedded: [libtinyxml2@meta-oe]
   opensuse: [tinyxml2-devel]
   rhel: [tinyxml2-devel]
@@ -6598,14 +7168,17 @@ tix:
   debian: [tix]
   fedora: [tix]
   gentoo: [dev-tcltk/tix]
+  nixos: [tix]
   ubuntu: [tix]
 tmux:
   debian: [tmux]
   fedora: [tmux]
   gentoo: [app-misc/tmux]
+  nixos: [tmux]
   ubuntu: [tmux]
 touchegg:
   arch: [touchegg]
+  nixos: [touchegg]
   ubuntu: [touchegg]
 trang:
   debian: [trang]
@@ -6618,6 +7191,7 @@ tree:
   debian: [tree]
   fedora: [tree]
   gentoo: [app-text/tree]
+  nixos: [tree]
   ubuntu: [tree]
 ttf-kochi-gothic:
   arch: [ttf-togoshi-gothic]
@@ -6651,6 +7225,7 @@ udev:
   debian: [udev]
   fedora: [systemd-udev]
   gentoo: [sys-fs/udev]
+  nixos: [udev]
   openembedded: [udev@openembedded-core]
   rhel: [systemd]
   ubuntu: [udev]
@@ -6667,6 +7242,7 @@ uncrustify:
   debian: [uncrustify]
   fedora: [uncrustify]
   gentoo: [uncrustify]
+  nixos: [uncrustify]
   osx:
     homebrew:
       packages: [uncrustify]
@@ -6677,6 +7253,7 @@ unison:
   debian: [unison]
   fedora: [unison240]
   gentoo: [net-misc/unison]
+  nixos: [unison]
   ubuntu: [unison]
 unison-gui:
   arch: [unison]
@@ -6689,12 +7266,14 @@ unoconv:
   debian: [unoconv]
   fedora: [unoconv]
   gentoo: [app-office/unoconv]
+  nixos: [unoconv]
   ubuntu: [unoconv]
 unrar:
   arch: [unrar]
   debian: [unrar]
   fedora: [unrar]
   gentoo: [app-arch/unrar]
+  nixos: [unrar]
   ubuntu: [unrar]
 unzip:
   arch: [unzip]
@@ -6703,6 +7282,7 @@ unzip:
   freebsd: [unzip]
   gentoo: [app-arch/unzip]
   macports: [unzip]
+  nixos: [unzip]
   openembedded: [unzip@openembedded-core]
   opensuse: [unzip]
   rhel: [unzip]
@@ -6715,6 +7295,7 @@ usbutils:
   fedora: [usbutils]
   gentoo: [sys-apps/usbutils]
   macports: [usbutils]
+  nixos: [usbutils]
   openembedded: [usbutils@openembedded-core]
   osx:
     homebrew:
@@ -6726,6 +7307,7 @@ util-linux:
   fedora: [util-linux]
   gentoo: [util-linux]
   macports: [util-linux]
+  nixos: [util-linux]
   ubuntu: [util-linux]
 uuid:
   arch: [util-linux]
@@ -6734,6 +7316,7 @@ uuid:
   freebsd: [e2fsprogs-libuuid]
   gentoo: [dev-libs/ossp-uuid]
   macports: [ossp-uuid]
+  nixos: [utillinux]
   openembedded: [util-linux@openembedded-core]
   opensuse: [libuuid-devel]
   rhel: [libuuid-devel]
@@ -6744,29 +7327,34 @@ uuid:
 uvcdynctrl:
   debian: [uvcdynctrl]
   fedora: [uvcdynctrl]
+  nixos: [uvcdynctrl]
   ubuntu: [uvcdynctrl]
 v4l-utils:
   arch: [v4l-utils]
   debian: [v4l-utils]
   fedora: [v4l-utils]
   gentoo: [media-tv/v4l-utils]
+  nixos: [v4l_utils]
   openembedded: [v4l-utils@meta-oe]
   ubuntu: [v4l-utils]
 valgrind:
   debian: [valgrind]
   fedora: [valgrind]
   gentoo: [dev-util/valgrind]
+  nixos: [valgrind]
   ubuntu: [valgrind]
 vim:
   debian: [vim]
   fedora: [vim-enhanced]
   gentoo: [app-editors/vim]
+  nixos: [vim]
   ubuntu: [vim]
 vlc:
   arch: [vlc]
   debian: [vlc]
   fedora: [vlc]
   gentoo: [media-video/vlc]
+  nixos: [vlc]
   openembedded: [vlc@meta-multimedia]
   ubuntu: [vlc]
 vorbis-tools:
@@ -6774,6 +7362,7 @@ vorbis-tools:
   debian: [vorbis-tools]
   fedora: [vorbis-tools]
   gentoo: [media-sound/vorbis-tools]
+  nixos: [vorbis-tools]
   ubuntu: [vorbis-tools]
 vrep:
   ubuntu:
@@ -6787,6 +7376,7 @@ wget:
   freebsd: [wget]
   gentoo: [net-misc/wget]
   macports: [wget]
+  nixos: [wget]
   openembedded: [wget@openembedded-core]
   opensuse: [wget]
   ubuntu: [wget]
@@ -6794,15 +7384,18 @@ wireless-tools:
   debian: [wireless-tools]
   fedora: [wireless-tools]
   gentoo: [net-wireless/wireless-tools]
+  nixos: [wirelesstools]
   ubuntu: [wireless-tools]
 wireshark:
   debian: [wireshark]
   fedora: [wireshark]
   gentoo: [net-analyzer/wireshark]
+  nixos: [wireshark]
   ubuntu: [wireshark]
 wireshark-common:
   debian: [wireshark-common]
   fedora: [wireshark-cli]
+  nixos: [wireshark-cli]
   ubuntu: [wireshark-common]
 wkhtmltopdf:
   arch: [wkhtmltopdf]
@@ -6828,6 +7421,7 @@ wx-common:
   debian: [wx-common]
   fedora: [wxGTK3-devel]
   gentoo: [x11-libs/wxGTK]
+  nixos: [wxGTK]
   openembedded: [wxwidgets@meta-ros-common]
   rhel:
     '*': [wxGTK3-devel]
@@ -6844,6 +7438,7 @@ wxwidgets:
   freebsd: [wxgtk2]
   gentoo: [x11-libs/wxGTK]
   macports: [wxWidgets-python]
+  nixos: [wxGTK]
   openembedded: [wxwidgets@meta-ros-common]
   opensuse: [wxGTK-devel]
   rhel: [wxGTK-devel]
@@ -6886,6 +7481,7 @@ xclip:
   debian: [xclip]
   fedora: [xclip]
   gentoo: [x11-misc/xclip]
+  nixos: [xclip]
   osx:
     homebrew:
       packages: [xclip]
@@ -6895,6 +7491,7 @@ xdotool:
   debian: [xdotool]
   fedora: [xdotool]
   gentoo: [x11-misc/xdotool]
+  nixos: [xdotool]
   ubuntu: [xdotool]
 xerces:
   arch: [xerces-c]
@@ -6915,12 +7512,14 @@ xfonts-100dpi:
   fedora: [xorg-x11-fonts-100dpi]
   gentoo: [media-fonts/font-adobe-100dpi, media-fonts/font-bh-100dpi, media-fonts/font-bh-lucidatypewriter-100dpi, media-fonts/font-bitstream-100dpi]
   macports:
+  nixos: [xorg.fontadobe100dpi, xorg.fontbh100dpi, xorg.fontbhlucidatypewriter100dpi, xorg.fontbitstream100dpi]
   ubuntu: [xfonts-100dpi]
 xfonts-75dpi:
   debian: [xfonts-75dpi]
   fedora: [xorg-x11-fonts-100dpi]
   gentoo: [media-fonts/font-adobe-75dpi, media-fonts/font-bh-75dpi, media-fonts/font-bh-lucidatypewriter-75dpi, media-fonts/font-bitstream-75dpi]
   macports:
+  nixos: [xorg.fontadobe75dpi, xorg.fontbh75dpi, xorg.fontbhlucidatypewriter75dpi, xorg.fontbitstream75dpi]
   ubuntu: [xfonts-75dpi]
 xpath-perl:
   arch: [perl-xml-xpath]
@@ -6934,12 +7533,14 @@ xsltproc:
   debian: [xsltproc]
   fedora: [libxslt]
   gentoo: [dev-libs/libxslt]
+  nixos: [libxslt]
   ubuntu: [xsltproc]
 xterm:
   arch: [xterm]
   debian: [xterm]
   fedora: [xterm]
   gentoo: [x11-terms/xterm]
+  nixos: [xterm]
   openembedded: [xterm@meta-oe]
   ubuntu: [xterm]
 xulrunner-1.9.2:
@@ -6965,6 +7566,7 @@ xvfb:
   debian: [xvfb]
   fedora: [xorg-x11-server-Xvfb]
   gentoo: [x11-misc/xvfb-run]
+  nixos: [xorg.xorgserver]
   ubuntu: [xvfb]
 xz-utils:
   arch: [xz]
@@ -6979,6 +7581,7 @@ yaml:
   fedora: [libyaml]
   gentoo: [dev-libs/libyaml]
   macports: [libyaml]
+  nixos: [libyaml]
   openembedded: [libyaml@openembedded-core]
   rhel: [libyaml-devel]
   ubuntu: [libyaml-dev]
@@ -6998,6 +7601,7 @@ yaml-cpp:
   freebsd: [yaml-cpp]
   gentoo: [dev-cpp/yaml-cpp]
   macports: [yaml-cpp]
+  nixos: [libyamlcpp]
   openembedded: [yaml-cpp@meta-ros-common]
   opensuse: [yaml-cpp-devel]
   rhel: [yaml-cpp-devel]
@@ -7038,12 +7642,14 @@ yasm:
   debian: [yasm]
   fedora: [yasm]
   gentoo: [dev-lang/yasm]
+  nixos: [yasm]
   ubuntu: [yasm]
 zbar:
   arch: [zbar]
   debian: [libzbar-dev]
   fedora: [zbar-devel]
   gentoo: [media-gfx/zbar]
+  nixos: [zbar]
   openembedded: [zbar@meta-oe]
   ubuntu: [libzbar-dev]
 zenity:
@@ -7051,17 +7657,20 @@ zenity:
   debian: [zenity]
   fedora: [zenity]
   gentoo: [gnome-extra/zenity]
+  nixos: [gnome3.zenity]
   ubuntu: [zenity]
 zeromq3:
   arch: [zeromq]
   debian: [libzmq5]
   fedora: [zeromq]
   gentoo: [zeromq]
+  nixos: [zeromq]
   ubuntu: [libzmq5]
 zip:
   debian: [zip]
   fedora: [zip]
   gentoo: [app-arch/zip]
+  nixos: [zip]
   ubuntu: [zip]
 zlib:
   alpine: [zlib-dev]
@@ -7072,6 +7681,7 @@ zlib:
   freebsd: [builtin]
   gentoo: [sys-libs/zlib]
   macports: [zlib]
+  nixos: [zlib]
   openembedded: [zlib@openembedded-core]
   opensuse: [zlib-devel]
   rhel: [zlib-devel]
@@ -7086,6 +7696,7 @@ zziplib:
   freebsd: [zziplib]
   gentoo: [dev-libs/zziplib]
   macports: [libzzip]
+  nixos: [zziplib]
   opensuse: [zziplib-devel]
   rhel: [zziplib-devel]
   ubuntu: [libzzip-0-13, libzzip-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -119,12 +119,14 @@ cython:
   debian: [cython]
   fedora: [Cython]
   gentoo: [dev-python/cython]
+  nixos: [pythonPackages.cython]
   ubuntu: [cython]
 cython3:
   arch: [cython]
   debian: [cython3]
   fedora: [python3-Cython]
   gentoo: [dev-python/cython]
+  nixos: [python3Packages.cython]
   ubuntu: [cython3]
 dpath-pip:
   ubuntu:
@@ -201,10 +203,12 @@ ipython:
   fedora: [python-ipython]
   gentoo: [dev-python/ipython]
   macports: [py27-ipython]
+  nixos: [pythonPackages.ipython]
   ubuntu: [ipython]
 ipython3:
   debian: [ipython3]
   fedora: [ipython3]
+  nixos: [python3Packages.ipython]
   openembedded: [python3-ipython@meta-python]
   ubuntu: [ipython3]
 jupyter-nbconvert:
@@ -212,6 +216,7 @@ jupyter-nbconvert:
   debian: [jupyter-nbconvert]
   fedora: [python3-nbconvert]
   gentoo: [dev-python/nbconvert]
+  nixos: [python3Packages.nbconvert]
   ubuntu:
     '*': [jupyter-nbconvert]
     xenial: null
@@ -246,6 +251,7 @@ paramiko:
   freebsd: [py27-paramiko]
   gentoo: [dev-python/paramiko]
   macports: [py27-paramiko]
+  nixos: [pythonPackages.paramiko]
   openembedded: ['${PYTHON_PN}-paramiko@meta-ros-common']
   opensuse: [python-paramiko]
   osx:
@@ -277,6 +283,7 @@ pydocstyle:
     stretch: [pydocstyle]
   fedora: [python3-pydocstyle]
   gentoo: [dev-python/pydocstyle]
+  nixos: [python3Packages.pydocstyle]
   openembedded: ['${PYTHON_PN}-pydocstyle@meta-ros-common']
   osx:
     pip:
@@ -300,6 +307,7 @@ pyflakes3:
   debian: [pyflakes3]
   fedora: [python3-pyflakes]
   gentoo: [dev-python/pyflakes]
+  nixos: [python3Packages.pyflakes]
   openembedded: ['${PYTHON_PN}-pyflakes@meta-ros-common']
   osx:
     pip:
@@ -395,6 +403,7 @@ python:
   freebsd: [python2]
   gentoo: [dev-lang/python]
   macports: [python26, python_select]
+  nixos: [python]
   openembedded: [python@meta-python2]
   opensuse: [python-devel]
   rhel: [python2-devel]
@@ -486,6 +495,7 @@ python-apparmor:
 python-argcomplete:
   fedora: [python-argcomplete]
   gentoo: [dev-python/argcomplete]
+  nixos: [pythonPackages.argcomplete]
   openembedded: [python3-argcomplete@meta-python]
   ubuntu: [python-argcomplete]
 python-argh:
@@ -506,6 +516,7 @@ python-argparse:
   freebsd: [py27-argparse]
   gentoo: [dev-lang/python]
   macports: [py27-argparse]
+  nixos: [python]
   openembedded: []
   opensuse: [python-argparse]
   osx:
@@ -538,6 +549,7 @@ python-attrs:
   debian: [python-attr]
   fedora: [python2-attrs]
   gentoo: [dev-python/attrs]
+  nixos: [pythonPackages.attrs]
   ubuntu:
     '*':
       packages: [python-attr]
@@ -560,6 +572,7 @@ python-autobahn:
     pip:
       packages: [autobahn]
   gentoo: [dev-python/autobahn]
+  nixos: [pythonPackages.autobahn]
   openembedded: ['${PYTHON_PN}-autobahn@meta-python']
   osx:
     pip:
@@ -595,6 +608,7 @@ python-avahi:
   debian: [python-avahi]
   fedora: [avahi-ui-tools]
   gentoo: ['net-dns/avahi[python]']
+  nixos: [pythonPackages.avahi]
   ubuntu: [python-avahi]
 python-babel:
   debian: [python-babel]
@@ -624,6 +638,7 @@ python-backports.ssl-match-hostname:
   debian: [python-backports.ssl-match-hostname]
   fedora: [python-backports.ssl-match-hostname]
   gentoo: [dev-python/backports-ssl-match-hostname]
+  nixos: [pythonPackages.backports_ssl_match_hostname]
   openembedded: ['${PYTHON_PN}-backports-ssl@meta-python']
   ubuntu:
     artful: [python-backports.ssl-match-hostname]
@@ -643,6 +658,7 @@ python-bcrypt:
   debian: [python-bcrypt]
   fedora: [python-bcrypt]
   gentoo: [dev-python/bcrypt]
+  nixos: [pythonPackages.bcrypt]
   ubuntu: [python-bcrypt]
 python-beautifulsoup:
   arch: [python2-beautifulsoup3]
@@ -660,6 +676,7 @@ python-bitstring:
     buster: [python-bitstring]
     stretch: [python-bitstring]
   gentoo: [dev-python/bitstring]
+  nixos: [pythonPackages.bitstring]
   ubuntu:
     artful: [python-bitstring]
     bionic: [python-bitstring]
@@ -696,6 +713,7 @@ python-bluez:
   debian: [python-bluez]
   fedora: [pybluez]
   gentoo: [dev-python/pybluez]
+  nixos: [pythonPackages.pybluez]
   openembedded: ['${PYTHON_PN}-pybluez@meta-python']
   ubuntu: [python-bluez]
 python-bokeh-pip:
@@ -742,6 +760,7 @@ python-boto3:
   debian: [python-boto3]
   fedora: [python2-boto3]
   gentoo: [dev-python/boto3]
+  nixos: [pythonPackages.boto3]
   openembedded: ['${PYTHON_PN}-boto3@meta-ros-common']
   opensuse: [python-boto3]
   ubuntu:
@@ -764,11 +783,13 @@ python-bs4:
   debian: [python-bs4]
   fedora: [python-beautifulsoup4]
   gentoo: [=dev-python/beautifulsoup-4*]
+  nixos: [pythonPackages.beautifulsoup4]
   ubuntu: [python-bs4]
 python-bson:
   debian: [python-bson]
   fedora: [python-bson]
   gentoo: [dev-python/pymongo]
+  nixos: [pythonPackages.bson]
   openembedded: ['${PYTHON_PN}-pymongo@meta-python']
   osx:
     pip:
@@ -780,6 +801,7 @@ python-cairo:
   fedora: [pycairo]
   freebsd: [py27-cairo]
   gentoo: [dev-python/pycairo]
+  nixos: [pythonPackages.pycairo]
   opensuse: [python-cairo]
   rhel:
     '*': [python2-cairo]
@@ -793,6 +815,7 @@ python-cairosvg:
   debian: [python-cairosvg]
   fedora: [python-cairosvg]
   gentoo: [media-gfx/cairosvg]
+  nixos: [pythonPackages.cairosvg]
   ubuntu: [python-cairosvg]
 python-can:
   alpine:
@@ -885,6 +908,7 @@ python-catkin-pkg:
       packages: [catkin-pkg]
   gentoo: [dev-python/catkin_pkg]
   macports: [python-catkin-pkg]
+  nixos: [pythonPackages.catkin-pkg]
   openembedded: ['${PYTHON_PN}-catkin-pkg@meta-ros-common']
   opensuse: [python-catkin_pkg]
   osx:
@@ -928,6 +952,7 @@ python-catkin-pkg-modules:
       packages: [catkin-pkg]
   gentoo: [dev-python/catkin_pkg]
   macports: [python-catkin-pkg]
+  nixos: [pythonPackages.catkin-pkg]
   openembedded: ['${PYTHON_PN}-catkin-pkg@meta-ros-common']
   opensuse: [python-catkin_pkg]
   osx:
@@ -997,6 +1022,7 @@ python-chainer-pip:
   fedora:
     pip:
       packages: [chainer]
+  nixos: [pythonPackages.chainer]
   osx:
     pip:
       packages: [chainer]
@@ -1024,12 +1050,14 @@ python-cheetah:
   debian: [python-cheetah]
   fedora: [python-cheetah]
   gentoo: [dev-python/cheetah]
+  nixos: [pythonPackages.cheetah]
   openembedded: ['${PYTHON_PN}-cheetah@meta-python']
   ubuntu: [python-cheetah]
 python-cherrypy:
   debian: [python-cherrypy3]
   fedora: [python-cherrypy]
   gentoo: [dev-python/cherrypy]
+  nixos: [pythonPackages.cherrypy]
   ubuntu: [python-cherrypy3]
 python-clearsilver:
   debian: [python-clearsilver]
@@ -1048,6 +1076,7 @@ python-click:
         packages: [python-click]
   fedora: [python-click]
   gentoo: [dev-python/click]
+  nixos: [pythonPackages.click]
   openembedded: ['${PYTHON_PN}-click@meta-python']
   osx:
     pip:
@@ -1087,6 +1116,7 @@ python-colorama:
   debian: [python-colorama]
   fedora: [python-colorama]
   gentoo: [dev-python/colorama]
+  nixos: [pythonPackages.colorama]
   osx:
     pip:
       packages: [colorama]
@@ -1143,6 +1173,7 @@ python-cookiecutter-pip:
   fedora:
     pip:
       packages: [cookiecutter]
+  nixos: [pythonPackages.cookiecutter]
   osx:
     pip:
       packages: [cookiecutter]
@@ -1161,6 +1192,7 @@ python-coverage:
   fedora: [python-coverage]
   freebsd: [py27-coverage]
   gentoo: [dev-python/coverage]
+  nixos: [pythonPackages.coverage]
   opensuse: [python-coverage]
   osx:
     pip:
@@ -1219,6 +1251,7 @@ python-crcmod:
   fedora:
     pip:
       packages: [crcmod]
+  nixos: [pythonPackages.crcmod]
   osx:
     pip:
       packages: [crcmod]
@@ -1232,6 +1265,7 @@ python-crypto:
   fedora: [python-crypto]
   freebsd: [py27-pycrypto]
   gentoo: [dev-python/pycrypto]
+  nixos: [pythonPackages.pycrypto]
   openembedded: ['${PYTHON_PN}-pycrypto@meta-python']
   osx:
     pip:
@@ -1273,6 +1307,7 @@ python-cvxopt:
   debian: [python-cvxopt]
   fedora: [python-cvxopt]
   macports: [py27-cvxopt]
+  nixos: [pythonPackages.cvxopt]
   ubuntu: [python-cvxopt]
 python-cwiid:
   arch: [cwiid]
@@ -1304,6 +1339,7 @@ python-dateutil:
   debian: [python-dateutil]
   fedora: [python-dateutil]
   gentoo: [dev-python/python-dateutil]
+  nixos: [pythonPackages.dateutil]
   osx:
     pip:
       packages: [python-dateutil]
@@ -1339,6 +1375,7 @@ python-debian:
 python-decorator:
   debian: [python-decorator]
   gentoo: [dev-python/decorator]
+  nixos: [pythonPackages.decorator]
   osx:
     pip: [decorator]
   ubuntu: [python-decorator]
@@ -1360,6 +1397,7 @@ python-defusedxml:
   fedora: [python-defusedxml]
   freebsd: [py27-defusedxml]
   gentoo: [dev-python/defusedxml]
+  nixos: [pythonPackages.defusedxml]
   openembedded: ['${PYTHON_PN}-defusedxml@meta-ros-common']
   opensuse: [python-defusedxml]
   osx:
@@ -1407,23 +1445,27 @@ python-dlib:
     pip: [dlib]
   fedora:
     pip: [dlib]
+  nixos: [pythonPackages.dlib]
   ubuntu:
     pip: [dlib]
 python-docker:
   arch: [python-docker]
   debian: [python-docker]
   fedora: [python-docker]
+  nixos: [pythonPackages.docker]
   ubuntu: [python-docker]
 python-docopt:
   debian: [python-docopt]
   fedora: [python-docopt]
   gentoo: [dev-python/docopt]
+  nixos: [pythonPackages.docopt]
   ubuntu: [python-docopt]
 python-docutils:
   arch: [python2-docutils]
   debian: [python-docutils]
   fedora: [python-docutils]
   gentoo: [dev-python/docutils]
+  nixos: [pythonPackages.docutils]
   ubuntu:
     artful: [python-docutils]
     bionic: [python-docutils]
@@ -1461,6 +1503,7 @@ python-empy:
   freebsd: [py27-empy]
   gentoo: [dev-python/empy]
   macports: [py27-empy]
+  nixos: [pythonPackages.empy]
   openembedded: ['${PYTHON_PN}-empy@meta-ros-common']
   opensuse: [python-empy]
   osx:
@@ -1485,6 +1528,7 @@ python-enum34:
     stretch: [python-enum34]
   fedora: [python-enum34]
   gentoo: [virtual/python-enum34]
+  nixos: [pythonPackages.enum34]
   openembedded: ['${PYTHON_PN}-enum34@meta-python']
   ubuntu: [python-enum34]
 python-enum34-pip:
@@ -1608,6 +1652,7 @@ python-flake8:
   debian: [python-flake8]
   fedora: [python-flake8]
   gentoo: [dev-python/flake8]
+  nixos: [python3Packages.flake8]
   openembedded: ['${PYTHON_PN}-flake8@meta-ros-common']
   ubuntu:
     '*': [python-flake8]
@@ -1617,6 +1662,7 @@ python-flask:
   debian: [python-flask]
   fedora: [python-flask]
   gentoo: [dev-python/flask]
+  nixos: [pythonPackages.flask]
   ubuntu:
     '*': [python-flask]
     trusty_python3: [python3-flask]
@@ -1644,6 +1690,7 @@ python-flask-restful:
   debian: [python-flask-restful]
   fedora: [python-flask-restful]
   gentoo: [dev-python/flask-restful]
+  nixos: [pythonPackages.flask-restful]
   ubuntu:
     saucy:
       pip:
@@ -1670,6 +1717,7 @@ python-freezegun-pip:
   fedora:
     pip:
       packages: [freezegun]
+  nixos: [pythonPackages.freezegun]
   osx:
     pip:
       packages: [freezegun]
@@ -1694,6 +1742,7 @@ python-future:
   debian: [python-future]
   fedora: [python-future]
   gentoo: [dev-python/future]
+  nixos: [pythonPackages.future]
   openembedded: ['${PYTHON_PN}-future@meta-python']
   osx:
     pip:
@@ -1785,6 +1834,7 @@ python-geocoder-pip:
 python-geographiclib:
   debian: [python-geographiclib]
   fedora: [python-GeographicLib]
+  nixos: [pythonPackages.geographiclib]
   ubuntu: [python-geographiclib]
 python-geopy:
   debian: [python-geopy]
@@ -1800,11 +1850,13 @@ python-gi:
   debian: [python-gi]
   fedora: [pygobject3]
   gentoo: [dev-python/pygobject]
+  nixos: [pythonPackages.pygobject3]
   ubuntu: [python-gi]
 python-gi-cairo:
   debian: [python-gi-cairo]
   fedora: [pygobject3]
   gentoo: [dev-python/pygobject]
+  nixos: [pythonPackages.pygobject3]
   ubuntu: [python-gi-cairo]
 python-git:
   arch: [python2-gitpython]
@@ -1852,6 +1904,7 @@ python-gnupg:
   fedora: [python-gnupg]
   freebsd: [py27-python-gnupg]
   gentoo: [dev-python/python-gnupg]
+  nixos: [pythonPackages.python-gnupg]
   openembedded: ['${PYTHON_PN}-gnupg@meta-ros-common']
   rhel:
     '7': [python2-gnupg]
@@ -2019,6 +2072,7 @@ python-grpc-tools:
       pip: [grpcio-tools]
     stretch:
       pip: [grpcio-tools]
+  nixos: [pythonPackages.grpcio-tools]
   ubuntu:
     '*': [python-grpc-tools]
     bionic:
@@ -2093,6 +2147,7 @@ python-gtk2:
   freebsd: [py-gtk2]
   gentoo: [=dev-python/pygtk-2*]
   macports: [py27-gtk]
+  nixos: [pythonPackages.pygtk]
   opensuse: [python-gtk]
   osx:
     pip:
@@ -2103,6 +2158,7 @@ python-h5py:
   debian: [python-h5py]
   fedora: [h5py]
   gentoo: [dev-python/h5py]
+  nixos: [pythonPackages.h5py]
   ubuntu:
     '*': [python-h5py]
     trusty_python3: [python3-h5py]
@@ -2138,6 +2194,7 @@ python-imageio:
     pip:
       packages: [imageio]
   gentoo: [dev-python/imageio]
+  nixos: [pythonPackages.imageio]
   ubuntu:
     '*': [python-imageio]
     trusty:
@@ -2157,6 +2214,7 @@ python-imaging:
   freebsd: [py27-pillow]
   gentoo: [dev-python/pillow]
   macports: [py27-pil]
+  nixos: [pythonPackages.pillow]
   openembedded: ['${PYTHON_PN}-pillow@meta-python']
   opensuse: [python-imaging]
   osx:
@@ -2196,11 +2254,13 @@ python-imaging-imagetk:
 python-impacket:
   debian: [python-impacket]
   fedora: [python-impacket]
+  nixos: [pythonPackages.impacket]
   ubuntu: [python-impacket]
 python-influxdb:
   debian:
     buster: [python-influxdb]
     jessie: [python-influxdb]
+  nixos: [pythonPackages.influxdb]
   ubuntu:
     bionic: [python-influxdb]
     disco: [python-influxdb]
@@ -2259,6 +2319,7 @@ python-jinja2:
   debian: [python-jinja2]
   fedora: [python-jinja2]
   gentoo: [=dev-python/jinja-2*]
+  nixos: [pythonPackages.jinja2]
   ubuntu: [python-jinja2]
 python-jira-pip:
   ubuntu:
@@ -2276,6 +2337,7 @@ python-joblib:
   debian: [python-joblib]
   fedora: [python-joblib]
   gentoo: [dev-python/joblib]
+  nixos: [pythonPackages.joblib]
   ubuntu: [python-joblib]
 python-jsonpickle:
   arch: [python-jsonpickle]
@@ -2348,6 +2410,7 @@ python-kitchen:
   debian: [python-kitchen]
   fedora: [python-kitchen]
   gentoo: [dev-python/kitchen]
+  nixos: [pythonPackages.kitchen]
   osx:
     pip:
       packages: [kitchen]
@@ -2441,6 +2504,7 @@ python-lxml:
   fedora: [python-lxml]
   freebsd: [py27-lxml]
   gentoo: [dev-python/lxml]
+  nixos: [pythonPackages.lxml]
   openembedded: ['${PYTHON_PN}-lxml@meta-python']
   osx:
     pip:
@@ -2490,6 +2554,7 @@ python-matplotlib:
   freebsd: [py27-matplotlib]
   gentoo: [dev-python/matplotlib]
   macports: [py27-matplotlib]
+  nixos: [pythonPackages.matplotlib]
   openembedded: ['${PYTHON_PN}-matplotlib@meta-python']
   opensuse: [python-matplotlib]
   osx:
@@ -2529,6 +2594,7 @@ python-mechanize:
   debian: [python-mechanize]
   fedora: [python-mechanize]
   gentoo: [dev-python/mechanize]
+  nixos: [pythonPackages.mechanize]
   ubuntu: [python-mechanize]
 python-mock:
   alpine: [py-mock]
@@ -2537,6 +2603,7 @@ python-mock:
   fedora: [python-mock]
   freebsd: [py27-mock]
   gentoo: [dev-python/mock]
+  nixos: [pythonPackages.mock]
   openembedded: ['${PYTHON_PN}-mock@meta-python']
   opensuse: [python-mock]
   osx:
@@ -2600,6 +2667,7 @@ python-msgpack:
   debian: [python-msgpack]
   fedora: [python-msgpack]
   gentoo: [dev-python/msgpack]
+  nixos: [pythonPackages.msgpack]
   openembedded: ['${PYTHON_PN}-msgpack@meta-python2']
   ubuntu: [python-msgpack]
 python-multicast:
@@ -2697,6 +2765,7 @@ python-netcdf4:
   freebsd: [py27-netCDF4]
   gentoo: [dev-python/netcdf4-python]
   macports: [py27-netcdf4]
+  nixos: [pythonPackages.netcdf4]
   ubuntu: [python-netcdf4]
 python-netifaces:
   alpine: [py-netifaces]
@@ -2706,6 +2775,7 @@ python-netifaces:
   freebsd: [py27-netifaces]
   gentoo: [dev-python/netifaces]
   macports: [p27-netifaces]
+  nixos: [pythonPackages.netifaces]
   openembedded: ['${PYTHON_PN}-netifaces@meta-ros-common']
   opensuse: [python-netifaces]
   osx:
@@ -2763,6 +2833,7 @@ python-nose:
   freebsd: [py27-nose]
   gentoo: [dev-python/nose]
   macports: [py27-nose]
+  nixos: [pythonPackages.nose]
   openembedded: ['${PYTHON_PN}-nose@openembedded-core']
   opensuse: [python-nose]
   osx:
@@ -2788,6 +2859,7 @@ python-numpy:
   freebsd: [py27-numpy]
   gentoo: [dev-python/numpy]
   macports: [py27-numpy]
+  nixos: [pythonPackages.numpy]
   openembedded: ['${PYTHON_PN}-numpy@openembedded-core']
   opensuse: [python-numpy]
   osx:
@@ -2887,6 +2959,7 @@ python-opencv:
   debian: [python-opencv]
   freebsd: [py27-opencv]
   gentoo: ['media-libs/opencv[python]']
+  nixos: [pythonPackages.opencv3]
   openembedded: [opencv@meta-oe]
   opensuse: [python-opencv]
   rhel:
@@ -2900,6 +2973,7 @@ python-opengl:
   freebsd: [py27-PyOpenGL]
   gentoo: [dev-python/pyopengl]
   macports: [py27-opengl]
+  nixos: [pythonPackages.pyopengl]
   opensuse: [python-opengl]
   osx:
     pip:
@@ -2940,6 +3014,7 @@ python-oyaml-pip:
 python-packaging:
   debian: [python-packaging]
   fedora: [python-packaging]
+  nixos: [pythonPackages.packaging]
   ubuntu: [python-packaging]
 python-paho-mqtt:
   debian:
@@ -2962,6 +3037,7 @@ python-pandas:
   debian: [python-pandas]
   fedora: [python-pandas]
   gentoo: [dev-python/pandas]
+  nixos: [pythonPackages.pandas]
   ubuntu: [python-pandas]
 python-parameterized:
   debian:
@@ -3007,6 +3083,7 @@ python-paramiko:
   freebsd: [py27-paramiko]
   gentoo: [dev-python/paramiko]
   macports: [py27-paramiko]
+  nixos: [pythonPackages.paramiko]
   openembedded: ['${PYTHON_PN}-paramiko@meta-ros-common']
   opensuse: [python-paramiko]
   osx:
@@ -3039,6 +3116,7 @@ python-pastedeploy:
   debian: [python-pastedeploy]
   fedora: [python-paste-deploy]
   gentoo: [dev-python/pastedeploy]
+  nixos: [pythonPackages.PasteDeploy]
   ubuntu: [python-pastedeploy]
 python-path.py:
   gentoo: [dev-python/path-py]
@@ -3052,12 +3130,14 @@ python-pathlib:
   arch: [python2-pathlib]
   debian: [python-pathlib]
   gentoo: [dev-python/pathlib]
+  nixos: [pythonPackages.pathlib]
   ubuntu: [python-pathlib]
 python-pathlib2:
   arch: [python2-pathlib2]
   debian: [python-pathlib2]
   fedora: [python-pathlib2]
   gentoo: [dev-python/pathlib2]
+  nixos: [pythonPackages.pathlib2]
   ubuntu:
     '*': [python-pathlib2]
     xenial: null
@@ -3100,6 +3180,7 @@ python-pep8:
   debian: [pep8]
   fedora: [python-pep8]
   gentoo: [dev-python/pep8]
+  nixos: [pythonPackages.pep8]
   osx:
     pip:
       packages: [pep8]
@@ -3127,6 +3208,7 @@ python-percol:
   fedora:
     pip:
       packages: [percol]
+  nixos: [pythonPackages.percol]
   osx:
     pip:
       packages: [percol]
@@ -3170,6 +3252,7 @@ python-pip:
   debian: [python-pip]
   fedora: [python-pip]
   gentoo: [dev-python/pip]
+  nixos: [pythonPackages.pip]
   openembedded: ['${PYTHON_PN}-pip@meta-python']
   ubuntu: [python-pip]
 python-pixel-ring-pip:
@@ -3184,6 +3267,7 @@ python-pixel-ring-pip:
       packages: [pixel-ring]
 python-pkg-resources:
   debian: [python-pkg-resources]
+  nixos: [pythonPackages.setuptools]
   ubuntu: [python-pkg-resources]
 python-planar-pip:
   ubuntu:
@@ -3227,6 +3311,7 @@ python-progressbar:
   debian: [python-progressbar]
   fedora: [python-progressbar]
   gentoo: [dev-python/progressbar]
+  nixos: [pythonPackages.progressbar]
   osx:
     pip:
       packages: [progressbar]
@@ -3269,6 +3354,7 @@ python-psutil:
   freebsd: [py27-psutil]
   gentoo: [dev-python/psutil]
   macports: [py27-psutil]
+  nixos: [pythonPackages.psutil]
   openembedded: ['${PYTHON_PN}-psutil@meta-python']
   opensuse: [python-psutil]
   osx:
@@ -3328,6 +3414,7 @@ python-pyaudio:
   debian: [python-pyaudio]
   fedora: [pyaudio]
   gentoo: [dev-python/pyaudio]
+  nixos: [pythonPackages.pyaudio]
   openembedded: ['${PYTHON_PN}-pyalsaaudio@meta-python']
   ubuntu: [python-pyaudio]
 python-pycodestyle:
@@ -3338,6 +3425,7 @@ python-pycodestyle:
     stretch: [python-pycodestyle]
   fedora: [python-pycodestyle]
   gentoo: [dev-python/pycodestyle]
+  nixos: [pythonPackages.pycodestyle]
   rhel: [python2-pycodestyle]
   ubuntu:
     '*': null
@@ -3357,6 +3445,7 @@ python-pycryptodome:
   debian: [python-pycryptodome]
   fedora: [python-pycryptodomex]
   gentoo: [dev-python/pycryptodome]
+  nixos: [pythonPackages.pycryptodomex]
   openembedded: ['${PYTHON_PN}-pycryptodomex@openembedded-core']
   osx:
     pip:
@@ -3386,6 +3475,7 @@ python-pydot:
   freebsd: [py27-pydot]
   gentoo: [dev-python/pydot]
   macports: [py27-pydot]
+  nixos: [pythonPackages.pydot]
   openembedded: ['${PYTHON_PN}-pydot@meta-ros-common']
   opensuse: [python-pydot]
   osx:
@@ -3408,6 +3498,7 @@ python-pygame:
   debian: [python-pygame]
   fedora: [pygame-devel]
   gentoo: [dev-python/pygame]
+  nixos: [pythonPackages.pygame]
   ubuntu: [python-pygame]
 python-pygithub3:
   debian:
@@ -3441,6 +3532,7 @@ python-pygraphviz:
   fedora: [graphviz-python]
   freebsd: [py27-pygraphviz]
   gentoo: [dev-python/pygraphviz]
+  nixos: [pythonPackages.pygraphviz]
   opensuse: [python-pygraphviz]
   osx:
     pip:
@@ -3508,6 +3600,7 @@ python-pymongo:
   debian: [python-pymongo]
   fedora: [python-pymongo]
   gentoo: [dev-python/pymongo]
+  nixos: [pythonPackages.pymongo]
   openembedded: ['${PYTHON_PN}-pymongo@meta-python']
   osx:
     pip:
@@ -3574,6 +3667,7 @@ python-pyproj:
   debian: [python-pyproj]
   fedora: [pyproj]
   gentoo: [dev-python/pyproj]
+  nixos: [pythonPackages.pyproj]
   openembedded: ['${PYTHON_PN}-pyproj@meta-ros-common']
   osx:
     pip:
@@ -3609,6 +3703,7 @@ python-pyqtgraph:
   gentoo:
     pip:
       packages: [pyqtgraph]
+  nixos: [pythonPackages.pyqtgraph]
   ubuntu:
     bionic: [python-pyqtgraph]
     xenial: [python-pyqtgraph]
@@ -3616,6 +3711,7 @@ python-pyquery:
   debian: [python-pyquery]
   fedora: [python-pyquery]
   gentoo: [dev-python/pyquery]
+  nixos: [pythonPackages.pyquery]
   osx:
     pip:
       packages: [pyquery]
@@ -3706,6 +3802,7 @@ python-pytest:
   debian: [python-pytest]
   fedora: [python-pytest]
   gentoo: [dev-python/pytest]
+  nixos: [pythonPackages.pytest]
   openembedded: ['${PYTHON_PN}-pytest@openembedded-core']
   ubuntu: [python-pytest]
 python-pytest-cov:
@@ -3713,6 +3810,7 @@ python-pytest-cov:
   debian: [python-pytest-cov]
   fedora: [python-pytest-cov]
   gentoo: [dev-python/pytest-cov]
+  nixos: [pythonPackages.pytestcov]
   ubuntu: [python-pytest-cov]
 python-pytest-dependency-pip:
   debian:
@@ -3765,6 +3863,7 @@ python-pyudev:
   debian: [python-pyudev]
   fedora: [python-pyudev]
   gentoo: [dev-python/pyudev]
+  nixos: [pythonPackages.pyudev]
   openembedded: ['${PYTHON_PN}-pyudev@meta-python']
   ubuntu:
     '*': [python-pyudev]
@@ -3779,6 +3878,7 @@ python-pyusb-pip:
     pip: [pyusb]
   fedora:
     pip: [pyusb]
+  nixos: [pythonPackages.pyusb]
   ubuntu:
     pip: [pyusb]
 python-pyuserinput:
@@ -3867,6 +3967,7 @@ python-qt5-bindings:
   fedora: [python-qt5-devel, sip]
   freebsd: [py27-qt5]
   gentoo: ['dev-python/PyQt5[gui,widgets]']
+  nixos: [pythonPackages.pyqt5]
   openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
   opensuse: [python-qt5]
   slackware: [PyQt5]
@@ -3886,6 +3987,7 @@ python-qt5-bindings-gl:
   fedora: [python-qt5]
   freebsd: [py27-qt5-opengl]
   gentoo: ['dev-python/PyQt5[opengl]']
+  nixos: [pythonPackages.pyqt5]
   openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
   opensuse: [python-qt5]
   slackware: [PyQt5]
@@ -3913,6 +4015,7 @@ python-qt5-bindings-webkit:
   fedora: [python-qt5]
   freebsd: [py27-qt5-webkit]
   gentoo: ['dev-python/PyQt5[webkit]']
+  nixos: [pythonPackages.pyqt5_with_qtwebkit]
   openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
   ubuntu:
     artful: [python-pyqt5.qtwebkit]
@@ -3954,6 +4057,7 @@ python-requests:
   debian: [python-requests]
   fedora: [python-requests]
   gentoo: [dev-python/requests]
+  nixos: [pythonPackages.requests]
   openembedded: ['${PYTHON_PN}-requests@openembedded-core']
   osx:
     pip:
@@ -3990,6 +4094,7 @@ python-rosdep:
     pip:
       packages: [rosdep]
   gentoo: [dev-util/rosdep]
+  nixos: [pythonPackages.rosdep]
   openembedded: ['${PYTHON_PN}-rosdep@meta-ros-common']
   opensuse: [python-rosdep]
   osx:
@@ -4034,6 +4139,7 @@ python-rosdep-modules:
     pip:
       packages: [rosdep]
   gentoo: [dev-util/rosdep]
+  nixos: [pythonPackages.rosdep]
   openembedded: ['${PYTHON_PN}-rosdep@meta-ros-common']
   opensuse: [python-rosdep]
   osx:
@@ -4111,6 +4217,7 @@ python-rospkg:
       packages: [rospkg]
   gentoo: [dev-python/rospkg]
   macports: [py27-rospkg]
+  nixos: [pythonPackages.rospkg]
   openembedded: ['${PYTHON_PN}-rospkg@meta-ros-common']
   opensuse: [python-rospkg]
   osx:
@@ -4142,6 +4249,7 @@ python-rospkg-modules:
       packages: [rospkg]
   gentoo: [dev-python/rospkg]
   macports: [py27-rospkg]
+  nixos: [pythonPackages.rospkg]
   opensuse: [python-rospkg]
   osx:
     pip:
@@ -4216,6 +4324,7 @@ python-ruamel.yaml:
     jessie: [python-ruamel.yaml]
     stretch: [python-ruamel.yaml]
   fedora: [python-ruamel-yaml]
+  nixos: [pythonPackages.ruamel_yaml]
   ubuntu:
     artful: [python-ruamel.yaml]
     bionic: [python-ruamel.yaml]
@@ -4239,6 +4348,7 @@ python-scapy:
   ubuntu: [python-scapy]
 python-schedule:
   debian: [python-schedule]
+  nixos: [pythonPackages.schedule]
   ubuntu: [python-schedule]
 python-scipy:
   arch: [python2-scipy]
@@ -4247,6 +4357,7 @@ python-scipy:
   freebsd: [py-scipy]
   gentoo: [sci-libs/scipy]
   macports: [py27-scipy]
+  nixos: [pythonPackages.scipy]
   opensuse: [python-scipy]
   osx:
     pip:
@@ -4302,12 +4413,14 @@ python-selenium-pip:
   fedora:
     pip:
       packages: [selenium]
+  nixos: [pythonPackages.selenium]
   ubuntu:
     pip:
       packages: [selenium]
 python-semantic-version:
   debian: [python-semantic-version]
   fedora: [python2-semantic_version]
+  nixos: [pythonPackages.semantic-version]
   ubuntu:
     bionic: [python-semantic-version]
     xenial: [python-semantic-version]
@@ -4320,6 +4433,7 @@ python-serial:
   debian: [python-serial]
   fedora: [pyserial]
   gentoo: [dev-python/pyserial]
+  nixos: [pythonPackages.pyserial]
   openembedded: ['${PYTHON_PN}-pyserial@meta-python']
   ubuntu:
     artful: [python-serial]
@@ -4357,6 +4471,7 @@ python-setuptools:
   fedora: [python-setuptools]
   gentoo: [dev-python/setuptools]
   macports: [py27-setuptools]
+  nixos: [pythonPackages.setuptools]
   openembedded: ['${PYTHON_PN}-setuptools@openembedded-core']
   osx:
     pip:
@@ -4431,6 +4546,7 @@ python-simplejson:
   debian: [python-simplejson]
   fedora: [python-simplejson]
   gentoo: [dev-python/simplejson]
+  nixos: [pythonPackages.simplejson]
   openembedded: ['${PYTHON_PN}-simplejson@openembedded-core']
   ubuntu: [python-simplejson]
 python-singledispatch:
@@ -4445,6 +4561,7 @@ python-sip:
   freebsd: [py27-sip]
   gentoo: [dev-python/sip]
   macports: [py27-sip]
+  nixos: [pythonPackages.sip]
   openembedded: [sip@meta-oe]
   opensuse: [python-sip-devel]
   rhel:
@@ -4466,12 +4583,14 @@ python-six:
   debian: [python-six]
   fedora: [python-six]
   gentoo: [dev-python/six]
+  nixos: [pythonPackages.six]
   openembedded: ['${PYTHON_PN}-six@openembedded-core']
   ubuntu: [python-six]
 python-skimage:
   debian: [python-skimage]
   fedora: [python-scikit-image]
   gentoo: [sci-libs/scikits_image]
+  nixos: [pythonPackages.scikitimage]
   osx:
     pip:
       packages: [scikit-image]
@@ -4503,6 +4622,7 @@ python-sklearn:
   debian: [python-sklearn]
   fedora: [python-scikit-learn]
   gentoo: [sci-libs/scikits_learn]
+  nixos: [pythonPackages.scikitlearn]
   osx:
     pip:
       packages: [scikit-learn]
@@ -4576,6 +4696,7 @@ python-sphinx:
   freebsd: [py27-sphinx]
   gentoo: [dev-python/sphinx]
   macports: [py27-sphinx]
+  nixos: [pythonPackages.sphinx]
   openembedded: ['${PYTHON_PN}-sphinx@meta-ros-common']
   opensuse: [python-Sphinx]
   osx:
@@ -4687,6 +4808,7 @@ python-sympy:
   debian: [python-sympy]
   fedora: [sympy]
   gentoo: [dev-python/sympy]
+  nixos: [pythonPackages.sympy]
   ubuntu:
     artful: [python-sympy]
     bionic: [python-sympy]
@@ -4708,6 +4830,7 @@ python-systemd:
   debian:
     buster: [python-systemd]
     stretch: [python-systemd]
+  nixos: [pythonPackages.systemd]
   ubuntu:
     bionic: [python-systemd]
     xenial: [python-systemd]
@@ -4734,6 +4857,7 @@ python-tabulate:
     buster: [python-tabulate]
     stretch: [python-tabulate]
   gentoo: [dev-python/tabulate]
+  nixos: [pythonPackages.tabulate]
   ubuntu:
     artful: [python-tabulate]
     bionic: [python-tabulate]
@@ -4747,6 +4871,7 @@ python-tabulate-pip:
   fedora:
     pip:
       packages: [tabulate]
+  nixos: [pythonPackages.tabulate]
   osx:
     pip:
       packages: [tabulate]
@@ -4836,6 +4961,7 @@ python-termcolor:
         packages: [termcolor]
   fedora: [python-termcolor]
   gentoo: [dev-python/termcolor]
+  nixos: [pythonPackages.termcolor]
   osx:
     pip:
       packages: [termcolor]
@@ -4865,6 +4991,7 @@ python-texttable:
     stretch: [python-texttable]
   fedora: [python-texttable]
   gentoo: [dev-python/texttable]
+  nixos: [pythonPackages.texttable]
   osx:
     pip:
       packages: [texttable]
@@ -4920,6 +5047,7 @@ python-theano:
 python-tilestache:
   debian: [tilestache]
   fedora: [python-tilestache]
+  nixos: [pythonPackages.tilestache]
   ubuntu: [tilestache]
 python-tinydb-pip:
   debian:
@@ -4932,6 +5060,7 @@ python-tk:
   arch: [python2, tk]
   debian: [python-tk]
   fedora: [python2-tkinter]
+  nixos: [pythonPackages.tkinter]
   openembedded: ['${PYTHON_PN}-tkinter@openembedded-core']
   rhel:
     '*': [python2-tkinter]
@@ -4953,6 +5082,7 @@ python-tornado:
   debian: [python-tornado]
   fedora: [python-tornado]
   gentoo: [www-servers/tornado]
+  nixos: [pythonPackages.tornado]
   openembedded: [python-tornado45@meta-ros-python2]
   osx:
     pip:
@@ -5076,6 +5206,7 @@ python-twisted-core:
   debian: [python-twisted-core]
   fedora: [python-twisted-core]
   gentoo: [dev-python/twisted]
+  nixos: [pythonPackages.twisted]
   openembedded: ['${PYTHON_PN}-twisted-core@meta-python']
   ubuntu: [python-twisted-core]
 python-twisted-web:
@@ -5083,6 +5214,7 @@ python-twisted-web:
   debian: [python-twisted-web]
   fedora: [python-twisted-web]
   gentoo: [dev-python/twisted]
+  nixos: [pythonPackages.twisted]
   ubuntu: [python-twisted-web]
 python-twitter:
   debian:
@@ -5097,6 +5229,7 @@ python-typing:
   debian: [python-typing]
   fedora: [python2-typing]
   gentoo: [dev-python/typing]
+  nixos: [pythonPackages.typing]
   ubuntu:
     '*': [python-typing]
     trusty: null
@@ -5113,8 +5246,10 @@ python-tz:
   debian: [python-tz]
   fedora: [pytz]
   gentoo: [dev-python/pytz]
+  nixos: [pythonPackages.pytz]
   ubuntu: [python-tz]
 python-tzlocal-pip:
+  nixos: [pythonPackages.tzlocal]
   ubuntu:
     pip:
       packages: [tzlocal]
@@ -5131,6 +5266,7 @@ python-ujson:
     stretch: [python-ujson]
   fedora: [python-ujson]
   gentoo: [dev-python/ujson]
+  nixos: [pythonPackages.ujson]
   osx:
     pip:
       packages: [ujson]
@@ -5151,6 +5287,7 @@ python-ujson:
 python-unittest2:
   debian: [python-unittest2]
   fedora: [python-unittest2]
+  nixos: [pythonPackages.unittest2]
   osx:
     pip:
       packages: [unittest2]
@@ -5160,6 +5297,7 @@ python-urlgrabber:
   debian: [python-urlgrabber]
   fedora: [python-urlgrabber]
   gentoo: [dev-python/urlgrabber]
+  nixos: [pythonPackages.urlgrabber]
   opensuse: [python-urlgrabber]
   osx:
     pip:
@@ -5171,11 +5309,13 @@ python-urllib3:
   debian: [python-urllib3]
   fedora: [python-urllib3]
   gentoo: [dev-python/urllib3]
+  nixos: [pythonPackages.urllib3]
   ubuntu: [python-urllib3]
 python-usb:
   debian: [python-usb]
   fedora: [pyusb]
   gentoo: [dev-python/pyusb]
+  nixos: [pythonPackages.pyusb]
   openembedded: ['${PYTHON_PN}-pyusb@meta-python']
   ubuntu: [python-usb]
 python-utm-pip:
@@ -5226,6 +5366,7 @@ python-virtualenv:
   debian: [python-virtualenv]
   fedora: [python-virtualenv]
   gentoo: [dev-python/virtualenv]
+  nixos: [pythonPackages.virtualenv]
   openembedded: ['${PYTHON_PN}-virtualenv@meta-ros2']
   rhel:
     '*': [python2-virtualenv]
@@ -5253,6 +5394,7 @@ python-voluptuous:
   debian: [python-voluptuous]
   fedora: [python-voluptuous]
   gentoo: [dev-python/voluptuous]
+  nixos: [pythonPackages.voluptuous]
   ubuntu: [python-voluptuous]
 python-vtk:
   arch: [vtk]
@@ -5278,6 +5420,7 @@ python-waitress:
   debian: [python-waitress]
   fedora: [python-waitress]
   gentoo: [dev-python/waitress]
+  nixos: [pythonPackages.waitress]
   ubuntu: [python-waitress]
 python-walrus-pip:
   ubuntu:
@@ -5295,6 +5438,7 @@ python-webob:
   debian: [python-webob]
   fedora: [python-webob]
   gentoo: [dev-python/webob]
+  nixos: [pythonPackages.webob]
   ubuntu: [python-webob]
 python-webpy:
   arch: [python2-webpy]
@@ -5319,6 +5463,7 @@ python-websocket:
   debian: [python-websocket]
   fedora: [python-websocket-client]
   gentoo: [dev-python/websocket-client]
+  nixos: [pythonPackages.websocket_client]
   openembedded: ['${PYTHON_PN}-websocket-client@meta-python']
   ubuntu:
     artful: [python-websocket]
@@ -5359,6 +5504,7 @@ python-werkzeug:
   debian: [python-werkzeug]
   fedora: [python-werkzeug]
   gentoo: [dev-python/werkzeug]
+  nixos: [pythonPackages.werkzeug]
   ubuntu: [python-werkzeug]
 python-wheel:
   debian: [python-wheel]
@@ -5367,6 +5513,7 @@ python-wheel:
   ubuntu: [python-wheel]
 python-whichcraft:
   debian: [python-whichcraft]
+  nixos: [pythonPackages.whichcraft]
   ubuntu: [python-whichcraft]
 python-wrapt:
   debian: [python-wrapt]
@@ -5398,6 +5545,7 @@ python-wxtools:
   fedora: [wxPython]
   freebsd: [py27-wxPython30]
   gentoo: [dev-python/wxpython]
+  nixos: [pythonPackages.wxPython]
   openembedded: [wxpython@meta-ros-python2]
   rhel:
     '7': [wxPython]
@@ -5411,6 +5559,7 @@ python-xlib:
   debian: [python-xlib]
   fedora: [python-xlib]
   gentoo: [dev-python/python-xlib]
+  nixos: [pythonPackages.xlib]
   ubuntu: [python-xlib]
 python-xlrd:
   debian: [python-xlrd]
@@ -5457,6 +5606,7 @@ python-yaml:
   freebsd: [py27-yaml]
   gentoo: [dev-python/pyyaml]
   macports: [py27-yaml]
+  nixos: [pythonPackages.pyyaml]
   openembedded: ['${PYTHON_PN}-pyyaml@meta-python']
   opensuse: [python-PyYAML]
   osx:
@@ -5500,6 +5650,7 @@ python-zmq:
   debian: [python-zmq]
   fedora: [python-zmq]
   gentoo: [dev-python/pyzmq]
+  nixos: [pythonPackages.pyzmq]
   ubuntu:
     '*': [python-zmq]
     trusty_python3: [python3-zmq]
@@ -5507,6 +5658,7 @@ python3:
   debian: [python3-dev]
   fedora: [python3-devel]
   gentoo: [dev-lang/python]
+  nixos: [python3]
   openembedded: [python3@openembedded-core]
   rhel: ['python%{python3_pkgversion}-devel']
   ubuntu: [python3-dev]
@@ -5560,6 +5712,7 @@ python3-argcomplete:
   fedora: [python3-argcomplete]
   freebsd: [py37-argcomplete]
   gentoo: [dev-python/argcomplete]
+  nixos: [python3Packages.argcomplete]
   openembedded: [python3-argcomplete@meta-python]
   rhel: ['python%{python3_pkgversion}-argcomplete']
   ubuntu: [python3-argcomplete]
@@ -5571,6 +5724,7 @@ python3-autobahn:
   debian: [python3-autobahn]
   fedora: [python3-autobahn]
   gentoo: [dev-python/autobahn]
+  nixos: [python3Packages.autobahn]
   openembedded: [python3-autobahn@meta-python]
   rhel:
     '*': ['python%{python3_pkgversion}-autobahn']
@@ -5605,6 +5759,7 @@ python3-bitarray:
   debian: [python3-bitarray]
   fedora: [python3-bitarray]
   gentoo: [dev-python/bitarray]
+  nixos: [python3Packages.bitarray]
   ubuntu: [python3-bitarray]
 python3-bluez:
   debian: [python3-bluez]
@@ -5652,6 +5807,7 @@ python3-bosdyn-mission-pip:
 python3-boto3:
   debian: [python3-boto3]
   fedora: [python3-boto3]
+  nixos: [python3Packages.boto3]
   openembedded: [python3-boto3@meta-ros-common]
   opensuse: [python3-boto3]
   rhel:
@@ -5662,11 +5818,13 @@ python3-bs4:
   arch: [python-beautifulsoup4]
   debian: [python3-bs4]
   fedora: [python-beautifulsoup4]
+  nixos: [python3Packages.beautifulsoup4]
   ubuntu: [python3-bs4]
 python3-bson:
   debian: [python3-bson]
   fedora: [python3-bson]
   gentoo: [dev-python/pymongo]
+  nixos: [python3Packages.bson]
   openembedded: [python3-pymongo@meta-python]
   osx:
     pip:
@@ -5679,6 +5837,7 @@ python3-cairo:
   fedora: [python3-cairo]
   freebsd: [py3-cairo]
   gentoo: [dev-python/pycairo]
+  nixos: [python3Packages.pycairo]
   openembedded: [python3-pycairo@openembedded-core]
   opensuse: [python3-cairo]
   rhel: ['python%{python3_pkgversion}-cairo']
@@ -5715,6 +5874,7 @@ python3-catkin-pkg:
   debian: [python3-catkin-pkg]
   fedora: [python3-catkin_pkg]
   gentoo: [dev-python/catkin_pkg]
+  nixos: [python3Packages.catkin-pkg]
   openembedded: [python3-catkin-pkg@meta-ros-common]
   rhel: ['python%{python3_pkgversion}-catkin_pkg']
   ubuntu: [python3-catkin-pkg]
@@ -5723,6 +5883,7 @@ python3-catkin-pkg-modules:
   debian: [python3-catkin-pkg-modules]
   fedora: [python3-catkin_pkg]
   gentoo: [dev-python/catkin_pkg]
+  nixos: [python3Packages.catkin-pkg]
   openembedded: [python3-catkin-pkg@meta-ros-common]
   osx:
     pip:
@@ -5738,6 +5899,7 @@ python3-cffi:
   debian: [python3-cffi]
   fedora: [python3-cffi]
   gentoo: [dev-python/cffi]
+  nixos: [python3Packages.cffi]
   rhel: ['python%{python3_pkgversion}-cffi']
   ubuntu: [python3-cffi]
 python3-cherrypy3:
@@ -5747,6 +5909,7 @@ python3-click:
   debian: [python3-click]
   fedora: [python3-click]
   gentoo: [dev-python/click]
+  nixos: [python3Packages.click]
   openembedded: [python3-click@meta-python]
   rhel: ['python%{python3_pkgversion}-click']
   ubuntu: [python3-click]
@@ -5779,6 +5942,7 @@ python3-colorama:
   debian: [python3-colorama]
   fedora: [python3-colorama]
   gentoo: [dev-python/colorama]
+  nixos: [python3Packages.colorama]
   openembedded: [python3-colorama@meta-python]
   rhel: ['python%{python3_pkgversion}-colorama']
   ubuntu: [python3-colorama]
@@ -5807,11 +5971,13 @@ python3-construct:
   debian: [python3-construct]
   fedora: [python3-construct]
   gentoo: [dev-python/construct]
+  nixos: [python3Packages.construct]
   ubuntu: [python3-construct]
 python3-coverage:
   debian: [python3-coverage]
   fedora: [python3-coverage]
   gentoo: [dev-python/coverage]
+  nixos: [python3Packages.coverage]
   openembedded: [python3-coverage@meta-python]
   rhel: ['python%{python3_pkgversion}-coverage']
   ubuntu: [python3-coverage]
@@ -5820,6 +5986,7 @@ python3-crcmod:
   fedora:
     pip:
       packages: [crcmod]
+  nixos: [python3Packages.crcmod]
   osx:
     pip:
       packages: [crcmod]
@@ -5829,6 +5996,7 @@ python3-cryptography:
   debian: [python3-cryptography]
   fedora: [python3-cryptography]
   gentoo: [dev-python/cryptography]
+  nixos: [python3Packages.cryptography]
   openembedded: [python3-cryptography@meta-python]
   rhel: ['python%{python3_pkgversion}-cryptography']
   ubuntu: [python3-cryptography]
@@ -5839,11 +6007,13 @@ python3-datadog-pip:
 python3-dbus:
   debian: [python3-dbus]
   fedora: [python3-dbus]
+  nixos: [python3Packages.dbus-python]
   ubuntu: [python3-dbus]
 python3-decorator:
   debian: [python3-decorator]
   fedora: [python3-decorator]
   gentoo: [dev-python/decorator]
+  nixos: [python3Packages.decorator]
   osx:
     pip: [decorator]
   ubuntu: [python3-decorator]
@@ -5851,6 +6021,7 @@ python3-defusedxml:
   debian: [python3-defusedxml]
   fedora: [python3-defusedxml]
   gentoo: [dev-python/defusedxml]
+  nixos: [python3Packages.defusedxml]
   openembedded: [python3-defusedxml@meta-python]
   rhel: ['python%{python3_pkgversion}-defusedxml']
   ubuntu: [python3-defusedxml]
@@ -5858,6 +6029,7 @@ python3-dev:
   debian: [python3-dev]
   fedora: [python3-devel]
   gentoo: [=dev-lang/python-3*]
+  nixos: [python3]
   openembedded: [python3@openembedded-core]
   rhel: ['python%{python3_pkgversion}-devel']
   ubuntu: [python3-dev]
@@ -5865,6 +6037,7 @@ python3-distro:
   debian: [python3-distro]
   fedora: [python3-distro]
   gentoo: [dev-python/distro]
+  nixos: [python3Packages.distro]
   ubuntu: [python3-distro]
 python3-distutils:
   debian:
@@ -5872,6 +6045,7 @@ python3-distutils:
     stretch: null
   fedora: [python3]
   gentoo: [dev-lang/python]
+  nixos: [python3]
   ubuntu:
     '*': [python3-distutils]
     xenial: null
@@ -5897,6 +6071,7 @@ python3-docker:
   debian: [python3-docker]
   fedora: [python3-docker]
   gentoo: [dev-python/docker-py]
+  nixos: [python3Packages.docker]
   rhel:
     '7': ['python%{python3_pkgversion}-docker']
   ubuntu: [python3-docker]
@@ -5905,12 +6080,14 @@ python3-docopt:
   debian: [python3-docopt]
   fedora: [python3-docopt]
   gentoo: [dev-python/docopt]
+  nixos: [python3Packages.docopt]
   ubuntu: [python3-docopt]
 python3-docutils:
   arch: [python-docutils]
   debian: [python3-docutils]
   fedora: [python3-docutils]
   gentoo: [dev-python/docutils]
+  nixos: [python3Packages.docutils]
   openembedded: [python3-docutils@openembedded-core]
   ubuntu: [python3-docutils]
 python3-empy:
@@ -5922,6 +6099,7 @@ python3-empy:
     stretch: [python3-empy]
   fedora: [python3-empy]
   gentoo: [dev-python/empy]
+  nixos: [python3Packages.empy]
   openembedded: [python3-empy@meta-ros-common]
   rhel: ['python%{python3_pkgversion}-empy']
   ubuntu: [python3-empy]
@@ -5958,6 +6136,7 @@ python3-ezdxf:
         packages: [ezdxf]
   fedora: [python3-ezdxf]
   freebsd: [py37-ezdxf]
+  nixos: [python3Packages.ezdxf]
   ubuntu:
     '*': [python3-ezdxf]
     bionic:
@@ -6004,6 +6183,7 @@ python3-flake8:
     stretch: [python3-flake8]
   fedora: [python3-flake8]
   gentoo: [dev-python/flake8]
+  nixos: [python3Packages.flake8]
   openembedded: [python3-flake8@meta-ros-common]
   osx:
     pip:
@@ -6016,6 +6196,7 @@ python3-flask:
   debian: [python3-flask]
   fedora: [python3-flask]
   gentoo: [dev-python/flask]
+  nixos: [python3Packages.flask]
   ubuntu: [python3-flask]
 python3-flask-cors:
   debian: [python3-flask-cors]
@@ -6031,6 +6212,7 @@ python3-future:
   debian: [python3-future]
   fedora: [python3-future]
   gentoo: [dev-python/future]
+  nixos: [python3Packages.future]
   openembedded: [python3-future@meta-python]
   rhel: ['python%{python3_pkgversion}-future']
   ubuntu: [python3-future]
@@ -6050,12 +6232,14 @@ python3-geomag-pip:
 python3-geopy:
   debian: [python3-geopy]
   fedora: [python3-geopy]
+  nixos: [python3Packages.geopy]
   ubuntu: [python3-geopy]
 python3-gi:
   arch: [python-gobject]
   debian: [python3-gi]
   fedora: [python3-gobject]
   gentoo: [dev-python/pygobject]
+  nixos: [python3Packages.pygobject3]
   openembedded: [python3-pygobject@openembedded-core]
   ubuntu: [python3-gi]
 python3-git:
@@ -6063,6 +6247,7 @@ python3-git:
   debian: [python3-git]
   fedora: [python3-GitPython]
   gentoo: [dev-python/git-python]
+  nixos: [python3Packages.GitPython]
   ubuntu: [python3-git]
 python3-github:
   debian: [python3-github]
@@ -6095,6 +6280,7 @@ python3-gnupg:
   debian: [python3-gnupg]
   fedora: [python3-gnupg]
   gentoo: [dev-python/python-gnupg]
+  nixos: [python3Packages.python-gnupg]
   openembedded: [python3-gnupg@meta-python]
   ubuntu: [python3-gnupg]
 python3-gql-pip:
@@ -6111,6 +6297,7 @@ python3-grpc-tools:
   debian:
     '*': [python3-grpc-tools]
     stretch: null
+  nixos: [python3Packages.grpcio-tools]
   openembedded: [python3-grpcio-tools@meta-python]
   ubuntu:
     '*': [python3-grpc-tools]
@@ -6120,6 +6307,7 @@ python3-grpcio:
   debian:
     '*': [python3-grpcio]
     stretch: null
+  nixos: [python3Packages.grpcio]
   openembedded: [python3-grpcio@meta-python]
   ubuntu:
     '*': [python3-grpcio]
@@ -6129,6 +6317,7 @@ python3-h5py:
   debian: [python3-h5py]
   fedora: [python3-h5py]
   gentoo: [dev-python/h5py]
+  nixos: [python3Packages.h5py]
   openembedded: [python3-h5py@meta-python]
   ubuntu: [python3-h5py]
 python3-httplib2:
@@ -6154,6 +6343,7 @@ python3-ifcfg:
 python3-imageio:
   debian: [python3-imageio]
   gentoo: [dev-python/imageio]
+  nixos: [python3Packages.imageio]
   openembedded: [python3-imageio@meta-python]
   ubuntu: [python3-imageio]
 python3-importlib-metadata:
@@ -6192,6 +6382,7 @@ python3-importlib-resources:
         packages: [importlib-resources]
   fedora: [python3]
   gentoo: [dev-python/importlib_resources]
+  nixos: [python3Packages.importlib-resources]
   openembedded: [python3@openembedded-core]
   rhel:
     '*': ['python%{python3_pkgversion}-importlib-resources']
@@ -6219,6 +6410,7 @@ python3-interpreter:
   debian: [python3-minimal]
   fedora: [python3]
   gentoo: [dev-lang/python]
+  nixos: [python3]
   opensuse: [python3]
   rhel: [python3]
   slackware: [python3]
@@ -6228,6 +6420,7 @@ python3-jinja2:
   debian: [python3-jinja2]
   fedora: [python3-jinja2]
   gentoo: [=dev-python/jinja-2*]
+  nixos: [python3Packages.jinja2]
   ubuntu: [python3-jinja2]
 python3-jsonpickle:
   arch: [python-jsonpickle]
@@ -6239,6 +6432,7 @@ python3-jsonschema:
   debian: [python3-jsonschema]
   fedora: [python3-jsonschema]
   gentoo: [dev-python/jsonschema]
+  nixos: [python3Packages.jsonschema]
   ubuntu: [python3-jsonschema]
 python3-junitparser:
   debian:
@@ -6253,6 +6447,7 @@ python3-kitchen:
   debian: [python3-kitchen]
   fedora: [python3-kitchen]
   gentoo: [dev-python/kitchen]
+  nixos: [python3Packages.kitchen]
   osx:
     pip:
       packages: [kitchen]
@@ -6267,6 +6462,7 @@ python3-lark-parser:
     stretch: [python3-lark-parser]
   fedora: [python3-lark-parser]
   gentoo: [dev-python/lark]
+  nixos: [python3Packages.lark-parser]
   openembedded: [python3-lark-parser@meta-ros-common]
   rhel: ['python%{python3_pkgversion}-lark-parser']
   ubuntu:
@@ -6288,6 +6484,7 @@ python3-lxml:
   fedora: [python3-lxml]
   freebsd: [py36-lxml]
   gentoo: [dev-python/lxml]
+  nixos: [python3Packages.lxml]
   openembedded: [python3-lxml@meta-python]
   osx:
     pip:
@@ -6311,6 +6508,7 @@ python3-markdown:
   debian: [python3-markdown]
   fedora: [python3-markdown]
   gentoo: [dev-python/markdown]
+  nixos: [python3Packages.markdown]
   ubuntu: [python3-markdown]
 python3-matplotlib:
   alpine: [py3-matplotlib]
@@ -6318,6 +6516,7 @@ python3-matplotlib:
   debian: [python3-matplotlib]
   fedora: [python3-matplotlib]
   gentoo: [dev-python/matplotlib]
+  nixos: [python3Packages.matplotlib]
   openembedded: [python3-matplotlib@meta-python]
   opensuse: [python3-matplotlib]
   osx:
@@ -6334,6 +6533,7 @@ python3-mechanize:
     '*': [python3-mechanize]
     buster: null
   fedora: [python3-mechanize]
+  nixos: [python3Packages.mechanize]
   ubuntu:
     '*': [python3-mechanize]
     bionic: null
@@ -6347,6 +6547,7 @@ python3-mock:
   debian: [python3-mock]
   fedora: [python3-mock]
   gentoo: [dev-python/mock]
+  nixos: [python3Packages.mock]
   openembedded: [python3-mock@meta-ros-common]
   rhel: ['python%{python3_pkgversion}-mock']
   ubuntu: [python3-mock]
@@ -6361,6 +6562,7 @@ python3-msgpack:
   debian:
     '*': [python3-msgpack]
     stretch: null
+  nixos: [python3Packages.msgpack]
   openembedded: [python3-msgpack@meta-python]
   ubuntu: [python3-msgpack]
 python3-mypy:
@@ -6372,6 +6574,7 @@ python3-mypy:
     stretch: [mypy]
   fedora: [python3-mypy]
   gentoo: [dev-python/mypy]
+  nixos: [python3Packages.mypy]
   openembedded: [python3-mypy@meta-ros-common]
   ubuntu: [python3-mypy]
 python3-nclib-pip:
@@ -6391,23 +6594,27 @@ python3-netcdf4:
   freebsd: [py37-netCDF4]
   gentoo: [dev-python/netcdf4-python]
   macports: [py37-netcdf4]
+  nixos: [python3Packages.netcdf4]
   ubuntu: [python3-netcdf4]
 python3-netifaces:
   alpine: [py3-netifaces]
   debian: [python3-netifaces]
   fedora: [python3-netifaces]
   gentoo: [dev-python/netifaces]
+  nixos: [python3Packages.netifaces]
   openembedded: [python3-netifaces@meta-ros-common]
   rhel: ['python%{python3_pkgversion}-netifaces']
   ubuntu: [python3-netifaces]
 python3-networkx:
   debian: [python3-networkx]
   fedora: [python3-networkx]
+  nixos: [python3Packages.networkx]
   ubuntu: [python3-networkx]
 python3-nose:
   debian: [python3-nose]
   fedora: [python3-nose]
   gentoo: [dev-python/nose]
+  nixos: [python3Packages.nose]
   openembedded: [python3-nose@openembedded-core]
   rhel: ['python%{python3_pkgversion}-nose']
   ubuntu: [python3-nose]
@@ -6423,12 +6630,14 @@ python3-numpy:
   debian: [python3-numpy]
   fedora: [python3-numpy]
   gentoo: [dev-python/numpy]
+  nixos: [python3Packages.numpy]
   openembedded: [python3-numpy@openembedded-core]
   rhel: ['python%{python3_pkgversion}-numpy']
   ubuntu: [python3-numpy]
 python3-numpy-stl:
   debian: [python3-numpy-stl]
   fedora: [python3-numpy-stl]
+  nixos: [python3Packages.numpy-stl]
   ubuntu:
     '*': [python3-numpy-stl]
     xenial: null
@@ -6447,6 +6656,7 @@ python3-opencv:
     buster: [python3-opencv]
   fedora: [python3-opencv]
   gentoo: ['media-libs/opencv[python]']
+  nixos: [python3Packages.opencv3]
   openembedded: [opencv@meta-oe]
   ubuntu:
     bionic: [python3-opencv]
@@ -6458,6 +6668,7 @@ python3-opengl:
   debian: [python3-opengl]
   fedora: [python3-pyopengl]
   gentoo: [dev-python/pyopengl]
+  nixos: [python3Packages.pyopengl]
   ubuntu: [python3-opengl]
 python3-owlready2-pip:
   debian:
@@ -6473,6 +6684,7 @@ python3-packaging:
   debian: [python3-packaging]
   fedora: [python3-packaging]
   gentoo: [dev-python/packaging]
+  nixos: [python3Packages.packaging]
   openembedded: [python3-packaging@openembedded-core]
   rhel: ['python%{python3_pkgversion}-packaging']
   ubuntu: [python3-packaging]
@@ -6485,6 +6697,7 @@ python3-pandas:
   debian: [python3-pandas]
   fedora: [python3-pandas]
   gentoo: [dev-python/pandas]
+  nixos: [python3Packages.pandas]
   openembedded: [python3-pandas@meta-python]
   rhel:
     '*': ['python%{python3_pkgversion}-pandas']
@@ -6509,6 +6722,7 @@ python3-paramiko:
   debian: [python3-paramiko]
   fedora: [python3-paramiko]
   gentoo: [dev-python/paramiko]
+  nixos: [python3Packages.paramiko]
   openembedded: [python3-paramiko@meta-ros-common]
   rhel: ['python%{python3_pkgversion}-paramiko']
   ubuntu: [python3-paramiko]
@@ -6531,6 +6745,7 @@ python3-pep8:
     '30': [python3-pep8]
     '31': [python3-pep8]
   gentoo: [dev-python/pep8]
+  nixos: [python3Packages.pep8]
   openembedded: [python3-pep8@meta-ros-common]
   osx:
     pip:
@@ -6549,6 +6764,7 @@ python3-pil:
   fedora: [python3-pillow, python3-pillow-qt]
   freebsd: [py3-pillow]
   gentoo: [dev-python/pillow]
+  nixos: [python3Packages.pillow]
   openembedded: [python3-pillow@meta-python]
   opensuse: [python3-pillow]
   osx:
@@ -6569,6 +6785,7 @@ python3-pkg-resources:
   debian: [python3-pkg-resources]
   fedora: [python3-setuptools]
   gentoo: [dev-python/setuptools]
+  nixos: [python3Packages.setuptools]
   openembedded: [python3-setuptools@openembedded-core]
   rhel: ['python%{python3_pkgversion}-setuptools']
   ubuntu: [python3-pkg-resources]
@@ -6589,12 +6806,14 @@ python3-prettytable:
   debian: [python3-prettytable]
   fedora: [python3-prettytable]
   gentoo: [dev-python/prettytable]
+  nixos: [python3Packages.prettytable]
   ubuntu: [python3-prettytable]
 python3-progressbar:
   arch: [python-progressbar]
   debian: [python3-progressbar]
   fedora: [python3-progressbar2]
   gentoo: [dev-python/progressbar]
+  nixos: [python3Packages.progressbar]
   ubuntu: [python3-progressbar]
 python3-prometheus-client:
   debian: [python3-prometheus-client]
@@ -6604,6 +6823,7 @@ python3-protobuf:
   debian: [python3-protobuf]
   fedora: [python3-protobuf]
   gentoo: [dev-python/protobuf-python]
+  nixos: [python3Packages.protobuf]
   ubuntu: [python3-protobuf]
 python3-psutil:
   alpine: [py3-psutil]
@@ -6612,6 +6832,7 @@ python3-psutil:
   fedora: [python3-psutil]
   gentoo: [dev-python/psutil]
   macports: [py36-psutil]
+  nixos: [python3Packages.psutil]
   openembedded: [python3-psutil@meta-python]
   opensuse: [python3-psutil]
   osx:
@@ -6634,6 +6855,7 @@ python3-pyaudio:
   debian: [python3-pyaudio]
   fedora: [python3-pyaudio]
   gentoo: [dev-python/pyaudio]
+  nixos: [python3Packages.pyaudio]
   osx:
     pip:
       packages: [pyaudio]
@@ -6654,6 +6876,7 @@ python3-pybullet-pip:
 python3-pyclipper:
   debian: [python3-pyclipper]
   fedora: [python3-pyclipper]
+  nixos: [python3Packages.pyclipper]
   ubuntu: [python3-pyclipper]
 python3-pycodestyle:
   alpine: [py3-pycodestyle]
@@ -6661,6 +6884,7 @@ python3-pycodestyle:
   debian: [python3-pycodestyle]
   fedora: [python3-pycodestyle]
   gentoo: [dev-python/pycodestyle]
+  nixos: [python3Packages.pycodestyle]
   openembedded: [python3-pycodestyle@meta-python]
   rhel: ['python%{python3_pkgversion}-pycodestyle']
   ubuntu: [python3-pycodestyle]
@@ -6670,6 +6894,7 @@ python3-pycryptodome:
   debian: [python3-pycryptodome]
   fedora: [python3-pycryptodomex]
   gentoo: [dev-python/pycryptodome]
+  nixos: [python3Packages.pycryptodomex]
   openembedded: [python3-pycryptodome@meta-python]
   osx:
     pip:
@@ -6700,6 +6925,7 @@ python3-pydot:
   debian: [python3-pydot]
   fedora: [python3-pydot]
   gentoo: [dev-python/pydot]
+  nixos: [python3Packages.pydot]
   openembedded: [python3-pydot@meta-ros-common]
   rhel:
     '*': ['python%{python3_pkgversion}-pydot']
@@ -6712,6 +6938,7 @@ python3-pygame:
       pip: [pygame]
   fedora: [python3-pygame]
   gentoo: [dev-python/pygame]
+  nixos: [python3Packages.pygame]
   ubuntu:
     '*': [python3-pygame]
     bionic:
@@ -6725,6 +6952,7 @@ python3-pygraphviz:
   fedora: [python3-pygraphviz]
   freebsd: [py-pygraphviz]
   gentoo: [dev-python/pygraphviz]
+  nixos: [python3Packages.pygraphviz]
   openembedded: [python3-pygraphviz@meta-ros-common]
   opensuse: [python-pygraphviz]
   osx:
@@ -6743,6 +6971,7 @@ python3-pykdl:
     '30': null
     '31': null
   gentoo: [dev-python/python_orocos_kdl]
+  nixos: [python3Packages.pykdl]
   openembedded: [python3-pykdl@meta-ros1-noetic]
   ubuntu:
     '*': [python3-pykdl]
@@ -6771,17 +7000,20 @@ python3-pymongo:
   debian: [python3-pymongo]
   fedora: [python3-pymongo]
   gentoo: [dev-python/pymongo]
+  nixos: [python3Packages.pymongo]
   openembedded: [python3-pymongo@meta-python]
   ubuntu: [python3-pymongo]
 python3-pyosmium:
   debian: [python3-pyosmium]
   fedora: [python3-osmium]
+  nixos: [python3Packages.pyosmium]
   ubuntu: [python3-pyosmium]
 python3-pyparsing:
   arch: [python-pyparsing]
   debian: [python3-pyparsing]
   fedora: [python3-pyparsing]
   gentoo: [dev-python/pyparsing]
+  nixos: [python3Packages.pyparsing]
   openembedded: [python3-pyparsing@meta-python]
   ubuntu: [python3-pyparsing]
 python3-pypng:
@@ -6797,6 +7029,7 @@ python3-pyproj:
   debian: [python3-pyproj]
   fedora: [python3-pyproj]
   gentoo: [dev-python/pyproj]
+  nixos: [python3Packages.pyproj]
   openembedded: [python3-pyproj@meta-ros-common]
   rhel:
     '*': ['python%{python3_pkgversion}-pyproj']
@@ -6807,6 +7040,7 @@ python3-pyqrcode:
   debian: [python3-pyqrcode]
   fedora: [python3-pyqrcode]
   gentoo: [dev-python/pyqrcode]
+  nixos: [python3Packages.pyqrcode]
   ubuntu: [python3-pyqrcode]
 python3-pyqt5.qtwebengine:
   debian: [python3-pyqt5.qtwebengine]
@@ -6817,6 +7051,7 @@ python3-pyqtgraph:
   debian: [python3-pyqtgraph]
   fedora: [python3-pyqtgraph]
   gentoo: [dev-python/pyqtgraph]
+  nixos: [python3Packages.pyqtgraph]
   ubuntu: [python3-pyqtgraph]
 python3-pyrr-pip:
   debian:
@@ -6840,6 +7075,7 @@ python3-pyside2.qtopengl:
 python3-pystemd:
   debian:
     bullseye: [python3-pystemd]
+  nixos: [python3Packages.pystemd]
   ubuntu:
     '*': [python3-pystemd]
     bionic:
@@ -6864,6 +7100,7 @@ python3-pytest:
   debian: [python3-pytest]
   fedora: [python3-pytest]
   gentoo: [dev-python/pytest]
+  nixos: [pythonPackages.pytest]
   openembedded: [python3-pytest@meta-python]
   osx:
     pip:
@@ -6876,6 +7113,7 @@ python3-pytest-cov:
   debian: [python3-pytest-cov]
   fedora: [python3-pytest-cov]
   gentoo: [dev-python/pytest-cov]
+  nixos: [python3Packages.pytestcov]
   rhel: ['python%{python3_pkgversion}-pytest-cov']
   ubuntu: [python3-pytest-cov]
 python3-pytest-mock:
@@ -6884,6 +7122,7 @@ python3-pytest-mock:
   debian: [python3-pytest-mock]
   fedora: [python3-pytest-mock]
   gentoo: [dev-python/pytest-mock]
+  nixos: [python3Packages.pytest-mock]
   openembedded: [python3-pytest-mock@meta-ros-common]
   rhel: ['python%{python3_pkgversion}-pytest-mock']
   ubuntu: [python3-pytest-mock]
@@ -6911,6 +7150,7 @@ python3-qt5-bindings:
     stretch: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
   fedora: [python3-qt5-devel, libXext-devel]
   gentoo: [dev-python/PyQt5]
+  nixos: [python3Packages.pyqt5]
   openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python3-qt5]
   rhel: ['python%{python3_pkgversion}-qt5-devel', libXext-devel, redhat-rpm-config]
@@ -6929,6 +7169,7 @@ python3-qt5-bindings-gl:
   debian: [python3-pyqt5.qtopengl]
   fedora: [python3-qt5]
   gentoo: ['dev-python/PyQt5[opengl]']
+  nixos: [python3Packages.pyqt5]
   openembedded: [python3-pyqt5@meta-qt5]
   ubuntu: [python3-pyqt5.qtopengl]
 python3-qt5-bindings-webkit:
@@ -6941,6 +7182,7 @@ python3-qtpy:
   arch: [python-qtpy]
   debian: [python3-qtpy]
   gentoo: [dev-python/QtPy]
+  nixos: [python3Packages.qtpy]
   ubuntu: [python3-qtpy]
 python3-rafcon-pip:
   debian:
@@ -6957,12 +7199,14 @@ python3-rdflib:
   debian: [python3-rdflib]
   fedora: [python3-rdflib]
   gentoo: [dev-python/rdflib]
+  nixos: [python3Packages.rdflib]
   rhel:
     '8': ['python%{python3_pkgversion}-rdflib']
   ubuntu: [python3-rdflib]
 python3-requests:
   debian: [python3-requests]
   fedora: [python3-requests]
+  nixos: [python3Packages.requests]
   openembedded: [python3-requests@meta-python]
   rhel: ['python%{python3_pkgversion}-requests']
   ubuntu: [python3-requests]
@@ -6980,6 +7224,7 @@ python3-retrying:
   debian: [python3-retrying]
   fedora: [python3-retrying]
   gentoo: [retrying]
+  nixos: [python3Packages.retrying]
   osx:
     pip:
       packages: [retrying]
@@ -6998,6 +7243,7 @@ python3-rosdep-modules:
   debian: [python3-rosdep-modules]
   fedora: [python3-rosdep]
   gentoo: [dev-util/rosdep]
+  nixos: [python3Packages.rosdep]
   openembedded: [python3-rosdep@meta-ros-common]
   rhel: ['python%{python3_pkgversion}-rosdep']
   ubuntu: [python3-rosdep-modules]
@@ -7006,6 +7252,7 @@ python3-rosdistro-modules:
   debian: [python3-rosdistro-modules]
   fedora: [python3-rosdistro]
   gentoo: [dev-python/rosdistro]
+  nixos: [python3Packages.rosdistro]
   openembedded: [python3-rosdistro@meta-ros-common]
   rhel: ['python%{python3_pkgversion}-rosdistro']
   ubuntu: [python3-rosdistro-modules]
@@ -7019,6 +7266,7 @@ python3-rospkg:
     pip:
       packages: [rospkg]
   gentoo: [dev-python/rospkg]
+  nixos: [python3Packages.rospkg]
   openembedded: [python3-rospkg@meta-ros-common]
   opensuse: [python3-rospkg]
   osx:
@@ -7040,6 +7288,7 @@ python3-rospkg-modules:
     pip:
       packages: [rospkg]
   gentoo: [dev-python/rospkg]
+  nixos: [python3Packages.rospkg]
   openembedded: [python3-rospkg@meta-ros-common]
   opensuse: [python3-rospkg]
   osx:
@@ -7058,10 +7307,12 @@ python3-ruamel.yaml:
     buster: [python3-ruamel.yaml]
     jessie: [python3-ruamel.yaml]
     stretch: [python3-ruamel.yaml]
+  nixos: [python3Packages.ruamel_yaml]
   openembedded: [python3-ruamel-yaml@meta-python]
   ubuntu: [python3-ruamel.yaml]
 python3-schedule:
   debian: [python3-schedule]
+  nixos: [python3Packages.schedule]
   ubuntu: [python3-schedule]
 python3-scipy:
   arch: [python-scipy]
@@ -7070,6 +7321,7 @@ python3-scipy:
   freebsd: [py37-scipy]
   gentoo: [sci-libs/scipy]
   macports: [py37-scipy]
+  nixos: [python3Packages.scipy]
   opensuse: [python3-scipy]
   osx:
     pip:
@@ -7091,6 +7343,7 @@ python3-selenium:
   debian: [python3-selenium]
   fedora: [python3-selenium]
   gentoo: [dev-python/selenium]
+  nixos: [python3Packages.selenium]
   osx:
     pip:
       packages: [selenium]
@@ -7098,6 +7351,7 @@ python3-selenium:
 python3-semantic-version:
   debian: [python3-semantic-version]
   fedora: [python3-semantic_version]
+  nixos: [python3Packages.semantic-version]
   ubuntu: [python3-semantic-version]
 python3-semver:
   debian: [python3-semver]
@@ -7121,6 +7375,7 @@ python3-sense-hat-pip:
 python3-serial:
   debian: [python3-serial]
   fedora: [python3-pyserial]
+  nixos: [python3Packages.pyserial]
   openembedded: [python3-pyserial@meta-python]
   rhel:
     '*': ['python%{python3_pkgversion}-pyserial']
@@ -7131,6 +7386,7 @@ python3-setuptools:
   debian: [python3-setuptools]
   fedora: [python3-setuptools]
   gentoo: [dev-python/setuptools]
+  nixos: [python3Packages.setuptools]
   openembedded: [python3-setuptools@openembedded-core]
   osx:
     pip:
@@ -7146,6 +7402,7 @@ python3-sexpdata:
     stretch:
       pip:
         packages: [sexpdata]
+  nixos: [python3Packages.sexpdata]
   ubuntu:
     '*': [python3-sexpdata]
     bionic:
@@ -7158,12 +7415,14 @@ python3-sh:
   debian: [python3-sh]
   fedora: [python3-sh]
   gentoo: [dev-python/sh]
+  nixos: [python3Packages.sh]
   ubuntu: [python3-sh]
 python3-shapely:
   arch: [python-shapely]
   debian: [python3-shapely]
   fedora: [python3-shapely]
   gentoo: [sci-libs/Shapely]
+  nixos: [python3Packages.shapely]
   osx:
     pip:
       packages: [shapely]
@@ -7189,12 +7448,14 @@ python3-simplejson:
   debian: [python3-simplejson]
   fedora: [python3-simplejson]
   gentoo: [dev-python/simplejson]
+  nixos: [python3Packages.simplejson]
   openembedded: [python3-simplejson@meta-python]
   ubuntu: [python3-simplejson]
 python3-sip:
   debian: [python3-sip-dev]
   fedora: [python3-sip]
   gentoo: [dev-python/sip]
+  nixos: [python3Packages.sip]
   ubuntu: [python3-sip-dev]
 python3-siphon-pip:
   debian:
@@ -7217,11 +7478,13 @@ python3-six:
   debian: [python3-six]
   fedora: [python3-six]
   gentoo: [dev-python/six]
+  nixos: [python3Packages.six]
   ubuntu: [python3-six]
 python3-skimage:
   debian: [python3-skimage]
   fedora: [python3-scikit-image]
   gentoo: [sci-libs/scikits_image]
+  nixos: [python3Packages.scikitimage]
   osx:
     pip:
       packages: [scikit-image]
@@ -7230,6 +7493,7 @@ python3-sklearn:
   debian: [python3-sklearn]
   fedora: [python3-scikit-learn]
   gentoo: [sci-libs/scikits_learn]
+  nixos: [python3Packages.scikitlearn]
   osx:
     pip:
       packages: [scikit-learn]
@@ -7250,33 +7514,40 @@ python3-smbus2-pip:
 python3-sphinx:
   debian: [python3-sphinx]
   fedora: [python3-sphinx]
+  nixos: [python3Packages.sphinx]
   openembedded: [python3-sphinx@meta-ros-common]
   rhel: ['python%{python3_pkgversion}-sphinx']
   ubuntu: [python3-sphinx]
 python3-sphinx-argparse:
   debian: [python3-sphinx-argparse]
   fedora: [python3-sphinx-argparse]
+  nixos: [python3Packages.sphinx-argparse]
   ubuntu: [python3-sphinx-argparse]
 python3-sphinx-rtd-theme:
   debian: [python3-sphinx-rtd-theme]
   fedora: [python3-sphinx_rtd_theme]
+  nixos: [python3Packages.sphinx_rtd_theme]
   rhel: ['python%{python3_pkgversion}-sphinx_rtd_theme']
   ubuntu: [python3-sphinx-rtd-theme]
 python3-sqlalchemy:
   debian: [python3-sqlalchemy]
+  nixos: [python3Packages.sqlalchemy]
   ubuntu: [python3-sqlalchemy]
 python3-sympy:
   debian: [python3-sympy]
   fedora: [python3-sympy]
   gentoo: [dev-python/sympy]
+  nixos: [python3Packages.sympy]
   ubuntu: [python3-sympy]
 python3-systemd:
   debian: [python3-systemd]
+  nixos: [python3Packages.systemd]
   ubuntu: [python3-systemd]
 python3-tabulate:
   debian: [python3-tabulate]
   fedora: [python3-tabulate]
   gentoo: [dev-python/tabulate]
+  nixos: [python3Packages.tabulate]
   ubuntu: [python3-tabulate]
 python3-tensorboardX-pip:
   debian:
@@ -7295,12 +7566,14 @@ python3-termcolor:
   debian: [python3-termcolor]
   fedora: [python3-termcolor]
   gentoo: [dev-python/termcolor]
+  nixos: [python3Packages.termcolor]
   openembedded: [python3-termcolor@meta-python]
   ubuntu: [python3-termcolor]
 python3-texttable:
   debian: [python3-texttable]
   fedora: [python3-texttable]
   gentoo: [dev-python/texttable]
+  nixos: [python3Packages.texttable]
   openembedded: [python3-texttable@meta-python]
   rhel: ['python%{python3_pkgversion}-texttable']
   ubuntu: [python3-texttable]
@@ -7327,6 +7600,7 @@ python3-tilestache-pip:
 python3-tk:
   debian: [python3-tk]
   fedora: [python3-tkinter]
+  nixos: [python3Packages.tkinter]
   openembedded: [python3-tkinter@openembedded-core]
   rhel: ['python%{python3_pkgversion}-tkinter']
   ubuntu: [python3-tk]
@@ -7334,12 +7608,14 @@ python3-toml:
   debian: [python3-toml]
   fedora: [python3-toml]
   gentoo: [dev-python/toml]
+  nixos: [python3Packages.toml]
   ubuntu: [python3-toml]
 python3-tornado:
   arch: [python-tornado]
   debian: [python3-tornado]
   fedora: [python3-tornado]
   gentoo: [www-servers/tornado]
+  nixos: [python3Packages.tornado]
   openembedded: [python3-tornado@meta-python]
   osx:
     pip:
@@ -7350,6 +7626,7 @@ python3-tqdm:
   alpine: [py3-tqdm]
   debian: [python3-tqdm]
   fedora: [python3-tqdm]
+  nixos: [python3Packages.tqdm]
   osx:
     pip:
       packages: [tqdm]
@@ -7382,12 +7659,14 @@ python3-trimesh-pip:
 python3-twilio:
   debian: [python3-twilio]
   fedora: [python3-twilio]
+  nixos: [python3Packages.twilio]
   ubuntu: [python3-twilio]
 python3-twisted:
   arch: [python-twisted]
   debian: [python3-twisted]
   fedora: [python3-twisted]
   gentoo: [dev-python/twisted]
+  nixos: [python3Packages.twisted]
   openembedded: [python3-twisted@meta-python]
   rhel:
     '*': ['python%{python3_pkgversion}-twisted']
@@ -7402,10 +7681,12 @@ python3-urllib3:
   debian: [python3-urllib3]
   fedora: [python3-urllib3]
   gentoo: [dev-python/urllib3]
+  nixos: [python3Packages.urllib3]
   ubuntu: [python3-urllib3]
 python3-usb:
   debian: [python3-usb]
   gentoo: [dev-python/pyusb]
+  nixos: [python3Packages.pyusb]
   openembedded: [python3-pyusb@meta-python]
   ubuntu: [python3-usb]
 python3-vcstool:
@@ -7434,11 +7715,13 @@ python3-vedo-pip:
 python3-venv:
   debian: [python3-venv]
   fedora: [python3-libs]
+  nixos: [python3]
   ubuntu: [python3-venv]
 python3-watchdog:
   debian: [python3-watchdog]
   fedora: [python3-watchdog]
   gentoo: [dev-python/watchdog]
+  nixos: [python3Packages.watchdog]
   ubuntu: [python3-watchdog]
 python3-websocket:
   debian: [python3-websocket]
@@ -7452,6 +7735,7 @@ python3-websockets:
   debian: [python3-websockets]
   fedora: [python-websockets]
   gentoo: [dev-python/websockets]
+  nixos: [python3Packages.websockets]
   openembedded: [python3-websockets@meta-python]
   ubuntu: [python3-websockets]
 python3-werkzeug:
@@ -7472,11 +7756,13 @@ python3-whichcraft:
   debian: [python3-whichcraft]
   fedora: [python3-whichcraft]
   gentoo: [dev-python/whichcraft]
+  nixos: [python3Packages.whichcraft]
   ubuntu: [python3-whichcraft]
 python3-wxgtk4.0:
   debian: [python3-wxgtk4.0]
   fedora: [python3-wxpython4]
   gentoo: [dev-python/wxpython]
+  nixos: [python3Packages.wxPython_4_0]
   ubuntu: [python3-wxgtk4.0]
 python3-xmlschema:
   debian:
@@ -7485,6 +7771,7 @@ python3-xmlschema:
       pip:
         packages: [xmlschema]
   fedora: [python3-xmlschema]
+  nixos: [python3Packages.xmlschema]
   ubuntu:
     pip:
       packages: [xmlschema]
@@ -7493,12 +7780,14 @@ python3-xmltodict:
   arch: [python-xmltodict]
   debian: [python3-xmltodict]
   fedora: [python3-xmltodict]
+  nixos: [python3Packages.xmltodict]
   ubuntu: [python3-xmltodict]
 python3-yaml:
   alpine: [py3-yaml]
   debian: [python3-yaml]
   fedora: [python3-PyYAML]
   gentoo: [dev-python/pyyaml]
+  nixos: [python3Packages.pyyaml]
   openembedded: [python3-pyyaml@meta-python]
   osx:
     pip:
@@ -7523,6 +7812,7 @@ python3-zmq:
   debian: [python3-zmq]
   fedora: [python3-zmq]
   gentoo: [dev-python/pyzmq]
+  nixos: [python3Packages.pyzmq]
   ubuntu: [python3-zmq]
 qdarkstyle-pip:
   debian:
@@ -7601,6 +7891,7 @@ urdf2webots-pip:
 virtualenv:
   debian: [virtualenv]
   fedora: [virtualenv]
+  nixos: [python3Packages.virtualenv]
   ubuntu: [virtualenv]
 wxpython:
   arch: [wxpython]
@@ -7614,6 +7905,7 @@ wxpython:
   freebsd: [py27-wxPython]
   gentoo: [dev-python/wxpython]
   macports: [py27-wxpython, py27-gobject, py27-gtk, py27-cairo]
+  nixos: [pythonPackages.wxPython]
   openembedded: [wxpython@meta-ros-python2]
   opensuse: [python-wxGTK]
   rhel:
@@ -7638,6 +7930,7 @@ yapf:
   debian:
     buster: [yapf]
     stretch: [yapf]
+  nixos: [python3Packages.yapf]
   ubuntu:
     '*': [yapf]
     saucy:
@@ -7664,6 +7957,7 @@ yapf:
 yapf3:
   debian: [yapf3]
   fedora: [python3-yapf]
+  nixos: [python3Packages.yapf]
   ubuntu:
     '*': [yapf3]
     xenial: null

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -78,6 +78,7 @@ ruby:
   fedora: [ruby, ruby-devel, openssl-devel, rubygems]
   gentoo: [dev-lang/ruby]
   macports: [ruby]
+  nixos: [ruby]
   ubuntu:
     '*': [ruby]
     lucid: [ruby1.8-dev, libopenssl-ruby1.8, rubygems1.8]
@@ -105,12 +106,14 @@ ruby-dev:
   fedora: [ruby-devel, openssl-devel, rubygems]
   gentoo: [dev-lang/ruby]
   macports: [ruby]
+  nixos: [ruby]
   ubuntu: [ruby-dev]
 ruby-ronn:
   arch: [ruby-ronn]
   debian: [ruby-ronn]
   fedora: [rubygem-ronn]
   gentoo: [app-text/ronn]
+  nixos: [ronn]
   ubuntu: [ruby-ronn]
 ruby-sass:
   debian: [ruby-sass]


### PR DESCRIPTION
Adds rosdep keys for a large number of packages in nixpkgs. I use this with my [fork of superflore](https://github.com/lopsided98/superflore) to generate [nix-ros-overlay](https://github.com/lopsided98/nix-ros-overlay).

The following command can be used to verify that all the packages names are valid:
```
yq -r '[.[].nixos | select(.) | .[]] | unique | map("\(.).drvPath") | .[]' rosdep/*.yaml | xargs -n1 nix-instantiate --eval https://github.com/lopsided98/nix-ros-overlay/archive/refs/heads/master.tar.gz -A
```
There should be no errors like the following: 
```
error: attribute '<name>' in selection path '<name>' not found
```
There will be some errors due to packages that are currently broken in nixpkgs, or due to some packages no longer supporting Python 2. Including packages without Python 2 support is still useful for the case where I override the Python version in order to build melodic with Python 3.