### PR TITLE
move_basic: 0.4.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6446,6 +6446,22 @@ repositories:
       url: https://github.com/MarkNaeem/move_base_sequence.git
       version: main
     status: maintained
+  move_basic:
+    doc:
+      type: git
+      url: https://github.com/UbiquityRobotics/move_basic.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/UbiquityRobotics-release/move_basic-release.git
+      version: 0.4.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/UbiquityRobotics/move_basic.git
+      version: kinetic-devel
+    status: maintained
   moveit:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_basic` to `0.4.1-1`:

- upstream repository: https://github.com/UbiquityRobotics/move_basic.git
- release repository: https://github.com/UbiquityRobotics-release/move_basic-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `null`

## move_basic

```
* Removed backward drive
* Cosine Runaway safety abort
* Minimum velocity parameters
* Stop service
* Contributors: Janez Cimerman, Jim Vaughan, Mark Johnston, MoffKalast, Rohan Agrawal, Teodor Janez Podobnik
```
