### PR TITLE
iris_lama: 1.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4589,7 +4589,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/eupedrosa/iris_lama-release.git
-      version: 1.1.0-2
+      version: 1.2.0-1
     status: developed
   iris_lama_ros:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `iris_lama` to `1.2.0-1`:

- upstream repository: https://github.com/iris-ua/iris_lama.git
- release repository: https://github.com/eupedrosa/iris_lama-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `1.1.0-2`

## iris_lama

```
* Expose localization covariance
```
