### PR TITLE
iris_lama_ros: 1.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2836,7 +2836,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/eupedrosa/iris_lama_ros-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     status: developed
   ivcon:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `iris_lama_ros` to `1.2.0-1`:

- upstream repository: https://github.com/iris-ua/iris_lama_ros.git
- release repository: https://github.com/eupedrosa/iris_lama_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `1.1.0-1`

## iris_lama_ros

```
* Remove backlash from frame ids
* Fix laser orientation checks in the localization node
* Add launch file for localization node
* Remove backlash from global namespace topics
* Publish localization covariance
```
