### PR TITLE
rviz: 1.13.17-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11910,7 +11910,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.13.16-1
+      version: 1.13.17-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.13.17-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `1.13.16-1`

## rviz

```
* [maint] Switch to GHA: pre-commit + industrial_ci
* [fix]   Fix spurious resizing issue for ImageDisplay panel (#1611 <https://github.com/ros-visualization/rviz/issues/1611>)
* [fix]   ColorEditor: maintain edited text + cursor pos (#1609 <https://github.com/ros-visualization/rviz/issues/1609>)
* [fix]   Keep ColorDialog on top of main window (#1604 <https://github.com/ros-visualization/rviz/issues/1604>)
* [fix]   Fix memory leaks in dialog handling
* [fix]   Enable Mesa workaround also on Mesa 21 (#1598 <https://github.com/ros-visualization/rviz/issues/1598>)
* [fix]   Avoid shifting of text in EditableEnumProperty's lineedit
* Contributors: Martin Pecka, Robert Haschke, jeffryHo
```
