### PR TITLE
Add libgpiod-dev key.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2814,6 +2814,13 @@ libgphoto-dev:
     precise: [libgphoto2-2-dev]
     raring: [libgphoto2-2-dev]
     saucy: [libgphoto2-6-dev]
+libgpiod-dev:
+  arch: [libgpiod]
+  debian: [libgpiod-dev]
+  fedora: [libgpiod-devel]
+  opensuse: [libgpiod]
+  rhel: [libgpiod-devel]
+  ubuntu: [libgpiod-dev]
 libgps:
   arch: [gpsd]
   debian: [libgps-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2815,11 +2815,12 @@ libgphoto-dev:
     raring: [libgphoto2-2-dev]
     saucy: [libgphoto2-6-dev]
 libgpiod-dev:
-  arch: [libgpiod]
   debian: [libgpiod-dev]
   fedora: [libgpiod-devel]
-  opensuse: [libgpiod]
-  rhel: [libgpiod-devel]
+  opensuse: [libgpiod-devel]
+  rhel:
+    '*': [libgpiod-devel]
+    '7': null
   ubuntu: [libgpiod-dev]
 libgps:
   arch: [gpsd]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

libgpiod-dev

## Package Upstream Source:

https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git

## Purpose of using this:
libgpiod provides an interface to the Linux GPIO character device, which replaced the previous sysfs interface.

I'm currently using it in a package which toggles the gpio pins on a raspberry pi.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/buster/libgpiod-dev
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/bionic/libgpiod-dev
- Fedora: https://src.fedoraproject.org/browse/projects/
  - https://koji.fedoraproject.org/koji/rpminfo?rpmID=25659722
- Arch: https://www.archlinux.org/packages/
  - https://aur.archlinux.org/packages/libgpiod/
- RHEL:
  - https://koji.fedoraproject.org/koji/rpminfo?rpmID=21513967
- openSuse:
  - https://software.opensuse.org/package/libgpiod