### PR TITLE
rviz: 1.14.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6926,7 +6926,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.14.6-1
+      version: 1.14.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.14.7-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `1.14.6-1`

## rviz

```
* [maint] Switch to GHA: pre-commit + industrial_ci
* [maint] Remove unused LineEditWithButton::simulateReturnPressed() (#1608 <https://github.com/ros-visualization/rviz/issues/1608>)
* [fix]   Fix spurious resizing issue for ImageDisplay panel (#1611 <https://github.com/ros-visualization/rviz/issues/1611>)
* [fix]   ColorEditor: maintain edited text + cursor pos (#1609 <https://github.com/ros-visualization/rviz/issues/1609>)
* [fix]   Keep ColorDialog on top of main window (#1604 <https://github.com/ros-visualization/rviz/issues/1604>)
* [fix]   Fix memory leaks in dialog handling
* [fix]   Enable Mesa workaround also on Mesa 21 (#1598 <https://github.com/ros-visualization/rviz/issues/1598>)
* [fix]   Avoid shifting of text in EditableEnumProperty's lineedit
* Contributors: Martin Pecka, Robert Haschke, jeffryHo
```
