### PR TITLE
rmw_gurumdds: 0.7.11-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2523,7 +2523,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
-      version: 0.7.10-1
+      version: 0.7.11-1
     source:
       type: git
       url: https://github.com/ros2/rmw_gurumdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_gurumdds` to `0.7.11-1`:

- upstream repository: https://github.com/ros2/rmw_gurumdds.git
- release repository: https://github.com/ros2-gbp/rmw_gurumdds-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `0.7.10-1`

## rmw_gurumdds_cpp

```
* Use dds_free instead of free for dll library
* Contributors: Youngjin Yun
```

## rmw_gurumdds_shared_cpp

```
* fix typo
* Contributors: Youngjin Yun
```
