### PR TITLE
Add python3-flask-cors and python3-flask-socketio 

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6012,6 +6012,16 @@ python3-flask:
   fedora: [python3-flask]
   gentoo: [dev-python/flask]
   ubuntu: [python3-flask]
+python3-flask-cors:
+  debian: [python3-flask-cors]
+  ubuntu: [python3-flask-cors]
+python3-flask-socketio:
+  debian:
+    pip:
+      packages: [flask-socketio]
+  ubuntu:
+    pip:
+      packages: [flask-socketio]
 python3-flask-restplus-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6020,12 +6020,8 @@ python3-flask-restplus-pip:
     pip:
       packages: [flask-restplus]
 python3-flask-socketio:
-  debian:
-    pip:
-      packages: [flask-socketio]
-  ubuntu:
-    pip:
-      packages: [flask-socketio]
+  debian: [python3-flask-socketio]
+  ubuntu: [python3-flask-socketio]
 python3-future:
   debian: [python3-future]
   fedora: [python3-future]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6015,6 +6015,10 @@ python3-flask:
 python3-flask-cors:
   debian: [python3-flask-cors]
   ubuntu: [python3-flask-cors]
+python3-flask-restplus-pip:
+  ubuntu:
+    pip:
+      packages: [flask-restplus]
 python3-flask-socketio:
   debian:
     pip:
@@ -6022,10 +6026,6 @@ python3-flask-socketio:
   ubuntu:
     pip:
       packages: [flask-socketio]
-python3-flask-restplus-pip:
-  ubuntu:
-    pip:
-      packages: [flask-restplus]
 python3-future:
   debian: [python3-future]
   fedora: [python3-future]


### PR DESCRIPTION
## Package name:

`flask-cors` and `flask-socketio`

## Purpose of using this:

This is used by https://github.com/open-rmf/rmf_demos/ 's  `rmf_demos_panel` web server

## Links to Distribution Packages

### python3-flask-cors
- Debian: https://packages.debian.org/buster/python3-flask-cors
- Ubuntu: https://packages.ubuntu.com/groovy/python3-flask-cors

### flask-socketio
- Pip3: https://pypi.org/project/Flask-SocketIO/
- Note: the ubuntu package of `flask-socketio` is version 4.x . A latest version of 5.X is prefered as it not backward compatible.

Edit: After feedback, will switch back `flask-socketio` to deb and ubuntu package for consistency
