### PR TITLE
Revert "volta_simulation: 1.1.1-1 in 'melodic/distribution.yaml' [blo…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -14047,7 +14047,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/botsync-gbp/volta_simulation-release.git
-      version: 1.1.1-1
+      version: 1.1.0-2
     source:
       type: git
       url: https://github.com/botsync/volta_simulation.git


### PR DESCRIPTION
…om] (#28780)"

This reverts commit 72233cc865843d0fe365263c8e52afeab6e7bdb6.

This hasn't built since it was merged almost a month ago, so revert back to the working version for now.  @toship-botsync FYI.