### PR TITLE
picovoice-ros: 0.0.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4817,7 +4817,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/reinzor/picovoice_ros-release.git
-      version: 0.0.3-1
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/reinzor/picovoice_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `picovoice-ros` to `0.0.4-1`:

- upstream repository: https://github.com/reinzor/picovoice_ros.git
- release repository: https://github.com/reinzor/picovoice_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `0.0.3-1`

## picovoice_driver

```
* Merge pull request #3 <https://github.com/reinzor/picovoice_ros/issues/3> from reinzor/fix/cmake-system-processor
  fix(cmake): Use CMAKE_SYSTEM_PROCESSOR
* fix(cmake): Use CMAKE_SYSTEM_PROCESSOR
  Should fix the armhf build
* Contributors: Rein Appeldoorn
```

## picovoice_msgs

- No changes
