### PR TITLE
opw_kinematics: 0.4.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4629,7 +4629,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-industrial-release/opw_kinematics-release.git
-      version: 0.4.0-1
+      version: 0.4.1-2
     source:
       type: git
       url: https://github.com/Jmeyer1292/opw_kinematics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `opw_kinematics` to `0.4.1-2`:

- upstream repository: https://github.com/Jmeyer1292/opw_kinematics.git
- release repository: https://github.com/ros-industrial-release/opw_kinematics-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `0.4.0-1`

## opw_kinematics

```
* Only enable initialize_code_coverage if code coverage is enabled
* Add cpack archive package
* Add package debian github action leveraging cpack
* Add CONTRIBUTING.md
* Contributors: Levi Armstrong
```
