### PR TITLE
rmw_cyclonedds: 0.22.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1807,7 +1807,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 0.22.0-1
+      version: 0.22.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `0.22.1-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `0.22.0-1`

## rmw_cyclonedds_cpp

```
* Use the macros from Cyclone DDS to work with sample payload when using SHM (#300 <https://github.com/ros2/rmw_cyclonedds/issues/300>)
* Contributors: Sumanth Nirmal
```
