### PR TITLE
rclpy: 1.8.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1681,7 +1681,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 1.8.0-1
+      version: 1.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `1.8.1-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `1.8.0-1`

## rclpy

```
* typo fix. (#768 <https://github.com/ros2/rclpy/issues/768>)
* Restore exceptions for Connext and message timestamps on Windows (#765 <https://github.com/ros2/rclpy/issues/765>)
* Use correct type when creating test publisher (#764 <https://github.com/ros2/rclpy/issues/764>)
* Add a test for destroy_node while spinning (#663 <https://github.com/ros2/rclpy/issues/663>)
* Add __enter__ and __exit__ to Waitable (#761 <https://github.com/ros2/rclpy/issues/761>)
* Check if shutdown callback weak method is valid before calling it (#754 <https://github.com/ros2/rclpy/issues/754>)
* Contributors: Andrea Sorbini, Ivan Santiago Paunovic, Scott K Logan, Shane Loretz, Tomoya Fujita
```
