### PR TITLE
rclcpp: 9.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1665,7 +1665,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 9.0.0-1
+      version: 9.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `9.0.1-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `9.0.0-1`

## rclcpp

```
* Restore test exception for Connext (#1625 <https://github.com/ros2/rclcpp/issues/1625>)
* Fix race condition in TimeSource clock thread setup (#1623 <https://github.com/ros2/rclcpp/issues/1623>)
* Contributors: Andrea Sorbini, Michel Hidalgo
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
