### PR TITLE
Update the rolling rqt_graph branch to match release repo.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2385,7 +2385,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_graph.git
-      version: foxy-devel
+      version: galactic-devel
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2395,7 +2395,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_graph.git
-      version: foxy-devel
+      version: galactic-devel
     status: maintained
   rqt_image_view:
     doc:


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>