### PR TITLE
rqt_msg: 1.0.3-1 in 'foxy/distribution.yaml'

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3898,16 +3898,16 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_msg.git
-      version: crystal-devel
+      version: foxy-devel
     release:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_msg-release.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_msg.git
-      version: crystal-devel
+      version: foxy-devel
     status: maintained
   rqt_plot:
     doc:


### PR DESCRIPTION
This was openned manually, see https://github.com/ros/rosdistro/pull/29105#issuecomment-818079290.

The content of this description was filled manually.
For rolling, `bloom-release` gives me the content of the PR to copy-paste even when it fails, that doesn't seem to be the case when releasing for foxy.

---

Increasing version of package(s) in repository `rqt_msg` to `1.0.3-1`:

- upstream repository: https://github.com/ros-visualization/rqt_msg.git
- release repository: https://github.com/ros2-gbp/rqt_msg-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `1.0.2-1`

## rqt_msg

```
* Use rosidl_runtype_py instead of message_helpers where possible (#11 <https://github.com/ros-visualization/rqt_msg/issues/11>)
* Contributors: Ivan Santiago Paunovic
```
