### PR TITLE
rqt: 1.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3795,7 +3795,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
-      version: 1.0.7-1
+      version: 1.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `1.1.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros2-gbp/rqt-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `1.0.7-1`

## rqt

- No changes

## rqt_gui

- No changes

## rqt_gui_cpp

- No changes

## rqt_gui_py

```
* Fix a crash at shutdown (#248 <https://github.com/ros-visualization/rqt/issues/248>)
* Contributors: Michael Jeronimo
```

## rqt_py_common

- No changes
