### PR TITLE
robot_body_filter: 1.1.8-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5545,6 +5545,21 @@ repositories:
       url: https://github.com/ros-drivers/rgbd_launch.git
       version: noetic-devel
     status: maintained
+  robot_body_filter:
+    doc:
+      type: git
+      url: https://github.com/peci1/robot_body_filter.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/peci1/robot_body_filter-release.git
+      version: 1.1.8-3
+    source:
+      type: git
+      url: https://github.com/peci1/robot_body_filter.git
+      version: master
+    status: maintained
   robot_calibration:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_body_filter` to `1.1.8-3`:

- upstream repository: https://github.com/peci1/robot_body_filter
- release repository: https://github.com/peci1/robot_body_filter-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `null`

## robot_body_filter

```
* Fixed typo.
* Contributors: Martin Pecka
```
