### PR TITLE
sros2: 0.10.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2678,7 +2678,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.10.1-1
+      version: 0.10.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.10.2-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `0.10.1-1`

## sros2

```
* Skip mypy test on platforms using importlib_resources (#258 <https://github.com/ros2/sros2/issues/258>)
* Enable topic "ros_discovery_info" for rmw_connextdds (#253 <https://github.com/ros2/sros2/issues/253>)
* Declare missing dependency on python3-importlib-resources (#249 <https://github.com/ros2/sros2/issues/249>)
  Co-authored-by:  <mailto:mikael.arguedas@gmail.com>
* Fix namedtuple names. (#250 <https://github.com/ros2/sros2/issues/250>)
* Contributors: Andrea Sorbini, Chris Lalancette, Scott K Logan, Mikael Arguedas
```

## sros2_cmake

- No changes
