### PR TITLE
qt_gui_core: 0.3.18-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11282,7 +11282,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.3.17-1
+      version: 0.3.18-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `0.3.18-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros-gbp/qt_gui_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `0.3.17-1`

## qt_dotgraph

```
* Update Maintainers (#240 <https://github.com/ros-visualization/qt_gui_core/issues/240>) (#241 <https://github.com/ros-visualization/qt_gui_core/issues/241>)
* Contributors: Shane Loretz
```

## qt_gui

```
* Update Maintainers (#240 <https://github.com/ros-visualization/qt_gui_core/issues/240>) (#241 <https://github.com/ros-visualization/qt_gui_core/issues/241>)
* Contributors: Shane Loretz
```

## qt_gui_app

```
* Update Maintainers (#240 <https://github.com/ros-visualization/qt_gui_core/issues/240>) (#241 <https://github.com/ros-visualization/qt_gui_core/issues/241>)
* Contributors: Shane Loretz
```

## qt_gui_cpp

```
* Update Maintainers (#240 <https://github.com/ros-visualization/qt_gui_core/issues/240>) (#241 <https://github.com/ros-visualization/qt_gui_core/issues/241>)
* Contributors: Shane Loretz
```

## qt_gui_py_common

```
* Update Maintainers (#240 <https://github.com/ros-visualization/qt_gui_core/issues/240>) (#241 <https://github.com/ros-visualization/qt_gui_core/issues/241>)
* Contributors: Shane Loretz
```
