### PR TITLE
genpy: 0.6.15-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4191,7 +4191,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/genpy-release.git
-      version: 0.6.14-1
+      version: 0.6.15-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genpy` to `0.6.15-1`:

- upstream repository: git@github.com:ros/genpy.git
- release repository: https://github.com/ros-gbp/genpy-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `0.6.14-1`

## genpy

```
* Update maintainers (#135 <https://github.com/ros/genpy/issues/135>)
* Check for Python 3 before looking up codec (#134 <https://github.com/ros/genpy/issues/134>)
* Add check for float32 and float64 to check_type (#131 <https://github.com/ros/genpy/issues/131>)
* Contributors: Dirk Thomas, Martin Günther, Shane Loretz
```
