### PR TITLE
genpy: 0.6.15-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3515,7 +3515,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/genpy-release.git
-      version: 0.6.14-1
+      version: 0.6.15-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genpy` to `0.6.15-1`:

- upstream repository: https://github.com/ros/genpy.git
- release repository: https://github.com/ros-gbp/genpy-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `0.6.14-1`

## genpy

```
* Update maintainers (#135 <https://github.com/ros/genpy/issues/135>)
* Check for Python 3 before looking up codec (#134 <https://github.com/ros/genpy/issues/134>)
* Add check for float32 and float64 to check_type (#131 <https://github.com/ros/genpy/issues/131>)
* Contributors: Dirk Thomas, Martin Günther, Shane Loretz
```
