### PR TITLE
osqp_vendor: 0.0.3-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2182,7 +2182,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/tier4/osqp_vendor-release.git
-      version: 0.0.2-1
+      version: 0.0.3-2
     source:
       type: git
       url: https://github.com/tier4/osqp_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `osqp_vendor` to `0.0.3-2`:

- upstream repository: https://github.com/tier4/osqp_vendor.git
- release repository: https://github.com/tier4/osqp_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `0.0.2-1`
