### PR TITLE
geometric_shapes: 2.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1160,7 +1160,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/moveit/geometric_shapes-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `2.0.1-1`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/moveit/geometric_shapes-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `2.0.0-1`

## geometric_shapes

```
* Set target compile options in cmake for warnings
* [fix] cmake install command (#164 <https://github.com/ros-planning/geometric_shapes/issues/164>)
* Contributors: Tyler Weaver
```
