### PR TITLE
srdfdom: 2.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4254,7 +4254,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/moveit/srdfdom-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ros-planning/srdfdom.git


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom` to `2.0.1-1`:

- upstream repository: https://github.com/ros-planning/srdfdom.git
- release repository: https://github.com/moveit/srdfdom-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `2.0.0-1`

## srdfdom

```
* SRDFWriter: Add functionality to generate xml for the joint properties
* Add a new JointProperties xml tag
* Add diff_drive type to virtual joints
* [fix] export cmake library install (#76 <https://github.com/ros-planning/srdfdom/issues/76>)
* Contributors: David V. Lu, Jafar Abdi, Mark Moll, Robert Haschke, Tyler Weaver
```
