### PR TITLE
moveit: 2.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1831,27 +1831,34 @@ repositories:
       version: main
     release:
       packages:
+      - moveit
       - moveit_common
       - moveit_core
       - moveit_fake_controller_manager
       - moveit_kinematics
+      - moveit_planners
       - moveit_planners_ompl
+      - moveit_plugins
+      - moveit_ros
       - moveit_ros_benchmarks
       - moveit_ros_move_group
       - moveit_ros_occupancy_map_monitor
+      - moveit_ros_perception
       - moveit_ros_planning
       - moveit_ros_planning_interface
       - moveit_ros_robot_interaction
       - moveit_ros_visualization
       - moveit_ros_warehouse
+      - moveit_runtime
       - moveit_servo
       - moveit_simple_controller_manager
       - run_move_group
       - run_moveit_cpp
+      - run_ompl_constrained_planning
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/moveit/moveit2-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.1.1-1`:

- upstream repository: https://github.com/ros-planning/moveit2.git
- release repository: https://github.com/moveit/moveit2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `2.1.0-1`

## moveit

```
* Add black formatter (#392 <https://github.com/ros-planning/moveit2/issues/392>)
* Enable linting of moveit package (#378 <https://github.com/ros-planning/moveit2/issues/378>)
* Enable ament_lint tests (#340 <https://github.com/ros-planning/moveit2/issues/340>)
* Compile metapackages
* Contributors: Henning Kayser, Tyler Weaver
```

## moveit_common

```
* Enable linting for moveit_common package (#379 <https://github.com/ros-planning/moveit2/issues/379>)
* Enable ament_lint tests (#340 <https://github.com/ros-planning/moveit2/issues/340>)
* Fix repo URLs in package.xml files
* Contributors: Henning Kayser, Tyler Weaver
```

## moveit_core

```
* Update doxygen comments for distance() and interpolate() (#401 <https://github.com/ros-planning/moveit2/issues/401>)
* Add differential drive joint model (#390 <https://github.com/ros-planning/moveit2/issues/390>)
  * RobotModelBuilder: Add new function addJointProperty to add a property for a joint
  * Add angular_distance_weight joint property
  * Add motion_model joint property
  * Add min_translational_distance joint property
* Add initialize function for moveit_sensor_manager plugin (#386 <https://github.com/ros-planning/moveit2/issues/386>)
* Eliminate ability to keep multiple collision detectors updated (#364 <https://github.com/ros-planning/moveit2/issues/364>)
  * Fix seg faults in setCollisionDetectorType()
  * Add unit test for switching collision detector types
* Port of Bullet collision to ROS2 (#322 <https://github.com/ros-planning/moveit2/issues/322>)
* Fix EXPORT install in CMake (#372 <https://github.com/ros-planning/moveit2/issues/372>)
* Bug fixes in main branch (#362 <https://github.com/ros-planning/moveit2/issues/362>)
  * robot_trajectory: Fix bugs in getRobotTrajectoryMsg function
  * controller_manager: Use Duration(-1) as infinite timeout
  * ActionBasedControllerHandle: fix dangling reference in case of timeout
  * TfPublisher: tf frame name can't start with '/'
* Sync main branch with MoveIt 1 from previous head https://github.com/ros-planning/moveit/commit/0247ed0027ca9d7f1a7f066e62c80c9ce5dbbb5e up to https://github.com/ros-planning/moveit/commit/74b3e30db2e8683ac17b339cc124675ae52a5114
* [fix] export cmake library install (#339 <https://github.com/ros-planning/moveit2/issues/339>)
* Clean up collision-related log statements (#2480 <https://github.com/ros-planning/moveit2/issues/2480>)
* Fix RobotState::dropAccelerations/dropEffort to not drop velocities (#2478 <https://github.com/ros-planning/moveit2/issues/2478>)
* Provide a function to set the position of active joints in a JointModelGroup (#2456 <https://github.com/ros-planning/moveit2/issues/2456>)
  * RobotState::setJointGroupPositions: assert correct size of  vector
  * setJointGroupActivePositions sets only the positions of active joints
  * implement JointModelGroup::getActiveVariableCount
* Fix doxygen documentation for setToIKSolverFrame (#2461 <https://github.com/ros-planning/moveit2/issues/2461>)
  * Fix doxygen documentation for setToIKSolverFrame
  * "Convert" -> "Transform"
  * Make function private. Update comments.
  * Make inline and private
  * Longer function should not be inline
* Fix validation of orientation constraints (#2434 <https://github.com/ros-planning/moveit2/issues/2434>)
* RobotModelBuilder: Add parameter to specify the joint rotation axis
* RobotModelBuilder: Allow adding end effectors (#2454 <https://github.com/ros-planning/moveit2/issues/2454>)
* Delete CollisionRequest min_cost_density
* Fix OrientationConstraint::decide (#2414 <https://github.com/ros-planning/moveit2/issues/2414>)
* Changed processing_thread_ spin to use std::make_unique instead of new (#2412 <https://github.com/ros-planning/moveit2/issues/2412>)
* Update collision-related comments (#2382 <https://github.com/ros-planning/moveit2/issues/2382>) (#2388 <https://github.com/ros-planning/moveit2/issues/2388>)
* Contributors: AndyZe, David V. Lu!!, Henning Kayser, Jafar Abdi, Jorge Nicho, Robert Haschke, Simon Schmeisser, Stuart Anderson, Thomas G, Tyler Weaver, sevangelatos
```

## moveit_fake_controller_manager

```
* Enable ament_lint tests (#340 <https://github.com/ros-planning/moveit2/issues/340>)
* Fix EXPORT install in CMake (#372 <https://github.com/ros-planning/moveit2/issues/372>)
* Fix repo URLs in package.xml files
* Contributors: Henning Kayser, Tyler Weaver
```

## moveit_kinematics

```
* Fix EXPORT install in CMake (#372 <https://github.com/ros-planning/moveit2/issues/372>)
* Sync main branch with MoveIt 1 from previous head https://github.com/ros-planning/moveit/commit/0247ed0027ca9d7f1a7f066e62c80c9ce5dbbb5e up to https://github.com/ros-planning/moveit/commit/74b3e30db2e8683ac17b339cc124675ae52a5114
* [fix] export cmake library install (#339 <https://github.com/ros-planning/moveit2/issues/339>)
* Python3 compatibility for ikfast's round_collada_numbers.py (#2473 <https://github.com/ros-planning/moveit2/issues/2473>)
* Fix repo URLs in package.xml files
* Contributors: Henning Kayser, Jafar Abdi, Tobias Fischer, Tyler Weaver
```

## moveit_planners

```
* Enable ament_lint tests (#340 <https://github.com/ros-planning/moveit2/issues/340>)
* Fix repo URLs in package.xml files
* Compile metapackages
* Contributors: Henning Kayser, Tyler Weaver
```

## moveit_planners_ompl

```
* Add differential drive joint model (#390 <https://github.com/ros-planning/moveit2/issues/390>)
* Fix EXPORT install in CMake (#372 <https://github.com/ros-planning/moveit2/issues/372>)
* OMPL constrained planning (#347 <https://github.com/ros-planning/moveit2/issues/347>)
  Co-authored-by: JeroenDM <mailto:jeroendemaeyer@live.be>
* [fix] export cmake library install (#339 <https://github.com/ros-planning/moveit2/issues/339>)
* Fix repo URLs in package.xml files
* Contributors: Boston Cleek, David V. Lu!!, Henning Kayser, Tyler Weaver
```

## moveit_plugins

```
* Enable ament_lint tests (#340 <https://github.com/ros-planning/moveit2/issues/340>)
* Compile metapackages
* Contributors: Henning Kayser, Tyler Weaver
```

## moveit_ros

```
* Enable ament_lint tests (#340 <https://github.com/ros-planning/moveit2/issues/340>)
* Fix repo URLs in package.xml files
* Compile metapackages
* Contributors: Henning Kayser, Tyler Weaver
```

## moveit_ros_benchmarks

```
* Fix EXPORT install in CMake (#372 <https://github.com/ros-planning/moveit2/issues/372>)
* Fix repo URLs in package.xml files
* Contributors: Henning Kayser, Tyler Weaver
```

## moveit_ros_move_group

```
* Fix EXPORT install in CMake (#372 <https://github.com/ros-planning/moveit2/issues/372>)
* TfPublisher: tf frame name can't start with '/'
* [fix] Export libs for MoveGroup capabilities and MoveItSimpleControllerManager (#344 <https://github.com/ros-planning/moveit2/issues/344>)
* Fix repo URLs in package.xml files
* Contributors: Boston Cleek, Henning Kayser, Jafar Abdi, Tyler Weaver
```

## moveit_ros_occupancy_map_monitor

```
* Fix EXPORT install in CMake (#372 <https://github.com/ros-planning/moveit2/issues/372>)
* Porting moveit_ros_perception/pointcloud_octomap_updater (#307 <https://github.com/ros-planning/moveit2/issues/307>)
* Fix repo URLs in package.xml files
* Contributors: Henning Kayser, Tyler Weaver, Yu Yan
```

## moveit_ros_perception

```
* Fix porting errors in depth_image_octomap_updater (#383 <https://github.com/ros-planning/moveit2/issues/383>)
  * Fix error of not being able to receive depth image
  * Fix mismatching time source
* Port moveit_ros_perception/depth_image_octomap_updater (#354 <https://github.com/ros-planning/moveit2/issues/354>)
* Fix EXPORT install in CMake (#372 <https://github.com/ros-planning/moveit2/issues/372>)
* [fix] export cmake library install (#339 <https://github.com/ros-planning/moveit2/issues/339>)
* Porting moveit_ros_perception/pointcloud_octomap_updater (#307 <https://github.com/ros-planning/moveit2/issues/307>)
* Fix repo URLs in package.xml files
* Contributors: Henning Kayser, Tyler Weaver, Yu Yan
```

## moveit_ros_planning

```
* Declare joint limit parameters (#408 <https://github.com/ros-planning/moveit2/issues/408>)
* Add initialize function for moveit_sensor_manager plugin (#386 <https://github.com/ros-planning/moveit2/issues/386>)
* Eliminate ability to keep multiple collision detectors updated (#364 <https://github.com/ros-planning/moveit2/issues/364>)
* Fix EXPORT install in CMake (#372 <https://github.com/ros-planning/moveit2/issues/372>)
* Sync main branch with MoveIt 1 from previous head https://github.com/ros-planning/moveit/commit/0247ed0027ca9d7f1a7f066e62c80c9ce5dbbb5e up to https://github.com/ros-planning/moveit/commit/74b3e30db2e8683ac17b339cc124675ae52a5114
* [fix] export cmake library install (#339 <https://github.com/ros-planning/moveit2/issues/339>)
* MTC compatibility fixes (#323 <https://github.com/ros-planning/moveit2/issues/323>)
* trajectory_execution_manager: Fix creating duration from double
* current_state_monitor: Fix creating duration from double & converting duration to seconds
* Fix some typos in comments (#2466 <https://github.com/ros-planning/moveit2/issues/2466>)
* Fix repo URLs in package.xml files
* Contributors: AndyZe, Boston Cleek, Henning Kayser, Jafar Abdi, Tyler Weaver, Udbhavbisarya23, Yu Yan
```

## moveit_ros_planning_interface

```
* Update launch files to use ros2 control spawner (#405 <https://github.com/ros-planning/moveit2/issues/405>)
* Use fake_components::GenericSystem from ros2_control (#361 <https://github.com/ros-planning/moveit2/issues/361>)
* Solved small issue with a message not being logged due to an early return statement (#368 <https://github.com/ros-planning/moveit2/issues/368>)
* OMPL constrained planning (#347 <https://github.com/ros-planning/moveit2/issues/347>)
* Sync main branch with MoveIt 1 from previous head https://github.com/ros-planning/moveit/commit/0247ed0027ca9d7f1a7f066e62c80c9ce5dbbb5e up to https://github.com/ros-planning/moveit/commit/74b3e30db2e8683ac17b339cc124675ae52a5114
* [fix] MGI server timeout, infinite duration by default (#349 <https://github.com/ros-planning/moveit2/issues/349>)
  By setting the default server timeout duration to -1, the MoveGroupInterface is ensured to be ready to use after construction.
* [fix] export cmake library install (#339 <https://github.com/ros-planning/moveit2/issues/339>)
* Fix scaling factor parameter names (#2452 <https://github.com/ros-planning/moveit2/issues/2452>)
* MTC compatibility fixes (#323 <https://github.com/ros-planning/moveit2/issues/323>)
* Fix node remapping
* Make sure planning scene interface have a unique name for the internal node
* planning_scene_interface: Fix node name being empty
* Fix repo URLs in package.xml files
* Contributors: Boston Cleek, FlorisE, Henning Kayser, Jafar Abdi, Shota Aoki, Tyler Weaver
```

## moveit_ros_robot_interaction

```
* Enable ament_lint tests (#340 <https://github.com/ros-planning/moveit2/issues/340>)
* Fix EXPORT install in CMake (#372 <https://github.com/ros-planning/moveit2/issues/372>)
* Sync main branch with MoveIt 1 from previous head https://github.com/ros-planning/moveit/commit/0247ed0027ca9d7f1a7f066e62c80c9ce5dbbb5e up to https://github.com/ros-planning/moveit/commit/74b3e30db2e8683ac17b339cc124675ae52a5114
* [fix] export cmake library install (#339 <https://github.com/ros-planning/moveit2/issues/339>)
* Fix repo URLs in package.xml files
* Contributors: Henning Kayser, Jafar Abdi, Robert Haschke, Tyler Weaver
```

## moveit_ros_visualization

```
* Fix EXPORT install in CMake (#372 <https://github.com/ros-planning/moveit2/issues/372>)
* Add a private node to the interactive marker display (#342 <https://github.com/ros-planning/moveit2/issues/342>)
* Sync main branch with MoveIt 1 from previous head https://github.com/ros-planning/moveit/commit/0247ed0027ca9d7f1a7f066e62c80c9ce5dbbb5e up to https://github.com/ros-planning/moveit/commit/74b3e30db2e8683ac17b339cc124675ae52a5114
* [fix] export cmake likbrary install (#339 <https://github.com/ros-planning/moveit2/issues/339>)
* MTC compatibility fixes (#323 <https://github.com/ros-planning/moveit2/issues/323>)
* Remove redundant exports
* moveit_ros_visualization: export libraries and include directory
* Catch exceptions during RobotModel loading in rviz (#2468 <https://github.com/ros-planning/moveit2/issues/2468>)
* Fix repo URLs in package.xml files
* Contributors: Henning Kayser, Jafar Abdi, Simon Schmeisser, Tyler Weaver
```

## moveit_ros_warehouse

```
* Fix EXPORT install in CMake (#372 <https://github.com/ros-planning/moveit2/issues/372>)
* [fix] export cmake library install (#339 <https://github.com/ros-planning/moveit2/issues/339>)
* Fix repo URLs in package.xml files
* Contributors: Henning Kayser, Tyler Weaver
```

## moveit_runtime

```
* Enable ament_lint tests (#340 <https://github.com/ros-planning/moveit2/issues/340>)
* Compile metapackages
* Contributors: Henning Kayser, Tyler Weaver
```

## moveit_servo

```
* Do not output positions at all if they are set to false (#410 <https://github.com/ros-planning/moveit2/issues/410>)
* Update launch files to use ros2 control spawner (#405 <https://github.com/ros-planning/moveit2/issues/405>)
* Include boost optional in pose_tracking (#406 <https://github.com/ros-planning/moveit2/issues/406>)
* Use fake_components::GenericSystem from ros2_control (#361 <https://github.com/ros-planning/moveit2/issues/361>)
* Fix EXPORT install in CMake (#372 <https://github.com/ros-planning/moveit2/issues/372>)
* moveit servo: fix constructing duration from double & fix bug in insertRedundantPointsIntoTrajectory function (#374 <https://github.com/ros-planning/moveit2/issues/374>)
* port pose tracking (#320 <https://github.com/ros-planning/moveit2/issues/320>)
* Fix 'start_servo' service topic in demo
* Sync main branch with MoveIt 1 from previous head https://github.com/ros-planning/moveit/commit/0247ed0027ca9d7f1a7f066e62c80c9ce5dbbb5e up to https://github.com/ros-planning/moveit/commit/74b3e30db2e8683ac17b339cc124675ae52a5114
* Protect paused_ flag, for thread safety (#2494 <https://github.com/ros-planning/moveit2/issues/2494>)
* Do not break out of loop -- need to update low pass filters (#2496 <https://github.com/ros-planning/moveit2/issues/2496>)
* [Servo] Fix initial angle error is always 0 (#2464 <https://github.com/ros-planning/moveit2/issues/2464>)
* Add an important sleep in Servo pose tracking (#2463 <https://github.com/ros-planning/moveit2/issues/2463>)
* Prevent moveit_servo transforms between fixed frames from causing timeout (#2418 <https://github.com/ros-planning/moveit2/issues/2418>)
* [feature] Low latency mode (#2401 <https://github.com/ros-planning/moveit2/issues/2401>)
* Move timer initialization down to fix potential race condition
* Contributors: Abishalini Sivaraman, AdamPettinger, AndyZe, Boston Cleek, Henning Kayser, Jafar Abdi, Nathan Brooks, Tyler Weaver
```

## moveit_simple_controller_manager

```
* Fix EXPORT install in CMake (#372 <https://github.com/ros-planning/moveit2/issues/372>)
* ActionBasedControllerHandle: fix dangling reference in case of timeout
* [fix] Export libs for MoveGroup capabilities and MoveItSimpleControllerManager (#344 <https://github.com/ros-planning/moveit2/issues/344>)
* MTC compatibility fixes (#323 <https://github.com/ros-planning/moveit2/issues/323>)
* Replace workaround for controllerDoneCallback with promise/future
* moveit_simple_controller_manager: Fix waiting for execution
* Fix repo URLs in package.xml files
* Contributors: Boston Cleek, Henning Kayser, Jafar Abdi, Tyler Weaver
```

## run_move_group

```
* Update launch files to use ros2 control spawner (#405 <https://github.com/ros-planning/moveit2/issues/405>)
* Use fake_components::GenericSystem from ros2_control (#361 <https://github.com/ros-planning/moveit2/issues/361>)
* Fix EXPORT install in CMake (#372 <https://github.com/ros-planning/moveit2/issues/372>)
* MTC compatibility fixes (#323 <https://github.com/ros-planning/moveit2/issues/323>)
* Fix node remapping
* Contributors: Henning Kayser, Jafar Abdi, Tyler Weaver
```

## run_moveit_cpp

```
* Update launch files to use ros2 control spawner (#405 <https://github.com/ros-planning/moveit2/issues/405>)
* Use fake_components::GenericSystem from ros2_control (#361 <https://github.com/ros-planning/moveit2/issues/361>)
* Fix EXPORT install in CMake (#372 <https://github.com/ros-planning/moveit2/issues/372>)
* Contributors: Jafar Abdi, Tyler Weaver
```

## run_ompl_constrained_planning

```
* Update launch files to use ros2 control spawner (#405 <https://github.com/ros-planning/moveit2/issues/405>)
* Use fake_components::GenericSystem from ros2_control (#361 <https://github.com/ros-planning/moveit2/issues/361>)
* Fix EXPORT install in CMake (#372 <https://github.com/ros-planning/moveit2/issues/372>)
* Contributors: Boston Cleek, Jafar Abdi, Tyler Weaver
```
