### PR TITLE
Update python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4826,6 +4826,10 @@ python-tensorflow-pip:
   ubuntu:
     pip:
       packages: [tensorflow]
+python-tensorflow-serving-api-pip:
+  ubuntu:
+    pip:
+      packages: [tensorflow-serving-api]
 python-termcolor:
   debian:
     buster: [python-termcolor]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4827,6 +4827,15 @@ python-tensorflow-pip:
     pip:
       packages: [tensorflow]
 python-tensorflow-serving-api-pip:
+  debian:
+    pip:
+      packages: [tensorflow-serving-api]
+  fedora:
+    pip:
+      packages: [tensorflow-serving-api]]
+  osx:
+    pip:
+      packages: [tensorflow-serving-api]]
   ubuntu:
     pip:
       packages: [tensorflow-serving-api]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4832,10 +4832,10 @@ python-tensorflow-serving-api-pip:
       packages: [tensorflow-serving-api]
   fedora:
     pip:
-      packages: [tensorflow-serving-api]]
+      packages: [tensorflow-serving-api]
   osx:
     pip:
-      packages: [tensorflow-serving-api]]
+      packages: [tensorflow-serving-api]
   ubuntu:
     pip:
       packages: [tensorflow-serving-api]


### PR DESCRIPTION
TensorFlow Serving API support would be appreciated :) 
https://pypi.org/project/tensorflow-serving-api/

Please add the following dependency to the rosdep database.

## Package name:

tensorflow-serving-api

## Package Upstream Source:

https://github.com/tensorflow/serving

## Purpose of using this:

This dependency enables the usage of the TensorFlow Serving API which helps to deploy NNs easy into production. In my case, I can easily run NNs in an enclosed Docker and do inference. 

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/
  - not available
- Ubuntu: https://packages.ubuntu.com/
   - not available
- Fedora: https://src.fedoraproject.org/browse/projects/
  - not available
