### PR TITLE
Update Foxy source branch to 2.1.x

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1018,7 +1018,7 @@ repositories:
       test_pull_requests: false
       type: git
       url: https://github.com/eProsima/Fast-DDS.git
-      version: 2.0.x
+      version: 2.1.x
     status: maintained
   filters:
     doc:


### PR DESCRIPTION
Parallel change to https://github.com/ros2/ros2/pull/1113.
The discussion is in the linked PR and this change should be merged if and only if that one is as well.