### PR TITLE
rviz_visual_tools: 4.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4116,6 +4116,20 @@ repositories:
       url: https://github.com/ros2/rviz.git
       version: foxy
     status: maintained
+  rviz_visual_tools:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/rviz_visual_tools.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/PickNikRobotics/rviz_visual_tools-release.git
+      version: 4.0.0-1
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/rviz_visual_tools.git
+      version: foxy-devel
   sbg_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `4.0.0-1`:

- upstream repository: https://github.com/PickNikRobotics/rviz_visual_tools.git
- release repository: https://github.com/PickNikRobotics/rviz_visual_tools-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `null`

## rviz_visual_tools

```
* Fix warning about deprecation (#180 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/180>)
  rclcpp::executor::FutureReturnCode was removed
* Update to offer shared_ptr to create_timer
* Fix rviz_visual_tools_gui (#147 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/147>)
* Compilation for Windows (#143 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/143>)
* Remove stl file in preparation for LFS setup (#140 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/140>)
* Add function deleteMarker: deletes marker for given namespace and id (#137 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/137>)
* fix waitForSubscriber time (#142 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/142>)
* Eloquent cleanup (#135 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/135>)
  * some misc cleanup of the imarker simple lib
  * actually reset marker counts
  * changes for using IMarker simple as a library
* Fix rviz warnings about scale and uninitialized quaternions (#129 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/129>)
* Normalize interactive marker quaternions. (#132 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/132>)
* normalize before publish (#131 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/131>)
* New helper function getIdentityPose() (#122 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/122>)
* For ABCD planes: better comments, ensure the plane equation is satisfied. (#120 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/120>)
  Co-Authored-By: Henning Kayser <mailto:henningkayser@picknik.ai>
* Make rviz_visual_tools publish triangle mesh and tf_visual_tools clean published transforms (#117 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/117>)
  * Add clearAllTransform method to tf_visual_tools
  * Add new function to publish mesh marker from triangles and vertices
* Publish plane from Ax+By+Cz+D=0 equation (#119 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/119>)
* Fixed publishCylinder namespace (#109 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/109>)
* Remove default arguments to make function calls not ambiguous (#112 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/112>)
* Initialize quaternions in demo to avoid warning (#111 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/111>)
* Fix node type in demo launch files (#110 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/110>)
* Use LOGNAME for logging re:moveit styel (#106 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/106>)
* Contributors: AndyZe, Bjar Ne, Dave Coleman, Jafar Abdi, Mike Lautman, Mori, MoriKen, Nathan Brooks, Sean Yen, Victor Lamoine, Yu Yan, d-walsh, hshose
```
