### PR TITLE
razor_imu_9dof: 1.3.0-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11553,16 +11553,16 @@ repositories:
   razor_imu_9dof:
     doc:
       type: git
-      url: https://github.com/KristofRobot/razor_imu_9dof.git
+      url: https://github.com/ENSTABretagneRobotics/razor_imu_9dof.git
       version: indigo-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/KristofRobot/razor_imu_9dof-release.git
+      url: https://github.com/ENSTABretagneRobotics/razor_imu_9dof-release.git
       version: 1.3.0-2
     source:
       type: git
-      url: https://github.com/KristofRobot/razor_imu_9dof.git
+      url: https://github.com/ENSTABretagneRobotics/razor_imu_9dof.git
       version: indigo-devel
     status: maintained
   rb1_base_common:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11559,7 +11559,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/KristofRobot/razor_imu_9dof-release.git
-      version: 1.2.0-0
+      version: 1.3.0-2
     source:
       type: git
       url: https://github.com/KristofRobot/razor_imu_9dof.git


### PR DESCRIPTION
Increasing version of package(s) in repository `razor_imu_9dof` to `1.3.0-2`:

- upstream repository: https://github.com/ENSTABretagneRobotics/razor_imu_9dof.git
- release repository: https://github.com/ENSTABretagneRobotics/razor_imu_9dof-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `1.2.0-0`

## razor_imu_9dof

```
* Adding firmware support for SPX-15846 and DEV-16832 (OpenLog Artemis) (lebarsfa)
```
