### PR TITLE
razor_imu_9dof: 1.3.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9500,6 +9500,21 @@ repositories:
       url: https://github.com/rt-net/raspimouse_sim.git
       version: melodic-devel
     status: developed
+  razor_imu_9dof:
+    doc:
+      type: git
+      url: https://github.com/ENSTABretagneRobotics/razor_imu_9dof.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ENSTABretagneRobotics/razor_imu_9dof-release.git
+      version: 1.3.0-2
+    source:
+      type: git
+      url: https://github.com/ENSTABretagneRobotics/razor_imu_9dof.git
+      version: indigo-devel
+    status: maintained
   rc_cloud_accumulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `razor_imu_9dof` to `1.3.0-2`:

- upstream repository: https://github.com/ENSTABretagneRobotics/razor_imu_9dof.git
- release repository: https://github.com/ENSTABretagneRobotics/razor_imu_9dof-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `null`

## razor_imu_9dof

```
* Adding firmware support for SPX-15846 and DEV-16832 (OpenLog Artemis) (lebarsfa)
```
