### PR TITLE
razor_imu_9dof: 1.3.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5344,6 +5344,21 @@ repositories:
       url: https://github.com/NewEagleRaptor/raptor-dbw-ros.git
       version: master
     status: maintained
+  razor_imu_9dof:
+    doc:
+      type: git
+      url: https://github.com/ENSTABretagneRobotics/razor_imu_9dof.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ENSTABretagneRobotics/razor_imu_9dof-release.git
+      version: 1.3.0-2
+    source:
+      type: git
+      url: https://github.com/ENSTABretagneRobotics/razor_imu_9dof.git
+      version: indigo-devel
+    status: maintained
   rc_common_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `razor_imu_9dof` to `1.3.0-2`:

- upstream repository: https://github.com/ENSTABretagneRobotics/razor_imu_9dof.git
- release repository: https://github.com/ENSTABretagneRobotics/razor_imu_9dof-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `null`

## razor_imu_9dof

```
* Adding firmware support for SPX-15846 and DEV-16832 (OpenLog Artemis) (lebarsfa)
```
