### PR TITLE
add python3-lgsvl-lib in 'rosdep/python3.yaml'

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6254,6 +6254,15 @@ python3-lark-parser:
     '*': [python3-lark]
     bionic: [python3-lark-parser]
     xenial: [python3-lark-parser]
+python3-lgsvl-lib:
+  arch:
+    pip:
+      packages: [git+https://github.com/lgsvl/PythonAPI.git]
+      version: 2021.1
+  ubuntu:
+    pip:
+      packages: [git+https://github.com/lgsvl/PythonAPI.git]
+      version: 2021.1
 python3-lttng:
   alpine: [py3-lttng]
   debian: [python3-lttng]


### PR DESCRIPTION
Add lgsvl(Python API) in python3.yaml to install third-party-librarys by
rosdep. Those libs aim to control SVL simulator by python script.

<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

A Python API of lgsvl to control SVL Simulator by python script. 

## Package Upstream Source:

https://github.com/lgsvl/PythonAPI

## Purpose of using this:

Some people might use source code to install ros2 foxy and [autoware.auto](file:///home/yanraywang/adehome/AutowareAuto/docs/_build/html/installation-no-ade.html). This dependency helps them to install simulator-related libraries easily. This dependency is being used for this reason. This is why I think it's valuable to be added to the rosdep database. 

Distro packaging links:

## Links to Distribution Packages

**Not sure on this point.**

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/
   - REQUIRED
- Fedora: https://src.fedoraproject.org/browse/projects/
  - IF AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE



<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

https://github.com/YanrayWang/rosdistro/blob/master/rosdep/python.yaml#L6257

# The source is here: 

https://github.com/lgsvl/PythonAPI


# Checks
 - [ ] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro

# Note

This is not a standard python library installed by pip/pip3. But it does a python third-party-library. I found there is no github links in rosdep/python3.yaml. It looks fine the rosdep would use `sudo -H pip3 install -U git+https://github.com/lgsvl/PythonAPI.git` to install the libraries. However, I still need to pin the version so I added 2021.1. I'm not sure whether this would work. Furthermore, I found out when installation is done, it prints `Successfully installed lgsvl-0.0.0
ERROR: the following rosdeps failed to install
  pip: Failed to detect successful installation of [git+https://github.com/lgsvl/PythonAPI.git]
` I think it's not a standard library, so it's not detected by rosdep, is it right? Please help me with this, appreciate it! 