### PR TITLE
jderobot_drones: 1.3.8-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4778,7 +4778,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/JdeRobot/drones-release.git
-      version: 1.3.7-3
+      version: 1.3.8-1
     source:
       type: git
       url: https://github.com/JdeRobot/drones.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_drones` to `1.3.8-1`:

- upstream repository: https://github.com/JdeRobot/drones.git
- release repository: https://github.com/JdeRobot/drones-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `1.3.7-3`

## drone_assets

```
* Added urdf as installed dir
* Contributors: pariaspe
```

## drone_wrapper

- No changes

## jderobot_drones

```
* Added urdf dir to drone_assets
* Contributors: pariaspe
```

## rqt_drone_teleop

- No changes

## rqt_ground_robot_teleop

- No changes
