### PR TITLE
ament_index: 1.0.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -88,7 +88,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_index-release.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_index` to `1.0.5-1`:

- upstream repository: https://github.com/ament/ament_index.git
- release repository: https://github.com/ros2-gbp/ament_index-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `1.0.4-1`
