### PR TITLE
rmw_connextdds: 0.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1790,7 +1790,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 0.5.0-1
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `0.6.0-1`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `0.5.0-1`

## rmw_connextdds

```
* Use rmw_qos_profile_unknown when adding entity to graph (#28 <https://github.com/rticommunity/rmw_connextdds/issues/28>)
* Resolve issues identified while investigating #21 <https://github.com/rticommunity/rmw_connextdds/issues/21> (#22 <https://github.com/rticommunity/rmw_connextdds/issues/22>)
* Use Rolling in README's Quick Start
* Improved implementation of client::is_service_available for Connext Pro
* Only add request header to typecode with Basic req/rep profile
* Remove commented/unused code
* Avoid topic name validation in get_info functions
* Reduce shutdown period to 10ms
* Pass HistoryQosPolicy to graph cache
* Reset error string after looking up type support
* Remove DDS-based WaitSet implementation
* Contributors: Andrea Sorbini, Ivan Santiago Paunovic
```

## rmw_connextdds_common

```
* Use rmw_qos_profile_unknown when adding entity to graph (#28 <https://github.com/rticommunity/rmw_connextdds/issues/28>)
* Resolve issues identified while investigating #21 <https://github.com/rticommunity/rmw_connextdds/issues/21> (#22 <https://github.com/rticommunity/rmw_connextdds/issues/22>)
* Use Rolling in README's Quick Start
* Improved implementation of client::is_service_available for Connext Pro
* Only add request header to typecode with Basic req/rep profile
* Remove commented/unused code
* Avoid topic name validation in get_info functions
* Reduce shutdown period to 10ms
* Pass HistoryQosPolicy to graph cache
* Reset error string after looking up type support
* Remove DDS-based WaitSet implementation
* Contributors: Andrea Sorbini, Ivan Santiago Paunovic
```

## rti_connext_dds_cmake_module

- No changes
