### PR TITLE
tracetools_analysis: 2.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2847,7 +2847,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://gitlab.com/ros-tracing/tracetools_analysis-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://gitlab.com/ros-tracing/tracetools_analysis.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tracetools_analysis` to `2.0.1-1`:

- upstream repository: https://gitlab.com/ros-tracing/tracetools_analysis.git
- release repository: https://gitlab.com/ros-tracing/tracetools_analysis-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `2.0.0-1`
