### PR TITLE
rclcpp: 9.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1665,7 +1665,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 9.0.1-1
+      version: 9.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `9.0.2-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `9.0.1-1`

## rclcpp

```
* Avoid returning loan when none was obtained. (#1629 <https://github.com/ros2/rclcpp/issues/1629>)
* Use a different implementation of mutex two priorities (#1628 <https://github.com/ros2/rclcpp/issues/1628>)
* Do not test the value of the history policy when testing the get_publishers/subscriptions_info_by_topic() methods (#1626 <https://github.com/ros2/rclcpp/issues/1626>)
* Check first parameter type and range before calling the user validation callbacks (#1627 <https://github.com/ros2/rclcpp/issues/1627>)
* Contributors: Ivan Santiago Paunovic, Miguel Company
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
