### PR TITLE
rosidl: 1.2.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3551,7 +3551,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 1.2.0-1
+      version: 1.2.1-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `1.2.1-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `1.2.0-1`

## rosidl_adapter

```
* Hex constants and tab as whitespace support (#568 <https://github.com/ros2/rosidl/issues/568>)
  * Treat t as whitespace (#557 <https://github.com/ros2/rosidl/issues/557>)
  * Support hex constants in msg files (#559 <https://github.com/ros2/rosidl/issues/559>)
* Contributors: Dereck Wonnacott
```

## rosidl_cmake

- No changes

## rosidl_generator_c

- No changes

## rosidl_generator_cpp

- No changes

## rosidl_parser

- No changes

## rosidl_runtime_c

```
* Update quality declaration links (re: ros2/docs.ros2.org#52 <https://github.com/ros2/docs.ros2.org/issues/52>) (#582 <https://github.com/ros2/rosidl/issues/582>)
* Contributors: Simon Honigmann
```

## rosidl_runtime_cpp

```
* Update quality declaration links (re: ros2/docs.ros2.org#52 <https://github.com/ros2/docs.ros2.org/issues/52>) (#582 <https://github.com/ros2/rosidl/issues/582>)
* Contributors: Simon Honigmann
```

## rosidl_typesupport_interface

```
* Update quality declaration links (re: ros2/docs.ros2.org#52 <https://github.com/ros2/docs.ros2.org/issues/52>) (#582 <https://github.com/ros2/rosidl/issues/582>)
* Contributors: Simon Honigmann
```

## rosidl_typesupport_introspection_c

- No changes

## rosidl_typesupport_introspection_cpp

- No changes
