### PR TITLE
rmw_implementation: 1.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3093,10 +3093,13 @@ repositories:
       url: https://github.com/ros2/rmw_implementation.git
       version: foxy
     release:
+      packages:
+      - rmw_implementation
+      - test_rmw_implementation
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_implementation-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_implementation` to `1.0.2-1`:

- upstream repository: https://github.com/ros2/rmw_implementation.git
- release repository: https://github.com/ros2-gbp/rmw_implementation-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `1.0.1-1`

## rmw_implementation

```
* Update quality declaration links (re: ros2/docs.ros2.org#52 <https://github.com/ros2/docs.ros2.org/issues/52>) (#184 <https://github.com/ros2/rmw_implementation/issues/184>)
* Update QD to QL 1 (#167 <https://github.com/ros2/rmw_implementation/issues/167>)
* Updated performance QD section (#153 <https://github.com/ros2/rmw_implementation/issues/153>)
* Move the QD into the rmw_implementation subdirectory. (#111 <https://github.com/ros2/rmw_implementation/issues/111>)
* Add nominal test for symbol prefetch() and unload. (#145 <https://github.com/ros2/rmw_implementation/issues/145>)
* Added benchmark test to rmw_implementation (#127 <https://github.com/ros2/rmw_implementation/issues/127>)
* Test load and lookup functionality. (#135 <https://github.com/ros2/rmw_implementation/issues/135>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Michel Hidalgo, Scott K Logan, Simon Honigmann, Stephen Brawner
```

## test_rmw_implementation

- No changes
