### PR TITLE
rcl_logging: 1.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2769,7 +2769,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 1.0.1-1
+      version: 1.1.0-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `1.1.0-1`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `1.0.1-1`

## rcl_logging_log4cxx

- No changes

## rcl_logging_noop

- No changes

## rcl_logging_spdlog

```
* Update quality declaration links (re: ros2/docs.ros2.org#52 <https://github.com/ros2/docs.ros2.org/issues/52>) (#74 <https://github.com/ros2/rcl_logging/issues/74>)
* Allow configuring logging directory through environment variables (#70 <https://github.com/ros2/rcl_logging/issues/70>)
* Fix build.ros2.org links (#68 <https://github.com/ros2/rcl_logging/issues/68>)
* Update QD to QL 1 (#67 <https://github.com/ros2/rcl_logging/issues/67>)
* Fixed backported tests on rcl_logging_spdlog
* Add fault injection unittest to increase coverage (#49 <https://github.com/ros2/rcl_logging/issues/49>)
* More rcl_logging_spdlog tests (#40 <https://github.com/ros2/rcl_logging/issues/40>)
* Added benchmark test to rcl_logging_spdlog (#52 <https://github.com/ros2/rcl_logging/issues/52>)
* Contributors: Alejandro Hernández Cordero, Scott K Logan, Simon Honigmann, Stephen Brawner, Tom Greier
```
