### PR TITLE
rcl: 1.1.11-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2722,7 +2722,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 1.1.10-1
+      version: 1.1.11-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `1.1.11-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `1.1.10-1`

## rcl

```
* Update quality declaration links (re: ros2/docs.ros2.org#52 <https://github.com/ros2/docs.ros2.org/issues/52>) (#910 <https://github.com/ros2/rcl/issues/910>)
* Contributors: Simon Honigmann
```

## rcl_action

```
* Update quality declaration links (re: ros2/docs.ros2.org#52 <https://github.com/ros2/docs.ros2.org/issues/52>) (#910 <https://github.com/ros2/rcl/issues/910>)
* Contributors: Simon Honigmann
```

## rcl_lifecycle

```
* Update quality declaration links (re: ros2/docs.ros2.org#52 <https://github.com/ros2/docs.ros2.org/issues/52>) (#910 <https://github.com/ros2/rcl/issues/910>)
* Contributors: Simon Honigmann
```

## rcl_yaml_param_parser

```
* Update quality declaration links (re: ros2/docs.ros2.org#52 <https://github.com/ros2/docs.ros2.org/issues/52>) (#910 <https://github.com/ros2/rcl/issues/910>)
* Contributors: Simon Honigmann
```
