### PR TITLE
libyaml_vendor: 1.0.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1668,7 +1668,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/libyaml_vendor-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `libyaml_vendor` to `1.0.4-1`:

- upstream repository: https://github.com/ros2/libyaml_vendor.git
- release repository: https://github.com/ros2-gbp/libyaml_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `1.0.3-1`

## libyaml_vendor

```
* Update quality declaration links (re: ros2/docs.ros2.org#52 <https://github.com/ros2/docs.ros2.org/issues/52>) (#39 <https://github.com/ros2/libyaml_vendor/issues/39>)
* Fix target_link_directories/link_directories in cmake (#29 <https://github.com/ros2/libyaml_vendor/issues/29>) (#32 <https://github.com/ros2/libyaml_vendor/issues/32>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Simon Honigmann
```
