### PR TITLE
launch_ros: 0.11.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1607,7 +1607,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.11.1-1
+      version: 0.11.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.11.2-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `0.11.1-1`

## launch_ros

```
* Fix namespace with LifecycleNode (#222 <https://github.com/ros2/launch_ros/issues/222>)
* Handle any substitution types for SetParameter name argument (#182 <https://github.com/ros2/launch_ros/issues/182>) (#218 <https://github.com/ros2/launch_ros/issues/218>)
* Contributors: Jacob Perron, Michael Jeronimo
```

## launch_testing_ros

- No changes

## ros2launch

```
* Support non-interactive ros2 launch executions (#210 <https://github.com/ros2/launch_ros/issues/210>) (#225 <https://github.com/ros2/launch_ros/issues/225>)
* Contributors: Felix Divo, Michel Hidalgo
```
