### PR TITLE
launch: 0.10.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1572,7 +1572,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.10.4-1
+      version: 0.10.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.10.5-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `0.10.4-1`

## launch

```
* Support non-interactive launch.LaunchService runs (#475 <https://github.com/ros2/launch/issues/475>) (#500 <https://github.com/ros2/launch/issues/500>)
* Add arg_choice arg to DeclareLaunchArguments (#483 <https://github.com/ros2/launch/issues/483>) (#485 <https://github.com/ros2/launch/issues/485>)
* Add respawn and respawn_delay support (#426 <https://github.com/ros2/launch/issues/426>) (#478 <https://github.com/ros2/launch/issues/478>)
* Allow configuring logging directory through environment variables (#460 <https://github.com/ros2/launch/issues/460>) (#477 <https://github.com/ros2/launch/issues/477>)
* Contributors: Christophe Bedard, Felix Divo, Michel Hidalgo, Tom Greier, Victor Lopez, Vitaliy Bondar
```

## launch_testing

```
* Fix max() with empty sequence (#440 <https://github.com/ros2/launch/issues/440>) (#491 <https://github.com/ros2/launch/issues/491>)
* Contributors: Dirk Thomas, Michel Hidalgo
```

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
