### PR TITLE
class_loader: 2.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -487,7 +487,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/class_loader-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `2.0.2-1`:

- upstream repository: https://github.com/ros/class_loader.git
- release repository: https://github.com/ros2-gbp/class_loader-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `2.0.1-1`

## class_loader

```
* Update QD to QL 1 (#178 <https://github.com/ros/class_loader/issues/178>)
* Update console_bridge QL in QD
* Increase coverage with a graveyard behavior test and unmanaged instance test (#159 <https://github.com/ros/class_loader/issues/159>)
* Add Security Vulnerability Policy pointing to REP-2006. (#157 <https://github.com/ros/class_loader/issues/157>)
* Clean up and improve documentation (#156 <https://github.com/ros/class_loader/issues/156>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Louise Poubel, Michel Hidalgo, Stephen Brawner
```
