### PR TITLE
rmw_fastrtps: 1.2.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3061,7 +3061,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 1.2.4-1
+      version: 1.2.5-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `1.2.5-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `1.2.4-1`

## rmw_fastrtps_cpp

```
* Update quality declaration links (re: ros2/docs.ros2.org#52 <https://github.com/ros2/docs.ros2.org/issues/52>) (#521 <https://github.com/eProsima/rmw_fastrtps/issues/521>)
* Contributors: Simon Honigmann
```

## rmw_fastrtps_dynamic_cpp

```
* Update quality declaration links (re: ros2/docs.ros2.org#52 <https://github.com/ros2/docs.ros2.org/issues/52>) (#521 <https://github.com/eProsima/rmw_fastrtps/issues/521>)
* Contributors: Simon Honigmann
```

## rmw_fastrtps_shared_cpp

```
* Update quality declaration links (re: ros2/docs.ros2.org#52 <https://github.com/ros2/docs.ros2.org/issues/52>) (#521 <https://github.com/eProsima/rmw_fastrtps/issues/521>)
* Use interface whitelist for localhost only (#476 <https://github.com/eProsima/rmw_fastrtps/issues/476>)
* Avoid unused identifier variable warnings (#422 <https://github.com/eProsima/rmw_fastrtps/issues/422>) (#494 <https://github.com/eProsima/rmw_fastrtps/issues/494>)
* Contributors: Jacob Perron, Michel Hidalgo, Miguel Company, Simon Honigmann, Tomoya Fujita
```
