### PR TITLE
tesseract: 0.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7554,7 +7554,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-industrial-release/tesseract-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/ros-industrial-consortium/tesseract.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tesseract` to `0.3.1-1`:

- upstream repository: https://github.com/ros-industrial-consortium/tesseract.git
- release repository: https://github.com/ros-industrial-release/tesseract-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `0.3.0-1`

## tesseract_collision

```
* Add bullet-extras depends to tesseract_collision package.xml
* Move tesseract_variables() before any use of custom macros
* Contributors: Levi Armstrong
```

## tesseract_common

```
* Move tesseract_variables() before any use of custom macros
* Contributors: Levi Armstrong
```

## tesseract_environment

```
* Move tesseract_variables() before any use of custom macros
* Contributors: Levi Armstrong
```

## tesseract_geometry

```
* Move tesseract_variables() before any use of custom macros
* Contributors: Levi Armstrong
```

## tesseract_kinematics

```
* Move tesseract_variables() before any use of custom macros
* Contributors: Levi Armstrong
```

## tesseract_scene_graph

```
* Move tesseract_variables() before any use of custom macros
* Contributors: Levi Armstrong
```

## tesseract_support

- No changes

## tesseract_urdf

```
* Add missing pcl depends to tesseract_urdf package.xml
* Move tesseract_variables() before any use of custom macros
* Contributors: Levi Armstrong
```

## tesseract_visualization

```
* Move tesseract_variables() before any use of custom macros
* Contributors: Levi Armstrong
```
