### PR TITLE
dynamixel_sdk: 3.7.51-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2965,10 +2965,13 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
       version: kinetic-devel
     release:
+      packages:
+      - dynamixel_sdk
+      - dynamixel_sdk_examples
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release.git
-      version: 3.7.31-1
+      version: 3.7.51-2
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_sdk` to `3.7.51-2`:

- upstream repository: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
- release repository: https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `3.7.31-1`

## dynamixel_sdk

```
* Add Sync / Bulk read write ROS examples
* Contributors: JaehyunShim
```
