### PR TITLE
dynamixel_sdk: 3.7.51-4 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2510,10 +2510,13 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
       version: melodic-devel
     release:
+      packages:
+      - dynamixel_sdk
+      - dynamixel_sdk_examples
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release.git
-      version: 3.7.31-1
+      version: 3.7.51-4
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_sdk` to `3.7.51-4`:

- upstream repository: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
- release repository: https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `3.7.31-1`

## dynamixel_sdk

```
* Add Sync / Bulk read write ROS examples
* Contributors: JaehyunShim
```
