### PR TITLE
dynamixel_sdk: 3.7.51-4 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1540,10 +1540,13 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
       version: noetic-devel
     release:
+      packages:
+      - dynamixel_sdk
+      - dynamixel_sdk_examples
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release.git
-      version: 3.7.31-1
+      version: 3.7.51-4
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_sdk` to `3.7.51-4`:

- upstream repository: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
- release repository: https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `3.7.31-1`

## dynamixel_sdk

```
* Add Sync / Bulk read write ROS examples
* Contributors: JaehyunShim
```
