### PR TITLE
dynamixel_sdk: 3.7.40-10 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -733,10 +733,14 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
       version: dashing-devel
     release:
+      packages:
+      - dynamixel_sdk
+      - dynamixel_sdk_custom_interfaces
+      - dynamixel_sdk_examples
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/robotis-ros2-release/dynamixel_sdk-release.git
-      version: 3.7.30-1
+      version: 3.7.40-10
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_sdk` to `3.7.40-10`:

- upstream repository: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
- release repository: https://github.com/robotis-ros2-release/dynamixel_sdk-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `3.7.30-1`

## dynamixel_sdk

```
* Add ROS 2 basic example
* Bug fix
* Contributors: Will Son
```

## dynamixel_sdk_custom_interfaces

```
* Add ROS 2 basic example
* Contributors: Will Son
```

## dynamixel_sdk_examples

```
* Add ROS 2 basic example
* Contributors: Will Son
```