### PR TITLE
gazebo_ros_pkgs: 3.5.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1125,7 +1125,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
-      version: 3.5.0-2
+      version: 3.5.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `3.5.3-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs
- release repository: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `3.5.0-2`

## gazebo_dev

```
* colcon.pkg: build gazebo first in colcon workspace (#1192 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1192>)
  Add a colcon.pkg file to gazebo_dev with gazebo's cmake project
  name "Gazebo" listed as a dependency to support building
  gazebo from source in a colcon workspace.
  * Add colcon.pkg files for other packages
  Copy colcon.pkg to gazebo_ros, gazebo_plugins, and
  gazebo_ros_control so that --merge-install won't be required.
* Contributors: Steve Peters
```

## gazebo_msgs

```
* [ROS 2] Bridge to republish PerformanceMetrics in ROS 2 (#1147 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1147>)
* Contributors: Alejandro Hernández Cordero
```

## gazebo_plugins

```
* Make p3d offset element names singular (#1210 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1210>)
  * Make p3d offset element names singular
  - <xyz_offsets> is renamed to <xyz_offset>
  - <rpy_offsets> is renamed to <rpy_offsets>
  The old names can still be used, but are deprecated.
  This is more consistent with the naming convention used in ROS 1 versions.
  * Add test for deprecated functionality
* colcon.pkg: build gazebo first in colcon workspace (#1192 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1192>)
  Add a colcon.pkg file to gazebo_dev with gazebo's cmake project
  name "Gazebo" listed as a dependency to support building
  gazebo from source in a colcon workspace.
  * Add colcon.pkg files for other packages
  Copy colcon.pkg to gazebo_ros, gazebo_plugins, and
  gazebo_ros_control so that --merge-install won't be required.
* publish with QoS reliable as default (#1224 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1224>)
  * default to reliable publishers
* adding buffer to gzebo ros hand of god plugin (#1179 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1179>)
  Fixes #1178 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1178>.
* [gazebo_plugins] address warnings (#1151 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1151>)
  * use .c_str() for variadic template
  * silence warnings
  Co-authored-by: Steve Peters <mailto:scpeters@openrobotics.org>
* Port wheel slip plugin to ros2 (forward port from eloquent) (#1148 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1148>)
  Forward port of wheel slip plugin from eloquent (#1099 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1099>)
  to foxy.
  It includes a similar change to #1111 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1111>, which moved the
  WheelSlipPlugin::Load call before the parameter callback
  so that the values from SDF/URDF are set first.
  Then the callback is changed to ignore negative values, and the
  default slip parameter values are set to -1, so that the SDF/URDF
  values are still preferred unless a different parameter value
  is specified in a launch file.
  Co-authored-by: Jacob Perron <jacob@openrobotics.org>
* Added ignition common profiler to ros2 (#1141 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1141>)
  * Added ignition common profiler to ros2
  * Make linters happy
  * minor fixes
  * Removed warning: handler for the param change callback
* Contributors: Alejandro Hernández Cordero, Brett Downing, Jacob Perron, Karsten Knese, Steve Macenski, Steve Peters
```

## gazebo_ros

```
* Update default spawn_service_timeout to be consistent with other ROS2 distros (#1264 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1264>)
  * update default timeout value to be consistent with other ROS2 distros
  * define timeout as a constant
* Fix executor to avoid random exceptions when shutting down (#1212 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1212>)
  * Fix executor to avoid random exceptions when shutting down
  * Add link to related issue in rclcpp
* ros2: Only subscribe to /gazebo/performance_metrics when necessary (#1205 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1205>)
  We are currently subscribing to the /gazebo/performance_metrics topic
  even if there are no subscribers to the ROS topic forwarding this data.
  This changes gazebo_ros_init to only subscribe to the gazebo topic
  if there are any subscribers to the corresponding ROS topic.
  While advertiser callbacks are used in ROS 1 but are not yet in ROS2,
  here we use polling in the GazeboRosInitPrivate::PublishSimTime
  callback to check for subscribers since it is called for each Gazebo
  time step.
  This also helps workaround the deadlock documented in #1175 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1175> and
  osrf/gazebo#2902 <https://github.com/osrf/gazebo/issues/2902>.
  This also adds a macro to reduce duplication of the version checking
  logic.
* colcon.pkg: build gazebo first in colcon workspace (#1192 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1192>)
  Add a colcon.pkg file to gazebo_dev with gazebo's cmake project
  name "Gazebo" listed as a dependency to support building
  gazebo from source in a colcon workspace.
  * Add colcon.pkg files for other packages
  Copy colcon.pkg to gazebo_ros, gazebo_plugins, and
  gazebo_ros_control so that --merge-install won't be required.
* [ROS 2] Bridge to republish PerformanceMetrics in ROS 2 (#1147 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1147>)
* [Windows] Add missing visibility control. (#1150 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1150>)
* [ros2] Enable the force system on launch files (#1035 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1035>)
* make compile wo/ warnings on osx (#1149 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1149>)
* Added lockstep argument to gzserver (#1146 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1146>)
* Contributors: Alejandro Hernández Cordero, Ivan Santiago Paunovic, Karsten Knese, Louise Poubel, M. Mei, Sean Yen, Steve Peters
```

## gazebo_ros_pkgs

- No changes
