### PR TITLE
Ignition Edifice rosdep keys

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1696,16 +1696,16 @@ ignition-tools:
     buster: [libignition-tools-dev]
   ubuntu:
     focal: [libignition-tools-dev]
-ignition-transport8:
-  debian:
-    buster: [libignition-transport8-dev]
-  ubuntu:
-    focal: [libignition-transport8-dev]
 ignition-transport10:
   debian:
     buster: [libignition-transport10-dev]
   ubuntu:
     focal: [libignition-transport10-dev]
+ignition-transport8:
+  debian:
+    buster: [libignition-transport8-dev]
+  ubuntu:
+    focal: [libignition-transport8-dev]
 ignition-utils1:
   debian:
     buster: [libignition-utils1-dev]
@@ -3096,16 +3096,16 @@ libignition-sensors5:
     buster: [libignition-sensors5]
   ubuntu:
     focal: [libignition-sensors5]
-libignition-transport8:
-  debian:
-    buster: [libignition-transport8]
-  ubuntu:
-    focal: [libignition-transport8]
 libignition-transport10:
   debian:
     buster: [libignition-transport10]
   ubuntu:
     focal: [libignition-transport10]
+libignition-transport8:
+  debian:
+    buster: [libignition-transport8]
+  ubuntu:
+    focal: [libignition-transport8]
 libignition-utils1:
   debian:
     buster: [libignition-utils1]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1586,26 +1586,56 @@ ignition-common3:
     buster: [libignition-common3-dev]
   ubuntu:
     focal: [libignition-common3-dev]
+ignition-common4:
+  debian:
+    buster: [libignition-common4-dev]
+  ubuntu:
+    focal: [libignition-common4-dev]
+ignition-edifice:
+  debian:
+    buster: [ignition-edifice]
+  ubuntu:
+    focal: [ignition-edifice]
 ignition-fuel-tools4:
   debian:
     buster: [libignition-fuel-tools4-dev]
   ubuntu:
     focal: [libignition-fuel-tools4-dev]
+ignition-fuel-tools6:
+  debian:
+    buster: [libignition-fuel-tools6-dev]
+  ubuntu:
+    focal: [libignition-fuel-tools6-dev]
 ignition-gazebo3:
   debian:
     buster: [libignition-gazebo3-dev]
   ubuntu:
     focal: [libignition-gazebo3-dev]
+ignition-gazebo5:
+  debian:
+    buster: [libignition-gazebo5-dev]
+  ubuntu:
+    focal: [libignition-gazebo5-dev]
 ignition-gui3:
   debian:
     buster: [libignition-gui3-dev]
   ubuntu:
     focal: [libignition-gui3-dev]
+ignition-gui5:
+  debian:
+    buster: [libignition-gui5-dev]
+  ubuntu:
+    focal: [libignition-gui5-dev]
 ignition-launch2:
   debian:
     buster: [libignition-launch2-dev]
   ubuntu:
     focal: [libignition-launch2-dev]
+ignition-launch4:
+  debian:
+    buster: [libignition-launch4-dev]
+  ubuntu:
+    focal: [libignition-launch4-dev]
 ignition-math6:
   debian:
     buster: [libignition-math6-dev]
@@ -1621,11 +1651,21 @@ ignition-msgs5:
     buster: [libignition-msgs5-dev]
   ubuntu:
     focal: [libignition-msgs5-dev]
+ignition-msgs7:
+  debian:
+    buster: [libignition-msgs7-dev]
+  ubuntu:
+    focal: [libignition-msgs7-dev]
 ignition-physics2:
   debian:
     buster: [libignition-physics2-dev]
   ubuntu:
     focal: [libignition-physics2-dev]
+ignition-physics4:
+  debian:
+    buster: [libignition-physics4-dev]
+  ubuntu:
+    focal: [libignition-physics4-dev]
 ignition-plugin:
   debian:
     buster: [libignition-plugin-dev]
@@ -1636,11 +1676,21 @@ ignition-rendering3:
     buster: [libignition-rendering3-dev]
   ubuntu:
     focal: [libignition-rendering3-dev]
+ignition-rendering5:
+  debian:
+    buster: [libignition-rendering5-dev]
+  ubuntu:
+    focal: [libignition-rendering5-dev]
 ignition-sensors3:
   debian:
     buster: [libignition-sensors3-dev]
   ubuntu:
     focal: [libignition-sensors3-dev]
+ignition-sensors5:
+  debian:
+    buster: [libignition-sensors5-dev]
+  ubuntu:
+    focal: [libignition-sensors5-dev]
 ignition-tools:
   debian:
     buster: [libignition-tools-dev]
@@ -1651,6 +1701,21 @@ ignition-transport8:
     buster: [libignition-transport8-dev]
   ubuntu:
     focal: [libignition-transport8-dev]
+ignition-transport10:
+  debian:
+    buster: [libignition-transport10-dev]
+  ubuntu:
+    focal: [libignition-transport10-dev]
+ignition-utils1:
+  debian:
+    buster: [libignition-utils1-dev]
+  ubuntu:
+    focal: [libignition-utils1-dev]
+ignition-utils1-cli:
+  debian:
+    buster: [libignition-utils1-cli-dev]
+  ubuntu:
+    focal: [libignition-utils1-cli-dev]
 imagemagick:
   arch: [imagemagick]
   debian: [imagemagick]
@@ -2941,26 +3006,51 @@ libignition-common3:
     buster: [libignition-common3]
   ubuntu:
     focal: [libignition-common3]
+libignition-common4:
+  debian:
+    buster: [libignition-common4]
+  ubuntu:
+    focal: [libignition-common4]
 libignition-fuel-tools4:
   debian:
     buster: [libignition-fuel-tools4]
   ubuntu:
     focal: [libignition-fuel-tools4]
+libignition-fuel-tools6:
+  debian:
+    buster: [libignition-fuel-tools6]
+  ubuntu:
+    focal: [libignition-fuel-tools6]
 libignition-gazebo3:
   debian:
     buster: [libignition-gazebo3]
   ubuntu:
     focal: [libignition-gazebo3]
+libignition-gazebo5:
+  debian:
+    buster: [libignition-gazebo5]
+  ubuntu:
+    focal: [libignition-gazebo5]
 libignition-gui3:
   debian:
     buster: [libignition-gui3]
   ubuntu:
     focal: [libignition-gui3]
+libignition-gui5:
+  debian:
+    buster: [libignition-gui5]
+  ubuntu:
+    focal: [libignition-gui5]
 libignition-launch2:
   debian:
     buster: [libignition-launch2]
   ubuntu:
     focal: [libignition-launch2]
+libignition-launch4:
+  debian:
+    buster: [libignition-launch4]
+  ubuntu:
+    focal: [libignition-launch4]
 libignition-math6:
   debian:
     buster: [libignition-math6]
@@ -2971,26 +3061,56 @@ libignition-msgs5:
     buster: [libignition-msgs5]
   ubuntu:
     focal: [libignition-msgs5]
+libignition-msgs7:
+  debian:
+    buster: [libignition-msgs7]
+  ubuntu:
+    focal: [libignition-msgs7]
 libignition-physics2:
   debian:
     buster: [libignition-physics2]
   ubuntu:
     focal: [libignition-physics2]
+libignition-physics4:
+  debian:
+    buster: [libignition-physics4]
+  ubuntu:
+    focal: [libignition-physics4]
 libignition-rendering3:
   debian:
     buster: [libignition-rendering3]
   ubuntu:
     focal: [libignition-rendering3]
+libignition-rendering5:
+  debian:
+    buster: [libignition-rendering5]
+  ubuntu:
+    focal: [libignition-rendering5]
 libignition-sensors3:
   debian:
     buster: [libignition-sensors3]
   ubuntu:
     focal: [libignition-sensors3]
+libignition-sensors5:
+  debian:
+    buster: [libignition-sensors5]
+  ubuntu:
+    focal: [libignition-sensors5]
 libignition-transport8:
   debian:
     buster: [libignition-transport8]
   ubuntu:
     focal: [libignition-transport8]
+libignition-transport10:
+  debian:
+    buster: [libignition-transport10]
+  ubuntu:
+    focal: [libignition-transport10]
+libignition-utils1:
+  debian:
+    buster: [libignition-utils1]
+  ubuntu:
+    focal: [libignition-utils1]
 libimage-exiftool-perl:
   arch: [perl-image-exiftool]
   debian: [libimage-exiftool-perl]
@@ -6023,6 +6143,11 @@ sdformat:
     saucy: [libsdformat-dev]
     trusty: [libsdformat-dev]
     xenial: [libsdformat4-dev]
+sdformat11:
+  debian:
+    buster: [libsdformat11-dev]
+  ubuntu:
+    focal: [libsdformat11-dev]
 sdl:
   arch: [sdl]
   debian: [libsdl1.2-dev]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

Part of https://github.com/ros/rosdistro/issues/28960, depends on https://github.com/ros-infrastructure/reprepro-updater/pull/109.

## Package name:

[Ignition Edifice libraries](https://ignitionrobotics.org/docs/edifice)

## Package Upstream Source:

* Most libraries are on this org: https://github.com/ignitionrobotics/
* SDFormat is here: https://github.com/osrf/sdformat/

## Purpose of using this:

As defined on [REP-2000](https://www.ros.org/reps/rep-2000.html#galactic-geochelone-may-2021-may-2022), Ignition Edifice will be the official Ignition version to be used with ROS Galactic. Edifice was released 2 weeks ago into http://packages.osrfoundation.org and is now in the process of being ported to https://packages.ros.org.

Once the rosdep keys are available, we'll make a release of [ros_ign](https://github.com/ignitionrobotics/ros_ign/) into Rolling / Galactic. ROS packages can interface with Ignition Gazebo through `ros_ign`, and they can also use Ignition libraries directly.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/
  - http://packages.osrfoundation.org/gazebo/debian-stable/
- Ubuntu: https://packages.ubuntu.com/
   - http://packages.osrfoundation.org/gazebo/ubuntu-stable/
- macOS: https://formulae.brew.sh/
  - https://github.com/osrf/homebrew-simulation/
