### PR TITLE
iceoryx: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -874,7 +874,7 @@ repositories:
     source:
       type: git
       url: https://github.com/eclipse-iceoryx/iceoryx.git
-      version: master
+      version: release_1.0
     status: developed
   ifm3d_core:
     release:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -870,7 +870,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ApexAI/iceoryx-release.git
-      version: 0.99.7-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/eclipse-iceoryx/iceoryx.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -455,7 +455,7 @@ repositories:
     source:
       type: git
       url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-      version: master
+      version: iceoryx
     status: maintained
   demos:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `iceoryx` to `1.0.0-1`:

- upstream repository: https://github.com/eclipse-iceoryx/iceoryx.git
- release repository: https://github.com/ApexAI/iceoryx-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `0.99.7-1`
