### PR TITLE
hls_lfcd_lds_driver: 2.0.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1171,7 +1171,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/robotis-ros2-release/hls_lfcd_lds_driver-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hls_lfcd_lds_driver` to `2.0.2-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
- release repository: https://github.com/robotis-ros2-release/hls_lfcd_lds_driver-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `2.0.1-1`

## hls_lfcd_lds_driver

```
* fix laserscan data bug
* rename nav2 params
* fox bug, deprecated param name
* use static param type for Galactic
* Contributors: Will Son
```