### PR TITLE
hls_lfcd_lds_driver: 2.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -861,6 +861,21 @@ repositories:
       url: https://github.com/flynneva/grbl_ros.git
       version: devel
     status: maintained
+  hls_lfcd_lds_driver:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
+      version: rolling-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/robotis-ros2-release/hls_lfcd_lds_driver-release.git
+      version: 2.0.2-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
+      version: rolling-devel
+    status: developed
   iceoryx:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `hls_lfcd_lds_driver` to `2.0.2-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
- release repository: https://github.com/robotis-ros2-release/hls_lfcd_lds_driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `null`

## hls_lfcd_lds_driver

```
* fix laserscan data bug
* rename nav2 params
* fox bug, deprecated param name
* use static param type for Galactic
* Contributors: Will Son
```
