### PR TITLE
hls-lfcd-lds-driver: 1.1.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4942,7 +4942,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/hls-lfcd-lds-driver-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hls-lfcd-lds-driver` to `1.1.2-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
- release repository: https://github.com/ROBOTIS-GIT-release/hls-lfcd-lds-driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `1.1.1-1`

## hls_lfcd_lds_driver

```
* fix LDS data issue
* Contributors: Will Son
```
