### PR TITLE
add python-albumentations-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -434,19 +434,6 @@ python-adafruit-bno055-pip:
   ubuntu:
     pip:
       packages: [adafruit_bno055]
-python-albumentations-pip:
-  debian:
-    pip:
-      packages: [albumentations]
-  fedora:
-    pip:
-      packages: [albumentations]
-  osx:
-    pip:
-      packages: [albumentations]
-  ubuntu:
-    pip:
-      packages: [albumentations]
 python-alembic:
   debian:
     buster: [python-alembic]
@@ -5566,6 +5553,19 @@ python3-adafruit-circuitpython-mcp230xx-pip:
   ubuntu:
     pip:
       packages: [adafruit-circuitpython-mcp230xx]
+python3-albumentations-pip:
+  debian:
+    pip:
+      packages: [albumentations]
+  fedora:
+    pip:
+      packages: [albumentations]
+  osx:
+    pip:
+      packages: [albumentations]
+  ubuntu:
+    pip:
+      packages: [albumentations]
 python3-ansible-runner-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -434,6 +434,19 @@ python-adafruit-bno055-pip:
   ubuntu:
     pip:
       packages: [adafruit_bno055]
+python-albumentations-pip:
+  debian:
+    pip:
+      packages: [albumentations]
+  fedora:
+    pip:
+      packages: [albumentations]
+  osx:
+    pip:
+      packages: [albumentations]
+  ubuntu:
+    pip:
+      packages: [albumentations]
 python-alembic:
   debian:
     buster: [python-alembic]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`python-albumentations-pip`

## Package Upstream Source:
https://pypi.org/project/albumentations/
(pip only package - no release found, see below)

## Purpose of using this:

https://pypi.org/project/albumentations/#description

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/
  - NOT_FOUND
- Ubuntu: https://packages.ubuntu.com/
   - NOT_FOUND
- Fedora: https://src.fedoraproject.org/browse/projects/
  - NOT_FOUND
- Arch: https://www.archlinux.org/packages/
  - NOT_FOUND
- Gentoo: https://packages.gentoo.org/
  - NOT_FOUND
- macOS: https://formulae.brew.sh/
  - NOT_FOUND
- Alpine: https://pkgs.alpinelinux.org/packages
  - NOT_FOUND

