### PR TITLE
vision_msgs: 3.0.0-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3110,6 +3110,21 @@ repositories:
       url: https://github.com/ros2/variants.git
       version: master
     status: maintained
+  vision_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/vision_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/Kukanani/vision_msgs-release.git
+      version: 3.0.0-4
+    source:
+      type: git
+      url: https://github.com/ros-perception/vision_msgs.git
+      version: ros2
+    status: maintained
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
> If you're making a new release with bloom please use bloom to create the pull request automatically.
> If you've already run the release bloom has a `--pull-request-only` option you can use.

Bloom fails to create the PR for me: https://github.com/ros-infrastructure/bloom/issues/632

Therefore I'm doing this one manually.

This is an updated release of `vision_msgs` and the first release for `rolling`.

# Please Add This Package to be indexed in the rosdistro.

rolling

# The source is here: 

https://github.com/ros-perception/vision_msgs

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro