### PR TITLE
ros_ign: 0.233.1-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2044,6 +2044,28 @@ repositories:
       url: https://github.com/ros/ros_environment.git
       version: foxy
     status: maintained
+  ros_ign:
+    doc:
+      type: git
+      url: https://github.com/ignitionrobotics/ros_ign.git
+      version: ros2
+    release:
+      packages:
+      - ros_ign
+      - ros_ign_bridge
+      - ros_ign_gazebo
+      - ros_ign_gazebo_demos
+      - ros_ign_image
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_ign-release.git
+      version: 0.233.1-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ignitionrobotics/ros_ign.git
+      version: ros2
+    status: developed
   ros_testing:
     doc:
       type: git


### PR DESCRIPTION
Opening PR manually due to https://github.com/ros-infrastructure/bloom/issues/632

---

Increasing version of package(s) in repository `ros_ign` to `0.233.1-4`:

- upstream repository: https://github.com/ignitionrobotics/ros_ign
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `null`

## ros_ign

- No changes

## ros_ign_bridge

```
* Default to Edifice for Rolling (#150 <https://github.com/osrf/ros_ign/issues/150>)
* Ignore local publications for ROS 2 subscriber (#146 <https://github.com/osrf/ros_ign/issues/146>)
  - Note: Does not work with all rmw implementations (e.g.: FastRTPS)
* Update documentation for installation instructions and bridge examples (#142 <https://github.com/osrf/ros_ign/issues/142>)
* Edifice support (#140 <https://github.com/osrf/ros_ign/issues/140>)
* Add JointTrajectory message conversion (#121 <https://github.com/osrf/ros_ign/issues/121>)
  Conversion between
  - ignition::msgs::JointTrajectory
  - trajectory_msgs::msg::JointTrajectory
* Add TFMessage / Pose_V and Float64 / Double conversions (#117 <https://github.com/osrf/ros_ign/issues/117>)
  Addresses issue #116 <https://github.com/osrf/ros_ign/issues/116>
* Updated prereq & branch name (#113 <https://github.com/osrf/ros_ign/issues/113>)
* Update releases (#108 <https://github.com/osrf/ros_ign/issues/108>)
* Updated README.md (#104 <https://github.com/osrf/ros_ign/issues/104>)
* Add support for Dome (#103 <https://github.com/osrf/ros_ign/issues/103>)
* Contributors: Alejandro Hernández Cordero, Andrej Orsula, Florent Audonnet, Jenn, Louise Poubel, Luca Della Vedova
```

## ros_ign_gazebo

```
* Default to Edifice for Rolling (#150 <https://github.com/osrf/ros_ign/issues/150>)
* Edifice support (#140 <https://github.com/osrf/ros_ign/issues/140>)
  Co-authored-by: Alejandro Hernández <mailto:ahcorde@gmail.com>
* Add topic flag to create robot  (#128 <https://github.com/osrf/ros_ign/issues/128>)
  Now it is possible to run ros_ign_gazebo create specifying a topic as
  source of the robot description
  Add a launch file starting a ignition gazebo world and spawn a sphere in it.
  Additionally a rviz2 interface is loaded to show that also Rviz can load
  the robot description
  The newly created demo introduce a dependency on the robot_state_publisher package
* Add default value for plugin path in launch script (#125 <https://github.com/osrf/ros_ign/issues/125>)
* Fix overwriting of plugin path in launch script (#122 <https://github.com/osrf/ros_ign/issues/122>)
  - IGN_GAZEBO_SYSTEM_PLUGIN_PATH was overwritten by LD_LIBRARY_PATH
  - Now it is instead extended by LD_LIBRARY_PATH
  - This allows use of ign_gazebo.launch.py with custom gazebo plugins
* Changed for loading xml from ROS param(#119 <https://github.com/osrf/ros_ign/issues/119>) (#120 <https://github.com/osrf/ros_ign/issues/120>)
* ros_ign_gazebo exec depend on ign-gazebo (#110 <https://github.com/osrf/ros_ign/issues/110>)
* Update releases (#108 <https://github.com/osrf/ros_ign/issues/108>)
* Add support for Dome (#103 <https://github.com/osrf/ros_ign/issues/103>)
* Contributors: Andrej Orsula, Louise Poubel, Luca Della Vedova, Valerio Magnago, chama1176
```

## ros_ign_gazebo_demos

```
* Default to Edifice for Rolling (#150 <https://github.com/osrf/ros_ign/issues/150>)
* Minor updates for demos (#144 <https://github.com/osrf/ros_ign/issues/144>)
  * Re-enable air pressure demo
  - Resolves https://github.com/ignitionrobotics/ros_ign/issues/78
  * Add RQt topic viewer to IMU demo
  * Add image_topic argument for image_bridge demo
  * Do not normalize depth image in RViz2
* Edifice support (#140 <https://github.com/osrf/ros_ign/issues/140>)
* Add topic flag to create robot  (#128 <https://github.com/osrf/ros_ign/issues/128>)
  Now it is possible to run ros_ign_gazebo create specifying a topic as
  source of the robot description
  Add a launch file starting a ignition gazebo world and spawn a sphere in it.
  Additionally a rviz2 interface is loaded to show that also Rviz can load
  the robot description
  The newly created demo introduce a dependency on the robot_state_publisher package
* [ros2] Update releases (#108 <https://github.com/osrf/ros_ign/issues/108>)
* Contributors: Andrej Orsula, Louise Poubel, Valerio Magnago
```

## ros_ign_image

```
* Default to Edifice for Rolling (#150 <https://github.com/osrf/ros_ign/issues/150>)
* Edifice support (#140 <https://github.com/osrf/ros_ign/issues/140>)
* Update releases (#108 <https://github.com/osrf/ros_ign/issues/108>)
* Add support for Dome (#103 <https://github.com/osrf/ros_ign/issues/103>)
* Contributors: Louise Poubel, Luca Della Vedova
```
