### PR TITLE
vision_msgs: 3.0.0-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3110,6 +3110,12 @@ repositories:
       url: https://github.com/ros2/variants.git
       version: master
     status: maintained
+  vision_msgs:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/Kukanani/vision_msgs-release.git
+      version: 3.0.0-4
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_msgs` to `3.0.0-4`:

- upstream repository: https://github.com/ros-perception/vision_msgs.git
- release repository: https://github.com/Kukanani/vision_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## vision_msgs

```
* Add license snippet in CONTRIBUTING.md
* Decouple source data from the detection/classification messages. (#53 <https://github.com/ros-perception/vision_msgs/issues/53>)
  * Decouple source data from the detection/classification messages.
  This commit drops dependency on sensor_msgs
  * Improved documentation.
* Merge pull request #52 <https://github.com/ros-perception/vision_msgs/issues/52> from mintar/clarify-class-object-id
  Rename tracking_id -> id, id -> class_id
* Rename DetectionXD.tracking_id -> id
* Rename ObjectHypothesis.id -> class_id
* Merge pull request #51 <https://github.com/ros-perception/vision_msgs/issues/51> from ros-perception/clarify-bbox-size
  Clarify comment for size fields in bounding box messages
* Revert confusing comment about bbox orientation
* Merge pull request #50 <https://github.com/ros-perception/vision_msgs/issues/50> from ros-perception/remove-is-tracking-field
  Remove is_tracking field
* Remove other mentions to is_tracking field
* Clarify bbox size comment
* Remove tracking_id from Detection3D as well
* Remove is_tracking field
  This field does not seem useful, and we are not aware of anyone using it at this time. VisionInfo is probably a better place for this information anyway, if it were needed.
  See #47 <https://github.com/ros-perception/vision_msgs/issues/47> for earlier discussions.
* Clarify: ObjectHypothesis[] ~= Classification (#49 <https://github.com/ros-perception/vision_msgs/issues/49>)
  * Clarify: ObjectHypothesis[] ~= Classification
  https://github.com/ros-perception/vision_msgs/issues/46 requested Array message types for ObjectHypothesis and/or ObjectHypothesisWithPose. As pointed out in the issue, these already exist in the form of the ClassificationXD and DetectionXD message types.
  * Clarify ObjectHypothesisWithPose[] ~= Detection
* Use composition in ObjectHypothesisWithPose (#48 <https://github.com/ros-perception/vision_msgs/issues/48>)
* Contributors: Adam Allevato, Martin Günther, Martin Pecka, root
```
