### PR TITLE
octomap_msgs: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1292,6 +1292,21 @@ repositories:
       url: https://github.com/ubuntu-robotics/nodl.git
       version: master
     status: developed
+  octomap_msgs:
+    doc:
+      type: git
+      url: https://github.com/octomap/octomap_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros-gbp/octomap_msgs-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/octomap/octomap_msgs.git
+      version: ros2
+    status: maintained
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_msgs` to `2.0.0-1`:

- upstream repository: https://github.com/OctoMap/octomap_msgs.git
- release repository: https://github.com/ros-gbp/octomap_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## octomap_msgs

```
* Change version to 2.0.0 for ROS2; update maintainer
* Porting to ROS2, based on ROS version 0.3.3 #13 <https://github.com/OctoMap/octomap_msgs/pull/13>
* Contributors: Yan Yu, Ibai Apellaniz, Henning Kayser, Wolfgang Merkt
```
