### PR TITLE
prbt_grippers: 0.0.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5105,6 +5105,24 @@ repositories:
       url: https://github.com/pr2/pr2_power_drivers.git
       version: kinetic-devel
     status: unmaintained
+  prbt_grippers:
+    doc:
+      type: git
+      url: https://github.com/PilzDE/prbt_grippers.git
+      version: kinetic-devel
+    release:
+      packages:
+      - prbt_grippers
+      - prbt_pg70_support
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/PilzDE/prbt_grippers-release.git
+      version: 0.0.5-1
+    source:
+      type: git
+      url: https://github.com/PilzDE/prbt_grippers.git
+      version: kinetic-devel
+    status: maintained
   prosilica_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `prbt_grippers` to `0.0.5-1`:

- upstream repository: https://github.com/PilzDE/prbt_grippers.git
- release repository: https://github.com/PilzDE/prbt_grippers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## prbt_grippers

```
* Fixes cmake minimum required to remove developer warning on ubuntu 20
* Contributors: Pilz GmbH and Co. KG
```

## prbt_pg70_support

```
* Fixes cmake minimum required to remove developer warning on ubuntu 20
* Contributors: Pilz GmbH and Co. KG
```
