### PR TITLE
slider_publisher: 1.0.2-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4264,6 +4264,17 @@ repositories:
       url: https://github.com/SteveMacenski/slam_toolbox.git
       version: foxy-devel
     status: maintained
+  slider_publisher:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/oKermorgant/slider_publisher-release.git
+      version: 1.0.2-2
+    source:
+      type: git
+      url: https://github.com/oKermorgant/slider_publisher.git
+      version: ros2
+    status: maintained
   sophus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `slider_publisher` to `1.0.2-2`:

- upstream repository: https://github.com/oKermorgant/slider_publisher.git
- release repository: https://github.com/oKermorgant/slider_publisher-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## slider_publisher

```
* README typo
* Contributors: Olivier Kermorgant
```
