### PR TITLE
slider_publisher: 1.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7237,6 +7237,17 @@ repositories:
       url: https://github.com/SteveMacenski/slam_toolbox.git
       version: noetic-devel
     status: maintained
+  slider_publisher:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/oKermorgant/slider_publisher-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/oKermorgant/slider_publisher.git
+      version: ros1
+    status: maintained
   sob_layer:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `slider_publisher` to `1.0.0-1`:

- upstream repository: https://github.com/oKermorgant/slider_publisher.git
- release repository: https://github.com/oKermorgant/slider_publisher-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## slider_publisher

```
* Update README.md
* baxter example
* Remove dependency to sympy
* empty lines
* Python 3 compat
* solve bug when multiple keys with same name
* robust eval for numeric vs PI expressions
* with RPY sliders
* multiarray bug in some cases
* fix init bug for arrays
* Contributors: Olivier Kermorgant
```
