### PR TITLE
gazebo_ros2_control: 0.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1108,7 +1108,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.0.1-1
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros2_control` to `0.0.2-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros2_control/
- release repository: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.1-1`

## gazebo_ros2_control

```
* add ros parameters file to node context (#60 <https://github.com/ros-simulation/gazebo_ros2_control//issues/60>)
  Co-authored-by: ahcorde <mailto:ahcorde@gmail.com>
* Expose include path (#58 <https://github.com/ros-simulation/gazebo_ros2_control//issues/58>)
* Added License file (#55 <https://github.com/ros-simulation/gazebo_ros2_control//issues/55>)
* Fixed state interfaces (#53 <https://github.com/ros-simulation/gazebo_ros2_control//issues/53>)
* Contributors: Alejandro Hernández Cordero, Chen Bainian, Karsten Knese
```

## gazebo_ros2_control_demos

```
* Remove Unnecessary parameter in demo (#68 <https://github.com/ros-simulation/gazebo_ros2_control//issues/68>)
* Add effort_controller exec_depend on demos (#69 <https://github.com/ros-simulation/gazebo_ros2_control//issues/69>)
* add ros parameters file to node context (#60 <https://github.com/ros-simulation/gazebo_ros2_control//issues/60>)
  Co-authored-by: ahcorde <mailto:ahcorde@gmail.com>
* add ros2_controllers as exec dependency (#56 <https://github.com/ros-simulation/gazebo_ros2_control//issues/56>)
  fixes #49 <https://github.com/ros-simulation/gazebo_ros2_control//issues/49>
* Contributors: Alejandro Hernández Cordero, Karsten Knese
```

