### PR TITLE
rosbag2: 0.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2086,6 +2086,7 @@ repositories:
       - rosbag2_compression
       - rosbag2_compression_zstd
       - rosbag2_cpp
+      - rosbag2_interfaces
       - rosbag2_performance_benchmarking
       - rosbag2_py
       - rosbag2_storage
@@ -2099,7 +2100,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.7.0-1
+      version: 0.8.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.8.0-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.0-1`

## ros2bag

```
* /clock publisher in Player (#695 <https://github.com/ros2/rosbag2/issues/695>)
* Introducing Reindexer CLI (#699 <https://github.com/ros2/rosbag2/issues/699>)
* rosbag2_py pybind wrapper for "record" - remove rosbag2_transport_py (#702 <https://github.com/ros2/rosbag2/issues/702>)
* Add rosbag2_py::Player::play to replace rosbag2_transport_python version (#693 <https://github.com/ros2/rosbag2/issues/693>)
* Explicitly add emersonknapp as maintainer (#692 <https://github.com/ros2/rosbag2/issues/692>)
* Contributors: Emerson Knapp, jhdcs
```

## rosbag2

```
* Explicitly add emersonknapp as maintainer (#692 <https://github.com/ros2/rosbag2/issues/692>)
* Contributors: Emerson Knapp
```

## rosbag2_compression

```
* Explicitly add emersonknapp as maintainer (#692 <https://github.com/ros2/rosbag2/issues/692>)
* Reindexer core (#641 <https://github.com/ros2/rosbag2/issues/641>)
  Add a new C++ Reindexer class for reconstructing metadata from bags that are missing it.
* Contributors: Emerson Knapp, jhdcs
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Add set_rate to PlayerClock (#727 <https://github.com/ros2/rosbag2/issues/727>)
* Enforce non-null now_fn in TimeControllerClock (#731 <https://github.com/ros2/rosbag2/issues/731>)
* Fix pause snapshot behavior and add regression test (#730 <https://github.com/ros2/rosbag2/issues/730>)
* Pause/resume PlayerClock (#704 <https://github.com/ros2/rosbag2/issues/704>)
* Remove -Werror from builds, enable it in Action CI (#722 <https://github.com/ros2/rosbag2/issues/722>)
* Enable thread safety analysis for rosbag2_cpp and add annotations in TimeControllerClock (#710 <https://github.com/ros2/rosbag2/issues/710>)
* PlayerClock initial implementation - Player functionally unchanged (#689 <https://github.com/ros2/rosbag2/issues/689>)
* Explicitly add emersonknapp as maintainer (#692 <https://github.com/ros2/rosbag2/issues/692>)
* Reindexer core (#641 <https://github.com/ros2/rosbag2/issues/641>)
  Add a new C++ Reindexer class for reconstructing metadata from bags that are missing it.
* use rclcpp serialized messages to write data (#457 <https://github.com/ros2/rosbag2/issues/457>)
* Contributors: Emerson Knapp, Karsten Knese, jhdcs
```

## rosbag2_interfaces

```
* Add rosbag2_interfaces package with playback service definitions (#728 <https://github.com/ros2/rosbag2/issues/728>)
* Contributors: Emerson Knapp
```

## rosbag2_performance_benchmarking

- No changes

## rosbag2_py

```
* Remove -Werror from builds, enable it in Action CI (#722 <https://github.com/ros2/rosbag2/issues/722>)
* Split Rosbag2Transport into Player and Recorder classes - first pass to enable further progress (#721 <https://github.com/ros2/rosbag2/issues/721>)
* /clock publisher in Player (#695 <https://github.com/ros2/rosbag2/issues/695>)
* Introducing Reindexer CLI (#699 <https://github.com/ros2/rosbag2/issues/699>)
* Fix rosbag2_py transport test for py capsule (#707 <https://github.com/ros2/rosbag2/issues/707>)
* rosbag2_py pybind wrapper for "record" - remove rosbag2_transport_py (#702 <https://github.com/ros2/rosbag2/issues/702>)
* Add rosbag2_py::Player::play to replace rosbag2_transport_python version (#693 <https://github.com/ros2/rosbag2/issues/693>)
* Explicitly add emersonknapp as maintainer (#692 <https://github.com/ros2/rosbag2/issues/692>)
* Contributors: Emerson Knapp, jhdcs
```

## rosbag2_storage

```
* Remove -Werror from builds, enable it in Action CI (#722 <https://github.com/ros2/rosbag2/issues/722>)
* PlayerClock initial implementation - Player functionally unchanged (#689 <https://github.com/ros2/rosbag2/issues/689>)
* Explicitly add emersonknapp as maintainer (#692 <https://github.com/ros2/rosbag2/issues/692>)
* Reindexer core (#641 <https://github.com/ros2/rosbag2/issues/641>)
  Add a new C++ Reindexer class for reconstructing metadata from bags that are missing it.
* Contributors: Emerson Knapp, jhdcs
```

## rosbag2_storage_default_plugins

```
* Remove -Werror from builds, enable it in Action CI (#722 <https://github.com/ros2/rosbag2/issues/722>)
* Explicitly add emersonknapp as maintainer (#692 <https://github.com/ros2/rosbag2/issues/692>)
* Reindexer core (#641 <https://github.com/ros2/rosbag2/issues/641>)
  Add a new C++ Reindexer class for reconstructing metadata from bags that are missing it.
* Contributors: Emerson Knapp, jhdcs
```

## rosbag2_test_common

```
* Remove -Werror from builds, enable it in Action CI (#722 <https://github.com/ros2/rosbag2/issues/722>)
* Fix bad_function_call by replacing rclcpp::spin_some with SingleThreadedExecutor (#705 <https://github.com/ros2/rosbag2/issues/705>)
* Explicitly add emersonknapp as maintainer (#692 <https://github.com/ros2/rosbag2/issues/692>)
* Contributors: Emerson Knapp
```

## rosbag2_tests

```
* Remove -Werror from builds, enable it in Action CI (#722 <https://github.com/ros2/rosbag2/issues/722>)
* Explicitly add emersonknapp as maintainer (#692 <https://github.com/ros2/rosbag2/issues/692>)
* Reindexer core (#641 <https://github.com/ros2/rosbag2/issues/641>)
  Add a new C++ Reindexer class for reconstructing metadata from bags that are missing it.
* use rclcpp serialized messages to write data (#457 <https://github.com/ros2/rosbag2/issues/457>)
* Contributors: Emerson Knapp, Karsten Knese, jhdcs
```

## rosbag2_transport

```
* cleanup cmakelists (#726 <https://github.com/ros2/rosbag2/issues/726>)
* turn recorder into a node (#724 <https://github.com/ros2/rosbag2/issues/724>)
* turn player into a node (#723 <https://github.com/ros2/rosbag2/issues/723>)
* Remove -Werror from builds, enable it in Action CI (#722 <https://github.com/ros2/rosbag2/issues/722>)
* Split Rosbag2Transport into Player and Recorder classes - first pass to enable further progress (#721 <https://github.com/ros2/rosbag2/issues/721>)
* /clock publisher in Player (#695 <https://github.com/ros2/rosbag2/issues/695>)
* use rclcpp logging macros (#715 <https://github.com/ros2/rosbag2/issues/715>)
* use rclcpp::Node for generic pub/sub (#714 <https://github.com/ros2/rosbag2/issues/714>)
* PlayerClock initial implementation - Player functionally unchanged (#689 <https://github.com/ros2/rosbag2/issues/689>)
* Fix bad_function_call by replacing rclcpp::spin_some with SingleThreadedExecutor (#705 <https://github.com/ros2/rosbag2/issues/705>)
* rosbag2_py pybind wrapper for "record" - remove rosbag2_transport_py (#702 <https://github.com/ros2/rosbag2/issues/702>)
* Add rosbag2_py::Player::play to replace rosbag2_transport_python version (#693 <https://github.com/ros2/rosbag2/issues/693>)
* Fix and clarify logic in test_play filter test (#690 <https://github.com/ros2/rosbag2/issues/690>)
* Explicitly add emersonknapp as maintainer (#692 <https://github.com/ros2/rosbag2/issues/692>)
* Add QoS decoding translation for infinite durations to RMW_DURATION_INFINITE (#684 <https://github.com/ros2/rosbag2/issues/684>)
* Contributors: Emerson Knapp, Karsten Knese
```

## shared_queues_vendor

```
* Explicitly add emersonknapp as maintainer (#692 <https://github.com/ros2/rosbag2/issues/692>)
* Contributors: Emerson Knapp
```

## sqlite3_vendor

```
* Explicitly add emersonknapp as maintainer (#692 <https://github.com/ros2/rosbag2/issues/692>)
* Contributors: Emerson Knapp
```

## zstd_vendor

```
* Explicitly add emersonknapp as maintainer (#692 <https://github.com/ros2/rosbag2/issues/692>)
* Contributors: Emerson Knapp
```
