### PR TITLE
Fix the branches for iceoryx and cyclonedds in Rolling/Galactic.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -455,7 +455,7 @@ repositories:
     source:
       type: git
       url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-      version: master
+      version: iceoryx
     status: maintained
   demos:
     doc:
@@ -874,7 +874,7 @@ repositories:
     source:
       type: git
       url: https://github.com/eclipse-iceoryx/iceoryx.git
-      version: master
+      version: release_1.0
     status: developed
   ifm3d_core:
     release:


### PR DESCRIPTION
This matches what is in ros2.repos.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>
