### PR TITLE
simple_launch: 1.0.3-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4242,7 +4242,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/oKermorgant/simple_launch-release.git
-      version: 1.0.2-1
+      version: 1.0.3-2
     source:
       type: git
       url: https://github.com/oKermorgant/simple_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_launch` to `1.0.3-2`:

- upstream repository: https://github.com/oKermorgant/simple_launch.git
- release repository: https://github.com/oKermorgant/simple_launch-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.2-1`

## simple_launch

```
* solve typo in node_args
* better handling of node arguments in nested lists
* bug fixes around Substitutions
* Merge pull request #1 <https://github.com/oKermorgant/simple_launch/issues/1> from oKermorgant/master
  deduce executable from package name if needed
* Contributors: Olivier Kermorgant
```
