### PR TITLE
Add ROS 2 Galactic Geochelone

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,5 +12,5 @@ kinetic/* @tfoote
 lunar/* @clalancette
 melodic/* @clalancette
 noetic/* @sloretz
-rolling/* @cottsay @nuclearsandwich
+rolling/* @nuclearsandwich
 rosdep/* @ros/rosdeputies

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@ crystal/* @nuclearsandwich
 dashing/* @nuclearsandwich
 eloquent/* @mjcarroll
 foxy/* @jacobperron
+galactic/* @cottsay
 indigo/* @tfoote
 kinetic/* @tfoote
 lunar/* @clalancette

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1,0 +1,12 @@
+%YAML 1.1
+# ROS distribution file
+# see REP 143: http://ros.org/reps/rep-0143.html
+---
+release_platforms:
+  rhel:
+  - '8'
+  ubuntu:
+  - focal
+repositories:
+type: distribution
+version: 2

--- a/index-v4.yaml
+++ b/index-v4.yaml
@@ -39,6 +39,12 @@ distributions:
     distribution_status: active
     distribution_type: ros2
     python_version: 3
+  galactic:
+    distribution: [galactic/distribution.yaml]
+    distribution_cache: http://repo.ros2.org/rosdistro_cache/galactic-cache.yaml.gz
+    distribution_status: active
+    distribution_type: ros2
+    python_version: 3
   groovy:
     distribution: [groovy/distribution.yaml]
     distribution_cache: http://repositories.ros.org/rosdistro_cache/groovy-cache.yaml.gz

--- a/index.yaml
+++ b/index.yaml
@@ -21,6 +21,9 @@ distributions:
   foxy:
     distribution: [foxy/distribution.yaml]
     distribution_cache: http://repo.ros2.org/rosdistro_cache/foxy-cache.yaml.gz
+  galactic:
+    distribution: [galactic/distribution.yaml]
+    distribution_cache: http://repo.ros2.org/rosdistro_cache/galactic-cache.yaml.gz
   groovy:
     distribution: [groovy/distribution.yaml]
     distribution_cache: http://repositories.ros.org/rosdistro_cache/groovy-cache.yaml.gz


### PR DESCRIPTION
To prepare for the branch from Rolling this week, this change creates an empty Galactic distribution in the rosdistro index.

REP 2000 for Galactic: https://www.ros.org/reps/rep-2000.html#galactic-geochelone-may-2021-may-2022

I manually initialized an empty cache and uploaded it to repo.ros2.org.