### PR TITLE
Ensure clone is successful during migration

### DIFF
--- a/migration-tools/migrate-rosdistro.py
+++ b/migration-tools/migrate-rosdistro.py
@@ -123,7 +123,7 @@ for repo_name in sorted(new_repositories + repositories_to_retry):
             raise ValueError('This script can only handle git repositories.')
         remote_url = release_spec.url
         release_repo = remote_url.split('/')[-1][:-4]
-        subprocess.call(['git', 'clone', remote_url])
+        subprocess.check_call(['git', 'clone', remote_url])
         os.chdir(release_repo)
         tracks = read_tracks_file()
 


### PR DESCRIPTION
I think this should have `check_call`. It looks like later code assumes that the operation succeeds.