### PR TITLE
Update rosdep only once during migration

### DIFF
--- a/migration-tools/migrate-rosdistro.py
+++ b/migration-tools/migrate-rosdistro.py
@@ -114,6 +114,9 @@ repositories_with_errors = []
 workdir = tempfile.mkdtemp()
 os.chdir(workdir)
 os.environ['ROSDISTRO_INDEX_URL'] = rosdistro_index_url
+os.environ['BLOOM_SKIP_ROSDEP_UPDATE'] = '1'
+
+subprocess.check_call(['rosdep', 'update'])
 
 for repo_name in sorted(new_repositories + repositories_to_retry):
     try:

--- a/migration-tools/migrate-rosdistro.py
+++ b/migration-tools/migrate-rosdistro.py
@@ -116,6 +116,9 @@ os.chdir(workdir)
 os.environ['ROSDISTRO_INDEX_URL'] = rosdistro_index_url
 os.environ['BLOOM_SKIP_ROSDEP_UPDATE'] = '1'
 
+# This call to update rosdep is critical because we're setting
+# ROSDISTRO_INDEX_URL above and also suppressing the automatic
+# update in Bloom itself.
 subprocess.check_call(['rosdep', 'update'])
 
 for repo_name in sorted(new_repositories + repositories_to_retry):


### PR DESCRIPTION
Leverage ros-infrastructure/bloom#565 to prevent automatic calls to rosdep update by Bloom, but perform one explicit update at the start.

This should make the process substantially faster.