### PR TITLE
During migration, fail gracefully with unreleased repos

### DIFF
--- a/migration-tools/migrate-rosdistro.py
+++ b/migration-tools/migrate-rosdistro.py
@@ -127,6 +127,9 @@ for repo_name in sorted(new_repositories + repositories_to_retry):
         os.chdir(release_repo)
         tracks = read_tracks_file()
 
+        if not tracks['tracks'].get(args.source):
+            raise ValueError('Repository has not been released.')
+
         if release_repo not in org_release_repos:
             release_org.create_repo(release_repo)
         new_release_repo_url = f'https://github.com/{args.release_org}/{release_repo}.git'


### PR DESCRIPTION
This will prevent a `KeyError` from causing the entire script to exit when encountering a repository release mapping which has no `version`, such as this one: https://github.com/ros/rosdistro/blob/757cd196fe76cc8c83d8c0cf089f6f6d8039cda0/rolling/distribution.yaml#L1150-L1166