### PR TITLE
openzen_driver: 1.2.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2169,6 +2169,21 @@ repositories:
       url: https://github.com/OpenVSLAM-Community/openvslam.git
       version: foxy-devel
     status: developed
+  openzen_driver:
+    doc:
+      type: git
+      url: https://bitbucket.org/lpresearch/openzenros2.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/lp-research/openzen_sensor_ros2-release.git
+      version: 1.2.0-2
+    source:
+      type: git
+      url: https://bitbucket.org/lpresearch/openzenros2.git
+      version: master
+    status: developed
   oroca_rqt_command:
     doc:
       type: git


### PR DESCRIPTION
This is a port of the existing ROS1 package openzen_sensor (http://wiki.ros.org/openzen_sensor) for IMU and GPS sensor readout to ROS2. The core library OpenZen for sensor connection and parsing is the same but the ROS-facing code has been adapted to ROS2's rclcpp and integration test facilities. Furthermore, the package name (openzen_sensor -> openzen_driver) and the node binary name (openzen_sensor_node -> openzen_node) have been renamed to conform better to ROS naming schemes used.
Thanks for having a look!

Increasing version of package(s) in repository `openzen_driver` to `1.2.0-2`:

- upstream repository: https://bitbucket.org/lpresearch/openzenros2.git
- release repository: https://github.com/lp-research/openzen_sensor_ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## openzen_driver

```
* init version
```
