### PR TITLE
fadecandy_ros: 0.2.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2895,6 +2895,10 @@ repositories:
       version: master
     status: maintained
   fadecandy_ros:
+    doc:
+      type: git
+      url: https://github.com/iron-ox/fadecandy_ros.git
+      version: master
     release:
       packages:
       - fadecandy_driver
@@ -2902,7 +2906,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/iron-ox/fadecandy_ros-release.git
-      version: 0.1.3-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/iron-ox/fadecandy_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fadecandy_ros` to `0.2.1-1`:

- upstream repository: https://github.com/iron-ox/fadecandy_ros.git
- release repository: https://github.com/iron-ox/fadecandy_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `0.1.3-1`

## fadecandy_driver

```
* chore(package.xml): Update maintainers
* Contributors: Rein Appeldoorn
```

## fadecandy_msgs

```
* chore(package.xml): Update maintainers
* Contributors: Rein Appeldoorn
```
