### PR TITLE
fadecandy_ros: 0.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1819,6 +1819,10 @@ repositories:
       version: 1.0.0-1
     status: maintained
   fadecandy_ros:
+    doc:
+      type: git
+      url: https://github.com/iron-ox/fadecandy_ros.git
+      version: master
     release:
       packages:
       - fadecandy_driver
@@ -1826,7 +1830,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/iron-ox/fadecandy_ros-release.git
-      version: 0.1.3-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/iron-ox/fadecandy_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fadecandy_ros` to `0.2.1-1`:

- upstream repository: https://github.com/iron-ox/fadecandy_ros.git
- release repository: https://github.com/iron-ox/fadecandy_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `0.1.3-1`

## fadecandy_driver

```
* chore(package.xml): Update maintainers
* Contributors: Rein Appeldoorn
```

## fadecandy_msgs

```
* chore(package.xml): Update maintainers
* Contributors: Rein Appeldoorn
```
