### PR TITLE
boost_sml: 0.1.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -941,7 +941,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PickNikRobotics/boost_sml-release.git
-      version: 0.1.0-3
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/boost_sml.git


### PR DESCRIPTION
Increasing version of package(s) in repository `boost_sml` to `0.1.2-1`:

- upstream repository: https://github.com/PickNikRobotics/boost_sml.git
- release repository: https://github.com/PickNikRobotics/boost_sml-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.1.0-3`

## boost_sml

```
* Add GitHub actions (#7 <https://github.com/PickNikRobotics/boost_sml/issues/7>)
* Fix Debian Buster build
* Contributors: Tyler Weaver
```
