### PR TITLE
rqt_pose_view: 0.5.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6661,7 +6661,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_pose_view-release.git
-      version: 0.5.10-1
+      version: 0.5.11-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_pose_view.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_pose_view` to `0.5.11-1`:

- upstream repository: https://github.com/ros-visualization/rqt_pose_view.git
- release repository: https://github.com/ros-gbp/rqt_pose_view-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.5.10-1`

## rqt_pose_view

```
* fix shebang line for python3 (#7 <https://github.com/ros-visualization/rqt_pose_view/issues/7>)
* Contributors: Mikael Arguedas
```
