### PR TITLE
rqt_runtime_monitor: 0.5.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6799,7 +6799,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_runtime_monitor-release.git
-      version: 0.5.8-1
+      version: 0.5.9-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_runtime_monitor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_runtime_monitor` to `0.5.9-1`:

- upstream repository: https://github.com/ros-visualization/rqt_runtime_monitor.git
- release repository: https://github.com/ros-gbp/rqt_runtime_monitor-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.5.8-1`

## rqt_runtime_monitor

```
* fix shebang line for python3 (#6 <https://github.com/ros-visualization/rqt_runtime_monitor/issues/6>)
* Contributors: Mikael Arguedas
```
