### PR TITLE
rqt_service_caller: 0.4.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6826,7 +6826,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_service_caller-release.git
-      version: 0.4.9-1
+      version: 0.4.10-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_service_caller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_service_caller` to `0.4.10-1`:

- upstream repository: https://github.com/ros-visualization/rqt_service_caller.git
- release repository: https://github.com/ros-gbp/rqt_service_caller-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.9-1`

## rqt_service_caller

```
* Merge pull request #18 <https://github.com/ros-visualization/rqt_service_caller/issues/18> from ros-visualization/sloretz-update-maintainer
  Update maintainer in package.xml
* Update maintainer in package.xml
* fix shebang line for python3 (#16 <https://github.com/ros-visualization/rqt_service_caller/issues/16>)
* Contributors: Michael Carroll, Mikael Arguedas, Shane Loretz
```
