### PR TITLE
rqt_web: 0.4.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6917,7 +6917,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_web-release.git
-      version: 0.4.9-1
+      version: 0.4.10-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_web.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_web` to `0.4.10-1`:

- upstream repository: https://github.com/ros-visualization/rqt_web.git
- release repository: https://github.com/ros-gbp/rqt_web-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.9-1`

## rqt_web

```
* fix shebang line for python3 (#4 <https://github.com/ros-visualization/rqt_web/issues/4>)
* Contributors: Mikael Arguedas
```
