### PR TITLE
psen_scan_v2: 0.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5148,7 +5148,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/PilzDE/psen_scan_v2-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/PilzDE/psen_scan_v2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `psen_scan_v2` to `0.2.1-1`:

- upstream repository: https://github.com/PilzDE/psen_scan_v2.git
- release repository: https://github.com/PilzDE/psen_scan_v2-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.0-1`

## psen_scan_v2

```
* Fix issues with smaller angle ranges than default range (#183 <https://github.com/PilzDE/psen_scan_v2/issues/183>)
* Add action for pull request todos (#184 <https://github.com/PilzDE/psen_scan_v2/issues/184>)
* Contributors: Pilz GmbH and Co. KG
```
