### PR TITLE
vision_visp: 0.12.0-1 in 'noetic/distribution.yaml'

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8133,6 +8133,28 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: noetic
     status: maintained
+  vision_visp:
+    doc:
+      type: git
+      url: https://github.com/lagadic/vision_visp.git
+      version: noetic
+    release:
+      packages:
+      - vision_visp
+      - visp_auto_tracker
+      - visp_bridge
+      - visp_camera_calibration
+      - visp_hand2eye_calibration
+      - visp_tracker
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/lagadic/vision_visp-release.git
+      version: 0.12.0-1
+    source:
+      type: git
+      url: https://github.com/lagadic/vision_visp.git
+      version: noetic-devel
+    status: maintained
   visp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_visp` to `0.12.0-1`:

- upstream repository: https://github.com/lagadic/vision_visp.git
- release repository: https://github.com/lagadic/vision_visp-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
