### PR TITLE
Set Galactic's status to prerelease.

### DIFF
--- a/index-v4.yaml
+++ b/index-v4.yaml
@@ -42,7 +42,7 @@ distributions:
   galactic:
     distribution: [galactic/distribution.yaml]
     distribution_cache: http://repo.ros2.org/rosdistro_cache/galactic-cache.yaml.gz
-    distribution_status: active
+    distribution_status: prerelease
     distribution_type: ros2
     python_version: 3
   groovy:


### PR DESCRIPTION
Galactic is currently a prerelease distribution and is not yet active.

`prerelease` is one of the semantic statuses described in https://www.ros.org/reps/rep-0153.html#index-file
