### PR TITLE
adding qml-module-qtquick-extras rosdep key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5917,6 +5917,9 @@ qml-module-qtquick-controls2:
 qml-module-qtquick-dialogs:
   debian: [qml-module-qtquick-dialogs]
   ubuntu: [qml-module-qtquick-dialogs]
+qml-module-qtquick-extras:
+  debian: [qml-module-qtquick-extras]
+  ubuntu: [qml-module-qtquick-extras]
 qml-module-qtquick-layouts:
   debian: [qml-module-qtquick-layouts]
   ubuntu: [qml-module-qtquick-layouts]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

qml-module-qtquick-extras

## Package Upstream Source:

See https://doc.qt.io/qt-5/qtquick-extras-qmlmodule.html

## Purpose of using this:

This package provides QML components for circular gauge and other widgets.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/
  - REQUIRED
  -  https://packages.debian.org/stretch/qml-module-qtquick-extras
- Ubuntu: https://packages.ubuntu.com/
   - REQUIRED
   - https://packages.ubuntu.com/bionic/qml-module-qtquick-extras
- Fedora: https://src.fedoraproject.org/browse/projects/
  - IF AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE



# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
