### PR TITLE
gazebo_ros_pkgs: 2.9.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2107,6 +2107,10 @@ repositories:
       version: master
     status: maintained
   gazebo_ros_pkgs:
+    doc:
+      type: git
+      url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
+      version: noetic-devel
     release:
       packages:
       - gazebo_dev
@@ -2118,7 +2122,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.9.1-1
+      version: 2.9.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.9.2-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `2.9.1-1`

## gazebo_dev

```
* colcon.pkg: build gazebo first in colcon workspace (#1135 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1135>)
  Add a colcon.pkg file to gazebo_dev with gazebo's cmake project
  name "Gazebo" listed as a dependency to support building
  gazebo from source in a colcon workspace.
  * Add colcon.pkg files for other packages
  Copy colcon.pkg to gazebo_ros, gazebo_plugins, and
  gazebo_ros_control so that --merge-install won't be required.
* Contributors: Steve Peters
```

## gazebo_msgs

```
* [Noetic] Bridge to republish PerformanceMetrics in ROS (#1145 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1145>)
  Co-authored-by: Ian Chen <mailto:ichen@osrfoundation.org>
* Contributors: Alejandro Hernández Cordero
```

## gazebo_plugins

```
* gazebo_ros_utils: don't set tf_prefix if empty (#1173 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1173>)
  Similar changes were made in #1143 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1143> to address #554 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/554>,
  but this class wasn't included.
* Update test worlds to use the correct element names for xyzOffset and rpyOffset (#1206 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1206>)
  The test worlds add an extra 's' character, but the real names are singular.
* [noetic][planar_move_controller] add cmdTimeout param (#1133 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1133>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* [noetic][Windows] Removing extra CameraPlugin header inclusion from gazebo_ros_camera_utils (#1161 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1161>)
* multi roboti example updated for noetic (#1154 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1154>)
* Leave empty tf_prefix values unset (#1143 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1143>)
  As reported in #554 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/554>, tf_prefix has been long deprecated,
  so if it is unset, leave it empty instead of giving a default value.
  Fixes #554 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/554>.
* Added directives if profiler is not installed (#1144 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1144>)
* colcon.pkg: build gazebo first in colcon workspace (#1135 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1135>)
  Add a colcon.pkg file to gazebo_dev with gazebo's cmake project  name "Gazebo" listed as a dependency to support building
  gazebo from source in a colcon workspace. Add colcon.pkg files for other packages
  Copy colcon.pkg to gazebo_ros, gazebo_plugins, and  gazebo_ros_control so that --merge-install won't be required.
* [Noetic] Added Ignition common profiler to gazebo_plugins (#1139 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1139>)
  * Added Ignition common profiler
  * Fixed typo
* WheelSlip.cfg: ignore default parameter values (#1126 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1126>)
  The WheelSlipPlugin already has default values for the slip
  compliance parameters, so ignore the default values set in
  WheelSlip.cfg by making them negative and instruct the
  callback to ignore negative values.
  Also, ignore the level variable in callback so that
  parameters set in launch file will not be ignored.
* Contributors: Alejandro Hernández Cordero, G.Doisy, Jacob Perron, Markus Bader, Sean Yen, Steve Peters
```

## gazebo_ros

```
* Only subscribe to /gazebo/performance_metrics when necessary (#1202 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1202>)
  We are currently subscribing to the /gazebo/performance_metrics topic
  even if there are no subscribers to the ROS topic forwarding this data.
  The link_states and model_states topics currently use an advertise
  mechanism with callbacks when a subscriber connects or disconnects,
  so I've used that same pattern for the performance_metrics topic.
  This also helps workaround the deadlock documented in #1175 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1175> and
  osrf/gazebo#2902 <https://github.com/osrf/gazebo/issues/2902>.
  This also adds a GAZEBO_ROS_HAS_PERFORMANCE_METRICS
  macro that reduces duplication of the version checking logic for
  performance metrics in gazebo and adds fixes some doc-string and
  typos in existing code
* [Noetic] Bridge to republish PerformanceMetrics in ROS (#1145 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1145>)
  Co-authored-by: Ian Chen <mailto:ichen@osrfoundation.org>
* delete request msgs (#1160 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1160>)
* gazebo_ros_api_plugin cleanup (#1137 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1137>)
  Remove an unused overload of publishSimTime and add doxygen
  for the remaining publishSimTime function.
  * Remove duplicate code for /clock advertisement
  The /clock topic is advertised in both loadGazeboRosApiPlugin
  and advertiseServices. This removes the code from advertiseServices
  and moves it earlier in loadGazeboRosApiPlugin.
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* colcon.pkg: build gazebo first in colcon workspace (#1135 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1135>)
  Add a colcon.pkg file to gazebo_dev with gazebo's cmake project
  name "Gazebo" listed as a dependency to support building
  gazebo from source in a colcon workspace.
  * Add colcon.pkg files for other packages
  Copy colcon.pkg to gazebo_ros, gazebo_plugins, and
  gazebo_ros_control so that --merge-install won't be required.
* Contributors: Alejandro Hernández Cordero, Ian Chen, Steve Peters
```

## gazebo_ros_control

```
* colcon.pkg: build gazebo first in colcon workspace (#1135 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1135>)
  Add a colcon.pkg file to gazebo_dev with gazebo's cmake project
  name "Gazebo" listed as a dependency to support building
  gazebo from source in a colcon workspace.
  * Add colcon.pkg files for other packages
  Copy colcon.pkg to gazebo_ros, gazebo_plugins, and
  gazebo_ros_control so that --merge-install won't be required.
* Contributors: Steve Peters
```

## gazebo_ros_pkgs

- No changes

close https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1262
