### PR TITLE
gpio_control: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3664,6 +3664,11 @@ repositories:
       type: git
       url: https://github.com/cst0/gpio_control.git
       version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/cst0/gpio_control-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/cst0/gpio_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gpio_control` to `1.0.0-1`:

- upstream repository: https://github.com/cst0/gpio_control.git
- release repository: https://github.com/cst0/gpio_control-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `null`
