### PR TITLE
realsense2_camera: 2.2.24-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11854,7 +11854,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
-      version: 2.2.22-1
+      version: 2.2.24-1
     source:
       type: git
       url: https://github.com/IntelRealSense/realsense-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `2.2.24-1`:

- upstream repository: https://github.com/IntelRealSense/realsense-ros.git
- release repository: https://github.com/IntelRealSense/realsense-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.2.22-1`

## realsense2_camera

```
* Enabling pointcloud while align_depth is set to true creates a pointcloud aligned to color image.
* Removed option to align depth to other streams other then color.
* Contributors: doronhi
```

## realsense2_description

```
* Add conditional param use_mesh.
* Contributors: Teo Cardoso
```
