### PR TITLE
hls_lfcd_lds_driver: 2.0.2-4 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1302,7 +1302,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/robotis-ros2-release/hls_lfcd_lds_driver-release.git
-      version: 2.0.2-3
+      version: 2.0.2-4
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hls_lfcd_lds_driver` to `2.0.2-4`:

- upstream repository: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
- release repository: https://github.com/robotis-ros2-release/hls_lfcd_lds_driver-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `2.0.2-3`

## hls_lfcd_lds_driver

```
* fix laserscan data bug
* rename nav2 params
* fox bug, deprecated param name
* use static param type for Galactic
* Contributors: Will Son
```
