### PR TITLE
core_perception: 1.14.15-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1871,7 +1871,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/nobleo/core_perception-release.git
-      version: 1.14.13-2
+      version: 1.14.15-1
     source:
       type: git
       url: https://github.com/nobleo/core_perception.git


### PR DESCRIPTION
Increasing version of package(s) in repository `core_perception` to `1.14.15-1`:

- upstream repository: https://github.com/nobleo/core_perception.git
- release repository: https://github.com/nobleo/core_perception-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `1.14.13-2`

## points_preprocessor

```
* Don't declare type again
* Contributors: Tim Clephas
```
