### PR TITLE
add python3 dependency

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5441,6 +5441,10 @@ python-dev:
   ubuntu:
     '*': [python-dev]
     'focal': [python2-dev]
+python3-dev:
+  debian: [python3-dev]
+  fedora: [python3-devel]
+  ubuntu: [python3-dev]
 qhull-bin:
   arch: [qhull]
   debian: [qhull-bin]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`python3-dev`

## Package Upstream Source:

https://www.python.org/download/releases/

## Purpose of using this:

Use key `python3-dev` besides `python-dev` for Python 3 dependencies.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/buster/python3-dev
- Ubuntu: https://packages.ubuntu.com/focal/python3-dev
- Fedora: https://src.fedoraproject.org/rpms/python3
