### PR TITLE
sot-core: 4.11.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7340,7 +7340,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/stack-of-tasks/sot-core-ros-release.git
-      version: 4.11.5-2
+      version: 4.11.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sot-core` to `4.11.6-1`:

- upstream repository: https://github.com/stack-of-tasks/sot-core.git
- release repository: https://github.com/stack-of-tasks/sot-core-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `4.11.5-2`
