### PR TITLE
catkin: 0.8.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -545,7 +545,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.8.9-1
+      version: 0.8.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.8.10-1`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `0.8.9-1`

## catkin

```
* Fix problem with Googletest's LIBRARY_OUTPUT_DIRECTORY (#1135 <https://github.com/ros/catkin/issues/1135>)
* deduplicate dependency lists of exported code generation targets (#1123 <https://github.com/ros/catkin/issues/1123>)
* Update maintainers (#1124 <https://github.com/ros/catkin/issues/1124>)
* Contributors: Michael Carroll, Timo Röhling, pseyfert
```
