### PR TITLE
moveit: 2.1.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1863,7 +1863,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/moveit/moveit2-release.git
-      version: 2.1.1-1
+      version: 2.1.2-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.1.2-1`:

- upstream repository: https://github.com/ros-planning/moveit2.git
- release repository: https://github.com/moveit/moveit2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.1-1`

## moveit

```
* Unify PickNik name in copyrights (#419 <https://github.com/ros-planning/moveit2/issues/419>)
* Contributors: Tyler Weaver
```

## moveit_common

```
* Unify PickNik name in copyrights (#419 <https://github.com/ros-planning/moveit2/issues/419>)
* Contributors: Tyler Weaver
```

## moveit_core

```
* Fix robot_model & moveit_ros_visualization dependencies (#421 <https://github.com/ros-planning/moveit2/issues/421>)
* Unify PickNik name in copyrights (#419 <https://github.com/ros-planning/moveit2/issues/419>)
* Contributors: Jafar Abdi, Tyler Weaver
```

## moveit_fake_controller_manager

- No changes

## moveit_kinematics

```
* Unify PickNik name in copyrights (#419 <https://github.com/ros-planning/moveit2/issues/419>)
* Contributors: Tyler Weaver
```

## moveit_planners

- No changes

## moveit_planners_ompl

- No changes

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

```
* Unify PickNik name in copyrights (#419 <https://github.com/ros-planning/moveit2/issues/419>)
* Contributors: Tyler Weaver
```

## moveit_ros_move_group

- No changes

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

- No changes

## moveit_ros_planning

```
* Unify PickNik name in copyrights (#419 <https://github.com/ros-planning/moveit2/issues/419>)
* Contributors: Tyler Weaver
```

## moveit_ros_planning_interface

```
* Re-enable test_servo_pose_tracking integration test (#423 <https://github.com/ros-planning/moveit2/issues/423>)
  Co-authored-by: AndyZe <mailto:zelenak@picknik.ai>
* Re-enable moveit_ros_warehouse for moveit_ros_planning_interface (#424 <https://github.com/ros-planning/moveit2/issues/424>)
  * Remove warehouse_ros_mongo from moveit_ros_planning_interface test depends
* Unify PickNik name in copyrights (#419 <https://github.com/ros-planning/moveit2/issues/419>)
* Contributors: Jafar Abdi, Tyler Weaver, Vatan Aksoy Tezer
```

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

```
* Fix robot_model & moveit_ros_visualization dependencies (#421 <https://github.com/ros-planning/moveit2/issues/421>)
* Remove move_group namespace from MotionPlanning display (#420 <https://github.com/ros-planning/moveit2/issues/420>)
* Contributors: Jafar Abdi, Vatan Aksoy Tezer
```

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_servo

```
* Re-enable test_servo_pose_tracking integration test (#423 <https://github.com/ros-planning/moveit2/issues/423>)
  Co-authored-by: AndyZe <mailto:zelenak@picknik.ai>
* Unify PickNik name in copyrights (#419 <https://github.com/ros-planning/moveit2/issues/419>)
* Contributors: Tyler Weaver, Vatan Aksoy Tezer
```

## moveit_simple_controller_manager

- No changes

## run_move_group

```
* Remove move_group namespace from MotionPlanning display (#420 <https://github.com/ros-planning/moveit2/issues/420>)
* Fix node install directory in run_move_group (#418 <https://github.com/ros-planning/moveit2/issues/418>)
* Contributors: Vatan Aksoy Tezer
```

## run_moveit_cpp

```
* Unify PickNik name in copyrights (#419 <https://github.com/ros-planning/moveit2/issues/419>)
* Contributors: Tyler Weaver
```

## run_ompl_constrained_planning

```
* Unify PickNik name in copyrights (#419 <https://github.com/ros-planning/moveit2/issues/419>)
* Remove move_group namespace from MotionPlanning display (#420 <https://github.com/ros-planning/moveit2/issues/420>)
* Contributors: Tyler Weaver, Vatan Aksoy Tezer
```
