### PR TITLE
urg_stamped: 0.0.11-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13675,7 +13675,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/seqsense/urg_stamped-release.git
-      version: 0.0.10-1
+      version: 0.0.11-1
     source:
       type: git
       url: https://github.com/seqsense/urg_stamped.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_stamped` to `0.0.11-1`:

- upstream repository: https://github.com/seqsense/urg_stamped.git
- release repository: https://github.com/seqsense/urg_stamped-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.10-1`

## urg_stamped

```
* Send QT command twice to avoid being ignored (#103 <https://github.com/seqsense/urg_stamped/issues/103>)
* Change TM0 status 10 error log level (#100 <https://github.com/seqsense/urg_stamped/issues/100>)
* Fallback timeout during time synchronization (#97 <https://github.com/seqsense/urg_stamped/issues/97>)
* Contributors: Atsushi Watanabe
```
