### PR TITLE
jderobot_drones: 1.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2912,6 +2912,18 @@ repositories:
       url: https://github.com/JdeRobot/assets.git
       version: noetic-devel
     status: developed
+  jderobot_drones:
+    release:
+      packages:
+      - drone_assets
+      - drone_wrapper
+      - jderobot_drones
+      - rqt_drone_teleop
+      - rqt_ground_robot_teleop
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/JdeRobot/drones-release.git
+      version: 1.4.0-1
   joint_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_drones` to `1.4.0-1`:

- upstream repository: https://github.com/JdeRobot/drones.git
- release repository: https://github.com/JdeRobot/drones-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `null`

## drone_assets

```
* Noetic release
* Contributors: pariaspe
```

## drone_wrapper

```
* Noetic release
* Removed unused dependency.
* Contributors: pariaspe
```

## jderobot_drones

```
* Noetic release
* Contributors: pariaspe
```

## rqt_drone_teleop

```
* Noetic release
* Contributors: pariaspe
```

## rqt_ground_robot_teleop

```
* Noetic release
* Contributors: pariaspe
```
