### PR TITLE
leo_robot: 1.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5544,7 +5544,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_robot-release.git
-      version: 1.1.3-1
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_robot` to `1.2.0-1`:

- upstream repository: https://github.com/LeoRover/leo_robot.git
- release repository: https://github.com/fictionlab-gbp/leo_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `1.1.3-1`

## leo_bringup

```
* Core2 parameters: change input_timeout to float, add robot and odom frame_id parameters
* Delete launch prefix from serial_node
* Avoid deprecation warnings from xacro and robot_state_publisher
* Update author and maintainer info
```

## leo_fw

```
* Bundle a new firmware binary release (v1.2.0)
* Add flash script to CMakeLists
* Add flash script for flashing custom firmware
* Add arguments to the flash_firmware function
* Update author and maintainer info
```

## leo_robot

```
* Update author and maintainer info
```
