### PR TITLE
tesseract: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7601,13 +7601,14 @@ repositories:
       - tesseract_geometry
       - tesseract_kinematics
       - tesseract_scene_graph
+      - tesseract_srdf
       - tesseract_support
       - tesseract_urdf
       - tesseract_visualization
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-industrial-release/tesseract-release.git
-      version: 0.3.1-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/ros-industrial-consortium/tesseract.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tesseract` to `0.4.0-1`:

- upstream repository: https://github.com/ros-industrial-consortium/tesseract.git
- release repository: https://github.com/ros-industrial-release/tesseract-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.1-1`

## tesseract_collision

```
* Fix package build depends
* Contributors: Levi Armstrong
```

## tesseract_common

```
* Add windows compile definition NOMINMAX
* Improve tesseract_common unit test coverage
* Add equal operator support to Any type erasure
* Fix package build depends
* Improve tesseract_common unit coverage
* Disable compile option -mno-avx for arm builds
* Move printNestedException and leverage forward declarations for tesseract_urdf
* Contributors: Levi Armstrong
```

## tesseract_environment

```
* Update tesseract_srdf to leverage nested exceptions
* Move srdf code to its own package tesseract_srdf
* Move printNestedException and leverage forward declarations for tesseract_urdf
* Do not catch exception in parseURDFString and parseURDFFile
* Contributors: Levi Armstrong
```

## tesseract_geometry

```
* No changes
```

## tesseract_kinematics

```
* Move srdf code to its own package tesseract_srdf
* Contributors: Levi Armstrong
```

## tesseract_scene_graph

```
* Move srdf code to its own package tesseract_srdf
* Contributors: Levi Armstrong
```

## tesseract_srdf

```
* Fix test names in tesseract_srdf
* Fix spelling in tesseract_srdf package.xml
* Update tesseract_srdf to leverage nested exceptions
* Move srdf code to its own package tesseract_srdf
* Contributors: Levi Armstrong
```

## tesseract_support

```
* Fix package build depends
* Contributors: Levi Armstrong
```

## tesseract_urdf

```
* Improve tesseract_common unit test coverage
* Improve exception text in urdf_parser
* Fix package build depends
* Move printNestedException and leverage forward declarations for tesseract_urdf
* Do not catch exception in parseURDFString and parseURDFFile
* Move tesseract_urdf implementation to cpp and fix clang tidy errors
* Improve tesseract_urdf unit test coverage
* Switch tesseract_urdf to use nested exception instead of custom status code class
* Contributors: Levi Armstrong
```

## tesseract_visualization

```
* Fix issue in trajectory_player calling size if trajectory does not exist
* Contributors: Levi Armstrong
```
