### PR TITLE
Clean up kinetic branches

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15353,7 +15353,7 @@ repositories:
     source:
       type: git
       url: https://github.com/RethinkRobotics-opensource/sns_ik.git
-      version: master
+      version: kinetic-devel
     status: maintained
   soem:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9914,7 +9914,7 @@ repositories:
     source:
       type: git
       url: https://github.com/allenh1/p2os.git
-      version: master
+      version: main
     status: maintained
   packml:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -18299,7 +18299,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/yujinrobot/yocs_msgs.git
-      version: kinetic
+      version: release/0.6-kinetic
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -18308,7 +18308,7 @@ repositories:
     source:
       type: git
       url: https://github.com/yujinrobot/yocs_msgs.git
-      version: kinetic
+      version: release/0.6-kinetic
     status: developed
   yoctopuce_altimeter:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15370,7 +15370,7 @@ repositories:
     source:
       type: git
       url: https://github.com/stonier/sophus.git
-      version: indigo
+      version: release/0.9.1-kinetic
     status: maintained
   sophus_ros_toolkit:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15523,7 +15523,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-simulation/stage_ros.git
-      version: master
+      version: indigo-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -15532,7 +15532,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-simulation/stage_ros.git
-      version: master
+      version: indigo-devel
     status: maintained
   static_tf:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8439,11 +8439,11 @@ repositories:
     doc:
       type: git
       url: https://github.com/injones/mycroft_ros.git
-      version: kinetic-devel
+      version: devel
     source:
       type: git
       url: https://github.com/injones/mycroft_ros.git
-      version: kinetic-devel
+      version: devel
     status: maintained
   nanomsg:
     release:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9888,7 +9888,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/allenh1/p2os.git
-      version: master
+      version: main
     release:
       packages:
       - p2os_doc

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16087,7 +16087,7 @@ repositories:
     source:
       type: git
       url: https://github.com/Terabee/teraranger_array.git
-      version: ros-release
+      version: master
     status: maintained
   teraranger_array_converter:
     release:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5085,16 +5085,6 @@ repositories:
       url: https://github.com/humanoid-path-planner/hpp-fcl.git
       version: devel
     status: developed
-  hr_msgs:
-    doc:
-      type: git
-      url: https://github.com/hansonrobotics/hr_msgs.git
-      version: master
-    source:
-      type: git
-      url: https://github.com/hansonrobotics/hr_msgs.git
-      version: master
-    status: developed
   hrpsys:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10992,7 +10992,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/stonier/py_trees_msgs.git
-      version: release/0.3-kinetic
+      version: release/0.3.x
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -11001,7 +11001,7 @@ repositories:
     source:
       type: git
       url: https://github.com/stonier/py_trees_msgs.git
-      version: devel
+      version: release/0.3.x
     status: developed
   py_trees_ros:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1117,7 +1117,7 @@ repositories:
   binpicking_utils:
     doc:
       type: git
-      url: https://github.com/durovsky/binpicking_utils.git
+      url: https://github.com/durovsky/bin_pose_emulator.git
       version: master
     release:
       packages:
@@ -1131,7 +1131,7 @@ repositories:
       version: 0.1.4-0
     source:
       type: git
-      url: https://github.com/durovsky/binpicking_utils.git
+      url: https://github.com/durovsky/bin_pose_emulator.git
       version: master
     status: maintained
   blender_gazebo:


### PR DESCRIPTION
This is a bulk follow up to https://github.com/ros/rosdistro/issues/26853

@stonier @allenh1 @wjwwood @injones @wenwei-dev @durovsky @IanTheEngineer Please check these changes. They were my best guesses to at least get extant branches evaluating the available branches and the released version numbers.