### PR TITLE
Update dartsim source version

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2399,7 +2399,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/dartsim/dart.git
-      version: release-6.3
+      version: v6.3.1
   dataspeed_can:
     doc:
       type: git


### PR DESCRIPTION
Since dartsim's `release-6.3` branch was retired, we should switch rosdistro to using the `v6.3.1` tag instead, which gives a snapshot of where the `release-6.3` branch left off.