### PR TITLE
fetch_robots: 0.9.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1894,7 +1894,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_robots-release.git
-      version: 0.9.2-1
+      version: 0.9.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_robots` to `0.9.3-1`:

- upstream repository: git@github.com:fetchrobotics/fetch_robots.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_robots-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.9.2-1`

## fetch_bringup

- No changes

## fetch_drivers

```
* New bump to binary drivers (0.9.3)
  
    * Fix: Loosen tolerance for torso startup position
    * Fix: Longer signal from mainboard to computer for shutdown
  
* Contributors: Eric Relson
```

## freight_bringup

- No changes
