### PR TITLE
prbt_grippers: 0.0.5-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5152,7 +5152,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/PilzDE/prbt_grippers-release.git
-      version: 0.0.5-1
+      version: 0.0.5-2
     source:
       type: git
       url: https://github.com/PilzDE/prbt_grippers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `prbt_grippers` to `0.0.5-2`:

- upstream repository: https://github.com/PilzDE/prbt_grippers.git
- release repository: https://github.com/PilzDE/prbt_grippers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.5-1`

## prbt_grippers

```
* Fixes cmake minimum required to remove developer warning on ubuntu 20
* Contributors: Pilz GmbH and Co. KG
```

## prbt_pg70_support

```
* Fixes cmake minimum required to remove developer warning on ubuntu 20
* Contributors: Pilz GmbH and Co. KG
```
