### PR TITLE
Revert "system_modes: 0.7.1-1 in 'foxy/distribution.yaml' [bloom] (#29247)"

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4376,11 +4376,10 @@ repositories:
       packages:
       - system_modes
       - system_modes_examples
-      - system_modes_msgs
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/microROS/system_modes-release.git
-      version: 0.7.1-1
+      version: 0.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
This reverts commit cab3f973c50e610520c7d3ab2101e305a4814a70.

The build is currently broken: https://build.ros2.org/view/Fbin_uF64/job/Fbin_uF64__system_modes_msgs__ubuntu_focal_amd64__binary/

Reverting to a previously working version.

@norro FYI https://github.com/ros/rosdistro/pull/29247#issuecomment-825891914
