### PR TITLE
Revert hls_lfcd_lds_driver to 2.0.1  in 'foxy/distribution.yaml'

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1302,7 +1302,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/robotis-ros2-release/hls_lfcd_lds_driver-release.git
-      version: 2.0.2-4
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git


### PR DESCRIPTION
This is in an effort to fix a broken Foxy build: https://build.ros2.org/job/Fbin_ubv8_uFv8__hls_lfcd_lds_driver__ubuntu_focal_arm64__binary

Reverting to a previously working version.

@ROBOTIS-Will FYI https://github.com/ros/rosdistro/pull/29243#issuecomment-825913759