### PR TITLE
ros2cli_common_extensions: 0.1.1-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2063,7 +2063,11 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli_common_extensions-release.git
-      version: 0.1.1-1
+      version: 0.1.1-2
+    source:
+      type: git
+      url: https://github.com/ros2/ros2cli_common_extensions.git
+      version: galactic
     status: maintained
   ros_canopen:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli_common_extensions` to `0.1.1-2`:

- upstream repository: https://github.com/ros2/ros2cli_common_extensions.git
- release repository: https://github.com/ros2-gbp/ros2cli_common_extensions-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.1-1`

## ros2cli_common_extensions

```
* remove maintainer (#5 <https://github.com/ros2/ros2cli_common_extensions/issues/5>)
* update maintainer (#4 <https://github.com/ros2/ros2cli_common_extensions/issues/4>)
* Contributors: Claire Wang
```
