### PR TITLE
bagger: 0.1.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -824,7 +824,8 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/squarerobot/bagger-release.git
-      version: 0.1.3-0
+      version: 0.1.4-1
+    status: maintained
   baldor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bagger` to `0.1.4-1`:

- upstream repository: https://github.com/squarerobot/bagger.git
- release repository: https://github.com/squarerobot/bagger-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `0.1.3-0`

## bagger

```
* Proper waiting for record processing. Fixes #6 <https://github.com/squarerobot/bagger/issues/6>
* Fix test timing synchronisity issue.
  Tests were beginning before the last test's latest bag_states message
  was published.
* Contributors: Brenden Gibbons
```
