### PR TITLE
bagger: 0.1.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -961,7 +961,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/squarerobot/bagger-release.git
-      version: 0.1.3-2
+      version: 0.1.4-1
     source:
       type: git
       url: https://github.com/squarerobot/bagger.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bagger` to `0.1.4-1`:

- upstream repository: https://github.com/squarerobot/bagger.git
- release repository: https://github.com/squarerobot/bagger-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `0.1.3-2`

## bagger

```
* Proper waiting for record processing. Fixes #6 <https://github.com/squarerobot/bagger/issues/6>
* Fix test timing synchronisity issue.
  Tests were beginning before the last test's latest bag_states message
  was published.
* Contributors: Brenden Gibbons
```
