### PR TITLE
ros2cli: 0.13.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2030,7 +2030,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.13.0-2
+      version: 0.13.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.13.1-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.13.0-2`
