### PR TITLE
bagger: 0.1.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -359,7 +359,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/squarerobot/bagger-release.git
-      version: 0.1.3-4
+      version: 0.1.4-1
     source:
       type: git
       url: https://github.com/squarerobot/bagger.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bagger` to `0.1.4-1`:

- upstream repository: https://github.com/squarerobot/bagger.git
- release repository: https://github.com/squarerobot/bagger-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `0.1.3-4`

## bagger

```
* Proper waiting for record processing. Fixes #6 <https://github.com/squarerobot/bagger/issues/6>
* Fix test timing synchronisity issue.
  Tests were beginning before the last test's latest bag_states message
  was published.
* Contributors: Brenden Gibbons
```
