### PR TITLE
launch_ros: 0.14.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1109,7 +1109,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.14.1-2
+      version: 0.14.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.14.2-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.14.1-2`

## launch_ros

- No changes

## launch_testing_ros

```
* Use underscores in setup.cfg instead of dashes. (#227 <https://github.com/ros2/launch_ros/issues/227>)
* Contributors: Mike Purvis
```

## ros2launch

- No changes
