### PR TITLE
ros_canopen: 2.0.0-3 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2054,7 +2054,8 @@ repositories:
       - can_msgs
       tags:
         release: release/galactic/{package}/{version}
-      url: https://github.com/ros-industrial-release/ros_canopen-release.git
+      url: https://github.com/ros2-gbp/ros_canopen-release.git
+      version: 2.0.0-3
     source:
       type: git
       url: https://github.com/ros-industrial/ros_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_canopen` to `2.0.0-3`:

- upstream repository: https://github.com/ros-industrial/ros_canopen.git
- release repository: https://github.com/ros2-gbp/ros_canopen-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## can_msgs

```
* port can_msgs to ROS2
* Contributors: Joshua Whitley, Mathias Lüdtke
```
