### PR TITLE
fmi_adapter: 2.1.0-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -683,6 +683,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/fmi_adapter-release.git
+      version: 2.1.0-2
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fmi_adapter` to `2.1.0-2`:

- upstream repository: https://github.com/boschresearch/fmi_adapter.git
- release repository: https://github.com/ros2-gbp/fmi_adapter-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## fmi_adapter

```
* Adapted launch files to API changes.
```

## fmi_adapter_examples

```
* Adapted launch files to API changes.
```
