### PR TITLE
ethercat_grant: 0.2.5-6 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1731,7 +1731,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/shadow-robot/ethercat_grant-release.git
-      version: 0.2.5-3
+      version: 0.2.5-6
     source:
       type: git
       url: https://github.com/shadow-robot/ethercat_grant.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ethercat_grant` to `0.2.5-6`:

- upstream repository: https://github.com/shadow-robot/ethercat_grant.git
- release repository: https://github.com/shadow-robot/ethercat_grant-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.5-3`
