### PR TITLE
Fix libav rosdep on Ubuntu

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1930,7 +1930,7 @@ libav:
   fedora: []
   gentoo: [virtual/ffmpeg]
   ubuntu:
-    '*': [ffmpeg]
+    '*': null
     xenial: [libav-tools]
 libavahi-client-dev:
   arch: [avahi]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1929,7 +1929,9 @@ libav:
   debian: [libav-tools]
   fedora: []
   gentoo: [virtual/ffmpeg]
-  ubuntu: [libav-tools]
+  ubuntu:
+    '*': [ffmpeg]
+    xenial: [libav-tools]
 libavahi-client-dev:
   arch: [avahi]
   debian: [libavahi-client-dev]


### PR DESCRIPTION
There is no package `libav-tools` in any other distro than Xenial: https://packages.ubuntu.com/xenial/libav-tools . All other releases have only `ffmpeg`, which should do the same job.

I fixed the rosdep key to install `libav-tools` on Xenial and `ffmpeg` on all other Ubuntus. 