### PR TITLE
Revert "psen_scan_v2: 0.2.1-1 in 'melodic/distribution.yaml' (#29282)"

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9038,7 +9038,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/psen_scan_v2-release.git
-      version: 0.2.1-1
+      version: 0.1.6-1
     source:
       type: git
       url: https://github.com/PilzDE/psen_scan_v2.git


### PR DESCRIPTION
This reverts commit 1971b7a34a1a65397d62357fd8418c6220d4fb20.