### PR TITLE
Update python.yaml added python-is-python3

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2240,7 +2240,10 @@ python-ipdb:
   gentoo: [dev-python/ipdb]
   ubuntu: [python-ipdb]
 python-is-python3:
-  ubuntu: [python-is-python3]
+  ubuntu: 
+    '*': [python-is-python3]
+    bionic: null
+    xenial: null
 python-itsdangerous:
   debian:
     buster: [python-itsdangerous]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2240,7 +2240,7 @@ python-ipdb:
   gentoo: [dev-python/ipdb]
   ubuntu: [python-ipdb]
 python-is-python3:
-  ubuntu: 
+  ubuntu:
     '*': [python-is-python3]
     bionic: null
     xenial: null

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2239,6 +2239,8 @@ python-ipdb:
   debian: [python-ipdb]
   gentoo: [dev-python/ipdb]
   ubuntu: [python-ipdb]
+python-is-python3:
+  ubuntu: [python-is-python3]
 python-itsdangerous:
   debian:
     buster: [python-itsdangerous]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:
python-is-python3

## Package Upstream Source:

apt?

## Purpose of using this:

In Ubuntu, all python packages use explicit python3 or python2
interpreter and do not use unversioned /usr/bin/python at all. Some
third-party code is now predominantly python3 based, yet may use
/usr/bin/python.
This is a convenience package which ships a symlink to point
the /usr/bin/python interpreter at the current default python3. It may
improve compatibility with other modern systems, whilst breaking some
obsolete or 3rd-party software.

Distro packaging links:
https://ubuntu.pkgs.org/20.04/ubuntu-main-amd64/python-is-python3_3.8.2-4_all.deb.html

## Links to Distribution Packages

- Debian: -
- Ubuntu: https://packages.ubuntu.com/focal/python-is-python3

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
