### PR TITLE
gpio_control: 1.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4359,6 +4359,11 @@ repositories:
       type: git
       url: https://github.com/cst0/gpio_control.git
       version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/cst0/gpio_control-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/cst0/gpio_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gpio_control` to `1.0.0-1`:

- upstream repository: https://github.com/cst0/gpio_control.git
- release repository: https://github.com/cst0/gpio_control-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
