### PR TITLE
common_interfaces: 2.2.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -392,7 +392,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 2.2.2-1
+      version: 2.2.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_interfaces` to `2.2.3-1`:

- upstream repository: https://github.com/ros2/common_interfaces.git
- release repository: https://github.com/ros2-gbp/common_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.2.2-1`

## actionlib_msgs

- No changes

## common_interfaces

- No changes

## diagnostic_msgs

- No changes

## geometry_msgs

- No changes

## nav_msgs

- No changes

## sensor_msgs

- No changes

## sensor_msgs_py

```
* Use underscores instead of dashes in setup.cfg (#150 <https://github.com/ros2/common_interfaces/issues/150>)
* Contributors: Ivan Santiago Paunovic
```

## shape_msgs

- No changes

## std_msgs

- No changes

## std_srvs

- No changes

## stereo_msgs

- No changes

## trajectory_msgs

- No changes

## visualization_msgs

- No changes
