### PR TITLE
rqt_top: 1.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4101,7 +4101,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_top-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_top.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_top` to `1.0.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_top.git
- release repository: https://github.com/ros2-gbp/rqt_top-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.0-1`

## rqt_top

```
* Changed the build type to ament_python and fixed package to run with ros2 run (#8 <https://github.com/ros-visualization/rqt_top/issues/8>)
* Contributors: Alejandro Hernández Cordero
```
