### PR TITLE
rqt_service_caller: 1.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2620,7 +2620,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_service_caller-release.git
-      version: 1.0.3-2
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_service_caller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_service_caller` to `1.0.4-1`:

- upstream repository: https://github.com/ros-visualization/rqt_service_caller.git
- release repository: https://github.com/ros2-gbp/rqt_service_caller-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.3-2`

## rqt_service_caller

```
* Changed the build type to ament_python and fixed package to run with ros2 run (#13 <https://github.com/ros-visualization/rqt_service_caller/issues/13>)
* ignore services that don't use the SRV_MODE ('srv') (#20 <https://github.com/ros-visualization/rqt_service_caller/issues/20>)
* Contributors: Alejandro Hernández Cordero, William Woodall
```
