### PR TITLE
rqt_publisher: 1.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2544,7 +2544,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_publisher-release.git
-      version: 1.1.1-2
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_publisher` to `1.1.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_publisher.git
- release repository: https://github.com/ros2-gbp/rqt_publisher-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.1-2`

## rqt_publisher

```
* Changed the build type to ament_python and fixed package to run with ros2 run (#18 <https://github.com/ros-visualization/rqt_publisher/issues/18>)
* Drop numpy.float128 references (#26 <https://github.com/ros-visualization/rqt_publisher/issues/26>)
* Contributors: Alejandro Hernández Cordero, Michel Hidalgo
```
