### PR TITLE
rqt_msg: 1.0.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3950,7 +3950,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_msg-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_msg.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_msg` to `1.0.4-1`:

- upstream repository: https://github.com/ros-visualization/rqt_msg.git
- release repository: https://github.com/ros2-gbp/rqt_msg-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.3-1`

## rqt_msg

```
* Changed the build type to ament_python and fixed package to run with ros2 run (#8 <https://github.com/ros-visualization/rqt_msg/issues/8>)
* Contributors: Alejandro Hernández Cordero
```
