### PR TITLE
rqt_console: 2.0.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2432,7 +2432,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_console-release.git
-      version: 2.0.0-2
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_console` to `2.0.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_console.git
- release repository: https://github.com/ros2-gbp/rqt_console-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-2`

## rqt_console

```
* Use underscores in setup.cfg instead of dashes (#31 <https://github.com/ros-visualization/rqt_console/issues/31>)
* Contributors: Michel Hidalgo
```
