### PR TITLE
system_modes: 0.7.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2752,10 +2752,11 @@ repositories:
       packages:
       - system_modes
       - system_modes_examples
+      - system_modes_msgs
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/system_modes-release.git
-      version: 0.6.0-2
+      version: 0.7.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `system_modes` to `0.7.1-1`:

- upstream repository: https://github.com/micro-ROS/system_modes.git
- release repository: https://github.com/ros2-gbp/system_modes-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.0-2`

## system_modes

```
* Improved metadata for ROS 2 package releases
```

## system_modes_examples

```
* Improved metadata for ROS 2 package releases
```

## system_modes_msgs

```
* Improved metadata for ROS 2 package releases
```
