### PR TITLE
Revert "volta_simulation: 1.1.1-2 in 'melodic/distribution.yaml' [blo…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -14115,7 +14115,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/botsync-gbp/volta_simulation-release.git
-      version: 1.1.1-2
+      version: 1.1.0-2
     source:
       type: git
       url: https://github.com/botsync/volta_simulation.git


### PR DESCRIPTION
…om] (#29222)"

This reverts commit be63bdfb6d459d0a4490e1c309c5b557d2a4dac0.

This package hasn't built since this update: https://build.ros.org/view/Mbin_ubv8_uBv8/job/Mbin_ubv8_uBv8__volta_simulation__ubuntu_bionic_arm64__binary/#28637 

@toship-botsync FYI