### PR TITLE
tango_icons_vendor: 0.1.0-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2775,7 +2775,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/tango_icons_vendor-release.git
-      version: 0.0.1-2
+      version: 0.1.0-2
     source:
       type: git
       url: https://github.com/ros-visualization/tango_icons_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tango_icons_vendor` to `0.1.0-2`:

- upstream repository: https://github.com/ros-visualization/tango_icons_vendor.git
- release repository: https://github.com/ros2-gbp/tango_icons_vendor-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.1-2`

## tango_icons_vendor

```
* Add exec_depend on tango-icon-theme system package (#8 <https://github.com/ros-visualization/tango_icons_vendor/issues/8>)
* Contributors: Scott K Logan
```
