### PR TITLE
ompl: 1.5.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1342,6 +1342,12 @@ repositories:
       url: https://github.com/octomap/octomap_msgs.git
       version: ros2
     status: maintained
+  ompl:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros-gbp/ompl-release.git
+      version: 1.5.2-1
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl` to `1.5.2-1`:

- upstream repository: https://github.com/ompl/ompl.git
- release repository: https://github.com/ros-gbp/ompl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
