### PR TITLE
tutorial_interfaces: 1.0.3-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4628,6 +4628,12 @@ repositories:
       url: https://github.com/ros/ros_tutorials.git
       version: foxy-devel
     status: maintained
+  tutorial_interfaces:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/dlebansais/Ros2-tutorial_interfaces-release.git
+      version: 1.0.3-2
   tvm_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `tutorial_interfaces` to `1.0.3-2`:

- upstream repository: https://github.com/dlebansais/Ros2-tutorial_interfaces.git
- release repository: https://github.com/dlebansais/Ros2-tutorial_interfaces-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
