### PR TITLE
osqp_vendor: 0.0.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1345,6 +1345,21 @@ repositories:
       url: https://github.com/ros2/orocos_kinematics_dynamics.git
       version: galactic
     status: maintained
+  osqp_vendor:
+    doc:
+      type: git
+      url: https://github.com/tier4/osqp_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/tier4/osqp_vendor-release.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/tier4/osqp_vendor.git
+      version: main
+    status: maintained
   osrf_pycommon:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `osqp_vendor` to `0.0.3-1`:

- upstream repository: https://github.com/tier4/osqp_vendor.git
- release repository: https://github.com/tier4/osqp_vendor-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
