### PR TITLE
genpyi: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2237,6 +2237,16 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: kinetic-devel
     status: maintained
+  genpyi:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/rospypi/genpyi-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/rospypi/genpyi.git
+      version: master
   geographic_info:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `genpyi` to `0.2.0-1`:

- upstream repository: https://github.com/rospypi/genpyi.git
- release repository: https://github.com/rospypi/genpyi-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## genpyi

```
* Generate py.typed in catkin built packages (#30 <https://github.com/rospypi/genpy_stubgen/issues/30>)
* Make package catkin compatible (#29 <https://github.com/rospypi/genpy_stubgen/issues/29>)
```
