### PR TITLE
genpy: 0.6.16-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3518,7 +3518,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/genpy.git
-      version: kinetic-devel
+      version: main
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -3528,7 +3528,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/genpy.git
-      version: kinetic-devel
+      version: main
     status: maintained
   geographic_info:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3523,7 +3523,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/genpy-release.git
-      version: 0.6.15-1
+      version: 0.6.16-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genpy` to `0.6.16-1`:

- upstream repository: https://github.com/ros/genpy.git
- release repository: https://github.com/ros-gbp/genpy-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `0.6.15-1`

## genpy

```
* Fix runtime incompatibility with messages generated with 0.6.14 (#139 <https://github.com/ros/genpy/issues/139>)
* Contributors: Shane Loretz
```
