### PR TITLE
Add flann rules for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2567,6 +2567,7 @@ libflann:
   gentoo: [sci-libs/flann]
   macports: [flann]
   openembedded: [libflann@meta-ros-common]
+  rhel: [flann]
   ubuntu:
     '*': [libflann1.9]
     precise: [libflann1]
@@ -2585,6 +2586,7 @@ libflann-dev:
   gentoo: [sci-libs/flann]
   macports: [flann]
   openembedded: [libflann@meta-ros-common]
+  rhel: [flann-devel]
   ubuntu: [libflann-dev]
 libfltk-dev:
   arch: [fltk]


### PR DESCRIPTION
These packages are supplied by EPEL, and are available for both RHEL 7 and RHEL 8.

https://src.fedoraproject.org/rpms/flann#bodhi_updates