### PR TITLE
Fix opende rule for Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5558,7 +5558,7 @@ opencl-headers:
 opende:
   arch: [ode]
   debian: [libode-dev]
-  fedora: [ode]
+  fedora: [ode-devel]
   gentoo: [dev-games/ode]
   ubuntu: [libode-dev]
 opengl:


### PR DESCRIPTION
The other rules for this key include development files, so the Fedora one should as well.

https://src.fedoraproject.org/rpms/ode#bodhi_updates
