### PR TITLE
ur_client_library: 0.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13528,7 +13528,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
-      version: 0.1.1-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `0.2.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.1-1`

## ur_client_library

```
* Add function to set keepalive counter
* Use a non-blocking tcp server for the ReverseInterface and ScriptSender.
* Added header and control loop definitions.
* Update documentation on ReverseInterface
* Testing improvements:
  + Run coverage on tests
  + Added unit test for tcp server
  + Remove the special boost include dir from the ci pipeline
  + Install boost in test container
* Implement a TCPServer class
* Move script file to resources folder instead of examples/resources
* Add interface function to receive configured RTDE output recipe from driver
* Added loghandler, this enables the possibility for the driver to change the behavior when logging messages with this library.
* Fixed links in README (#35 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/35>)
* Documentation improvements:
  + Added Compiler minimum version table
  + Corrected links to driver's files
  + Add a requirements section to the README
  + Removed unstable warning
  + Added a requirement note about Linux
  + Further elaborated license statements in README
  + readme: missing whitespace
* Merge changes from boost branch
  Changes
  * Added changelog from boost branch
  * fixed build warnings
* Reduce build warnings
  + Removing unused code
  + Bumping the minimum required cmake version to 3.0.2
  + Using const qualifiers for size_t variables used to initialize arrays
* Use const qualifier for array size_t variables
* Removed unused and incomplete code from example
* Bump minimum required cmake version to 3.0.2
* Install package.xml when built with catkin support
* Contributors: Felix Exner, G.A. vd. Hoorn, urmahp
```
