### PR TITLE
moveit_resources: 0.8.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3989,7 +3989,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit_resources-release.git
-      version: 0.7.2-1
+      version: 0.8.0-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_resources.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `0.8.0-1`:

- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros-gbp/moveit_resources-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.2-1`

## moveit_resources

- No changes

## moveit_resources_fanuc_description

- No changes

## moveit_resources_fanuc_moveit_config

```
* Let users specify fake execution type for demo.launch (#61 <https://github.com/ros-planning/moveit_resources/issues/61>)
  Required to invoke demo.launch use_rviz:=false with execution speedup for tests.
  See https://github.com/ros-planning/moveit/pull/2602
  for the corresponding patch in the setup assistant.
* Contributors: Michael Görner
```

## moveit_resources_panda_description

- No changes

## moveit_resources_panda_moveit_config

```
* Let users specify fake execution type for demo.launch (#61 <https://github.com/ros-planning/moveit_resources/issues/61>)
  Required to invoke demo.launch use_rviz:=false with execution speedup for tests.
  See https://github.com/ros-planning/moveit/pull/2602
  for the corresponding patch in the setup assistant.
* Contributors: Michael Görner
```

## moveit_resources_pr2_description

- No changes

## moveit_resources_prbt_ikfast_manipulator_plugin

- No changes

## moveit_resources_prbt_moveit_config

```
* Let users specify fake execution type for demo.launch (#61 <https://github.com/ros-planning/moveit_resources/issues/61>)
  Required to invoke demo.launch use_rviz:=false with execution speedup for tests.
  See https://github.com/ros-planning/moveit/pull/2602
  for the corresponding patch in the setup assistant.
* Contributors: Michael Görner
```

## moveit_resources_prbt_pg70_support

- No changes

## moveit_resources_prbt_support

- No changes
