### PR TITLE
moveit_resources: 0.7.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6603,7 +6603,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/moveit_resources-release.git
-      version: 0.7.2-1
+      version: 0.7.3-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_resources.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `0.7.3-1`:

- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros-gbp/moveit_resources-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.2-1`

## moveit_resources

```
* Change package maintainer: Dave to Robert (#49 <https://github.com/ros-planning/moveit_resources/issues/49>)
  * Change package maintainer to MoveIt Release Team
  Co-authored-by: Robert Haschke <mailto:rhaschke@techfak.uni-bielefeld.de>
* Contributors: Dave Coleman
```

## moveit_resources_fanuc_description

```
* Change package maintainer: Dave to Robert (#49 <https://github.com/ros-planning/moveit_resources/issues/49>)
  * Change package maintainer to MoveIt Release Team
  Co-authored-by: Robert Haschke <mailto:rhaschke@techfak.uni-bielefeld.de>
* Contributors: Dave Coleman
```

## moveit_resources_fanuc_moveit_config

```
* Let users specify fake execution type for demo.launch (#61 <https://github.com/ros-planning/moveit_resources/issues/61>)
  Required to invoke demo.launch use_rviz:=false with execution speedup for tests.
  See https://github.com/ros-planning/moveit/pull/2602
  for the corresponding patch in the setup assistant.
* Fix formatting issues
* Change package maintainer: Dave to Robert (#49 <https://github.com/ros-planning/moveit_resources/issues/49>)
  * Change package maintainer to MoveIt Release Team
  Co-authored-by: Robert Haschke <mailto:rhaschke@techfak.uni-bielefeld.de>
* Adding RPBT config (#43 <https://github.com/ros-planning/moveit_resources/issues/43>)
  Co-authored-by: Joachim Schleicher <mailto:J.Schleicher@pilz.de>
* Contributors: Pilz GmbH and Co. KG, Christian Henkel, Dave Coleman, Michael Görner, Tyler Weaver
```

## moveit_resources_panda_description

```
* Fix formatting issues
* Change package maintainer: Dave to Robert (#49 <https://github.com/ros-planning/moveit_resources/issues/49>)
  * Change package maintainer to MoveIt Release Team
  Co-authored-by: Robert Haschke <mailto:rhaschke@techfak.uni-bielefeld.de>
* Contributors: Dave Coleman, Tyler Weaver
```

## moveit_resources_panda_moveit_config

```
* Let users specify fake execution type for demo.launch (#61 <https://github.com/ros-planning/moveit_resources/issues/61>)
  Required to invoke demo.launch use_rviz:=false with execution speedup for tests.
  See https://github.com/ros-planning/moveit/pull/2602
  for the corresponding patch in the setup assistant.
* Fix formatting issues
* Update panda_moveit_config launch files, add use_rviz parameter (#52 <https://github.com/ros-planning/moveit_resources/issues/52>)
  Regenerated demo.launch and rviz.launch from setup assistant.
  The main motivation for this change is the additional use_rviz argument
  through which rviz can be disabled.
  The rviz_tutorial parameter in moveit_rviz.launch was only ever used
  through demo.launch and it's easier to handle the different rviz configurations there.
* Adding RPBT config (#43 <https://github.com/ros-planning/moveit_resources/issues/43>)
  Co-authored-by: Joachim Schleicher <mailto:J.Schleicher@pilz.de>
* Contributors: Pilz GmbH and Co. KG, Christian Henkel, Michael Görner, Tyler Weaver
```

## moveit_resources_pr2_description

```
* Fix formatting issues
* Change package maintainer: Dave to Robert (#49 <https://github.com/ros-planning/moveit_resources/issues/49>)
  * Change package maintainer to MoveIt Release Team
  Co-authored-by: Robert Haschke <mailto:rhaschke@techfak.uni-bielefeld.de>
* Contributors: Dave Coleman, Tyler Weaver
```

## moveit_resources_prbt_ikfast_manipulator_plugin

```
* Adding RPBT config (#43 <https://github.com/ros-planning/moveit_resources/issues/43>)
  Co-authored-by: Joachim Schleicher <mailto:J.Schleicher@pilz.de>
* Contributors: Pilz GmbH and Co. KG, Christian Henkel
```

## moveit_resources_prbt_moveit_config

```
* Let users specify fake execution type for demo.launch (#61 <https://github.com/ros-planning/moveit_resources/issues/61>)
  Required to invoke demo.launch use_rviz:=false with execution speedup for tests.
  See https://github.com/ros-planning/moveit/pull/2602
  for the corresponding patch in the setup assistant.
* Adding RPBT config (#43 <https://github.com/ros-planning/moveit_resources/issues/43>)
  Co-authored-by: Joachim Schleicher <mailto:J.Schleicher@pilz.de>
* Contributors: Pilz GmbH and Co. KG, Christian Henkel, Michael Görner
```

## moveit_resources_prbt_pg70_support

```
* Fix formatting issues
* Adding RPBT config (#43 <https://github.com/ros-planning/moveit_resources/issues/43>)
  Co-authored-by: Joachim Schleicher <mailto:J.Schleicher@pilz.de>
* Contributors: Pilz GmbH and Co. KG, Christian Henkel, Tyler Weaver
```

## moveit_resources_prbt_support

```
* Fix formatting issues
* Adding RPBT config (#43 <https://github.com/ros-planning/moveit_resources/issues/43>)
  Co-authored-by: Joachim Schleicher <mailto:J.Schleicher@pilz.de>
* Contributors: Pilz GmbH and Co. KG, Christian Henkel, Tyler Weaver
```
