### PR TITLE
pilz_industrial_motion: 0.5.0-4 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4871,6 +4871,24 @@ repositories:
       url: https://github.com/PilzDE/pilz_common.git
       version: noetic-devel
     status: developed
+  pilz_industrial_motion:
+    doc:
+      type: git
+      url: https://github.com/PilzDE/pilz_industrial_motion.git
+      version: noetic-devel
+    release:
+      packages:
+      - pilz_industrial_motion
+      - pilz_robot_programming
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/PilzDE/pilz_industrial_motion-release.git
+      version: 0.5.0-4
+    source:
+      type: git
+      url: https://github.com/PilzDE/pilz_industrial_motion.git
+      version: noetic-devel
+    status: maintained
   pilz_robots:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_industrial_motion` to `0.5.0-4`:

- upstream repository: https://github.com/PilzDE/pilz_industrial_motion.git
- release repository: https://github.com/PilzDE/pilz_industrial_motion-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## pilz_industrial_motion

```
* Port to ROS Noetic (ubuntu 20.04, python3)
  * Remove pilz_store_positions package
  * Update branching model in README.md
  * Use relative paths for test-data/movecmd.py (colcon support)
  * Misc minor refactorings
* Update maintainer list
* Move pilz command planner to moveit
* Contributors: Pilz GmbH and Co. KG
```

## pilz_robot_programming

```
* Adapt to changes in MoveThread api
* Port to ROS Noetic (ubuntu 20.04, python3)
  * Remove pilz_store_positions package
  * Update branching model in README.md
  * Use relative paths for test-data/movecmd.py (colcon support)
  * Misc minor refactorings
* Fix KeyError on calling release twice
* Fix blend-radius and misunderstandings in Tests (#341, #330)
* Fix architecture documentation
* Use public acceptance-test utility methods
* Move pilz command planner to moveit
* Contributors: Pilz GmbH and Co. KG
```
