### PR TITLE
Revert "genpy: 0.6.15-1 in 'kinetic/distribution.yaml' [bloom] (#29114)"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4194,7 +4194,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/genpy-release.git
-      version: 0.6.15-1
+      version: 0.6.14-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
This reverts commit e1fb647ae1175bcccbb9a510f5c51c3fbb765206.

Signed-off-by: Shane Loretz <sloretz@osrfoundation.org>

Reverting because of https://github.com/ros/genpy/issues/138