### PR TITLE
trac_ik: 1.6.1-8 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7668,7 +7668,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/traclabs/trac_ik-release.git
-      version: 1.6.1-6
+      version: 1.6.1-8
     source:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git


### PR DESCRIPTION
Increasing version of package(s) in repository `trac_ik` to `1.6.1-8`:

- upstream repository: https://bitbucket.org/traclabs/trac_ik.git
- release repository: https://github.com/traclabs/trac_ik-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.6.1-6`
