### PR TITLE
stag_ros: 0.3.9-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7412,7 +7412,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/usrl-uofsc/stag_ros-release.git
-      version: 0.3.7-1
+      version: 0.3.9-3
     source:
       type: git
       url: https://github.com/usrl-uofsc/stag_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `stag_ros` to `0.3.9-3`:

- upstream repository: https://github.com/usrl-uofsc/stag_ros.git
- release repository: https://github.com/usrl-uofsc/stag_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.7-1`

## stag_ros

```
* Merge pull request #11 <https://github.com/usrl-uofsc/stag_ros/issues/11> from janfelixklein/patch-1
  Update README.md
* added dependency on generated type to node(let)
* Update README.md
* Updated readme
* Updated readme 2
* Updated readme
* Updated package.xml
* Contributors: Brennan Cain, Mike Kalaitzakis, MikeK4y, janfelixklein
```
