### PR TITLE
stag_ros: 0.1.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15503,7 +15503,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/usrl-uofsc/stag_ros-release.git
-      version: 0.1.1-6
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/usrl-uofsc/stag_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `stag_ros` to `0.1.2-1`:

- upstream repository: https://github.com/usrl-uofsc/stag_ros.git
- release repository: https://github.com/usrl-uofsc/stag_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.1-6`

## stag_ros

```
* Merged noetic into kinetic
* Merge branch 'kinetic-devel' of github.com:usrl-uofsc/stag_ros into kinetic-devel
* Fixed GHANGELOG.rst
* Merged from noetic
* Update README.md
* 0.1.1
* Added Changelog
* Merge branch 'noetic-devel' into kinetic-devel
* Merge branch 'noetic-devel' into kinetic-devel
* Merge branch 'noetic-devel' into kinetic-devel
* set initial kinetic version
* Contributors: Brennan Cain, MikeK4y
```
