### PR TITLE
stag_ros: 0.2.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12544,7 +12544,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/usrl-uofsc/stag_ros-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/usrl-uofsc/stag_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `stag_ros` to `0.2.2-1`:

- upstream repository: https://github.com/usrl-uofsc/stag_ros.git
- release repository: https://github.com/usrl-uofsc/stag_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.1-1`

## stag_ros

```
* Merge noetic to melodic
* Merge branch 'melodic-devel' of github.com:usrl-uofsc/stag_ros into melodic-devel
* Fixed GHANGELOG.rst
* Merged from noetic
* Update README.md
* 0.2.1
* Added Changelog
* Merge branch 'noetic-devel' into melodic-devel
* Merge branch 'noetic-devel' into melodic-devel
* Merge branch 'noetic-devel' into melodic-devel
* set initial melodic version
* Contributors: Brennan Cain, MikeK4y
```
