### PR TITLE
ros2_control: 0.5.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3243,7 +3243,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 0.4.0-1
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `0.5.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.4.0-1`

## controller_interface

```
* Add NodeOptions parameter to init function of controller_interface (#382 <https://github.com/ros-controls/ros2_control/issues/382>)
* guard around pragmas (#397 <https://github.com/ros-controls/ros2_control/issues/397>)
* avoid deprecations (#393 <https://github.com/ros-controls/ros2_control/issues/393>)
* Contributors: Auguste Bourgois, Karsten Knese, Bence Magyar
```

## controller_manager

```
* Make controller manager update rate optional (#404 <https://github.com/ros-controls/ros2_control/issues/404>)
* Bump wait_for_service timeout to 10 seconds (#403 <https://github.com/ros-controls/ros2_control/issues/403>)
* introduce --stopped for spawner (#402 <https://github.com/ros-controls/ros2_control/issues/402>)
* hardware_interface mode switching using prepareSwitch doSwitch approach (#348 <https://github.com/ros-controls/ros2_control/issues/348>)
* Avoid std::stringstream (#391 <https://github.com/ros-controls/ros2_control/issues/391>)
* avoid deprecations (#393 <https://github.com/ros-controls/ros2_control/issues/393>)
* Use RCLCPP_DEBUG_STREAM for char * (#389 <https://github.com/ros-controls/ros2_control/issues/389>)
* Check controller_interface::init return value when loading (#386 <https://github.com/ros-controls/ros2_control/issues/386>)
* Do not throw when controller type is not found, return nullptr instead (#387 <https://github.com/ros-controls/ros2_control/issues/387>)
* Contributors: Auguste Bourgois, Karsten Knese, Matt Reynolds, Tyler Weaver, Mathias Hauan Arbo, Bence Magyar
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Make hardware interface types as const char array rather than const char pointer (#408 <https://github.com/ros-controls/ros2_control/issues/408>)
* use auto instead of uint (#398 <https://github.com/ros-controls/ros2_control/issues/398>)
* hardware_interface mode switching using prepareSwitch doSwitch approach (#348 <https://github.com/ros-controls/ros2_control/issues/348>)
* avoid deprecations (#393 <https://github.com/ros-controls/ros2_control/issues/393>)
* move deprecation note before function definition instead of inside (#381 <https://github.com/ros-controls/ros2_control/issues/381>)
* Replace standard interfaces' hard-coded strings by constants (#376 <https://github.com/ros-controls/ros2_control/issues/376>)
* add deprecation note for with_value_ptr (#378 <https://github.com/ros-controls/ros2_control/issues/378>)
* Contributors: El Jawad Alaa, Jafar Abdi, Karsten Knese, Mateus Amarante, Mathias Hauan Arbo, Bence Magyar
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* correct return values in CLI (#401 <https://github.com/ros-controls/ros2_control/issues/401>)
* [python] Update files in ros2controlcli to use format strings (#358 <https://github.com/ros-controls/ros2_control/issues/358>)
* Add starting doc for ros2controlcli (#377 <https://github.com/ros-controls/ros2_control/issues/377>)
* Contributors: Bence Magyar, Karsten Knese, NovusEdge
```

## transmission_interface

```
* Replace standard interfaces' hard-coded strings by constants (#376 <https://github.com/ros-controls/ros2_control/issues/376>)
* Contributors: Mateus Amarante
```
