### PR TITLE
ros2_controllers: 0.2.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3259,6 +3259,7 @@ repositories:
       - diff_drive_controller
       - effort_controllers
       - forward_command_controller
+      - joint_state_broadcaster
       - joint_state_controller
       - joint_trajectory_controller
       - position_controllers
@@ -3267,7 +3268,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `0.2.1-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.2.0-1`

## diff_drive_controller

```
* Migrate from deprecated controller_interface::return_type::SUCCESS -> OK (#167 <https://github.com/ros-controls/ros2_controllers/issues/167>)
* Add basic user docs pages for each package (#156 <https://github.com/ros-controls/ros2_controllers/issues/156>)
* [diff_drive_controller] Change header math.h in cmath for better C++ compliance (#148 <https://github.com/ros-controls/ros2_controllers/issues/148>)
  and isnan inclusion.
* Contributors: Bence Magyar, Olivier Stasse
```

## effort_controllers

```
* Migrate from deprecated controller_interface::return_type::SUCCESS -> OK (#167 <https://github.com/ros-controls/ros2_controllers/issues/167>)
* Add basic user docs pages for each package (#156 <https://github.com/ros-controls/ros2_controllers/issues/156>)
* Contributors: Bence Magyar
```

## forward_command_controller

```
* Migrate from deprecated controller_interface::return_type::SUCCESS -> OK (#167 <https://github.com/ros-controls/ros2_controllers/issues/167>)
* Add basic user docs pages for each package (#156 <https://github.com/ros-controls/ros2_controllers/issues/156>)
* Contributors: Bence Magyar
```

## joint_state_broadcaster

```
* Migrate from deprecated controller_interface::return_type::SUCCESS -> OK (#167 <https://github.com/ros-controls/ros2_controllers/issues/167>)
* Rename joint_state_controller -> joint_state_broadcaster (#160 <https://github.com/ros-controls/ros2_controllers/issues/160>)
  * Rename joint_state_controller -> _broadcaster
  * Update accompanying files (Ament, CMake, etc)
  * Update C++ from _controller to _broadcaster
  * Apply cpplint
  * Create stub controller to redirect to _broadcaster
  * Add test for loading old joint_state_controller
  * Add missing dependency on hardware_interface
  * Add link to documentation
  * Add joint_state_broadcaster to metapackage
  * Apply suggestions from code review
  Co-authored-by: Denis Štogl <mailto:destogl@users.noreply.github.com>
  * Update joint_state_broadcaster/joint_state_plugin.xml
  Co-authored-by: Denis Štogl <mailto:destogl@users.noreply.github.com>
  Co-authored-by: Bence Magyar <mailto:bence.magyar.robotics@gmail.com>
  Co-authored-by: Denis Štogl <mailto:destogl@users.noreply.github.com>
* Contributors: Bence Magyar, Matt Reynolds
* Migrate from deprecated controller_interface::return_type::SUCCESS -> OK (#167 <https://github.com/ros-controls/ros2_controllers/issues/167>)
* Rename joint_state_controller -> joint_state_broadcaster (#160 <https://github.com/ros-controls/ros2_controllers/issues/160>)
  * Rename joint_state_controller -> _broadcaster
  * Update accompanying files (Ament, CMake, etc)
  * Update C++ from _controller to _broadcaster
  * Apply cpplint
  * Create stub controller to redirect to _broadcaster
  * Add test for loading old joint_state_controller
  * Add missing dependency on hardware_interface
  * Add link to documentation
  * Add joint_state_broadcaster to metapackage
  * Apply suggestions from code review
  Co-authored-by: Denis Štogl <mailto:destogl@users.noreply.github.com>
  * Update joint_state_broadcaster/joint_state_plugin.xml
  Co-authored-by: Denis Štogl <mailto:destogl@users.noreply.github.com>
  Co-authored-by: Bence Magyar <mailto:bence.magyar.robotics@gmail.com>
  Co-authored-by: Denis Štogl <mailto:destogl@users.noreply.github.com>
* Contributors: Bence Magyar, Matt Reynolds
```

## joint_state_controller

```
* Rename joint_state_controller -> joint_state_broadcaster (#160 <https://github.com/ros-controls/ros2_controllers/issues/160>)
* Add basic user docs pages for each package (#156 <https://github.com/ros-controls/ros2_controllers/issues/156>)
* Contributors: Bence Magyar, Matt Reynolds
```

## joint_trajectory_controller

```
* Migrate from deprecated controller_interface::return_type::SUCCESS -> OK (#167 <https://github.com/ros-controls/ros2_controllers/issues/167>)
* [JTC] Add link to TODOs to provide better trackability (#169 <https://github.com/ros-controls/ros2_controllers/issues/169>)
* Fix JTC segfault (#164 <https://github.com/ros-controls/ros2_controllers/issues/164>)
  * Use a copy of the rt_active_goal to avoid segfault
  * Use RealtimeBuffer for thread-safety
* Add basic user docs pages for each package (#156 <https://github.com/ros-controls/ros2_controllers/issues/156>)
* Contributors: Bence Magyar, Matt Reynolds
```

## position_controllers

```
* Migrate from deprecated controller_interface::return_type::SUCCESS -> OK (#167 <https://github.com/ros-controls/ros2_controllers/issues/167>)
* Add basic user docs pages for each package (#156 <https://github.com/ros-controls/ros2_controllers/issues/156>)
* Contributors: Bence Magyar
```

## ros2_controllers

```
* Rename joint_state_controller -> joint_state_broadcaster (#160 <https://github.com/ros-controls/ros2_controllers/issues/160>)
* Contributors: Matt Reynolds
```

## velocity_controllers

```
* Migrate from deprecated controller_interface::return_type::SUCCESS -> OK (#167 <https://github.com/ros-controls/ros2_controllers/issues/167>)
* Add basic user docs pages for each package (#156 <https://github.com/ros-controls/ros2_controllers/issues/156>)
* Contributors: Bence Magyar
```
