### PR TITLE
trac_ik: 1.6.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7668,7 +7668,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/traclabs/trac_ik-release.git
-      version: 1.6.1-6
+      version: 1.6.4-1
     source:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git


### PR DESCRIPTION
Increasing version of package(s) in repository `trac_ik` to `1.6.4-1`:

- upstream repository: https://bitbucket.org/traclabs/trac_ik.git
- release repository: https://github.com/traclabs/trac_ik-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.6.1-6`

## trac_ik

- No changes

## trac_ik_examples

- No changes

## trac_ik_kinematics_plugin

- No changes

## trac_ik_lib

```
* added nlopt depends to traciklib cmake
* Contributors: Stephen Hart
```

## trac_ik_python

```
* added nlopt depends to traciklib cmake
* Contributors: Stephen Hart
```
