### PR TITLE
Add python3-collada rule for RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5774,6 +5774,7 @@ python3-collada:
     buster: null
     stretch: null
   fedora: [python3-collada]
+  rhel: ['python%{python3_pkgversion}-collada']
   ubuntu:
     '*': [python3-collada]
     bionic: null


### PR DESCRIPTION
This package is supplied by EPEL for both RHEL 7 and 8.

https://src.fedoraproject.org/rpms/python-collada/#bodhi_updates