### PR TITLE
Add stable baselines

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7288,6 +7288,19 @@ python3-sphinx-rtd-theme:
   fedora: [python3-sphinx_rtd_theme]
   rhel: ['python%{python3_pkgversion}-sphinx_rtd_theme']
   ubuntu: [python3-sphinx-rtd-theme]
+python3-stable-baselines3-pip:
+  debian:
+    pip:
+      packages: [stable-baselines3]
+  fedora:
+    pip:
+      packages: [stable-baselines3]
+  osx:
+    pip:
+      packages: [stable-baselines3]
+  ubuntu:
+    pip:
+      packages: [stable-baselines3]
 python3-sqlalchemy:
   debian: [python3-sqlalchemy]
   ubuntu: [python3-sqlalchemy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7288,6 +7288,9 @@ python3-sphinx-rtd-theme:
   fedora: [python3-sphinx_rtd_theme]
   rhel: ['python%{python3_pkgversion}-sphinx_rtd_theme']
   ubuntu: [python3-sphinx-rtd-theme]
+python3-sqlalchemy:
+  debian: [python3-sqlalchemy]
+  ubuntu: [python3-sqlalchemy]
 python3-stable-baselines-pip:
   debian:
     pip:
@@ -7301,9 +7304,6 @@ python3-stable-baselines-pip:
   ubuntu:
     pip:
       packages: [stable-baselines]
-python3-sqlalchemy:
-  debian: [python3-sqlalchemy]
-  ubuntu: [python3-sqlalchemy]
 python3-sympy:
   debian: [python3-sympy]
   fedora: [python3-sympy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7288,19 +7288,19 @@ python3-sphinx-rtd-theme:
   fedora: [python3-sphinx_rtd_theme]
   rhel: ['python%{python3_pkgversion}-sphinx_rtd_theme']
   ubuntu: [python3-sphinx-rtd-theme]
-python3-stable-baselines3-pip:
+python3-stable-baselines-pip:
   debian:
     pip:
-      packages: [stable-baselines3]
+      packages: [stable-baselines]
   fedora:
     pip:
-      packages: [stable-baselines3]
+      packages: [stable-baselines]
   osx:
     pip:
-      packages: [stable-baselines3]
+      packages: [stable-baselines]
   ubuntu:
     pip:
-      packages: [stable-baselines3]
+      packages: [stable-baselines]
 python3-sqlalchemy:
   debian: [python3-sqlalchemy]
   ubuntu: [python3-sqlalchemy]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

[Stable-baselines](https://stable-baselines.readthedocs.io/en/master/)

## Package Upstream Source:

[Stable-baselines](https://stable-baselines.readthedocs.io/en/master/)

## Purpose of using this:

This dependency is often used for training RL agents. It is a dependency of the https://bitbucket.org/theconstructcore/openai_examples_projects/src/master/ package.

PIP packaging links:
  - https://pypi.org/project/stable-baselines/

