### PR TITLE
genmypy: 0.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2229,6 +2229,16 @@ repositories:
       url: https://github.com/ros/genmsg.git
       version: kinetic-devel
     status: maintained
+  genmypy:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/rospypi/genmypy-release.git
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/rospypi/genmypy.git
+      version: master
   gennodejs:
     release:
       tags:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2230,6 +2230,10 @@ repositories:
       version: kinetic-devel
     status: maintained
   genmypy:
+    doc:
+      type: git
+      url: https://github.com/rospypi/genmypy.git
+      version: master
     release:
       tags:
         release: release/noetic/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `genmypy` to `0.3.0-1`:

- upstream repository: https://github.com/rospypi/genmypy.git
- release repository: https://github.com/rospypi/genmypy-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## genmypy

```
* Rename genpyi to genmypy (#35 <https://github.com/rospypi/genmypy/issues/35>)
```
