### PR TITLE
genmypy: 0.3.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3500,6 +3500,10 @@ repositories:
       version: kinetic-devel
     status: maintained
   genmypy:
+    doc:
+      type: git
+      url: https://github.com/rospypi/genmypy.git
+      version: master
     release:
       tags:
         release: release/melodic/{package}/{version}

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3499,6 +3499,16 @@ repositories:
       url: https://github.com/ros/genmsg.git
       version: kinetic-devel
     status: maintained
+  genmypy:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/rospypi/genmypy-release.git
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/rospypi/genmypy.git
+      version: master
   gennodejs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genmypy` to `0.3.0-1`:

- upstream repository: https://github.com/rospypi/genmypy.git
- release repository: https://github.com/rospypi/genmypy-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## genmypy

```
* Rename genpyi to genmypy (#35 <https://github.com/rospypi/genmypy/issues/35>)
```
