### PR TITLE
ros2_tracing: 2.3.0-3 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2021,8 +2021,8 @@ repositories:
       - tracetools_trace
       tags:
         release: release/galactic/{package}/{version}
-      url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 2.3.0-2
+      url: https://gitlab.com/ros-tracing/ros2_tracing-release.git
+      version: 2.3.0-3
     source:
       type: git
       url: https://gitlab.com/ros-tracing/ros2_tracing.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `2.3.0-3`:

- upstream repository: https://gitlab.com/ros-tracing/ros2_tracing.git
- release repository: https://gitlab.com/ros-tracing/ros2_tracing-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.0-2`

## tracetools

```
* Update QD to be more specific about public API
* Namespace tracetools C++ functions and macros and deprecate current ones
* Contributors: Christophe Bedard
```

## tracetools_test

```
* Update after namespacing C++ tracetools functions and macros
* Contributors: Christophe Bedard
```
