### PR TITLE
moveit: 1.1.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3964,7 +3964,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 1.1.2-1
+      version: 1.1.3-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `1.1.3-1`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.2-1`

## chomp_motion_planner

- No changes

## moveit

- No changes

## moveit_chomp_optimizer_adapter

- No changes

## moveit_commander

```
* Add planning_pipeline_id setting to Python MGI (#2622 <https://github.com/ros-planning/moveit/issues/2622>)
* Add clear() to Python PSI, allow empty call to remove_attached_object (#2609 <https://github.com/ros-planning/moveit/issues/2609>)
* Contributors: Felix von Drigalski
```

## moveit_core

```
* Set rotation value of cartesian MaxEEFStep by default (#2614 <https://github.com/ros-planning/moveit/issues/2614>)
* Lock the Bullet collision environment, for thread safety (#2598 <https://github.com/ros-planning/moveit/issues/2598>)
* Contributors: Felix von Drigalski, Michael Görner
```

## moveit_fake_controller_manager

- No changes

## moveit_kinematics

- No changes

## moveit_planners

- No changes

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

- No changes

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

- No changes

## moveit_ros_move_group

- No changes

## moveit_ros_occupancy_map_monitor

```
* Document solution in ROS_ERROR on failed self-filtering (#2627 <https://github.com/ros-planning/moveit/issues/2627>)
* Contributors: Michael Görner
```

## moveit_ros_perception

```
* Document solution in ROS_ERROR on failed self-filtering (#2627 <https://github.com/ros-planning/moveit/issues/2627>)
* Contributors: Michael Görner
```

## moveit_ros_planning

- No changes

## moveit_ros_planning_interface

```
* Add planning_pipeline_id setting to Python MGI (#2622 <https://github.com/ros-planning/moveit/issues/2622>)
* Fix docstring in MGI API (#2626 <https://github.com/ros-planning/moveit/issues/2626>)
* Contributors: Felix von Drigalski, Michael Görner
```

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

```
* Several minor fixups in PlanningSceneDisplay (#2618 <https://github.com/ros-planning/moveit/issues/2618>)
* Contributors: Michael Görner, Robert Haschke
```

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_servo

```
* Avoid joint jump when SuddenHalt() is called in velocity mode (#2594 <https://github.com/ros-planning/moveit/issues/2594>)
* Contributors: Nathan Brooks
```

## moveit_setup_assistant

```
* Let users override fake execution type from demo.launch (#2602 <https://github.com/ros-planning/moveit/issues/2602>)
* Contributors: Michael Görner
```

## moveit_simple_controller_manager

- No changes

## pilz_industrial_motion_planner

```
* Skip fixed joints when checking velocity limits (#2610 <https://github.com/ros-planning/moveit/issues/2610>)
* Contributors: Christian Landgraf
```

## pilz_industrial_motion_planner_testutils

- No changes
