### PR TITLE
mavros: 1.8.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6034,7 +6034,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 1.7.1-1
+      version: 1.8.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `1.8.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.7.1-1`

## libmavconn

- No changes

## mavros

```
* lib: ftf: allow both Quaterniond and Quaternionf for quaternion_to_mavlink()
* extras: distance_sensor: rename param for custom orientation, apply uncrustify
* px4_config: Add distance_sensor parameters
* convert whole expression to mm
* Contributors: Alexey Rogachevskiy, Thomas, Vladimir Ermakov
```

## mavros_extras

```
* extras: #1370 <https://github.com/mavlink/mavros/issues/1370>: set obstacle aangle offset
* extras: distance_sensor: rename param for custom orientation, apply uncrustify
* distance_sensor: Add horizontal_fov_ratio, vertical_fov_ratio, sensor_orientation parameters
* distance_sensor: Fill horizontal_fov, vertical_fov, quaternion
* Contributors: Alexey Rogachevskiy, Vladimir Ermakov
```

## mavros_msgs

- No changes

## test_mavros

- No changes
