### PR TITLE
ntpd_driver: 1.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4443,6 +4443,21 @@ repositories:
       url: https://github.com/novatel/novatel_oem7_driver.git
       version: master
     status: developed
+  ntpd_driver:
+    doc:
+      type: git
+      url: https://github.com/vooon/ntpd_driver.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/vooon/ntpd_driver-release.git
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://github.com/vooon/ntpd_driver.git
+      version: master
+    status: maintained
   object_recognition_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ntpd_driver` to `1.2.0-1`:

- upstream repository: https://github.com/vooon/ntpd_driver.git
- release repository: https://github.com/vooon/ntpd_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ntpd_driver

```
* #2 <https://github.com/vooon/ntpd_driver/issues/2>: allow both UDPROS and TCPROS
* Contributors: Vladimir Ermakov
```
