### PR TITLE
mavlink: 2021.5.5-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1215,6 +1215,21 @@ repositories:
       url: https://github.com/swri-robotics/marti_messages.git
       version: dashing-devel
     status: developed
+  mavlink:
+    doc:
+      type: git
+      url: https://github.com/mavlink/mavlink-gbp-release.git
+      version: release/galactic/mavlink
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/mavlink/mavlink-gbp-release.git
+      version: 2021.5.5-1
+    source:
+      type: git
+      url: https://github.com/mavlink/mavlink-gbp-release.git
+      version: release/galactic/mavlink
+    status: developed
   message_filters:
     doc:
       type: git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1218,8 +1218,8 @@ repositories:
   mavlink:
     doc:
       type: git
-      url: https://github.com/mavlink/mavlink.git
-      version: master
+      url: https://github.com/mavlink/mavlink-gbp-release.git
+      version: release/galactic/mavlink
     release:
       tags:
         release: release/galactic/{package}/{version}
@@ -1227,8 +1227,8 @@ repositories:
       version: 2021.5.5-1
     source:
       type: git
-      url: https://github.com/mavlink/mavlink.git
-      version: master
+      url: https://github.com/mavlink/mavlink-gbp-release.git
+      version: release/galactic/mavlink
     status: developed
   message_filters:
     doc:

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1218,8 +1218,8 @@ repositories:
   mavlink:
     doc:
       type: git
-      url: https://github.com/mavlink/mavlink-gbp-release.git
-      version: release/galactic/mavlink
+      url: https://github.com/mavlink/mavlink.git
+      version: master
     release:
       tags:
         release: release/galactic/{package}/{version}
@@ -1227,8 +1227,8 @@ repositories:
       version: 2021.5.5-1
     source:
       type: git
-      url: https://github.com/mavlink/mavlink-gbp-release.git
-      version: release/galactic/mavlink
+      url: https://github.com/mavlink/mavlink.git
+      version: master
     status: developed
   message_filters:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `mavlink` to `2021.5.5-1`:

- upstream repository: https://github.com/mavlink/mavlink.git
- release repository: https://github.com/mavlink/mavlink-gbp-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
