### PR TITLE
[rosdep] Adding aio-pika to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5540,6 +5540,19 @@ python3-ansible-runner-pip:
   ubuntu:
     pip:
       packages: [ansible-runner]
+python3-aio-pika-pip:
+  debian:
+    pip:
+      packages: [aio-pika]
+  fedora:
+    pip:
+      packages: [aio-pika]
+  gentoo:
+    pip:
+      packages: [aio-pika]
+  ubuntu:
+    pip:
+      packages: [aio-pika]
 python3-argcomplete:
   alpine: [py3-argcomplete]
   arch: [python-argcomplete]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5710,6 +5710,19 @@ python3-adafruit-circuitpython-mcp230xx-pip:
   ubuntu:
     pip:
       packages: [adafruit-circuitpython-mcp230xx]
+python3-aio-pika-pip:
+  debian:
+    pip:
+      packages: [aio-pika]
+  fedora:
+    pip:
+      packages: [aio-pika]
+  gentoo:
+    pip:
+      packages: [aio-pika]
+  ubuntu:
+    pip:
+      packages: [aio-pika]
 python3-albumentations-pip:
   debian:
     pip:
@@ -5736,19 +5749,6 @@ python3-ansible-runner-pip:
   ubuntu:
     pip:
       packages: [ansible-runner]
-python3-aio-pika-pip:
-  debian:
-    pip:
-      packages: [aio-pika]
-  fedora:
-    pip:
-      packages: [aio-pika]
-  gentoo:
-    pip:
-      packages: [aio-pika]
-  ubuntu:
-    pip:
-      packages: [aio-pika]
 python3-argcomplete:
   alpine: [py3-argcomplete]
   arch: [python-argcomplete]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-aio-pika-pip

## Package Upstream Source:

https://github.com/mosquito/aio-pika

## Purpose of using this:

We are using aio-pika in place of pika since we need asynchronous AMQP operation.

aio-pika is a wrapper around [aiormq](https://github.com/mosquito/aiormq/) for asyncio.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

Only available through PyPI: https://pypi.org/project/aio-pika/

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->
