### PR TITLE
mavlink: 2021.5.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1230,6 +1230,21 @@ repositories:
       url: https://github.com/swri-robotics/marti_messages.git
       version: dashing-devel
     status: developed
+  mavlink:
+    doc:
+      type: git
+      url: https://github.com/mavlink/mavlink-gbp-release.git
+      version: release/rolling/mavlink
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/mavlink/mavlink-gbp-release.git
+      version: 2021.5.5-1
+    source:
+      type: git
+      url: https://github.com/mavlink/mavlink-gbp-release.git
+      version: release/rolling/mavlink
+    status: developed
   message_filters:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavlink` to `2021.5.5-1`:

- upstream repository: https://github.com/mavlink/mavlink.git
- release repository: https://github.com/mavlink/mavlink-gbp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
