### PR TITLE
[rosdep] Adding jupyros

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6486,6 +6486,14 @@ python3-jsonschema:
   gentoo: [dev-python/jsonschema]
   nixos: [python3Packages.jsonschema]
   ubuntu: [python3-jsonschema]
+python3-junitparser:
+  debian:
+    '*': [python3-junitparser]
+    stretch: null
+  ubuntu:
+    '*': [python3-junitparser]
+    bionic: null
+    xenial: null
 python3-jupyros-pip:
   debian:
     pip:
@@ -6499,14 +6507,6 @@ python3-jupyros-pip:
   ubuntu:
     pip:
       packages: [jupyros]
-python3-junitparser:
-  debian:
-    '*': [python3-junitparser]
-    stretch: null
-  ubuntu:
-    '*': [python3-junitparser]
-    bionic: null
-    xenial: null
 python3-kitchen:
   arch: [python-kitchen]
   debian: [python3-kitchen]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6202,6 +6202,19 @@ python3-jsonschema:
   fedora: [python3-jsonschema]
   gentoo: [dev-python/jsonschema]
   ubuntu: [python3-jsonschema]
+python3-jupyros-pip:
+  debian:
+    pip:
+      packages: [jupyros]
+  fedora:
+    pip:
+      packages: [jupyros]
+  gentoo:
+    pip:
+      packages: [jupyros]
+  ubuntu:
+    pip:
+      packages: [jupyros]
 python3-kitchen:
   arch: [python-kitchen]
   debian: [python3-kitchen]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-jupyros-pip

## Package Upstream Source:

https://github.com/RoboStack/jupyter-ros

## Purpose of using this:

jupyros is an extension to Jupyter Notebook that enables easy connections to ROS.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

Only available through PyPI: https://pypi.org/project/jupyros/

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->
