### PR TITLE
ntpd_driver: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1327,6 +1327,21 @@ repositories:
       url: https://github.com/ubuntu-robotics/nodl.git
       version: master
     status: developed
+  ntpd_driver:
+    doc:
+      type: git
+      url: https://github.com/vooon/ntpd_driver.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/vooon/ntpd_driver-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/vooon/ntpd_driver.git
+      version: ros2
+    status: maintained
   octomap_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ntpd_driver` to `2.1.0-1`:

- upstream repository: https://github.com/vooon/ntpd_driver.git
- release repository: https://github.com/vooon/ntpd_driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ntpd_driver

```
* make linker happy
* fix loading as a component
* Contributors: Vladimir Ermakov
```
