### PR TITLE
system_modes: 0.7.1-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2796,7 +2796,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/system_modes-release.git
-      version: 0.7.1-3
+      version: 0.7.1-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `system_modes` to `0.7.1-4`:

- upstream repository: https://github.com/micro-ROS/system_modes.git
- release repository: https://github.com/ros2-gbp/system_modes-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.1-3`

## system_modes

```
* Improved metadata for ROS 2 package releases
```

## system_modes_examples

```
* Improved metadata for ROS 2 package releases
```

## system_modes_msgs

```
* Improved metadata for ROS 2 package releases
```
