### PR TITLE
Adds pygit2 python package rule

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6997,6 +6997,18 @@ python3-pygame:
       pip: [pygame]
     xenial:
       pip: [pygame]
+python3-pygit2:
+  alpine: [py3-pygit2]
+  debian: [python3-pygit2]
+  fedora: [python3-pygit2]
+  freebsd: [py37-pygit2]
+  gentoo: [dev-python/pygit2]
+  opensuse: [python3-pygit2]
+  osx:
+    pip:
+      packages: [pygit2]
+  rhel: ['python%{python3_pkgversion}-pyflakes']
+  ubuntu: [python3-pygit2]
 python3-pygraphviz:
   alpine: [py3-graphviz]
   arch: [python2-pygraphviz]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7007,7 +7007,7 @@ python3-pygit2:
   osx:
     pip:
       packages: [pygit2]
-  rhel: ['python%{python3_pkgversion}-pyflakes']
+  rhel: ['python%{python3_pkgversion}-pygit2']
   ubuntu: [python3-pygit2]
 python3-pygraphviz:
   alpine: [py3-graphviz]


### PR DESCRIPTION
## Package name:

[Pygit2](https://www.pygit2.org/)

## Package Upstream Source:

https://github.com/libgit2/pygit2

## Purpose of using this:

This dependency can be used to perform git cmd line actions using python. It is in my opinion a bit cleaner and better documented than [gitpython](https://gitpython.readthedocs.io/en/stable/).

Distro packaging links:

https://pkgs.org/search/?q=pygit2

## Links to Distribution Packages

- Debian: https://packages.debian.org/buster/python3-pygit2
- Ubuntu: https://packages.ubuntu.com/hirsute/python3-pygit2
- Fedora: https://fedora.pkgs.org/34/fedora-aarch64/python3-pygit2-1.5.0-1.fc34.aarch64.rpm.html
- Freebsd: https://freebsd.pkgs.org/13/freebsd-aarch64/py37-pygit2-1.3.0.txz.html
- osx: https://pypi.org/project/pygit2/
