### PR TITLE
ros_pytest: 0.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6178,9 +6178,9 @@ repositories:
       version: noetic-devel
     release:
       tags:
-        release: release/melodic/{package}/{version}
+        release: release/noetic/{package}/{version}
       url: https://github.com/machinekoder/ros_pytest-release.git
-      version: 0.2.0-0
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/machinekoder/ros_pytest.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_pytest` to `0.2.1-1`:

- upstream repository: https://github.com/machinekoder/ros_pytest.git
- release repository: https://github.com/machinekoder/ros_pytest-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.0-0`

## ros_pytest

```
* Merge pull request #9 <https://github.com/machinekoder/ros_pytest/issues/9> from jspricke/missing_dependencies
  Add dependency on python-pytest-cov
* Contributors: Alexander Rössler, Jochen Sprickerhof
```
