### PR TITLE
azure-iot-sdk-c: 1.7.0-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -342,10 +342,10 @@ repositories:
       url: https://github.com/nobleo/azure-iot-sdk-c-release.git
       version: 1.7.0-3
     source:
+      test_commits: false
       type: git
       url: https://github.com/Azure/azure-iot-sdk-c.git
       version: master
-      test_commits: false
     status: maintained
   backward_ros:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -335,6 +335,21 @@ repositories:
       url: https://github.com/astuff/avt_vimba_camera.git
       version: master
     status: maintained
+  azure-iot-sdk-c:
+    doc:
+      type: git
+      url: https://github.com/Azure/azure-iot-sdk-c.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/nobleo/azure-iot-sdk-c-release.git
+      version: 1.7.0-3
+    source:
+      type: git
+      url: https://github.com/Azure/azure-iot-sdk-c.git
+      version: master
+    status: maintained
   backward_ros:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -336,10 +336,6 @@ repositories:
       version: master
     status: maintained
   azure-iot-sdk-c:
-    doc:
-      type: git
-      url: https://github.com/Azure/azure-iot-sdk-c.git
-      version: master
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -349,6 +345,7 @@ repositories:
       type: git
       url: https://github.com/Azure/azure-iot-sdk-c.git
       version: master
+      test_commits: false
     status: maintained
   backward_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `azure-iot-sdk-c` to `1.7.0-3`:

- upstream repository: https://github.com/Azure/azure-iot-sdk-c.git
- release repository: https://github.com/nobleo/azure-iot-sdk-c-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
