### PR TITLE
octomap: 1.9.7-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1327,6 +1327,25 @@ repositories:
       url: https://github.com/vooon/ntpd_driver.git
       version: ros2
     status: maintained
+  octomap:
+    doc:
+      type: git
+      url: https://github.com/octomap/octomap.git
+      version: master
+    release:
+      packages:
+      - dynamic_edt_3d
+      - octomap
+      - octovis
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros-gbp/octomap-release.git
+      version: 1.9.7-1
+    source:
+      type: git
+      url: https://github.com/octomap/octomap.git
+      version: devel
+    status: maintained
   octomap_msgs:
     doc:
       type: git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1331,7 +1331,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/octomap/octomap.git
-      version: master
+      version: devel
     release:
       packages:
       - dynamic_edt_3d


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap` to `1.9.7-1`:

- upstream repository: https://github.com/OctoMap/octomap.git
- release repository: https://github.com/ros-gbp/octomap-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
