### PR TITLE
realsense2_camera: 2.3.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11849,7 +11849,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
-      version: 2.2.24-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/IntelRealSense/realsense-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `2.3.0-1`:

- upstream repository: https://github.com/IntelRealSense/realsense-ros.git
- release repository: https://github.com/IntelRealSense/realsense-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.2.24-1`

## realsense2_camera

```
* Fix pointcloud message size when no texture is added.
* Added filling correct Tx, Ty values in projection matrix of right camera.
* Fixed frame_id of right sensor to match left sensor in a stereo pair.pair
* Contributors: Pavlo Kolomiiets, doronhi
```

## realsense2_description

- No changes
