### PR TITLE
Adds the osrf-pycommon python rule

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6722,6 +6722,10 @@ python3-opengl:
   gentoo: [dev-python/pyopengl]
   nixos: [python3Packages.pyopengl]
   ubuntu: [python3-opengl]
+python3-osrf-pycommon:
+  fedora: [python3-osrf-pycommon]
+  gentoo: [dev-python/osrf_pycommon]
+  ubuntu: [python3-osrf-pycommon]
 python3-owlready2-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

[osrf_pycommon](https://osrf-pycommon.readthedocs.io/en/latest/)

## Package Upstream Source:

[osrf_pycommon](https://github.com/osrf/osrf_pycommon)

## Purpose of using this:

This dependency is needed for the catkin-tools package due to a bug that is present (see this [ros answer](https://answers.ros.org/question/353113/catkin-build-in-ubuntu-2004-noetic/) and [this issue](https://github.com/catkin/catkin_tools/issues/594)).

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - I could not find the right package
- Ubuntu: https://packages.ubuntu.com/
   - Strange enough I can not find it in the package index but I am able to install it on ubuntu 20.04
- Fedora: https://fedora.pkgs.org/34/fedora-x86_64/python3-osrf-pycommon-0.2.1-1.fc34.noarch.rpm.html
- Gentoo: https://packages.gentoo.org/packages/dev-python/osrf_pycommon