### PR TITLE
ur_client_library: 0.2.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4719,6 +4719,21 @@ repositories:
       url: https://github.com/ros2/unique_identifier_msgs.git
       version: foxy
     status: maintained
+  ur_client_library:
+    doc:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git
+      version: boost
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
+      version: 0.2.1-1
+    source:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git
+      version: boost
+    status: developed
   urdf:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `0.2.1-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ur_client_library

```
* Run ci also for ROS2 foxy
* Prepare package.xml and cmakelists for ROS2
* Add downstream workspace
* Contributors: Felix Exner, Lennart Puck
```
