### PR TITLE
trac_ik: 1.6.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7757,7 +7757,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/traclabs/trac_ik-release.git
-      version: 1.6.5-1
+      version: 1.6.6-1
     source:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git


### PR DESCRIPTION
Increasing version of package(s) in repository `trac_ik` to `1.6.6-1`:

- upstream repository: https://bitbucket.org/traclabs/trac_ik.git
- release repository: https://github.com/traclabs/trac_ik-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.6.5-1`

## trac_ik

- No changes

## trac_ik_examples

```
* propagated nlopt deps to sat packages
* Contributors: Stephen Hart
```

## trac_ik_kinematics_plugin

```
* removed bad depends
* propagated nlopt deps to sat packages
* Contributors: Stephen Hart
```

## trac_ik_lib

- No changes

## trac_ik_python

```
* propagated nlopt deps to sat packages
* Contributors: Stephen Hart
```
