### PR TITLE
rmw_gurumdds: 0.7.12-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2527,7 +2527,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
-      version: 0.7.11-1
+      version: 0.7.12-1
     source:
       type: git
       url: https://github.com/ros2/rmw_gurumdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_gurumdds` to `0.7.12-1`:

- upstream repository: https://github.com/ros2/rmw_gurumdds.git
- release repository: https://github.com/ros2-gbp/rmw_gurumdds-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.11-1`

## rmw_gurumdds_cpp

```
* Update code about build error on windows
* Contributors: Youngjin Yun
```

## rmw_gurumdds_shared_cpp

```
* fix typo: check namespace_ allocate
* Contributors: Youngjin Yun
```
