### PR TITLE
pr2_controllers: 1.10.18-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5155,6 +5155,32 @@ repositories:
       url: https://github.com/pr2/pr2_common.git
       version: melodic-devel
     status: unmaintained
+  pr2_controllers:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_controllers.git
+      version: melodic-devel
+    release:
+      packages:
+      - ethercat_trigger_controllers
+      - joint_trajectory_action
+      - pr2_calibration_controllers
+      - pr2_controllers
+      - pr2_controllers_msgs
+      - pr2_gripper_action
+      - pr2_head_action
+      - pr2_mechanism_controllers
+      - robot_mechanism_controllers
+      - single_joint_position_action
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_controllers-release.git
+      version: 1.10.18-1
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_controllers.git
+      version: melodic-devel
+    status: unmaintained
   pr2_ethercat_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_controllers` to `1.10.18-1`:

- upstream repository: https://github.com/pr2/pr2_controllers.git
- release repository: https://github.com/pr2-gbp/pr2_controllers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ethercat_trigger_controllers

- No changes

## joint_trajectory_action

- No changes

## pr2_calibration_controllers

- No changes

## pr2_controllers

- No changes

## pr2_controllers_msgs

- No changes

## pr2_gripper_action

- No changes

## pr2_head_action

```
* Fix for noetic (#401 <https://github.com/PR2/pr2_controllers/issues/401>)
  
    * install liborocos for noetic
    * conver to package 3
  
* Contributors: Kei Okada
```

## pr2_mechanism_controllers

```
* 2to3 -w -f print . (#401 <https://github.com/PR2/pr2_controllers/issues/401>)
* Contributors: Kei Okada
```

## robot_mechanism_controllers

```
* Fix for noetic, 2to3 -w -f print (#401 <https://github.com/PR2/pr2_controllers/issues/401>)
* use install(PROGRAMS scripts/effort.py posture.py instaed of install(FILES (#398 <https://github.com/PR2/pr2_controllers/issues/398>)
* add effort values in joint_trajectory_action_controller/state (#397 <https://github.com/PR2/pr2_controllers/issues/397>)
* do not find deprecated boost signals package, it was not used either (#395 <https://github.com/PR2/pr2_controllers/issues/395>)
* add missing / to constraints parameter,  This never worked before...
* Contributors: Kei Okada, Michael Görner, Shingo Kitagawa
```

## single_joint_position_action

- No changes
