### PR TITLE
azure-iot-sdk-c: 1.7.0-4 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -340,7 +340,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/nobleo/azure-iot-sdk-c-release.git
-      version: 1.7.0-3
+      version: 1.7.0-4
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `azure-iot-sdk-c` to `1.7.0-4`:

- upstream repository: https://github.com/Azure/azure-iot-sdk-c.git
- release repository: https://github.com/nobleo/azure-iot-sdk-c-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.7.0-3`
