### PR TITLE
py_trees_msgs: 0.3.7-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5318,7 +5318,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/stonier/py_trees_msgs-release.git
-      version: 0.3.6-1
+      version: 0.3.7-2
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_msgs` to `0.3.7-2`:

- upstream repository: https://github.com/splintered-reality/py_trees_msgs.git
- release repository: https://github.com/stonier/py_trees_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.6-1`
