### PR TITLE
genmypy: 0.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2250,11 +2250,12 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/rospypi/genmypy-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/rospypi/genmypy.git
       version: master
+    status: developed
   gennodejs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `genmypy` to `0.3.1-1`:

- upstream repository: https://github.com/rospypi/genmypy.git
- release repository: https://github.com/rospypi/genmypy-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.0-1`

## genmypy

```
* Use bytes for uint8[] field (#40 <https://github.com/rospypi/genmypy/issues/40>)
* Use bytes in serialize/deserialize methods (#39 <https://github.com/rospypi/genmypy/issues/39>)
* Generate type aliases for request_class and response_class (#37 <https://github.com/rospypi/genmypy/issues/37>)
```
