### PR TITLE
rqt_py_trees: 0.4.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6845,7 +6845,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/stonier/rqt_py_trees-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/stonier/rqt_py_trees.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_py_trees` to `0.4.1-1`:

- upstream repository: https://github.com/stonier/rqt_py_trees.git
- release repository: https://github.com/stonier/rqt_py_trees-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.0-1`

## rqt_py_trees

```
* bugfix a python2->3 iterator->list generator in dynamic_timeline
* provide a --topic argument on the command line
```
