### PR TITLE
wifi_ddwrt: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8470,6 +8470,21 @@ repositories:
       type: git
       url: https://github.com/ros-drivers/wge100_driver.git
       version: noetic-devel
+  wifi_ddwrt:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/wifi_ddwrt.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/wifi_ddwrt-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/wifi_ddwrt.git
+      version: noetic-devel
+    status: unmaintained
   willow_maps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wifi_ddwrt` to `0.2.0-1`:

- upstream repository: https://github.com/ros-drivers/wifi_ddwrt.git
- release repository: https://github.com/ros-gbp/wifi_ddwrt-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`
