### PR TITLE
py_trees: 2.1.5-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2441,7 +2441,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/stonier/py_trees-release.git
-      version: 2.1.2-1
+      version: 2.1.5-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `2.1.5-2`:

- upstream repository: https://github.com/splintered-reality/py_trees.git
- release repository: https://github.com/stonier/py_trees-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.2-1`

## py_trees

```
* [composites] sequences w/o memory, #325 <https://github.com/splintered-reality/py_trees/pull/325>
* [composites] selectors with memory, #324 <https://github.com/splintered-reality/py_trees/pull/324>
* [display] unicode trees are unicode, not ascii #324 <https://github.com/splintered-reality/py_trees/pull/324>
```
