### PR TITLE
py_trees_ros: 2.1.1-3 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2473,7 +2473,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/stonier/py_trees_ros-release.git
-      version: 2.1.0-1
+      version: 2.1.1-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `2.1.1-3`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros.git
- release repository: https://github.com/stonier/py_trees_ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.0-1`

## py_trees_ros

```
* [trees] publish with/without memory information (supports new selector/sequence modes)
```
