### PR TITLE
librealsense2: 2.45.0-1 in 'dashing/distribution.yaml'

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1488,23 +1488,22 @@ repositories:
       url: https://github.com/lgsvl/lgsvl_msgs.git
       version: dashing-devel
     status: developed
-  librealsense:
+  librealsense2:
     doc:
       type: git
       url: https://github.com/IntelRealSense/librealsense.git
-      version: ros2debian
+      version: ros2
     release:
-      packages:
-      - librealsense2
       tags:
         release: release/dashing/{package}/{version}
-      url: https://github.com/ros2-gbp/librealsense-release.git
-      version: 2.16.5-1
+      url: https://github.com/IntelRealSense/librealsense2-release.git
+      version: 2.45.0-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/IntelRealSense/librealsense.git
-      version: ros2debian
-    status: maintained
+      version: ros2
+    status: developed
   libyaml_vendor:
     release:
       tags:


### PR DESCRIPTION
replace librealsense2 entry to match package name.
replace source for librealsense2. Change status to developed
update librealsense2 version.
