### PR TITLE
rclpy: 1.8.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1752,7 +1752,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 1.8.1-2
+      version: 1.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `1.8.2-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.8.1-2`

## rclpy

```
* Break log function execution ASAP if configured severity is too high (#776 <https://github.com/ros2/rclpy/issues/776>) (#783 <https://github.com/ros2/rclpy/issues/783>)
* Contributors: ksuszka
```
