### PR TITLE
geometry2: 0.17.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -777,7 +777,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.17.1-2
+      version: 0.17.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.17.2-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.17.1-2`

## examples_tf2_py

```
* Use underscores instead of dashes in setup.cfg. (#403 <https://github.com/ros2/geometry2/issues/403>) (#404 <https://github.com/ros2/geometry2/issues/404>)
* Contributors: Chris Lalancette
```

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

- No changes

## tf2_ros_py

```
* Use underscores instead of dashes in setup.cfg. (#403 <https://github.com/ros2/geometry2/issues/403>) (#404 <https://github.com/ros2/geometry2/issues/404>)
* Contributors: Chris Lalancette
```

## tf2_sensor_msgs

- No changes

## tf2_tools

```
* Use underscores instead of dashes in setup.cfg. (#403 <https://github.com/ros2/geometry2/issues/403>) (#404 <https://github.com/ros2/geometry2/issues/404>)
* Contributors: Chris Lalancette
```
