### PR TITLE
rqt_reconfigure: 1.0.8-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4011,7 +4011,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_reconfigure-release.git
-      version: 1.0.7-1
+      version: 1.0.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_reconfigure` to `1.0.8-1`:

- upstream repository: https://github.com/ros-visualization/rqt_reconfigure.git
- release repository: https://github.com/ros2-gbp/rqt_reconfigure-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.7-1`

## rqt_reconfigure

```
* Cleanups to the install scripts. (#103 <https://github.com/ros-visualization/rqt_reconfigure/issues/103>)
* Contributors: Chris Lalancette
```
