### PR TITLE
rclpy: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1767,7 +1767,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 1.8.1-1
+      version: 2.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `2.0.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `1.8.1-1`

## rclpy

```
* Print 'Infinite' for infinite durations in topic endpoint info (#722 <https://github.com/ros2/rclpy/issues/722>)
* Break log function execution ASAP if configured severity is too high (#776 <https://github.com/ros2/rclpy/issues/776>)
* Convert Node and Context to use C++ Classes (#771 <https://github.com/ros2/rclpy/issues/771>)
* Misc action server improvements (#774 <https://github.com/ros2/rclpy/issues/774>)
* Misc action goal handle improvements (#767 <https://github.com/ros2/rclpy/issues/767>)
* Convert Guardcondition to use C++ classes (#772 <https://github.com/ros2/rclpy/issues/772>)
* Removed unused structs ``rclpy_client_t`` and ``rclpy_service_t`` (#770 <https://github.com/ros2/rclpy/issues/770>)
* Convert WaitSet to use C++ Classes (#769 <https://github.com/ros2/rclpy/issues/769>)
* Convert ActionServer to use C++ Classes (#766 <https://github.com/ros2/rclpy/issues/766>)
* Convert ActionClient to use C++ classes (#759 <https://github.com/ros2/rclpy/issues/759>)
* Use py::class_ for rcl_action_goal_handle_t (#751 <https://github.com/ros2/rclpy/issues/751>)
* Convert Publisher and Subscription to use C++ Classes (#756 <https://github.com/ros2/rclpy/issues/756>)
* Contributors: Alejandro Hernández Cordero, Emerson Knapp, Greg Balke, Shane Loretz, ksuszka
```
