### PR TITLE
realsense2_camera: 3.2.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2388,6 +2388,26 @@ repositories:
       url: https://github.com/ros2/rcutils.git
       version: dashing
     status: developed
+  realsense2_camera:
+    doc:
+      type: git
+      url: https://github.com/IntelRealSense/realsense-ros.git
+      version: ros2
+    release:
+      packages:
+      - realsense2_camera
+      - realsense2_camera_msgs
+      - realsense2_description
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/IntelRealSense/realsense-ros-release.git
+      version: 3.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/IntelRealSense/realsense-ros.git
+      version: ros2
+    status: developed
   realtime_support:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `3.2.1-1`:

- upstream repository: https://github.com/IntelRealSense/realsense-ros.git
- release repository: https://github.com/IntelRealSense/realsense-ros-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## realsense2_camera

```
* Add build dependency **ros_environment**
* Contributors: doronhi
```

## realsense2_camera_msgs

- No changes

## realsense2_description

- No changes
