### PR TITLE
librealsense2: 2.45.0-1 in 'dashing/distribution.yaml' - fix

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1492,7 +1492,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/IntelRealSense/librealsense.git
-      version: ros2
+      version: master
     release:
       tags:
         release: release/dashing/{package}/{version}
@@ -1502,7 +1502,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/IntelRealSense/librealsense.git
-      version: ros2
+      version: master
     status: developed
   libyaml_vendor:
     release:


### PR DESCRIPTION
fix librealsense2 branch from ros2 to master
Fix error in [build](https://build.ros2.org/job/Ddev__librealsense2__ubuntu_bionic_amd64/1/display/redirect)