### PR TITLE
ros_realtime: 1.0.25-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6243,6 +6243,27 @@ repositories:
       url: https://github.com/machinekoder/ros_pytest.git
       version: noetic-devel
     status: developed
+  ros_realtime:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_realtime.git
+      version: noetic-devel
+    release:
+      packages:
+      - allocators
+      - lockfree
+      - ros_realtime
+      - rosatomic
+      - rosrt
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/ros_realtime-release.git
+      version: 1.0.25-1
+    source:
+      type: git
+      url: https://github.com/ros/ros_realtime.git
+      version: noetic-devel
+    status: maintained
   ros_tutorials:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_realtime` to `1.0.25-1`:

- upstream repository: https://github.com/ros/ros_realtime.git
- release repository: https://github.com/ros-gbp/ros_realtime-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ros_realtime

- No changes
