### PR TITLE
azure-iot-sdk-c: 1.7.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -813,6 +813,17 @@ repositories:
       url: https://github.com/ros-drivers/axis_camera.git
       version: master
     status: unmaintained
+  azure-iot-sdk-c:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/nobleo/azure-iot-sdk-c-release.git
+      version: 1.7.0-2
+    source:
+      type: git
+      url: https://github.com/Azure/azure-iot-sdk-c.git
+      version: master
+    status: maintained
   backward_ros:
     release:
       tags:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -820,6 +820,7 @@ repositories:
       url: https://github.com/nobleo/azure-iot-sdk-c-release.git
       version: 1.7.0-2
     source:
+      test_commits: false
       type: git
       url: https://github.com/Azure/azure-iot-sdk-c.git
       version: master


### PR DESCRIPTION
Increasing version of package(s) in repository `azure-iot-sdk-c` to `1.7.0-2`:

- upstream repository: https://github.com/Azure/azure-iot-sdk-c.git
- release repository: https://github.com/nobleo/azure-iot-sdk-c-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
