### PR TITLE
paho-mqtt-c: 1.3.8-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4774,7 +4774,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/nobleo/paho.mqtt.c-release.git
-      version: 1.3.8-2
+      version: 1.3.8-3
     source:
       test_commits: false
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4769,6 +4769,17 @@ repositories:
       url: https://github.com/allenh1/p2os.git
       version: main
     status: maintained
+  paho-mqtt-c:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/nobleo/paho.mqtt.c-release.git
+      version: 1.3.8-2
+    source:
+      type: git
+      url: https://github.com/eclipse/paho.mqtt.c.git
+      version: master
+    status: maintained
   panda_moveit_config:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4776,6 +4776,7 @@ repositories:
       url: https://github.com/nobleo/paho.mqtt.c-release.git
       version: 1.3.8-2
     source:
+      test_commits: false
       type: git
       url: https://github.com/eclipse/paho.mqtt.c.git
       version: master


### PR DESCRIPTION
Increasing version of package(s) in repository `paho-mqtt-c` to `1.3.8-2`:

- upstream repository: https://github.com/eclipse/paho.mqtt.c.git
- release repository: https://github.com/nobleo/paho.mqtt.c-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
