### PR TITLE
Add spirv rosdep keys

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6882,6 +6882,24 @@ speex:
     vivid: [speex]
     wily: [speex]
     xenial: [speex]
+spirv-headers:
+  arch: [spirv-headers]
+  debian: [spirv-headers]
+  fedora: [spirv-headers-devel]
+  gentoo: [dev-util/spirv-headers]
+  ubuntu:
+    '*': [spirv-headers]
+    bionic: null
+    xenial: null
+spirv-tools:
+  arch: [spirv-tools]
+  debian: [spirv-tools]
+  fedora: [spirv-tools, spirv-tools-devel, spirv-tools-libs]
+  gentoo: [dev-util/spirv-tools]
+  ubuntu:
+    '*': [spirv-tools]
+    bionic: null
+    xenial: null
 sqlite3:
   arch: [sqlite]
   debian: [sqlite3]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:
spirv-headers and spirv-tools

## Package Upstream Source:

https://github.com/KhronosGroup/SPIRV-Headers
https://github.com/KhronosGroup/SPIRV-Tools

## Purpose of using this:

This dependency is being used for compiling TVM with Vulkan backend enabled.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/buster/spirv-headers
  - https://packages.debian.org/buster/spirv-tools
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/focal/spirv-headers
   - https://packages.ubuntu.com/focal/spirv-tools
- Fedora: https://src.fedoraproject.org/browse/projects/
  - https://koji.fedoraproject.org/koji/buildinfo?buildID=1616507
  - https://koji.fedoraproject.org/koji/buildinfo?buildID=1616505
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/community/any/spirv-headers/
  - https://archlinux.org/packages/extra/x86_64/spirv-tools/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-util/spirv-headers
  - https://packages.gentoo.org/packages/dev-util/spirv-tools
- macOS: https://formulae.brew.sh/
  - headers not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not done
