### PR TITLE
rclcpp: 10.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1751,7 +1751,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 9.0.2-1
+      version: 10.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `10.0.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `9.0.2-1`

## rclcpp

```
* Fix doc typo (#1663 <https://github.com/ros2/rclcpp/issues/1663>)
* [rclcpp] Type Adaptation feature (#1557 <https://github.com/ros2/rclcpp/issues/1557>)
* Do not attempt to use void allocators for memory allocation. (#1657 <https://github.com/ros2/rclcpp/issues/1657>)
* Keep custom allocator in publisher and subscription options alive. (#1647 <https://github.com/ros2/rclcpp/issues/1647>)
* Fix get_publishers_subscriptions_info_by_topic test in test_node.cpp (#1648 <https://github.com/ros2/rclcpp/issues/1648>)
* Use OnShutdown callback handle instead of OnShutdown callback (#1639 <https://github.com/ros2/rclcpp/issues/1639>)
* use dynamic_pointer_cast to detect allocator mismatch in intra process manager (#1643 <https://github.com/ros2/rclcpp/issues/1643>)
* Increase cppcheck timeout to 500s (#1634 <https://github.com/ros2/rclcpp/issues/1634>)
* Clarify node parameters docs (#1631 <https://github.com/ros2/rclcpp/issues/1631>)
* Contributors: Audrow Nash, Barry Xu, Jacob Perron, Michel Hidalgo, Shane Loretz, William Woodall
```

## rclcpp_action

```
* Returns CancelResponse::REJECT while goal handle failed to transit to CANCELING state (#1641 <https://github.com/ros2/rclcpp/issues/1641>)
* Fix action server deadlock issue that caused by other mutexes locked in CancelCallback (#1635 <https://github.com/ros2/rclcpp/issues/1635>)
* Contributors: Kaven Yau
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* [rclcpp] Type Adaptation feature (#1557 <https://github.com/ros2/rclcpp/issues/1557>)
* Contributors: Audrow Nash, William Woodall
```
