### PR TITLE
base.yaml updates for openSUSE  (1 of 6)

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -441,6 +441,7 @@ ca-certificates:
   gentoo: [app-misc/ca-certificates]
   nixos: [cacert]
   openembedded: [ca-certificates@openembedded-core]
+  opensuse: [ca-certificates]
   ubuntu: [ca-certificates]
 can-utils:
   debian: [can-utils]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -57,6 +57,7 @@ alsa-utils:
   fedora: [alsa-utils]
   gentoo: [media-sound/alsa-utils]
   nixos: [alsaUtils]
+  opensuse: [alsa-utils]
   ubuntu: [alsa-utils]
 ant:
   arch: [apache-ant]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -49,6 +49,7 @@ alsa-oss:
   fedora: [alsa-oss]
   gentoo: [media-libs/alsa-oss]
   nixos: [alsaOss]
+  opensuse: [alsa-oss]
   ubuntu: [alsa-oss]
 alsa-utils:
   arch: [alsa-utils]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -830,6 +830,7 @@ dvipng:
   debian: [dvipng]
   fedora: [texlive-dvipng-bin]
   gentoo: [app-text/dvipng]
+  opensuse: [texlive-dvipng-bin]
   ubuntu: [dvipng]
 eclipse:
   arch: [eclipse, eclipse-rcp, eclipse-emf, eclipse-pde]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -168,7 +168,7 @@ assimp:
   macports: [assimp]
   nixos: [assimp]
   openembedded: [assimp@openembedded-core]
-  opensuse: [libassimp3]
+  opensuse: [assimp-devel]
   rhel: [assimp-devel]
   slackware: [assimp]
   ubuntu:
@@ -186,7 +186,7 @@ assimp-dev:
   gentoo: [media-libs/assimp]
   nixos: [assimp]
   openembedded: [assimp@openembedded-core]
-  opensuse: [libassimp3]
+  opensuse: [assimp-devel]
   rhel: [assimp-devel]
   slackware: [assimp]
   ubuntu:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -405,7 +405,7 @@ bullet:
   macports: [bullet]
   nixos: [bullet]
   openembedded: [bullet@meta-ros-common]
-  opensuse: [libbullet]
+  opensuse: [libbullet-devel]
   rhel: [bullet-devel]
   ubuntu:
     '*': [libbullet-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -678,7 +678,7 @@ cppunit:
   macports: [cppunit]
   nixos: [cppunit]
   openembedded: [cppunit@meta-oe]
-  opensuse: [libcppunit-devel]
+  opensuse: [cppunit-devel]
   rhel: [cppunit-devel]
   slackware: [cppunit]
   ubuntu: [libcppunit-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -866,7 +866,7 @@ eigen:
   macports: [eigen3]
   nixos: [eigen]
   openembedded: [libeigen@meta-oe]
-  opensuse: [libeigen3-devel]
+  opensuse: [eigen3-devel]
   rhel: [eigen3-devel]
   slackware:
     slackpkg:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -809,6 +809,7 @@ doxygen:
   macports: [doxygen]
   nixos: [doxygen]
   openembedded: [doxygen@meta-oe]
+  opensuse: [doxygen]
   rhel: [doxygen]
   ubuntu: [doxygen]
 dpkg:


### PR DESCRIPTION
I have a lot of updates for openSUSE and was asked to break them up for easier digestion.

These keys are not necessarily related to each other. I'm just processing these commits alphabetically and breaking them up into groups of approx. 10.

https://software.opensuse.org/package/alsa-oss
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/alsa-oss/standard
https://software.opensuse.org/package/alsa-utils
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.15468/standard
https://software.opensuse.org/package/assimp
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/assimp/standard
https://software.opensuse.org/package/libbullet
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/libbullet/standard
https://software.opensuse.org/package/ca-certificates
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/ca-certificates/standard
https://software.opensuse.org/package/cppunit
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/cppunit/standard
https://software.opensuse.org/package/doxygen
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/doxygen/standard
https://software.opensuse.org/package/texlive-dvipng-bin
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/texlive/standard
https://software.opensuse.org/package/eigen3
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/eigen3/standard

