### PR TITLE
calibration: 0.10.15-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -487,6 +487,33 @@ repositories:
       url: https://gitlab.com/botasys/bota_driver.git
       version: noetic-devel
     status: developed
+  calibration:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/calibration.git
+      version: noetic-devel
+    release:
+      packages:
+      - calibration
+      - calibration_estimation
+      - calibration_launch
+      - calibration_msgs
+      - calibration_setup_helper
+      - image_cb_detector
+      - interval_intersection
+      - joint_states_settler
+      - laser_cb_detector
+      - monocam_settler
+      - settlerlib
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/calibration-release.git
+      version: 0.10.15-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/calibration.git
+      version: noetic-devel
+    status: maintained
   capabilities:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `calibration` to `0.10.15-1`:

- upstream repository: http://github.com/ros-perception/calibration.git
- release repository: https://github.com/ros-gbp/calibration-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## calibration

```
* update maintainer for most packages; first try at setup for travis testing (#46 <https://github.com/ros-perception/calibration/issues/46>)
* Contributors: Dave Feil-Seifer
```

## calibration_estimation

```
* Merge pull request #47 <https://github.com/ros-perception/calibration/issues/47> from PR2-prime/noetic-devel
  Noetic devel
* fixed test errors for python3 compatibility
* fixed python3 compatibility issues
* update maintainer for most packages; first try at setup for travis testing (#46 <https://github.com/ros-perception/calibration/issues/46>)
* more python3 package fixes
* more python3 package fixes
* only depend on python_orocos_kdl for python2
* spell exec correctly
* updated package.xml file for python3 dependencies
* Contributors: Dave Feil-Seifer
```

## calibration_launch

```
* Merge pull request #47 <https://github.com/ros-perception/calibration/issues/47> from PR2-prime/noetic-devel
  Noetic devel
* fixed python3 compatibility issues
* update maintainer for most packages; first try at setup for travis testing (#46 <https://github.com/ros-perception/calibration/issues/46>)
* Contributors: Dave Feil-Seifer
```

## calibration_msgs

```
* Merge pull request #47 <https://github.com/ros-perception/calibration/issues/47> from PR2-prime/noetic-devel
  Noetic devel
* fixes for compiler warnings CMP0048 and CMP0046
* update maintainer for most packages; first try at setup for travis testing (#46 <https://github.com/ros-perception/calibration/issues/46>)
* Contributors: Dave Feil-Seifer
```

## calibration_setup_helper

- No changes

## image_cb_detector

```
* Merge pull request #47 <https://github.com/ros-perception/calibration/issues/47> from PR2-prime/noetic-devel
  Noetic devel
* fixes for compiler warnings CMP0048 and CMP0046
* update maintainer for most packages; first try at setup for travis testing (#46 <https://github.com/ros-perception/calibration/issues/46>)
* fixed unit tests for compile/testing in focal/noetic/opencv4
* Contributors: Dave Feil-Seifer
```

## interval_intersection

```
* Merge pull request #47 <https://github.com/ros-perception/calibration/issues/47> from PR2-prime/noetic-devel
  Noetic devel
* fixes for compiler warnings CMP0048 and CMP0046
* update maintainer for most packages; first try at setup for travis testing (#46 <https://github.com/ros-perception/calibration/issues/46>)
* Merge pull request #41 <https://github.com/ros-perception/calibration/issues/41> from Hodorgasm/hydro
  Fix "stdlib.h: No such file or directory" errors in GCC-6
* Fix "stdlib.h: No such file or directory" errors in GCC-6
  Including '-isystem /usr/include' breaks building with GCC-6.
  See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129
* Contributors: Dave Feil-Seifer, Hodorgasm, Vincent Rabaud
```

## joint_states_settler

```
* Merge pull request #47 <https://github.com/ros-perception/calibration/issues/47> from PR2-prime/noetic-devel
  Noetic devel
* fixes for compiler warnings CMP0048 and CMP0046
* update maintainer for most packages; first try at setup for travis testing (#46 <https://github.com/ros-perception/calibration/issues/46>)
* Contributors: Dave Feil-Seifer
```

## laser_cb_detector

```
* Merge pull request #47 <https://github.com/ros-perception/calibration/issues/47> from PR2-prime/noetic-devel
  Noetic devel
* fixes for compiler warnings CMP0048 and CMP0046
* update maintainer for most packages; first try at setup for travis testing (#46 <https://github.com/ros-perception/calibration/issues/46>)
* fixed opencv issue with laser_cb test
* fixed unit tests for compile/testing in focal/noetic/opencv4
* Contributors: Dave Feil-Seifer
```

## monocam_settler

```
* Merge pull request #47 <https://github.com/ros-perception/calibration/issues/47> from PR2-prime/noetic-devel
  Noetic devel
* fixes for compiler warnings CMP0048 and CMP0046
* update maintainer for most packages; first try at setup for travis testing (#46 <https://github.com/ros-perception/calibration/issues/46>)
* Contributors: Dave Feil-Seifer
```

## settlerlib

```
* Merge pull request #47 <https://github.com/ros-perception/calibration/issues/47> from PR2-prime/noetic-devel
  Noetic devel
* fixes for compiler warnings CMP0048 and CMP0046
* update maintainer for most packages; first try at setup for travis testing (#46 <https://github.com/ros-perception/calibration/issues/46>)
* Contributors: Dave Feil-Seifer
```
