### PR TITLE
nixos: replace deprecated aliases

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -645,7 +645,7 @@ couchdb:
   debian: [couchdb]
   fedora: [couchdb]
   gentoo: [dev-db/couchdb]
-  nixos: [couchdb]
+  nixos: [couchdb3]
   ubuntu: [couchdb]
 cppad:
   debian: [cppad]
@@ -923,7 +923,7 @@ exfat-utils:
   arch: [exfat-utils]
   debian: [exfat-utils]
   gentoo: [sys-fs/exfat-utils]
-  nixos: [exfat-utils]
+  nixos: [exfat]
   ubuntu: [exfat-utils]
 f2c:
   arch: [f2c]
@@ -1373,7 +1373,7 @@ google-mock:
   fedora: [gmock-devel]
   freebsd: [googlemock]
   gentoo: [dev-cpp/gtest]
-  nixos: [gmock]
+  nixos: [gtest]
   openembedded: [gtest@meta-oe]
   opensuse: [gmock-devel]
   rhel: [gmock-devel]
@@ -1917,7 +1917,7 @@ iproute2:
   debian: [iproute2]
   fedora: [iproute]
   gentoo: [sys-apps/iproute2]
-  nixos: [iproute]
+  nixos: [iproute2]
   openembedded: [iproute2@openembedded-core]
   opensuse: [iproute2]
   ubuntu: [iproute2]
@@ -2018,7 +2018,7 @@ kate:
   debian: [kate]
   fedora: [kate]
   gentoo: [kde-apps/kate]
-  nixos: [kate]
+  nixos: [plasma5Packages.kate]
   ubuntu: [kate]
 kgraphviewer:
   arch: [kgraphviewer]
@@ -2031,7 +2031,7 @@ konsole:
   debian: [konsole]
   fedora: [konsole]
   gentoo: [kde-apps/konsole]
-  nixos: [konsole]
+  nixos: [plasma5Packages.konsole]
   ubuntu: [konsole]
 language-pack-de:
   fedora: [filesystem]
@@ -3630,7 +3630,7 @@ liblttng-ust-dev:
 liblzma-dev:
   debian: [liblzma-dev]
   fedora: [lzma-devel]
-  nixos: [lzma]
+  nixos: [xz]
   ubuntu: [liblzma-dev]
 libmagick:
   arch: [imagemagick]
@@ -3717,7 +3717,7 @@ libmpich-dev:
 libmpich2-dev:
   debian: [libmpich2-dev]
   gentoo: [sys-cluster/mpich2]
-  nixos: [mpich2]
+  nixos: [mpich]
   ubuntu: [libmpich2-dev]
 libmysqlclient-dev:
   arch: [mariadb]
@@ -4393,12 +4393,12 @@ libqhull:
 libqrencode:
   debian: [libqrencode3]
   gentoo: [media-gfx/qrencode]
-  nixos: [libqrencode]
+  nixos: [qrencode]
   ubuntu: [libqrencode3]
 libqrencode-dev:
   debian: [libqrencode-dev]
   gentoo: [media-gfx/qrencode]
-  nixos: [libqrencode]
+  nixos: [qrencode]
   ubuntu: [libqrencode-dev]
 libqt4:
   arch: [qt4]
@@ -4633,7 +4633,7 @@ libqwt-qt5-dev:
   debian: [libqwt-qt5-dev]
   fedora: [qwt-qt5-devel]
   gentoo: ['x11-libs/qwt:6']
-  nixos: [qwt6]
+  nixos: [libsForQt5.qwt]
   openembedded: [qwt-qt5@meta-qt5]
   ubuntu:
     '*': [libqwt-qt5-dev]
@@ -4649,7 +4649,7 @@ libqwt6:
   debian: [libqwt-dev]
   fedora: [qwt-devel]
   gentoo: ['x11-libs/qwt:6']
-  nixos: [qwt6]
+  nixos: [libsForQt5.qwt]
   ubuntu: [libqwt-dev]
 libqwtplot3d-qt4-dev:
   arch: [qwtplot3d]
@@ -4999,7 +4999,7 @@ libudev-dev:
   debian: [libudev-dev]
   fedora: [libudev-devel]
   gentoo: [virtual/libudev]
-  nixos: [libudev]
+  nixos: [udev]
   openembedded: [udev@openembedded-core]
   rhel: [libudev-devel]
   ubuntu: [libudev-dev]
@@ -5084,7 +5084,7 @@ libusb-1.0:
   debian: [libusb-1.0-0]
   fedora: [libusbx]
   gentoo: ['virtual/libusb:1']
-  nixos: [libusb]
+  nixos: [libusb1]
   openembedded: [libusb1@openembedded-core]
   opensuse: [libusb-1_0-0]
   rhel: [libusbx]
@@ -5106,7 +5106,7 @@ libusb-dev:
   fedora: [libusb-devel]
   gentoo: [virtual/libusb]
   macports: [libusb]
-  nixos: [libusb]
+  nixos: [libusb1]
   openembedded: [libusb1@openembedded-core]
   rhel: [libusb-devel]
   ubuntu: [libusb-dev]
@@ -6843,7 +6843,7 @@ smbclient:
   debian: [smbclient]
   fedora: [samba-client]
   gentoo: [net-fs/samba]
-  nixos: [smbclient]
+  nixos: [samba]
   ubuntu: [smbclient]
 snappy:
   arch: [snappy]
@@ -7378,7 +7378,7 @@ uuid:
   freebsd: [e2fsprogs-libuuid]
   gentoo: [dev-libs/ossp-uuid]
   macports: [ossp-uuid]
-  nixos: [utillinux]
+  nixos: [util-linux]
   openembedded: [util-linux@openembedded-core]
   opensuse: [libuuid-devel]
   rhel: [libuuid-devel]
@@ -7396,7 +7396,7 @@ v4l-utils:
   debian: [v4l-utils]
   fedora: [v4l-utils]
   gentoo: [media-tv/v4l-utils]
-  nixos: [v4l_utils]
+  nixos: [v4l-utils]
   openembedded: [v4l-utils@meta-oe]
   ubuntu: [v4l-utils]
 valgrind:
@@ -7719,7 +7719,7 @@ zenity:
   debian: [zenity]
   fedora: [zenity]
   gentoo: [gnome-extra/zenity]
-  nixos: [gnome3.zenity]
+  nixos: [gnome.zenity]
   ubuntu: [zenity]
 zeromq3:
   arch: [zeromq]


### PR DESCRIPTION
The `libusb` package in nixpkgs is a deprecated alias for the `libusb1` package. This PR updates the rosdep key to use the recommended name.