### PR TITLE
laser_geometry: 2.2.2-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1068,7 +1068,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/laser_geometry-release.git
-      version: 2.2.1-1
+      version: 2.2.2-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_geometry` to `2.2.2-4`:

- upstream repository: https://github.com/ros-perception/laser_geometry.git
- release repository: https://github.com/ros2-gbp/laser_geometry-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.2.1-1`

## laser_geometry

```
* Export sensor_msgs, tf2, and rclcpp as dependencies
* Contributors: Mabel Zhang, Michel Hidalgo
```
