### PR TITLE
pr2_power_drivers: 1.1.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5269,7 +5269,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_power_drivers-release.git
-      version: 1.1.8-1
+      version: 1.1.9-1
     source:
       type: git
       url: https://github.com/pr2/pr2_power_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_power_drivers` to `1.1.9-1`:

- upstream repository: https://github.com/pr2/pr2_power_drivers.git
- release repository: https://github.com/pr2-gbp/pr2_power_drivers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.1.8-1`

## ocean_battery_driver

```
* added boost_program_options as build dependency
* fixed CMP0048 compiler warning for noetic/focal
* Contributors: Dave Feil-Seifer
```

## power_monitor

- No changes

## pr2_power_board

```
* added dependency to pr2_power_drivers for boost_program_options
* Contributors: Dave Feil-Seifer
```

## pr2_power_drivers

- No changes
