### PR TITLE
rmf_cmake_uncrustify: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1844,6 +1844,17 @@ repositories:
       url: https://github.com/ros/resource_retriever.git
       version: ros2
     status: maintained
+  rmf_cmake_uncrustify:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_cmake_uncrustify-release.git
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_cmake_uncrustify.git
+      version: rolling
+    status: developed
   rmw:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1845,6 +1845,10 @@ repositories:
       version: ros2
     status: maintained
   rmf_cmake_uncrustify:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_cmake_uncrustify.git
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_cmake_uncrustify` to `1.2.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_cmake_uncrustify.git
- release repository: https://github.com/ros2-gbp/rmf_cmake_uncrustify-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
