### PR TITLE
mir_robot: 1.1.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3875,7 +3875,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/uos-gbp/mir_robot-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mir_robot` to `1.1.2-1`:

- upstream repository: https://github.com/dfki-ric/mir_robot.git
- release repository: https://github.com/uos-gbp/mir_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.1-1`

## mir_actions

- No changes

## mir_description

```
* Fix laser scan frame_id with gazebo_plugins 2.9.2
* Contributors: Martin Günther
```

## mir_driver

- No changes

## mir_dwb_critics

- No changes

## mir_gazebo

```
* Fix laser scan frame_id with gazebo_plugins 2.9.2
* Contributors: Martin Günther
```

## mir_msgs

- No changes

## mir_navigation

```
* Uncomment available dependencies in noetic (#79 <https://github.com/dfki-ric/mir_robot/issues/79>)
* Contributors: Oscar Lima
```

## mir_robot

- No changes

## sdc21x0

- No changes
