### PR TITLE
moveit: 1.1.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3991,7 +3991,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 1.1.3-1
+      version: 1.1.4-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `1.1.4-1`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.3-1`

## chomp_motion_planner

- No changes

## moveit

- No changes

## moveit_chomp_optimizer_adapter

- No changes

## moveit_commander

- No changes

## moveit_core

```
* Lock the octomap/octree while collision checking (#2596 <https://github.com/ros-planning/moveit/issues/2596>)
* Add sphinx-rtd-theme for python docs as a dependency (#2645 <https://github.com/ros-planning/moveit/issues/2645>)
* Contributors: Peter Mitrano, Simon Schmeisser
```

## moveit_fake_controller_manager

- No changes

## moveit_kinematics

```
* Fix ikfast script: install sympy 0.7.1 from git (#2650 <https://github.com/ros-planning/moveit/issues/2650>)
* Contributors: ags-dy
```

## moveit_planners

- No changes

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

- No changes

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

- No changes

## moveit_ros_move_group

- No changes

## moveit_ros_occupancy_map_monitor

```
* Lock the octomap/octree while collision checking (#2596 <https://github.com/ros-planning/moveit/issues/2596>)
* Contributors: Simon Schmeisser
```

## moveit_ros_perception

```
* Lock the octomap/octree while collision checking (#2596 <https://github.com/ros-planning/moveit/issues/2596>)
* Contributors: Simon Schmeisser
```

## moveit_ros_planning

```
* Lock the octomap/octree while collision checking (#2596 <https://github.com/ros-planning/moveit/issues/2596>)
* Use private NodeHandle instead of child for PlanningPipeline topics (#2652 <https://github.com/ros-planning/moveit/issues/2652>)
* Print an error if the planning pipelines are empty (#2639 <https://github.com/ros-planning/moveit/issues/2639>)
* Simplify logic in PSM (#2632 <https://github.com/ros-planning/moveit/issues/2632>)
* Contributors: Henning Kayser, Luc Bettaieb, Michael Görner, Simon Schmeisser, Rojas Rafael
```

## moveit_ros_planning_interface

```
* planning_interface: synchronize async interfaces in unit tests (#2640 <https://github.com/ros-planning/moveit/issues/2640>)
* Contributors: Michael Görner
```

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

- No changes

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_servo

- No changes

## moveit_setup_assistant

- No changes

## moveit_simple_controller_manager

- No changes

## pilz_industrial_motion_planner

- No changes

## pilz_industrial_motion_planner_testutils

- No changes
