### PR TITLE
urdf: 2.5.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3101,7 +3101,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/urdf-release.git
-      version: 2.5.1-2
+      version: 2.5.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf` to `2.5.2-1`:

- upstream repository: https://github.com/ros2/urdf.git
- release repository: https://github.com/ros2-gbp/urdf-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.5.1-2`

## urdf

- No changes

## urdf_parser_plugin

```
* Export urdfdom_headers as urdf_parser_plugin dependency. (#25 <https://github.com/ros2/urdf/issues/25>)
* Contributors: Michel Hidalgo
```
