### PR TITLE
robot_upstart: 0.3.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10139,7 +10139,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/robot_upstart-release.git
-      version: 0.3.2-1
+      version: 0.3.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_upstart` to `0.3.3-1`:

- upstream repository: https://github.com/clearpathrobotics/robot_upstart.git
- release repository: https://github.com/clearpath-gbp/robot_upstart-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.2-1`

## robot_upstart

```
* Enable customization of  After= in service (#104 <https://github.com/clearpathrobotics/robot_upstart/issues/104>)
  * Cosmetic
  Remove unnecessary parenthesis.
  * Correct typo
  * FIX: Remove unreachable code
  * Enable customizable After= in service
  This feature enables the user to define the services after which the
  generated service will. This is handy when hardware-related system
  services have to start before the ROS software.
* Added util-linux as dependency for setpriv.
* Bumped CMake version to avoid author warning.
* Contributors: Tkostas, Tony Baltovski
```
