### PR TITLE
rmw_fastrtps: 5.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1929,7 +1929,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 5.0.0-1
+      version: 5.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `5.1.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `5.0.0-1`

## rmw_fastrtps_cpp

```
* Loan messages implementation (#523 <https://github.com/ros2/rmw_fastrtps/issues/523>)
  * Added is_plain_ attribute to base TypeSupport.
  * Added new methods to base TypeSupport.
  * Implementation of rmw_borrow_loaned_message.
  * Implementation of rmw_return_loaned_message_from_publisher.
  * Enable loan messages on publishers of plain types.
  * Implementation for taking loaned messages.
  * Enable loan messages on subscriptions of plain types.
* Contributors: Miguel Company
```

## rmw_fastrtps_dynamic_cpp

```
* Loan messages implementation (#523 <https://github.com/ros2/rmw_fastrtps/issues/523>)
  * Added is_plain_ attribute to base TypeSupport.
  * Added new methods to base TypeSupport.
  * Implementation of rmw_borrow_loaned_message.
  * Implementation of rmw_return_loaned_message_from_publisher.
  * Enable loan messages on publishers of plain types.
  * Implementation for taking loaned messages.
  * Enable loan messages on subscriptions of plain types.
* Contributors: Miguel Company
```

## rmw_fastrtps_shared_cpp

```
* Loan messages implementation (#523 <https://github.com/ros2/rmw_fastrtps/issues/523>)
  * Added is_plain_ attribute to base TypeSupport.
  * Added new methods to base TypeSupport.
  * Implementation of rmw_borrow_loaned_message.
  * Implementation of rmw_return_loaned_message_from_publisher.
  * Enable loan messages on publishers of plain types.
  * Implementation for taking loaned messages.
  * Enable loan messages on subscriptions of plain types.
* Export rmw_dds_common as an rmw_fastrtps_shared_cpp dependency (#530 <https://github.com/ros2/rmw_fastrtps/issues/530>)
* Update includes after rcutils/get_env.h deprecation (#529 <https://github.com/ros2/rmw_fastrtps/issues/529>)
* Contributors: Christophe Bedard, Michel Hidalgo, Miguel Company
```
