### PR TITLE
moveit_calibration: 0.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3997,6 +3997,24 @@ repositories:
       url: https://github.com/ros-planning/moveit.git
       version: noetic-devel
     status: maintained
+  moveit_calibration:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_calibration.git
+      version: 0.1.0
+    release:
+      packages:
+      - moveit_calibration_gui
+      - moveit_calibration_plugins
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/JStech/moveit_calibration-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_calibration.git
+      version: 0.1.0
+    status: developed
   moveit_msgs:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4013,7 +4013,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-planning/moveit_calibration.git
-      version: 0.1.0
+      version: master
     status: developed
   moveit_msgs:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4001,7 +4001,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-planning/moveit_calibration.git
-      version: 0.1.0
+      version: master
     release:
       packages:
       - moveit_calibration_gui


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_calibration` to `0.1.0-1`:

- upstream repository: https://github.com/ros-planning/moveit_calibration.git
- release repository: https://github.com/JStech/moveit_calibration-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
