### PR TITLE
mcl_3dl: 0.6.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3699,7 +3699,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/at-wat/mcl_3dl-release.git
-      version: 0.5.4-1
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/at-wat/mcl_3dl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mcl_3dl` to `0.6.0-1`:

- upstream repository: https://github.com/at-wat/mcl_3dl.git
- release repository: https://github.com/at-wat/mcl_3dl-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.5.4-1`

## mcl_3dl

```
* Add option to load cloud through "load_pcd" service (#381 <https://github.com/at-wat/mcl_3dl/issues/381>)
* Update assets to v0.3.1 (#382 <https://github.com/at-wat/mcl_3dl/issues/382>)
* Update assets to v0.3.0 (#380 <https://github.com/at-wat/mcl_3dl/issues/380>)
* Update assets to v0.2.0 (#379 <https://github.com/at-wat/mcl_3dl/issues/379>)
* Contributors: Atsushi Watanabe, Remco
```
