### PR TITLE
roscompile: 1.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6357,7 +6357,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/wu-robotics/roscompile-release.git
-      version: 1.2.0-1
+      version: 1.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscompile` to `1.2.1-1`:

- upstream repository: https://github.com/DLu/roscompile.git
- release repository: https://github.com/wu-robotics/roscompile-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.0-1`
