### PR TITLE
dbw_polaris_ros: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2117,7 +2117,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_polaris_ros-release.git
-      version: 0.0.4-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/dbw_polaris_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_polaris_ros` to `1.0.0-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/dbw_polaris_ros.git
- release repository: https://github.com/DataspeedInc-release/dbw_polaris_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.4-1`

## dbw_polaris

- No changes

## dbw_polaris_can

```
* Bump firmware versions
* C++17 and std::clamp()
* Remove ROS Kinetic support
* Populate brake/throttle/steering command values even if enable is false
* Use 'steering_cmd' topic as preferred method of steering calibration
* Fix socketcan error frame lock up
* Contributors: Kevin Hallenbeck, Robert Maupin
```

## dbw_polaris_description

- No changes

## dbw_polaris_joystick_demo

```
* Use 'steering_cmd' topic as preferred method of steering calibration
* Contributors: Kevin Hallenbeck
```

## dbw_polaris_msgs

```
* Increase steering wheel command maximum angle to 600 degrees
* Contributors: Kevin Hallenbeck
```
