### PR TITLE
dbw_fca_ros: 1.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1349,7 +1349,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_fca_ros-release.git
-      version: 1.0.10-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/dbw_fca_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_fca_ros` to `1.2.0-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/dbw_fca_ros.git
- release repository: https://github.com/DataspeedInc-release/dbw_fca_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.10-1`

## dbw_fca

- No changes

## dbw_fca_can

```
* Bump firmware versions
* C++17 and std::clamp()
* Remove ROS Kinetic support
* Populate brake/throttle/steering command values even if enable is false
* Fix socketcan error frame lock up
* Contributors: Kevin Hallenbeck, Robert Maupin
```

## dbw_fca_description

- No changes

## dbw_fca_joystick_demo

- No changes

## dbw_fca_msgs

- No changes
