### PR TITLE
Mark Kinetic as end-of-life

### DIFF
--- a/index-v4.yaml
+++ b/index-v4.yaml
@@ -72,7 +72,7 @@ distributions:
   kinetic:
     distribution: [kinetic/distribution.yaml]
     distribution_cache: http://repositories.ros.org/rosdistro_cache/kinetic-cache.yaml.gz
-    distribution_status: active
+    distribution_status: end-of-life
     distribution_type: ros1
     python_version: 2
   lunar:


### PR DESCRIPTION
We've finished the [final sync](https://discourse.ros.org/t/new-package-for-kinetic-kame-2021-05-11-final-sync/20370?u=tfoote). It's time to retire Kinetic. 