### PR TITLE
demos: 0.15.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -487,7 +487,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.14.2-1
+      version: 0.15.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.15.0-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.14.2-1`

## action_tutorials_cpp

- No changes

## action_tutorials_interfaces

- No changes

## action_tutorials_py

- No changes

## composition

- No changes

## demo_nodes_cpp

```
* Revert "Use sizeof(char) in place for sizeof(void) (#515 <https://github.com/ros2/demos/issues/515>)" (#516 <https://github.com/ros2/demos/issues/516>)
* change how serialized message works with subscription (#497 <https://github.com/ros2/demos/issues/497>)
* Use sizeof(char) in place for sizeof(void) (#515 <https://github.com/ros2/demos/issues/515>)
* Fix small print issue in allocator tutorial. (#509 <https://github.com/ros2/demos/issues/509>)
* Contributors: Chris Lalancette, Michel Hidalgo, William Woodall
```

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

- No changes

## dummy_map_server

- No changes

## dummy_robot_bringup

- No changes

## dummy_sensors

- No changes

## image_tools

```
* Add support for visualizing yuv422 (#499 <https://github.com/ros2/demos/issues/499>)
* Contributors: joshua-qnx
```

## intra_process_demo

- No changes

## lifecycle

- No changes

## logging_demo

- No changes

## pendulum_control

- No changes

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

- No changes

## quality_of_service_demo_py

- No changes

## topic_monitor

```
* Fix topic_monitor for high publication rate (#461 <https://github.com/ros2/demos/issues/461>)
* Use is_alive for threads. (#510 <https://github.com/ros2/demos/issues/510>)
* Contributors: Chris Lalancette, Elias De Coninck
```

## topic_statistics_demo

- No changes
