### PR TITLE
rosdep: OpenEmbedded updates

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4784,6 +4784,7 @@ libsndfile1-dev:
   fedora: [libsndfile-devel]
   gentoo: [media-libs/libsndfile]
   nixos: [libsndfile]
+  openembedded: [libsndfile1@openembedded-core]
   rhel: [libsndfile-devel]
   ubuntu: [libsndfile1-dev]
 libsoqt4-dev:
@@ -5364,6 +5365,7 @@ libx11:
   gentoo: [x11-libs/libX11]
   macports: [xorg-libX11]
   nixos: [xorg.libX11]
+  openembedded: [libx11@openembedded-core]
   opensuse: [libX11-6]
   ubuntu: [libx11-dev]
 libx11-dev:
@@ -5521,6 +5523,7 @@ libxt-dev:
   fedora: [libXt-devel]
   gentoo: [x11-libs/libXt]
   nixos: [xorg.libXtst]
+  openembedded: [libxt@openembedded-core]
   ubuntu: [libxt-dev]
 libxtst-dev:
   arch: [libxtst]
@@ -6361,12 +6364,14 @@ portaudio:
   fedora: [portaudio-devel]
   gentoo: [media-libs/portaudio]
   nixos: [portaudio]
+  openembedded: [portaudio-v19@meta-oe]
   ubuntu: [libportaudio-dev]
 portaudio19-dev:
   debian: [portaudio19-dev]
   fedora: [libportaudio-devel]
   gentoo: [=media-libs/portaudio-19*]
   nixos: [portaudio]
+  openembedded: [portaudio-v19@meta-oe]
   ubuntu: [portaudio19-dev]
 postgresql:
   debian: [postgresql, postgresql-contrib]
@@ -6665,6 +6670,7 @@ qttools5-dev:
 qttools5-dev-tools:
   debian: [qttools5-dev-tools]
   fedora: [qt5-qttools-devel]
+  openembedded: [qttools@meta-qt5]
   rhel: [qt5-qttools-devel]
   ubuntu: [qttools5-dev-tools]
 r-base:
@@ -7194,6 +7200,7 @@ tar:
   gentoo: [dev-libs/libtar]
   macports: [libtar]
   nixos: [libtar]
+  openembedded: [tar@openembedded-core]
   opensuse: [libtar-devel]
   rhel: [libtar-devel]
   ubuntu: [libtar-dev]
@@ -7454,6 +7461,7 @@ util-linux:
   gentoo: [util-linux]
   macports: [util-linux]
   nixos: [util-linux]
+  openembedded: [util-linux@openembedded-core]
   ubuntu:
     '*': [util-linux]
     bionic: [setpriv, util-linux]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3816,6 +3816,7 @@ python-pytest-cov:
   fedora: [python-pytest-cov]
   gentoo: [dev-python/pytest-cov]
   nixos: [pythonPackages.pytestcov]
+  openembedded: ['${PYTHON_PN}-pytest-cov@meta-ros-common']
   ubuntu: [python-pytest-cov]
 python-pytest-dependency-pip:
   debian:
@@ -4980,6 +4981,7 @@ python-termcolor:
   fedora: [python-termcolor]
   gentoo: [dev-python/termcolor]
   nixos: [pythonPackages.termcolor]
+  openembedded: ['${PYTHON_PN}-termcolor@openembedded-core']
   osx:
     pip:
       packages: [termcolor]
@@ -7256,6 +7258,7 @@ python3-pytest-cov:
   fedora: [python3-pytest-cov]
   gentoo: [dev-python/pytest-cov]
   nixos: [python3Packages.pytestcov]
+  openembedded: [python3-pytest-cov@meta-ros-common]
   rhel: ['python%{python3_pkgversion}-pytest-cov']
   ubuntu: [python3-pytest-cov]
 python3-pytest-mock:


### PR DESCRIPTION
libsndfile1: https://layers.openembedded.org/layerindex/recipe/733/
portaudio-v1: https://layers.openembedded.org/layerindex/recipe/1080/
tar: https://layers.openembedded.org/layerindex/recipe/71/
qttools: https://layers.openembedded.org/layerindex/recipe/24103/
libx11: https://layers.openembedded.org/layerindex/recipe/5883/
libxt: https://layers.openembedded.org/layerindex/recipe/5128/
python3-termcolor: https://layers.openembedded.org/layerindex/recipe/96040/
python3-pytest-cov: will be added in meta-ros with https://github.com/ros/meta-ros/pull/849
