### PR TITLE
plotjuggler_ros: 1.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8582,7 +8582,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler_ros` to `1.1.1-1`:

- upstream repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
- release repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.0-1`

## plotjuggler_ros

```
* Mitigate proble with ros::ok()
* prepare for newer PJ version
* address issue with INT64
* Update README.md
* fix issue #399 <https://github.com/PlotJuggler/plotjuggler-ros-plugins/issues/399> and #398 <https://github.com/PlotJuggler/plotjuggler-ros-plugins/issues/398>
* Contributors: Davide Faconti
```
