### PR TITLE
plotjuggler: 3.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5032,7 +5032,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.1.0-1
+      version: 3.1.1-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.1.1-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.1.0-1`

## plotjuggler

```
* ulog: ignore parameter default message (#413 <https://github.com/facontidavide/PlotJuggler/issues/413>)
* Fix typo in "load transformations" prompt (#416 <https://github.com/facontidavide/PlotJuggler/issues/416>)
* added CSV export plugin
* fix opengl preference
* added options to enable OpenGL and TreeView
* Add libqt5x11extras5-dev into installation guide for fedora/ubuntu users. (#418 <https://github.com/facontidavide/PlotJuggler/issues/418>)
* Fix issue #405 <https://github.com/facontidavide/PlotJuggler/issues/405> with ULOG in windows
* Use format string when time index is not a number (#406 <https://github.com/facontidavide/PlotJuggler/issues/406>)
* XY curve markers: fixed colors and removed ghosts symbols (#407 <https://github.com/facontidavide/PlotJuggler/issues/407>)
* Updated support for windows build + installer (#396 <https://github.com/facontidavide/PlotJuggler/issues/396>)
* fix warnings and move to C++17
* fix warnings in MSVS
* Contributors: Beat Küng, Davide Faconti, Faisal Shah, Gabriel, Shawn, alessandro, alkaes
```
