### PR TITLE
plotjuggler_msgs: 0.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1500,6 +1500,13 @@ repositories:
       url: https://github.com/ros-drivers/phidgets_drivers.git
       version: galactic
     status: maintained
+  plotjuggler_msgs:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/facontidavide/plotjuggler_msgs-release.git
+      version: 0.1.2-1
+    status: developed
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler_msgs` to `0.1.2-1`:

- upstream repository: https://github.com/facontidavide/plotjuggler_msgs.git
- release repository: https://github.com/facontidavide/plotjuggler_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
