### PR TITLE
rmf_cmake_uncrustify: 1.2.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1853,7 +1853,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_cmake_uncrustify-release.git
-      version: 1.2.0-1
+      version: 1.2.0-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_cmake_uncrustify.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_cmake_uncrustify` to `1.2.0-2`:

- upstream repository: https://github.com/open-rmf/rmf_cmake_uncrustify.git
- release repository: https://github.com/ros2-gbp/rmf_cmake_uncrustify-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.2.0-1`
