### PR TITLE
point_cloud_msg_wrapper: 1.0.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2407,6 +2407,17 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: foxy
     status: maintained
+  point_cloud_msg_wrapper:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://gitlab.com/ApexAI/point_cloud_msg_wrapper-release
+      version: 1.0.5-1
+    source:
+      type: git
+      url: https://gitlab.com/ApexAI/point_cloud_msg_wrapper
+      version: foxy
+    status: developed
   pointcloud_to_laserscan:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_msg_wrapper` to `1.0.5-1`:

- upstream repository: https://gitlab.com/ApexAI/point_cloud_msg_wrapper
- release repository: https://gitlab.com/ApexAI/point_cloud_msg_wrapper-release
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
