### PR TITLE
point_cloud_msg_wrapper: 1.0.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1517,6 +1517,10 @@ repositories:
       version: ros2
     status: maintained
   point_cloud_msg_wrapper:
+    doc:
+      type: git
+      url: https://gitlab.com/ApexAI/point_cloud_msg_wrapper
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1516,6 +1516,17 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: ros2
     status: maintained
+  point_cloud_msg_wrapper:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://gitlab.com/ApexAI/point_cloud_msg_wrapper-release
+      version: 1.0.5-1
+    source:
+      type: git
+      url: https://gitlab.com/ApexAI/point_cloud_msg_wrapper
+      version: rolling
+    status: developed
   pybind11_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_msg_wrapper` to `1.0.5-1`:

- upstream repository: https://gitlab.com/ApexAI/point_cloud_msg_wrapper
- release repository: https://gitlab.com/ApexAI/point_cloud_msg_wrapper-release
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
