### PR TITLE
locator_ros_bridge: 1.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3512,6 +3512,23 @@ repositories:
       url: https://github.com/clearpathrobotics/lms1xx.git
       version: noetic-devel
     status: maintained
+  locator_ros_bridge:
+    doc:
+      type: git
+      url: https://github.com/boschglobal/locator_ros_bridge.git
+      version: noetic
+    release:
+      packages:
+      - bosch_locator_bridge
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/locator_ros_bridge-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/boschglobal/locator_ros_bridge.git
+      version: noetic
+    status: maintained
   log_view:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `locator_ros_bridge` to `1.0.0-1`:

- upstream repository: https://github.com/boschglobal/locator_ros_bridge.git
- release repository: https://github.com/ros-gbp/locator_ros_bridge-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## bosch_locator_bridge

```
* initial version
* Contributors: Stefan Laible
```
