### PR TITLE
locator_ros_bridge: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1177,6 +1177,23 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: master
     status: maintained
+  locator_ros_bridge:
+    doc:
+      type: git
+      url: https://github.com/boschglobal/locator_ros_bridge.git
+      version: rolling
+    release:
+      packages:
+      - bosch_locator_bridge
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/locator_ros_bridge-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/boschglobal/locator_ros_bridge.git
+      version: rolling
+    status: maintained
   marti_common:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1181,7 +1181,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git
-      version: rolling
+      version: main
     release:
       packages:
       - bosch_locator_bridge
@@ -1192,7 +1192,7 @@ repositories:
     source:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git
-      version: rolling
+      version: main
     status: maintained
   marti_common:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `locator_ros_bridge` to `2.1.0-1`:

- upstream repository: https://github.com/boschglobal/locator_ros_bridge.git
- release repository: https://github.com/ros2-gbp/locator_ros_bridge-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## bosch_locator_bridge

```
* initial version
* Contributors: Stefan Laible
```
