### PR TITLE
mocap_msgs: 0.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1829,6 +1829,17 @@ repositories:
       url: https://github.com/ros2/mimick_vendor.git
       version: master
     status: maintained
+  mocap_msgs:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/MOCAP4ROS2-Project/mocap_msgs-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/MOCAP4ROS2-Project/mocap_msgs.git
+      version: master
+    status: developed
   moveit:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mocap_msgs` to `0.0.2-1`:

- upstream repository: https://github.com/MOCAP4ROS2-Project/mocap_msgs.git
- release repository: https://github.com/MOCAP4ROS2-Project/mocap_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## mocap_msgs

```
* Cleaning
* ImusInfo added
* Remove srvs/msgs not used
* mocap4ros2_msgs replaced for mocap_msgs
* Add control msg
* Renaming mocap_msgs package
* Update README.md
* Marker(s)WithId msgs added
* Update README.md
* Names modified
* Add id to marker
* README modified
* Initial commit, msgs added
* Contributors: Francisco Martin Rico, Lorena Bajo Rebollo
```
