### PR TITLE
rosbag2: 0.9.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2227,7 +2227,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.8.0-1
+      version: 0.9.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.9.0-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.8.0-1`

## ros2bag

- No changes

## rosbag2

- No changes

## rosbag2_compression

```
* Rename Reader/Writer 'reset' to 'close' (#760 <https://github.com/ros2/rosbag2/issues/760>)
* Contributors: Emerson Knapp
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Naive clock jump implementation - allows for clock reuse and simplified Player setup (#754 <https://github.com/ros2/rosbag2/issues/754>)
* Rename Reader/Writer 'reset' to 'close' (#760 <https://github.com/ros2/rosbag2/issues/760>)
* Expose pause/resume related services on the Player (#729 <https://github.com/ros2/rosbag2/issues/729>)
* player owns the reader (#725 <https://github.com/ros2/rosbag2/issues/725>)
* Contributors: Emerson Knapp, Karsten Knese
```

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_py

```
* remove rosbag2_transport header (#742 <https://github.com/ros2/rosbag2/issues/742>)
* Include utility to quiet cpplint. (#744 <https://github.com/ros2/rosbag2/issues/744>)
* player owns the reader (#725 <https://github.com/ros2/rosbag2/issues/725>)
* Contributors: Chris Lalancette, Karsten Knese
```

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

```
* Add play_next() API to the player class (#762 <https://github.com/ros2/rosbag2/issues/762>)
* use rclcpp::SerializedMessage in MemoryManagement (#750 <https://github.com/ros2/rosbag2/issues/750>)
* remodel publication manager (#749 <https://github.com/ros2/rosbag2/issues/749>)
* use public recorder api in tests (#741 <https://github.com/ros2/rosbag2/issues/741>)
* player owns the reader (#725 <https://github.com/ros2/rosbag2/issues/725>)
* Contributors: Karsten Knese, Michael Orlov
```

## rosbag2_tests

```
* Correct expectation for exit code in play_end_to_end test since after redesign we are getting exception in constructor. (#763 <https://github.com/ros2/rosbag2/issues/763>)
* remodel publication manager (#749 <https://github.com/ros2/rosbag2/issues/749>)
* correct exit code assertion (#747 <https://github.com/ros2/rosbag2/issues/747>)
* Contributors: Karsten Knese, Michael Orlov
```

## rosbag2_transport

```
* Expose play_next service (#767 <https://github.com/ros2/rosbag2/issues/767>)
* Add play_next() API to the player class (#762 <https://github.com/ros2/rosbag2/issues/762>)
* Naive clock jump implementation - allows for clock reuse and simplified Player setup (#754 <https://github.com/ros2/rosbag2/issues/754>)
* Rename Reader/Writer 'reset' to 'close' (#760 <https://github.com/ros2/rosbag2/issues/760>)
* simply constructor for rosbag2_transport::Player (#757 <https://github.com/ros2/rosbag2/issues/757>)
* Expose GetRate/SetRate services for playback (#753 <https://github.com/ros2/rosbag2/issues/753>)
* Expose pause/resume related services on the Player (#729 <https://github.com/ros2/rosbag2/issues/729>)
* remodel publication manager (#749 <https://github.com/ros2/rosbag2/issues/749>)
* remove rosbag2_transport header (#742 <https://github.com/ros2/rosbag2/issues/742>)
* use public recorder api in tests (#741 <https://github.com/ros2/rosbag2/issues/741>)
* Use public player API in tests (#740 <https://github.com/ros2/rosbag2/issues/740>)
* public recorder and player (#739 <https://github.com/ros2/rosbag2/issues/739>)
* player owns the reader (#725 <https://github.com/ros2/rosbag2/issues/725>)
* Contributors: Emerson Knapp, Karsten Knese, Michael Orlov
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
