### PR TITLE
mocap_msgs: 0.0.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1851,7 +1851,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/MOCAP4ROS2-Project/mocap_msgs-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/MOCAP4ROS2-Project/mocap_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mocap_msgs` to `0.0.3-1`:

- upstream repository: https://github.com/MOCAP4ROS2-Project/mocap_msgs.git
- release repository: https://github.com/MOCAP4ROS2-Project/mocap_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.2-1`

## mocap_msgs

```
* Change license
* Update README.md
* Contributors: Francisco Martín Rico
```
