### PR TITLE
mocap_optitrack: 0.1.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6371,7 +6371,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/mocap_optitrack-release.git
-      version: 0.1.2-1
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/ros-drivers/mocap_optitrack.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mocap_optitrack` to `0.1.3-1`:

- upstream repository: https://github.com/ros-drivers/mocap_optitrack.git
- release repository: https://github.com/ros-drivers-gbp/mocap_optitrack-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.2-1`

## mocap_optitrack

```
* Add sleep function to avoid the high load of while() function
* Contributors: Moju Zhao
```
