### PR TITLE
rqt_robot_dashboard: 0.6.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2647,6 +2647,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_reconfigure.git
       version: dashing
     status: maintained
+  rqt_robot_dashboard:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_dashboard.git
+      version: ROS2
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_robot_dashboard-release.git
+      version: 0.6.1-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_dashboard.git
+      version: ROS2
+    status: maintained
   rqt_robot_monitor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_dashboard` to `0.6.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_robot_dashboard.git
- release repository: https://github.com/ros-gbp/rqt_robot_dashboard-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
