### PR TITLE
rosbag2_bag_v2: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2340,7 +2340,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2_bag_v2-release.git
-      version: 0.1.0-2
+      version: 0.2.0-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2_bag_v2` to `0.2.0-1`:

- upstream repository: https://github.com/ros2/rosbag2_bag_v2.git
- release repository: https://github.com/ros2-gbp/rosbag2_bag_v2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.0-2`

## ros1_rosbag_storage_vendor

- No changes

## rosbag2_bag_v2_plugins

```
* remove rosbag2 transport (#43 <https://github.com/ros2/rosbag2_bag_v2/issues/43>)
* Contributors: Karsten Knese
```
