### PR TITLE
rosbag2_bag_v2: 0.2.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2264,7 +2264,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rosbag2_bag_v2.git
-      version: master
+      version: galactic
     release:
       packages:
       - ros1_rosbag_storage_vendor
@@ -2277,7 +2277,7 @@ repositories:
       test_commits: false
       type: git
       url: https://github.com/ros2/rosbag2_bag_v2.git
-      version: master
+      version: galactic
     status: maintained
   rosidl:
     doc:

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2272,7 +2272,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2_bag_v2-release.git
-      version: 0.1.0-3
+      version: 0.2.0-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2_bag_v2` to `0.2.0-1`:

- upstream repository: https://github.com/ros2/rosbag2_bag_v2.git
- release repository: https://github.com/ros2-gbp/rosbag2_bag_v2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.0-3`

## ros1_rosbag_storage_vendor

- No changes

## rosbag2_bag_v2_plugins

```
* remove rosbag2 transport (#43 <https://github.com/ros2/rosbag2_bag_v2/issues/43>)
* Contributors: Karsten Knese
```
