### PR TITLE
rclcpp: 11.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1830,7 +1830,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 10.0.0-1
+      version: 11.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `11.0.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `10.0.0-1`

## rclcpp

```
* Allow declare uninitialized parameters (#1673 <https://github.com/ros2/rclcpp/issues/1673>)
* Fix syntax issue with gcc (#1674 <https://github.com/ros2/rclcpp/issues/1674>)
* [service] Don't use a weak_ptr to avoid leaking (#1668 <https://github.com/ros2/rclcpp/issues/1668>)
* Contributors: Ivan Santiago Paunovic, Jacob Perron, William Woodall
```

## rclcpp_action

```
* Bump the benchmark timeout for benchmark_action_client (#1671 <https://github.com/ros2/rclcpp/issues/1671>)
* Contributors: Scott K Logan
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* Fix destruction order in lifecycle benchmark (#1675 <https://github.com/ros2/rclcpp/issues/1675>)
* Contributors: Scott K Logan
```
