### PR TITLE
add haproxy to rosdep/base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1664,6 +1664,11 @@ gv:
   gentoo: [app-text/gv]
   nixos: [gv]
   ubuntu: [gv]
+haproxy:
+  debian: [haproxy]
+  fedora: [haproxy]
+  gentoo: [net-proxy/haproxy]
+  ubuntu: [haproxy]
 hddtemp:
   arch: [hddtemp]
   debian: [hddtemp]


### PR DESCRIPTION
I want to add haproxy to base.yaml.

Links:
- https://packages.debian.org/buster/haproxy (debian)
- https://src.fedoraproject.org/rpms/haproxy (fedora)
- https://packages.ubuntu.com/bionic/haproxy (ubuntu)