### PR TITLE
rt_usb_9axisimu_driver: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11851,7 +11851,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/rt-net-gbp/rt_usb_9axisimu_driver-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rt_usb_9axisimu_driver` to `1.0.1-1`:

- upstream repository: https://github.com/rt-net/rt_usb_9axisimu_driver.git
- release repository: https://github.com/rt-net-gbp/rt_usb_9axisimu_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.0-1`

## rt_usb_9axisimu_driver

```
* Contributors: Daisuke Sato, Shota Aoki
```
