### PR TITLE
geometric_shapes: 0.6.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3612,7 +3612,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/geometric_shapes-release.git
-      version: 0.6.3-1
+      version: 0.6.4-1
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.6.4-1`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/ros-gbp/geometric_shapes-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.3-1`

## geometric_shapes

```
* [fix]   Fix memory leak (#168 <https://github.com/ros-planning/geometric_shapes/issues/168>)
* [fix]   Use proper Eigen alignment for make_shared calls (#187 <https://github.com/ros-planning/geometric_shapes/issues/187>)
* [maint] Migrate from Travis to GitHub actions (#172 <https://github.com/ros-planning/geometric_shapes/issues/172>)
* Contributors: Dave Coleman, Martin Pecka, Robert Haschke, Tyler Weaver
```
