### PR TITLE
geometric_shapes: 0.7.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2330,7 +2330,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/geometric_shapes-release.git
-      version: 0.7.2-1
+      version: 0.7.3-1
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.7.3-1`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/ros-gbp/geometric_shapes-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.2-1`

## geometric_shapes

```
* [fix]   Fix memory leak (#168 <https://github.com/ros-planning/geometric_shapes/issues/168>)
* [fix]   Use proper Eigen alignment for make_shared calls (#187 <https://github.com/ros-planning/geometric_shapes/issues/187>)
* [maint] Migrate from Travis to GitHub Actions (#171 <https://github.com/ros-planning/geometric_shapes/issues/171>)
* Contributors: Robert Haschke, Tyler Weaver
```
