### PR TITLE
Update default gazebo version on debian buster to 11

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1140,7 +1140,7 @@ gawk:
 gazebo:
   arch: [gazebo]
   debian:
-    buster: [gazebo9]
+    buster: [gazebo11]
     jessie: [gazebo7]
     stretch: [gazebo9]
   fedora: [gazebo]


### PR DESCRIPTION
This would fix the inconsistency described in #27851