### PR TITLE
sensor_filters: 1.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7384,6 +7384,21 @@ repositories:
       type: git
       url: https://github.com/allxone/sensehat_ros.git
       version: master
+  sensor_filters:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/sensor_filters.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ctu-vras/sensor_filters-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ctu-vras/sensor_filters.git
+      version: master
+    status: developed
   septentrio_gnss_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sensor_filters` to `1.0.1-1`:

- upstream repository: https://github.com/ctu-vras/sensor_filters.git
- release repository: https://github.com/ctu-vras/sensor_filters-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## sensor_filters

```
* Initial version.
* Contributors: Martin Pecka
```
