### PR TITLE
rclpy: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1863,7 +1863,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 2.0.0-1
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `3.0.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-1`

## rclpy

```
* Allow declaring uninitialized parameters (#798 <https://github.com/ros2/rclpy/issues/798>)
* Reject cancel request if failed to transit to CANCEL_GOAL state (#791 <https://github.com/ros2/rclpy/issues/791>)
* Deleted handle as it should no longer be used (#786 <https://github.com/ros2/rclpy/issues/786>)
* Removed some functions in common.c and replaced them in utils.cpp (#787 <https://github.com/ros2/rclpy/issues/787>)
* Moved exception.cpp/hpp to the _rclpy_pybind11 module (#788 <https://github.com/ros2/rclpy/issues/788>)
* Contributors: Alejandro Hernández Cordero, Jacob Perron, Tomoya Fujita
```
