### PR TITLE
pr2_power_drivers: 1.1.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5331,7 +5331,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_power_drivers-release.git
-      version: 1.1.9-1
+      version: 1.1.10-1
     source:
       type: git
       url: https://github.com/pr2/pr2_power_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_power_drivers` to `1.1.10-1`:

- upstream repository: https://github.com/pr2/pr2_power_drivers.git
- release repository: https://github.com/pr2-gbp/pr2_power_drivers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.9-1`

## ocean_battery_driver

```
* fixes for boost dependencies
* Contributors: Dave Feil-Seifer
```

## power_monitor

```
* cmake changes for warnings under noetic
* Contributors: Dave Feil-Seifer
```

## pr2_power_board

```
* fixes for boost dependencies
* cmake changes for warnings under noetic
* Contributors: Dave Feil-Seifer
```

## pr2_power_drivers

```
* cmake changes for warnings under noetic
* Contributors: Dave Feil-Seifer
```
