### PR TITLE
pr2_common_actions: 0.0.12-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5218,6 +5218,29 @@ repositories:
       url: https://github.com/pr2/pr2_common.git
       version: melodic-devel
     status: unmaintained
+  pr2_common_actions:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_common_actions.git
+      version: kinetic-devel
+    release:
+      packages:
+      - joint_trajectory_action_tools
+      - joint_trajectory_generator
+      - pr2_arm_move_ik
+      - pr2_common_action_msgs
+      - pr2_common_actions
+      - pr2_tilt_laser_interface
+      - pr2_tuck_arms_action
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_common_actions-release.git
+      version: 0.0.12-1
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_common_actions.git
+      version: kinetic-devel
+    status: unmaintained
   pr2_controllers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_common_actions` to `0.0.12-1`:

- upstream repository: https://github.com/PR2/pr2_common_actions.git
- release repository: https://github.com/pr2-gbp/pr2_common_actions-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## joint_trajectory_action_tools

```
* Merge pull request #41 <https://github.com/PR2/pr2_common_actions//issues/41> from k-okada/fix_travis
* 2to3 -w -f print .
* Contributors: Kei Okada
```

## joint_trajectory_generator

```
* Merge pull request #41 <https://github.com/PR2/pr2_common_actions//issues/41> from k-okada/fix_travis
* joint_trajectory_generator/package.xml: use liborocos-kdl for noetic
* joint_trajectory_generator/package.xml: update to format=3
* Contributors: Kei Okada
```

## pr2_arm_move_ik

- No changes

## pr2_common_action_msgs

- No changes

## pr2_common_actions

- No changes

## pr2_tilt_laser_interface

```
* Merge pull request #39 <https://github.com/PR2/pr2_common_actions//issues/39> from lopsided98/remove-boost-signals
  pr2_tilt_laser_interface: remove unused Boost signals dependency
* pr2_tilt_laser_interface: remove unused Boost signals dependency
* Contributors: Ben Wolsieffer, Michael Görner
```

## pr2_tuck_arms_action

```
* Merge pull request #41 <https://github.com/PR2/pr2_common_actions//issues/41> from k-okada/fix_travis
* pr2_tuck_arms_action: fix for noetic with catkin_install_python, see http://wiki.ros.org/noetic/Migration and http://wiki.ros.org/UsingPython3/SourceCodeChanges
* 2to3 -w -f print .
* Contributors: Kei Okada
```
