### PR TITLE
rmf_building_map_msgs: 1.2.0-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1949,7 +1949,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_building_map_msgs-release.git
-      version: 1.2.0-2
+      version: 1.2.0-4
     source:
       type: git
       url: https://github.com/open-rmf/rmf_building_map_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_building_map_msgs` to `1.2.0-4`:

- upstream repository: https://github.com/open-rmf/rmf_building_map_msgs.git
- release repository: https://github.com/ros2-gbp/rmf_building_map_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.0-2`

## rmf_building_map_msgs

```
* Add first pass of quality declarations for all packages (#235 <https://github.com/osrf/traffic_editor/issues/235>)
* Contributors: Geoffrey Biggs, Marco A. Gutierrez, Marco A. Gutiérrez
```
