### PR TITLE
imu_from_ios_sensorlog: 0.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2820,7 +2820,7 @@ repositories:
         release: release/noetic/{package}/{version}
       url: https://github.com/pietrocolombo/imu_from_ios_sensorlog-release.git
       version: 0.0.1-1
-    status: unmaintained
+    status: maintained
   imu_pipeline:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2810,6 +2810,13 @@ repositories:
       url: https://github.com/ros-perception/image_transport_plugins.git
       version: noetic-devel
     status: unmaintained
+  imu_from_ios_sensorlog:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/pietrocolombo/imu_from_ios_sensorlog-release.git
+      version: 0.0.1-1
+    status: unmaintained
   imu_pipeline:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2820,7 +2820,6 @@ repositories:
         release: release/noetic/{package}/{version}
       url: https://github.com/pietrocolombo/imu_from_ios_sensorlog-release.git
       version: 0.0.1-1
-    status: maintained
     source:
       type: git
       url: https://github.com/pietrocolombo/imu_from_ios_sensorlog.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2821,6 +2821,11 @@ repositories:
       url: https://github.com/pietrocolombo/imu_from_ios_sensorlog-release.git
       version: 0.0.1-1
     status: maintained
+    source:
+      type: git
+      url: https://github.com/pietrocolombo/imu_from_ios_sensorlog.git
+      version: noetic-devel
+    status: maintained
   imu_pipeline:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2814,7 +2814,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/pietrocolombo/imu_from_ios_sensorlog.git
-      version: main
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2811,6 +2811,10 @@ repositories:
       version: noetic-devel
     status: unmaintained
   imu_from_ios_sensorlog:
+  doc:
+      type: git
+      url: https://github.com/pietrocolombo/imu_from_ios_sensorlog.git
+      version: main
     release:
       tags:
         release: release/noetic/{package}/{version}

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2811,7 +2811,7 @@ repositories:
       version: noetic-devel
     status: unmaintained
   imu_from_ios_sensorlog:
-  doc:
+    doc:
       type: git
       url: https://github.com/pietrocolombo/imu_from_ios_sensorlog.git
       version: main


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_from_ios_sensorlog` to `0.0.1-1`:

- upstream repository: https://github.com/pietrocolombo/imu_from_ios_sensorlog.git
- release repository: https://github.com/pietrocolombo/imu_from_ios_sensorlog-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## imu_from_ios_sensorlog

```
* initial version
* Contributors: Pietro Colombo, pietrocolombo
```
