### PR TITLE
toposens: 2.2.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13027,7 +13027,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 2.2.0-1
+      version: 2.2.1-1
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toposens` to `2.2.1-1`:

- upstream repository: https://gitlab.com/toposens/public/ros-packages.git
- release repository: https://gitlab.com/toposens/public/toposens-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.2.0-1`

## toposens

```
* Update Maintainer
* Contributors: Dennis Maier
```

## toposens_bringup

```
* Update Maintainer
* Contributors: Dennis Maier
```

## toposens_description

```
* Update Maintainer
* Contributors: Dennis Maier
```

## toposens_driver

```
* Update Maintainer
* Minor Update
* Contributors: Dennis Maier
```

## toposens_markers

```
* Update Maintainer
* Contributors: Dennis Maier
```

## toposens_msgs

```
* Update Maintainer
* Contributors: Dennis Maier
```

## toposens_pointcloud

```
* Update Maintainer
* Contributors: Dennis Maier
```

## toposens_sync

```
* Update Maintainer
* Minor Update
* Contributors: Dennis Maier
```
