### PR TITLE
domain_bridge: 0.3.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -539,7 +539,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/domain_bridge-release.git
-      version: 0.2.0-2
+      version: 0.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `domain_bridge` to `0.3.0-1`:

- upstream repository: https://github.com/ros2/domain_bridge.git
- release repository: https://github.com/ros2-gbp/domain_bridge-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.0-2`

## domain_bridge

```
* Override handle_serialized_message (#21 <https://github.com/ros2/domain_bridge/issues/21>)
* Do not crash if there's an error querying endpoint info (#20 <https://github.com/ros2/domain_bridge/issues/20>)
* Add topic remapping (#19 <https://github.com/ros2/domain_bridge/issues/19>)
* Fix doc link in readme (#18 <https://github.com/ros2/domain_bridge/issues/18>)
* Contributors: Chris Lalancette, Jacob Perron, Tully Foote
```
