### PR TITLE
navigation2: 1.0.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1276,6 +1276,53 @@ repositories:
       url: https://github.com/MRPT/mrpt.git
       version: develop
     status: developed
+  navigation2:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/navigation2.git
+      version: galactic
+    release:
+      packages:
+      - costmap_queue
+      - dwb_core
+      - dwb_critics
+      - dwb_msgs
+      - dwb_plugins
+      - nav2_amcl
+      - nav2_behavior_tree
+      - nav2_bringup
+      - nav2_bt_navigator
+      - nav2_common
+      - nav2_controller
+      - nav2_core
+      - nav2_costmap_2d
+      - nav2_dwb_controller
+      - nav2_gazebo_spawner
+      - nav2_lifecycle_manager
+      - nav2_map_server
+      - nav2_msgs
+      - nav2_navfn_planner
+      - nav2_planner
+      - nav2_recoveries
+      - nav2_regulated_pure_pursuit_controller
+      - nav2_rviz_plugins
+      - nav2_smac_planner
+      - nav2_system_tests
+      - nav2_util
+      - nav2_voxel_grid
+      - nav2_waypoint_follower
+      - nav_2d_msgs
+      - nav_2d_utils
+      - navigation2
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/SteveMacenski/navigation2-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/navigation2.git
+      version: galactic
+    status: developed
   navigation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation2` to `1.0.0-1`:

- upstream repository: https://github.com/ros-planning/navigation2.git
- release repository: https://github.com/SteveMacenski/navigation2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
