### PR TITLE
radar_msgs: 0.2.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1663,6 +1663,13 @@ repositories:
       url: https://github.com/ros-visualization/qt_gui_core.git
       version: galactic-devel
     status: maintained
+  radar_msgs:
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/radar_msgs-release.git
+      version: 0.2.1-1
+    status: maintained
   rc_common_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `radar_msgs` to `0.2.1-1`:

- upstream repository: https://github.com/ros-perception/radar_msgs.git
- release repository: https://github.com/ros2-gbp/radar_msgs-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
