### PR TITLE
robot_localization: 3.2.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2062,6 +2062,16 @@ repositories:
       url: https://github.com/ros2/rmw_implementation.git
       version: galactic
     status: developed
+  robot_localization:
+    doc:
+      type: git
+      url: https://github.com/cra-ros-pkg/robot_localization.git
+      version: galactic
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/cra-ros-pkg/robot_localization-release.git
+      version: 3.2.1-1
   robot_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `3.2.1-1`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/cra-ros-pkg/robot_localization-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
