### PR TITLE
Add python3-zmq rule for RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7954,6 +7954,7 @@ python3-zmq:
   fedora: [python3-zmq]
   gentoo: [dev-python/pyzmq]
   nixos: [python3Packages.pyzmq]
+  rhel: [python3-zmq]
   ubuntu: [python3-zmq]
 qdarkstyle-pip:
   debian:


### PR DESCRIPTION
This package is supplied by EPEL for both RHEL 7 and RHEL 8.

https://src.fedoraproject.org/rpms/python-zmq#bodhi_updates

This rule is used by the `nav2_system_tests` package. Follow-up to #29593.