### PR TITLE
sensor_filters: 1.0.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7416,7 +7416,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ctu-vras/sensor_filters-release.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/ctu-vras/sensor_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sensor_filters` to `1.0.3-1`:

- upstream repository: https://github.com/ctu-vras/sensor_filters.git
- release repository: https://github.com/ctu-vras/sensor_filters-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.2-1`

## sensor_filters

```
* Fixed data types of nodes.
* Contributors: Martin Pecka
```
