### PR TITLE
Add geographiclib rules for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1248,12 +1248,14 @@ geographiclib:
   fedora: [GeographicLib-devel]
   nixos: [geographiclib]
   openembedded: [geographiclib@meta-ros-common]
+  rhel: [GeographicLib-devel]
   ubuntu: [libgeographic-dev]
 geographiclib-tools:
   debian: [geographiclib-tools]
   fedora: [GeographicLib]
   nixos: [geographiclib]
   openembedded: [geographiclib@meta-ros-common]
+  rhel: [GeographicLib]
   ubuntu: [geographiclib-tools]
 geos:
   arch: [geos]


### PR DESCRIPTION
These packages are provided by EPEL for both RHEL 7 and RHEL 8.

https://src.fedoraproject.org/rpms/GeographicLib#bodhi_updates

Follow-up to #29596