### PR TITLE
rmw_connextdds: 0.6.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1968,7 +1968,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 0.6.1-1
+      version: 0.6.2-1
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `0.6.2-1`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.1-1`

## rmw_connextdds

- No changes

## rmw_connextdds_common

```
* Improved conversion of time values between ROS and DDS formats (#43 <https://github.com/ros2/rmw_connextdds/issues/43>) (#54 <https://github.com/ros2/rmw_connextdds/issues/54>)
* Contributors: Andrea Sorbini
```

## rti_connext_dds_cmake_module

- No changes
