### PR TITLE
Target 'galactic' branch in 'image_common'

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -907,7 +907,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/image_common.git
-      version: ros2
+      version: galactic
     release:
       packages:
       - camera_calibration_parsers
@@ -922,7 +922,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/image_common.git
-      version: ros2
+      version: galactic
     status: maintained
   image_pipeline:
     doc:


### PR DESCRIPTION
There are new changes in the 'ros2' branch which shouldn't be released in Galactic.
