### PR TITLE
fcl: 0.6.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -670,6 +670,17 @@ repositories:
       url: https://github.com/eProsima/Fast-DDS.git
       version: 2.3.x
     status: maintained
+  fcl:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/fcl-release.git
+      version: 0.6.1-1
+    source:
+      type: git
+      url: https://github.com/flexible-collision-library/fcl.git
+      version: master
+    status: maintained
   filters:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fcl` to `0.6.1-1`:

- upstream repository: https://github.com/flexible-collision-library/fcl.git
- release repository: https://github.com/ros2-gbp/fcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
