### PR TITLE
pr2_apps: 0.6.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5197,6 +5197,29 @@ repositories:
       type: git
       url: https://github.com/fetchrobotics/power_msgs.git
       version: ros1
+  pr2_apps:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_apps.git
+      version: melodic-devel
+    release:
+      packages:
+      - pr2_app_manager
+      - pr2_apps
+      - pr2_mannequin_mode
+      - pr2_position_scripts
+      - pr2_teleop
+      - pr2_teleop_general
+      - pr2_tuckarm
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_apps-release.git
+      version: 0.6.2-1
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_apps.git
+      version: melodic-devel
+    status: unmaintained
   pr2_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_apps` to `0.6.2-1`:

- upstream repository: https://github.com/PR2/pr2_apps.git
- release repository: https://github.com/pr2-gbp/pr2_apps-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## pr2_app_manager

```
* Merge pull request #42 <https://github.com/pr2/pr2_apps/issues/42> from k-okada/fix_travis
* 2to3 -w -f print .
* Merge pull request #40 <https://github.com/pr2/pr2_apps/issues/40> from k-okada/add_roslaunch_add_file_check
  add test for roslaunch_add_file_check
* disable to run roslaunch_add_file_check
  pr2_app_manager.launch: /home/applications/robot.yaml does not exist, it is generated by scripts/install_applications.sh
  whole_pr2_apps.launch: /etc/ros/robot.yaml only exists in real robot
* add test for roslaunch_add_file_check
* Contributors: Kei Okada, Michael Görner
```

## pr2_apps

```
* remove superfluous test_depends
  catkin build complains about these in melodic
* Merge pull request #40 <https://github.com/pr2/pr2_apps/issues/40> from k-okada/add_roslaunch_add_file_check
  add test for roslaunch_add_file_check
* add test for roslaunch_add_file_check
* Contributors: Kei Okada, Michael Görner, v4hn
```

## pr2_mannequin_mode

```
* Merge pull request #42 <https://github.com/pr2/pr2_apps/issues/42> from k-okada/fix_travis
* 2to3 -w -f print .
* Merge pull request #40 <https://github.com/pr2/pr2_apps/issues/40> from k-okada/add_roslaunch_add_file_check
  add test for roslaunch_add_file_check
* Merge remote-tracking branch 'Affonso-Gui/fix_controllers_nohead' into add_roslaunch_add_file_check
* add test for roslaunch_add_file_check
* Use unspawner instead of stop on controllers_nohead
* Fix paths to config and launch on controllers_nohead
* Contributors: Guilherme Affonso, Kei Okada, Michael Görner
```

## pr2_position_scripts

```
* Merge pull request #42 <https://github.com/pr2/pr2_apps/issues/42> from k-okada/fix_travis
* pr2_position_scripts/scripts/torso_up.py: fix wrong new line
* 2to3 -w -f print .
* Merge pull request #40 <https://github.com/pr2/pr2_apps/issues/40> from k-okada/add_roslaunch_add_file_check
  add test for roslaunch_add_file_check
* add test for roslaunch_add_file_check
* Contributors: Kei Okada, Michael Görner
```

## pr2_teleop

```
* Merge pull request #40 <https://github.com/pr2/pr2_apps/issues/40> from k-okada/add_roslaunch_add_file_check
  add test for roslaunch_add_file_check
* add test for roslaunch_add_file_check
* Contributors: Kei Okada, Michael Görner
```

## pr2_teleop_general

```
* Merge pull request #40 <https://github.com/pr2/pr2_apps/issues/40> from k-okada/add_roslaunch_add_file_check
  add test for roslaunch_add_file_check
* add test for roslaunch_add_file_check
* Contributors: Kei Okada, Michael Görner
```

## pr2_tuckarm

```
* Merge pull request #42 <https://github.com/pr2/pr2_apps/issues/42> from k-okada/fix_travis
* 2to3 -w -f print .
* Merge pull request #40 <https://github.com/pr2/pr2_apps/issues/40> from k-okada/add_roslaunch_add_file_check
  add test for roslaunch_add_file_check
* add test for roslaunch_add_file_check
* Contributors: Kei Okada, Michael Görner
```
