### PR TITLE
wifi_ddwrt: 0.2.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8661,7 +8661,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/wifi_ddwrt-release.git
-      version: 0.2.0-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/ros-drivers/wifi_ddwrt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wifi_ddwrt` to `0.2.2-1`:

- upstream repository: https://github.com/ros-drivers/wifi_ddwrt.git
- release repository: https://github.com/ros-gbp/wifi_ddwrt-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.0-1`

## wifi_ddwrt

```
* 0.2.1
* update changelogs
* Merge pull request #15 <https://github.com/ros-drivers/wifi_ddwrt/issues/15> from k-okada/add_travis
  add travsi CI
* update CHANGELOG.rst
* Merge pull request #14 <https://github.com/ros-drivers/wifi_ddwrt/issues/14> from PR2-prime/noetic-devel
* add travsi CI
* updated for focal/noetic/python3 compatibility
* Merge pull request #7 <https://github.com/ros-drivers/wifi_ddwrt/issues/7> from furushchev/fix-typo
  [wifi_ddwrt] fix typo
* [wifi_ddwrt] fix typo
* Update README.md
* Create README. Fixes #1 <https://github.com/ros-drivers/wifi_ddwrt/issues/1>
* Contributors: Austin, Dave Feil-Seifer, Kei Okada, Yuki Furuta
```
