### PR TITLE
Add glpk

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1342,6 +1342,7 @@ glpk:
   arch: [glpk-git]
   debian: [libglpk-dev]
   fedora: [glpk-devel]
+  gentoo: [sci-mathematics/glpk]
   rhel: [glpk-devel]
   ubuntu: [libglpk-dev]
 glut:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1338,6 +1338,12 @@ glc:
   arch: [glc]
   gentoo: [media-libs/quesoglc]
   nixos: [quesoglc]
+glpk:
+  arch: [glpk-git]
+  debian: [libglpk-dev]
+  fedora: [glpk-devel]
+  rhel: [glpk-devel]
+  ubuntu: [libglpk-dev]
 glut:
   arch: [freeglut]
   debian: [freeglut3-dev]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

glpk

## Package Upstream Source:

https://ftp.gnu.org/gnu/glpk/

## Purpose of using this:

> The GLPK (GNU Linear Programming Kit) package is intended for solving large-scale linear programming (LP), mixed integer programming (MIP), and other related problems.

This is useful for some robotic algorithms. 

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/sid/libglpk-dev
- Ubuntu: https://packages.ubuntu.com/focal/libglpk-dev
- Fedora: https://fedora.pkgs.org/32/fedora-x86_64/glpk-devel-4.65-5.fc32.x86_64.rpm.html
- Arch: https://aur.archlinux.org/packages/glpk-git/