### PR TITLE
Add mpfr

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5895,7 +5895,8 @@ mpfr:
   arch: [mpfr]
   debian: [libmpfr-dev]
   fedora: [mpfr]
-  ubuntu: [libmpfr-dev] 
+  gentoo: [dev-libs/mpfr]
+  ubuntu: [libmpfr-dev]
 mpg123:
   arch: [mpg123]
   debian: [mpg123]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5891,6 +5891,11 @@ mosquittopp-dev:
   fedora: [mosquitto-devel]
   nixos: [mosquitto]
   ubuntu: [libmosquittopp-dev]
+mpfr:
+  arch: [mpfr]
+  debian: [libmpfr-dev]
+  fedora: [mpfr]
+  ubuntu: [libmpfr-dev] 
 mpg123:
   arch: [mpg123]
   debian: [mpg123]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

mpfr

## Package Upstream Source:

https://scm.gforge.inria.fr/anonscm/svn/mpfr/trunk/

## Purpose of using this:

> The MPFR library is a C library for multiple-precision floating-point computations with correct rounding.

Useful for some robotic algorithms

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/sid/libmpfr-dev
- Ubuntu: https://packages.ubuntu.com/focal/libmpfr-dev
- Fedora: https://fedora.pkgs.org/33/fedora-x86_64/mpfr-4.1.0-2.fc33.x86_64.rpm.html
- Arch: https://archlinux.org/packages/core/x86_64/mpfr/