### PR TITLE
ros_led: 0.0.11-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10564,7 +10564,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/CopterExpress/ros_led-release.git
-      version: 0.0.9-1
+      version: 0.0.11-1
     source:
       type: git
       url: https://github.com/CopterExpress/ros_led.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_led` to `0.0.11-1`:

- upstream repository: https://github.com/CopterExpress/ros_led.git
- release repository: https://github.com/CopterExpress/ros_led-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.9-1`

## led_msgs

```
* Version bump
```

## ws281x

```
* Added ros_environment build dependency
```
