### PR TITLE
phidgets_drivers: 2.2.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1560,7 +1560,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/phidgets_drivers-release.git
-      version: 2.1.0-2
+      version: 2.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `2.2.0-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros2-gbp/phidgets_drivers-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.0-2`

## libphidget22

- No changes

## phidgets_accelerometer

- No changes

## phidgets_analog_inputs

- No changes

## phidgets_api

- No changes

## phidgets_digital_inputs

- No changes

## phidgets_digital_outputs

- No changes

## phidgets_drivers

- No changes

## phidgets_gyroscope

- No changes

## phidgets_high_speed_encoder

- No changes

## phidgets_ik

- No changes

## phidgets_magnetometer

```
* Make sure to declare the type while declaring the parameter. (#89 <https://github.com/ros-drivers/phidgets_drivers/issues/89>)
* Contributors: Chris Lalancette
```

## phidgets_motors

- No changes

## phidgets_msgs

- No changes

## phidgets_spatial

```
* Make sure to declare the type while declaring the parameter. (#89 <https://github.com/ros-drivers/phidgets_drivers/issues/89>)
* Contributors: Chris Lalancette
```

## phidgets_temperature

- No changes
