### PR TITLE
c_wrapper: 0.0.1-3 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -395,6 +395,26 @@ repositories:
       url: https://github.com/ros/bond_core.git
       version: dashing-devel
     status: maintained
+  c_wrapper:
+    doc:
+      type: git
+      url: https://github.com/smilerobotics/c_wrapper.git
+      version: main
+    release:
+      packages:
+      - c_wrapper
+      - c_wrapper_nav2
+      - c_wrapper_ros2
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/smilerobotics/c_wrapper-release.git
+      version: 0.0.1-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/smilerobotics/c_wrapper.git
+      version: main
+    status: developed
   carla_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `c_wrapper` to `0.0.1-3`:

- upstream repository: https://github.com/smilerobotics/c_wrapper.git
- release repository: https://github.com/smilerobotics/c_wrapper-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## c_wrapper

```
* Start develop
* Contributors: Takashi Ogura
```

## c_wrapper_nav2

```
* Start develop
* Contributors: Takashi Ogura
```

## c_wrapper_ros2

```
* Start develop
* Contributors: Takashi Ogura
```
