### PR TITLE
rclcpp: 0.7.16-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2331,7 +2331,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 0.7.15-1
+      version: 0.7.16-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `0.7.16-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.15-1`

## rclcpp

```
* Fix documented example in create_publisher. (#1558 <https://github.com/ros2/rclcpp/issues/1558>) (#1560 <https://github.com/ros2/rclcpp/issues/1560>)
* Fix NodeOptions copy constructor. (#1376 <https://github.com/ros2/rclcpp/issues/1376>) (#1466 <https://github.com/ros2/rclcpp/issues/1466>)
* Contributors: Ivan Santiago Paunovic, Jacob Perron
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
