### PR TITLE
ros2_controllers: 0.3.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3307,7 +3307,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 0.2.1-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `0.3.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.2.1-1`

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## forward_command_controller

```
* [JointTrajectoryController] Enable position, velocity and acceleration interfaces (#140 <https://github.com/ros-controls/ros2_controllers/issues/140>)
  * joint_trajectory_controller should not go into FINALIZED state when fails to configure, remain in UNCONFIGURED
* Contributors: Denis Štogl, Bence Magyar
```

## joint_state_broadcaster

```
* Remove unused variable (#181 <https://github.com/ros-controls/ros2_controllers/issues/181>)
* Add extra joints parameter at joint state broadcaster (#179 <https://github.com/ros-controls/ros2_controllers/issues/179>)
* Contributors: Cesc Folch Aldehuelo, Karsten Knese
```

## joint_state_controller

- No changes

## joint_trajectory_controller

```
* joint_trajectory_controller publishes state in node namespace (#187 <https://github.com/ros-controls/ros2_controllers/issues/187>)
* [JointTrajectoryController] Enable position, velocity and acceleration interfaces (#140 <https://github.com/ros-controls/ros2_controllers/issues/140>)
  * joint_trajectory_controller should not go into FINALIZED state when fails to configure, remain in UNCONFIGURED
* Contributors: Bence Magyar, Denis Štogl
```

## position_controllers

- No changes

## ros2_controllers

- No changes

## velocity_controllers

- No changes
