### PR TITLE
rtabmap_ros: 0.20.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7276,7 +7276,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.20.9-3
+      version: 0.20.10-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap_ros` to `0.20.10-1`:

- upstream repository: https://github.com/introlab/rtabmap_ros.git
- release repository: https://github.com/introlab/rtabmap_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.20.9-3`
