### PR TITLE
ros2_controllers: 0.3.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3307,7 +3307,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `0.3.1-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.3.0-1`

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## forward_command_controller

- No changes

## joint_state_broadcaster

- No changes

## joint_state_controller

- No changes

## joint_trajectory_controller

```
* Reset external trajectory message upon activation (#185 <https://github.com/ros-controls/ros2_controllers/issues/185>)
  * Reset external trajectory message to prevent preserving the old goal on systems with hardware offsets
  * Fix has_trajectory_msg() function: two wrongs were making a right so functionally things were fine
* Contributors: Nathan Brooks, Matt Reynolds
```

## position_controllers

- No changes

## ros2_controllers

- No changes

## velocity_controllers

- No changes
