### PR TITLE
ros2_control: 0.6.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3282,7 +3282,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 0.5.0-1
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `0.6.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.5.0-1`

## controller_interface

```
* Added labels for controller states. (#414 <https://github.com/ros-controls/ros2_control/issues/414>)
* prevent variable-sized object initialization (#411 <https://github.com/ros-controls/ros2_control/issues/411>)
* Contributors: Denis Štogl, Karsten Knese, Bence Magyar
```

## controller_manager

```
* List controller claimed interfaces (#407 <https://github.com/ros-controls/ros2_control/issues/407>)
  * List controllers now also shows the claimed interfaces
  * Fixed tests that perform switches
  Successfull controller switches require more than one call to update()
  in order to update the controller list
  * Can now set the command interface configuration
  * Added checks for the claimed interfaces
* Contributors: Jordan Palacios
```

## controller_manager_msgs

```
* List controller claimed interfaces (#407 <https://github.com/ros-controls/ros2_control/issues/407>)
* Contributors: Jordan Palacios
```

## hardware_interface

```
* Remove the with_value_ptr and class templatization for ReadOnlyHandle (#379 <https://github.com/ros-controls/ros2_control/issues/379>)
* fake_components: Add mimic joint to generic system (#409 <https://github.com/ros-controls/ros2_control/issues/409>)
* List controller claimed interfaces (#407 <https://github.com/ros-controls/ros2_control/issues/407>)
* Contributors: El Jawad Alaa, Jafar Abdi, Jordan Palacios, Bence Magyar
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Renaming ros2controlcli verbs (#412 <https://github.com/ros-controls/ros2_control/issues/412>)
  * Renamed verbs to match services
  * README.rst redirects to docs/index.rst
  * argument {start/stop}_controllers -> {start/stop}
  * rst include did not work, try relative link
  * Moved configure_controller doc to deprecated
  * set_state -> set-state
* Contributors: Mathias Hauan Arbo, Denis Štogl
```

## transmission_interface

```
* Remove the with_value_ptr and class templatization for ReadOnlyHandle (#379 <https://github.com/ros-controls/ros2_control/issues/379>)
* Fix transmission interface test on OSX (#419 <https://github.com/ros-controls/ros2_control/issues/419>)
* Fix failing test on rolling (#416 <https://github.com/ros-controls/ros2_control/issues/416>)
* Contributors: El Jawad Alaa, Karsten Knese, Vatan Aksoy Tezer, Bence Magyar
```
