### PR TITLE
moveit: 1.1.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4035,7 +4035,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 1.1.4-1
+      version: 1.1.5-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `1.1.5-1`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.4-1`

## chomp_motion_planner

- No changes

## moveit

- No changes

## moveit_chomp_optimizer_adapter

- No changes

## moveit_commander

```
* Allow selecting planning pipeline in MotionSequenceAction (#2657 <https://github.com/ros-planning/moveit/issues/2657>)
* Contributors: Felix von Drigalski
```

## moveit_core

```
* Revert "Lock the octomap/octree while collision checking (#2683 <https://github.com/ros-planning/moveit/issues/2683>)
* RobotState interpolation: warn if interpolation parameter is out of range [0, 1] (#2664 <https://github.com/ros-planning/moveit/issues/2664>)
* Contributors: John Stechschulte, Michael Görner
```

## moveit_fake_controller_manager

- No changes

## moveit_kinematics

- No changes

## moveit_planners

- No changes

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

- No changes

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

- No changes

## moveit_ros_move_group

- No changes

## moveit_ros_occupancy_map_monitor

```
* Revert "Lock the octomap/octree while collision checking (#2683 <https://github.com/ros-planning/moveit/issues/2683>)
* Contributors: Michael Görner
```

## moveit_ros_perception

```
* Revert "Lock the octomap/octree while collision checking (#2683 <https://github.com/ros-planning/moveit/issues/2683>)
* Contributors: Michael Görner
```

## moveit_ros_planning

```
* Revert "Lock the octomap/octree while collision checking (#2683 <https://github.com/ros-planning/moveit/issues/2683>)
* Unify and simplify CSM::haveCompleteState overloads (#2663 <https://github.com/ros-planning/moveit/issues/2663>)
* Contributors: Michael Görner
```

## moveit_ros_planning_interface

```
* Allow selecting planning pipeline in MotionSequenceAction (#2657 <https://github.com/ros-planning/moveit/issues/2657>)
* Contributors: Felix von Drigalski
```

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

- No changes

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_servo

- No changes

## moveit_setup_assistant

- No changes

## moveit_simple_controller_manager

- No changes

## pilz_industrial_motion_planner

```
* Allow selecting planning pipeline in MotionSequenceAction (#2657 <https://github.com/ros-planning/moveit/issues/2657>)
* Contributors: Felix von Drigalski
```

## pilz_industrial_motion_planner_testutils

- No changes
