### PR TITLE
base.yaml updates for openSUSE (2 of 6)

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2551,6 +2551,7 @@ libcairo2-dev:
   gentoo: [x11-libs/cairo]
   nixos: [cairo]
   openembedded: [cairo@openembedded-core]
+  opensuse: [cairo-devel]
   rhel: [cairo-devel]
   ubuntu: [libcairo2-dev]
 libcap-dev:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1013,6 +1013,7 @@ flex:
   macports: [flex]
   nixos: [flex]
   openembedded: [flex@openembedded-core]
+  opensuse: [flex]
   ubuntu: [flex]
 fltk:  # Consider using the libfltk-dev and fluid (fltk runtime) keys instead.
   arch: [fltk]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1124,6 +1124,7 @@ g++-static:
   gentoo: [sys-devel/gcc]
   nixos: []
   openembedded: []
+  opensuse: [gcc-c++, glibc-devel, libstdc++-devel]
   rhel: [gcc-c++, glibc-devel, glibc-static, libstdc++-devel, libstdc++-static]
   ubuntu: [g++]
 gamin:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1346,6 +1346,7 @@ glut:
   macports: [freeglut]
   nixos: [freeglut]
   openembedded: [freeglut@meta-oe]
+  opensuse: [freeglut-devel]
   rhel: [freeglut-devel]
   ubuntu: [freeglut3-dev]
 gnat:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1615,7 +1615,7 @@ gtest:
   macports: [ros-gtest]
   nixos: [gtest]
   openembedded: [gtest@meta-oe]
-  opensuse: [googletest-devel]
+  opensuse: [gtest]
   rhel: [gtest-devel]
   slackware: [gtest]
   ubuntu: [libgtest-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2049,6 +2049,7 @@ lcov:
   gentoo: [dev-util/lcov]
   nixos: [lcov]
   openembedded: [lcov@meta-oe]
+  opensuse: [lcov]
   rhel:
     '7': [lcov]
   ubuntu: [lcov]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1378,7 +1378,7 @@ google-mock:
   gentoo: [dev-cpp/gtest]
   nixos: [gmock]
   openembedded: [gtest@meta-oe]
-  opensuse: [gmock-devel]
+  opensuse: [gmock]
   rhel: [gmock-devel]
   ubuntu: [google-mock]
 gpac:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1731,6 +1731,7 @@ ifstat:
   fedora: [ifstat]
   gentoo: [net-analyzer/ifstat]
   nixos: [ifstat-legacy]
+  opensuse: [iproute2]
   ubuntu: [ifstat]
 ignition-citadel:
   debian:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -966,7 +966,7 @@ ffmpeg:
   macports: [ffmpeg]
   nixos: [ffmpeg]
   openembedded: [ffmpeg@openembedded-core]
-  opensuse: [ffmpeg]
+  opensuse: [ffmpeg-4-libavcodec-devel,ffmpeg-4-libavdevice-devel,ffmpeg-4-libavfilter-devel,ffmpeg-4-libavformat-devel,ffmpeg-4-libavresample-devel,ffmpeg-4-libavutil-devel,ffmpeg-4-libpostproc-devel,ffmpeg-4-libswresample-devel,ffmpeg-4-libswscale-devel,ffmpeg-4-private-devel]
   slackware: [ffmpeg]
   ubuntu:
     '*': [ffmpeg, libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev]


### PR DESCRIPTION
This is a continuation of the base.yaml updates for openSUSE
https://github.com/ros/rosdistro/pull/29494

These keys are not necessarily related to each other. I'm just processing these commits alphabetically and breaking them up into groups of approx. 10.

https://software.opensuse.org/package/ffmpeg-4
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.15607/standard
https://software.opensuse.org/package/flex
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/flex/standard
https://software.opensuse.org/package/gcc-c++
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/gcc/standard
https://software.opensuse.org/package/glibc
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.13703/standard
https://software.opensuse.org/package/freeglut
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/freeglut/standard
https://software.opensuse.org/package/gmock
https://software.opensuse.org/package/gtest
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/googletest/standard
https://software.opensuse.org/package/iproute2
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/iproute2/standard
https://software.opensuse.org/package/lcov
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/lcov/standard
https://software.opensuse.org/package/cairo
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/cairo/standard