### PR TITLE
base.yaml updates for openSUSE (3 of 6)

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2991,7 +2991,7 @@ libgconf2:
 libgdal-dev:
   debian: [libgdal-dev]
   nixos: [gdal]
-  opensuse: [gdal]
+  opensuse: [gdal-devel]
   ubuntu: [libgdal-dev]
 libgeographiclib-dev:
   debian:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3468,7 +3468,7 @@ libjpeg:
   macports: [jpeg]
   nixos: [libjpeg]
   openembedded: [jpeg@openembedded-core]
-  opensuse: [libjpeg62-devel]
+  opensuse: [libjpeg8-devel]
   rhel: [libjpeg-turbo-devel]
   slackware: [libjpeg-turbo]
   ubuntu:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3130,6 +3130,7 @@ libgpgme-dev:
   gentoo: [app-crypt/gpgme]
   nixos: [gpgme]
   openembedded: [gpgme@openembedded-core]
+  opensuse: [libgpgme-devel]
   rhel: [gpgme-devel]
   ubuntu:
     '*': [libgpgme-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3044,6 +3044,7 @@ libglew-dev:
   gentoo: [media-libs/glew]
   nixos: [glew]
   openembedded: [glew@openembedded-core]
+  opensuse: [glew-devel]
   rhel: [glew-devel]
   ubuntu: [libglew-dev]
 libglfw3-dev:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3517,6 +3517,7 @@ libjsoncpp:
   gentoo: [dev-libs/jsoncpp]
   nixos: [jsoncpp]
   openembedded: [jsoncpp@meta-oe]
+  opensuse: [libjsoncpp19]
   rhel: [jsoncpp]
   ubuntu:
     '*': [libjsoncpp1]
@@ -3533,6 +3534,7 @@ libjsoncpp-dev:
   gentoo: [dev-libs/jsoncpp]
   nixos: [jsoncpp]
   openembedded: [jsoncpp@meta-oe]
+  opensuse: [jsoncpp-devel]
   rhel: [jsoncpp-devel]
   ubuntu: [libjsoncpp-dev]
 libkdtree++-dev:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2518,6 +2518,7 @@ libcap-dev:
   gentoo: [sys-libs/libcap]
   nixos: [libcap]
   openembedded: [libcap@openembedded-core]
+  opensuse: [libcap-devel]
   ubuntu: [libcap-dev]
 libcap-ng-dev:
   debian: [libcap-ng-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2911,6 +2911,7 @@ libftdi-dev:
   gentoo: [dev-embedded/libftdi]
   nixos: [libftdi]
   openembedded: [libftdi@meta-oe]
+  opensuse: [libftdi1-devel]
   rhel: [libftdi-devel]
   ubuntu: [libftdi-dev]
 libftdi1-dev:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3114,6 +3114,7 @@ libgoogle-glog-dev:
   gentoo: [dev-cpp/glog]
   nixos: [glog]
   openembedded: [glog@meta-oe]
+  opensuse: [glog-devel]
   rhel: [glog-devel]
   ubuntu: [libgoogle-glog-dev]
 libgpgme-dev:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3022,6 +3022,7 @@ libgflags-dev:
   gentoo: [dev-cpp/gflags]
   nixos: [gflags]
   openembedded: [gflags@meta-oe]
+  opensuse: [gflags-devel]
   rhel: [gflags-devel]
   ubuntu: [libgflags-dev]
 libgfortran3:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2709,6 +2709,7 @@ libdw-dev:
   gentoo: [dev-libs/elfutils]
   nixos: [elfutils]
   openembedded: [elfutils@openembedded-core]
+  opensuse: [libdw-devel]
   ubuntu: [libdw-dev]
 libdxflib-dev:
   debian: [libdxflib-dev]


### PR DESCRIPTION
This is a continuation of the base.yaml updates for openSUSE
#29494 #29640

These keys are not necessarily related to each other. I'm just processing these commits alphabetically and breaking them up into groups of approx. 10.

https://software.opensuse.org/package/libcap
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.16019/standard
https://software.opensuse.org/package/libdw1
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/elfutils/standard
https://software.opensuse.org/package/libftdi1
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/libftdi1/standard
https://software.opensuse.org/package/gdal
https://build.opensuse.org/package/show/openSUSE%3ALeap%3A15.2/gdal
https://software.opensuse.org/package/gflags
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/gflags/standard
https://software.opensuse.org/package/glew
https://build.opensuse.org/package/show/openSUSE%3ALeap%3A15.2/glew
https://software.opensuse.org/package/google-glog
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/google-glog/standard
https://software.opensuse.org/package/libgpgme11
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.16131/standard
https://software.opensuse.org/package/libjpeg8
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.13954/standard
https://software.opensuse.org/package/libjsoncpp19
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/jsoncpp/standard
