### PR TITLE
base.yaml updates for openSUSE (4 of 6)

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3963,6 +3963,7 @@ libopenscenegraph:
   fedora: [OpenSceneGraph, OpenSceneGraph-devel, OpenThreads, OpenThreads-devel]
   gentoo: [dev-games/openscenegraph]
   nixos: [openscenegraph]
+  opensuse: [OpenSceneGraph, libOpenSceneGraph-devel, libOpenThreads-devel]
   ubuntu: [openscenegraph, libopenscenegraph-dev]
 libopensplice67:
   gentoo: [=sci-libs/opensplice-6.7.*]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4536,6 +4536,7 @@ libqt5-svg-dev:
   gentoo: ['dev-qt/qtsvg:5']
   nixos: [qt5.qtsvg]
   openembedded: [qtsvg@meta-qt5]
+  opensuse: [libqt5-qtsvg-devel]
   ubuntu: [libqt5svg5-dev]
 libqt5-websockets-dev:
   arch: [qt5-websockets]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4149,7 +4149,7 @@ libpng-dev:
   macports: [libpng]
   nixos: [libpng]
   openembedded: [libpng@openembedded-core]
-  opensuse: [libpng12-devel]
+  opensuse: [libpng16-devel,libpng16-compat-devel]
   rhel: [libpng-devel]
   slackware: [libpng]
   ubuntu:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4490,6 +4490,7 @@ libqt5-opengl-dev:
   gentoo: ['dev-qt/qtopengl:5']
   nixos: [qt5.qtbase]
   openembedded: [qtbase@meta-qt5]
+  opensuse: [libQt5OpenGL-devel]
   rhel: [qt5-qtbase-devel]
   slackware: [qt5]
   ubuntu: [libqt5opengl5-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4467,6 +4467,7 @@ libqt5-network:
   gentoo: ['dev-qt/qtnetwork:5']
   nixos: [qt5.qtbase]
   openembedded: [qtbase@meta-qt5]
+  opensuse: [libQt5Network5]
   ubuntu: [libqt5network5]
 libqt5-opengl:
   alpine: [qt5-qtbase-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4781,6 +4781,7 @@ libssl-dev:
   gentoo: [dev-libs/openssl]
   nixos: [openssl]
   openembedded: [openssl@openembedded-core]
+  opensuse: [libopenssl-devel]
   rhel: [openssl-devel]
   ubuntu: [libssl-dev]
 libstdc++5:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4692,6 +4692,7 @@ libsensors4-dev:
   gentoo: ['sys-apps/lm_sensors:0']
   nixos: [lm_sensors]
   openembedded: [lmsensors@meta-oe]
+  opensuse: [libsensors4-devel]
   ubuntu: [libsensors4-dev]
 libserial-dev:
   debian: [libserial-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3544,6 +3544,7 @@ liblapack-dev:
   gentoo: [virtual/lapack]
   nixos: [liblapack]
   openembedded: [lapack@meta-oe]
+  opensuse: [lapack-devel]
   rhel: [lapack-devel]
   ubuntu: [liblapack-dev]
 liblapacke-dev:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3841,7 +3841,7 @@ libogre-dev:
   macports: [ogre]
   nixos: [ogre1_9]
   openembedded: [ogre@meta-ros-common]
-  opensuse: [ogre-devel]
+  opensuse: [libOgreMain-devel,libOgreOverlay-devel,libOgrePaging-devel,libOgreProperty-devel,libOgreRTShaderSystem-devel,libOgreTerrain-devel,libOgreVolume-devel]
   slackware: [ogre]
   ubuntu:
     artful: [libogre-1.9-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3910,6 +3910,7 @@ libopencv-dev:
   macports: [opencv]
   nixos: [opencv3]
   openembedded: [opencv@meta-oe]
+  opensuse: [opencv-devel]
   rhel: [opencv-devel]
   ubuntu: [libopencv-dev]
 libopencv-imgproc-dev:


### PR DESCRIPTION
This is a continuation of the base.yaml updates for openSUSE
#29494 #29640 #29641

These keys are not necessarily related to each other. I'm just processing these commits alphabetically and breaking them up into groups of approx. 10.

https://software.opensuse.org/package/lapack
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/lapack/standard
https://software.opensuse.org/package/libOgreMain1_9_0
https://software.opensuse.org/package/libOgreOverlay1_9_0
https://software.opensuse.org/package/libOgrePaging1_9_0
https://software.opensuse.org/package/libOgreProperty1_9_0
https://software.opensuse.org/package/libOgreRTShaderSystem1_9_0
https://software.opensuse.org/package/libOgreTerrain1_9_0
https://software.opensuse.org/package/libOgreVolume1_9_0
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/ogre/standard
https://software.opensuse.org/package/opencv
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/opencv/standard
https://software.opensuse.org/package/OpenSceneGraph
https://software.opensuse.org/package/libOpenSceneGraph158
https://software.opensuse.org/package/libOpenThreads21
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/OpenSceneGraph/standard
https://software.opensuse.org/package/libpng16
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/libpng16/standard
https://software.opensuse.org/package/libQt5Network5
https://software.opensuse.org/package/libQt5OpenGL5
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.15202/standard
https://software.opensuse.org/package/libqt5-qtsvg
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/libqt5-qtsvg/standard
https://software.opensuse.org/package/libsensors4
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/sensors/standard
https://software.opensuse.org/package/libopenssl1_1
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.15927/standard

