### PR TITLE
Remove sloretz as Noetic CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,5 @@ indigo/* @tfoote
 kinetic/* @tfoote
 lunar/* @clalancette
 melodic/* @clalancette
-noetic/* @sloretz
 rolling/* @nuclearsandwich
 rosdep/* @ros/rosdeputies


### PR DESCRIPTION
CODEOWNDERS automatically request reviews, but this floods my inbox with PRs I mostly don't need to look at. Removing this will help me see the important mentions and review requests