### PR TITLE
robot_localization: 3.2.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2079,7 +2079,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/cra-ros-pkg/robot_localization-release.git
-      version: 3.2.1-1
+      version: 3.2.2-1
   robot_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `3.2.2-1`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/cra-ros-pkg/robot_localization-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.2.1-1`
