### PR TITLE
Remove clalancette from CODEOWNERS.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,5 @@ foxy/* @jacobperron
 galactic/* @cottsay
 indigo/* @tfoote
 kinetic/* @tfoote
-lunar/* @clalancette
-melodic/* @clalancette
 rolling/* @nuclearsandwich
 rosdep/* @ros/rosdeputies


### PR DESCRIPTION
It doesn't really fit my workflow anymore, so stop these
notifications.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Much like @sloretz did in #29643, remove myself from the Lunar and Melodic CODEOWNERS.