### PR TITLE
srdfdom: 2.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4382,7 +4382,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/moveit/srdfdom-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/ros-planning/srdfdom.git


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom` to `2.0.2-1`:

- upstream repository: https://github.com/ros-planning/srdfdom.git
- release repository: https://github.com/moveit/srdfdom-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.1-1`

## srdfdom

```
* Support rolling CI (#85 <https://github.com/ros-planning/srdfdom/issues/85>)
* Contributors: Vatan Aksoy Tezer
```
