### PR TITLE
random_numbers: 2.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2657,7 +2657,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/moveit/random_numbers-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `random_numbers` to `2.0.1-1`:

- upstream repository: https://github.com/ros-planning/random_numbers.git
- release repository: https://github.com/moveit/random_numbers-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-1`

## random_numbers

```
* Support rolling on CI (#32 <https://github.com/ros-planning/random_numbers/issues/32>)
* Migrate to GitHub Actions (#30 <https://github.com/ros-planning/random_numbers/issues/30>)
* Fix Travis README badge (#26 <https://github.com/ros-planning/random_numbers/issues/26>)
* Enable WINDOWS_EXPORT_ALL_SYMBOLS property for MSVC support (#23 <https://github.com/ros-planning/random_numbers/issues/23>)
* Declare specific boost depedencies (#22 <https://github.com/ros-planning/random_numbers/issues/22>)
  * removed unnecessary libboost-math libraries as only headers-only parts are used
* Fix clang-format, ament_lint_cmake (#25 <https://github.com/ros-planning/random_numbers/issues/25>)
* Contributors: Henning Kayser, Lior Lustgarten, Mikael Arguedas, Robert Haschke, Tyler Weaver, Vatan Aksoy Tezer
```
