### PR TITLE
moveit_msgs: 2.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1906,7 +1906,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/moveit/moveit_msgs-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_msgs` to `2.0.1-1`:

- upstream repository: https://github.com/ros-planning/moveit_msgs.git
- release repository: https://github.com/moveit/moveit_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-1`

## moveit_msgs

```
* Add License Notice (#108 <https://github.com/ros-planning/moveit_msgs/issues/108>)
* Fix ccache in CI (#102 <https://github.com/ros-planning/moveit_msgs/issues/102>)
* Migrate to GitHub Actions (#99 <https://github.com/ros-planning/moveit_msgs/issues/99>)
* Contributors: Tyler Weaver
```
