### PR TITLE
geometric_shapes: 2.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1165,7 +1165,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/moveit/geometric_shapes-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `2.0.2-1`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/moveit/geometric_shapes-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.1-1`

## geometric_shapes

```
* Declare assimp add qhull as SYSTEM dependency to suppress compiler warnings (#186 <https://github.com/ros-planning/geometric_shapes/issues/186>)
* Fix export depends (#182 <https://github.com/ros-planning/geometric_shapes/issues/182>)
* Add rolling to CI test (#179 <https://github.com/ros-planning/geometric_shapes/issues/179>)
* Contributors: Jafar Abdi, Tyler Weaver
```
