### PR TITLE
moveit: 2.1.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1891,7 +1891,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/moveit/moveit2-release.git
-      version: 2.1.2-1
+      version: 2.1.3-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.1.3-1`:

- upstream repository: https://github.com/ros-planning/moveit2.git
- release repository: https://github.com/moveit/moveit2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.2-1`

## moveit

- No changes

## moveit_common

- No changes

## moveit_core

```
* Delete exclusive arg for collision detector creation (#466 <https://github.com/ros-planning/moveit2/issues/466>)
  * Delete exclusive arg for collision detector creation
  * Rename setActiveCollisionDetector->allocateCollisionDetector everywhere
* Cleanup collision_distance_field test dependencies (#465 <https://github.com/ros-planning/moveit2/issues/465>)
* Fix PlanningScene CollisionDetector diff handling (#464 <https://github.com/ros-planning/moveit2/issues/464>)
* Fix joint limit handling when velocities aren't included in robot state (#451 <https://github.com/ros-planning/moveit2/issues/451>)
* Contributors: AndyZe, Henning Kayser
```

## moveit_fake_controller_manager

- No changes

## moveit_kinematics

```
* Replace last ament_export_libraries macro calls with ament_export_targets (#448 <https://github.com/ros-planning/moveit2/issues/448>)
* Contributors: Sebastian Jahr
```

## moveit_planners

- No changes

## moveit_planners_ompl

```
* Fix incomplete start states in OMPL ThreadSafeStateStorage (#455 <https://github.com/ros-planning/moveit2/issues/455>)
* ompl_interface: Fix loading group's specific parameters (#461 <https://github.com/ros-planning/moveit2/issues/461>)
* Contributors: Jafar Abdi, Pradeep Rajendran
```

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_move_group

- No changes

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

- No changes

## moveit_ros_planning

```
* Delete exclusive arg for collision detector creation (#466 <https://github.com/ros-planning/moveit2/issues/466>)
  * Delete exclusive arg for collision detector creation
  * Rename setActiveCollisionDetector->allocateCollisionDetector everywhere
* Contributors: AndyZe
```

## moveit_ros_planning_interface

```
* Configure OMPL projection_evaluator in move_group_launch_test_common.py (#470 <https://github.com/ros-planning/moveit2/issues/470>)
* Contributors: Jafar Abdi
```

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

- No changes

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_servo

```
* Refactor Servo velocity bounds enforcement. Disable flaky unit tests. (#428 <https://github.com/ros-planning/moveit2/issues/428>)
* Fix joint limit handling when velocities aren't included in robot state (#451 <https://github.com/ros-planning/moveit2/issues/451>)
* Fix Servo logging frequency (#457 <https://github.com/ros-planning/moveit2/issues/457>)
* Replace last ament_export_libraries macro calls with ament_export_targets (#448 <https://github.com/ros-planning/moveit2/issues/448>)
* Contributors: AndyZe, Sebastian Jahr, Vatan Aksoy Tezer
```

## moveit_simple_controller_manager

- No changes

## run_move_group

```
* Load panda_hand_controller (#460 <https://github.com/ros-planning/moveit2/issues/460>)
* Contributors: Jafar Abdi
```

## run_moveit_cpp

- No changes

## run_ompl_constrained_planning

- No changes
