### PR TITLE
srdfdom: 2.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2943,6 +2943,21 @@ repositories:
       url: https://github.com/ros2/spdlog_vendor.git
       version: master
     status: maintained
+  srdfdom:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/srdfdom.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/moveit/srdfdom-release.git
+      version: 2.0.2-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/srdfdom.git
+      version: ros2
+    status: maintained
   sros2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom` to `2.0.2-1`:

- upstream repository: https://github.com/ros-planning/srdfdom.git
- release repository: https://github.com/moveit/srdfdom-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## srdfdom

```
* Support rolling CI (#85 <https://github.com/ros-planning/srdfdom/issues/85>)
* Contributors: Vatan Aksoy Tezer
```
