### PR TITLE
warehouse_ros: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3439,6 +3439,21 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: ros2
     status: maintained
+  warehouse_ros:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/moveit/warehouse_ros-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros.git
+      version: ros2
+    status: maintained
   webots_ros2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros` to `2.0.0-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros.git
- release repository: https://github.com/moveit/warehouse_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## warehouse_ros

```
* [maint] Fix -Wcast-qual compile warnings (#49 <https://github.com/ros-planning/warehouse_ros/issues/49>)
* [ros2-migration] Port to ROS 2 (#48 <https://github.com/ros-planning/warehouse_ros/issues/48>)
  * Migrate CMakeLists.txt, package.xml to ROS 2
  * ROS 2 API Migration (Logging, messages, node, tf2)
  * Implement ROS 2 message serialization
  * Hotfix for MD5sum message type matching
  * Enable CI: clang-format, ament_lint on Foxy
* Contributors: Yu Yan
```
