### PR TITLE
geometric_shapes: 2.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -768,6 +768,21 @@ repositories:
       url: https://github.com/ros-geographic-info/geographic_info.git
       version: ros2
     status: maintained
+  geometric_shapes:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/geometric_shapes.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/moveit/geometric_shapes-release.git
+      version: 2.0.2-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/geometric_shapes.git
+      version: ros2
+    status: maintained
   geometry2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `2.0.2-1`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/moveit/geometric_shapes-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## geometric_shapes

```
* Declare assimp add qhull as SYSTEM dependency to suppress compiler warnings (#186 <https://github.com/ros-planning/geometric_shapes/issues/186>)
* Fix export depends (#182 <https://github.com/ros-planning/geometric_shapes/issues/182>)
* Add rolling to CI test (#179 <https://github.com/ros-planning/geometric_shapes/issues/179>)
* Contributors: Jafar Abdi, Tyler Weaver
```
