### PR TITLE
warehouse_ros_mongo: 2.0.1-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5015,7 +5015,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/moveit/warehouse_ros_mongo-release.git
-      version: 2.0.1-1
+      version: 2.0.1-2
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros_mongo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros_mongo` to `2.0.1-2`:

- upstream repository: https://github.com/ros-planning/warehouse_ros_mongo.git
- release repository: https://github.com/moveit/warehouse_ros_mongo-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.1-1`

## warehouse_ros_mongo

```
* Fix installation path for FindMONGODB.cmake (#42 <https://github.com/ros-planning/warehouse_ros_mongo/issues/42>)
* Fix cmake export of MONGODB dependency (#41 <https://github.com/ros-planning/warehouse_ros_mongo/issues/41>)
* Contributors: Jafar Abdi, Robert Haschke, Tyler Weaver
```
