### PR TITLE
warehouse_ros_mongo: 2.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3531,6 +3531,8 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros.git
+      version: ros2
+    status: maintained
   warehouse_ros_mongo:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3439,6 +3439,21 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: ros2
     status: maintained
+  warehouse_ros_mongo:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros_mongo.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/moveit/warehouse_ros_mongo-release.git
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros_mongo.git
+      version: ros2
+    status: maintained
   webots_ros2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros_mongo` to `2.0.1-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros_mongo.git
- release repository: https://github.com/moveit/warehouse_ros_mongo-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## warehouse_ros_mongo

```
* Fix installation path for FindMONGODB.cmake (#42 <https://github.com/ros-planning/warehouse_ros_mongo/issues/42>)
* Fix cmake export of MONGODB dependency (#41 <https://github.com/ros-planning/warehouse_ros_mongo/issues/41>)
* Contributors: Jafar Abdi, Robert Haschke, Tyler Weaver
```
