### PR TITLE
ur_msgs: 1.3.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13626,7 +13626,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-industrial-release/ur_msgs-release.git
-      version: 1.3.3-1
+      version: 1.3.4-1
     source:
       type: git
       url: https://github.com/ros-industrial/ur_msgs.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13626,7 +13626,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-industrial-release/ur_msgs-release.git
-      version: 1.3.2-1
+      version: 1.3.3-1
     source:
       type: git
       url: https://github.com/ros-industrial/ur_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_msgs` to `1.3.3-1`:

- upstream repository: https://github.com/ros-industrial/ur_msgs.git
- release repository: https://github.com/ros-industrial-release/ur_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.3.2-1`

## ur_msgs

```
* Migrate to Github Actions
* Fix SetPayload srv separater invalid (`#10 <https://github.com/ros-industrial/ur_msgs/issues/10>`_)
* Contributors: Chen Bainian, gavanderhoorn
```
