### PR TITLE
ur_msgs: 1.3.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8204,6 +8204,21 @@ repositories:
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git
       version: boost
     status: developed
+  ur_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/ur_msgs.git
+      version: melodic
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-industrial-release/ur_msgs-release.git
+      version: 1.3.4-1
+    source:
+      type: git
+      url: https://github.com/ros-industrial/ur_msgs.git
+      version: melodic-devel
+    status: maintained
   urdf:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_msgs` to `1.3.4-1`:

- upstream repository: https://github.com/ros-industrial/ur_msgs.git
- release repository: https://github.com/ros-industrial-release/ur_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ur_msgs

```
* Bump CMake version to ignore warning
* Contributors: gavanderhoorn
```
