### PR TITLE
base.yaml updates for openSUSE (5 of 6)

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4906,7 +4906,7 @@ libtool:
   macports: [libtool]
   nixos: [libtool]
   openembedded: [libtool@openembedded-core]
-  opensuse: [libtool, libltdl3]
+  opensuse: [libtool, libltdl7]
   rhel: [libtool, libtool-ltdl-devel]
   slackware: [libtool]
   ubuntu:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5466,6 +5466,7 @@ libzmq3-dev:
   gentoo: [net-libs/cppzmq]
   nixos: [cppzmq]
   openembedded: [zeromq@meta-oe]
+  opensuse: [zeromq-devel]
   rhel: [cppzmq-devel]
   ubuntu: [libzmq3-dev]
 libzmqpp-dev:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4941,7 +4941,7 @@ libturbojpeg:
   gentoo: [media-libs/libjpeg-turbo]
   nixos: [libjpeg_turbo]
   openembedded: [libjpeg-turbo@openembedded-core]
-  opensuse: [libturbojpeg0]
+  opensuse: [libturbojpeg0, libjpeg8-devel]
   rhel: [turbojpeg-devel]
   ubuntu:
     '*': [libturbojpeg0-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5070,6 +5070,7 @@ libusb-dev:
   macports: [libusb]
   nixos: [libusb]
   openembedded: [libusb1@openembedded-core]
+  opensuse: [libusb-1_0-devel]
   rhel: [libusb-devel]
   ubuntu: [libusb-dev]
 libuv-dev:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5126,6 +5126,7 @@ libvlc:
   gentoo: [media-video/vlc]
   nixos: [vlc]
   openembedded: [vlc@meta-multimedia]
+  opensuse: [libvlc5,vlc-noX]
   ubuntu:
     '*': [libvlc5, vlc-bin]
     precise: [libvlc5, vlc-nox]
@@ -5142,10 +5143,12 @@ libvlc-dev:
   gentoo: [media-video/vlc]
   nixos: [vlc]
   openembedded: [vlc@meta-multimedia]
+  opensuse: [vlc-devel]
   ubuntu: [libvlc-dev]
 libvlccore-dev:
   debian: [libvlccore-dev]
   fedora: [vlc-devel]
+  opensuse: [vlc-devel]
   ubuntu: [libvlccore-dev]
 libvpx-dev:
   debian: [libvpx-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5279,6 +5279,7 @@ libx11:
   gentoo: [x11-libs/libX11]
   macports: [xorg-libX11]
   nixos: [xorg.libX11]
+  opensuse: [libX11-6]
   ubuntu: [libx11-dev]
 libx11-dev:
   alpine: [libx11-dev]
@@ -5288,6 +5289,7 @@ libx11-dev:
   gentoo: [x11-libs/libX11]
   nixos: [xorg.libX11]
   openembedded: [libx11@openembedded-core]
+  opensuse: [libX11-devel]
   rhel: [libX11-devel]
   ubuntu: [libx11-dev]
 libx264-dev:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5644,7 +5644,7 @@ lz4:
   gentoo: [app-arch/lz4]
   nixos: [lz4]
   openembedded: [lz4@openembedded-core]
-  opensuse: [lz4]
+  opensuse: [liblz4-devel]
   rhel: [lz4-devel]
   slackware: [lz4]
   ubuntu: [liblz4-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4941,6 +4941,7 @@ libturbojpeg:
   gentoo: [media-libs/libjpeg-turbo]
   nixos: [libjpeg_turbo]
   openembedded: [libjpeg-turbo@openembedded-core]
+  opensuse: [libturbojpeg0]
   rhel: [turbojpeg-devel]
   ubuntu:
     '*': [libturbojpeg0-dev]


### PR DESCRIPTION
This is a continuation of the base.yaml updates for openSUSE
#29494 #29640 #29641 #29642

These keys are not necessarily related to each other. I'm just processing these commits alphabetically and breaking them up into groups of approx. 10.

https://software.opensuse.org/package/libtool
https://software.opensuse.org/package/libltdl7
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/libtool/standard
https://software.opensuse.org/package/libturbojpeg0
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.13954/standard
https://software.opensuse.org/package/libusb-1_0
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.15214/standard
https://software.opensuse.org/package/libvlc5
https://software.opensuse.org/package/vlc-noX
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.16218/standard
https://software.opensuse.org/package/libX11-6
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.15917/standard
https://software.opensuse.org/package/zeromq
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.14944/standard
https://software.opensuse.org/package/liblz4-1
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/lz4/standard
