### PR TITLE
base.yaml updates for openSUSE (6 of 6)

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6714,6 +6714,7 @@ sdl:
   macports: [libsdl]
   nixos: [SDL]
   openembedded: [libsdl@openembedded-core]
+  opensuse: [libSDL-devel]
   rhel: [SDL-devel]
   ubuntu: [libsdl1.2-dev]
 sdl-gfx:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5929,6 +5929,7 @@ network-manager:
   fedora: [NetworkManager]
   gentoo: [net-misc/networkmanager]
   nixos: [networkmanager]
+  opensuse: [NetworkManager]
   ubuntu: [network-manager]
 ninja-build:
   arch: [ninja]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6733,7 +6733,7 @@ sdl-image:
   macports: [libsdl_image]
   nixos: [SDL_image]
   openembedded: [libsdl-image@meta-oe]
-  opensuse: [SDL_image]
+  opensuse: [libSDL_image-devel]
   rhel:
     '7': [SDL_image-devel]
   ubuntu: [libsdl-image1.2-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5921,7 +5921,7 @@ netpbm:
   gentoo: [media-libs/netpbm]
   macports: [netpbm]
   nixos: [netpbm]
-  opensuse: [netpbm]
+  opensuse: [libnetpbm-devel]
   rhel: [netpbm-devel]
   ubuntu: [libnetpbm10-dev]
 network-manager:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7133,12 +7133,14 @@ texlive-latex-base:
   fedora: [texlive-latex, texlive-parskip]
   gentoo: [dev-texlive/texlive-latex]
   macports: [texlive]
+  opensuse: [texlive-latex, texlive-parskip]
   ubuntu: [texlive-latex-base]
 texlive-latex-extra:
   arch: [texlive-latexextra]
   debian: [texlive-latex-extra]
   fedora: [texlive-titlesec, texlive-wrapfig, texlive-multirow, texlive-fancybox]
   gentoo: [dev-texlive/texlive-latexextra]
+  opensuse: [texlive-titlesec, texlive-wrapfig, texlive-multirow, texlive-fancybox]
   ubuntu: [texlive-latex-extra]
 texlive-latex-recommended:
   arch: [texlive-core]
@@ -7146,6 +7148,7 @@ texlive-latex-recommended:
   fedora: [texlive-framed, texlive-threeparttable, texlive-ec, texlive-mdwtools]
   gentoo: [dev-texlive/texlive-latexrecommended]
   macports: [texlive-latex-recommended]
+  opensuse: [texlive-framed, texlive-threeparttable, texlive-ec, texlive-mdwtools]
   ubuntu: [texlive-latex-recommended]
 texmaker:
   debian: [texmaker]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6122,6 +6122,7 @@ openssl:
   gentoo: [dev-libs/openssl]
   nixos: [openssl]
   openembedded: [openssl@openembedded-core]
+  opensuse: [openssl]
   rhel: [openssl]
   ubuntu: [openssl]
 optipng:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5880,6 +5880,7 @@ muparser:
   fedora: [muParser-devel]
   gentoo: [dev-cpp/muParser]
   nixos: [muparser]
+  opensuse: [muparser-devel]
   ubuntu: [libmuparser-dev]
 nasm:
   arch: [nasm]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7163,6 +7163,7 @@ time:
   gentoo: [sys-process/time]
   nixos: [time]
   openembedded: [time@openembedded-core]
+  opensuse: [time]
   ubuntu: [time]
 tinyxml:
   alpine: [tinyxml-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6936,6 +6936,7 @@ suitesparse:
   macports: [SuiteSparse]
   nixos: [suitesparse]
   openembedded: [suitesparse-cxsparse@meta-ros-common, suitesparse-cholmod@meta-ros-common]
+  opensuse: [suitesparse-devel]
   rhel: [suitesparse-devel]
   ubuntu: [libsuitesparse-dev]
 supervisor:


### PR DESCRIPTION
This is a continuation of the base.yaml updates for openSUSE
#29494 #29640 #29641 #29642 #29663

These keys are not necessarily related to each other. I'm just processing these commits alphabetically and breaking them up into groups of approx. 10.

https://software.opensuse.org/package/muparser
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/muparser/standard
https://software.opensuse.org/package/libnetpbm11
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.15847/standard
https://software.opensuse.org/package/NetworkManager
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.13790/standard
https://software.opensuse.org/package/openssl
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/openssl/standard
https://software.opensuse.org/package/libSDL-1_2-0
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.14943/standard
https://software.opensuse.org/package/libSDL_image-1_2-0
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/SDL_image/standard
https://software.opensuse.org/package/suitesparse
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/suitesparse/standard
https://software.opensuse.org/package/texlive-latex
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/texlive-specs-m/standard
https://software.opensuse.org/package/texlive-parskip
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/texlive-specs-r/standard
https://software.opensuse.org/package/texlive-titlesec
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/texlive-specs-x/standard
https://software.opensuse.org/package/texlive-wrapfig
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/texlive-specs-y/standard
https://software.opensuse.org/package/texlive-multirow
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/texlive-specs-p/standard
https://software.opensuse.org/package/texlive-fancybox
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/texlive-specs-i/standard
https://software.opensuse.org/package/texlive-framed
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/texlive-specs-j/standard
https://software.opensuse.org/package/texlive-threeparttable
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/texlive-specs-w/standard
https://software.opensuse.org/package/texlive-ec
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/texlive-specs-h/standard
https://software.opensuse.org/package/texlive-mdwtools
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/texlive-specs-o/standard
https://software.opensuse.org/package/time
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/time/standard
