### PR TITLE
osrf_testing_tools_cpp: 1.4.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1489,7 +1489,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/osrf_testing_tools_cpp-release.git
-      version: 1.3.2-3
+      version: 1.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `osrf_testing_tools_cpp` to `1.4.0-1`:

- upstream repository: https://github.com/osrf/osrf_testing_tools_cpp.git
- release repository: https://github.com/ros2-gbp/osrf_testing_tools_cpp-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.3.2-3`

## osrf_testing_tools_cpp

```
* [osrf_testing_tools_cpp] Add warnings (#54 <https://github.com/osrf/osrf_testing_tools_cpp/issues/54>)
* Update cmake minimum version to 2.8.12 (#61 <https://github.com/osrf/osrf_testing_tools_cpp/issues/61>)
* Add googletest v1.10.0 (#55 <https://github.com/osrf/osrf_testing_tools_cpp/issues/55>)
* Workarounds for Android (#52 <https://github.com/osrf/osrf_testing_tools_cpp/issues/52>) (#60 <https://github.com/osrf/osrf_testing_tools_cpp/issues/60>)
* Change WIN32 to _WIN32 (#53 <https://github.com/osrf/osrf_testing_tools_cpp/issues/53>)
* fix execinfo.h not found for QNX (#50 <https://github.com/osrf/osrf_testing_tools_cpp/issues/50>)
* Contributors: Ahmed Sobhy, Audrow Nash, Dan Rose, Jacob Perron, Stephen Brawner
```

## test_osrf_testing_tools_cpp

- No changes
