### PR TITLE
Adding riptide_controllers to documentation index for noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5870,6 +5870,12 @@ repositories:
       url: https://github.com/ros-drivers/rgbd_launch.git
       version: noetic-devel
     status: maintained
+  riptide_controllers:
+    doc:
+      type: git
+      url: https://github.com/osu-uwrt/riptide_controllers.git
+      version: dev
+    status: maintained
   robot_body_filter:
     doc:
       type: git


### PR DESCRIPTION
I'd like riptide_controllers to be indexed and documented on ros.org.