### PR TITLE
pr2_robot: 1.6.32-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5395,6 +5395,30 @@ repositories:
       url: https://github.com/pr2/pr2_power_drivers.git
       version: kinetic-devel
     status: unmaintained
+  pr2_robot:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_robot.git
+      version: kinetic-devel
+    release:
+      packages:
+      - imu_monitor
+      - pr2_bringup
+      - pr2_camera_synchronizer
+      - pr2_computer_monitor
+      - pr2_controller_configuration
+      - pr2_ethercat
+      - pr2_robot
+      - pr2_run_stop_auto_restart
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_robot-release.git
+      version: 1.6.32-1
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_robot.git
+      version: kinetic-devel
+    status: unmaintained
   prbt_grippers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_robot` to `1.6.32-1`:

- upstream repository: https://github.com/pr2/pr2_robot.git
- release repository: https://github.com/pr2-gbp/pr2_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## imu_monitor

```
* Merge pull request #268 <https://github.com/pr2/pr2_robot/issues/268> from k-okada/fix_for_noetic
* [imu_monitor] convert to package format 3
* Contributors: Kei Okada
```

## pr2_bringup

```
* Merge pull request #268 <https://github.com/pr2/pr2_robot/issues/268> from k-okada/fix_for_noetic
* run 2to3 -w -fexcept .
* run 2to3 -w -fprint .
* Contributors: Kei Okada
```

## pr2_camera_synchronizer

```
* Merge pull request #268 <https://github.com/pr2/pr2_robot/issues/268> from k-okada/fix_for_noetic
* async is keyword in Python3.7
* python3 did not take tuple for lambda : https://stackoverflow.com/questions/11328312/python-lambda-does-not-accept-tuple-argument
* run 2to3 -w -fexcept .
* run 2to3 -w -fprint .
* Contributors: Kei Okada
```

## pr2_computer_monitor

```
* Merge pull request #268 <https://github.com/pr2/pr2_robot/issues/268> from k-okada/fix_for_noetic
* run 2to3 -w -fexcept .
* run 2to3 -w -fprint .
* Contributors: Kei Okada
```

## pr2_controller_configuration

```
* add pr2_joint_group_velocity_controllers.yaml
  add JointGroupVelocityController in pr2_controllers (see https://github.com/PR2/pr2_controllers/pull/400)
* Contributors: Shuang Li
```

## pr2_ethercat

```
* Merge pull request #268 <https://github.com/pr2/pr2_robot/issues/268> from k-okada/fix_for_noetic
* run 2to3 -w -fprint .
* Contributors: Kei Okada
```

## pr2_robot

- No changes

## pr2_run_stop_auto_restart

- No changes
