### PR TITLE
rqt_pr2_dashboard: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6992,6 +6992,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_pose_view.git
       version: master
     status: maintained
+  rqt_pr2_dashboard:
+    doc:
+      type: git
+      url: https://github.com/PR2/rqt_pr2_dashboard.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_pr2_dashboard-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/pr2/rqt_pr2_dashboard.git
+      version: kinetic-devel
+    status: maintained
   rqt_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_pr2_dashboard` to `0.4.0-1`:

- upstream repository: https://github.com/PR2/rqt_pr2_dashboard.git
- release repository: https://github.com/ros-gbp/rqt_pr2_dashboard-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## rqt_pr2_dashboard

```
* fix for kinetic (fix Qt path) #19 <https://github.com/pr2/rqt_pr2_dashboard/issues/19>
* Contributors: Furushchev
```
