### PR TITLE
image_common: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -962,7 +962,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 2.3.0-2
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `3.0.0-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.0-2`

## camera_calibration_parsers

```
* Update maintainers (#173 <https://github.com/ros-perception/image_common/issues/173>)
* Contributors: Alejandro Hernández Cordero
```

## camera_info_manager

```
* Update maintainers (#173 <https://github.com/ros-perception/image_common/issues/173>)
* Contributors: Alejandro Hernández Cordero
```

## image_common

- No changes

## image_transport

```
* Make sure to mark overridden methods as 'override'. (#192 <https://github.com/ros-perception/image_common/issues/192>)
* Expose subscription options (#186 <https://github.com/ros-perception/image_common/issues/186>)
* fix mistyping 'cammera_publisher.hpp -> camera_publisher.hpp' (#177 <https://github.com/ros-perception/image_common/issues/177>)
* Update maintainers (#173 <https://github.com/ros-perception/image_common/issues/173>)
* make CameraPublisher::getNumSubscribers() work (#163 <https://github.com/ros-perception/image_common/issues/163>)
* Contributors: Alejandro Hernández Cordero, Audrow Nash, Chris Lalancette, Hye-Jong KIM, Michael Ferguson
```
