### PR TITLE
clover: 0.21.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1308,7 +1308,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/CopterExpress/clover-release.git
-      version: 0.21.2-1
+      version: 0.21.3-1
     source:
       type: git
       url: https://github.com/CopterExpress/clover.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clover` to `0.21.3-1`:

- upstream repository: https://github.com/CopterExpress/clover.git
- release repository: https://github.com/CopterExpress/clover-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.21.2-1`
