### PR TITLE
rviz: 8.6.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2969,7 +2969,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 8.6.0-1
+      version: 8.6.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `8.6.0-2`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `8.6.0-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

- No changes

## rviz_default_plugins

```
* Export Qt5 dependencies properly (#687 <https://github.com/ros2/rviz/issues/687>)
* Add support for namespace-scoped DELETEALL action in Marker displays (#685 <https://github.com/ros2/rviz/issues/685>)
* Use image_transport to subscribe to image messages (#523 <https://github.com/ros2/rviz/issues/523>)
* Contributors: Audrow Nash, ketatam, Martin Idel, Michel Hidalgo
```

## rviz_ogre_vendor

```
* Strip RPATH from installed Ogre binaries (#688 <https://github.com/ros2/rviz/issues/688>)
* Contributors: Michel Hidalgo
```

## rviz_rendering

```
* Export Qt5 dependencies properly (#687 <https://github.com/ros2/rviz/issues/687>)
* Putting glsl 1.50 resources back in RenderSystem (#668 <https://github.com/ros2/rviz/issues/668>)
* Contributors: Michel Hidalgo, Piotr Jaroszek
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

```
* Update includes after rcutils/get_env.h deprecation (#677 <https://github.com/ros2/rviz/issues/677>)
* Contributors: Christophe Bedard
```
