### PR TITLE
Adding visp_ros to documentation index for melodic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -14082,6 +14082,11 @@ repositories:
       url: https://github.com/lagadic/visp-release.git
       version: 3.4.0-4
     status: maintained
+  visp_ros:
+    doc:
+      type: git
+      url: https://github.com/lagadic/visp_ros.git
+      version: master
   visualization_osg:
     release:
       packages:


### PR DESCRIPTION
I'd like `visp_ros` to be indexed and documented on ros.org 