### PR TITLE
Adding visp_ros to documentation index for noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8538,6 +8538,11 @@ repositories:
       url: https://github.com/lagadic/visp.git
       version: master
     status: maintained
+  visp_ros:
+    doc:
+      type: git
+      url: https://github.com/lagadic/visp_ros.git
+      version: master
   visualization_tutorials:
     doc:
       type: git


### PR DESCRIPTION
I'd like `visp_ros` to be indexed and documented on ros.org