### PR TITLE
foxglove_msgs: 1.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2129,6 +2129,21 @@ repositories:
       url: https://github.com/ros-drivers/four_wheel_steering_msgs.git
       version: master
     status: maintained
+  foxglove_msgs:
+    doc:
+      type: git
+      url: https://github.com/foxglove/ros_foxglove_msgs.git
+      version: 1.0.0
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/foxglove/ros_foxglove_msgs-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/foxglove/ros_foxglove_msgs.git
+      version: main
+    status: developed
   franka_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_msgs` to `1.0.0-1`:

- upstream repository: https://github.com/foxglove/ros_foxglove_msgs.git
- release repository: https://github.com/foxglove/ros_foxglove_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## foxglove_msgs

```
* Initial release with foxglove_msgs/ImageMarkerArray message
```
