### PR TITLE
rclc: changed version to 'galactic'

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1818,7 +1818,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rclc.git
-      version: master
+      version: galactic
     release:
       packages:
       - rclc
@@ -1832,7 +1832,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclc.git
-      version: master
+      version: galactic
     status: developed
   rclcpp:
     doc:


### PR DESCRIPTION
Changed branch-name that shall be used in the bloom-release from 'master' to 'galactic'.