### PR TITLE
rmf_traffic: 1.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2042,6 +2042,21 @@ repositories:
       url: https://github.com/open-rmf/rmf_cmake_uncrustify.git
       version: rolling
     status: developed
+  rmf_traffic:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_traffic.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_traffic-release.git
+      version: 1.3.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_traffic.git
+      version: rolling
+    status: developed
   rmf_utils:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_traffic` to `1.3.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_traffic.git
- release repository: https://github.com/ros2-gbp/rmf_traffic-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
