### PR TITLE
Adding libqt5-concurrent rosdep key for rhel

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4497,6 +4497,7 @@ libqt5-concurrent:
   nixos: [qt5.qtbase]
   openembedded: [qtbase@meta-qt5]
   opensuse: [libQt5Concurrent5]
+  rhel: [qt5-qtbase]
   slackware: [qt5]
   ubuntu: [libqt5concurrent5]
 libqt5-core:


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>

## Purpose of using this:

This dependency is used by [rmf_traffic_editor](https://github.com/open-rmf/rmf_traffic_editor)

