### PR TITLE
adding python3-shapely to rosdep keys for rhel

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7568,6 +7568,7 @@ python3-shapely:
   osx:
     pip:
       packages: [shapely]
+  rhel: [python3-shapely]
   ubuntu: [python3-shapely]
 python3-simple-pid-pip:
   debian:


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>

## Purpose of using this:

This dependency is used by [rmf_traffic_editor](https://github.com/open-rmf/rmf_traffic_editor)