### PR TITLE
rplidar_ros: 2.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3844,7 +3844,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/allenh1/rplidar_ros-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rplidar_ros` to `2.0.2-1`:

- upstream repository: https://github.com/allenh1/rplidar_ros
- release repository: https://github.com/allenh1/rplidar_ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.1-1`

## rplidar_ros

```
* Remove test_rplidar.launch.py, since relevant executables no longer exist (#24 <https://github.com/allenh1/rplidar_ros/issues/24>)
* Contributors: Hunter L. Allen
```
