### PR TITLE
rplidar_ros: 2.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2606,6 +2606,18 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_gurumdds.git
       version: master
     status: developed
+  rplidar_ros:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/allenh1/rplidar_ros-release.git
+      version: 2.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/allenh1/rplidar_ros.git
+      version: ros2
+    status: developed
   rpyutils:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rplidar_ros` to `2.0.2-1`:

- upstream repository: https://github.com/allenh1/rplidar_ros
- release repository: https://github.com/allenh1/rplidar_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## rplidar_ros

```
* Remove test_rplidar.launch.py, since relevant executables no longer exist (#24 <https://github.com/allenh1/rplidar_ros/issues/24>)
* Contributors: Hunter L. Allen
```
