### PR TITLE
rplidar_ros: 2.0.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2511,6 +2511,18 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_gurumdds.git
       version: galactic
     status: developed
+  rplidar_ros:
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/allenh1/rplidar_ros-release.git
+      version: 2.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/allenh1/rplidar_ros.git
+      version: ros2
+    status: developed
   rpyutils:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rplidar_ros` to `2.0.2-1`:

- upstream repository: https://github.com/allenh1/rplidar_ros
- release repository: https://github.com/allenh1/rplidar_ros-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## rplidar_ros

```
* Remove test_rplidar.launch.py, since relevant executables no longer exist (#24 <https://github.com/allenh1/rplidar_ros/issues/24>)
* Contributors: Hunter L. Allen
```
