### PR TITLE
Fix the rosdep_repo_check automation in CI

### DIFF
--- a/test/rosdep_repo_check/test_rosdep_repo_check.py
+++ b/test/rosdep_repo_check/test_rosdep_repo_check.py
@@ -57,11 +57,11 @@ def detect_lines(diffstr):
 
 
 def get_changed_line_numbers():
-    base_ref = 'HEAD^'
+    base_ref = ''
     GITHUB_BASE_REF = os.environ.get('GITHUB_BASE_REF')
     if GITHUB_BASE_REF:
-        base_ref = 'remotes/origin/' + GITHUB_BASE_REF
-    cmd = 'git diff --unified=0 %s... -- rosdep' % (base_ref,)
+        base_ref = 'remotes/origin/' + GITHUB_BASE_REF + '...'
+    cmd = 'git diff --unified=0 %s -- rosdep' % (base_ref,)
     print("Detecting changed rules with '%s'" % (cmd,))
     diff = subprocess.check_output(cmd.split()).decode('utf-8')
     return detect_lines(diff)


### PR DESCRIPTION
It seems that 'HEAD^' isn't usable in GitHub Actions for some reason. That isn't really a problem - we can mimic the same behavior by excluding the target ref entirely.

Invoking the test locally will now inspect only unstaged changes, where invoking the test in a GitHub PR will inspect incoming changes. During GitHub CI, no changes will be inspected.

Follow-up to #28902