### PR TITLE
graceful_controller: 0.3.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3772,7 +3772,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mikeferguson/graceful_controller-gbp.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/mikeferguson/graceful_controller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `graceful_controller` to `0.3.1-1`:

- upstream repository: https://github.com/mikeferguson/graceful_controller.git
- release repository: https://github.com/mikeferguson/graceful_controller-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.0-1`

## graceful_controller

- No changes

## graceful_controller_ros

```
* add feature for final rotation (#15 <https://github.com/mikeferguson/graceful_controller/issues/15>)
  if the final pose orientation is very different from the end
  of the path, we get a big sweeping turn. this feature uses
  the previous orientation to avoid that sweeping turn and
  instead does a final in-place rotation. Add filter and pose
  publisher.
* not sure how build is working without this being executable
* Contributors: Michael Ferguson
```
