### PR TITLE
Add Debian and README info describing config.yaml.

### DIFF
--- a/test/rosdep_repo_check/README.md
+++ b/test/rosdep_repo_check/README.md
@@ -15,3 +15,13 @@ To review the entire rosdep database and not only the rules that were changed in
 
 PYTHONPATH=test python3 -m rosdep_repo_check
 ```
+
+## Adding new repository checks
+
+Platform checks can be added by updating [config.yaml](./config.yaml).
+
+* `package_sources` contains a set of repository base urls for each operating system distribution
+* `package_dashboards` contains an optional list of matching repository url patterns and template urls which can be used to extract and compose web links to packages in the matching distributions.
+* `supported_versions` lists of operating system versions or codenames that checks should be checked with the package sources
+* `supported_architectures` lists of operating system architectures that checks should be checked with the package sources. Although rosdep is expected to work across architectures repositories are only checked on amd64/x86_64 to save time. If a distribution has a radically different set of packages for different architectures checks for additional architectures can be added.
+

--- a/test/rosdep_repo_check/README.md
+++ b/test/rosdep_repo_check/README.md
@@ -22,5 +22,5 @@ Platform checks can be added by updating [config.yaml](./config.yaml).
 
 * `package_sources` contains a set of repository base urls for each operating system distribution
 * `package_dashboards` contains an optional list of matching repository url patterns and template urls which can be used to extract and compose web links to packages in the matching distributions. This configuration is optional and may be omitted where appropriate.
-* `supported_versions` lists of operating system versions or codenames that checks should be checked with the package sources
-* `supported_architectures` lists of operating system architectures that checks should be checked with the package sources. Although rosdep is expected to work across architectures repositories are only checked on amd64/x86_64 to save time. If a distribution has a radically different set of packages for different architectures checks for additional architectures can be added.
+* `supported_versions` lists of operating system versions or codenames to run package presence checks for. The last version listed will be used to generate suggestions if there is no definition for that operating system.
+* `supported_architectures` lists of operating system architectures to run package presence checks for. Although rosdep is expected to work across architectures repositories are only checked on amd64/x86_64 to save time. If a distribution has a radically different set of packages for different architectures checks for additional architectures can be added.

--- a/test/rosdep_repo_check/README.md
+++ b/test/rosdep_repo_check/README.md
@@ -21,7 +21,6 @@ PYTHONPATH=test python3 -m rosdep_repo_check
 Platform checks can be added by updating [config.yaml](./config.yaml).
 
 * `package_sources` contains a set of repository base urls for each operating system distribution
-* `package_dashboards` contains an optional list of matching repository url patterns and template urls which can be used to extract and compose web links to packages in the matching distributions.
+* `package_dashboards` contains an optional list of matching repository url patterns and template urls which can be used to extract and compose web links to packages in the matching distributions. This configuration is optional and may be omitted where appropriate.
 * `supported_versions` lists of operating system versions or codenames that checks should be checked with the package sources
 * `supported_architectures` lists of operating system architectures that checks should be checked with the package sources. Although rosdep is expected to work across architectures repositories are only checked on amd64/x86_64 to save time. If a distribution has a radically different set of packages for different architectures checks for additional architectures can be added.
-

--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -1,5 +1,10 @@
 ---
 package_sources:
+  debian:
+    - !deb_base_url http://deb.debian.org/debian main
+    - !deb_base_url http://deb.debian.org/debian contrib
+    - !deb_base_url http://deb.debian.org/debian non-free
+    - !deb_base_url http://repos.ros.org/repos/ros_bootstrap main
   fedora:
     - !rpm_base_url https://dl.fedoraproject.org/pub/$distname/linux/releases/$releasever/Everything/$basearch/os/
     - !rpm_base_url https://dl.fedoraproject.org/pub/$distname/linux/updates/$releasever/Everything/$basearch/
@@ -25,12 +30,17 @@ package_sources:
     - !deb_base_url http://repos.ros.org/repos/ros_bootstrap main
 
 package_dashboards:
+  - pattern: !regular_expression .*//deb.debian.org/debian/.*
+    url: https://packages.debian.org/{os_code_name}/{binary_name}
   - pattern: !regular_expression .*//dl.fedoraproject.org/pub/.*
     url: https://src.fedoraproject.org/rpms/{source_name}#bodhi_updates
   - pattern: !regular_expression .*//archive.ubuntu.com/ubuntu/.*
     url: https://packages.ubuntu.com/{os_code_name}/{binary_name}
 
 supported_versions:
+  debian:
+    - stretch
+    - buster
   fedora:
     - '33'
     - '34'
@@ -42,6 +52,8 @@ supported_versions:
     - focal
 
 supported_arches:
+  debian:
+    - amd64
   fedora:
     - x86_64
   rhel:


### PR DESCRIPTION
Adds debian as a checked platform and tries to add info about adding
further platforms to the README.

Debian Bullseye couldn't be added because there is not yet a bootstrap
repository for it.