### PR TITLE
rclc: 2.0.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1827,7 +1827,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
-      version: 1.0.1-2
+      version: 2.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclc` to `2.0.1-1`:

- upstream repository: https://github.com/ros2/rclc.git
- release repository: https://github.com/ros2-gbp/rclc-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.1-2`

## rclc

```
* added quality declaration
```

## rclc_examples

```
* added quality declaration
```

## rclc_lifecycle

```
* added quality declaration
```
