### PR TITLE
Add python3-networkmanager to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6729,6 +6729,12 @@ python3-netifaces:
   openembedded: [python3-netifaces@meta-ros-common]
   rhel: ['python%{python3_pkgversion}-netifaces']
   ubuntu: [python3-netifaces]
+python3-networkmanager:
+  debian:
+    buster: [python3-networkmanager]
+    jessie: [python3-networkmanager]
+  fedora: [python3-networkmanager]
+  ubuntu: [python3-networkmanager]
 python3-networkx:
   debian: [python3-networkx]
   fedora: [python3-networkx]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-networkmanager

## Package Upstream Source:

https://github.com/seveas/python-networkmanager

## Purpose of using this:

python3 version of `python-networkmanager`
https://github.com/ros/rosdistro/blob/master/rosdep/python.yaml#L2815-L2820

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/buster/python3-networkmanager
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/focal/python3-networkmanager
- Fedora: https://src.fedoraproject.org/browse/projects/
  - https://src.fedoraproject.org/rpms/python-networkmanager#bodhi_updates
- Arch: https://www.archlinux.org/packages/
  - N/A
- Gentoo: https://packages.gentoo.org/
  - N/A
- macOS: https://formulae.brew.sh/
  - N/A
- Alpine: https://pkgs.alpinelinux.org/packages
  - N/A
- NixOS/nixpkgs: https://search.nixos.org/packages
  - N/A
