### PR TITLE
bond_core: 2.0.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -388,7 +388,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/bond_core-release.git
-      version: 2.0.0-1
+      version: 2.0.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `2.0.0-2`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros2-gbp/bond_core-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-1`

## bond

```
* Ros2 devel (#54 <https://github.com/ros/bond_core/issues/54>)
* Make Michael Carroll the maintainer (#40 <https://github.com/ros/bond_core/issues/40>)
* Contributors: Karsten Knese, Mikael Arguedas
```

## bond_core

```
* Ros2 devel (#54 <https://github.com/ros/bond_core/issues/54>)
* Make Michael Carroll the maintainer (#40 <https://github.com/ros/bond_core/issues/40>)
* Contributors: Karsten Knese, Mikael Arguedas
```

## bondcpp

```
* Lifecycle support 2 (#67 <https://github.com/ros/bond_core/issues/67>)
* find uuid correctly on ubuntu and osx (#55 <https://github.com/ros/bond_core/issues/55>)
* Ros2 devel (#54 <https://github.com/ros/bond_core/issues/54>)
* Make Michael Carroll the maintainer (#40 <https://github.com/ros/bond_core/issues/40>)
* Contributors: Karsten Knese, Mikael Arguedas, Steve Macenski
```

## smclib

```
* fix deprecation warnings (#56 <https://github.com/ros/bond_core/issues/56>)
* Ros2 devel (#54 <https://github.com/ros/bond_core/issues/54>)
* Make Michael Carroll the maintainer (#40 <https://github.com/ros/bond_core/issues/40>)
* Contributors: Karsten Knese, Mikael Arguedas
```

## test_bond

```
* Lifecycle support 2 (#67 <https://github.com/ros/bond_core/issues/67>)
* find uuid correctly on ubuntu and osx (#55 <https://github.com/ros/bond_core/issues/55>)
* Ros2 devel (#54 <https://github.com/ros/bond_core/issues/54>)
* Make Michael Carroll the maintainer (#40 <https://github.com/ros/bond_core/issues/40>)
* Contributors: Karsten Knese, Mikael Arguedas, Steve Macenski
```
