### PR TITLE
bond_core: 2.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -388,7 +388,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/bond_core-release.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `2.1.0-1`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros2-gbp/bond_core-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-1`

## bond

- No changes

## bond_core

- No changes

## bondcpp

```
* Fix lint and uncrustify issues on Foxy (#78 <https://github.com/ros/bond_core/issues/78>)
* Add build dependencies on pkg-config.
* Contributors: Chris Lalancette, Michael Carroll
```

## smclib

```
* Fix lint and uncrustify issues on Foxy (#78 <https://github.com/ros/bond_core/issues/78>)
* Contributors: Michael Carroll
```

## test_bond

```
* Add build dependencies on pkg-config.
* Contributors: Chris Lalancette
```
