### PR TITLE
Add repository checks for openSUSE

### DIFF
--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -9,6 +9,11 @@ package_sources:
     - !rpm_base_url https://dl.fedoraproject.org/pub/$distname/linux/releases/$releasever/Everything/$basearch/os/
     - !rpm_base_url https://dl.fedoraproject.org/pub/$distname/linux/updates/$releasever/Everything/$basearch/
     - !rpm_base_url https://download1.rpmfusion.org/free/$distname/releases/$releasever/Everything/$basearch/os/
+  opensuse:
+    - !rpm_base_url http://download.opensuse.org/distribution/leap/$releasever/repo/oss/
+    - !rpm_base_url http://download.opensuse.org/distribution/leap/$releasever/repo/non-oss/
+    - !rpm_base_url http://download.opensuse.org/update/leap/$releasever/oss/
+    - !rpm_base_url http://download.opensuse.org/update/leap/$releasever/non-oss/
   rhel:
     - '7':
       - !rpm_base_url https://dl.fedoraproject.org/pub/epel/$releasever/$basearch/
@@ -34,6 +39,8 @@ package_dashboards:
     url: https://packages.debian.org/{os_code_name}/{binary_name}
   - pattern: !regular_expression .*//dl.fedoraproject.org/pub/.*
     url: https://src.fedoraproject.org/rpms/{source_name}#bodhi_updates
+  - pattern: !regular_expression .*//download.opensuse.org/.*
+    url: https://software.opensuse.org/package/{source_name}
   - pattern: !regular_expression .*//archive.ubuntu.com/ubuntu/.*
     url: https://packages.ubuntu.com/{os_code_name}/{binary_name}
 
@@ -44,6 +51,8 @@ supported_versions:
   fedora:
     - '33'
     - '34'
+  opensuse:
+    - '15.2'
   rhel:
     - '7'
     - '8'
@@ -55,6 +64,8 @@ supported_arches:
   debian:
     - amd64
   fedora:
+    - x86_64
+  opensuse:
     - x86_64
   rhel:
     - x86_64


### PR DESCRIPTION
Building on #28902 to add support for openSUSE.

Specifically, I'd like feedback on this change from @neotinker. I'm particularly interested in whether 15.2 is the right version to target at the moment. I don't have any particular interest in supporting openSUSE myself, but its use of RPM repositories means that supporting it in this automation is relatively trivial.

This will result in formal enforcement of new openSUSE rules by PR automation, and would also add suggestions to new incoming rules if openSUSE might contain a package that satisfies the new rule based on some heuristics. More info about this new automation can be found in the referenced PR as well as the [README](https://github.com/ros/rosdistro/blob/master/test/rosdep_repo_check/README.md) that @nuclearsandwich was nice enough to put together.

A manual run using this config shows the following errors exist in the current database:
```
$ time PYTHONPATH=$PWD/test python3 -m rosdep_repo_check
Verify all rosdep keys in 'rosdep/base.yaml'
Reading RPM repository metadata from http://download.opensuse.org/distribution/leap/15.2/repo/oss/repodata/repomd.xml
Reading RPM primary metadata from http://download.opensuse.org/distribution/leap/15.2/repo/oss/repodata/ee17b27ef91d0fb16ac7311f04afe362fe2efeb1a90ff4d97811237ff14e7bec-primary.xml.gz
Reading RPM repository metadata from http://download.opensuse.org/distribution/leap/15.2/repo/non-oss/repodata/repomd.xml
Reading RPM primary metadata from http://download.opensuse.org/distribution/leap/15.2/repo/non-oss/repodata/024773c8cefa59877328aea3abe1841cf160a7443b842f4b47686959b816ed12-primary.xml.gz
Reading RPM repository metadata from http://download.opensuse.org/update/leap/15.2/oss/repodata/repomd.xml
Reading RPM primary metadata from http://download.opensuse.org/update/leap/15.2/oss/repodata/8d1d27973be2c96705dc1bf5bab3a8f48c8665c705502136af192b1f0d69c5d7-primary.xml.gz
Reading RPM repository metadata from http://download.opensuse.org/update/leap/15.2/non-oss/repodata/repomd.xml
Reading RPM primary metadata from http://download.opensuse.org/update/leap/15.2/non-oss/repodata/f2c5c9e9982551ac67144efebce6278e297cd17b4148efbe9f7a8c8c5286ba3c-primary.xml.gz
Verify all rosdep keys in 'rosdep/python.yaml'
* The following 21 packages were not found for opensuse 15.2 on x86_64:
- Package gazebo-devel for rosdep key libgazebo7-dev
- Package gmock-devel for rosdep key libgmock-dev
- Package libconsole_bridge0 for rosdep key libconsole-bridge-dev
- Package libltdl3 for rosdep key libtool
- Package libprotobuf9 for rosdep key protobuf
- Package libstdc++33 for rosdep key libstdc++5
- Package ogre-devel for rosdep key libogre
- Package pcl for rosdep key libpcl-all
- Package pcl for rosdep key libpcl-all-dev
- Package python-catkin_pkg for rosdep key python-catkin-pkg
- Package python-catkin_pkg for rosdep key python-catkin-pkg-modules
- Package python-mlflow for rosdep key python3-mlflow
- Package python-rosdep for rosdep key python-rosdep
- Package python-rosdep for rosdep key python-rosdep-modules
- Package python-rospkg for rosdep key python-rospkg
- Package python-rospkg for rosdep key python-rospkg-modules
- Package python3-pillow for rosdep key python3-pil
- Package python3-rospkg for rosdep key python3-rospkg
- Package python3-rospkg for rosdep key python3-rospkg-modules
- Package urdfdom-devel for rosdep key liburdfdom-dev
- Package urdfdom-headers-devel for rosdep key liburdfdom-headers-dev

real	0m51.187s
user	0m35.181s
sys	0m0.301s
```

We should address these errors somehow. Either the configuration (and documentation) are missing a repository, or these rules need to be updated or removed.