### PR TITLE
network_interface: 3.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4426,7 +4426,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/astuff/network_interface-release.git
-      version: 3.0.0-1
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/astuff/network_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `network_interface` to `3.1.0-1`:

- upstream repository: https://github.com/astuff/network_interface.git
- release repository: https://github.com/astuff/network_interface-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.0.0-1`

## network_interface

```
* Fix CMakeLists.txt include install (#40 <https://github.com/astuff/network_interface/issues/40>)
* UDP Server: Don't send reply if zero length (#38 <https://github.com/astuff/network_interface/issues/38>)
* Add stop function for terminating (#36 <https://github.com/astuff/network_interface/issues/36>)
* UDP Server Class (#35 <https://github.com/astuff/network_interface/issues/35>)
* Fix UDP read function, use buffer of fixed size and shrink down after receiving packet (#33 <https://github.com/astuff/network_interface/issues/33>)
* Contributors: icolwell-as
```
