### PR TITLE
rosdep: nixos: add fcl and libccd

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2607,6 +2607,7 @@ libccd-dev:
   debian: [libccd-dev]
   fedora: [libccd]
   gentoo: [sci-libs/libccd]
+  nixos: [libccd]
   openembedded: [libccd@meta-ros-common]
   ubuntu: [libccd-dev]
 libcdd-dev:
@@ -2849,6 +2850,7 @@ libfcl-dev:
     stretch: [libfcl-dev]
   fedora: [fcl-devel]
   gentoo: [sci-libs/fcl]
+  nixos: [fcl]
   openembedded: [fcl@meta-ros-common]
   ubuntu:
     '*': [libfcl-dev]


### PR DESCRIPTION
Adds NixOS/nixpkgs support for the `libccd-dev` and `libfcl-dev` rosdep keys. I recently added these packages to nixpkgs and they have been released to nixos-unstable.

nixpkgs sources:

* libccd: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/libccd/default.nix
* fcl: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/fcl/default.nix


