### PR TITLE
rosdep: nixos: add python3-importlib-metadata

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6456,6 +6456,7 @@ python3-importlib-metadata:
     '*': [python3]
     '31': [python3-importlib-metadata]
   gentoo: [dev-python/importlib_metadata]
+  nixos: [python3Packages.importlib-metadata]
   openembedded: [python3-importlib-metadata@openembedded-core]
   rhel:
     '*': ['python%{python3_pkgversion}-importlib-metadata']


### PR DESCRIPTION
Adds NixOS/nixpkgs support to the python3-importlib-metadata rosdep key. This is required by ament_package in galactic.

nixpkgs source: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/python-modules/importlib-metadata/default.nix