### PR TITLE
xacro: 1.14.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8780,7 +8780,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.14.6-2
+      version: 1.14.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.14.7-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.14.6-2`

## xacro

```
* [feature] Expose YamlDictWrapper as dotify() to allow dotted access to any dict (#274 <https://github.com/ros/xacro/issues/274>)
* [fix]     Scoped macro evaluation (#272 <https://github.com/ros/xacro/issues/272>)
* Contributors: Robert Haschke
```
