### PR TITLE
xacro: 2.0.6-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -4076,7 +4076,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/xacro.git
-      version: dashing-devel
+      version: ros2
     release:
       tags:
         release: release/dashing/{package}/{version}
@@ -4086,7 +4086,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/xacro.git
-      version: dashing-devel
+      version: ros2
     status: maintained
   yaml_cpp_vendor:
     release:

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -4081,7 +4081,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 2.0.5-1
+      version: 2.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `2.0.6-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.5-1`

## xacro

```
* [feature] Expose YamlDictWrapper as dotify() to allow dotted access to any dict (#274 <https://github.com/ros/xacro/issues/274>)
* [fix]     Scoped macro evaluation (#272 <https://github.com/ros/xacro/issues/272>)
* Contributors: Robert Haschke
```
