### PR TITLE
xacro: 2.0.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5070,7 +5070,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 2.0.5-1
+      version: 2.0.6-1
     source:
       type: git
       url: https://github.com/ros/xacro.git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5065,7 +5065,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/xacro.git
-      version: dashing-devel
+      version: ros2
     release:
       tags:
         release: release/foxy/{package}/{version}
@@ -5074,7 +5074,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/xacro.git
-      version: dashing-devel
+      version: ros2
     status: maintained
   xacro_live:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `2.0.6-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.5-1`

## xacro

```
* [feature] Expose YamlDictWrapper as dotify() to allow dotted access to any dict (#274 <https://github.com/ros/xacro/issues/274>)
* [fix]     Scoped macro evaluation (#272 <https://github.com/ros/xacro/issues/272>)
* Contributors: Robert Haschke
```
