### PR TITLE
rosdep: nixos: use SIP 4

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4566,7 +4566,7 @@ python-sip:
   freebsd: [py27-sip]
   gentoo: [dev-python/sip]
   macports: [py27-sip]
-  nixos: [pythonPackages.sip]
+  nixos: [pythonPackages.sip_4]
   openembedded: [sip@meta-oe]
   opensuse: [python-sip-devel]
   rhel:
@@ -7598,7 +7598,7 @@ python3-sip:
   debian: [python3-sip-dev]
   fedora: [python3-sip]
   gentoo: [dev-python/sip]
-  nixos: [python3Packages.sip]
+  nixos: [python3Packages.sip_4]
   ubuntu: [python3-sip-dev]
 python3-siphon-pip:
   debian:


### PR DESCRIPTION
nixpkgs recently changed the `pythonPackages.sip` attribute to point at SIP 5 (soon to be upgraded to 6). On most other other distributions the python-sip (or similar) package is SIP 4, therefore all ROS packages I know of currently only work with SIP 4. Newer SIP versions have significant changes, making upgrading somewhat involved.

nixpkgs source: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/python-modules/sip/4.x.nix