### PR TITLE
rosdep: nixos: add libomp-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3946,6 +3946,7 @@ libomp-dev:
   arch: [openmp]
   debian: [libomp-dev]
   fedora: [libomp-devel]
+  nixos: [llvmPackages.openmp]
   ubuntu: [libomp-dev]
 libopal-dev:
   debian: [libopal-dev]


### PR DESCRIPTION
Adds NixOS/nixpkgs support for `libomp-dev`.

nixpkgs source: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/compilers/llvm/7/openmp/default.nix