### PR TITLE
object_recognition_msgs: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1426,6 +1426,17 @@ repositories:
       url: https://github.com/vooon/ntpd_driver.git
       version: ros2
     status: maintained
+  object_recognition_msgs:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros-gbp/object_recognition_msgs-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/wg-perception/object_recognition_msgs.git
+      version: ros2
+    status: maintained
   octomap:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_msgs` to `2.0.0-1`:

- upstream repository: https://github.com/wg-perception/object_recognition_msgs.git
- release repository: https://github.com/ros-gbp/object_recognition_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## object_recognition_msgs

```
* Merge pull request #11 <https://github.com/wg-perception/object_recognition_msgs/issues/11> from PickNikRobotics/master
  Port to ROS2
* Suppress -Wredundant-decls warnings (#1 <https://github.com/wg-perception/object_recognition_msgs/issues/1>)
* fixing msg port
* Update package.xml build tool & enable message generation
* Update package.xml format
* Update package.xml dependencies
* Update CMakeLists package command
* Update CMakeLists file list & interface generator command
* Update CMakeLists find_package list
* Default to C++ 14 & cmake C++ flags
* Update CMakeLists cmake version
* Specify Header origin
* Contributors: Jonathan Binney, Michael Lautman, Yu, Yan, ibaiape
```
