### PR TITLE
stubborn_buddies: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3053,6 +3053,24 @@ repositories:
       url: https://github.com/ros2/sros2.git
       version: master
     status: developed
+  stubborn_buddies:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/stubborn_buddies.git
+      version: rolling
+    release:
+      packages:
+      - stubborn_buddies
+      - stubborn_buddies_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/stubborn_buddies-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/stubborn_buddies.git
+      version: rolling
+    status: developed
   system_modes:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `stubborn_buddies` to `1.0.0-1`:

- upstream repository: https://github.com/open-rmf/stubborn_buddies.git
- release repository: https://github.com/ros2-gbp/stubborn_buddies-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
