### PR TITLE
ros2_control: 0.6.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3291,7 +3291,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 0.6.0-1
+      version: 0.6.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `0.6.1-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.6.0-1`

## controller_interface

- No changes

## controller_manager

```
* Add missing dependency on controller_manager_msgs (#426 <https://github.com/ros-controls/ros2_control/issues/426>)
* Contributors: Denis Štogl
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Use correct names after changing arguments (#425 <https://github.com/ros-controls/ros2_control/issues/425>)
  In #412 <https://github.com/ros-controls/ros2_control/issues/412> we forgot to update the argument after changing flags.
* Contributors: Denis Štogl
```

## transmission_interface

- No changes
