### PR TITLE
ur_client_library: 0.2.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13611,7 +13611,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
-      version: 0.2.0-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `0.2.2-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.0-1`

## ur_client_library

```
* Add reverse_ip parameter to UrDriver (#52 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/pull/52>)
* Make calibration check optionally callable
* Use file= fields for license tags in package.xml (#63 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/63>)
* Install the resources folder instead of the script file directly (#62 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/62>)
* Contributors: Felix Exner, JS00000
```
