### PR TITLE
moveit: 2.1.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1876,7 +1876,6 @@ repositories:
       - moveit
       - moveit_common
       - moveit_core
-      - moveit_fake_controller_manager
       - moveit_kinematics
       - moveit_planners
       - moveit_planners_ompl
@@ -1900,7 +1899,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/moveit/moveit2-release.git
-      version: 2.1.3-1
+      version: 2.1.4-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.1.4-1`:

- upstream repository: https://github.com/ros-planning/moveit2.git
- release repository: https://github.com/moveit/moveit2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.3-1`

## moveit

- No changes

## moveit_common

```
* Fix ament_cmake 'buildtool_depend' in moveit_common (#480 <https://github.com/ros-planning/moveit2/issues/480>)
* Contributors: Henning Kayser
```

## moveit_core

```
* PlanningRequestAdapter helper method getParam()  (#468 <https://github.com/ros-planning/moveit2/issues/468>)
  * Implement parameters for adapter plugins
* Contributors: David V. Lu!!
```

## moveit_kinematics

```
* Enable LMA and KDL kinematic launch tests (#435 <https://github.com/ros-planning/moveit2/issues/435>)
* Contributors: Vatan Aksoy Tezer
```

## moveit_planners

- No changes

## moveit_planners_ompl

- No changes

## moveit_plugins

```
* Delete MoveIt fake_controller_manager (#471 <https://github.com/ros-planning/moveit2/issues/471>)
* Contributors: AndyZe
```

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_move_group

- No changes

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

- No changes

## moveit_ros_planning

```
* PlanningRequestAdapter helper method getParam()  (#468 <https://github.com/ros-planning/moveit2/issues/468>)
  * Implement parameters for adapter plugins
* Contributors: David V. Lu!!
```

## moveit_ros_planning_interface

```
* Disable flaky test (#482 <https://github.com/ros-planning/moveit2/issues/482>)
* Delete MoveIt fake_controller_manager (#471 <https://github.com/ros-planning/moveit2/issues/471>)
* Contributors: AndyZe, Vatan Aksoy Tezer
```

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

- No changes

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_servo

```
* Delete MoveIt fake_controller_manager (#471 <https://github.com/ros-planning/moveit2/issues/471>)
* Contributors: AndyZe
```

## moveit_simple_controller_manager

- No changes

## run_move_group

- No changes

## run_moveit_cpp

```
* Delete MoveIt fake_controller_manager (#471 <https://github.com/ros-planning/moveit2/issues/471>)
* Contributors: AndyZe
```

## run_ompl_constrained_planning

- No changes
