### PR TITLE
point_cloud_msg_wrapper: 1.0.6-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1596,11 +1596,15 @@ repositories:
       version: galactic
     status: maintained
   point_cloud_msg_wrapper:
+    doc:
+      type: git
+      url: https://gitlab.com/ApexAI/point_cloud_msg_wrapper
+      version: galactic
     release:
       tags:
         release: release/galactic/{package}/{version}
       url: https://gitlab.com/ApexAI/point_cloud_msg_wrapper-release
-      version: 1.0.5-1
+      version: 1.0.6-1
     source:
       type: git
       url: https://gitlab.com/ApexAI/point_cloud_msg_wrapper


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_msg_wrapper` to `1.0.6-1`:

- upstream repository: https://gitlab.com/ApexAI/point_cloud_msg_wrapper
- release repository: https://gitlab.com/ApexAI/point_cloud_msg_wrapper-release
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.5-1`
