### PR TITLE
py_trees: 2.1.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2489,7 +2489,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/stonier/py_trees-release.git
-      version: 2.1.5-2
+      version: 2.1.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `2.1.6-1`:

- upstream repository: https://github.com/splintered-reality/py_trees.git
- release repository: https://github.com/stonier/py_trees-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.5-2`

## py_trees

```
* [tests] mypy conformance,  #327 <https://github.com/splintered-reality/py_trees/pull/327>
* [composites] show ghost states for sequence children,  #330 <https://github.com/splintered-reality/py_trees/pull/330> (reverts behaviour introduced in #325 <https://github.com/splintered-reality/py_trees/pull/325>)
```
