### PR TITLE
xacro: 2.0.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3606,7 +3606,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/xacro.git
-      version: dashing-devel
+      version: ros2
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -3615,7 +3615,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/xacro.git
-      version: dashing-devel
+      version: ros2
     status: maintained
   yaml_cpp_vendor:
     release:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3611,7 +3611,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/xacro-release.git
-      version: 2.0.2-2
+      version: 2.0.6-1
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `2.0.6-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros2-gbp/xacro-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.2-2`

## xacro

```
* [feature] Expose YamlDictWrapper as dotify() to allow dotted access to any dict (#274 <https://github.com/ros/xacro/issues/274>)
* [fix]     Scoped macro evaluation (#272 <https://github.com/ros/xacro/issues/272>)
* Contributors: Robert Haschke
```
