### PR TITLE
stubborn_buddies: 1.0.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3091,7 +3091,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/stubborn_buddies-release.git
-      version: 1.0.0-1
+      version: 1.0.0-2
     source:
       type: git
       url: https://github.com/open-rmf/stubborn_buddies.git


### PR DESCRIPTION
Increasing version of package(s) in repository `stubborn_buddies` to `1.0.0-2`:

- upstream repository: https://github.com/open-rmf/stubborn_buddies.git
- release repository: https://github.com/ros2-gbp/stubborn_buddies-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.0-1`
