### PR TITLE
rmf_visualization_msgs: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2083,6 +2083,21 @@ repositories:
       url: https://github.com/open-rmf/rmf_utils.git
       version: rolling
     status: developed
+  rmf_visualization_msgs:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_visualization_msgs.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_visualization_msgs-release.git
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_visualization_msgs.git
+      version: rolling
+    status: developed
   rmw:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_visualization_msgs` to `1.2.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_visualization_msgs.git
- release repository: https://github.com/ros2-gbp/rmf_visualization_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
