### PR TITLE
rmf_battery: 0.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2036,7 +2036,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_battery.git
-      version: 0.1.0
+      version: master
     status: developed
   rmf_building_map_msgs:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2023,6 +2023,21 @@ repositories:
       url: https://github.com/ros/resource_retriever.git
       version: ros2
     status: maintained
+  rmf_battery:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_battery.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_battery-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_battery.git
+      version: 0.1.0
+    status: developed
   rmf_building_map_msgs:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2036,7 +2036,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_battery.git
-      version: master
+      version: main
     status: developed
   rmf_building_map_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_battery` to `0.1.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_battery.git
- release repository: https://github.com/ros2-gbp/rmf_battery-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
