### PR TITLE
rmf_traffic_editor: 1.3.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2068,6 +2068,26 @@ repositories:
       url: https://github.com/open-rmf/rmf_traffic.git
       version: rolling
     status: developed
+  rmf_traffic_editor:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_traffic_editor.git
+      version: rolling
+    release:
+      packages:
+      - rmf_building_map_tools
+      - rmf_traffic_editor
+      - rmf_traffic_editor_assets
+      - test_maps
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
+      version: 1.3.0-2
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_traffic_editor.git
+      version: rolling
+    status: developed
   rmf_utils:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_traffic_editor` to `1.3.0-2`:

- upstream repository: https://github.com/open-rmf/rmf_traffic_editor.git
- release repository: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## rmf_building_map_tools

```
* Added support for fuel textures (#342 <https://github.com/open-rmf/rmf_traffic_editor/issues/342>)
* Convert wall textures from 1d to 2d (#338 <https://github.com/open-rmf/rmf_traffic_editor/issues/338>)
* [Optimization] Remove duplicated textures (#337 <https://github.com/open-rmf/rmf_traffic_editor/issues/337>)
* clean dep and update readme (#336 <https://github.com/open-rmf/rmf_traffic_editor/issues/336>)
* building_map_server: don't crash when missing image file (#334 <https://github.com/open-rmf/rmf_traffic_editor/issues/334>)
* Fix material values for sdf compliance (#330 <https://github.com/open-rmf/rmf_traffic_editor/issues/330>)
* avoid crashing when generating undefined floor polygons. cleanup. (#322 <https://github.com/open-rmf/rmf_traffic_editor/issues/322>)
* improve usage of Shapely on very complex floor polygons (#321 <https://github.com/open-rmf/rmf_traffic_editor/issues/321>)
* auto download crowdsim models (#316 <https://github.com/open-rmf/rmf_traffic_editor/issues/316>)
* rename building_map_tools (#310 <https://github.com/open-rmf/rmf_traffic_editor/issues/310>)
* Account for package rename
* Rename packages and delete moved packages (#308 <https://github.com/open-rmf/rmf_traffic_editor/issues/308>)
* migration to open-rmf org, rename to rmf_building_map_tools
* Contributors: Geoffrey Biggs, Luca Della Vedova, Morgan Quigley, youliang
```

## rmf_traffic_editor

```
* Feature/display layer transforms in freefleet format (#347 <https://github.com/open-rmf/rmf_traffic_editor/issues/347>)
* Feature/layer rendering palette mapping (#344 <https://github.com/open-rmf/rmf_traffic_editor/issues/344>)
* Fix asset path after package renaming (#341 <https://github.com/open-rmf/rmf_traffic_editor/issues/341>)
* Automatic alignment of robot-map layers to floorplans (#340 <https://github.com/open-rmf/rmf_traffic_editor/issues/340>)
* Fix/ci package name (#339 <https://github.com/open-rmf/rmf_traffic_editor/issues/339>)
* clarify labels on property add/delete buttons (#326 <https://github.com/open-rmf/rmf_traffic_editor/issues/326>)
* handle editing multiple layers with same name. (#328 <https://github.com/open-rmf/rmf_traffic_editor/issues/328>)
* fix #324 <https://github.com/open-rmf/rmf_traffic_editor/issues/324>, update layer image immediately after OK button (#327 <https://github.com/open-rmf/rmf_traffic_editor/issues/327>)
* Bug/add layer button not visible in new building (#313 <https://github.com/open-rmf/rmf_traffic_editor/issues/313>)
* provide zoom-reset and clamp on scale factor (#318 <https://github.com/open-rmf/rmf_traffic_editor/issues/318>)
* avoid crash in empty crowdsim save routine (#312 <https://github.com/open-rmf/rmf_traffic_editor/issues/312>)
* rename building_map_tools (#310 <https://github.com/open-rmf/rmf_traffic_editor/issues/310>)
* Rename packages and delete moved packages (#308 <https://github.com/open-rmf/rmf_traffic_editor/issues/308>)
* Refactoring and Migration #308 https://github.com/open-rmf/rmf_traffic_editor/pull/308
* Contributors: Geoffrey Biggs, Luca Della Vedova, Morgan Quigley, youliang
```

## rmf_traffic_editor_assets

```
* Rename package
* Merge remote-tracking branch 'sourcedir/master'
* Move files in preparation for repository shift
* Contributors: Geoffrey Biggs
```

## test_maps

```
* rename building_map_tools (#310 <https://github.com/open-rmf/rmf_traffic_editor/issues/310>)
* Rename packages and delete moved packages (#308 <https://github.com/open-rmf/rmf_traffic_editor/issues/308>)
* Contributors: Geoffrey Biggs, youliang
```
