### PR TITLE
menge_vendor: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1292,6 +1292,21 @@ repositories:
       url: https://github.com/mavlink/mavlink-gbp-release.git
       version: release/rolling/mavlink
     status: developed
+  menge_vendor:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/menge_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/menge_vendor-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/menge_vendor.git
+      version: rolling
+    status: developed
   message_filters:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `menge_vendor` to `1.0.0-1`:

- upstream repository: https://github.com/open-rmf/menge_vendor.git
- release repository: https://github.com/ros2-gbp/menge_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## menge_vendor

```
* fix find_package problem when installed (#1 <https://github.com/osrf/menge_core/issues/1>)
* menge core
* Contributors: Marco A. Gutiérrez, Shao Guoliang, flooshao
```
