### PR TITLE
Added packages for the Rust compiler and Cargo

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -448,15 +448,15 @@ can-utils:
   fedora: [can-utils]
   nixos: [can-utils]
   ubuntu: [can-utils]
+cargo:
+  debian: [cargo]
+  ubuntu: [cargo]
 castxml:
   arch: [castxml]
   debian: [castxml]
   fedora: [castxml]
   macports: [castxml]
   ubuntu: [castxml]
-cargo:
-  debian: [cargo]
-  ubuntu: [cargo]
 cccc:
   debian: [cccc]
   gentoo: [dev-util/cccc]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6747,8 +6747,10 @@ rtmidi:
   nixos: [rtmidi]
   ubuntu: [librtmidi-dev]
 rustc:
+  archlinux: [rust]
   debian: [rustc]
   fedora: [rust]
+  opensuse: [rust]
   rhel: [rust]
   ubuntu: [rustc]
 sbcl:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -449,6 +449,7 @@ can-utils:
   nixos: [can-utils]
   ubuntu: [can-utils]
 cargo:
+  archlinux: [rust]
   debian: [cargo]
   fedora: [cargo]
   rhel: [cargo]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -450,6 +450,8 @@ can-utils:
   ubuntu: [can-utils]
 cargo:
   debian: [cargo]
+  fedora: [cargo]
+  rhel: [cargo]
   ubuntu: [cargo]
 castxml:
   arch: [castxml]
@@ -6744,6 +6746,8 @@ rtmidi:
   ubuntu: [librtmidi-dev]
 rustc:
   debian: [rustc]
+  fedora: [rust]
+  rhel: [rust]
   ubuntu: [rustc]
 sbcl:
   alpine: [sbcl]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -454,6 +454,9 @@ castxml:
   fedora: [castxml]
   macports: [castxml]
   ubuntu: [castxml]
+cargo:
+  debian: [cargo]
+  ubuntu: [cargo]
 cccc:
   debian: [cccc]
   gentoo: [dev-util/cccc]
@@ -6739,6 +6742,9 @@ rtmidi:
   fedora: [rtmidi-devel]
   nixos: [rtmidi]
   ubuntu: [librtmidi-dev]
+rustc:
+  debian: [rustc]
+  ubuntu: [rustc]
 sbcl:
   alpine: [sbcl]
   arch: [sbcl]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -452,6 +452,7 @@ cargo:
   archlinux: [rust]
   debian: [cargo]
   fedora: [cargo]
+  opensuse: [cargo]
   rhel: [cargo]
   ubuntu: [cargo]
 castxml:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

cargo
rustc

## Package Upstream Source:

https://github.com/rust-lang/cargo
https://github.com/rust-lang/rust

## Purpose of using this:

These two packages are being used by colcon-cargo, colcon-ros-cargo, rclrs and rclrs_common

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=cargo
  - https://packages.debian.org/search?keywords=rustc
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=cargo
  - https://packages.ubuntu.com/search?keywords=rustc