### PR TITLE
Fix the python3-pykdl rule for Debian

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7100,8 +7100,7 @@ python3-pygraphviz:
 python3-pykdl:
   debian:
     '*': [python3-pykdl]
-    'bionic': null
-    'xenial': null
+    stretch: null
   fedora:
     '*': [python3-pykdl]
     '30': null


### PR DESCRIPTION
It looks like there was some confusion when the Debian rules were made. This should resolve the CI failures I'm seeing in #29743.

https://packages.debian.org/search?keywords=python3-pykdl&searchon=names&exact=1&suite=all&section=all