### PR TITLE
plotjuggler_ros: 1.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2421,7 +2421,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
-      version: 1.1.1-4
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler_ros` to `1.2.0-1`:

- upstream repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
- release repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.1-4`

## plotjuggler_ros

```
* fix issue #15 <https://github.com/PlotJuggler/plotjuggler-ros-plugins/issues/15> for ROS1 too
* Merge pull request #4 <https://github.com/PlotJuggler/plotjuggler-ros-plugins/issues/4> from Tobias-Fischer/patch-1
  Fix Windows compilation
* fix bugs related to TopicPublishers (ros2)
* Fix isnan issues on Win
* Fix isnan compilation issue on Win
* Fix double-defined ERROR
* Contributors: Davide Faconti, Tobias Fischer
```
