### PR TITLE
paho-mqtt-c: 1.3.8-8 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4851,7 +4851,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/nobleo/paho.mqtt.c-release.git
-      version: 1.3.8-7
+      version: 1.3.8-8
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `paho-mqtt-c` to `1.3.8-8`:

- upstream repository: https://github.com/eclipse/paho.mqtt.c.git
- release repository: https://github.com/nobleo/paho.mqtt.c-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.3.8-7`
