### PR TITLE
cyclonedds: 0.8.0-5 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -466,7 +466,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/cyclonedds-release.git
-      version: 0.8.0-3
+      version: 0.8.0-5
     source:
       type: git
       url: https://github.com/eclipse-cyclonedds/cyclonedds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cyclonedds` to `0.8.0-5`:

- upstream repository: https://github.com/eclipse-cyclonedds/cyclonedds.git
- release repository: https://github.com/ros2-gbp/cyclonedds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.8.0-3`
