### PR TITLE
rmf_task: 0.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2108,6 +2108,21 @@ repositories:
       url: https://github.com/open-rmf/rmf_internal_msgs.git
       version: rolling
     status: developed
+  rmf_task:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_task.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_task-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_task.git
+      version: rolling
+    status: developed
   rmf_traffic:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_task` to `0.1.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_task.git
- release repository: https://github.com/ros2-gbp/rmf_task-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
