### PR TITLE
rmw_fastrtps: 5.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2258,7 +2258,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 5.1.0-1
+      version: 5.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `5.2.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `5.1.0-1`

## rmw_fastrtps_cpp

```
* Add rmw_publisher_wait_for_all_acked support. (#519 <https://github.com/ros2/rmw_fastrtps/issues/519>)
* Contributors: Barry Xu
```

## rmw_fastrtps_dynamic_cpp

```
* Add rmw_publisher_wait_for_all_acked support. (#519 <https://github.com/ros2/rmw_fastrtps/issues/519>)
* Contributors: Barry Xu
```

## rmw_fastrtps_shared_cpp

```
* Add rmw_publisher_wait_for_all_acked support. (#519 <https://github.com/ros2/rmw_fastrtps/issues/519>)
* Contributors: Barry Xu
```
