### PR TITLE
leo_common: 1.2.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5577,7 +5577,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_common-release.git
-      version: 1.2.1-1
+      version: 1.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_common` to `1.2.2-1`:

- upstream repository: https://github.com/LeoRover/leo_common.git
- release repository: https://github.com/fictionlab-gbp/leo_common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.1-1`

## leo

```
* Update author and maintainer info
```

## leo_description

```
* Fix swapped FR and RR wheels
* Update author and maintainer info
```

## leo_teleop

```
* Add key_teleop.launch which starts the key teleop node in xterm
* use exec in key_teleop script to not spawn another process
* Update author and maintainer info
```
