### PR TITLE
geographic_info: 0.5.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2326,6 +2326,10 @@ repositories:
       version: kinetic-devel
     status: maintained
   geographic_info:
+    doc:
+      type: git
+      url: https://github.com/ros-geographic-info/geographic_info.git
+      version: master
     release:
       packages:
       - geodesy
@@ -2334,7 +2338,11 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-geographic-info/geographic_info-release.git
-      version: 0.5.5-1
+      version: 0.5.6-1
+    source:
+      type: git
+      url: https://github.com/ros-geographic-info/geographic_info.git
+      version: master
     status: maintained
   geometric_shapes:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `geographic_info` to `0.5.6-1`:

- upstream repository: https://github.com/ros-geographic-info/geographic_info.git
- release repository: https://github.com/ros-geographic-info/geographic_info-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.5.5-1`
