### PR TITLE
Revert "control_msgs: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]"

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -455,7 +455,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/control_msgs-release.git
-      version: 3.0.0-1
+      version: 2.5.0-3
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
This revert is proposed in order to resolve package build failures due to an outdated bloom version used for the release. An alternative to this PR would be a new release of control_msgs 3.0.0 using bloom 0.10.7.

Reverts ros/rosdistro#29691