### PR TITLE
Add rosdep rules for git-lfs package

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1326,16 +1326,6 @@ git:
   opensuse: [git-core]
   rhel: [git]
   ubuntu: [git]
-gitg:
-  debian: [gitg]
-  fedora: [gitg]
-  gentoo: [dev-vcs/gitg]
-  nixos: [gitg]
-  ubuntu: [gitg]
-gitk:
-  debian: [gitk]
-  fedora: [gitk]
-  ubuntu: [gitk]
 git-lfs:
   alpine: [git-lfs]
   arch: [git-lfs]
@@ -1350,6 +1340,16 @@ git-lfs:
   opensuse: [git-lfs]
   rhel: [git-lfs]
   ubuntu: [git-lfs]
+gitg:
+  debian: [gitg]
+  fedora: [gitg]
+  gentoo: [dev-vcs/gitg]
+  nixos: [gitg]
+  ubuntu: [gitg]
+gitk:
+  debian: [gitk]
+  fedora: [gitk]
+  ubuntu: [gitk]
 gksu:
   debian: [gksu]
   gentoo: [x11-libs/gksu]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1339,7 +1339,9 @@ gitk:
 git-lfs:
   alpine: [git-lfs]
   arch: [git-lfs]
-  debian: [git-lfs]
+  debian:
+    '*': [git-lfs]
+    stretch: null
   fedora: [git-lfs]
   freebsd: [git-lfs]
   gentoo: [dev-vcs/git-lfs]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1336,6 +1336,18 @@ gitk:
   debian: [gitk]
   fedora: [gitk]
   ubuntu: [gitk]
+git-lfs:
+  alpine: [git-lfs]
+  arch: [git-lfs]
+  debian: [git-lfs]
+  fedora: [git-lfs]
+  freebsd: [git-lfs]
+  gentoo: [dev-vcs/git-lfs]
+  macports: [git-lfs]
+  nixos: [git-lfs]
+  opensuse: [git-lfs]
+  rhel: [git-lfs]
+  ubuntu: [git-lfs]
 gksu:
   debian: [gksu]
   gentoo: [x11-libs/gksu]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

## Package name:

git-lfs

## Package Upstream Source:

https://github.com/git-lfs/git-lfs

## Purpose of using this:

I would like to download the trained data with git-lfs when using ROS packages that use DNN.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/sid/git-lfs
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/bionic/vcs/git-lfs
- Fedora: https://src.fedoraproject.org/browse/projects/
  - https://src.fedoraproject.org/rpms/git-lfs
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/community/x86_64/git-lfs/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-vcs/git-lfs
- macOS: https://formulae.brew.sh/
  - N/A
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/v3.7/community/x86/git-lfs
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://hydra.nixos.org/job/nixos/release-21.05/nixpkgs.git-lfs.x86_64-linux
- FreeBSD
  - https://freebsd.pkgs.org/13/freebsd-amd64/git-lfs-2.13.3.txz.html
- RHEL
  - https://koji.fedoraproject.org/koji/rpminfo?rpmID=21513967
- MacPorts
  - https://ports.macports.org/port/git-lfs/summary
- OpenSUSE
  - https://software.opensuse.org/package/git-lfs