### PR TITLE
mavros: 2.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1817,7 +1817,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `2.0.1-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-1`

## libmavconn

```
* Merge branch 'master' into ros2
  * master:
  readme: update
  1.8.0
  update changelog
  Create semgrep-analysis.yml
  Create codeql-analysis.yml
* 1.8.0
* update changelog
* Contributors: Vladimir Ermakov
```

## mavros

```
* readme: update source build instruction
* Merge branch 'master' into ros2
  * master:
  readme: update
  1.8.0
  update changelog
  Create semgrep-analysis.yml
  Create codeql-analysis.yml
* 1.8.0
* update changelog
* Contributors: Vladimir Ermakov
```

## mavros_msgs

```
* Add rcl_interfaces dependency
* Merge branch 'master' into ros2
  * master:
  readme: update
  1.8.0
  update changelog
  Create semgrep-analysis.yml
  Create codeql-analysis.yml
* 1.8.0
* update changelog
* Contributors: Rob Clarke, Vladimir Ermakov
```
