### PR TITLE
ros2_control: 0.7.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3294,7 +3294,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 0.6.1-1
+      version: 0.7.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `0.7.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.1-1`

## controller_interface

```
* Add imu_sensor semantic component (#429 <https://github.com/ros-controls/ros2_control/issues/429>)
* Fix osx warnings (#428 <https://github.com/ros-controls/ros2_control/issues/428>)
* Add FTS as first semantic components to simplify controllers. (#370 <https://github.com/ros-controls/ros2_control/issues/370>)
* Contributors: bailaC, Denis Štogl, Jordan Palacios, Karsten Knese, Victor Lopez
```

## controller_manager

- No changes

## controller_manager_msgs

- No changes

## hardware_interface

```
* Add FTS as first semantic components to simplify controllers. (#370 <https://github.com/ros-controls/ros2_control/issues/370>)
* Contributors: bailaC, Denis Štogl, Jordan Palacios
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Updated arg reference to set_state from state since the argument name has been changed (#433 <https://github.com/ros-controls/ros2_control/issues/433>)
* Contributors: Andrew Lycas
```

## transmission_interface

- No changes
