### PR TITLE
turtlebot3_autorace_2020: 1.1.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8118,6 +8118,28 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/turtlebot3.git
       version: noetic-devel
     status: developed
+  turtlebot3_autorace_2020:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_autorace_2020.git
+      version: master
+    release:
+      packages:
+      - turtlebot3_autorace_2020
+      - turtlebot3_autorace_camera
+      - turtlebot3_autorace_core
+      - turtlebot3_autorace_detect
+      - turtlebot3_autorace_driving
+      - turtlebot3_autorace_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace_2020_release.git
+      version: 1.1.0-2
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_autorace_2020.git
+      version: master
+    status: developed
   turtlebot3_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_autorace_2020` to `1.1.0-2`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_autorace_2020.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace_2020_release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## turtlebot3_autorace_2020

```
* Noetic package release
* Contributors: Ashe Kim, Will Son
```

## turtlebot3_autorace_camera

```
* Noetic package release
* Contributors: Ashe Kim, Will Son
```

## turtlebot3_autorace_detect

```
* Noetic package release
* Contributors: Ashe Kim, Will Son
```

## turtlebot3_autorace_driving

```
* Noetic package release
* Contributors: Ashe Kim, Will Son
```

## turtlebot3_autorace_msgs

```
* Noetic package release
* Contributors: Ashe Kim, Will Son
```
