### PR TITLE
joystick_drivers: 1.15.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3048,13 +3048,11 @@ repositories:
       packages:
       - joy
       - joystick_drivers
-      - ps3joy
       - spacenav_node
-      - wiimote
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/joystick_drivers-release.git
-      version: 1.15.0-1
+      version: 1.15.1-1
     source:
       type: git
       url: https://github.com/ros-drivers/joystick_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `joystick_drivers` to `1.15.1-1`:

- upstream repository: https://github.com/ros-drivers/joystick_drivers.git
- release repository: https://github.com/ros-gbp/joystick_drivers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.15.0-1`

## joy

- No changes

## joystick_drivers

- No changes

## spacenav_node

- No changes
