### PR TITLE
Disable Noetic devel job for MoveIt

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4059,10 +4059,6 @@ repositories:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
       version: 1.1.5-1
-    source:
-      type: git
-      url: https://github.com/ros-planning/moveit.git
-      version: noetic-devel
     status: maintained
   moveit_calibration:
     doc:


### PR DESCRIPTION
... as it timeouts since ages: https://build.ros.org/job/Ndev__moveit__ubuntu_focal_amd64