### PR TITLE
rmf_ros2: 1.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2108,6 +2108,26 @@ repositories:
       url: https://github.com/open-rmf/rmf_internal_msgs.git
       version: rolling
     status: developed
+  rmf_ros2:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_ros2.git
+      version: rolling
+    release:
+      packages:
+      - rmf_fleet_adapter
+      - rmf_fleet_adapter_python
+      - rmf_task_ros2
+      - rmf_traffic_ros2
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_ros2-release.git
+      version: 1.3.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_ros2.git
+      version: main
+    status: developed
   rmf_task:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_ros2` to `1.3.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_ros2.git
- release repository: https://github.com/ros2-gbp/rmf_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
