### PR TITLE
parameter_pa: 1.2.3-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4899,6 +4899,11 @@ repositories:
       type: git
       url: https://github.com/tuc-proaut/ros_parameter.git
       version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/TUC-ProAut/ros_parameter-release.git
+      version: 1.2.3-2
     source:
       type: git
       url: https://github.com/tuc-proaut/ros_parameter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `parameter_pa` to `1.2.3-2`:

- upstream repository: https://github.com/TUC-ProAut/ros_parameter.git
- release repository: https://github.com/TUC-ProAut/ros_parameter-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## parameter_pa

```
* bumped cmake Version to 3.0.2 to avoid CMP0048
* Contributors: Peter Weissig
```
