### PR TITLE
neo_local_planner: 1.0.1-1 in 'noetic/distribution.yaml'

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4352,6 +4352,17 @@ repositories:
       url: https://github.com/TUC-ProAut/ros_nearfield_map.git
       version: master
     status: maintained
+  neo_local_planner:
+    doc:
+      type: git
+      url: https://github.com/neobotix/neo_local_planner.git
+      version: noetic
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/neobotix/neo_local_planner-release.git
+      version: 1.0.1-1
+    status: maintained
   neonavigation:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

noetic

# The source is here: 

https://github.com/neobotix/neo_local_planner



# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
