### PR TITLE
system_modes: 0.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3209,13 +3209,15 @@ repositories:
       version: master
     release:
       packages:
+      - launch_system_modes
       - system_modes
       - system_modes_examples
       - system_modes_msgs
+      - test_launch_system_modes
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/system_modes-release.git
-      version: 0.7.1-5
+      version: 0.8.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `system_modes` to `0.8.0-1`:

- upstream repository: https://github.com/micro-ROS/system_modes.git
- release repository: https://github.com/ros2-gbp/system_modes-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.1-5`

## launch_system_modes

```
* Launch integration, i.e. launch actions, events, and event handlers for system modes
```

## system_modes

```
* Launch integration, i.e. launch actions, events, and event handlers for system modes
```

## system_modes_examples

```
* Launch integration, i.e. launch actions, events, and event handlers for system modes
```

## system_modes_msgs

```
* Launch integration, i.e. launch actions, events, and event handlers for system modes
```

## test_launch_system_modes

```
* Launch integration, i.e. launch actions, events, and event handlers for system modes
```
