### PR TITLE
system_modes: 0.8.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4441,13 +4441,15 @@ repositories:
       version: master
     release:
       packages:
+      - launch_system_modes
       - system_modes
       - system_modes_examples
       - system_modes_msgs
+      - test_launch_system_modes
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/microROS/system_modes-release.git
-      version: 0.7.1-4
+      version: 0.8.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `system_modes` to `0.8.0-1`:

- upstream repository: https://github.com/micro-ROS/system_modes.git
- release repository: https://github.com/microROS/system_modes-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.1-4`

## launch_system_modes

```
* Launch integration, i.e. launch actions, events, and event handlers for system modes
```

## system_modes

```
* Launch integration, i.e. launch actions, events, and event handlers for system modes
```

## system_modes_examples

```
* Launch integration, i.e. launch actions, events, and event handlers for system modes
```

## system_modes_msgs

```
* Launch integration, i.e. launch actions, events, and event handlers for system modes
```

## test_launch_system_modes

```
* Launch integration, i.e. launch actions, events, and event handlers for system modes
```
