### PR TITLE
Add python-absl-py-pip to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -437,7 +437,7 @@ python-absl-py-pip:
   debian:
     pip:
       packages: [absl-py]
-    fedora:
+  fedora:
     pip:
       packages: [absl-py]
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -433,6 +433,16 @@ python:
     yakkety_python3: [python3-dev]
     zesty: [python-dev]
     zesty_python3: [python3-dev]
+python-absl-py-pip:
+  debian:
+    pip:
+      packages: [absl-py]
+    fedora:
+    pip:
+      packages: [absl-py]
+  ubuntu:
+    pip:
+      packages: [absl-py]
 python-adafruit-bno055-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

[absl-py](https://github.com/abseil/abseil-py)

## Package Upstream Source:

https://github.com/abseil/abseil-py

## Purpose of using this:
This dependency is often used to build Bazel-baed application in python.
https://github.com/stepjam/RLBench is an example project that uses absl-py.

## Links to Distribution Packages
PIP packaging link:
https://pypi.org/project/absl-py/
Documentation link:
https://abseil.io/docs/python/quickstart.html