### PR TITLE
tvm_vendor: 0.7.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4700,7 +4700,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/autowarefoundation/tvm_vendor-release.git
-      version: 0.7.2-1
+      version: 0.7.3-1
     source:
       type: git
       url: https://github.com/autowarefoundation/tvm_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tvm_vendor` to `0.7.3-1`:

- upstream repository: https://github.com/autowarefoundation/tvm_vendor.git
- release repository: https://github.com/autowarefoundation/tvm_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.2-1`

## tvm_vendor

```
* Merge pull request #6 <https://github.com/autowarefoundation/tvm_vendor/issues/6> from kurcha01-arm/main
  Fix 'No source or binary directory provided'
* Merge pull request #5 <https://github.com/autowarefoundation/tvm_vendor/issues/5> from kurcha01-arm/main
  Fix header inclusion, export without namespacing
* Merge pull request #4 <https://github.com/autowarefoundation/tvm_vendor/issues/4> from kurcha01-arm/main
  Fix dlpack and tvm-runtime header inclusion
* Merge pull request #3 <https://github.com/autowarefoundation/tvm_vendor/issues/3> from ambroise-arm/vulkan-backend
  Add Vulkan backend
* Contributors: Ambroise Vincent, Joshua Whitley, Kurtis Charnock
```
