### PR TITLE
Add spirv-headers and spirv-tools keys for rhel

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6990,6 +6990,7 @@ spirv-headers:
   debian: [spirv-headers]
   fedora: [spirv-headers-devel]
   gentoo: [dev-util/spirv-headers]
+  rhel: [spirv-headers-devel]
   ubuntu:
     '*': [spirv-headers]
     bionic: null
@@ -6999,6 +7000,7 @@ spirv-tools:
   debian: [spirv-tools]
   fedora: [spirv-tools, spirv-tools-devel, spirv-tools-libs]
   gentoo: [dev-util/spirv-tools]
+  rhel: [spirv-tools]
   ubuntu:
     '*': [spirv-tools]
     bionic: null


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

- `spirv-headers`
- `spirv-tools`

## Purpose of using this:

The package `tvm_vendor` depends on these packages. The keys are already available in other distros.

## Links to Distribution Packages

RHEL doesn't allow package searching without a subscription but they appear to be available in the Fedora package index:

- [spirv-headers](https://rpms.remirepo.net/rpmphp/zoom.php?rpm=spirv-headers)
- [spirv-tools](https://rpms.remirepo.net/rpmphp/zoom.php?rpm=spirv-tools)