### PR TITLE
Add vulkan keys for RHEL 8

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5338,6 +5338,9 @@ libvulkan-dev:
   debian: [libvulkan-dev]
   fedora: [vulkan-devel]
   gentoo: [media-libs/vulkan-loader]
+  rhel:
+    '7': [vulkan]
+    '8': [vulkan-loader, vulkan-headers]
   ubuntu:
     '*': [libvulkan-dev]
     trusty: null

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5339,8 +5339,8 @@ libvulkan-dev:
   fedora: [vulkan-devel]
   gentoo: [media-libs/vulkan-loader]
   rhel:
-    '7': [vulkan]
-    '8': [vulkan-loader, vulkan-headers]
+    '7': [vulkan-devel]
+    '8': [vulkan-loader-devel, vulkan-headers]
   ubuntu:
     '*': [libvulkan-dev]
     trusty: null


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

- `libvulkan-dev`

## Package Upstream Source:

- https://github.com/KhronosGroup/Vulkan-Headers
- https://github.com/KhronosGroup/Vulkan-Loader

## Purpose of using this:

Dependency of `tvm_vendor`.

Distro packaging links:

## Links to Distribution Packages

- RHEL
  - 7:
    - https://src.fedoraproject.org/rpms/vulkan
  - 8:
    - https://src.fedoraproject.org/rpms/vulkan-loader
    - https://src.fedoraproject.org/rpms/vulkan-headers