### PR TITLE
ament_cmake_catch2: 1.2.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -61,7 +61,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/ament_cmake_catch2.git
-      version: gallactic
+      version: galactic
     release:
       tags:
         release: release/galactic/{package}/{version}
@@ -70,7 +70,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/ament_cmake_catch2.git
-      version: main
+      version: galactic
     status: developed
   ament_cmake_ros:
     doc:

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -57,6 +57,21 @@ repositories:
       url: https://github.com/ament/ament_cmake.git
       version: galactic
     status: developed
+  ament_cmake_catch2:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/ament_cmake_catch2.git
+      version: gallactic
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_cmake_catch2-release.git
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/ament_cmake_catch2.git
+      version: main
+    status: developed
   ament_cmake_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake_catch2` to `1.2.0-1`:

- upstream repository: https://github.com/open-rmf/ament_cmake_catch2.git
- release repository: https://github.com/ros2-gbp/ament_cmake_catch2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
