### PR TITLE
menge_vendor: 1.0.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1245,6 +1245,21 @@ repositories:
       url: https://github.com/mavlink/mavlink-gbp-release.git
       version: release/galactic/mavlink
     status: developed
+  menge_vendor:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/menge_vendor.git
+      version: galactic
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/menge_vendor-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/menge_vendor.git
+      version: master
+    status: developed
   message_filters:
     doc:
       type: git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1258,7 +1258,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/menge_vendor.git
-      version: master
+      version: galactic
     status: developed
   message_filters:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `menge_vendor` to `1.0.0-1`:

- upstream repository: https://github.com/open-rmf/menge_vendor.git
- release repository: https://github.com/ros2-gbp/menge_vendor-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## menge_vendor

```
* fix find_package problem when installed (#1 <https://github.com/osrf/menge_core/issues/1>)
* menge core
* Contributors: Marco A. Gutiérrez, Shao Guoliang, flooshao
```
