### PR TITLE
rmf_cmake_uncrustify: 1.2.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1971,6 +1971,21 @@ repositories:
       url: https://github.com/ros/resource_retriever.git
       version: galactic
     status: maintained
+  rmf_cmake_uncrustify:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_cmake_uncrustify.git
+      version: galactic
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_cmake_uncrustify-release.git
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_cmake_uncrustify.git
+      version: galactic
+    status: developed
   rmw:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_cmake_uncrustify` to `1.2.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_cmake_uncrustify.git
- release repository: https://github.com/ros2-gbp/rmf_cmake_uncrustify-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
