### PR TITLE
control_toolbox: 2.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -461,6 +461,21 @@ repositories:
       url: https://github.com/ros-controls/control_msgs.git
       version: foxy-devel
     status: maintained
+  control_toolbox:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/control_toolbox.git
+      version: ros2-master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros-gbp/control_toolbox-release.git
+      version: 2.0.2-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/control_toolbox.git
+      version: ros2-master
+    status: maintained
   cyclonedds:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `2.0.2-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros-gbp/control_toolbox-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## control_toolbox

```
* remove unused variables
* Update visibility_control.hpp
* Windows bringup.
* Contributors: Karsten Knese, Sean Yen, Bence Magyar
```
