### PR TITLE
Revert the release of librealsense 2.45.0-1 in Dashing.

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1488,22 +1488,23 @@ repositories:
       url: https://github.com/lgsvl/lgsvl_msgs.git
       version: dashing-devel
     status: developed
-  librealsense2:
+  librealsense:
     doc:
       type: git
       url: https://github.com/IntelRealSense/librealsense.git
-      version: master
+      version: ros2debian
     release:
+      packages:
+      - librealsense2
       tags:
         release: release/dashing/{package}/{version}
-      url: https://github.com/IntelRealSense/librealsense2-release.git
-      version: 2.45.0-1
+      url: https://github.com/ros2-gbp/librealsense-release.git
+      version: 2.16.5-1
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/IntelRealSense/librealsense.git
-      version: master
-    status: developed
+      version: ros2debian
+    status: maintained
   libyaml_vendor:
     release:
       tags:


### PR DESCRIPTION
From the discussion in https://github.com/ros/rosdistro/pull/29474#issuecomment-856224741 it seems like this release includes substantial changes from previous Dashing releases of this project and while these changes are unquestionably improvements for both ROS and upstream, this substantial change has presented build difficulties on the build farm in testing which suggests that independent users are likely to encounter issues as well. Since we're preparing for the [final sync of Dashing](https://discourse.ros.org/t/preparing-for-final-dashing-sync-and-patch-release/20524) it makes the most sense to stick with the previous release, as long as it builds successfully once this is merged, in order to avoid de-stabilizing a stable distribution in its final moments of support.
