### PR TITLE
Add python3 pyftpdlib

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7059,6 +7059,7 @@ python3-pydot:
 python3-pyftpdlib:
   debian: [python3-pyftpdlib]
   gentoo: [dev-python/pyftpdlib]
+  opensuse: [python3-pyftpdlib]
   ubuntu: [python3-pyftpdlib]
 python3-pygame:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7056,6 +7056,10 @@ python3-pydot:
     '*': ['python%{python3_pkgversion}-pydot']
     '7': null
   ubuntu: [python3-pydot]
+python3-pyftpdlib:
+  debian: [python3-pyftpdlib]
+  gentoo: [dev-python/pyftpdlib]
+  ubuntu: [python3-pyftpdlib]
 python3-pygame:
   debian:
     '*': [python3-pygame]


### PR DESCRIPTION
## Package name:

`python3-pyftpdlib`
(see [`python-pyftpdlib`](https://github.com/ros/rosdistro/blob/c44c3aae0ba932f98922f7573672e73d73f5e855/rosdep/python.yaml#L3497))

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=python3-pyftpdlib
- Ubuntu: https://packages.ubuntu.com/search?suite=all&searchon=names&keywords=pyftpdlib
- Gentoo: https://packages.gentoo.org/packages/search?q=pyftpdlib
- OpenSUSE: https://software.opensuse.org/package/python3-pyftpdlib