### PR TITLE
rosdep: add python3-pydbus package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7044,6 +7044,14 @@ python3-pydantic:
       pip: [pydantic]
     xenial:
       pip: [pydantic]
+python3-pydbus:
+  debian: [python3-pydbus]
+  fedora: [python3-pydbus]
+  opensuse: [python3-pydbus]
+  rhel:
+    '*': ['python%{python3_pkgversion}-pydbus']
+    '7': null
+  ubuntu: [python3-pydbus]
 python3-pydot:
   alpine: [py3-pydot]
   arch: [python-pydot]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-pydbus

## Package Upstream Source:

https://github.com/LEW21/pydbus

## Purpose of using this:

This provides a python3 version of the already provided python-pydbus,
which is useful for interacting with dbus for things like systemd unit
manipulation.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/buster/python3-pydbus
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/focal/python3-pydbus
- Fedora: https://src.fedoraproject.org/browse/projects/
  - https://src.fedoraproject.org/rpms/python-pydbus
