### PR TITLE
Revert "realsense2_camera: 3.2.1-1 in 'dashing/distribution.yaml' [bloom] (#29484)"

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2389,26 +2389,6 @@ repositories:
       url: https://github.com/ros2/rcutils.git
       version: dashing
     status: developed
-  realsense2_camera:
-    doc:
-      type: git
-      url: https://github.com/IntelRealSense/realsense-ros.git
-      version: ros2
-    release:
-      packages:
-      - realsense2_camera
-      - realsense2_camera_msgs
-      - realsense2_description
-      tags:
-        release: release/dashing/{package}/{version}
-      url: https://github.com/IntelRealSense/realsense-ros-release.git
-      version: 3.2.1-1
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/IntelRealSense/realsense-ros.git
-      version: ros2
-    status: developed
   realtime_support:
     doc:
       type: git


### PR DESCRIPTION
This version of the realsense2_camera project is intended to work with
librealsense 2.45.0 which was previously reverted in #29820.
