### PR TITLE
Add several boost rules for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2216,6 +2216,7 @@ libboost-atomic:
   nixos: [boost]
   openembedded: [boost@openembedded-core]
   opensuse: [libboost_atomic1_66_0]
+  rhel: [boost-atomic]
   ubuntu:
     bionic: [libboost-atomic1.65.1]
     eoan: [libboost-atomic1.67.0]
@@ -2239,6 +2240,7 @@ libboost-chrono:
   nixos: [boost]
   openembedded: [boost@openembedded-core]
   opensuse: [libboost_chrono1_66_0]
+  rhel: [boost-chrono]
   ubuntu:
     bionic: [libboost-chrono1.65.1]
     eoan: [libboost-chrono1.67.0]
@@ -2262,6 +2264,7 @@ libboost-date-time:
   nixos: [boost]
   openembedded: [boost@openembedded-core]
   opensuse: [libboost_date_time1_66_0]
+  rhel: [boost-date-time]
   ubuntu:
     bionic: [libboost-date-time1.65.1]
     eoan: [libboost-date-time1.67.0]
@@ -2294,6 +2297,7 @@ libboost-filesystem:
   nixos: [boost]
   openembedded: [boost@openembedded-core]
   opensuse: [libboost_filesystem1_66_0]
+  rhel: [boost-filesystem]
   ubuntu:
     bionic: [libboost-filesystem1.65.1]
     eoan: [libboost-filesystem1.67.0]
@@ -2317,6 +2321,7 @@ libboost-iostreams:
   nixos: [boost]
   openembedded: [boost@openembedded-core]
   opensuse: [libboost_iostreams1_66_0]
+  rhel: [boost-iostreams]
   ubuntu:
     bionic: [libboost-iostreams1.65.1]
     eoan: [libboost-iostreams1.67.0]
@@ -2426,6 +2431,7 @@ libboost-random:
   nixos: [boost]
   openembedded: [boost@openembedded-core]
   opensuse: [libboost_random1_66_0]
+  rhel: [boost-random]
   ubuntu:
     bionic: [libboost-random1.65.1]
     disco: [libboost-random1.67.0]
@@ -2452,6 +2458,7 @@ libboost-regex:
   nixos: [boost]
   openembedded: [boost@openembedded-core]
   opensuse: [libboost_regex1_66_0]
+  rhel: [boost-regex]
   ubuntu:
     bionic: [libboost-regex1.65.1]
     eoan: [libboost-regex1.67.0]
@@ -2525,6 +2532,7 @@ libboost-thread:
   nixos: [boost]
   openembedded: [boost@openembedded-core]
   opensuse: [libboost_thread1_66_0]
+  rhel: [boost-thread]
   ubuntu:
     bionic: [libboost-thread1.65.1]
     disco: [libboost-thread1.67.0]


### PR DESCRIPTION
- 'boost-atomic'
  - 7: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/boost-atomic-1.53.0-28.el7.i686.rpm
  - 8: http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/Packages/boost-atomic-1.66.0-10.el8.i686.rpm
- 'boost-chrono'
  - 7: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/boost-chrono-1.53.0-28.el7.i686.rpm
  - 8: http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/Packages/boost-chrono-1.66.0-10.el8.i686.rpm
- 'boost-date-time'
  - 7: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/boost-date-time-1.53.0-28.el7.i686.rpm
  - 8: http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/Packages/boost-date-time-1.66.0-10.el8.i686.rpm
- 'boost-filesystem'
  - 7: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/boost-filesystem-1.53.0-28.el7.i686.rpm
  - 8: http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/Packages/boost-filesystem-1.66.0-10.el8.i686.rpm
- 'boost-iostreams'
  - 7: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/boost-iostreams-1.53.0-28.el7.i686.rpm
  - 8: http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/Packages/boost-iostreams-1.66.0-10.el8.i686.rpm
- 'boost-random'
  - 7: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/boost-random-1.53.0-28.el7.i686.rpm
  - 8: http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/Packages/boost-random-1.66.0-10.el8.i686.rpm
- 'boost-regex'
  - 7: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/boost-regex-1.53.0-28.el7.i686.rpm
  - 8: http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/Packages/boost-regex-1.66.0-10.el8.i686.rpm
- 'boost-thread'
  - 7: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/boost-thread-1.53.0-28.el7.i686.rpm
  - 8: http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/Packages/boost-thread-1.66.0-10.el8.i686.rpm