### PR TITLE
Add several misc RHEL rules for ROS 2

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -324,6 +324,7 @@ binutils:
   gentoo: [sys-devel/binutils]
   nixos: [binutils]
   openembedded: [binutils@openembedded-core]
+  rhel: [binutils-devel]
   ubuntu: [binutils-dev]
 bison:
   arch: [bison]
@@ -3726,6 +3727,8 @@ libmongoclient-dev:
   debian: [libmongoclient-dev]
   fedora: [mongo-cxx-driver]
   openembedded: [mongodb@meta-oe]
+  rhel:
+    '7': [mongo-cxx-driver-devel]
   ubuntu: [libmongoclient-dev]
 libmotif-dev:
   arch: [lesstif]
@@ -4356,6 +4359,9 @@ libqglviewer-dev-qt5:
   fedora: [libQGLViewer-qt5-devel]
   nixos: [libsForQt5.libqglviewer]
   openembedded: [qtbase@meta-qt5]
+  rhel:
+    '*': [libQGLViewer-qt5-devel]
+    '7': null
   ubuntu: [libqglviewer-dev-qt5]
 libqglviewer-qt4:
   arch: [libqglviewer-qt4]
@@ -4416,6 +4422,9 @@ libqglviewer2-qt5:
   debian: [libqglviewer2-qt5]
   fedora: [libQGLViewer-qt5]
   nixos: [libsForQt5.libqglviewer]
+  rhel:
+    '*': [libQGLViewer-qt5]
+    '7': null
   ubuntu: [libqglviewer2-qt5]
 libqhull:
   arch: [qhull]
@@ -4614,6 +4623,7 @@ libqt5-svg-dev:
   nixos: [qt5.qtsvg]
   openembedded: [qtsvg@meta-qt5]
   opensuse: [libqt5-qtsvg-devel]
+  rhel: [qt5-qtsvg-devel]
   ubuntu: [libqt5svg5-dev]
 libqt5-websockets-dev:
   arch: [qt5-websockets]
@@ -4622,6 +4632,7 @@ libqt5-websockets-dev:
   gentoo: ['dev-qt/qtwebsockets:5']
   nixos: [qt5.qtwebsockets]
   openembedded: [qtwebsockets@meta-qt5]
+  rhel: [qt5-qtwebsockets-devel]
   ubuntu: [libqt5websockets5-dev]
 libqt5-widgets:
   alpine: [qt5-qtbase-dev]
@@ -4655,6 +4666,7 @@ libqt5x11extras5-dev:
   gentoo: ['dev-qt/qtx11extras:5']
   nixos: [qt5.qtx11extras]
   openembedded: [qtx11extras@meta-qt5]
+  rhel: [qt5-qtx11extras-devel]
   ubuntu: [libqt5x11extras5-dev]
 libqtgui4:
   arch: [qt4]


### PR DESCRIPTION
- 'binutils-devel'
  - 7: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/binutils-devel-2.27-44.base.el7.i686.rpm
  - 8: http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/Packages/binutils-devel-2.30-93.el8.i686.rpm
- 'mongo-cxx-driver-devel'
  - 7: https://src.fedoraproject.org/rpms/mongo-cxx-driver#bodhi_updates
- 'libQGLViewer-qt5-devel'
  - 8: https://src.fedoraproject.org/rpms/libQGLViewer#bodhi_updates
- 'libQGLViewer-qt5'
  - 8: https://src.fedoraproject.org/rpms/libQGLViewer#bodhi_updates
- 'qt5-qtsvg-devel'
  - 7: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/qt5-qtsvg-devel-5.9.7-1.el7.i686.rpm
  - 8: http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/Packages/qt5-qtsvg-devel-5.12.5-1.el8.i686.rpm
- 'qt5-qtwebsockets-devel'
  - 7: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/qt5-qtwebsockets-devel-5.9.7-1.el7.i686.rpm
  - 8: http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/Packages/qt5-qtwebsockets-devel-5.12.5-2.el8.i686.rpm
- 'qt5-qtx11extras-devel'
  - 7: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/qt5-qtx11extras-devel-5.9.7-1.el7.i686.rpm
  - 8: http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/Packages/qt5-qtx11extras-devel-5.12.5-1.el8.i686.rpm