### PR TITLE
denso_robot_ros: 3.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2231,7 +2231,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/DENSORobot/denso_robot_ros-release.git
-      version: 3.1.2-1
+      version: 3.2.0-1
     source:
       type: git
       url: https://github.com/DENSORobot/denso_robot_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `denso_robot_ros` to `3.2.0-1`:

- upstream repository: https://github.com/DENSORobot/denso_robot_ros.git
- release repository: https://github.com/DENSORobot/denso_robot_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.1.2-1`

## bcap_core

- No changes

## bcap_service

- No changes

## bcap_service_test

- No changes

## denso_robot_bringup

- No changes

## denso_robot_control

```
* Add "ResetStoState" to initialization
```

## denso_robot_core

```
* Add "ResetStoState" to clear the STO state for RC9 and COBOTTA
* Add "ManualResetPreparation" to confirm safey-related command for COBOTTA
* Add "MotionPreparation" to execute Motion preparation for COBOTTA
* Add "AutoCal" to execute CALSET for COBOTTA
* Change "ClearError" to execute "ManualResetPreparation" first for COBOTTA
* Change most of the macros to constants
```

## denso_robot_core_test

- No changes

## denso_robot_descriptions

- No changes

## denso_robot_gazebo

- No changes

## denso_robot_moveit_config

- No changes

## denso_robot_ros

- No changes
