### PR TITLE
jsk_3rdparty: 2.1.22-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4925,14 +4925,17 @@ repositories:
       version: master
     release:
       packages:
+      - aques_talk
       - assimp_devel
       - bayesian_belief_networks
+      - chaplus_ros
       - collada_urdf_jsk_patch
       - dialogflow_task_executive
       - downward
       - ff
       - ffha
       - gdrive_ros
+      - google_cloud_texttospeech
       - jsk_3rdparty
       - julius
       - julius_ros
@@ -4955,7 +4958,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
-      version: 2.1.21-3
+      version: 2.1.22-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_3rdparty` to `2.1.22-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
- release repository: https://github.com/tork-a/jsk_3rdparty-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.21-3`

## aques_talk

```
* Ignore charactors which AquesTalk2 cannot recognize (#257 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/257>)
  
    * Update README on limitation
    * Delete certain characters when they come at the beginning of a sentence
    * fixed character replacement
    * Update README
    * Support Katakana
    * All charactors except [^a-zA-Z0-9ぁ-んー、。?？] are removed
    * Ignore charactors which AquesTalk2 cannot recognize
    * Add documentation path to README
  
* add sound_play_topic  and sound_play_node_name argument (#227 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/227>)
* Add build procedure for aques_talk (#236 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/236>)
* Replace numbers in text file for aques_talk to speak numbers (#229 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/229>)
  
    * Update README about input limitation
    * Replace alphabet for aques_talk
    * Use regular expression [0-9]+ instead of [0-9][0-9]*
  
* [aques_talk] catkinie aques_talk package (#224 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/224>)
* Contributors: Kei Okada, Naoya Yamaguchi, Ayaka Fujii, Koki Amabe
```

## assimp_devel

- No changes

## bayesian_belief_networks

- No changes

## chaplus_ros

```
* add chat agent interface for ros (#252 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/252>)
  
    * add A3RT chat engine
    * add chaplus ros interface see README.md for more information
  
* Contributors: Ayaka Fujii
```

## collada_urdf_jsk_patch

- No changes

## dialogflow_task_executive

```
* [dialogflow_task_executive] Change mux namespace for speech_to_textf( #221 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/221>)
* Contributors: Naoya Yamaguchi
```

## downward

- No changes

## ff

- No changes

## ffha

- No changes

## gdrive_ros

```
* set max authentication trial times as infinite (#249 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/249>)
* catch ServerNotFoundError in gdrive_server_node.py ((#240 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/240>)
* update doc links in gdrive_ros (#233 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/233>)
* [gdrive_ros] add node_name arg in gdrive_server.launch (#234 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/234>)
* add roslaunch test (#232 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/232>)
* [gdrive_ros] add argument respawn (#230 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/230>)
* Contributors: Shingo Kitagawa
```

## google_cloud_texttospeech

```
* add google_cloud_texttospeech packagef( #218 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/218>)
* Contributors: Shingo Kitagawa, Shun Hasegawa
```

## jsk_3rdparty

```
* [jsk_3rdparty] fix typo of dirname (#238 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/238>)
* Contributors: Koki Shinjo
```

## julius

- No changes

## julius_ros

- No changes

## laser_filters_jsk_patch

- No changes

## libcmt

- No changes

## libsiftfast

- No changes

## lpg_planner

- No changes

## mini_maxwell

- No changes

## nlopt

- No changes

## opt_camera

- No changes

## pgm_learner

- No changes

## respeaker_ros

```
* [respeaker_ros] Specify correct Python version in package.xml (#247 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/247>)
  
    * Fixes typo introduced in https://github.com/jsk-ros-pkg/jsk_3rdparty/commit/39be21894a38112a1633cf8385caf079c35536ff
  
* Add respawn_delay to respeaker_node.py to reduce CPU load (#241 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/241>)Kill respeaker_node.py when USBError occur to reduce CPU load
* [respeaker_ros] fix default sound_play action name of speech_to_text.py (#239 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/239>)
* Mistakes I found when I tried to use respeaker_ros on hirovision (#217 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/217>)
  
    * add speech_recognition_msgs
    * change the name from respeaker.launch to sample_respeaker.launch
  
* Contributors: Koki Shinjo, Miyabi Tanemoto, Naoya Yamaguchi, Shun Hasegawa
```

## ros_speech_recognition

```
* enable to change topic name from speech_recognition.launch (#254 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/254>)
* support SpeakerDiarization, see https://cloud.google.com/speech-to-text/docs/reference/rest/v1/speech/recognize#SpeechRecognitionAlternative (#244 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/244>)
  
    * [ros_speech_recognition] Add doc to speech_recognition.launch
      add doc to args, and we need to use rosparm for device, not param. because 'device: ' causes
      load_parameters: unable to set parameters (last param was [/speech_recognition/depth=16]): cannot marshal None unless allow_none is enabled  error
    * more exception message for self.recognize
  
* Use PYTHON_INTERPRETER python3 in ros_speech_recognition (#225 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/225>)
* Contributors: Kei Okada, Naoya Yamaguchi, Shingo Kitagawa
```

## rospatlite

- No changes

## rosping

```
* relax rosping test for GAf( #245 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/245>)
* Contributors: Kei Okada
```

## rostwitter

```
* Refactor rostwitter (#235 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/235>)
  
    * fix desired_encoding=bgr8
    * use action
    * speak warning
    * remove only if exists
    * add utf-8 encoding
    * add tweet_image_server
    * do not raise error
    * add util.py
    * add Tweet srv
    * add twitter.py for reuse
  
* Contributors: Shingo Kitagawa
```

## sesame_ros

- No changes

## slic

- No changes

## voice_text

```
* [voice_text] Fix README to follow supporting other speakers than SAYAKA (#220 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/220>)
* Contributors: Shun Hasegawa
```
