### PR TITLE
rmf_internal_msgs: 1.3.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1971,6 +1971,31 @@ repositories:
       url: https://github.com/ros/resource_retriever.git
       version: galactic
     status: maintained
+  rmf_internal_msgs:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_internal_msgs.git
+      version: galactic
+    release:
+      packages:
+      - rmf_charger_msgs
+      - rmf_dispenser_msgs
+      - rmf_door_msgs
+      - rmf_fleet_msgs
+      - rmf_ingestor_msgs
+      - rmf_lift_msgs
+      - rmf_task_msgs
+      - rmf_traffic_msgs
+      - rmf_workcell_msgs
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
+      version: 1.3.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_internal_msgs.git
+      version: galactic
+    status: developed
   rmw:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_internal_msgs` to `1.3.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_internal_msgs.git
- release repository: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
