### PR TITLE
rmf_visualization_msgs: 1.2.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1971,6 +1971,21 @@ repositories:
       url: https://github.com/ros/resource_retriever.git
       version: galactic
     status: maintained
+  rmf_visualization_msgs:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_visualization_msgs.git
+      version: galactic
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_visualization_msgs-release.git
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_visualization_msgs.git
+      version: galactic
+    status: developed
   rmw:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_visualization_msgs` to `1.2.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_visualization_msgs.git
- release repository: https://github.com/ros2-gbp/rmf_visualization_msgs-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
