### PR TITLE
rmf_visualization_msgs: 1.2.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2177,7 +2177,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_visualization_msgs.git
-      version: rolling
+      version: main
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2186,7 +2186,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_visualization_msgs.git
-      version: rolling
+      version: main
     status: developed
   rmw:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2182,7 +2182,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_visualization_msgs-release.git
-      version: 1.2.0-1
+      version: 1.2.0-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_visualization_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_visualization_msgs` to `1.2.0-2`:

- upstream repository: https://github.com/open-rmf/rmf_visualization_msgs.git
- release repository: https://github.com/ros2-gbp/rmf_visualization_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.0-1`
