### PR TITLE
stubborn_buddies: 1.0.0-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3196,7 +3196,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/stubborn_buddies-release.git
-      version: 1.0.0-2
+      version: 1.0.0-3
     source:
       type: git
       url: https://github.com/open-rmf/stubborn_buddies.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3188,7 +3188,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/stubborn_buddies.git
-      version: rolling
+      version: main
     release:
       packages:
       - stubborn_buddies
@@ -3200,7 +3200,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/stubborn_buddies.git
-      version: rolling
+      version: main
     status: developed
   system_modes:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `stubborn_buddies` to `1.0.0-3`:

- upstream repository: https://github.com/open-rmf/stubborn_buddies.git
- release repository: https://github.com/ros2-gbp/stubborn_buddies-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.0-2`
