### PR TITLE
point_cloud_msg_wrapper: 1.0.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1667,7 +1667,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://gitlab.com/ApexAI/point_cloud_msg_wrapper-release
-      version: 1.0.6-1
+      version: 1.0.7-1
     source:
       type: git
       url: https://gitlab.com/ApexAI/point_cloud_msg_wrapper


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_msg_wrapper` to `1.0.7-1`:

- upstream repository: https://gitlab.com/ApexAI/point_cloud_msg_wrapper
- release repository: https://gitlab.com/ApexAI/point_cloud_msg_wrapper-release
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.6-1`
