### PR TITLE
cartesian_control_msgs: 0.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -545,6 +545,21 @@ repositories:
       url: https://github.com/carla-simulator/ros-carla-msgs.git
       version: release
     status: developed
+  cartesian_control_msgs:
+    doc:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS_cartesian_control_msgs.git
+      version: main
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS_cartesian_control_msgs-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS_cartesian_control_msgs.git
+      version: main
+    status: developed
   cartesian_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cartesian_control_msgs` to `0.1.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS_cartesian_control_msgs.git
- release repository: https://github.com/UniversalRobots/Universal_Robots_ROS_cartesian_control_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## cartesian_control_msgs

```
* Add package for Cartesian trajectory interface definition
  The definition was publicly discussed and developed at:
  https://github.com/fzi-forschungszentrum-informatik/fzi_robot_interface_proposal/tree/msg_package
  Now it makes sense to have the message definitions here in this meta
  package for future Cartesian trajectory controllers.
* Contributors: Felix Exner, Rune Søe-Knudsen, Stefan Scherzinger
```
