### PR TITLE
scaled_controllers: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12146,6 +12146,26 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/sbpl-release.git
       version: 1.3.1-0
+  scaled_controllers:
+    doc:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS_scaled_controllers.git
+      version: main
+    release:
+      packages:
+      - scaled_controllers
+      - scaled_joint_trajectory_controller
+      - speed_scaling_interface
+      - speed_scaling_state_controller
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS_scaled_controllers-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS_scaled_controllers.git
+      version: main
+    status: developed
   scan_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `scaled_controllers` to `0.1.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS_scaled_controllers.git
- release repository: https://github.com/UniversalRobots/Universal_Robots_ROS_scaled_controllers-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## scaled_controllers

```
* Move out of ur_controllers package
* Contributors: Felix Exner
```

## scaled_joint_trajectory_controller

```
* Added metapackage
* Contributors: Felix Exner
```

## speed_scaling_interface

```
* Moved speed scaling interface to own package
* Contributors: Felix Exner
```

## speed_scaling_state_controller

```
* Move out of ur_controllers package
* Contributors: Felix Exner
```
