### PR TITLE
Fix packages swapped during cleanup.

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -407,7 +407,7 @@ repositories:
       version: dashing-devel
     release:
       packages:
-      - bond_core
+      - bond
       - smclib
       tags:
         release: release/dashing/{package}/{version}


### PR DESCRIPTION
bond is building successfully:
https://index.ros.org/doc/ros2/Installation/Dashing/#building-from-source
but bond_core is blocked because bondcpp is not building.
