### PR TITLE
Mark Dashing as end-of-life.

### DIFF
--- a/index-v4.yaml
+++ b/index-v4.yaml
@@ -24,7 +24,7 @@ distributions:
   dashing:
     distribution: [dashing/distribution.yaml]
     distribution_cache: http://repo.ros2.org/rosdistro_cache/dashing-cache.yaml.gz
-    distribution_status: active
+    distribution_status: end-of-life
     distribution_type: ros2
     python_version: 3
   eloquent:


### PR DESCRIPTION
So long and thanks for all the fish!

The last [Dashing sync](https://discourse.ros.org/t/new-packages-and-patch-release-for-ros-2-dashing-diademata-2021-06-10-final/20875) is out and further releases should not be merged.