### PR TITLE
fmi_adapter: 2.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1053,7 +1053,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/fmi_adapter-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fmi_adapter` to `2.1.1-1`:

- upstream repository: https://github.com/boschresearch/fmi_adapter.git
- release repository: https://github.com/ros2-gbp/fmi_adapter-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.0-1`

## fmi_adapter

```
* Adapted to statically typed parameters introduced in Galactic.
```

## fmi_adapter_examples

- No changes
