### PR TITLE
mir_robot: 1.0.8-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6359,7 +6359,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uos-gbp/mir_robot-release.git
-      version: 1.0.7-1
+      version: 1.0.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mir_robot` to `1.0.8-1`:

- upstream repository: https://github.com/dfki-ric/mir_robot.git
- release repository: https://github.com/uos-gbp/mir_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.7-1`

## mir_actions

```
* Merge branch 'melodic-2.8' into melodic
* Remove RelativeMove action
  It was removed in MiR software 2.4.0.
* Update mir_actions to MiR 2.8.3
* Adjust to changed MirMoveBase action (MiR >= 2.4.0)
  See #45 <https://github.com/dfki-ric/mir_robot/issues/45>.
* Contributors: Martin Günther
```

## mir_description

```
* Merge branch 'melodic-2.8' into melodic
* Rename tf frame and topic 'odom_comb' -> 'odom'
  This is how they are called on the real MiR since MiR software 2.0.
* Contributors: Martin Günther
```

## mir_driver

```
* Merge branch 'melodic-2.8' into melodic
* Subscribe to move_base_simple/goal in relative namespace
* Use absolute topics for /tf, /tf_static, /map etc.
* Rename tf frame and topic 'odom_comb' -> 'odom'
  This is how they are called on the real MiR since MiR software 2.0.
* Fix handling of tf_static topic
  This does two things:
  1. Make the tf_static topic latched.
  2. Cache all transforms, publish as one message.
* Increase queue_size for publishers + subscribers to 10
  One case where this was a problem was the tf_static topic: Since
  multiple messages are being published at once, the subscriber often
  missed one. The tf_static topic will be fixed anyway in the next commit,
  but let's increase the queue_size anyway to avoid such bugs in the
  future.
* Fix type warning
* Update topic list to 2.8.3.1
* Reformat python code using black
* Remove outdated topics
  These topics don't exist on MiR software 2.8.3 any more (most of them
  have been removed a long time ago).
  Fixes #37 <https://github.com/dfki-ric/mir_robot/issues/37>.
* Remove MirStatus
  This message was removed in MiR software 2.0 (Renamed to RobotStatus).
* Use same MirMoveBase params as real MiR (2.8.3)
  This shouldn't make a difference (it used to work before). Just removing
  one more potential source of error.
* Fix: Converts move_base_simple/goal into a move_base action. (#62 <https://github.com/dfki-ric/mir_robot/issues/62>)
  At least MIR software version 2.8 does not react properly to move_base_simple/goal messages. This implements a workaround.
  Closes #60 <https://github.com/dfki-ric/mir_robot/issues/60>.
* Fix: Adds subscription to "tf_static". (#58 <https://github.com/dfki-ric/mir_robot/issues/58>)
  Some transformations are published on this topic and are needed to
  obtain a full tf tree. E.g. "base_footprint" to "base_link"
* Minor: Removes /particlecloud from the list of published topics. (#57 <https://github.com/dfki-ric/mir_robot/issues/57>)
* Fix: Add missing dict_filter keyword argument for cmd_vel msgs (#56 <https://github.com/dfki-ric/mir_robot/issues/56>)
* Remove relative_move_action (MiR => 2.4.0)
  This action was merged into the generic MirMoveBaseAction in MiR
  software 2.4.0.
* Adjust to changed MirMoveBase action (MiR >= 2.4.0)
  See #45 <https://github.com/dfki-ric/mir_robot/issues/45>.
* Adjust cmd_vel topic to TwistStamped (MiR >= 2.7)
  See #45 <https://github.com/dfki-ric/mir_robot/issues/45>.
* Contributors: Martin Günther, matthias-mayr
```

## mir_dwb_critics

```
* Merge branch 'melodic-2.8' into melodic
* Reformat python code using black
* Contributors: Martin Günther
```

## mir_gazebo

```
* Merge branch 'melodic-2.8' into melodic
* Rename tf frame and topic 'odom_comb' -> 'odom'
  This is how they are called on the real MiR since MiR software 2.0.
* Contributors: Martin Günther
```

## mir_msgs

```
* Merge branch 'melodic-2.8' into melodic
* Update BMSData msg to MiR software 2.8.3.1
* Remove MirStatus
  This message was removed in MiR software 2.0 (Renamed to RobotStatus).
* Update mir_msgs to 2.8.2.2
* Contributors: Felix, Martin Günther
```

## mir_navigation

```
* Merge branch 'melodic-2.8' into melodic
* Rename tf frame and topic 'odom_comb' -> 'odom'
  This is how they are called on the real MiR since MiR software 2.0.
* Reformat python code using black
* Contributors: Martin Günther
```

## mir_robot

- No changes

## sdc21x0

- No changes
