### PR TITLE
rc_visard: 3.2.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9714,7 +9714,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_visard-release.git
-      version: 3.1.0-2
+      version: 3.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_visard` to `3.2.1-1`:

- upstream repository: https://github.com/roboception/rc_visard_ros.git
- release repository: https://github.com/roboception-gbp/rc_visard-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.1.0-2`

## rc_hand_eye_calibration_client

- No changes

## rc_pick_client

- No changes

## rc_roi_manager_gui

- No changes

## rc_silhouettematch_client

- No changes

## rc_tagdetect_client

- No changes

## rc_visard

- No changes

## rc_visard_description

- No changes

## rc_visard_driver

```
* Only checking for rc_visard as model and not for vendor when detecting devices
```
