### PR TITLE
rosidl_typesupport: 1.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2693,7 +2693,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-      version: 1.2.1-2
+      version: 1.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport` to `1.3.0-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.1-2`

## rosidl_typesupport_c

```
* Fix C and C++ typesupports CLI extensions (#111 <https://github.com/ros2/rosidl_typesupport/issues/111>)
* Contributors: Michel Hidalgo
```

## rosidl_typesupport_cpp

```
* Fix C and C++ typesupports CLI extensions (#111 <https://github.com/ros2/rosidl_typesupport/issues/111>)
* Contributors: Michel Hidalgo
```
