### PR TITLE
rosidl_python: 0.12.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2658,7 +2658,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.11.0-1
+      version: 0.12.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_python` to `0.12.0-1`:

- upstream repository: https://github.com/ros2/rosidl_python.git
- release repository: https://github.com/ros2-gbp/rosidl_python-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.11.0-1`

## rosidl_generator_py

```
* Added optimization for copying arrays using buffer protocol (#129 <https://github.com/ros2/rosidl_python/issues/129>)
* Add smoke test for CLI extension (#132 <https://github.com/ros2/rosidl_python/issues/132>)
* Install generated Python interfaces in a Python package (#131 <https://github.com/ros2/rosidl_python/issues/131>)
* Contributors: Michel Hidalgo, ksuszka
```
