### PR TITLE
rosidl: 2.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2603,7 +2603,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 2.2.1-1
+      version: 2.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `2.3.0-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.2.1-1`

## rosidl_adapter

```
* Fix escaping in string literals (#595 <https://github.com/ros2/rosidl/issues/595>)
* Ignore multiple ``#`` characters and dedent comments (#594 <https://github.com/ros2/rosidl/issues/594>)
* Contributors: Ivan Santiago Paunovic
```

## rosidl_cli

- No changes

## rosidl_cmake

- No changes

## rosidl_generator_c

```
* Fix a cpplint allocator regression. (#590 <https://github.com/ros2/rosidl/issues/590>)
* Use RCUtils allocators in rosidl_generator_c (#584 <https://github.com/ros2/rosidl/issues/584>)
* Contributors: Chris Lalancette, Pablo Garrido
```

## rosidl_generator_cpp

- No changes

## rosidl_parser

```
* Fix escaping in string literals (#595 <https://github.com/ros2/rosidl/issues/595>)
* Contributors: Ivan Santiago Paunovic
```

## rosidl_runtime_c

```
* Use RCUtils allocators in rosidl_generator_c (#584 <https://github.com/ros2/rosidl/issues/584>)
* Contributors: Pablo Garrido
```

## rosidl_runtime_cpp

- No changes

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

- No changes

## rosidl_typesupport_introspection_cpp

- No changes
