### PR TITLE
Added libfl.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2873,7 +2873,6 @@ libfftw3:
   ubuntu: [libfftw3-3, libfftw3-dev]
 libfl-dev:
   debian: [libfl-dev]
-  fedora: [libfl-devel]
   ubuntu: [libfl-dev]
 libflann:
   arch: [flann]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2873,6 +2873,10 @@ libfftw3:
   ubuntu: [libfftw3-3, libfftw3-dev]
 libfl-dev:
   debian: [libfl-dev]
+  fedora:
+    '*': [libfl-devel]
+    '33': [flex-devel]
+  opensuse: [libfl-devel]
   ubuntu: [libfl-dev]
 libflann:
   arch: [flann]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2871,6 +2871,10 @@ libfftw3:
   nixos: [fftw, fftwSinglePrec]
   openembedded: [fftw@meta-oe]
   ubuntu: [libfftw3-3, libfftw3-dev]
+libfl-dev:
+  debian: [libfl-dev]
+  fedora: [libfl-devel]
+  ubuntu: [libfl-dev]
 libflann:
   arch: [flann]
   debian:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

libfl-dev

## Package Upstream Source:

https://github.com/westes/flex

## Purpose of using this:

This lexical analyzer generator is generally useful as a development library.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/buster/libfl-dev

- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/focal/libfl-dev
   
- Fedora: https://src.fedoraproject.org/browse/projects/
  - NOT AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - NOT AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - NOT AVAILABLE
- macOS: https://formulae.brew.sh/
  - NOT AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - NOT AVAILABLE