### PR TITLE
Add libccd-dev rule for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2609,6 +2609,7 @@ libccd-dev:
   gentoo: [sci-libs/libccd]
   nixos: [libccd]
   openembedded: [libccd@meta-ros-common]
+  rhel: [libccd-devel]
   ubuntu: [libccd-dev]
 libcdd-dev:
   arch: [cddlib]


### PR DESCRIPTION
This package is supplied by EPEL for both RHEL 7 and 8:
- 'libccd-devel' for rhel 7: https://src.fedoraproject.org/rpms/libccd#bodhi_updates
- 'libccd-devel' for rhel 8: https://src.fedoraproject.org/rpms/libccd#bodhi_updates