### PR TITLE
openvslam: 0.2.3-3 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1485,6 +1485,21 @@ repositories:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros-gbp/ompl-release.git
       version: 1.5.2-1
+  openvslam:
+    doc:
+      type: git
+      url: https://github.com/OpenVSLAM-Community/openvslam.git
+      version: galactic-devel
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/OpenVSLAM-Community/openvslam-release.git
+      version: 0.2.3-3
+    source:
+      type: git
+      url: https://github.com/OpenVSLAM-Community/openvslam.git
+      version: galactic-devel
+    status: developed
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openvslam` to `0.2.3-3`:

- upstream repository: https://github.com/OpenVSLAM-Community/openvslam.git
- release repository: https://github.com/OpenVSLAM-Community/openvslam-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `null`
