### PR TITLE
plotjuggler: 3.1.2-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5147,7 +5147,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.1.2-1
+      version: 3.1.2-2
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.1.2-2`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.1.2-1`

## plotjuggler

```
* add disable_opnegl option in command line
* new API for MessagePublishers
* bug fix that affects statepublishers
  crash when application is closed
* bug fix in Plotwidget transform
* AppImage instructions added
* fix #445 <https://github.com/facontidavide/PlotJuggler/issues/445>
* change to QHostAddress::Any in UDP plugin (issue #410 <https://github.com/facontidavide/PlotJuggler/issues/410>)
* Contributors: Davide Faconti
```
