### PR TITLE
plotjuggler_ros: 1.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5177,7 +5177,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
-      version: 1.2.0-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler_ros` to `1.3.0-1`:

- upstream repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
- release repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.0-1`

## plotjuggler_ros

```
* use std::any
* temporary fix for 3.2
* Contributors: Davide Faconti
```
