### PR TITLE
ros_controllers: 0.19.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6311,7 +6311,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.18.1-1
+      version: 0.19.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.19.0-1`:

- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.18.1-1`

## ackermann_steering_controller

```
* Wait long enough for accumulator to be cleared
* Contributors: Matt Reynolds
```

## diff_drive_controller

```
* fix NaN bug
* fix test to expose NaN bug
* Wait long enough for accumulator to be cleared
* Add test for #532 <https://github.com/ros-controls/ros_controllers/issues/532>
  Close #540 <https://github.com/ros-controls/ros_controllers/issues/540>
* Contributors: Caio Amaral, Matt Reynolds, Melvin Wang
```

## effort_controllers

- No changes

## force_torque_sensor_controller

- No changes

## forward_command_controller

- No changes

## four_wheel_steering_controller

- No changes

## gripper_action_controller

- No changes

## imu_sensor_controller

- No changes

## joint_state_controller

```
* [joint_state_controller] Allow specification of joints or set specific order
  Introduces a 'joints' parameter similar to other controllers in order to
  be able to specify a subset of joints or a specific order of joints.
  This is useful when the HardwareInterface exposes joints in an order
  that is not desired or if certain joints are not meant to be published
  by a controller. If not provided, the controller publishes all joints
  and preserves backwards-compatibility.
* Contributors: Wolfgang Merkt, Matt Reynolds
```

## joint_trajectory_controller

```
* Set time_from_start for state error too
* joint_trajectory_controller: add time_from_start feedback
* Contributors: Alexander Rössler, Bence Magyar, Matt Reynolds
```

## position_controllers

- No changes

## ros_controllers

- No changes

## rqt_joint_trajectory_controller

- No changes

## velocity_controllers

- No changes
