### PR TITLE
turtlebot3_msgs: 2.2.2-3 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3206,6 +3206,21 @@ repositories:
       url: https://github.com/ros-drivers/transport_drivers.git
       version: main
     status: developed
+  turtlebot3_msgs:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
+      version: galactic-devel
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/robotis-ros2-release/turtlebot3_msgs-release.git
+      version: 2.2.2-3
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
+      version: galactic-devel
+    status: developed
   turtlesim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_msgs` to `2.2.2-3`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
- release repository: https://github.com/robotis-ros2-release/turtlebot3_msgs-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## turtlebot3_msgs

```
* ROS 2 Galactic Geochelone supported
* Contributors: Will Son
```
