### PR TITLE
adding rhel websocketpp-devel key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5355,6 +5355,7 @@ libwebsocketpp-dev:
   fedora: [websocketpp-devel]
   gentoo: [websocketpp]
   nixos: [websocketpp]
+  rhel: [websocketpp-devel]
   ubuntu: [libwebsocketpp-dev]
 libx11:
   alpine: [libx11]


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>

Please add the following dependency to the rosdep database.

## Purpose of using this:

This dependency is being used for the [rmf_visualization](https://github.com/open-rmf/rmf_visualization) package that needs to be released for `rhel`. This is why I think it's valuable to be added to the rosdep database. 
