### PR TITLE
raptor_dbw_ros2: 1.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2679,7 +2679,7 @@ repositories:
   raptor_dbw_ros2:
     release:
       packages:
-      - raptor_can_dbc_parser
+      - can_dbc_parser
       - raptor_dbw_can
       - raptor_dbw_joystick
       - raptor_dbw_msgs
@@ -2688,7 +2688,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/NewEagleRaptor/raptor-dbw-ros2-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/NewEagleRaptor/raptor-dbw-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `raptor_dbw_ros2` to `1.1.0-1`:

- upstream repository: https://github.com/NewEagleRaptor/raptor-dbw-ros2.git
- release repository: https://github.com/NewEagleRaptor/raptor-dbw-ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.0-1`

## can_dbc_parser

```
* Change package name raptor_can_dbc_parser back to can_dbc_parser (no function change)
* Contributors: neweagleraptor
```

## raptor_dbw_can

```
* Misc. cleanup & comment improvement
* Update DBW node to use params from launch file
* Fix unit conversion issues - steering was in radians, should be degrees
* Contributors: neweagleraptor
```

## raptor_dbw_joystick

```
* Misc. cleanup & comment improvement
* Update DBW node to use params from launch file
* Fix unit conversion issues - steering was in radians, should be degrees
* Contributors: neweagleraptor
```

## raptor_dbw_msgs

```
* Misc. cleanup & comment improvement
* Fixed HighBeamState off value to match DBC
* Contributors: neweagleraptor
```

## raptor_pdu

```
* Misc. cleanup & comment improvement (no function change)
* Contributors: neweagleraptor
```

## raptor_pdu_msgs

```
* Misc. cleanup & comment improvement (no function change)
* Contributors: neweagleraptor
```
