### PR TITLE
ros_controllers_cartesian: 0.1.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10540,6 +10540,27 @@ repositories:
       url: https://github.com/ros-controls/ros_controllers.git
       version: melodic-devel
     status: maintained
+  ros_controllers_cartesian:
+    doc:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian.git
+      version: main
+    release:
+      packages:
+      - cartesian_interface
+      - cartesian_trajectory_controller
+      - cartesian_trajectory_interpolation
+      - ros_controllers_cartesian
+      - twist_controller
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release.git
+      version: 0.1.2-1
+    source:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian.git
+      version: main
+    status: developed
   ros_emacs_utils:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers_cartesian` to `0.1.2-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian.git
- release repository: https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## cartesian_interface

- No changes

## cartesian_trajectory_controller

- No changes

## cartesian_trajectory_interpolation

- No changes

## ros_controllers_cartesian

- No changes

## twist_controller

```
* Remove more trailing whitespaces
* Contributors: Felix Exner
```
