### PR TITLE
dynamixel_hardware_interface: 0.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -762,6 +762,21 @@ repositories:
       url: https://github.com/stack-of-tasks/dynamic-graph.git
       version: devel
     status: maintained
+  dynamixel_hardware_interface:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/dynamixel_hardware_interface.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/OUXT-Polaris/dynamixel_hardware_interface-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/dynamixel_hardware_interface.git
+      version: master
+    status: developed
   dynamixel_sdk:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_hardware_interface` to `0.0.2-1`:

- upstream repository: https://github.com/OUXT-Polaris/dynamixel_hardware_interface.git
- release repository: https://github.com/OUXT-Polaris/dynamixel_hardware_interface-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
