### PR TITLE
neo_local_planner: 1.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4367,6 +4367,13 @@ repositories:
       url: https://github.com/TUC-ProAut/ros_nearfield_map.git
       version: master
     status: maintained
+  neo_local_planner:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/neobotix/neo_local_planner-release.git
+      version: 1.0.1-1
+    status: maintained
   neonavigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `neo_local_planner` to `1.0.1-1`:

- upstream repository: https://github.com/neobotix/neo_local_planner.git
- release repository: https://github.com/neobotix/neo_local_planner-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
