### PR TITLE
rc_reason_clients: 0.2.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1807,6 +1807,25 @@ repositories:
       url: https://github.com/roboception/rc_genicam_driver_ros2.git
       version: master
     status: developed
+  rc_reason_clients:
+    doc:
+      type: git
+      url: https://github.com/roboception/rc_reason_clients_ros2.git
+      version: master
+    release:
+      packages:
+      - rc_reason_clients
+      - rc_reason_msgs
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/roboception-gbp/rc_reason_clients-release.git
+      version: 0.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rc_reason_clients_ros2.git
+      version: master
+    status: developed
   rcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_reason_clients` to `0.2.1-1`:

- upstream repository: https://github.com/roboception/rc_reason_clients_ros2.git
- release repository: https://github.com/roboception-gbp/rc_reason_clients-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## rc_reason_clients

```
* cmake: detect if it is shallow clone on buildfarm and use version from package.xml
```

## rc_reason_msgs

```
* fix package dependencies for ROS buildfarm
```
