### PR TITLE
rc_reason_clients: 0.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5829,6 +5829,25 @@ repositories:
       url: https://github.com/roboception/rc_genicam_driver_ros.git
       version: master
     status: developed
+  rc_reason_clients:
+    doc:
+      type: git
+      url: https://github.com/roboception/rc_reason_clients_ros.git
+      version: master
+    release:
+      packages:
+      - rc_reason_clients
+      - rc_reason_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/roboception-gbp/rc_reason_clients_ros-release.git
+      version: 0.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rc_reason_clients_ros.git
+      version: master
+    status: developed
   rc_visard:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_reason_clients` to `0.2.1-1`:

- upstream repository: https://github.com/roboception/rc_reason_clients_ros.git
- release repository: https://github.com/roboception-gbp/rc_reason_clients_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## rc_reason_clients

- No changes

## rc_reason_msgs

```
* add missing build dependencies to package.xml
```
