### PR TITLE
moveit_msgs: 2.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1367,6 +1367,21 @@ repositories:
       url: https://github.com/ros2/mimick_vendor.git
       version: master
     status: maintained
+  moveit_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/moveit/moveit_msgs-release.git
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_msgs.git
+      version: ros2
+    status: developed
   moveit_resources:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_msgs` to `2.0.1-1`:

- upstream repository: https://github.com/ros-planning/moveit_msgs.git
- release repository: https://github.com/moveit/moveit_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## moveit_msgs

```
* Add License Notice (#108 <https://github.com/ros-planning/moveit_msgs/issues/108>)
* Fix ccache in CI (#102 <https://github.com/ros-planning/moveit_msgs/issues/102>)
* Migrate to GitHub Actions (#99 <https://github.com/ros-planning/moveit_msgs/issues/99>)
* Contributors: Tyler Weaver
```
