### PR TITLE
ros2_control: 0.7.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3294,7 +3294,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 0.7.0-1
+      version: 0.7.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `0.7.1-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.0-1`

## controller_interface

```
* Remove forgoten debug output (#439 <https://github.com/ros-controls/ros2_control/issues/439>)
* Contributors: Denis Štogl
```

## controller_manager

```
* Use namespace in controller_manager (#435 <https://github.com/ros-controls/ros2_control/issues/435>)
* Contributors: Jonatan Olofsson
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* [FakeSystem] Set default command interface to NaN (#424 <https://github.com/ros-controls/ros2_control/issues/424>)
* Contributors: Denis Štogl, Bence Magyar
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## transmission_interface

- No changes
