### PR TITLE
graceful_controller: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2510,7 +2510,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mikeferguson/graceful_controller-gbp.git
-      version: 0.3.1-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/mikeferguson/graceful_controller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `graceful_controller` to `0.4.0-1`:

- upstream repository: https://github.com/mikeferguson/graceful_controller.git
- release repository: https://github.com/mikeferguson/graceful_controller-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.3.1-1`

## graceful_controller

- No changes

## graceful_controller_ros

```
* add usage documentation (#19 <https://github.com/mikeferguson/graceful_controller/issues/19>)
  also remove unused min_vel_theta parameter
* implement changes from review (#18 <https://github.com/mikeferguson/graceful_controller/issues/18>)
  * Add collision checking during final rotation
  * Add comments about getRobotVel returning velocities
  * Rename path to simulated_path for clarity
  * Rename pose to target_pose and goal_pose (now separate variables)
  * Get rid of magic number for when to use final rotation
* simulate intial rotation properly (#17 <https://github.com/mikeferguson/graceful_controller/issues/17>)
  previously, this simulated the big arc that we wouldn't follow anyways.
  this could cause the robot to get stuck in corners or other tight areas.
* Contributors: Michael Ferguson
```
