### PR TITLE
dynamixel_hardware_interface: 0.0.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -771,7 +771,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/OUXT-Polaris/dynamixel_hardware_interface-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/OUXT-Polaris/dynamixel_hardware_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_hardware_interface` to `0.0.3-1`:

- upstream repository: https://github.com/OUXT-Polaris/dynamixel_hardware_interface.git
- release repository: https://github.com/OUXT-Polaris/dynamixel_hardware_interface-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.2-1`

## dynamixel_hardware_interface

```
* Merge pull request #12 <https://github.com/OUXT-Polaris/dynamixel_hardware_interface/issues/12> from OUXT-Polaris/fix/depends
  add boost to the depends
* add boost to the depends
* Contributors: Masaya Kataoka
```
