### PR TITLE
urdf_test: 2.0.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4867,6 +4867,21 @@ repositories:
       url: https://github.com/ros/urdf_parser_py.git
       version: foxy-devel
     status: maintained
+  urdf_test:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/urdf_test.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/pal-gbp/urdf_test-ros2-gbp.git
+      version: 2.0.0-2
+    source:
+      type: git
+      url: https://github.com/pal-robotics/urdf_test.git
+      version: foxy-devel
+    status: maintained
   urdfdom:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_test` to `2.0.0-2`:

- upstream repository: https://github.com/pal-robotics/urdf_test.git
- release repository: https://github.com/pal-gbp/urdf_test-ros2-gbp.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## urdf_test

```
* ROS2 migration
* Contributors: Victor Lopez
```
