### PR TITLE
ros_control: 0.19.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6300,7 +6300,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.19.4-1
+      version: 0.19.5-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.19.5-1`:

- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.19.4-1`

## combined_robot_hw

- No changes

## combined_robot_hw_tests

- No changes

## controller_interface

- No changes

## controller_manager

```
* Add wall clock timeout to avoid some deadlock situation when switching mode (#491 <https://github.com/ros-controls/ros_control/issues/491>)
  Co-authored-by: Krishna <mailto:chaitanyaradon89@gmail.com>
* Contributors: Bence Magyar
```

## controller_manager_msgs

- No changes

## controller_manager_tests

- No changes

## hardware_interface

```
* Correct exception msg for missing abs pos ptr
* fix broken links by making them relative
* Contributors: G.A. vd. Hoorn, Mikael Arguedas
```

## joint_limits_interface

- No changes

## ros_control

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
