### PR TITLE
pass_through_controllers: 0.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4924,6 +4924,21 @@ repositories:
       url: https://github.com/tuc-proaut/ros_parameter.git
       version: master
     status: maintained
+  pass_through_controllers:
+    doc:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS_passthrough_controllers.git
+      version: main
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS_passthrough_controllers-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS_passthrough_controllers.git
+      version: main
+    status: developed
   pcdfilter_pa:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pass_through_controllers` to `0.1.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS_passthrough_controllers.git
- release repository: https://github.com/UniversalRobots/Universal_Robots_ROS_passthrough_controllers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## pass_through_controllers

```
* Initial release
* Contributors: Felix Exner, Rune Søe-Knudsen, Stefan Scherzinger
```
