### PR TITLE
gazebo_ros2_control: 0.0.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1123,7 +1123,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros2_control` to `0.0.3-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros2_control/
- release repository: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.2-1`

## gazebo_ros2_control

```
* Forward sdf ros remappings to loaded controllers (#80 <https://github.com/ros-simulation/gazebo_ros2_control/issues/80>)
  Co-authored-by: Jonatan Olofsson <mailto:jonatan.olofsson@saabgroup.com>
* Join with the controller manager's executor thread on exit (#79 <https://github.com/ros-simulation/gazebo_ros2_control/issues/79>)
* Ensure that sim_joints_ always has the same number of elements as the… (#77 <https://github.com/ros-simulation/gazebo_ros2_control/issues/77>)
* Write joints on each simulation update period (#78 <https://github.com/ros-simulation/gazebo_ros2_control/issues/78>)
* Contributors: Jonatan Olofsson, Kenneth Bogert, Victor Lopez
```

## gazebo_ros2_control_demos

```
* Update code with recent change in ros2_control (#81 <https://github.com/ros-simulation/gazebo_ros2_control/issues/81>)
* Adding ros2_control dependency to demos (#74 <https://github.com/ros-simulation/gazebo_ros2_control/issues/74>) (#76 <https://github.com/ros-simulation/gazebo_ros2_control/issues/76>)
* Contributors: Alejandro Hernández Cordero, Ron Marrero
```
