### PR TITLE
Fix spirv-tools rule for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7032,7 +7032,7 @@ spirv-tools:
   debian: [spirv-tools]
   fedora: [spirv-tools, spirv-tools-devel, spirv-tools-libs]
   gentoo: [dev-util/spirv-tools]
-  rhel: [spirv-tools]
+  rhel: [spirv-tools, spirv-tools-devel, spirv-tools-libs]
   ubuntu:
     '*': [spirv-tools]
     bionic: null


### PR DESCRIPTION
It isn't clear from the Ubuntu package name, but 'spirv-tools' contains development resources like unversioned SO libraries, headers, and CMake modules. This change aligns the RHEL rule to include the additional packages which provide those resources.

On RHEL 8, this package is provided in AppStream. On RHEL 7, it is provided by EPEL.

- 'spirv-tools'
  - 7: https://src.fedoraproject.org/rpms/spirv-tools#bodhi_updates
  - 8: http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/Packages/spirv-tools-2020.5-3.20201208.gitb27b1af.el8.x86_64.rpm
- 'spirv-tools-devel'
  - 7: https://src.fedoraproject.org/rpms/spirv-tools#bodhi_updates
  - 8: http://mirror.centos.org/centos-8/8/PowerTools/x86_64/os/Packages/spirv-tools-devel-2020.5-3.20201208.gitb27b1af.el8.i686.rpm
- 'spirv-tools-libs'
  - 7: https://src.fedoraproject.org/rpms/spirv-tools#bodhi_updates
  - 8: http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/Packages/spirv-tools-libs-2020.5-3.20201208.gitb27b1af.el8.x86_64.rpm