### PR TITLE
rrt_star_global_planner: 0.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11934,6 +11934,22 @@ repositories:
       url: https://github.com/RoverRobotics/rr_openrover_stack.git
       version: melodic-devel
     status: developed
+  rrt_star_global_planner:
+    doc:
+      type: git
+      url: https://github.com/HyunsikSon/rrt_star_global_planner.git
+      version: melodic
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/HyunsikSon/rrt_star_global_planner-release.git
+      version: 0.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/HyunsikSon/rrt_star_global_planner.git
+      version: melodic
+    status: developed
   rt_usb_9axisimu_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rrt_star_global_planner` to `0.0.0-1`:

- upstream repository: https://github.com/HyunsikSon/rrt_star_global_planner.git
- release repository: https://github.com/HyunsikSon/rrt_star_global_planner-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
