### PR TITLE
ypspur_ros: 0.3.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9040,7 +9040,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/openspur/ypspur_ros-release.git
-      version: 0.3.4-1
+      version: 0.3.5-1
     source:
       type: git
       url: https://github.com/openspur/ypspur_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ypspur_ros` to `0.3.5-1`:

- upstream repository: https://github.com/openspur/ypspur_ros.git
- release repository: https://github.com/openspur/ypspur_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.4-1`

## ypspur_ros

```
* Avoid publishing duplicated odometry (#97 <https://github.com/openspur/ypspur_ros/issues/97>)
* Update assets to v0.3.1 (#96 <https://github.com/openspur/ypspur_ros/issues/96>)
* Update assets to v0.3.0 (#95 <https://github.com/openspur/ypspur_ros/issues/95>)
* Update assets to v0.2.0 (#94 <https://github.com/openspur/ypspur_ros/issues/94>)
* Migrate to tf2 (#93 <https://github.com/openspur/ypspur_ros/issues/93>)
* Update assets to v0.1.5 (#92 <https://github.com/openspur/ypspur_ros/issues/92>)
* Add LICENSE file (#91 <https://github.com/openspur/ypspur_ros/issues/91>)
* Contributors: Atsushi Watanabe, Naotaka Hatao, f-fl0
```
