### PR TITLE
python.yaml updates for openSUSE (1 of 11)

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -508,6 +508,7 @@ python-argcomplete:
   gentoo: [dev-python/argcomplete]
   nixos: [pythonPackages.argcomplete]
   openembedded: [python3-argcomplete@meta-python]
+  opensuse: [python2-argcomplete]
   ubuntu: [python-argcomplete]
 python-argh:
   debian: [python-argh]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -815,7 +815,7 @@ python-cairo:
   freebsd: [py27-cairo]
   gentoo: [dev-python/pycairo]
   nixos: [pythonPackages.pycairo]
-  opensuse: [python-cairo]
+  opensuse: [python2-cairo]
   rhel:
     '*': [python2-cairo]
     '7': [pycairo]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -530,7 +530,7 @@ python-argparse:
   macports: [py27-argparse]
   nixos: [python]
   openembedded: []
-  opensuse: [python-argparse]
+  opensuse: [python]
   osx:
     pip:
       packages: [argparse]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1211,7 +1211,7 @@ python-coverage:
   freebsd: [py27-coverage]
   gentoo: [dev-python/coverage]
   nixos: [pythonPackages.coverage]
-  opensuse: [python-coverage]
+  opensuse: [python2-coverage]
   osx:
     pip:
       packages: [coverage]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -829,6 +829,7 @@ python-cairosvg:
   fedora: [python-cairosvg]
   gentoo: [media-gfx/cairosvg]
   nixos: [pythonPackages.cairosvg]
+  opensuse: [python3-CairoSVG]
   ubuntu: [python-cairosvg]
 python-can:
   alpine:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -621,6 +621,7 @@ python-avahi:
   fedora: [avahi-ui-tools]
   gentoo: ['net-dns/avahi[python]']
   nixos: [pythonPackages.avahi]
+  opensuse: [python3-avahi]
   ubuntu: [python-avahi]
 python-babel:
   debian: [python-babel]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -204,6 +204,7 @@ ipython:
   gentoo: [dev-python/ipython]
   macports: [py27-ipython]
   nixos: [pythonPackages.ipython]
+  opensuse: [python2-ipython]
   ubuntu: [ipython]
 ipython3:
   debian: [ipython3]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1285,6 +1285,7 @@ python-crypto:
   gentoo: [dev-python/pycrypto]
   nixos: [pythonPackages.pycrypto]
   openembedded: ['${PYTHON_PN}-pycrypto@meta-python']
+  opensuse: [python2-pycrypto]
   osx:
     pip:
       packages: [pycrypto]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1069,6 +1069,7 @@ python-cheetah:
   gentoo: [dev-python/cheetah]
   nixos: [pythonPackages.cheetah]
   openembedded: ['${PYTHON_PN}-cheetah@meta-python']
+  opensuse: [python-Cheetah]
   ubuntu: [python-cheetah]
 python-cherrypy:
   debian: [python-cherrypy3]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1037,6 +1037,9 @@ python-chainer-pip:
     pip:
       packages: [chainer]
   nixos: [pythonPackages.chainer]
+  opensuse:
+    pip:
+      packages: [chainer]
   osx:
     pip:
       packages: [chainer]


### PR DESCRIPTION
I have a lot of updates for openSUSE and was asked to break them up for easier digestion per Draft PR #28385 

These keys are not necessarily related to each other. I'm just processing these commits alphabetically and breaking them up into groups of approx. 10.

https://software.opensuse.org/package/python-ipython
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-ipython/standard
https://software.opensuse.org/package/python2-argcomplete
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-argcomplete/standard
https://software.opensuse.org/package/python
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.15905/standard
https://software.opensuse.org/package/python3-avahi
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.13855/standard
https://software.opensuse.org/package/python2-cairo
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-cairo/standard
https://software.opensuse.org/package/python3-CairoSVG
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-CairoSVG/standard
https://pypi.org/project/chainer/
https://software.opensuse.org/package/python-Cheetah
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-Cheetah/standard
https://software.opensuse.org/package/python2-coverage
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-coverage/standard
https://software.opensuse.org/package/python2-pycrypto
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-pycrypto/standard