### PR TITLE
python.yaml updates for openSUSE (2 of 11)

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1541,6 +1541,7 @@ python-enum34:
   gentoo: [virtual/python-enum34]
   nixos: [pythonPackages.enum34]
   openembedded: ['${PYTHON_PN}-enum34@meta-python']
+  opensuse: [python-enum34]
   ubuntu: [python-enum34]
 python-enum34-pip:
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1759,6 +1759,7 @@ python-future:
   gentoo: [dev-python/future]
   nixos: [pythonPackages.future]
   openembedded: ['${PYTHON_PN}-future@meta-python']
+  opensuse: [python2-future]
   osx:
     pip:
       packages: [future]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1409,7 +1409,7 @@ python-defusedxml:
   gentoo: [dev-python/defusedxml]
   nixos: [pythonPackages.defusedxml]
   openembedded: ['${PYTHON_PN}-defusedxml@meta-ros-common']
-  opensuse: [python-defusedxml]
+  opensuse: [python2-defusedxml]
   osx:
     pip:
       packages: [defusedxml]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2176,6 +2176,7 @@ python-h5py:
   fedora: [h5py]
   gentoo: [dev-python/h5py]
   nixos: [pythonPackages.h5py]
+  opensuse: [python2-h5py]
   ubuntu:
     '*': [python-h5py]
     trusty_python3: [python3-h5py]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1516,7 +1516,7 @@ python-empy:
   macports: [py27-empy]
   nixos: [pythonPackages.empy]
   openembedded: ['${PYTHON_PN}-empy@meta-ros-common']
-  opensuse: [python-empy]
+  opensuse: [python2-empy]
   osx:
     pip:
       packages: [empy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1922,6 +1922,7 @@ python-gnupg:
   gentoo: [dev-python/python-gnupg]
   nixos: [pythonPackages.python-gnupg]
   openembedded: ['${PYTHON_PN}-gnupg@meta-ros-common']
+  opensuse: [python2-python-gnupg]
   rhel:
     '7': [python2-gnupg]
   ubuntu: [python-gnupg]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1476,6 +1476,7 @@ python-docutils:
   fedora: [python-docutils]
   gentoo: [dev-python/docutils]
   nixos: [pythonPackages.docutils]
+  opensuse: [python2-docutils]
   ubuntu:
     artful: [python-docutils]
     bionic: [python-docutils]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2213,6 +2213,7 @@ python-imageio:
       packages: [imageio]
   gentoo: [dev-python/imageio]
   nixos: [pythonPackages.imageio]
+  opensuse: [python2-imageio]
   ubuntu:
     '*': [python-imageio]
     trusty:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1730,6 +1730,9 @@ python-freezegun-pip:
     pip:
       packages: [freezegun]
   nixos: [pythonPackages.freezegun]
+  opensuse:
+    pip:
+      packages: [freezegun]
   osx:
     pip:
       packages: [freezegun]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2235,7 +2235,7 @@ python-imaging:
   macports: [py27-pil]
   nixos: [pythonPackages.pillow]
   openembedded: ['${PYTHON_PN}-pillow@meta-python']
-  opensuse: [python-imaging]
+  opensuse: [python2-Pillow]
   osx:
     pip:
       packages: [Pillow]


### PR DESCRIPTION
This is a continuation of the python.yaml updates for openSUSE
#29935

These keys are not necessarily related to each other. I'm just processing these commits alphabetically and breaking them up into groups of approx. 10.

https://software.opensuse.org/package/python2-defusedxml
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-defusedxml/standard
https://software.opensuse.org/package/python2-docutils
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-docutils/standard
https://software.opensuse.org/package/python2-empy
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-empy/standard
https://software.opensuse.org/package/python-enum34
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-enum34/standard
https://pypi.org/project/freezegun/
https://software.opensuse.org/package/python2-future
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-future/standard
https://software.opensuse.org/package/python2-python-gnupg
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-python-gnupg/standard
https://software.opensuse.org/package/python2-h5py
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-h5py/standard
https://software.opensuse.org/package/python2-imageio
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-imageio/standard
https://software.opensuse.org/package/python2-Pillow
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-Pillow/standard