### PR TITLE
srdfdom: 2.0.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3105,6 +3105,21 @@ repositories:
       url: https://github.com/ros2/spdlog_vendor.git
       version: galactic
     status: maintained
+  srdfdom:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/srdfdom.git
+      version: ros2
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/moveit/srdfdom-release.git
+      version: 2.0.2-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/srdfdom.git
+      version: ros2
+    status: maintained
   sros2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom` to `2.0.2-1`:

- upstream repository: https://github.com/ros-planning/srdfdom.git
- release repository: https://github.com/moveit/srdfdom-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## srdfdom

```
* Support rolling CI (#85 <https://github.com/ros-planning/srdfdom/issues/85>)
* Contributors: Vatan Aksoy Tezer
```
