### PR TITLE
random_numbers: 2.0.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1743,6 +1743,21 @@ repositories:
       url: https://github.com/ros2-gbp/radar_msgs-release.git
       version: 0.2.1-1
     status: maintained
+  random_numbers:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/random_numbers.git
+      version: ros2
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/moveit/random_numbers-release.git
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/random_numbers.git
+      version: ros2
+    status: maintained
   rc_common_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `random_numbers` to `2.0.1-1`:

- upstream repository: https://github.com/ros-planning/random_numbers.git
- release repository: https://github.com/moveit/random_numbers-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## random_numbers

```
* Support rolling on CI (#32 <https://github.com/ros-planning/random_numbers/issues/32>)
* Migrate to GitHub Actions (#30 <https://github.com/ros-planning/random_numbers/issues/30>)
* Fix Travis README badge (#26 <https://github.com/ros-planning/random_numbers/issues/26>)
* Enable WINDOWS_EXPORT_ALL_SYMBOLS property for MSVC support (#23 <https://github.com/ros-planning/random_numbers/issues/23>)
* Declare specific boost depedencies (#22 <https://github.com/ros-planning/random_numbers/issues/22>)
  * removed unnecessary libboost-math libraries as only headers-only parts are used
* Fix clang-format, ament_lint_cmake (#25 <https://github.com/ros-planning/random_numbers/issues/25>)
* Contributors: Henning Kayser, Lior Lustgarten, Mikael Arguedas, Robert Haschke, Tyler Weaver, Vatan Aksoy Tezer
```
