### PR TITLE
warehouse_ros: 2.0.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3635,6 +3635,21 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: ros2
     status: maintained
+  warehouse_ros:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros.git
+      version: ros2
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/moveit/warehouse_ros-release.git
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros.git
+      version: ros2
+    status: maintained
   webots_ros2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros` to `2.0.1-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros.git
- release repository: https://github.com/moveit/warehouse_ros-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## warehouse_ros

```
* List OpenSSL as build depend (#68 <https://github.com/ros-planning/warehouse_ros/issues/68>)
* Update CI and add Rolling Test (#69 <https://github.com/ros-planning/warehouse_ros/issues/69>)
* Add badges for CI to README (#62 <https://github.com/ros-planning/warehouse_ros/issues/62>)
* Add python black formatter to pre-commit (#66 <https://github.com/ros-planning/warehouse_ros/issues/66>)
* Add copyright notices and test (#53 <https://github.com/ros-planning/warehouse_ros/issues/53>)
* Add github actions ci using industrial_ci (#54 <https://github.com/ros-planning/warehouse_ros/issues/54>, #55 <https://github.com/ros-planning/warehouse_ros/issues/55>)
  * Enable ccache (#56 <https://github.com/ros-planning/warehouse_ros/issues/56>, #61 <https://github.com/ros-planning/warehouse_ros/issues/61>, #65 <https://github.com/ros-planning/warehouse_ros/issues/65>)
* Contributors: Tyler Weaver
```
