### PR TITLE
moveit_resources: 2.0.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1306,6 +1306,28 @@ repositories:
       url: https://github.com/ros2/mimick_vendor.git
       version: galactic
     status: maintained
+  moveit_resources:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_resources.git
+      version: ros2
+    release:
+      packages:
+      - moveit_resources
+      - moveit_resources_fanuc_description
+      - moveit_resources_fanuc_moveit_config
+      - moveit_resources_panda_description
+      - moveit_resources_panda_moveit_config
+      - moveit_resources_pr2_description
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/moveit/moveit_resources-release.git
+      version: 2.0.2-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_resources.git
+      version: ros2
+    status: developed
   mrpt2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `2.0.2-1`:

- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/moveit/moveit_resources-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## moveit_resources

- No changes

## moveit_resources_fanuc_description

- No changes

## moveit_resources_fanuc_moveit_config

```
* Remove move group prefixes from rviz configs (#62 <https://github.com/ros-planning/moveit_resources/issues/62>)
* Contributors: Vatan Aksoy Tezer
```

## moveit_resources_panda_description

- No changes

## moveit_resources_panda_moveit_config

```
* Add missing ros2_control parameters (#74 <https://github.com/ros-planning/moveit_resources/issues/74>)
* Add Panda demo.launch.py and RViz config (#64 <https://github.com/ros-planning/moveit_resources/issues/64>)
* Remove move group prefixes from rviz configs (#62 <https://github.com/ros-planning/moveit_resources/issues/62>)
* Ensure panda joint limits have the proper type (#63 <https://github.com/ros-planning/moveit_resources/issues/63>)
* Contributors: AndyZe, Henning Kayser, Vatan Aksoy Tezer
```

## moveit_resources_pr2_description

- No changes
