### PR TITLE
geometric_shapes: 2.1.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -783,6 +783,21 @@ repositories:
       url: https://github.com/ros-geographic-info/geographic_info.git
       version: ros2
     status: maintained
+  geometric_shapes:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/geometric_shapes.git
+      version: ros2
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/moveit/geometric_shapes-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/geometric_shapes.git
+      version: ros2
+    status: maintained
   geometry2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `2.1.0-1`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/moveit/geometric_shapes-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## geometric_shapes

```
* Add Galactic CI, cleanup rolling (#190 <https://github.com/ros-planning/geometric_shapes/issues/190>)
* Sync ros2 branch with noetic-devel up to d147f03 <https://github.com/ros-planning/geometric_shapes/commit/d147f0371afbece0b8c93a2d2d55149a284d5192> (#190 <https://github.com/ros-planning/geometric_shapes/issues/190>)
* Contributors: Jafar Abdi, Henning Kayser, Vatan Aksoy Tezer
```
