### PR TITLE
python.yaml updates for openSUSE (3 of 11)

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2622,7 +2622,7 @@ python-mock:
   gentoo: [dev-python/mock]
   nixos: [pythonPackages.mock]
   openembedded: ['${PYTHON_PN}-mock@meta-python']
-  opensuse: [python-mock]
+  opensuse: [python2-mock]
   osx:
     pip:
       packages: [mock]
@@ -6686,6 +6686,7 @@ python3-mock:
   gentoo: [dev-python/mock]
   nixos: [python3Packages.mock]
   openembedded: [python3-mock@meta-ros-common]
+  opensuse: [python3-mock]
   rhel: ['python%{python3_pkgversion}-mock']
   ubuntu: [python3-mock]
 python3-more-itertools:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2573,7 +2573,7 @@ python-matplotlib:
   macports: [py27-matplotlib]
   nixos: [pythonPackages.matplotlib]
   openembedded: ['${PYTHON_PN}-matplotlib@meta-python']
-  opensuse: [python-matplotlib]
+  opensuse: [python2-matplotlib]
   osx:
     pip:
       depends: [pkg-config, freetype, libpng12-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2686,6 +2686,7 @@ python-msgpack:
   gentoo: [dev-python/msgpack]
   nixos: [pythonPackages.msgpack]
   openembedded: ['${PYTHON_PN}-msgpack@meta-python2']
+  opensuse: [python2-msgpack]
   ubuntu: [python-msgpack]
 python-multicast:
   fedora:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2795,7 +2795,7 @@ python-netifaces:
   macports: [p27-netifaces]
   nixos: [pythonPackages.netifaces]
   openembedded: ['${PYTHON_PN}-netifaces@meta-ros-common']
-  opensuse: [python-netifaces]
+  opensuse: [python2-netifaces]
   osx:
     pip:
       packages: [netifaces]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2353,6 +2353,7 @@ python-joblib:
   fedora: [python-joblib]
   gentoo: [dev-python/joblib]
   nixos: [pythonPackages.joblib]
+  opensuse: [python2-joblib]
   ubuntu: [python-joblib]
 python-jsonpickle:
   arch: [python-jsonpickle]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2879,7 +2879,7 @@ python-numpy:
   macports: [py27-numpy]
   nixos: [pythonPackages.numpy]
   openembedded: ['${PYTHON_PN}-numpy@openembedded-core']
-  opensuse: [python-numpy]
+  opensuse: [python2-numpy]
   osx:
     pip:
       packages: [numpy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2979,7 +2979,7 @@ python-opencv:
   gentoo: ['media-libs/opencv[python]']
   nixos: [pythonPackages.opencv3]
   openembedded: [opencv@meta-oe]
-  opensuse: [python-opencv]
+  opensuse: [python2-opencv]
   rhel:
     '7': [opencv-python]
   slackware: [opencv]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2853,7 +2853,7 @@ python-nose:
   macports: [py27-nose]
   nixos: [pythonPackages.nose]
   openembedded: ['${PYTHON_PN}-nose@openembedded-core']
-  opensuse: [python-nose]
+  opensuse: [python2-nose]
   osx:
     pip:
       packages: [nose]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2522,6 +2522,7 @@ python-lxml:
   gentoo: [dev-python/lxml]
   nixos: [pythonPackages.lxml]
   openembedded: ['${PYTHON_PN}-lxml@meta-python']
+  opensuse: [python2-lxml]
   osx:
     pip:
       packages: [lxml]


### PR DESCRIPTION
This is a continuation of the python.yaml updates for openSUSE
#29935 #29936

These keys are not necessarily related to each other. I'm just processing these commits alphabetically and breaking them up into groups of approx. 10.

https://software.opensuse.org/package/python2-joblib
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-joblib/standard
https://software.opensuse.org/package/python2-lxml
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-lxml/standard
https://software.opensuse.org/package/python2-matplotlib
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-matplotlib/standard
https://software.opensuse.org/package/python2-mock
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.14706/standard
https://software.opensuse.org/package/python2-msgpack
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-msgpack/standard
https://software.opensuse.org/package/python2-netifaces
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-netifaces/standard
https://software.opensuse.org/package/python2-nose
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-nose/standard
https://software.opensuse.org/package/python2-numpy
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python2-numpy/standard
https://software.opensuse.org/package/python2-opencv
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/opencv/standard