### PR TITLE
moveit_msgs: 2.1.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1306,6 +1306,21 @@ repositories:
       url: https://github.com/ros2/mimick_vendor.git
       version: galactic
     status: maintained
+  moveit_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/moveit/moveit_msgs-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_msgs.git
+      version: ros2
+    status: developed
   mrpt2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_msgs` to `2.1.0-1`:

- upstream repository: https://github.com/ros-planning/moveit_msgs.git
- release repository: https://github.com/moveit/moveit_msgs-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## moveit_msgs

```
* Sync with master branch up to 460caab <https://github.com/ros-planning/moveit_msgs/commit/460caab755cfe018ad07effd7dd808127a7e5c61> (#120 <https://github.com/ros-planning/moveit_msgs/issues/120>)
* Enable CI on Rolling, Galactic (#117 <https://github.com/ros-planning/moveit_msgs/issues/117>)
* Pre-release testing workflow for ROS 2 (#118 <https://github.com/ros-planning/moveit_msgs/issues/118>)
* Contributors: Jafar Abdi, Henning Kayser, Tyler Weaver, Vatan Aksoy Tezer
```
