### PR TITLE
moveit_msgs: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1376,7 +1376,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/moveit/moveit_msgs-release.git
-      version: 2.0.1-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_msgs` to `2.1.0-1`:

- upstream repository: https://github.com/ros-planning/moveit_msgs.git
- release repository: https://github.com/moveit/moveit_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.1-1`

## moveit_msgs

```
* Sync with master branch up to 460caab <https://github.com/ros-planning/moveit_msgs/commit/460caab755cfe018ad07effd7dd808127a7e5c61> (#120 <https://github.com/ros-planning/moveit_msgs/issues/120>)
* Enable CI on Rolling, Galactic (#117 <https://github.com/ros-planning/moveit_msgs/issues/117>)
* Pre-release testing workflow for ROS 2 (#118 <https://github.com/ros-planning/moveit_msgs/issues/118>)
* Contributors: Jafar Abdi, Henning Kayser, Tyler Weaver, Vatan Aksoy Tezer
```
