### PR TITLE
Remove gentoo pip rosdep entries

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7734,7 +7734,7 @@ python3-tilestache-pip:
   fedora:
     pip:
       packages: [tilestache]
-  ubunru:
+  ubuntu:
     pip:
       packages: [tilestache]
 python3-tk:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1334,9 +1334,6 @@ python-cython-pip:
   fedora:
     pip:
       packages: [cython]
-  gentoo:
-    pip:
-      packages: [cython]
   ubuntu:
     pip:
       packages: [cython]
@@ -2700,9 +2697,6 @@ python-multiprocess-pip:
   fedora:
     pip:
       packages: [multiprocess]
-  gentoo:
-    pip:
-      packages: [multiprocess]
   ubuntu:
     pip:
       packages: [multiprocess]
@@ -3064,9 +3058,6 @@ python-parameterized:
       pip:
         packages: [parameterized]
   fedora: [python-parameterized]
-  gentoo:
-    pip:
-      packages: [parameterized]
   osx:
     pip:
       packages: [parameterized]
@@ -3713,9 +3704,6 @@ python-pyqrcode:
 python-pyqtgraph:
   debian: [python-pyqtgraph]
   fedora:
-    pip:
-      packages: [pyqtgraph]
-  gentoo:
     pip:
       packages: [pyqtgraph]
   nixos: [pythonPackages.pyqtgraph]
@@ -5727,9 +5715,6 @@ python3-aio-pika-pip:
   fedora:
     pip:
       packages: [aio-pika]
-  gentoo:
-    pip:
-      packages: [aio-pika]
   ubuntu:
     pip:
       packages: [aio-pika]
@@ -5751,9 +5736,6 @@ python3-ansible-runner-pip:
     pip:
       packages: [ansible-runner]
   fedora:
-    pip:
-      packages: [ansible-runner]
-  gentoo:
     pip:
       packages: [ansible-runner]
   ubuntu:
@@ -6557,9 +6539,6 @@ python3-jupyros-pip:
   fedora:
     pip:
       packages: [jupyros]
-  gentoo:
-    pip:
-      packages: [jupyros]
   ubuntu:
     pip:
       packages: [jupyros]
@@ -6852,6 +6831,7 @@ python3-parameterized:
   alpine: [py3-parameterized]
   debian: [python3-parameterized]
   fedora: [python3-parameterized]
+  gentoo: [dev-python/parameterized]
   ubuntu: [python3-parameterized]
 python3-paramiko:
   debian: [python3-paramiko]
@@ -7587,9 +7567,6 @@ python3-simple-pid-pip:
   fedora:
     pip:
       packages: [simple-pid]
-  gentoo:
-    pip:
-      packages: [simple-pid]
   osx:
     pip:
       packages: [simple-pid]
@@ -7615,9 +7592,6 @@ python3-siphon-pip:
     pip:
       packages: [siphon]
   fedora:
-    pip:
-      packages: [siphon]
-  gentoo:
     pip:
       packages: [siphon]
   osx:
@@ -7760,10 +7734,7 @@ python3-tilestache-pip:
   fedora:
     pip:
       packages: [tilestache]
-  gentoo:
-    pip:
-      packages: [tilestache]
-  ubuntu:
+  ubunru:
     pip:
       packages: [tilestache]
 python3-tk:
@@ -7864,9 +7835,7 @@ python3-vcstool:
     pip:
       packages: [vcstool]
   fedora: [python3-vcstool]
-  gentoo:
-    pip:
-      packages: [vcstool]
+  gentoo: [vcstool]
   macports:
     pip:
       packages: [vcstool]


### PR DESCRIPTION
Per #29909, remove gentoo pip entries because [pip installs on gentoo need to be done with `--user`](https://wiki.gentoo.org/wiki/Pip), and rosdep does system installs, so pip entries won't work on Gentoo.
The correct way is to create overlays. Will create a ticket in ros/ros-overlay for these.

## Package name:

Removed gentoo pip entries in the following keys:

python-cython-pip
python-multiprocess-pip
python-parameterized
python-pyqtgraph
python3-aio-pika-pip
python3-ansible-runner-pip
python3-jupyros-pip
python3-simple-pid-pip
python3-siphon-pip
python3-tilestache-pip
python3-vcstool

## Package Upstream Source:

## Purpose of using this:

See note at top.

## Links to Distribution Packages

Notes on a few entries that are removed but might have alternatives:

Replaced `parameterized` in key `python-parameterized`.
There is a `dev-python/parameterized` for Python 3, now added to `python3-parameterized` key.
https://packages.gentoo.org/packages/dev-python/parameterized

Removed `pyqtgraph` in key `python-pyqtgraph`.
There is a `dev-python/pyqtgraph` for Python 3, and it is already in `python3-pyqtgraph` key.
https://packages.gentoo.org/packages/dev-python/pyqtgraph

Removed `ansible-runner` in key `python3-ansible-runner-pip`.
There is a `dev-python/ansible-runner` for Python 3, but since the rosdep key name is `-pip`, I didn’t add the system package there.
If someone wants it for gentoo, they might just have to add a new key for `python3-ansible-runner`.
https://packages.gentoo.org/packages/dev-python/ansible-runner

Removed `siphon` in key `python3-siphon-pip`.
There is a `net-analyzer/siphon`, but it doesn’t say what Python it’s for, and the website is currently not accessible, and there isn’t a non-pip siphon rosdep key, so I didn’t add it.
https://packages.gentoo.org/packages/net-analyzer/siphon

Replaced `vcstool` pip entry in `python3-vcstool` with `vcstool` system dependency.
https://index.ros.org/d/python3-vcstool/

Other entries are simply removed because I didn't find alternatives.