### PR TITLE
warehouse_ros_mongo: 2.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5090,7 +5090,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/moveit/warehouse_ros_mongo-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros_mongo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros_mongo` to `2.0.2-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros_mongo.git
- release repository: https://github.com/moveit/warehouse_ros_mongo-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.1-1`

## warehouse_ros_mongo

```
* [ROS2] Add prerelease tests (#59 <https://github.com/ros-planning/warehouse_ros_mongo/issues/59>)
* Use libssl-dev build_depend for OpenSSL (#63 <https://github.com/ros-planning/warehouse_ros_mongo/issues/63>)
* Add CI for Galactic, Rolling (#57 <https://github.com/ros-planning/warehouse_ros_mongo/issues/57>)(#56 <https://github.com/ros-planning/warehouse_ros_mongo/issues/56>)
* Contributors: Henning Kayser, Vatan Aksoy Tezer
```
