### PR TITLE
warehouse_ros_mongo: 2.0.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3741,6 +3741,21 @@ repositories:
       url: https://github.com/ros-planning/warehouse_ros.git
       version: ros2
     status: maintained
+  warehouse_ros_mongo:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros_mongo.git
+      version: ros2
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/moveit/warehouse_ros_mongo-release.git
+      version: 2.0.2-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros_mongo.git
+      version: ros2
+    status: maintained
   webots_ros2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros_mongo` to `2.0.2-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros_mongo.git
- release repository: https://github.com/moveit/warehouse_ros_mongo-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## warehouse_ros_mongo

```
* [ROS2] Add prerelease tests (#59 <https://github.com/ros-planning/warehouse_ros_mongo/issues/59>)
* Use libssl-dev build_depend for OpenSSL (#63 <https://github.com/ros-planning/warehouse_ros_mongo/issues/63>)
* Add CI for Galactic, Rolling (#57 <https://github.com/ros-planning/warehouse_ros_mongo/issues/57>)(#56 <https://github.com/ros-planning/warehouse_ros_mongo/issues/56>)
* Contributors: Henning Kayser, Vatan Aksoy Tezer
```
