### PR TITLE
twist_mux: 4.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3569,6 +3569,21 @@ repositories:
       url: https://github.com/autowarefoundation/tvm_vendor.git
       version: main
     status: maintained
+  twist_mux:
+    doc:
+      type: git
+      url: https://github.com/ros-teleop/twist_mux.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros-gbp/twist_mux-release.git
+      version: 4.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-teleop/twist_mux.git
+      version: foxy-devel
+    status: maintained
   twist_stamper:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `twist_mux` to `4.0.1-1`:

- upstream repository: https://github.com/ros-teleop/twist_mux.git
- release repository: https://github.com/ros-gbp/twist_mux-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
