### PR TITLE
ur_client_library: 0.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8385,7 +8385,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
-      version: 0.2.2-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `0.3.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.2-1`

## ur_client_library

```
* Added Cartesian streaming interface #75 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/75> from UniversalRobots/cartesian_interface
* Add trajectory interface to library #72 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/72> from fmauch/trajectory_interface
* Refactor reverse interface #70 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/70> from fmauch/refactor_reverse_interface
* Contributors: Felix Exner, Mads Holm Peters, Tristan Schnell
```
