### PR TITLE
Revert "turtlebot3: 2.1.2-1 in 'galactic/distribution.yaml' [bloom]"

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3413,30 +3413,6 @@ repositories:
       url: https://github.com/ros-drivers/transport_drivers.git
       version: main
     status: developed
-  turtlebot3:
-    doc:
-      type: git
-      url: https://github.com/ROBOTIS-GIT/turtlebot3.git
-      version: galactic-devel
-    release:
-      packages:
-      - turtlebot3
-      - turtlebot3_bringup
-      - turtlebot3_cartographer
-      - turtlebot3_description
-      - turtlebot3_example
-      - turtlebot3_navigation2
-      - turtlebot3_node
-      - turtlebot3_teleop
-      tags:
-        release: release/galactic/{package}/{version}
-      url: https://github.com/robotis-ros2-release/turtlebot3-release.git
-      version: 2.1.2-1
-    source:
-      type: git
-      url: https://github.com/ROBOTIS-GIT/turtlebot3.git
-      version: galactic-devel
-    status: developed
   turtlebot3_msgs:
     doc:
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#29937

As mentioned in https://github.com/ros/rosdistro/pull/29937#issuecomment-863501218 this release is missing binary package data for Ubuntu Focal due to missing dependencies.

Once the dependencies have been released this package will be able to be re-released successfully.