### PR TITLE
launch: 0.18.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1165,7 +1165,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.17.0-1
+      version: 0.18.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.18.0-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.17.0-1`

## launch

```
* Add missing exec dependency on PyYAML (#493 <https://github.com/ros2/launch/issues/493>)
* Refactor TimerAction to allow RosTimer to extend (#512 <https://github.com/ros2/launch/issues/512>)
* Improve (Not)Equals condition type hinting (#510 <https://github.com/ros2/launch/issues/510>)
* Contributors: HMellor, Rebecca Butler, Scott K Logan
```

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
