### PR TITLE
astuff_sensor_msgs: 3.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -570,7 +570,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/astuff/astuff_sensor_msgs.git
-      version: release
+      version: melodic
     release:
       packages:
       - astuff_sensor_msgs
@@ -591,7 +591,7 @@ repositories:
     source:
       type: git
       url: https://github.com/astuff/astuff_sensor_msgs.git
-      version: release
+      version: melodic
     status: developed
   async_comm:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -587,7 +587,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/astuff/astuff_sensor_msgs-release.git
-      version: 3.0.1-1
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/astuff/astuff_sensor_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `astuff_sensor_msgs` to `3.0.2-1`:

- upstream repository: https://github.com/astuff/astuff_sensor_msgs.git
- release repository: https://github.com/astuff/astuff_sensor_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.0.1-1`

## astuff_sensor_msgs

- No changes

## delphi_esr_msgs

- No changes

## delphi_mrr_msgs

```
* Cherry-pick delphi_mrr_msgs from master
* Contributors: Ian Colwell
```

## delphi_srr_msgs

- No changes

## derived_object_msgs

- No changes

## ibeo_msgs

- No changes

## kartech_linear_actuator_msgs

- No changes

## mobileye_560_660_msgs

- No changes

## neobotix_usboard_msgs

- No changes

## pacmod_msgs

- No changes

## radar_msgs

- No changes
