### PR TITLE
rviz: 8.2.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4254,7 +4254,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 8.2.1-1
+      version: 8.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `8.2.2-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `8.2.1-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Expose VisualizationManager and YamlConfigReader to the public API (#649 <https://github.com/ros2/rviz/issues/649>) (#709 <https://github.com/ros2/rviz/issues/709>)
* Contributors: Michael Jeronimo
```

## rviz_default_plugins

```
* Make the types explicit in quaternion_helper.hpp. (#625 <https://github.com/ros2/rviz/issues/625>) (#673 <https://github.com/ros2/rviz/issues/673>)
  all calculations to floats.
* Contributors: Louise Poubel
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
