### PR TITLE
nao_interfaces: 0.0.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1382,7 +1382,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ijnek/nao_interfaces-release.git
-      version: 0.0.1-1
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/ijnek/nao_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_interfaces` to `0.0.2-1`:

- upstream repository: https://github.com/ijnek/nao_interfaces.git
- release repository: https://github.com/ijnek/nao_interfaces-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.1-1`

## nao_interfaces

```
* added ament_lint to package.xml
* add eyeleds message
```
