### PR TITLE
rviz: 1.13.18-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12100,7 +12100,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.13.17-1
+      version: 1.13.18-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.13.18-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.13.17-1`

## rviz

```
* Merge #1635 <https://github.com/ros-visualization/rviz/issues/1635>: Fix asynchronous message processing
  - Use threaded callback queue for PointCloud displays
  - Pause asynchronous ROS updates with synchronous ones
* Merge #1629 <https://github.com/ros-visualization/rviz/issues/1629>: Report mesh loading issues for Robot
* [featrue] PropertryTree help: Consider line breaks in string
* [feature] Update QProgressDialog / LoadingDialog during long running functions
* [feature] Show ProgressDialog when duplicating displays
* [maint]   Name quit action allowing rqt_rviz finding the action easily by name
* [maint]   Emit signal VisualizationFrame::displayConfigFileChanged to allow rqt_rviz notice config file changes
* [maint]   Cleanup quickfix since https://github.com/ros/geometry2/pull/402 is released
* [maint]   More explicit OGRE includes
* [maint]   Remove uses of QApplication::sync() + QApplication::flush()
* [maint]   Fixup github actions
* Contributors: Robert Haschke, Simon Schmeisser, sunzbllbz
```
