### PR TITLE
plotjuggler_msgs: 0.1.2-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1686,6 +1686,21 @@ repositories:
       url: https://github.com/facontidavide/PlotJuggler.git
       version: foxy
     status: developed
+  plotjuggler_msgs:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/plotjuggler_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/facontidavide/plotjuggler_msgs-release.git
+      version: 0.1.2-2
+    source:
+      type: git
+      url: https://github.com/facontidavide/plotjuggler_msgs.git
+      version: ros2
+    status: developed
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler_msgs` to `0.1.2-2`:

- upstream repository: https://github.com/facontidavide/plotjuggler_msgs.git
- release repository: https://github.com/facontidavide/plotjuggler_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
