### PR TITLE
plotjuggler: 3.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5188,7 +5188,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.2.0-2
+      version: 3.2.1-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.2.1-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.2.0-2`

## plotjuggler

```
* adding string reference
* qwt updated and fix for #463 <https://github.com/facontidavide/PlotJuggler/issues/463>
* fix #461 <https://github.com/facontidavide/PlotJuggler/issues/461>
* add quaternion to Euler conversion snippets (#459 <https://github.com/facontidavide/PlotJuggler/issues/459>)
  Add 3 functions to convert a Hamiltonian attitude quaternion to its Euler (Trait-Bryan 321) representation
* fix typo when building without ROS support (#460 <https://github.com/facontidavide/PlotJuggler/issues/460>)
* Update README.md
* Contributors: Davide Faconti, Mathieu Bresciani, Nuno Marques
```
