### PR TITLE
plotjuggler_ros: 1.5.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1740,21 +1740,6 @@ repositories:
       url: https://github.com/ros-drivers/phidgets_drivers.git
       version: galactic
     status: maintained
-  plotjuggler_ros:
-    doc:
-      type: git
-      url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
-      version: rolling
-    release:
-      tags:
-        release: release/galactic/{package}/{version}
-      url: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
-      version: 1.5.0-1
-    source:
-      type: git
-      url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
-      version: rolling
-    status: developed
   plotjuggler:
     doc:
       type: git
@@ -1769,6 +1754,21 @@ repositories:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git
       version: main
+    status: developed
+  plotjuggler_ros:
+    doc:
+      type: git
+      url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
+      version: rolling
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
+      version: 1.5.0-1
+    source:
+      type: git
+      url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
+      version: rolling
     status: developed
   pluginlib:
     doc:

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1702,6 +1702,21 @@ repositories:
       url: https://github.com/ros-drivers/phidgets_drivers.git
       version: galactic
     status: maintained
+  plotjuggler_ros:
+    doc:
+      type: git
+      url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
+      version: rolling
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
+      version: 1.5.0-1
+    source:
+      type: git
+      url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
+      version: rolling
+    status: developed
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler_ros` to `1.5.0-1`:

- upstream repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
- release repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## plotjuggler_ros

```
* massive changes
  - include consistent timestamp (suggested by @doisyg )
  - lazy initialization in parsers.
  - reusable Header parser
  - string field added
* add lazy parser inizialization and string field to ROS1
* Contributors: Davide Faconti
```
