### PR TITLE
plotjuggler: 3.2.1-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1702,6 +1702,21 @@ repositories:
       url: https://github.com/ros-drivers/phidgets_drivers.git
       version: galactic
     status: maintained
+  plotjuggler:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/PlotJuggler.git
+      version: main
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/facontidavide/plotjuggler-release.git
+      version: 3.2.1-2
+    source:
+      type: git
+      url: https://github.com/facontidavide/PlotJuggler.git
+      version: main
+    status: developed
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.2.1-2`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## plotjuggler

```
* adding string reference
* qwt updated and fix for #463 <https://github.com/facontidavide/PlotJuggler/issues/463>
* fix #461 <https://github.com/facontidavide/PlotJuggler/issues/461>
* add quaternion to Euler conversion snippets (#459 <https://github.com/facontidavide/PlotJuggler/issues/459>)
  Add 3 functions to convert a Hamiltonian attitude quaternion to its Euler (Trait-Bryan 321) representation
* fix typo when building without ROS support (#460 <https://github.com/facontidavide/PlotJuggler/issues/460>)
* Update README.md
* Contributors: Davide Faconti, Mathieu Bresciani, Nuno Marques
```
