### PR TITLE
mavros: 2.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1321,6 +1321,25 @@ repositories:
       url: https://github.com/mavlink/mavlink-gbp-release.git
       version: release/rolling/mavlink
     status: developed
+  mavros:
+    doc:
+      type: git
+      url: https://github.com/mavlink/mavros.git
+      version: ros2
+    release:
+      packages:
+      - libmavconn
+      - mavros
+      - mavros_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/mavlink/mavros-release.git
+      version: 2.0.3-1
+    source:
+      type: git
+      url: https://github.com/mavlink/mavros.git
+      version: ros2
+    status: developed
   menge_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `2.0.3-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## libmavconn

- No changes

## mavros

```
* param: fix Foxy build
* Contributors: Vladimir Ermakov
```

## mavros_msgs

- No changes
