### PR TITLE
dynamixel_sdk: 3.7.40-4 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -790,7 +790,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/robotis-ros2-release/dynamixel_sdk-release.git
-      version: 3.7.40-3
+      version: 3.7.40-4
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_sdk` to `3.7.40-4`:

- upstream repository: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
- release repository: https://github.com/robotis-ros2-release/dynamixel_sdk-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.7.40-3`

## dynamixel_sdk

```
* Add ROS 2 basic example
* Bug fix
* Contributors: Will Son
```

## dynamixel_sdk_custom_interfaces

```
* Add ROS 2 basic example
* Contributors: Will Son
```

## dynamixel_sdk_examples

```
* Add ROS 2 basic example
* Contributors: Will Son
```
