### PR TITLE
dynamixel_sdk: 3.7.40-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -576,6 +576,25 @@ repositories:
       url: https://github.com/ros2/domain_bridge.git
       version: main
     status: developed
+  dynamixel_sdk:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
+      version: ros2
+    release:
+      packages:
+      - dynamixel_sdk
+      - dynamixel_sdk_custom_interfaces
+      - dynamixel_sdk_examples
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/robotis-ros2-release/dynamixel_sdk-release.git
+      version: 3.7.40-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
+      version: ros2
+    status: maintained
   eigen3_cmake_module:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_sdk` to `3.7.40-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
- release repository: https://github.com/robotis-ros2-release/dynamixel_sdk-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## dynamixel_sdk

```
* Add ROS 2 basic example
* Bug fix
* Contributors: Will Son
```

## dynamixel_sdk_custom_interfaces

```
* Add ROS 2 basic example
* Contributors: Will Son
```

## dynamixel_sdk_examples

```
* Add ROS 2 basic example
* Contributors: Will Son
```
