### PR TITLE
Adding gmcl to documentation index for distro

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2467,7 +2467,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/adler-1994/gmcl.git
-      version: noetic-devel
+      version: master
     status: developed   
   gpp:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2462,7 +2462,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/adler-1994/gmcl.git
-      version: noetic-devel
+      version: master
     source:
       test_pull_requests: true
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2458,6 +2458,17 @@ repositories:
       url: https://github.com/ros-visualization/gl_dependency.git
       version: kinetic-devel
     status: maintained
+  gmcl:
+    doc:
+      type: git
+      url: https://github.com/adler-1994/gmcl.git
+      version: noetic-devel
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/adler-1994/gmcl.git
+      version: noetic-devel
+    status: developed   
   gpp:
     doc:
       type: git


### PR DESCRIPTION
I'd like gmcl to be indexed and documented.