### PR TITLE
rqt_rviz: 0.7.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11781,7 +11781,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_rviz-release.git
-      version: 0.6.0-0
+      version: 0.7.0-1
     source:
       test_pull_requests: true
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11776,7 +11776,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_rviz.git
-      version: lunar-devel
+      version: melodic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -11786,7 +11786,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_rviz.git
-      version: lunar-devel
+      version: melodic-devel
     status: maintained
   rqt_service_caller:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_rviz` to `0.7.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_rviz.git
- release repository: https://github.com/ros-gbp/rqt_rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.0-0`

## rqt_rviz

```
* Fixup catkin_lint issues
* Update maintainers
* Correctly update window title with context serial no
* Notice changes of display config file
* Find quit action by name
* Suppress rviz splash screen
* fix shebang line for python3 (#14 <https://github.com/ros-visualization/rqt_rviz/issues/14>)
* Contributors: Mikael Arguedas, Robert Haschke
```
