### PR TITLE
add python3-prompt-toolkit to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6953,6 +6953,13 @@ python3-progressbar:
 python3-prometheus-client:
   debian: [python3-prometheus-client]
   ubuntu: [python3-prometheus-client]
+python3-prompt-toolkit:
+  arch: [python-prompt_toolkit]
+  debian: [python3-prompt-toolkit]
+  fedora: [python-prompt-toolkit]
+  gentoo: [dev-python/prompt_toolkit]
+  rhel: [python3-prompt-toolkit]
+  ubuntu: [python3-prompt-toolkit]
 python3-protobuf:
   alpine: [py3-protobuf]
   debian: [python3-protobuf]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6958,7 +6958,9 @@ python3-prompt-toolkit:
   debian: [python3-prompt-toolkit]
   fedora: [python-prompt-toolkit]
   gentoo: [dev-python/prompt_toolkit]
-  rhel: [python3-prompt-toolkit]
+  rhel:
+    '*': [python3-prompt-toolkit]
+    '7': null
   ubuntu: [python3-prompt-toolkit]
 python3-protobuf:
   alpine: [py3-protobuf]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-prompt-toolkit

## Package Upstream Source:

https://github.com/prompt-toolkit/python-prompt-toolkit

## Purpose of using this:

prompt_toolkit is a library for building powerful interactive command line and terminal applications in Python.

We're using it to build terminal interfaces to interactively trigger some actions.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/buster/python3-prompt-toolkit
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/focal/python3-prompt-toolkit
- Fedora: https://src.fedoraproject.org/browse/projects/
  - https://src.fedoraproject.org/rpms/python-prompt-toolkit
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/community/any/python-prompt_toolkit/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/prompt_toolkit
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available
