### PR TITLE
tf_transformations: 1.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4574,6 +4574,21 @@ repositories:
       url: https://github.com/ros2/test_interface_files.git
       version: foxy
     status: maintained
+  tf_transformations:
+    doc:
+      type: git
+      url: https://github.com/DLu/tf_transformations.git
+      version: main
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/DLu/tf_transformations_release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/DLu/tf_transformations.git
+      version: main
+    status: maintained
   tinyxml2_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf_transformations` to `1.0.2-1`:

- upstream repository: https://github.com/DLu/tf_transformations.git
- release repository: https://github.com/DLu/tf_transformations_release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
