### PR TITLE
rmf_utils: 1.3.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2334,7 +2334,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_utils-release.git
-      version: 1.3.0-1
+      version: 1.3.0-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_utils.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2329,7 +2329,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_utils.git
-      version: rolling
+      version: main
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2338,7 +2338,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_utils.git
-      version: rolling
+      version: main
     status: developed
   rmf_visualization:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_utils` to `1.3.0-2`:

- upstream repository: https://github.com/open-rmf/rmf_utils.git
- release repository: https://github.com/ros2-gbp/rmf_utils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.3.0-1`

## rmf_utils

```
* Adding missing string include for test, only shows up when building with clang (#9 <https://github.com/open-rmf/rmf_utils/issues/9>)
* Add quality declaration documents (#1 <https://github.com/open-rmf/rmf_utils/issues/1>)
* Changed package requirement to QUIET to allow use in non-ROS 2 packages (#6 <https://github.com/open-rmf/rmf_utils/issues/6>)
* install rmf_code_style.cfg in rmf_utils_DIR (#4 <https://github.com/open-rmf/rmf_utils/issues/4>)
* change to catch2 test, uncrustify everything (#3 <https://github.com/open-rmf/rmf_utils/issues/3>)
* Contributors: Aaron Chong, Geoffrey Biggs, ddengster
```
