### PR TITLE
volta: 1.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2468,7 +2468,7 @@ repositories:
       type: git
       url: https://github.com/adler-1994/gmcl.git
       version: master
-    status: developed   
+    status: developed
   gpp:
     doc:
       type: git
@@ -8821,6 +8821,30 @@ repositories:
       type: git
       url: https://github.com/okalachev/vl53l1x_ros.git
       version: master
+    status: maintained
+  volta:
+    doc:
+      type: git
+      url: https://github.com/botsync/volta.git
+      version: noetic-devel
+    release:
+      packages:
+      - volta_base
+      - volta_control
+      - volta_description
+      - volta_localization
+      - volta_msgs
+      - volta_navigation
+      - volta_rules
+      - volta_teleoperator
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/botsync-gbp/volta-release.git
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://github.com/botsync/volta.git
+      version: noetic-devel
     status: maintained
   vrpn:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `volta` to `1.2.0-1`:

- upstream repository: https://github.com/botsync/volta.git
- release repository: https://github.com/botsync-gbp/volta-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## volta_base

```
* First Release
* Noetic-devel initial commit.
* Contributors: toship-botsync
```

## volta_control

```
* First Release
* Noetic-devel initial commit.
* Contributors: toship-botsync
```

## volta_description

```
* First Release
* Noetic-devel initial commit.
* Contributors: toship-botsync
```

## volta_localization

```
* First Release
* Noetic-devel initial commit.
* Contributors: toship-botsync
```

## volta_msgs

```
* First Release
* Noetic-devel initial commit.
* Contributors: toship-botsync
```

## volta_navigation

```
* First Release
* Added stage rviz config.
* Noetic-devel initial commit.
* Contributors: toship-botsync
```

## volta_rules

```
* First Release
* Noetic-devel initial commit.
* Contributors: toship-botsync
```

## volta_teleoperator

```
* First Release
* Noetic-devel initial commit.
* Contributors: toship-botsync
```
