### PR TITLE
copernicus: 1.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1910,6 +1910,30 @@ repositories:
       url: https://github.com/ros-gbp/convex_decomposition-release.git
       version: 0.1.12-0
     status: unmaintained
+  copernicus:
+    doc:
+      type: git
+      url: https://github.com/botsync/copernicus.git
+      version: melodic-devel
+    release:
+      packages:
+      - copernicus_base
+      - copernicus_control
+      - copernicus_description
+      - copernicus_localization
+      - copernicus_msgs
+      - copernicus_navigation
+      - copernicus_rules
+      - copernicus_teleoperator
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/botsync-gbp/copernicus-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/botsync/copernicus.git
+      version: melodic-devel
+    status: maintained
   core_perception:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `copernicus` to `1.1.0-1`:

- upstream repository: https://github.com/botsync/copernicus.git
- release repository: https://github.com/botsync-gbp/copernicus-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## copernicus_base

```
* First Release
```

## copernicus_control

```
* First Release
```

## copernicus_description

```
* First Release
```

## copernicus_localization

```
* First Release
```

## copernicus_msgs

```
* First Release
```

## copernicus_navigation

```
* First Release
```

## copernicus_rules

```
* First Release
```

## copernicus_teleoperator

```
* First Release
```
