### PR TITLE
geometry_tutorials: 0.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -849,6 +849,10 @@ repositories:
       version: ros2
     status: maintained
   geometry_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros/geometry_tutorials.git
+      version: ros2
     release:
       packages:
       - geometry_tutorials
@@ -856,7 +860,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros-gbp/geometry_tutorials-release.git
-      version: 0.0.1-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/ros/geometry_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_tutorials` to `0.3.1-1`:

- upstream repository: https://github.com/ros/geometry_tutorials
- release repository: https://github.com/ros-gbp/geometry_tutorials-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.1-1`

## geometry_tutorials

```
* Add Audrow as a maintainer and move Shyngys to author (#37 <https://github.com/ros/geometry_tutorials/issues/37>)
* Migrate turtle_tf2 tutorial package to ROS2 (#34 <https://github.com/ros/geometry_tutorials/issues/34>)
* Contributors: kurshakuz, Audrow Nash
```

## turtle_tf2_py

```
* Replace dependency on transforms3d pip package to tf_transformations ROS2 package (#38 <https://github.com/ros/geometry_tutorials/issues/38>)
* Contributors: kurshakuz
```
