### PR TITLE
Remove trailing whitespace.

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2468,7 +2468,7 @@ repositories:
       type: git
       url: https://github.com/adler-1994/gmcl.git
       version: master
-    status: developed   
+    status: developed
   gpp:
     doc:
       type: git


### PR DESCRIPTION
This causes CI errors and was not caught during PR review since there
was another CI failure due to ros/rosdistro#29964.
