### PR TITLE
Explicitly enable yamllint trailing spaces option.

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -48,4 +48,4 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         pip install yamllint
     - name: Run yamllint
-      run: yamllint */
+      run: "yamllint -d'rules: { trailing-spaces: enable}' */"

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -48,4 +48,4 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         pip install yamllint
     - name: Run yamllint
-      run: "yamllint -d'rules: { trailing-spaces: enable}' */"
+      run: yamllint */

--- a/.yamllint
+++ b/.yamllint
@@ -1,42 +1,17 @@
+extends:
+  default
+
 rules:
-  # braces:
-  #   min-spaces-inside: 0
-  #   max-spaces-inside: 0
-  # brackets:
-  #   min-spaces-inside: 0
-  #   max-spaces-inside: 0
-  # colons:
-  #   max-spaces-before: 0
-  #   max-spaces-after: 1
-  # commas:
-  #   max-spaces-before: 0
-  #   min-spaces-after: 1
-  #   max-spaces-after: 1
-  # comments:
-  #   level: warning
-  #   require-starting-space: yes
-  #   min-spaces-from-content: 2
-  # comments-indentation:
-  #   level: warning
-  # document-end: disable
-  # document-start:
-    # level: warning
-    # present: false
-  # empty-lines:
-  #   max: 2
-  #   max-start: 0
-  #   max-end: 0
-  # hyphens:
-  #   max-spaces-after: 1
-  # indentation:
-  #   spaces: consistent
-  #   indent-sequences: yes
-  #   check-multi-line-strings: no
+  document-start:
+    ignore: |
+      releases/*.yaml
+      rosdep/*.yaml
+  indentation:
+    spaces: consistent
+    indent-sequences: no
   key-duplicates: enable
-  # line-length:
-  #   max: 999
-  #   allow-non-breakable-words: yes
-  # new-line-at-end-of-file: enable
-  # new-lines:
-  #   type: unix
-  # trailing-spaces: enable
+  line-length:
+    max: 125
+    allow-non-breakable-words: yes
+    ignore: |
+      rosdep/*.yaml

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5261,7 +5261,7 @@ libvlc:
   gentoo: [media-video/vlc]
   nixos: [vlc]
   openembedded: [vlc@meta-multimedia]
-  opensuse: [libvlc5,vlc-noX]
+  opensuse: [libvlc5, vlc-noX]
   ubuntu:
     '*': [libvlc5, vlc-bin]
     precise: [libvlc5, vlc-nox]

--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -1,76 +1,76 @@
 ---
 package_sources:
   debian:
-    - !deb_base_url http://deb.debian.org/debian main
-    - !deb_base_url http://deb.debian.org/debian contrib
-    - !deb_base_url http://deb.debian.org/debian non-free
-    - !deb_base_url http://repos.ros.org/repos/ros_bootstrap main
+  - !deb_base_url http://deb.debian.org/debian main
+  - !deb_base_url http://deb.debian.org/debian contrib
+  - !deb_base_url http://deb.debian.org/debian non-free
+  - !deb_base_url http://repos.ros.org/repos/ros_bootstrap main
   fedora:
-    - !rpm_base_url https://dl.fedoraproject.org/pub/$distname/linux/releases/$releasever/Everything/$basearch/os/
-    - !rpm_base_url https://dl.fedoraproject.org/pub/$distname/linux/updates/$releasever/Everything/$basearch/
-    - !rpm_base_url https://download1.rpmfusion.org/free/$distname/releases/$releasever/Everything/$basearch/os/
+  - !rpm_base_url https://dl.fedoraproject.org/pub/$distname/linux/releases/$releasever/Everything/$basearch/os/
+  - !rpm_base_url https://dl.fedoraproject.org/pub/$distname/linux/updates/$releasever/Everything/$basearch/
+  - !rpm_base_url https://download1.rpmfusion.org/free/$distname/releases/$releasever/Everything/$basearch/os/
   opensuse:
-    - !rpm_base_url http://download.opensuse.org/distribution/leap/$releasever/repo/oss/
-    - !rpm_base_url http://download.opensuse.org/distribution/leap/$releasever/repo/non-oss/
-    - !rpm_base_url http://download.opensuse.org/update/leap/$releasever/oss/
-    - !rpm_base_url http://download.opensuse.org/update/leap/$releasever/non-oss/
+  - !rpm_base_url http://download.opensuse.org/distribution/leap/$releasever/repo/oss/
+  - !rpm_base_url http://download.opensuse.org/distribution/leap/$releasever/repo/non-oss/
+  - !rpm_base_url http://download.opensuse.org/update/leap/$releasever/oss/
+  - !rpm_base_url http://download.opensuse.org/update/leap/$releasever/non-oss/
   rhel:
-    - '7':
-      - !rpm_base_url https://dl.fedoraproject.org/pub/epel/$releasever/$basearch/
-      - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/os/$basearch/
-      - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/updates/$basearch/
-      - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/extras/$basearch/
-      - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/sclo/$basearch/rh/
-      '8':
-      - !rpm_base_url https://dl.fedoraproject.org/pub/epel/$releasever/Everything/$basearch/
-      - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/BaseOS/$basearch/os/
-      - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/AppStream/$basearch/os/
-      - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/PowerTools/$basearch/os/
-      - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/extras/$basearch/os/
-    - !rpm_base_url https://download1.rpmfusion.org/free/el/updates/$releasever/$basearch/
+  - '7':
+    - !rpm_base_url https://dl.fedoraproject.org/pub/epel/$releasever/$basearch/
+    - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/os/$basearch/
+    - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/updates/$basearch/
+    - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/extras/$basearch/
+    - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/sclo/$basearch/rh/
+    '8':
+    - !rpm_base_url https://dl.fedoraproject.org/pub/epel/$releasever/Everything/$basearch/
+    - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/BaseOS/$basearch/os/
+    - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/AppStream/$basearch/os/
+    - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/PowerTools/$basearch/os/
+    - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/extras/$basearch/os/
+  - !rpm_base_url https://download1.rpmfusion.org/free/el/updates/$releasever/$basearch/
   ubuntu:
-    - !deb_base_url http://archive.ubuntu.com/ubuntu main
-    - !deb_base_url http://archive.ubuntu.com/ubuntu universe
-    - !deb_base_url http://archive.ubuntu.com/ubuntu multiverse
-    - !deb_base_url http://repos.ros.org/repos/ros_bootstrap main
+  - !deb_base_url http://archive.ubuntu.com/ubuntu main
+  - !deb_base_url http://archive.ubuntu.com/ubuntu universe
+  - !deb_base_url http://archive.ubuntu.com/ubuntu multiverse
+  - !deb_base_url http://repos.ros.org/repos/ros_bootstrap main
 
 package_dashboards:
-  - pattern: !regular_expression .*//deb.debian.org/debian/.*
-    url: https://packages.debian.org/{os_code_name}/{binary_name}
-  - pattern: !regular_expression .*//dl.fedoraproject.org/pub/.*
-    url: https://src.fedoraproject.org/rpms/{source_name}#bodhi_updates
-  - pattern: !regular_expression .*//download.opensuse.org/.*
-    url: https://software.opensuse.org/package/{source_name}
-  - pattern: !regular_expression .*//archive.ubuntu.com/ubuntu/.*
-    url: https://packages.ubuntu.com/{os_code_name}/{binary_name}
+- pattern: !regular_expression .*//deb.debian.org/debian/.*
+  url: https://packages.debian.org/{os_code_name}/{binary_name}
+- pattern: !regular_expression .*//dl.fedoraproject.org/pub/.*
+  url: https://src.fedoraproject.org/rpms/{source_name}#bodhi_updates
+- pattern: !regular_expression .*//download.opensuse.org/.*
+  url: https://software.opensuse.org/package/{source_name}
+- pattern: !regular_expression .*//archive.ubuntu.com/ubuntu/.*
+  url: https://packages.ubuntu.com/{os_code_name}/{binary_name}
 
 supported_versions:
   debian:
-    - stretch
-    - buster
+  - stretch
+  - buster
   fedora:
-    - '33'
-    - '34'
+  - '33'
+  - '34'
   opensuse:
-    - '15.2'
+  - '15.2'
   rhel:
-    - '7'
-    - '8'
+  - '7'
+  - '8'
   ubuntu:
-    - bionic
-    - focal
+  - bionic
+  - focal
 
 supported_arches:
   debian:
-    - amd64
+  - amd64
   fedora:
-    - x86_64
+  - x86_64
   opensuse:
-    - x86_64
+  - x86_64
   rhel:
-    - x86_64
+  - x86_64
   ubuntu:
-    - amd64
+  - amd64
 
 name_replacements:
   fedora:


### PR DESCRIPTION
When investigating #30010 I realized that this is something yamllint should also be catching, which would have helped add corroborating signal to offset the noise in the nosetests.

Looking at the [yamllint docs](https://yamllint.readthedocs.io/en/stable/configuration.html), trailing whitespace checks should be enabled by default but aren't behaving that way in 1.26.1. This explicitly enables trailing whitespace checks which might be a good idea while I figure out what's happening in yamllint and share my discovery upstream.