### PR TITLE
rosdep: add python3-smc-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7654,6 +7654,19 @@ python3-smbus2-pip:
   ubuntu:
     pip:
       packages: [smbus2]
+python3-smc-pip:
+  debian:
+    pip:
+      packages: [smc]
+  fedora:
+    pip:
+      packages: [smc]
+  osx:
+    pip:
+      packages: [smc]
+  ubuntu:
+    pip:
+      packages: [smc]
 python3-sphinx:
   debian: [python3-sphinx]
   fedora: [python3-sphinx]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

Pololu Simple Motor Controller

## Package Upstream Source:

https://github.com/MomsFriendlyRobotCompany/smc

## Purpose of using this:

Used to provide a simple Python interface for Pololu motor controllers.

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

## PIP packaging links:
   - https://pypi.org/project/smc/