### PR TITLE
thunder_line_follower_pmr3100: 0.1.0-1 in 'noetic/distibution.yml'

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8134,6 +8134,21 @@ repositories:
       url: https://github.com/RobotWebTools/tf2_web_republisher.git
       version: master
     status: unmaintained
+  thunder_line_follower_pmr3100:
+    doc:
+      type: git
+      url: https://github.com/ThundeRatz/thunder_line_follower_pmr3100.git
+      version: main
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ThundeRatz/thunder_line_follower_pmr3100-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/ThundeRatz/thunder_line_follower_pmr3100.git
+      version: main
+    status: maintained
   toposens:
     doc:
       type: git


### PR DESCRIPTION
Please add thunder_line_follower_pmr3100 to be indexed in the rosdistro for noetic

# The source is here: 

https://github.com/ThundeRatz/thunder_line_follower_pmr3100

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
