### PR TITLE
Update Rolling branches for image_pipeline

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1021,7 +1021,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/image_pipeline.git
-      version: ros2
+      version: rolling
     release:
       packages:
       - camera_calibration
@@ -1040,7 +1040,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/image_pipeline.git
-      version: ros2
+      version: rolling
     status: maintained
   image_transport_plugins:
     doc:


### PR DESCRIPTION
Pointing to a new branch tracking the latest development for Rolling.

 https://github.com/ros-perception/image_pipeline/tree/rolling

@JWhitleyWork FYI.