### PR TITLE
thunder_line_follower_pmr3100: 0.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8145,6 +8145,17 @@ repositories:
       url: https://github.com/RobotWebTools/tf2_web_republisher.git
       version: master
     status: unmaintained
+  thunder_line_follower_pmr3100:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ThundeRatz/thunder_line_follower_pmr3100-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/ThundeRatz/thunder_line_follower_pmr3100.git
+      version: master
+    status: developed
   toposens:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `thunder_line_follower_pmr3100` to `0.1.1-1`:

- upstream repository: https://github.com/ThundeRatz/thunder_line_follower_pmr3100.git
- release repository: https://github.com/ThundeRatz/thunder_line_follower_pmr3100-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## thunder_line_follower_pmr3100

```
* First working version o/
```
