### PR TITLE
robotis_manipulator: 1.1.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6191,6 +6191,21 @@ repositories:
       url: https://github.com/roboticsgroup/roboticsgroup_upatras_gazebo_plugins.git
       version: master
     status: developed
+  robotis_manipulator:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/robotis_manipulator.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/robotis_manipulator-release.git
+      version: 1.1.1-2
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/robotis_manipulator.git
+      version: noetic-devel
+    status: maintained
   ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_manipulator` to `1.1.1-2`:

- upstream repository: https://github.com/ROBOTIS-GIT/robotis_manipulator.git
- release repository: https://github.com/ROBOTIS-GIT-release/robotis_manipulator-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## robotis_manipulator

```
* supports Noetic
* Contributors: Will Son
```
