### PR TITLE
bota_driver: 0.6.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -477,7 +477,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.com/botasys/bota_driver-release.git
-      version: 0.6.0-1
+      version: 0.6.0-2
     source:
       type: git
       url: https://gitlab.com/botasys/bota_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bota_driver` to `0.6.0-2`:

- upstream repository: https://gitlab.com/botasys/bota_driver.git
- release repository: https://gitlab.com/botasys/bota_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.0-1`

## bota_driver

```
* New launch interface - the topology is in the launch file
* Contributors: Mike Karamousadakis
```

## bota_node

- No changes

## bota_signal_handler

- No changes

## bota_worker

- No changes

## rokubimini

```
* New launch interface - the topology is in the launch file
* Contributors: Mike Karam, Mike Karamousadakis
```

## rokubimini_bus_manager

```
* Feature - Make bus managers bota nodes
* Contributors: Mike Karamousadakis
```

## rokubimini_description

- No changes

## rokubimini_ethercat

```
* Fix - mean wrench before reset
* New launch interface - the topology is in the launch file
* Fix bugs
* Contributors: Ilias Patsiaouras, Lefteris Kotsonis, Martin, Mike Karamousadakis
```

## rokubimini_msgs

- No changes

## rokubimini_serial

```
* Fix bugs
* Acknowledgement of serial commands
* Parsing of product name and boot messages of serial sensor
* Publishing based on the timestamp of serial sensor
* Automatically change to the maximum available baud rate
* New launch interface - the topology is in the launch file
* Feature - add format of commands based on command classes
* Feature - add regex and command classes
* Fix - mean wrench before reset
* Contributors: Ilias Patsiaouras, Lefteris Kotsonis, Mike Karamousadakis
```
