### PR TITLE
Add libconfig++-dev key for nixos.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2703,6 +2703,7 @@ libcoin80-dev:
 libconfig++-dev:
   debian: [libconfig++-dev]
   gentoo: ['dev-libs/libconfig[cxx]']
+  nixos: [libconfig]
   ubuntu: [libconfig++-dev]
 libconfig-dev:
   debian: [libconfig-dev]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

The same nixos package is already referenced for `libconfig-dev`, but it also supplies the C++ headers and so should be supplied when `libconfig++-dev` is called for.

## Links to Distribution Packages

- NixOS/nixpkgs: https://search.nixos.org/packages?channel=21.05&query=libconfig

FYI @lopsided98 