### PR TITLE
[rosdep] Add rhel key for subversion

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7112,6 +7112,7 @@ subversion:
   nixos: [subversion]
   openembedded: [subversion@openembedded-core]
   opensuse: [subversion]
+  rhel: [subversion]
   ubuntu: [subversion]
 suitesparse:
   arch: [suitesparse]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`subversion`

## Package Upstream Source:

https://svn.apache.org/repos/asf/subversion/

## Purpose of using this:

Used for `qpoases_vendor` and likely other vendor packages.

## Links to Distribution Packages

- RHEL: https://src.fedoraproject.org/rpms/subversion#bodhi_updates