### PR TITLE
open_manipulator_msgs: 1.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4755,6 +4755,21 @@ repositories:
       url: https://github.com/ros-perception/open_karto.git
       version: melodic-devel
     status: maintained
+  open_manipulator_msgs:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator_msgs.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/open_manipulator_msgs-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator_msgs.git
+      version: noetic-devel
+    status: maintained
   open_street_map:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator_msgs` to `1.0.1-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator_msgs.git
- release repository: https://github.com/ROBOTIS-GIT-release/open_manipulator_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## open_manipulator_msgs

```
* Noetic support
* Contributors: Will Son
```
