### PR TITLE
open_manipulator_simulations: 1.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4755,6 +4755,24 @@ repositories:
       url: https://github.com/ros-perception/open_karto.git
       version: melodic-devel
     status: maintained
+  open_manipulator_simulations:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator_simulations.git
+      version: noetic-devel
+    release:
+      packages:
+      - open_manipulator_gazebo
+      - open_manipulator_simulations
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/open_manipulator_simulations-release.git
+      version: 1.1.1-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator_simulations.git
+      version: noetic-devel
+    status: maintained
   open_street_map:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator_simulations` to `1.1.1-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator_simulations.git
- release repository: https://github.com/ROBOTIS-GIT-release/open_manipulator_simulations-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## open_manipulator_gazebo

```
* Noetic support
* Contributors: Will Son
```

## open_manipulator_simulations

```
* Noetic support
* Contributors: Will Son
```
