### PR TITLE
qpoases_vendor: 3.2.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1863,6 +1863,17 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: galactic-devel
     status: maintained
+  qpoases_vendor:
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/Autoware-AI/qpoases_vendor-release.git
+      version: 3.2.3-1
+    source:
+      type: git
+      url: https://github.com/Autoware-AI/qpoases_vendor.git
+      version: ros2
+    status: maintained
   qt_gui_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qpoases_vendor` to `3.2.3-1`:

- upstream repository: https://github.com/Autoware-AI/qpoases_vendor.git
- release repository: https://github.com/Autoware-AI/qpoases_vendor-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## qpoases_vendor

```
* Updating for ROS2
* Contributors: Joshua Whitley
```
