### PR TITLE
ueye_cam: 2.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4831,6 +4831,22 @@ repositories:
       url: https://github.com/flynneva/udp_msgs.git
       version: devel
     status: maintained
+  ueye_cam:
+    doc:
+      type: git
+      url: https://github.com/stonier/ueye_cam.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/stonier/ueye_cam-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/stonier/ueye_cam.git
+      version: ros2
+    status: maintained
   uncrustify_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye_cam` to `2.0.0-1`:

- upstream repository: https://github.com/stonier/ueye_cam
- release repository: https://github.com/stonier/ueye_cam-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ueye_cam

```
* ros2 port for Foxy
* export IDS configuration files
* Contributors: jmackay2, stonier
```
