### PR TITLE
qpoases_vendor: 3.2.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1836,6 +1836,17 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: main
     status: maintained
+  qpoases_vendor:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/Autoware-AI/qpoases_vendor-release.git
+      version: 3.2.3-1
+    source:
+      type: git
+      url: https://github.com/Autoware-AI/qpoases_vendor.git
+      version: ros2
+    status: maintained
   qt_gui_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qpoases_vendor` to `3.2.3-1`:

- upstream repository: https://github.com/Autoware-AI/qpoases_vendor.git
- release repository: https://github.com/Autoware-AI/qpoases_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## qpoases_vendor

```
* Updating for ROS2
* Contributors: Joshua Whitley
```
