### PR TITLE
ros_amr_interop: 1.0.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3519,6 +3519,23 @@ repositories:
       url: https://github.com/ros2/ros2cli_common_extensions.git
       version: foxy
     status: maintained
+  ros_amr_interop:
+    doc:
+      type: git
+      url: https://github.com/inorbit-ai/ros_amr_interop.git
+      version: foxy-devel
+    release:
+      packages:
+      - massrobotics_amr_sender
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/inorbit-ai/ros_amr_interop-release.git
+      version: 1.0.0-2
+    source:
+      type: git
+      url: https://github.com/inorbit-ai/ros_amr_interop.git
+      version: foxy-devel
+    status: maintained
   ros_canopen:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_amr_interop` to `1.0.0-2`:

- upstream repository: https://github.com/inorbit-ai/ros_amr_interop.git
- release repository: https://github.com/inorbit-ai/ros_amr_interop-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## massrobotics_amr_sender

```
* Adding bits for first release (#7 <https://github.com/inorbit-ai/ros_amr_interop/issues/7>)
```
