### PR TITLE
add python3-fcn-pip key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1620,7 +1620,7 @@ python-fcl-pip:
     pip:
       depends: [libfcl-dev]
       packages: [python-fcl]
-python-fcn-pip:
+python-fcn-pip: &migrate_eol_2025_04_30_python3_fcn_pip
   debian:
     pip:
       depends: [liblapack-dev]
@@ -6220,6 +6220,7 @@ python3-fastnumbers-pip:
   ubuntu:
     pip:
       packages: [fastnumbers]
+python3-fcn-pip: *migrate_eol_2025_04_30_python3_fcn_pip
 python3-filterpy-pip:
   debian:
     pip:


### PR DESCRIPTION
I add `python3-fcn-pip` key for python3.
I follow the instruction in https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#pip-1 and use anchor/alias for yaml.

pypi URL: https://pypi.org/project/fcn/