### PR TITLE
add python3-chainer-pip key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1025,7 +1025,7 @@ python-chainer-mask-rcnn-pip:
     pip:
       depends: [cython, python-numpy]
       packages: [chainer-mask-rcnn]
-python-chainer-pip:
+python-chainer-pip: &migrate_eol_2025_04_30_python3_chainer_pip
   debian:
     pip:
       packages: [chainer]
@@ -5940,6 +5940,7 @@ python3-cffi:
   nixos: [python3Packages.cffi]
   rhel: ['python%{python3_pkgversion}-cffi']
   ubuntu: [python3-cffi]
+python3-chainer-pip: *migrate_eol_2025_04_30_python3_chainer_pip
 python3-cherrypy3:
   debian: [python3-cherrypy3]
   ubuntu: [python3-cherrypy3]


### PR DESCRIPTION
I add `python3-chainer-pip` key.
I follow the instruction in master/CONTRIBUTING.md#pip-1 and use anchor/alias for yaml.
PyPI URL: https://pypi.org/project/chainer/