### PR TITLE
add python3-gdown-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1832,7 +1832,7 @@ python-gdal:
   ubuntu:
     bionic: [python-gdal]
     xenial: [python-gdal]
-python-gdown-pip:
+python-gdown-pip: &migrate_eol_2025_04_30_python3_gdown_pip
   debian:
     pip:
       packages: [gdown]
@@ -6334,6 +6334,7 @@ python3-future:
   openembedded: [python3-future@meta-python]
   rhel: ['python%{python3_pkgversion}-future']
   ubuntu: [python3-future]
+python3-gdown-pip: *migrate_eol_2025_04_30_python3_gdown_pip
 python3-geomag-pip:
   debian:
     pip:


### PR DESCRIPTION
I add `python3-gdown-pip` key.
I follow the instruction in https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#pip-1 and use anchor/alias for yaml.

PyPI URL: https://pypi.org/project/gdown/