### PR TITLE
alpine: deps for galactic - patch 1

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -327,6 +327,7 @@ binutils:
   rhel: [binutils-devel]
   ubuntu: [binutils-dev]
 bison:
+  alpine: [bison]
   arch: [bison]
   debian: [bison]
   fedora: [bison]
@@ -1485,6 +1486,7 @@ graphicsmagick:
   rhel: [GraphicsMagick-c++-devel]
   ubuntu: [libgraphicsmagick++1-dev, graphicsmagick-libmagick-dev-compat]
 graphviz:
+  alpine: [graphviz]
   arch: [graphviz]
   debian: [graphviz]
   fedora: [graphviz]
@@ -2150,6 +2152,7 @@ libasound2-dev:
   openembedded: [alsa-lib@openembedded-core]
   ubuntu: [libasound2-dev]
 libatomic:
+  alpine: [libatomic]
   arch: [gcc-libs]
   debian: [libatomic1]
   fedora: [libatomic]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5673,6 +5673,7 @@ python-zmq:
     '*': [python-zmq]
     trusty_python3: [python3-zmq]
 python3:
+  alpine: [python3]
   debian: [python3-dev]
   fedora: [python3-devel]
   gentoo: [dev-lang/python]
@@ -6065,6 +6066,7 @@ python3-defusedxml:
   rhel: ['python%{python3_pkgversion}-defusedxml']
   ubuntu: [python3-defusedxml]
 python3-dev:
+  alpine: [python3-dev]
   debian: [python3-dev]
   fedora: [python3-devel]
   gentoo: [=dev-lang/python-3*]
@@ -6438,6 +6440,7 @@ python3-imageio:
   openembedded: [python3-imageio@meta-python]
   ubuntu: [python3-imageio]
 python3-importlib-metadata:
+  alpine: [py3-importlib-metadata]
   debian:
     '*': [python3-importlib-metadata]
     buster:
@@ -6803,6 +6806,7 @@ python3-owlready2-pip:
     pip:
       packages: [owlready2]
 python3-packaging:
+  alpine: [py3-packaging]
   debian: [python3-packaging]
   fedora: [python3-packaging]
   gentoo: [dev-python/packaging]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

- [python3-importlib-metadata] https://pkgs.alpinelinux.org/package/edge/community/x86_64/py3-importlib-metadata
- [bison] for OS [alpine] https://pkgs.alpinelinux.org/package/edge/main/x86_64/bison
- [libatomic] for OS [alpine] https://pkgs.alpinelinux.org/package/edge/main/x86_64/libatomic
- [graphviz] for OS [alpine] https://pkgs.alpinelinux.org/package/edge/main/x86_64/graphviz
- [python3-packaging] for OS [alpine] https://pkgs.alpinelinux.org/package/edge/main/x86_64/py3-packaging
- [python3-dev] for OS [alpine] https://pkgs.alpinelinux.org/package/edge/main/x86_64/python3-dev

## Purpose of using this:

Support for ROS2 on alpine.


~~In addition I have fixed Alpine python2 dependencies to use pip, as~~ all python2 ports have been removed from the tree. However I am unsure if they got much use if any, so should they just be removed? The packages python2, python2-dev and boost-python2 have also been removed. Should these be purged?