### PR TITLE
python-gdal key not found in ubuntu 20.04 error

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1812,7 +1812,8 @@ python-gdal:
   debian: [python-gdal]
   fedora: [python2-gdal]
   gentoo: ['sci-libs/gdal[python]']
-  ubuntu: [python-gdal]
+  ubuntu:
+    bionic: [python-gdal]
 python-gdown-pip:
   debian:
     pip:


### PR DESCRIPTION
fix error found in #30036 