### PR TITLE
rmf_ros2: 1.3.0-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2284,7 +2284,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 1.3.0-2
+      version: 1.3.0-3
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_ros2` to `1.3.0-3`:

- upstream repository: https://github.com/open-rmf/rmf_ros2.git
- release repository: https://github.com/ros2-gbp/rmf_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.3.0-2`
