### PR TITLE
rmf_traffic: 1.3.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2282,6 +2282,21 @@ repositories:
       url: https://github.com/open-rmf/rmf_internal_msgs.git
       version: galactic
     status: developed
+  rmf_traffic:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_traffic.git
+      version: galactic
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_traffic-release.git
+      version: 1.3.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_traffic.git
+      version: galactic
+    status: developed
   rmf_utils:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_traffic` to `1.3.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_traffic.git
- release repository: https://github.com/ros2-gbp/rmf_traffic-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
