### PR TITLE
industrial_core: 0.7.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2896,13 +2896,28 @@ repositories:
       version: noetic
     status: developed
   industrial_core:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/industrial_core.git
+      version: melodic
     release:
       packages:
+      - industrial_core
+      - industrial_deprecated
       - industrial_msgs
+      - industrial_robot_client
+      - industrial_robot_simulator
+      - industrial_trajectory_filters
+      - industrial_utils
+      - simple_message
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-industrial-release/industrial_core-release.git
-      version: 0.7.1-1
+      version: 0.7.2-1
+    source:
+      type: git
+      url: https://github.com/ros-industrial/industrial_core.git
+      version: melodic
     status: maintained
   industrial_robot_status_controller:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `industrial_core` to `0.7.2-1`:

- upstream repository: https://github.com/ros-industrial/industrial_core.git
- release repository: https://github.com/ros-industrial-release/industrial_core-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.1-1`

## industrial_core

```
* target Melodic and newer.
* add Noetic compatibility (#258 <https://github.com/ros-industrial/industrial_core/issues/258>)
* update maintainers (#243 <https://github.com/ros-industrial/industrial_core/issues/243>)
* for a complete list of changes see the commit log for 0.7.2 <https://github.com/ros-industrial/industrial_core/compare/0.7.1...0.7.2>.
* contributors: Felix Messmer, Simon Schmeisser, gavanderhoorn
```

## industrial_deprecated

```
* target Melodic and newer.
* add Noetic compatibility (#258 <https://github.com/ros-industrial/industrial_core/issues/258>)
* update maintainers (#243 <https://github.com/ros-industrial/industrial_core/issues/243>)
* for a complete list of changes see the commit log for 0.7.2 <https://github.com/ros-industrial/industrial_core/compare/0.7.1...0.7.2>.
* contributors: Felix Messmer, Simon Schmeisser, gavanderhoorn
```

## industrial_msgs

```
* target Melodic and newer.
* catkin_lint all packages (#266 <https://github.com/ros-industrial/industrial_core/issues/266>)
* add Noetic compatibility (#258 <https://github.com/ros-industrial/industrial_core/issues/258>)
* mark as arch independent (#248 <https://github.com/ros-industrial/industrial_core/issues/248>)
* update maintainers (#243 <https://github.com/ros-industrial/industrial_core/issues/243>)
* for a complete list of changes see the commit log for 0.7.2 <https://github.com/ros-industrial/industrial_core/compare/0.7.1...0.7.2>.
* contributors: Felix Messmer, ipa-nhg, Simon Schmeisser, gavanderhoorn
```

## industrial_robot_client

```
* target Melodic and newer.
* fix line-endings -- all files (#268 <https://github.com/ros-industrial/industrial_core/issues/268>)
* catkin_lint all packages (#266 <https://github.com/ros-industrial/industrial_core/issues/266>)
* add Windows compatibility (#264 <https://github.com/ros-industrial/industrial_core/issues/264>)
* export compiler flags (#262 <https://github.com/ros-industrial/industrial_core/issues/262>)
* always send trajectory stop request (#260 <https://github.com/ros-industrial/industrial_core/issues/260>)
* add Noetic compatibility (#258 <https://github.com/ros-industrial/industrial_core/issues/258>)
* mark as arch independent (#248 <https://github.com/ros-industrial/industrial_core/issues/248>)
* update maintainers (#243 <https://github.com/ros-industrial/industrial_core/issues/243>)
* for a complete list of changes see the commit log for 0.7.2 <https://github.com/ros-industrial/industrial_core/compare/0.7.1...0.7.2>.
* contributors: Felix Messmer, Joseph Schornak, Josh Langsfeld, ipa-nhg, Sean Yen, Simon Schmeisser, gavanderhoorn
```

## industrial_robot_simulator

```
* target Melodic and newer.
* catkin_lint all packages (#266 <https://github.com/ros-industrial/industrial_core/issues/266>)
* add Noetic compatibility (#258 <https://github.com/ros-industrial/industrial_core/issues/258>)
* update maintainers (#243 <https://github.com/ros-industrial/industrial_core/issues/243>)
* for a complete list of changes see the commit log for 0.7.2 <https://github.com/ros-industrial/industrial_core/compare/0.7.1...0.7.2>.
* contributors: Felix Messmer, Simon Schmeisser, ipa-nhg, gavanderhoorn
```

## industrial_trajectory_filters

```
* target Melodic and newer.
* catkin_lint all packages (#266 <https://github.com/ros-industrial/industrial_core/issues/266>)
* add Windows compatibility (#264 <https://github.com/ros-industrial/industrial_core/issues/264>)
* add Noetic compatibility (#258 <https://github.com/ros-industrial/industrial_core/issues/258>)
* update maintainers (#243 <https://github.com/ros-industrial/industrial_core/issues/243>)
* for a complete list of changes see the commit log for 0.7.2 <https://github.com/ros-industrial/industrial_core/compare/0.7.1...0.7.2>.
* contributors: Felix Messmer, Simon Schmeisser, ipa-nhg, Sean Yen, gavanderhoorn
```

## industrial_utils

```
* target Melodic and newer.
* fix line-endings -- all files (#268 <https://github.com/ros-industrial/industrial_core/issues/268>)
* catkin_lint all packages (#266 <https://github.com/ros-industrial/industrial_core/issues/266>)
* add Windows compatibility (#264 <https://github.com/ros-industrial/industrial_core/issues/264>)
* add Noetic compatibility (#258 <https://github.com/ros-industrial/industrial_core/issues/258>)
* update maintainers (#243 <https://github.com/ros-industrial/industrial_core/issues/243>)
* for a complete list of changes see the commit log for 0.7.2 <https://github.com/ros-industrial/industrial_core/compare/0.7.1...0.7.2>.
* contributors: Felix Messmer, ipa-nhg, Sean Yen, gavanderhoorn
```

## simple_message

```
* target Melodic and newer.
* fix line-endings -- all files (#268 <https://github.com/ros-industrial/industrial_core/issues/268>)
* add receive timeouts for simple socket (#267 <https://github.com/ros-industrial/industrial_core/issues/267>)
* catkin_lint all packages (#266 <https://github.com/ros-industrial/industrial_core/issues/266>)
* add Windows compatibility (#264 <https://github.com/ros-industrial/industrial_core/issues/264>)
* improve TcpClient's connection re-establish behaviour (#263 <https://github.com/ros-industrial/industrial_core/issues/263>)
* export compiler flags (#262 <https://github.com/ros-industrial/industrial_core/issues/262>)
* remove exec permission on source files (#259 <https://github.com/ros-industrial/industrial_core/issues/259>)
* add Noetic compatibility (#258 <https://github.com/ros-industrial/industrial_core/issues/258>)
* update maintainers (#243 <https://github.com/ros-industrial/industrial_core/issues/243>)
* for a complete list of changes see the commit log for 0.7.2 <https://github.com/ros-industrial/industrial_core/compare/0.7.1...0.7.2>.
* contributors: Felix Messmer, Gaël Écorchard, Josh Langsfeld, Tim Perkins, ipa-nhg, Sean Yen, Paul Glaubitz, gavanderhoorn
```
