### PR TITLE
rmw_dds_common: 1.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2456,7 +2456,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_dds_common-release.git
-      version: 1.2.1-1
+      version: 1.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_dds_common` to `1.3.0-1`:

- upstream repository: https://github.com/ros2/rmw_dds_common.git
- release repository: https://github.com/ros2-gbp/rmw_dds_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.1-1`

## rmw_dds_common

```
* Add a common function for security files. (#51 <https://github.com/ros2/rmw_dds_common/issues/51>)
* Normalize rmw_time_t according to DDS spec (#48 <https://github.com/ros2/rmw_dds_common/issues/48>)
* Contributors: Andrea Sorbini, Chris Lalancette
```
