### PR TITLE
moveit_python: 0.4.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6687,7 +6687,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mikeferguson/moveit_python-release.git
-      version: 0.4.1-1
+      version: 0.4.2-1
     source:
       type: git
       url: https://github.com/mikeferguson/moveit_python.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_python` to `0.4.2-1`:

- upstream repository: https://github.com/mikeferguson/moveit_python.git
- release repository: https://github.com/mikeferguson/moveit_python-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.4.1-1`

## moveit_python

```
* New cone primitive and box primitive frame fix (#30 <https://github.com/mikeferguson/moveit_python/issues/30>)
  * Box primitive frame independent of planning scene
  * Added cone solid primitive
* Contributors: Kiran Prasad
```
