### PR TITLE
moveit_python: 0.4.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4122,7 +4122,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mikeferguson/moveit_python-release.git
-      version: 0.4.1-1
+      version: 0.4.2-1
     source:
       type: git
       url: https://github.com/mikeferguson/moveit_python.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_python` to `0.4.2-1`:

- upstream repository: https://github.com/mikeferguson/moveit_python.git
- release repository: https://github.com/mikeferguson/moveit_python-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.4.1-1`

## moveit_python

```
* New cone primitive and box primitive frame fix (#30 <https://github.com/mikeferguson/moveit_python/issues/30>)
  * Box primitive frame independent of planning scene
  * Added cone solid primitive
* Contributors: Kiran Prasad
```
