### PR TITLE
Revert "ueye_cam: 2.0.0-1 in 'foxy/distribution.yaml' [bloom] (#30030)"

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4851,22 +4851,6 @@ repositories:
       url: https://github.com/flynneva/udp_msgs.git
       version: devel
     status: maintained
-  ueye_cam:
-    doc:
-      type: git
-      url: https://github.com/stonier/ueye_cam.git
-      version: ros2
-    release:
-      tags:
-        release: release/foxy/{package}/{version}
-      url: https://github.com/stonier/ueye_cam-release.git
-      version: 2.0.0-1
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/stonier/ueye_cam.git
-      version: ros2
-    status: maintained
   uncrustify_vendor:
     release:
       tags:


### PR DESCRIPTION
This reverts commit 4c4fbb302a559e4ddbf7ef722c3a0ebce3c3c680. Problems
with the binary packaging step will take some effort reproducing and
working around since it's got rather esoteric build/packaging
requirements.
