### PR TITLE
dynamixel-workbench-msgs: 2.0.2-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1603,6 +1603,23 @@ repositories:
       url: https://github.com/ros/dynamic_reconfigure.git
       version: noetic-devel
     status: maintained
+  dynamixel-workbench-msgs:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
+      version: noetic-devel
+    release:
+      packages:
+      - dynamixel_workbench_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-msgs-release.git
+      version: 2.0.2-2
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
+      version: noetic-devel
+    status: maintained
   dynamixel_sdk:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel-workbench-msgs` to `2.0.2-2`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
- release repository: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## dynamixel_workbench_msgs

```
* Noetic support
* Contributors: Will Son
```
