### PR TITLE
steering_functions: 0.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12924,7 +12924,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/nobleo/steering_functions-release.git
-      version: 0.0.0-1
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/hbanzhaf/steering_functions.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12915,6 +12915,21 @@ repositories:
       url: https://github.com/ros/std_msgs.git
       version: kinetic-devel
     status: maintained
+  steering_functions:
+    doc:
+      type: git
+      url: https://github.com/hbanzhaf/steering_functions.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/nobleo/steering_functions-release.git
+      version: 0.0.0-1
+    source:
+      type: git
+      url: https://github.com/hbanzhaf/steering_functions.git
+      version: master
+    status: maintained
   swri_console:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `steering_functions` to `0.0.0-1`:

- upstream repository: https://github.com/hbanzhaf/steering_functions.git
- release repository: https://github.com/nobleo/steering_functions-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
