### PR TITLE
steering_functions: 0.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8021,6 +8021,21 @@ repositories:
       url: https://github.com/ros/std_msgs.git
       version: kinetic-devel
     status: maintained
+  steering_functions:
+    doc:
+      type: git
+      url: https://github.com/hbanzhaf/steering_functions.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/nobleo/steering_functions-release.git
+      version: 0.0.0-1
+    source:
+      type: git
+      url: https://github.com/hbanzhaf/steering_functions.git
+      version: master
+    status: maintained
   swri_console:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8030,7 +8030,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/nobleo/steering_functions-release.git
-      version: 0.0.0-1
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/hbanzhaf/steering_functions.git


### PR DESCRIPTION
Increasing version of package(s) in repository `steering_functions` to `0.0.0-1`:

- upstream repository: https://github.com/hbanzhaf/steering_functions.git
- release repository: https://github.com/nobleo/steering_functions-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
