### PR TITLE
psen_scan_v2: 0.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5595,7 +5595,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/PilzDE/psen_scan_v2-release.git
-      version: 0.2.1-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/PilzDE/psen_scan_v2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `psen_scan_v2` to `0.3.0-1`:

- upstream repository: https://github.com/PilzDE/psen_scan_v2.git
- release repository: https://github.com/PilzDE/psen_scan_v2-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.1-1`

## psen_scan_v2

```
* Set prefix for node name (same value as for tf frames)
* Introduce bringup.launch for starting only the scanner node
* Omit closing the data client before destruction. Fixes #212
* Distance value at angle_end is now included in the scan range
* Default scan range changed to [-137.4..137.4]deg at 0.1 deg resolution
* Add options for modifying resolution and enabling intensities
* Add launchfile option for disabling rviz at startup (default: enable)
* Handle the infinity codes from the scanner correctly
* Inform user about current scan range
* Fix wrong behavior when angle_start and angle_end are equal
* Contributors: Pilz GmbH and Co. KG
```
