### PR TITLE
Update python-gdal key for focal and bullseye.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1809,10 +1809,14 @@ python-gcloud-pip:
     pip:
       packages: [gcloud]
 python-gdal:
-  debian: [python-gdal]
+  debian:
+    buster: [python-gdal]
+    stretch: [python-gdal]
   fedora: [python2-gdal]
   gentoo: ['sci-libs/gdal[python]']
-  ubuntu: [python-gdal]
+  ubuntu:
+    bionic: [python-gdal]
+    xenial: [python-gdal]
 python-gdown-pip:
   debian:
     pip:


### PR DESCRIPTION
Future Debian derived distributions do not have Python 2 (python-)
packages for python-gdal. This approach will cause key errors on older
unsupported platforms but is forwards compatible vs a '*'-and-null
approach for undefining the key explicitly for new platforms.
