### PR TITLE
geometric_shapes: 2.1.0-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -811,7 +811,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/moveit/geometric_shapes-release.git
-      version: 2.1.0-1
+      version: 2.1.0-2
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `2.1.0-2`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/moveit/geometric_shapes-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.0-1`

## geometric_shapes

```
* Add Galactic CI, cleanup rolling (#190 <https://github.com/ros-planning/geometric_shapes/issues/190>)
* Sync ros2 branch with noetic-devel up to d147f03 <https://github.com/ros-planning/geometric_shapes/commit/d147f0371afbece0b8c93a2d2d55149a284d5192> (#190 <https://github.com/ros-planning/geometric_shapes/issues/190>)
* Contributors: Jafar Abdi, Henning Kayser, Vatan Aksoy Tezer
```
