### PR TITLE
warehouse_ros: 2.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3935,7 +3935,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/moveit/warehouse_ros-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros` to `2.0.2-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros.git
- release repository: https://github.com/moveit/warehouse_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.1-1`

## warehouse_ros

```
* Use ament_export_targets to fix exporting dependencies (#80 <https://github.com/ros-planning/warehouse_ros/issues/80>)
* Sync with kinetic-devel branch up-to https://github.com/ros-planning/warehouse_ros/commit/25c94751a96b02e46859fec36915c9e8f38106e5 (#78 <https://github.com/ros-planning/warehouse_ros/issues/78>)
* Fix MD5 calculation (#79 <https://github.com/ros-planning/warehouse_ros/issues/79>)
  MD5 checksums may contain NULLs, but are not guaranteed to be zero-terminated.
  Co-authored-by: Bjar Ne <mailto:gleichdick@users.noreply.github.com>
* [ROS2] Add prerelease tests (#76 <https://github.com/ros-planning/warehouse_ros/issues/76>)
* Add Galactic CI (#75 <https://github.com/ros-planning/warehouse_ros/issues/75>)
* Fix building on windows (#73 <https://github.com/ros-planning/warehouse_ros/issues/73>)
* Contributors: Akash, Bjar Ne, Jafar Abdi, Vatan Aksoy Tezer
```
