### PR TITLE
image_common: 3.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1014,7 +1014,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 3.0.0-1
+      version: 3.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `3.1.0-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.0.0-1`

## camera_calibration_parsers

- No changes

## camera_info_manager

- No changes

## image_common

- No changes

## image_transport

```
* Fix SimpleSubscriberPlugin (#195 <https://github.com/ros-perception/image_common/issues/195>)
* Contributors: Ivan Santiago Paunovic
```
