### PR TITLE
python.yaml updates for openSUSE (4 of 11)

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3269,6 +3269,7 @@ python-pip:
   gentoo: [dev-python/pip]
   nixos: [pythonPackages.pip]
   openembedded: ['${PYTHON_PN}-pip@meta-python']
+  opensuse: [python2-pip]
   ubuntu: [python-pip]
 python-pixel-ring-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3550,7 +3550,7 @@ python-pygraphviz:
   freebsd: [py27-pygraphviz]
   gentoo: [dev-python/pygraphviz]
   nixos: [pythonPackages.pygraphviz]
-  opensuse: [python-pygraphviz]
+  opensuse: [python2-pygraphviz]
   osx:
     pip:
       packages: [pygraphviz]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3619,6 +3619,7 @@ python-pymongo:
   gentoo: [dev-python/pymongo]
   nixos: [pythonPackages.pymongo]
   openembedded: ['${PYTHON_PN}-pymongo@meta-python']
+  opensuse: [python2-pymongo]
   osx:
     pip:
       packages: [pymongo]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3494,7 +3494,7 @@ python-pydot:
   macports: [py27-pydot]
   nixos: [pythonPackages.pydot]
   openembedded: ['${PYTHON_PN}-pydot@meta-ros-common']
-  opensuse: [python-pydot]
+  opensuse: [python2-pydot]
   osx:
     pip:
       packages: [pydot]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3100,7 +3100,7 @@ python-paramiko:
   macports: [py27-paramiko]
   nixos: [pythonPackages.paramiko]
   openembedded: ['${PYTHON_PN}-paramiko@meta-ros-common']
-  opensuse: [python-paramiko]
+  opensuse: [python2-paramiko]
   osx:
     pip:
       packages: [paramiko]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4007,7 +4007,7 @@ python-qt5-bindings-gl:
   gentoo: ['dev-python/PyQt5[opengl]']
   nixos: [pythonPackages.pyqt5]
   openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
-  opensuse: [python-qt5]
+  opensuse: [python2-qt5]
   slackware: [PyQt5]
   ubuntu:
     artful: [python-pyqt5.qtopengl]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2989,7 +2989,7 @@ python-opengl:
   gentoo: [dev-python/pyopengl]
   macports: [py27-opengl]
   nixos: [pythonPackages.pyopengl]
-  opensuse: [python-opengl]
+  opensuse: [python2-opengl]
   osx:
     pip:
       packages: [PyOpenGL]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3987,7 +3987,7 @@ python-qt5-bindings:
   gentoo: ['dev-python/PyQt5[gui,widgets]']
   nixos: [pythonPackages.pyqt5]
   openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
-  opensuse: [python-qt5]
+  opensuse: [python2-qt5]
   slackware: [PyQt5]
   ubuntu:
     artful: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3463,6 +3463,7 @@ python-pycryptodome:
   gentoo: [dev-python/pycryptodome]
   nixos: [pythonPackages.pycryptodomex]
   openembedded: ['${PYTHON_PN}-pycryptodomex@openembedded-core']
+  opensuse: [python2-pycryptodomex]
   osx:
     pip:
       packages: [pycryptodome]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4035,6 +4035,7 @@ python-qt5-bindings-webkit:
   gentoo: ['dev-python/PyQt5[webkit]']
   nixos: [pythonPackages.pyqt5_with_qtwebkit]
   openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
+  opensuse: [python2-qt5]
   ubuntu:
     artful: [python-pyqt5.qtwebkit]
     bionic: [python-pyqt5.qtwebkit]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3372,7 +3372,7 @@ python-psutil:
   macports: [py27-psutil]
   nixos: [pythonPackages.psutil]
   openembedded: ['${PYTHON_PN}-psutil@meta-python']
-  opensuse: [python-psutil]
+  opensuse: [python2-psutil]
   osx:
     pip:
       packages: [psutil]


### PR DESCRIPTION
This is a continuation of the python.yaml updates for openSUSE
#29935 #29936 #29944

These keys are not necessarily related to each other. I'm just processing these commits alphabetically and breaking them up into groups of approx. 10.

https://software.opensuse.org/package/python2-opengl
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-opengl/standard
https://software.opensuse.org/package/python2-paramiko
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.12946/standard
https://software.opensuse.org/package/python2-pip
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.14312/standard
https://software.opensuse.org/package/python2-psutil
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-psutil/standard
https://software.opensuse.org/package/python2-pycryptodomex
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.15806/standard
https://software.opensuse.org/package/python2-pydot
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-pydot/standard
https://software.opensuse.org/package/python2-pygraphviz
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-pygraphviz/standard
https://software.opensuse.org/package/python2-pymongo
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-pymongo/standard
https://software.opensuse.org/package/python2-qt5
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-qt5/standard
