### PR TITLE
python.yaml updates for openSUSE (5 of 11)

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4489,6 +4489,7 @@ python-setuptools:
   macports: [py27-setuptools]
   nixos: [pythonPackages.setuptools]
   openembedded: ['${PYTHON_PN}-setuptools@openembedded-core']
+  opensuse: [python2-setuptools]
   osx:
     pip:
       packages: [setuptools]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5094,6 +5094,7 @@ python-tk:
   fedora: [python2-tkinter]
   nixos: [pythonPackages.tkinter]
   openembedded: ['${PYTHON_PN}-tkinter@openembedded-core']
+  opensuse: [python-tk]
   rhel:
     '*': [python2-tkinter]
     '7': [tkinter]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4746,6 +4746,7 @@ python-sphinx-rtd-theme:
     buster: [python-sphinx-rtd-theme]
     jessie: [python-sphinx-rtd-theme]
     stretch: [python-sphinx-rtd-theme]
+  opensuse: [python2-sphinx_rtd_theme]
   ubuntu:
     artful: [python-sphinx-rtd-theme]
     artful_python3: [python3-sphinx-rtd-theme]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5241,6 +5241,7 @@ python-twisted-core:
   gentoo: [dev-python/twisted]
   nixos: [pythonPackages.twisted]
   openembedded: ['${PYTHON_PN}-twisted-core@meta-python']
+  opensuse: [python2-Twisted]
   ubuntu: [python-twisted-core]
 python-twisted-web:
   arch: [python2-twisted]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4580,7 +4580,7 @@ python-sip:
   macports: [py27-sip]
   nixos: [pythonPackages.sip_4]
   openembedded: [sip@meta-oe]
-  opensuse: [python-sip-devel]
+  opensuse: [python2-sip-devel]
   rhel:
     '7': [sip-devel]
   slackware:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4640,6 +4640,7 @@ python-sklearn:
   fedora: [python-scikit-learn]
   gentoo: [sci-libs/scikits_learn]
   nixos: [pythonPackages.scikitlearn]
+  opensuse: [python2-scikit-learn]
   osx:
     pip:
       packages: [scikit-learn]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4450,6 +4450,7 @@ python-serial:
   gentoo: [dev-python/pyserial]
   nixos: [pythonPackages.pyserial]
   openembedded: ['${PYTHON_PN}-pyserial@meta-python']
+  opensuse: [python2-pyserial]
   ubuntu:
     artful: [python-serial]
     artful_python3: [python3-serial]


### PR DESCRIPTION
This is a continuation of the python.yaml updates for openSUSE
#29935 #29936 #29944 #30062

These keys are not necessarily related to each other. I'm just processing these commits alphabetically and breaking them up into groups of approx. 10.

https://software.opensuse.org/package/python2-pyserial
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-pyserial/standard
https://software.opensuse.org/package/python2-setuptools
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.15196/standard
https://software.opensuse.org/package/python2-sip
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-sip/standard
https://software.opensuse.org/package/python2-scikit-learn
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python2-scikit-learn/standard
https://software.opensuse.org/package/python2-sphinx_rtd_theme
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-sphinx_rtd_theme/standard
https://software.opensuse.org/package/python-tk
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.15905/standard
https://software.opensuse.org/package/python2-Twisted
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-Twisted/standard


