### PR TITLE
python.yaml updates for openSUSE (6 of 11)

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5483,6 +5483,7 @@ python-websocket:
   gentoo: [dev-python/websocket-client]
   nixos: [pythonPackages.websocket_client]
   openembedded: ['${PYTHON_PN}-websocket-client@meta-python']
+  opensuse: [python2-websocket-client]
   ubuntu:
     artful: [python-websocket]
     artful_python3: [python3-websocket]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5776,6 +5776,7 @@ python3-babeltrace:
   debian: [python3-babeltrace]
   fedora: [python3-babeltrace]
   gentoo: [dev-util/babeltrace]
+  opensuse: [python3-babeltrace]
   ubuntu: [python3-babeltrace]
 python3-backoff-pip:
   arch:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5680,6 +5680,7 @@ python3:
   gentoo: [dev-lang/python]
   nixos: [python3]
   openembedded: [python3@openembedded-core]
+  opensuse: [python3-devel]
   rhel: ['python%{python3_pkgversion}-devel']
   ubuntu: [python3-dev]
 python3-adafruit-blinka-pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5628,7 +5628,7 @@ python-yaml:
   macports: [py27-yaml]
   nixos: [pythonPackages.pyyaml]
   openembedded: ['${PYTHON_PN}-pyyaml@meta-python']
-  opensuse: [python-PyYAML]
+  opensuse: [python2-PyYAML]
   osx:
     pip:
       depends: [yaml]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5566,6 +5566,7 @@ python-wxtools:
   gentoo: [dev-python/wxpython]
   nixos: [pythonPackages.wxPython]
   openembedded: [wxpython@meta-ros-python2]
+  opensuse: [python-wxWidgets-3_0-devel]
   rhel:
     '7': [wxPython]
   ubuntu: [python-wxtools]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6077,6 +6077,7 @@ python3-dev:
   gentoo: [=dev-lang/python-3*]
   nixos: [python3]
   openembedded: [python3@openembedded-core]
+  opensuse: [python3-devel]
   rhel: ['python%{python3_pkgversion}-devel']
   ubuntu: [python3-dev]
 python3-distro:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6068,6 +6068,7 @@ python3-defusedxml:
   gentoo: [dev-python/defusedxml]
   nixos: [python3Packages.defusedxml]
   openembedded: [python3-defusedxml@meta-python]
+  opensuse: [python3-defusedxml]
   rhel: ['python%{python3_pkgversion}-defusedxml']
   ubuntu: [python3-defusedxml]
 python3-dev:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6042,6 +6042,7 @@ python3-cryptography:
   gentoo: [dev-python/cryptography]
   nixos: [python3Packages.cryptography]
   openembedded: [python3-cryptography@meta-python]
+  opensuse: [python3-cryptography]
   rhel: ['python%{python3_pkgversion}-cryptography']
   ubuntu: [python3-cryptography]
 python3-datadog-pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6022,6 +6022,7 @@ python3-coverage:
   gentoo: [dev-python/coverage]
   nixos: [python3Packages.coverage]
   openembedded: [python3-coverage@meta-python]
+  opensuse: [python3-coverage]
   rhel: ['python%{python3_pkgversion}-coverage']
   ubuntu: [python3-coverage]
 python3-crcmod:


### PR DESCRIPTION
This is a continuation of the python.yaml updates for openSUSE
#29935 #29936 #29944 #30062 #30063

These keys are not necessarily related to each other. I'm just processing these commits alphabetically and breaking them up into groups of approx. 10.

https://software.opensuse.org/package/python2-websocket-client
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.16008/standard
https://software.opensuse.org/package/python-wxWidgets-3_0
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-wxWidgets-3_0/standard
https://software.opensuse.org/package/python2-PyYAML
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.16008/standard
https://software.opensuse.org/package/python3
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.15401/standard
https://software.opensuse.org/package/python3-babeltrace
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/babeltrace/standard
https://software.opensuse.org/package/python3-coverage
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-coverage/standard
https://software.opensuse.org/package/python3-cryptography
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.15225/standard
https://software.opensuse.org/package/python3-defusedxml
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-defusedxml/standard
