### PR TITLE
python.yaml updates for openSUSE (7 of 11)

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6096,6 +6096,7 @@ python3-django:
 python3-django-cors-headers:
   debian: [python3-django-cors-headers]
   fedora: [python3-django-cors-headers]
+  opensuse: [python3-django-cors-headers]
   ubuntu: [python3-django-cors-headers]
 python3-django-extensions:
   debian: [python3-django-extensions]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6700,6 +6700,7 @@ python3-mypy:
   gentoo: [dev-python/mypy]
   nixos: [python3Packages.mypy]
   openembedded: [python3-mypy@meta-ros-common]
+  opensuse: [mypy]
   ubuntu: [python3-mypy]
 python3-nclib-pip:
   arch:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6091,6 +6091,7 @@ python3-distutils:
 python3-django:
   debian: [python3-django]
   fedora: [python3-django]
+  opensuse: [python3-Django]
   ubuntu: [python3-django]
 python3-django-cors-headers:
   debian: [python3-django-cors-headers]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6379,6 +6379,7 @@ python3-gnupg:
   gentoo: [dev-python/python-gnupg]
   nixos: [python3Packages.python-gnupg]
   openembedded: [python3-gnupg@meta-python]
+  opensuse: [python3-python-gnupg]
   ubuntu: [python3-gnupg]
 python3-gql-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6157,6 +6157,7 @@ python3-empy:
   gentoo: [dev-python/empy]
   nixos: [python3Packages.empy]
   openembedded: [python3-empy@meta-ros-common]
+  opensuse: [python3-empy]
   rhel: ['python%{python3_pkgversion}-empy']
   ubuntu: [python3-empy]
 python3-environs-pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6127,6 +6127,7 @@ python3-docker:
   fedora: [python3-docker]
   gentoo: [dev-python/docker-py]
   nixos: [python3Packages.docker]
+  opensuse: [python3-docker]
   rhel:
     '7': ['python%{python3_pkgversion}-docker']
   ubuntu: [python3-docker]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6249,6 +6249,7 @@ python3-flake8:
   gentoo: [dev-python/flake8]
   nixos: [python3Packages.flake8]
   openembedded: [python3-flake8@meta-ros-common]
+  opensuse: [python3-flake8]
   osx:
     pip:
       packages: [flake8]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6106,6 +6106,7 @@ python3-django-extra-views:
   ubuntu: [python3-django-extra-views]
 python3-djangorestframework:
   debian: [python3-djangorestframework]
+  opensuse: [python3-djangorestframework]
   ubuntu: [python3-djangorestframework]
 python3-dlib-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6595,6 +6595,7 @@ python3-lxml:
   gentoo: [dev-python/lxml]
   nixos: [python3Packages.lxml]
   openembedded: [python3-lxml@meta-python]
+  opensuse: [python3-lxml]
   osx:
     pip:
       packages: [lxml]


### PR DESCRIPTION
This is a continuation of the python.yaml updates for openSUSE
#29935 #29936 #29944 #30062 #30063 #30064

These keys are not necessarily related to each other. I'm just processing these commits alphabetically and breaking them up into groups of approx. 10.

https://software.opensuse.org/package/python3-Django
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-Django/standard
https://software.opensuse.org/package/python3-django-cors-headers
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-django-cors-headers/standard
https://software.opensuse.org/package/python3-djangorestframework
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.15814/standard
https://software.opensuse.org/package/python3-docker
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-docker/standard
https://software.opensuse.org/package/python3-empy
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-empy/standard
https://software.opensuse.org/package/python3-flake8
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-flake8/standard
https://software.opensuse.org/package/python3-python-gnupg
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-python-gnupg/standard
https://software.opensuse.org/package/python3-lxml
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-lxml/standard
https://software.opensuse.org/package/mypy
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/mypy/standard
