### PR TITLE
rqt_publisher: 1.1.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3139,7 +3139,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_publisher-release.git
-      version: 1.1.2-1
+      version: 1.1.3-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_publisher` to `1.1.3-1`:

- upstream repository: https://github.com/ros-visualization/rqt_publisher.git
- release repository: https://github.com/ros2-gbp/rqt_publisher-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.2-1`

## rqt_publisher

```
* Fix: Do not ignore field values introduced by the user. (#28 <https://github.com/ros-visualization/rqt_publisher/issues/28>)
* Fix modern setuptools warning about dashes instead of underscores. (#29 <https://github.com/ros-visualization/rqt_publisher/issues/29>)
* Contributors: Chris Lalancette, coalman321
```
