### PR TITLE
ros2_control: 0.7.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2549,6 +2549,30 @@ repositories:
       url: https://github.com/ros2/ros1_bridge.git
       version: master
     status: maintained
+  ros2_control:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/ros2_control.git
+      version: master
+    release:
+      packages:
+      - controller_interface
+      - controller_manager
+      - controller_manager_msgs
+      - hardware_interface
+      - ros2_control
+      - ros2_control_test_assets
+      - ros2controlcli
+      - transmission_interface
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_control-release.git
+      version: 0.7.1-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/ros2_control.git
+      version: master
+    status: developed
   ros2_ouster_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `0.7.1-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## controller_interface

```
* Remove forgoten debug output (#439 <https://github.com/ros-controls/ros2_control/issues/439>)
* Contributors: Denis Štogl
```

## controller_manager

```
* Use namespace in controller_manager (#435 <https://github.com/ros-controls/ros2_control/issues/435>)
* Contributors: Jonatan Olofsson
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* [FakeSystem] Set default command interface to NaN (#424 <https://github.com/ros-controls/ros2_control/issues/424>)
* Contributors: Denis Štogl, Bence Magyar
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## transmission_interface

- No changes
