### PR TITLE
warehouse_ros: 2.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3935,7 +3935,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/moveit/warehouse_ros-release.git
-      version: 2.0.2-1
+      version: 2.0.3-1
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros` to `2.0.3-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros.git
- release repository: https://github.com/moveit/warehouse_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.2-1`

## warehouse_ros

```
* Fix OpenSSL export, use package.xml format 3 (#83 <https://github.com/ros-planning/warehouse_ros/issues/83>)
* Contributors: Henning Kayser
```
