### PR TITLE
open_manipulator_p_simulations: 1.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4817,6 +4817,24 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/open_manipulator_msgs.git
       version: noetic-devel
     status: maintained
+  open_manipulator_p_simulations:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator_p_simulations.git
+      version: noetic-devel
+    release:
+      packages:
+      - open_manipulator_p_gazebo
+      - open_manipulator_p_simulations
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/open_manipulator_p_simulations-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator_p_simulations.git
+      version: noetic-devel
+    status: maintained
   open_manipulator_simulations:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator_p_simulations` to `1.0.1-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator_p_simulations.git
- release repository: https://github.com/ROBOTIS-GIT-release/open_manipulator_p_simulations-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## open_manipulator_p_gazebo

```
* Noetic support
* Remove dependency of open_manipulator_p package
* Contributors: Will Son
```

## open_manipulator_p_simulations

```
* Noetic support
* Remove dependency of open_manipulator_p package
* Contributors: Will Son
```
