### PR TITLE
launch_pal: 0.0.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1608,7 +1608,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/pal-gbp/launch_pal-release.git
-      version: 0.0.2-3
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/pal-robotics/launch_pal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_pal` to `0.0.3-1`:

- upstream repository: https://github.com/pal-robotics/launch_pal.git
- release repository: https://github.com/pal-gbp/launch_pal-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.2-3`

## launch_pal

```
* Add arg_utils.py
* Contributors: Victor Lopez
```
