### PR TITLE
moveit: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1409,6 +1409,45 @@ repositories:
       url: https://github.com/ros2/mimick_vendor.git
       version: master
     status: maintained
+  moveit:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit2.git
+      version: main
+    release:
+      packages:
+      - moveit
+      - moveit_common
+      - moveit_core
+      - moveit_kinematics
+      - moveit_planners
+      - moveit_planners_ompl
+      - moveit_plugins
+      - moveit_ros
+      - moveit_ros_benchmarks
+      - moveit_ros_move_group
+      - moveit_ros_occupancy_map_monitor
+      - moveit_ros_perception
+      - moveit_ros_planning
+      - moveit_ros_planning_interface
+      - moveit_ros_robot_interaction
+      - moveit_ros_visualization
+      - moveit_ros_warehouse
+      - moveit_runtime
+      - moveit_servo
+      - moveit_simple_controller_manager
+      - run_move_group
+      - run_moveit_cpp
+      - run_ompl_constrained_planning
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/moveit/moveit2-release.git
+      version: 2.2.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit2.git
+      version: main
+    status: developed
   moveit_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.2.0-1`:

- upstream repository: https://github.com/ros-planning/moveit2.git
- release repository: https://github.com/moveit/moveit2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## moveit

- No changes

## moveit_common

- No changes

## moveit_core

```
* Enable Bullet and fix plugin configuration (#489 <https://github.com/ros-planning/moveit2/issues/489>)
* Fix typo in joint_model_group.h (#510 <https://github.com/ros-planning/moveit2/issues/510>)
* Enable Rolling and Galactic CI (#494 <https://github.com/ros-planning/moveit2/issues/494>)
* Add pluginlib dependency (#485 <https://github.com/ros-planning/moveit2/issues/485>)
* [sync] MoveIt's master branch up-to https://github.com/ros-planning/moveit/commit/0d0a6a171b3fbea97a0c4f284e13433ba66a4ea4
  * Use thread_local var's in FCL distanceCallback() (#2698 <https://github.com/ros-planning/moveit/issues/2698>)
  * Remove octomap from catkin_packages LIBRARIES entries (#2700 <https://github.com/ros-planning/moveit/issues/2700>)
  * CI: Use compiler flag --pedantic (#2691 <https://github.com/ros-planning/moveit/issues/2691>)
  * Remove deprecated header deprecation.h (#2693 <https://github.com/ros-planning/moveit/issues/2693>)
  * collision_detection_fcl: Report link_names in correct order (#2682 <https://github.com/ros-planning/moveit/issues/2682>)
  * RobotState interpolation: warn if interpolation parameter is out of range [0, 1] (#2664 <https://github.com/ros-planning/moveit/issues/2664>)
  * Add sphinx-rtd-theme for python docs as a dependency (#2645 <https://github.com/ros-planning/moveit/issues/2645>)
  * Set rotation value of cartesian MaxEEFStep by default (#2614 <https://github.com/ros-planning/moveit/issues/2614>)
  * Lock the Bullet collision environment, for thread safety (#2598 <https://github.com/ros-planning/moveit/issues/2598>)
  * Make setToIKSolverFrame accessible again (#2580 <https://github.com/ros-planning/moveit/issues/2580>)
  * Python bindings for moveit_core (#2547 <https://github.com/ros-planning/moveit/issues/2547>)
  * Add get_active_joint_names (#2533 <https://github.com/ros-planning/moveit/issues/2533>)
  * Update doxygen comments for distance() and interpolate() (#2528 <https://github.com/ros-planning/moveit/issues/2528>)
  * Replaced eigen+kdl conversions with tf2_eigen + tf2_kdl (#2472 <https://github.com/ros-planning/moveit/issues/2472>)
  * Fix logic, improve function comment for clearDiffs() (#2497 <https://github.com/ros-planning/moveit/issues/2497>)
* Contributors: 0Nel, AndyZe, David V. Lu!!, Felix von Drigalski, JafarAbdi, Jochen Sprickerhof, John Stechschulte, Jorge Nicho, Max Schwarz, Michael Görner, Peter Mitrano, Robert Haschke, Simon Schmeisser, Tyler Weaver, Vatan Aksoy Tezer, petkovich
```

## moveit_kinematics

```
* [sync] MoveIt's master branch up-to https://github.com/ros-planning/moveit/commit/0d0a6a171b3fbea97a0c4f284e13433ba66a4ea4
  * Improve ikfast QUIET handling (#2685 <https://github.com/ros-planning/moveit/issues/2685>)
  * ikfast script: install sympy 0.7.1 from git (#2650 <https://github.com/ros-planning/moveit/issues/2650>)
  * Replaced eigen+kdl conversions with tf2_eigen + tf2_kdl (#2472 <https://github.com/ros-planning/moveit/issues/2472>)
* Contributors: JafarAbdi, Robert Haschke, Tyler Weaver, ags-dy, petkovich
```

## moveit_planners

- No changes

## moveit_planners_ompl

```
* Enable Rolling and Galactic CI (#494 <https://github.com/ros-planning/moveit2/issues/494>)
* Temporarily disable flaky OMPL test (#495 <https://github.com/ros-planning/moveit2/issues/495>)
* [sync] MoveIt's master branch up-to https://github.com/ros-planning/moveit/commit/0d0a6a171b3fbea97a0c4f284e13433ba66a4ea4
  * CI: Use compiler flag --pedantic (#2691 <https://github.com/ros-planning/moveit/issues/2691>)
  * Replaced eigen+kdl conversions with tf2_eigen + tf2_kdl (#2472 <https://github.com/ros-planning/moveit/issues/2472>)
* Contributors: JafarAbdi, Michael Görner, Robert Haschke, Tyler Weaver, Vatan Aksoy Tezer, petkovich
```

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_move_group

```
* Fix deprecated planner namespace in MoveGroup (#524 <https://github.com/ros-planning/moveit2/issues/524>)
* [sync] MoveIt's master branch up-to https://github.com/ros-planning/moveit/commit/0d0a6a171b3fbea97a0c4f284e13433ba66a4ea4
  * Support multiple planning pipelines with MoveGroup via MoveItCpp (#2127 <https://github.com/ros-planning/moveit/issues/2127>)
  * Fix missing isEmpty check in compute_ik service (#2544 <https://github.com/ros-planning/moveit/issues/2544>)
* Contributors: Henning Kayser, Jafar Abdi, JafarAbdi, Michael Görner, Robert Haschke, Tyler Weaver
```

## moveit_ros_occupancy_map_monitor

```
* [sync] with MoveIt's master branch up-to https://github.com/ros-planning/moveit/commit/0d0a6a171b3fbea97a0c4f284e13433ba66a4ea4
  * Add missing OCTOMAP_INCLUDE_DIRS (#2671 <https://github.com/ros-planning/moveit/issues/2671>)
  * document solution in ROS_ERROR on failed self-filtering (#2627 <https://github.com/ros-planning/moveit/issues/2627>)
  * It's not an error not to define a plugin (#2521 <https://github.com/ros-planning/moveit/issues/2521>)
* Contributors: 0Nel, JafarAbdi, Michael Görner, Robert Haschke, Simon Schmeisser, Tyler Weaver, v4hn
```

## moveit_ros_perception

```
* Compilation fixes for MoveIt on macOS (#498 <https://github.com/ros-planning/moveit2/issues/498>)
* [sync] MoveIt's master branch up-to https://github.com/ros-planning/moveit/commit/0d0a6a171b3fbea97a0c4f284e13433ba66a4ea4
  * document solution in ROS_ERROR on failed self-filtering (#2627 <https://github.com/ros-planning/moveit/issues/2627>)
  * Fixed flood of errors on startup for mesh_filter (#2550 <https://github.com/ros-planning/moveit/issues/2550>)
  * Enable mesh filter (#2448 <https://github.com/ros-planning/moveit/issues/2448>)
* Contributors: Jafar Abdi, JafarAbdi, John Stechschulte, Michael Görner, Nisala Kalupahana, Robert Haschke, Simon Schmeisser, Tyler Weaver
```

## moveit_ros_planning

```
* Fix stopping the TrajectoryExecutionManager's execution (#506 <https://github.com/ros-planning/moveit2/issues/506>)
* Enable Rolling and Galactic CI (#494 <https://github.com/ros-planning/moveit2/issues/494>)
* [sync] MoveIt's master branch up-to https://github.com/ros-planning/moveit/commit/0d0a6a171b3fbea97a0c4f284e13433ba66a4ea4
  * PSM: Don't read padding parameters from private namespace (#2706 <https://github.com/ros-planning/moveit/issues/2706>)
  * MSA: Fix template (max_safe_path_cost) (#2703 <https://github.com/ros-planning/moveit/issues/2703>)
  * CI: Use compiler flag --pedantic (#2691 <https://github.com/ros-planning/moveit/issues/2691>)
  * CI: Fail on warnings (#2687 <https://github.com/ros-planning/moveit/issues/2687>)
  * Refine CSM::haveCompleteState (#2663 <https://github.com/ros-planning/moveit/issues/2663>)
  * Use private namespace instead of child for PlanningPipeline topics (#2652 <https://github.com/ros-planning/moveit/issues/2652>)
  * Print error before returning (#2639 <https://github.com/ros-planning/moveit/issues/2639>)
  * Simplify logic in PSM (#2632 <https://github.com/ros-planning/moveit/issues/2632>)
  * PlanExecution: Correctly handle preempt-requested flag (#2554 <https://github.com/ros-planning/moveit/issues/2554>)
  * Support multiple planning pipelines with MoveGroup via MoveItCpp (#2127 <https://github.com/ros-planning/moveit/issues/2127>)Deprecate namespace moveit::planning_interface in favor of moveit_cpp
  
    * thread safety in clear octomap & only update geometry (#2500 <https://github.com/ros-planning/moveit/issues/2500>)
  
* Contributors: Henning Kayser, Jafar Abdi, JafarAbdi, Luc Bettaieb, Martin Günther, Michael Görner, Robert Haschke, Simon Schmeisser, Tyler Weaver, Vatan Aksoy Tezer, v4hn
```

## moveit_ros_planning_interface

```
* Enable Rolling and Galactic CI (#494 <https://github.com/ros-planning/moveit2/issues/494>)
* [sync] with MoveIt's master branch up-to https://github.com/ros-planning/moveit/commit/0d0a6a171b3fbea97a0c4f284e13433ba66a4ea4
  * Allow selecting planning pipeline in MotionSequenceAction (#2657 <https://github.com/ros-planning/moveit/issues/2657>)
  * planning_interface: synchronize async interfaces in test (#2640 <https://github.com/ros-planning/moveit/issues/2640>)
  * Add planning_pipeline_id setting to Python MGI (#2622 <https://github.com/ros-planning/moveit/issues/2622>)
  * fix docstring in MGI API (#2626 <https://github.com/ros-planning/moveit/issues/2626>)
  * Support multiple planning pipelines with MoveGroup via MoveItCpp (#2127 <https://github.com/ros-planning/moveit/issues/2127>)Deprecate namespace moveit::planning_interface in favor of moveit_cpp
  
    * add get_active_joint_names (#2533 <https://github.com/ros-planning/moveit/issues/2533>)
    * Add debugging log statement for a common error (#2509 <https://github.com/ros-planning/moveit/issues/2509>)
    * Replaced eigen+kdl conversions with tf2_eigen + tf2_kdl (#2472 <https://github.com/ros-planning/moveit/issues/2472>)
  
* Contributors: Felix von Drigalski, Henning Kayser, JafarAbdi, Michael Görner, Peter Mitrano, Robert Haschke, Tyler Weaver, Vatan Aksoy Tezer, petkovich
```

## moveit_ros_robot_interaction

```
* Enable Rolling and Galactic CI (#494 <https://github.com/ros-planning/moveit2/issues/494>)
* [sync] MoveIt's master branch up-to https://github.com/ros-planning/moveit/commit/0d0a6a171b3fbea97a0c4f284e13433ba66a4ea4
* Contributors: JafarAbdi, Tyler Weaver, Vatan Aksoy Tezer
```

## moveit_ros_visualization

```
* Declare warehouse params in rviz plugin (#513 <https://github.com/ros-planning/moveit2/issues/513>)
* [sync] MoveIt's master branch up-to https://github.com/ros-planning/moveit/commit/0d0a6a171b3fbea97a0c4f284e13433ba66a4ea4
  * CI: Use compiler flag --pedantic (#2691 <https://github.com/ros-planning/moveit/issues/2691>)
  * Runtime fixes to PlanningSceneDisplay, MotionPlanningDisplay (#2618 <https://github.com/ros-planning/moveit/issues/2618>),(#2588 <https://github.com/ros-planning/moveit2/issues/2588>)
  * Support multiple planning pipelines with MoveGroup via MoveItCpp (#2127 <https://github.com/ros-planning/moveit/issues/2127>)Allow selecting planning pipeline in RViz MotionPlanningDisplay
* Contributors: Bjar Ne, Henning Kayser, JafarAbdi, Michael Görner, Robert Haschke, Tyler Weaver
```

## moveit_ros_warehouse

```
* Clean warehouse_ros OpenSSL depend (#514 <https://github.com/ros-planning/moveit2/issues/514>)
* Contributors: Henning Kayser, Vatan Aksoy Tezer
```

## moveit_runtime

- No changes

## moveit_servo

```
* Allow a negative joint margin (#501 <https://github.com/ros-planning/moveit2/issues/501>)
* Move servo doc and examples to moveit2_tutorials (#486 <https://github.com/ros-planning/moveit2/issues/486>)
* Remove faulty gtest include (#526 <https://github.com/ros-planning/moveit2/issues/526>)
* Fix segfault when publish_joint_velocities set to false and a joint is close to position limit (#497 <https://github.com/ros-planning/moveit2/issues/497>)
* Enable Rolling and Galactic CI (#494 <https://github.com/ros-planning/moveit2/issues/494>)
* [sync] MoveIt's master branch up-to https://github.com/ros-planning/moveit/commit/0d0a6a171b3fbea97a0c4f284e13433ba66a4ea4
  * Misspelled MoveIt (#2692 <https://github.com/ros-planning/moveit/issues/2692>)
  * Avoid joint jump when SuddenHalt() is called in velocity mode (#2594 <https://github.com/ros-planning/moveit/issues/2594>)
  * Halt Servo command on Pose Tracking stop (#2501 <https://github.com/ros-planning/moveit/issues/2501>)
  * stop_requested_ flag clearing fix (#2537 <https://github.com/ros-planning/moveit/issues/2537>)
  * add missing include (#2519 <https://github.com/ros-planning/moveit/issues/2519>)
  * Refactor velocity bounds enforcement (#2471 <https://github.com/ros-planning/moveit/issues/2471>)
* Contributors: AdamPettinger, AndyZe, Henning Kayser, Jafar Abdi, JafarAbdi, Jere Liukkonen, Michael Görner, Nathan Brooks, Robert Haschke, Tyler Weaver, Vatan Aksoy Tezer, parunapu
```

## moveit_simple_controller_manager

```
* Enable Rolling and Galactic CI (#494 <https://github.com/ros-planning/moveit2/issues/494>)
* [sync] MoveIt's master branch up-to https://github.com/ros-planning/moveit/commit/0d0a6a171b3fbea97a0c4f284e13433ba66a4ea4
* Contributors: Henning Kayser, JafarAbdi, Tyler Weaver, Vatan Aksoy Tezer
```

## run_move_group

```
* [sync] MoveIt's master branch up-to https://github.com/ros-planning/moveit/commit/0d0a6a171b3fbea97a0c4f284e13433ba66a4ea4
* Contributors: JafarAbdi
```

## run_moveit_cpp

```
* [sync] MoveIt's master branch up-to https://github.com/ros-planning/moveit/commit/0d0a6a171b3fbea97a0c4f284e13433ba66a4ea4
* Contributors: JafarAbdi
```

## run_ompl_constrained_planning

- No changes
