### PR TITLE
Adding libqt5-quick key for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4634,6 +4634,7 @@ libqt5-quick:
   debian: [libqt5quick5]
   nixos: [qt5.qtdeclarative]
   ubuntu: [libqt5quick5]
+  rhel: [qt5-qtdeclarative]
 libqt5-serialport:
   arch: [qt5-serialport]
   debian: [libqt5serialport5]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4633,8 +4633,8 @@ libqt5-qml:
 libqt5-quick:
   debian: [libqt5quick5]
   nixos: [qt5.qtdeclarative]
-  ubuntu: [libqt5quick5]
   rhel: [qt5-qtdeclarative]
+  ubuntu: [libqt5quick5]
 libqt5-serialport:
   arch: [qt5-serialport]
   debian: [libqt5serialport5]


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>

Please add the following dependency to the rosdep database.

## Package name:

[rmf_robot_sim_ignition_plugins](https://github.com/open-rmf/rmf_simulation/tree/main/rmf_robot_sim_ignition_plugins)

## Package Upstream Source:

https://github.com/open-rmf/rmf_simulation

## Purpose of using this:

We are using libqt5-quick [here](https://github.com/open-rmf/rmf_simulation/blob/main/rmf_robot_sim_ignition_plugins/package.xml) and we need the rosdep key in order to release the package for RHEL.
