### PR TITLE
ros2_controllers: 0.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2573,6 +2573,34 @@ repositories:
       url: https://github.com/ros-controls/ros2_control.git
       version: master
     status: developed
+  ros2_controllers:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/ros2_controllers.git
+      version: master
+    release:
+      packages:
+      - diff_drive_controller
+      - effort_controllers
+      - force_torque_sensor_broadcaster
+      - forward_command_controller
+      - gripper_controllers
+      - imu_sensor_broadcaster
+      - joint_state_broadcaster
+      - joint_state_controller
+      - joint_trajectory_controller
+      - position_controllers
+      - ros2_controllers
+      - velocity_controllers
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_controllers-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/ros2_controllers.git
+      version: master
+    status: developed
   ros2_ouster_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `0.4.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## diff_drive_controller

```
* Force torque sensor broadcaster (#152 <https://github.com/ros-controls/ros2_controllers/issues/152>)
  * Add  rclcpp::shutdown(); to all standalone test functions
* Fixes for Windows (#205 <https://github.com/ros-controls/ros2_controllers/issues/205>)
  * Fix MSVC build for diff_drive_controller test
* Fix parameter initialisation for galactic (#199 <https://github.com/ros-controls/ros2_controllers/issues/199>)
* Contributors: Akash, Denis Štogl, Tim Clephas
```

## effort_controllers

```
* Force torque sensor broadcaster (#152 <https://github.com/ros-controls/ros2_controllers/issues/152>)
  * Add  rclcpp::shutdown(); to all standalone test functions
* Contributors: Denis Štogl
```

## force_torque_sensor_broadcaster

```
* Fix dependency (#208 <https://github.com/ros-controls/ros2_controllers/issues/208>)
* Force torque sensor broadcaster (#152 <https://github.com/ros-controls/ros2_controllers/issues/152>)
  * Stabilize joint_trajectory_controller tests
  * Add  rclcpp::shutdown(); to all standalone test functions
* Contributors: Bence Magyar, Denis Štogl, Nisala Kalupahana, Subhas Das
```

## forward_command_controller

```
* Force torque sensor broadcaster (#152 <https://github.com/ros-controls/ros2_controllers/issues/152>)
  * Add  rclcpp::shutdown(); to all standalone test functions
* Fix parameter initialisation for galactic (#199 <https://github.com/ros-controls/ros2_controllers/issues/199>)
* Contributors: Denis Štogl, Tim Clephas
```

## gripper_controllers

```
* Force torque sensor broadcaster (#152 <https://github.com/ros-controls/ros2_controllers/issues/152>)
  * Add  rclcpp::shutdown(); to all standalone test functions
* Fixes for Windows (#205 <https://github.com/ros-controls/ros2_controllers/issues/205>)
  * Disable gripper on Windows too
* disable gripper on OSX (#192 <https://github.com/ros-controls/ros2_controllers/issues/192>)
* Port gripper action controller to ROS2 (#162 <https://github.com/ros-controls/ros2_controllers/issues/162>)
* Contributors: Bence Magyar, Denis Štogl, Jafar Abdi
```

## imu_sensor_broadcaster

```
* Add imu sensor broadcaster (#195 <https://github.com/ros-controls/ros2_controllers/issues/195>)
  * Add imu_sensor_broadcaster
  * Link IMU Sensor broadcaster in controllers docs
* Contributors: Bence Magyar, Victor Lopez
```

## joint_state_broadcaster

```
* Force torque sensor broadcaster (#152 <https://github.com/ros-controls/ros2_controllers/issues/152>)
  * Add  rclcpp::shutdown(); to all standalone test functions
* Contributors: Denis Štogl
```

## joint_state_controller

```
* Force torque sensor broadcaster (#152 <https://github.com/ros-controls/ros2_controllers/issues/152>)
  * Add  rclcpp::shutdown(); to all standalone test functions
* Contributors: Denis Štogl
```

## joint_trajectory_controller

```
* Force torque sensor broadcaster (#152 <https://github.com/ros-controls/ros2_controllers/issues/152>)
  * Stabilize joint_trajectory_controller tests
  * Add  rclcpp::shutdown(); to all standalone test functions
* Fixes for Windows (#205 <https://github.com/ros-controls/ros2_controllers/issues/205>)
  * Export protected joint trajectory controller functions
* Fix deprecation warnings on Rolling, remove rcutils dependency (#204 <https://github.com/ros-controls/ros2_controllers/issues/204>)
* Fix parameter initialisation for galactic (#199 <https://github.com/ros-controls/ros2_controllers/issues/199>)
  * Fix parameter initialisation for galactic
  * Fix forward_command_controller the same way
  * Fix other compiler warnings
  * Missing space
* Fix rolling build (#200 <https://github.com/ros-controls/ros2_controllers/issues/200>)
  * Fix rolling build
  * Stick to printf style
  * Add back :: around interface type
  Co-authored-by: Bence Magyar <mailto:bence.magyar.robotics@gmail.com>
* Contributors: Akash, Bence Magyar, Denis Štogl, Tim Clephas, Vatan Aksoy Tezer
```

## position_controllers

```
* Force torque sensor broadcaster (#152 <https://github.com/ros-controls/ros2_controllers/issues/152>)
  * Add  rclcpp::shutdown(); to all standalone test functions
* Contributors: Denis Štogl
```

## ros2_controllers

```
* Add imu sensor broadcaster (#195 <https://github.com/ros-controls/ros2_controllers/issues/195>)
  * Add imu_sensor_broadcaster
  * Link IMU Sensor broadcaster in controllers docs
  Co-authored-by: Bence Magyar <mailto:bence.magyar.robotics@gmail.com>
* Force torque sensor broadcaster (#152 <https://github.com/ros-controls/ros2_controllers/issues/152>)
  * Add  rclcpp::shutdown(); to all standalone test functions
* Contributors: Bence Magyar, Denis Štogl, Victor Lopez, Subhas Das
```

## velocity_controllers

```
* Force torque sensor broadcaster (#152 <https://github.com/ros-controls/ros2_controllers/issues/152>)
  * Add  rclcpp::shutdown(); to all standalone test functions
* Contributors: Denis Štogl
```
