### PR TITLE
Added python-aiohttp and python-aiohttp-cors to the rosdep database

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5746,17 +5746,17 @@ python3-aio-pika-pip:
     pip:
       packages: [aio-pika]
 python3-aiohttp:
-  debian: [python3-aiohttp]
-  ubuntu: [python3-aiohttp]
-  fedora: [python-aiohttp]
   arch: [python-aiohttp]
+  debian: [python3-aiohttp]
+  fedora: [python-aiohttp]
   gentoo: [dev-python/aiohttp]
+  ubuntu: [python3-aiohttp]
 python3-aiohttp-cors:
-  debian: [python3-aiohttp-cors]
-  ubuntu: [python3-aiohttp-cors]
-  fedora: [python-aiohttp-cors]
   arch: [python-aiohttp-cors]
+  debian: [python3-aiohttp-cors]
+  fedora: [python-aiohttp-cors]
   gentoo: [dev-python/aiohttp-cors]
+  ubuntu: [python3-aiohttp-cors]
 python3-albumentations-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5753,7 +5753,9 @@ python3-aiohttp:
   ubuntu: [python3-aiohttp]
 python3-aiohttp-cors:
   arch: [python-aiohttp-cors]
-  debian: [python3-aiohttp-cors]
+  debian:
+    '*': [python3-aiohttp-cors]
+    stretch: null
   fedora: [python-aiohttp-cors]
   gentoo: [dev-python/aiohttp-cors]
   ubuntu: [python3-aiohttp-cors]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5748,9 +5748,11 @@ python3-aio-pika-pip:
 python3-aiohttp:
   debian: [python3-aiohttp]
   ubuntu: [python3-aiohttp]
+  fedora: [python3-aiohttp]
 python3-aiohttp-cors:
   debian: [python3-aiohttp-cors]
   ubuntu: [python3-aiohttp-cors]
+  fedora: [python3-aiohttp-cors]
 python3-albumentations-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5763,6 +5763,10 @@ python3-aiohttp:
   debian: [python3-aiohttp]
   fedora: [python-aiohttp]
   gentoo: [dev-python/aiohttp]
+  opensuse: [python-aiohttp]
+  rhel:
+    '*': [python3-aiohttp]
+    '7': null
   ubuntu: [python3-aiohttp]
 python3-aiohttp-cors:
   arch: [python-aiohttp-cors]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5748,11 +5748,15 @@ python3-aio-pika-pip:
 python3-aiohttp:
   debian: [python3-aiohttp]
   ubuntu: [python3-aiohttp]
-  fedora: [python3-aiohttp]
+  fedora: [python-aiohttp]
+  arch: [python-aiohttp]
+  gentoo: [dev-python/aiohttp]
 python3-aiohttp-cors:
   debian: [python3-aiohttp-cors]
   ubuntu: [python3-aiohttp-cors]
-  fedora: [python3-aiohttp-cors]
+  fedora: [python-aiohttp-cors]
+  arch: [python-aiohttp-cors]
+  gentoo: [dev-python/aiohttp-cors]
 python3-albumentations-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5745,6 +5745,12 @@ python3-aio-pika-pip:
   ubuntu:
     pip:
       packages: [aio-pika]
+python3-aiohttp:
+  debian: [python3-aiohttp]
+  ubuntu: [python3-aiohttp]
+python3-aiohttp-cors:
+  debian: [python3-aiohttp-cors]
+  ubuntu: [python3-aiohttp-cors]
 python3-albumentations-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependencies to the rosdep database.

## Package name:
- python3-aiohttp
- python3-aiohttp-cors

## Package Upstream Source:
- https://github.com/aio-libs/aiohttp
- https://github.com/aio-libs/aiohttp-cors

## Purpose of using this:
aiohttp is an increasingly popular library for building HTTP clients and servers using Python3's asyncio library. The aiohttp-cors middleware is useful for development as it means the web page and HTTP server don't have to be hosted from the same origin in order for browsers to load resources, which is a common state of affairs when developing robots!

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/buster/python3-aiohttp
  - https://packages.debian.org/buster/python3-aiohttp-cors
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/focal/python3-aiohttp
  - https://packages.ubuntu.com/focal/python3-aiohttp-cors
- Fedora: https://src.fedoraproject.org/browse/projects/
  - https://src.fedoraproject.org/rpms/python-aiohttp
  - https://src.fedoraproject.org/rpms/python-aiohttp-cors
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/community/x86_64/python-aiohttp/
  - https://archlinux.org/packages/community/any/python-aiohttp-cors/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/aiohttp
  - https://packages.gentoo.org/packages/dev-python/aiohttp-cors
- macOS: https://formulae.brew.sh/
  - NOT AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - NOT AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL