### PR TITLE
realsense2_camera: 2.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6054,7 +6054,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
-      version: 2.3.0-1
+      version: 2.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `2.3.1-1`:

- upstream repository: https://github.com/IntelRealSense/realsense-ros.git
- release repository: https://github.com/IntelRealSense/realsense-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.0-1`

## realsense2_camera

```
* add respawn option
* add udev rules to debian installation
* Add support for L535
* Fix occasional missing diagnostic messages
* Contributors: Alex Fernandes Neves, doronhi
```

## realsense2_description

```
* add imu frames to _l515.urdf.xacro
* Contributors: Simon Honigmann, doronhi
```
