### PR TITLE
Remove Debian Stretch from the repository checks.

### DIFF
--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -46,7 +46,6 @@ package_dashboards:
 
 supported_versions:
   debian:
-  - stretch
   - buster
   fedora:
   - '33'


### PR DESCRIPTION
It is now in LTS support, and we haven't traditionally supported
new rosdep keys for Debian releases that are in LTS.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

See https://wiki.debian.org/LTS