### PR TITLE
python.yaml updates for openSUSE (8 of 11)

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6883,6 +6883,7 @@ python3-pep8:
   ubuntu: [python3-pep8]
 python3-pexpect:
   debian: [python3-pexpect]
+  opensuse: [python3-pexpect]
   ubuntu: [python3-pexpect]
 python3-pika:
   debian: [python3-pika]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6756,6 +6756,7 @@ python3-numpy:
   gentoo: [dev-python/numpy]
   nixos: [python3Packages.numpy]
   openembedded: [python3-numpy@openembedded-core]
+  opensuse: [python3-numpy]
   rhel: ['python%{python3_pkgversion}-numpy']
   ubuntu: [python3-numpy]
 python3-numpy-stl:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6739,6 +6739,7 @@ python3-nose:
   gentoo: [dev-python/nose]
   nixos: [python3Packages.nose]
   openembedded: [python3-nose@openembedded-core]
+  opensuse: [python3-nose]
   rhel: ['python%{python3_pkgversion}-nose']
   ubuntu: [python3-nose]
 python3-nose-parameterized:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6795,6 +6795,7 @@ python3-opengl:
   fedora: [python3-pyopengl]
   gentoo: [dev-python/pyopengl]
   nixos: [python3Packages.pyopengl]
+  opensuse: [python3-opengl]
   ubuntu: [python3-opengl]
 python3-owlready2-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6783,6 +6783,7 @@ python3-opencv:
   gentoo: ['media-libs/opencv[python]']
   nixos: [python3Packages.opencv3]
   openembedded: [opencv@meta-oe]
+  opensuse: [python3-opencv]
   ubuntu:
     bionic: [python3-opencv]
     cosmic: [python3-opencv]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6853,6 +6853,7 @@ python3-paramiko:
   gentoo: [dev-python/paramiko]
   nixos: [python3Packages.paramiko]
   openembedded: [python3-paramiko@meta-ros-common]
+  opensuse: [python3-paramiko]
   rhel: ['python%{python3_pkgversion}-paramiko']
   ubuntu: [python3-paramiko]
 python3-pcg-gazebo-pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6719,6 +6719,7 @@ python3-netifaces:
   gentoo: [dev-python/netifaces]
   nixos: [python3Packages.netifaces]
   openembedded: [python3-netifaces@meta-ros-common]
+  opensuse: [python3-netifaces]
   rhel: ['python%{python3_pkgversion}-netifaces']
   ubuntu: [python3-netifaces]
 python3-networkmanager:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6897,7 +6897,7 @@ python3-pil:
   gentoo: [dev-python/pillow]
   nixos: [python3Packages.pillow]
   openembedded: [python3-pillow@meta-python]
-  opensuse: [python3-pillow]
+  opensuse: [python3-Pillow]
   osx:
     pip:
       packages: [Pillow]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6826,6 +6826,7 @@ python3-pandas:
   gentoo: [dev-python/pandas]
   nixos: [python3Packages.pandas]
   openembedded: [python3-pandas@meta-python]
+  opensuse: [python3-pandas]
   rhel:
     '*': ['python%{python3_pkgversion}-pandas']
     '7': null


### PR DESCRIPTION
This is a continuation of the python.yaml updates for openSUSE
#29935 #29936 #29944 #30062 #30063 #30064 #30065

These keys are not necessarily related to each other. I'm just processing these commits alphabetically and breaking them up into groups of approx. 10.

https://software.opensuse.org/package/python3-netifaces
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-netifaces/standard
https://software.opensuse.org/package/python3-nose
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-nose/standard
https://software.opensuse.org/package/python3-numpy
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.13322/standard
https://software.opensuse.org/package/python3-opencv
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/opencv/standard
https://software.opensuse.org/package/python3-opengl
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-opengl/standard
https://software.opensuse.org/package/python3-pandas
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-pandas/standard
https://software.opensuse.org/package/python3-paramiko
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.12946/standard
https://software.opensuse.org/package/python3-pexpect
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.13468/standard
https://software.opensuse.org/package/python3-Pillow
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-Pillow/standard
