### PR TITLE
python.yaml updates for openSUSE (9 of 11)

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7023,6 +7023,7 @@ python3-pycryptodome:
   gentoo: [dev-python/pycryptodome]
   nixos: [python3Packages.pycryptodomex]
   openembedded: [python3-pycryptodomex@meta-python]
+  opensuse: [python3-pycryptodomex]
   osx:
     pip:
       packages: [pycryptodome]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6911,6 +6911,7 @@ python3-pkg-resources:
   gentoo: [dev-python/setuptools]
   nixos: [python3Packages.setuptools]
   openembedded: [python3-setuptools@openembedded-core]
+  opensuse: [python3-setuptools]
   rhel: ['python%{python3_pkgversion}-setuptools']
   ubuntu: [python3-pkg-resources]
 python3-pqdict-pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7200,6 +7200,7 @@ python3-pyqt5.qtwebengine:
   debian: [python3-pyqt5.qtwebengine]
   fedora: [python3-qt5-webengine]
   openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
+  opensuse: [python3-qtwebengine-qt5]
   ubuntu: [python3-pyqt5.qtwebengine]
 python3-pyqtgraph:
   debian: [python3-pyqtgraph]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7012,6 +7012,7 @@ python3-pycodestyle:
   gentoo: [dev-python/pycodestyle]
   nixos: [python3Packages.pycodestyle]
   openembedded: [python3-pycodestyle@meta-python]
+  opensuse: [python3-pycodestyle]
   rhel: ['python%{python3_pkgversion}-pycodestyle']
   ubuntu: [python3-pycodestyle]
 python3-pycryptodome:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6902,6 +6902,7 @@ python3-pip:
   debian: [python3-pip]
   fedora: [python3-pip]
   openembedded: [python3-pip@openembedded-core]
+  opensuse: [python3-pip]
   ubuntu: [python3-pip]
 python3-pkg-resources:
   alpine: [py3-setuptools]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7168,6 +7168,7 @@ python3-pyparsing:
   gentoo: [dev-python/pyparsing]
   nixos: [python3Packages.pyparsing]
   openembedded: [python3-pyparsing@meta-python]
+  opensuse: [python3-pyparsing]
   ubuntu: [python3-pyparsing]
 python3-pypng:
   arch: [python-pypng]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6981,6 +6981,7 @@ python3-pyaudio:
   fedora: [python3-pyaudio]
   gentoo: [dev-python/pyaudio]
   nixos: [python3Packages.pyaudio]
+  opensuse: [python3-PyAudio]
   osx:
     pip:
       packages: [pyaudio]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7063,6 +7063,7 @@ python3-pydot:
   gentoo: [dev-python/pydot]
   nixos: [python3Packages.pydot]
   openembedded: [python3-pydot@meta-ros-common]
+  opensuse: [python3-pydot]
   rhel:
     '*': ['python%{python3_pkgversion}-pydot']
     '7': null

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7108,7 +7108,7 @@ python3-pygraphviz:
   gentoo: [dev-python/pygraphviz]
   nixos: [python3Packages.pygraphviz]
   openembedded: [python3-pygraphviz@meta-ros-common]
-  opensuse: [python-pygraphviz]
+  opensuse: [python3-pygraphviz]
   osx:
     pip:
       packages: [pygraphviz]


### PR DESCRIPTION
This is a continuation of the python.yaml updates for openSUSE
#29935 #29936 #29944 #30062 #30063 #30064 #30065 #30095

These keys are not necessarily related to each other. I'm just processing these commits alphabetically and breaking them up into groups of approx. 10.

https://software.opensuse.org/package/python3-pip
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.14312/standard
https://software.opensuse.org/package/python3-setuptools
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.15196/standard
https://software.opensuse.org/package/python3-PyAudio
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-PyAudio/standard
https://software.opensuse.org/package/python3-pycodestyle
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-pycodestyle/standard
https://software.opensuse.org/package/python3-pycryptodomex
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.15806/standard
https://software.opensuse.org/package/python3-pydot
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-pydot/standard
https://software.opensuse.org/package/python3-pygraphviz
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-pygraphviz/standard
https://software.opensuse.org/package/python3-pyparsing
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-pyparsing/standard
https://software.opensuse.org/package/python3-qtwebengine-qt5
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-qtwebengine-qt5/standard
