### PR TITLE
python.yaml updates for openSUSE (10 of 11)

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7286,6 +7286,7 @@ python3-pytest-timeout:
   debian: [python3-pytest-timeout]
   fedora: [python3-pytest-timeout]
   gentoo: [dev-python/pytest-timeout]
+  opensuse: [python3-pytest-timeout]
   ubuntu: [python3-pytest-timeout]
 python3-pyvista-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7615,6 +7615,7 @@ python3-sip:
   fedora: [python3-sip]
   gentoo: [dev-python/sip]
   nixos: [python3Packages.sip_4]
+  opensuse: [python3-sip]
   ubuntu: [python3-sip-dev]
 python3-siphon-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7548,6 +7548,7 @@ python3-setuptools:
   gentoo: [dev-python/setuptools]
   nixos: [python3Packages.setuptools]
   openembedded: [python3-setuptools@openembedded-core]
+  opensuse: [python3-setuptools]
   osx:
     pip:
       packages: [setuptools]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7686,6 +7686,7 @@ python3-sphinx:
   fedora: [python3-sphinx]
   nixos: [python3Packages.sphinx]
   openembedded: [python3-sphinx@meta-ros-common]
+  opensuse: [python3-Sphinx]
   rhel: ['python%{python3_pkgversion}-sphinx']
   ubuntu: [python3-sphinx]
 python3-sphinx-argparse:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7490,6 +7490,7 @@ python3-scipy:
 python3-scp:
   debian: [python3-scp]
   fedora: [python3-scp]
+  opensuse: [python3-scp]
   ubuntu: [python3-scp]
 python3-seaborn:
   arch: [python-seaborn]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7328,6 +7328,7 @@ python3-qt5-bindings-gl:
   gentoo: ['dev-python/PyQt5[opengl]']
   nixos: [python3Packages.pyqt5]
   openembedded: [python3-pyqt5@meta-qt5]
+  opensuse: [python3-qt5]
   ubuntu: [python3-pyqt5.qtopengl]
 python3-qt5-bindings-webkit:
   debian: [python3-pyqt5.qtwebkit]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7706,6 +7706,7 @@ python3-sqlalchemy:
   fedora: [python3-sqlalchemy]
   gentoo: [dev-python/sqlalchemy]
   nixos: [python3Packages.sqlalchemy]
+  opensuse: [python3-SQLAlchemy]
   ubuntu: [python3-sqlalchemy]
 python3-stable-baselines3-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7279,6 +7279,7 @@ python3-pytest-mock:
   gentoo: [dev-python/pytest-mock]
   nixos: [python3Packages.pytest-mock]
   openembedded: [python3-pytest-mock@meta-ros-common]
+  opensuse: [python3-pytest-mock]
   rhel: ['python%{python3_pkgversion}-pytest-mock']
   ubuntu: [python3-pytest-mock]
 python3-pytest-timeout:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7335,6 +7335,7 @@ python3-qt5-bindings-webkit:
   fedora: [python3-qt5-webkit]
   gentoo: ['dev-python/PyQt5[webkit]']
   openembedded: [python3-pyqt5@meta-qt5]
+  opensuse: [python3-qt5]
   ubuntu: [python3-pyqt5.qtwebkit]
 python3-qtpy:
   arch: [python-qtpy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7255,6 +7255,7 @@ python3-pytest:
   gentoo: [dev-python/pytest]
   nixos: [pythonPackages.pytest]
   openembedded: [python3-pytest@meta-python]
+  opensuse: [python3-pytest]
   osx:
     pip:
       packages: [pytest]


### PR DESCRIPTION
This is a continuation of the python.yaml updates for openSUSE
#29935 #29936 #29944 #30062 #30063 #30064 #30065 #30095 #30096

These keys are not necessarily related to each other. I'm just processing these commits alphabetically and breaking them up into groups of approx. 10.

https://software.opensuse.org/package/python3-pytest
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.13468/standard
https://software.opensuse.org/package/python3-pytest-mock
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.13468/standard
https://software.opensuse.org/package/python3-pytest-timeout
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.16008/standard
https://software.opensuse.org/package/python3-qt5
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-qt5/standard
https://software.opensuse.org/package/python3-scp
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.16008/standard
https://software.opensuse.org/package/python3-setuptools
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.15196/standard
https://software.opensuse.org/package/python3-sip
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-sip/standard
https://software.opensuse.org/package/python3-Sphinx
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.13909/standard
https://software.opensuse.org/package/python3-SQLAlchemy
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.14875/standard
