### PR TITLE
python.yaml updates for openSUSE (11 of 11)

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8037,6 +8037,7 @@ rpy2:
   arch: [python-rpy2]
   debian: [python-rpy2]
   gentoo: [=dev-python/rpy-2*]
+  opensuse: [python3-rpy2]
   ubuntu: [python-rpy2]
 sphinxcontrib-bibtex-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7778,6 +7778,7 @@ python3-tk:
   fedora: [python3-tkinter]
   nixos: [python3Packages.tkinter]
   openembedded: [python3-tkinter@openembedded-core]
+  opensuse: [python3-tk]
   rhel: ['python%{python3_pkgversion}-tkinter']
   ubuntu: [python3-tk]
 python3-toml:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7846,6 +7846,7 @@ python3-twisted:
   gentoo: [dev-python/twisted]
   nixos: [python3Packages.twisted]
   openembedded: [python3-twisted@meta-python]
+  opensuse: [python3-Twisted]
   rhel:
     '*': ['python%{python3_pkgversion}-twisted']
     '7': null

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7746,6 +7746,7 @@ python3-termcolor:
   gentoo: [dev-python/termcolor]
   nixos: [python3Packages.termcolor]
   openembedded: [python3-termcolor@meta-python]
+  opensuse: [python3-termcolor]
   ubuntu: [python3-termcolor]
 python3-texttable:
   debian: [python3-texttable]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7794,6 +7794,7 @@ python3-tornado:
   gentoo: [www-servers/tornado]
   nixos: [python3Packages.tornado]
   openembedded: [python3-tornado@meta-python]
+  opensuse: [python3-tornado]
   osx:
     pip:
       packages: [tornado]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8100,7 +8100,7 @@ wxpython:
   macports: [py27-wxpython, py27-gobject, py27-gtk, py27-cairo]
   nixos: [pythonPackages.wxPython]
   openembedded: [wxpython@meta-ros-python2]
-  opensuse: [python-wxGTK]
+  opensuse: [python-wxWidgets-3_0-devel]
   rhel:
     '7': [wxPython-devel]
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8084,6 +8084,7 @@ virtualenv:
   debian: [virtualenv]
   fedora: [virtualenv]
   nixos: [python3Packages.virtualenv]
+  opensuse: [python2-virtualenv]
   ubuntu: [virtualenv]
 wxpython:
   arch: [wxpython]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8124,6 +8124,7 @@ yapf:
     buster: [yapf]
     stretch: [yapf]
   nixos: [python3Packages.yapf]
+  opensuse: [python2-yapf]
   ubuntu:
     '*': [yapf]
     saucy:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7893,6 +7893,7 @@ python3-venv:
   debian: [python3-venv]
   fedora: [python3-libs]
   nixos: [python3]
+  opensuse: [python3-virtualenv]
   ubuntu: [python3-venv]
 python3-virtualserialports-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7978,6 +7978,7 @@ python3-yaml:
   gentoo: [dev-python/pyyaml]
   nixos: [python3Packages.pyyaml]
   openembedded: [python3-pyyaml@meta-python]
+  opensuse: [python3-PyYAML]
   osx:
     pip:
       packages: [pyyaml]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7916,6 +7916,7 @@ python3-websocket:
   fedora: [python3-websocket-client]
   gentoo: [dev-python/websocket-client]
   openembedded: [python3-websocket-client@meta-python]
+  opensuse: [python3-websocket-client]
   rhel: ['python%{python3_pkgversion}-websocket-client']
   ubuntu: [python3-websocket]
 python3-websockets:


### PR DESCRIPTION
This is a continuation of the python.yaml updates for openSUSE
#29935 #29936 #29944 #30062 #30063 #30064 #30065 #30095 #30096 #30097

These keys are not necessarily related to each other. I'm just processing these commits alphabetically and breaking them up into groups of approx. 10.

https://software.opensuse.org/package/python3-termcolor
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-termcolor/standard
https://software.opensuse.org/package/python3-tk
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.15401/standard
https://software.opensuse.org/package/python3-tornado
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-tornado/standard
https://software.opensuse.org/package/python3-Twisted
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-Twisted/standard
https://software.opensuse.org/package/python3-virtualenv
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-virtualenv/standard
https://software.opensuse.org/package/python3-websocket-client
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.16008/standard
https://software.opensuse.org/package/python3-PyYAML
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2:Update/patchinfo.16008/standard
https://software.opensuse.org/package/python3-rpy2
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-rpy2/standard
https://software.opensuse.org/package/python2-virtualenv
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-virtualenv/standard
https://software.opensuse.org/package/python-wxWidgets-3_0
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-wxWidgets-3_0/standard
https://software.opensuse.org/package/python2-yapf
https://build.opensuse.org/package/binaries/openSUSE:Leap:15.2/python-yapf/standard
