### PR TITLE
adding key libqt5-qml for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4629,6 +4629,7 @@ libqt5-printsupport:
 libqt5-qml:
   debian: [libqt5qml5]
   nixos: [qt5.qtdeclarative]
+  rhel: [qt5-qtdeclarative]
   ubuntu: [libqt5qml5]
 libqt5-quick:
   debian: [libqt5quick5]


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>

Please add the following dependency to the rosdep database.

## Package name:

Used by rmf_building_sim_ignition_plugins and rmf_robot_sim_ignition_plugins

## Package Upstream Source:

https://github.com/open-rmf/rmf_simulation

## Purpose of using this:

This dependency is being used for [rmf_building_sim_ignition_plugins](https://github.com/open-rmf/rmf_simulation/blob/main/rmf_building_sim_ignition_plugins/package.xml) and for [rmf_robot_sim_ignition_plugins](https://github.com/open-rmf/rmf_simulation/blob/main/rmf_robot_sim_ignition_plugins/package.xml). This is why I think it's valuable to be added to the rosdep database. 


## Links to Distribution Packages

Ubuntu:
https://packages.ubuntu.com/search?keywords=libqt5qml5

RHEL 7 and 8:
https://centos.pkgs.org/8/centos-appstream-x86_64/qt5-qtdeclarative-5.12.5-1.el8.x86_64.rpm.html
https://centos.pkgs.org/8/centos-appstream-x86_64/qt5-qtdeclarative-5.12.5-1.el8.x86_64.rpm.html
