### PR TITLE
tests: add rosdep_repo_check alpine support

### DIFF
--- a/test/rosdep_repo_check/__init__.py
+++ b/test/rosdep_repo_check/__init__.py
@@ -252,8 +252,9 @@ def get_package_link(config, pkg, os_name, os_code_name, os_arch):
     :returns: a URL to a dashboard or package file.
     """
     for dashboard in config.get('package_dashboards', ()):
-        if dashboard['pattern'].match(pkg.url):
-            return dashboard['url'].format_map({
+        match = dashboard['pattern'].match(pkg.url)
+        if match:
+            return match.expand(dashboard['url']).format_map({
                 'binary_name': pkg.binary_name,
                 'name': pkg.name,
                 'os_arch': os_arch,

--- a/test/rosdep_repo_check/apk.py
+++ b/test/rosdep_repo_check/apk.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2021, Open Source Robotics Foundation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Willow Garage, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import tarfile
+
+from . import open_gz_url
+from . import PackageEntry
+from . import RepositoryCacheCollection
+
+
+def parse_apkindex(f):
+    # An example of an APKINDEX entry. Entries are divided by a blank line.
+
+    # V:2.1.1-r0
+    # A:x86_64
+    # S:6645
+    # I:28672
+    # T:RTP proxy (documentation)
+    # U:https://www.rtpproxy.org/
+    # L:BSD-2-CLause
+    # o:rtpproxy
+    # m:Natanael Copa <ncopa@alpinelinux.org>
+    # t:1602354892
+    # c:183e99f73bb1223768aa7231a836a3e98e94c03e
+    # i:docs rtpproxy=2.1.1-r0
+
+    while True:
+        entry = {}
+        while (l := f.readline().decode('utf-8')) not in ['', '\n']:
+            k, v = l.strip().split(':', 1)
+            entry[k] = v
+
+        if entry:
+            yield entry
+        else:
+            break
+
+
+def enumerate_apk_packages(base_url, os_name, os_code_name, os_arch):
+    """
+    Enumerate packages in an apk (Alpine Package) repository.
+
+    :param base_url: the apk repository base URL.
+    :param os_name: the name of the OS associated with the repository.
+    :param os_code_name: the OS version associated with the repository.
+    :param os_arch: the system architecture associated with the repository.
+
+    :returns: an enumeration of package entries.
+    """
+
+    base_url = base_url.replace('$releasever', os_code_name)
+    apkindex_url = os.path.join(base_url, os_arch, 'APKINDEX.tar.gz')
+    print('Reading apk package metadata from ' + apkindex_url)
+
+    with open_gz_url(apkindex_url) as f:
+        with tarfile.open(mode='r|', fileobj=f) as tf:
+            index = None
+            for ti in tf:
+                if ti.name == 'APKINDEX':
+                    index = tf.extractfile(ti)
+                    break
+            if index is None:
+                raise RuntimeError('APKINDEX url did not contain an APKINDEX file')
+
+            for index_entry in parse_apkindex(index):
+                pkg_name, pkg_version, source_name = index_entry['P'], index_entry['V'], index_entry['o']
+                pkg_filename = '%s-%s.apk' % (pkg_name, pkg_version)
+                pkg_url = os.path.join(base_url, pkg_filename)
+                yield PackageEntry(pkg_name, pkg_version, pkg_url, source_name=source_name)
+
+
+def apk_base_url(base_url):
+    """
+    Create an enumerable cache for an apk (Alpine Package) repository.
+
+    :param base_url: the URL of the apk repository.
+
+    :returns: an enumerable repository cache instance.
+    """
+    return RepositoryCacheCollection(
+        lambda os_name, os_code_name, os_arch:
+            enumerate_apk_packages(base_url, os_name, os_code_name, os_arch))

--- a/test/rosdep_repo_check/config.py
+++ b/test/rosdep_repo_check/config.py
@@ -29,6 +29,7 @@ import os
 import re
 import yaml
 
+from .apk import apk_base_url
 from .deb import deb_base_url
 from .rpm import rpm_base_url
 
@@ -36,6 +37,10 @@ from .rpm import rpm_base_url
 DEFAULT_CONFIG_PATH = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
     'config.yaml')
+
+
+def load_apk_base_url(loader, node):
+    return apk_base_url(node.value)
 
 
 def load_deb_base_url(loader, node):
@@ -51,6 +56,8 @@ def load_regex(loader, node):
     return re.compile(node.value)
 
 
+yaml.add_constructor(
+    u'!apk_base_url', load_apk_base_url, Loader=yaml.SafeLoader)
 yaml.add_constructor(
     u'!deb_base_url', load_deb_base_url, Loader=yaml.SafeLoader)
 yaml.add_constructor(

--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -1,5 +1,9 @@
 ---
 package_sources:
+  alpine:
+  - !apk_base_url https://dl-cdn.alpinelinux.org/alpine/$releasever/main
+  - !apk_base_url https://dl-cdn.alpinelinux.org/alpine/$releasever/community
+  - !apk_base_url https://dl-cdn.alpinelinux.org/alpine/$releasever/testing
   debian:
   - !deb_base_url http://deb.debian.org/debian main
   - !deb_base_url http://deb.debian.org/debian contrib
@@ -43,8 +47,12 @@ package_dashboards:
   url: https://software.opensuse.org/package/{source_name}
 - pattern: !regular_expression .*//archive.ubuntu.com/ubuntu/.*
   url: https://packages.ubuntu.com/{os_code_name}/{binary_name}
+- pattern: !regular_expression .*//dl-cdn.alpinelinux.org/alpine/[^/]+/([^/]+)/.*
+  url: https://pkgs.alpinelinux.org/package/{os_code_name}/\1/{os_arch}/{binary_name}
 
 supported_versions:
+  alpine:
+  - edge
   debian:
   - buster
   fedora:
@@ -60,6 +68,8 @@ supported_versions:
   - focal
 
 supported_arches:
+  alpine:
+  - x86_64
   debian:
   - amd64
   fedora:


### PR DESCRIPTION
As mentioned in #30037, I said I would add Alpine Linux test support.

This adds support for Alpine Linux style `apk` packages.