### PR TITLE
ros_industrial_cmake_boilerplate: 0.2.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6599,11 +6599,15 @@ repositories:
       version: noetic
     status: developed
   ros_industrial_cmake_boilerplate:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git
+      version: master
     release:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release.git
-      version: 0.2.9-2
+      version: 0.2.10-1
     source:
       type: git
       url: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_industrial_cmake_boilerplate` to `0.2.10-1`:

- upstream repository: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git
- release repository: https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.9-2`

## ros_industrial_cmake_boilerplate

```
* Improve target_clang_tidy to support individual options over single argument list
* Break out individual function from configure_package
* Contributors: G.A. vd. Hoorn, Levi Armstrong
```
