### PR TITLE
repository_name: 0.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3083,6 +3083,24 @@ repositories:
       url: https://github.com/ros-controls/realtime_tools.git
       version: foxy-devel
     status: maintained
+  repository_name:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/lua_vendor.git
+      version: 0.0.1
+    release:
+      packages:
+      - lua_vendor
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/OUXT-Polaris/lua_vendor-release.git
+      version: 0.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/OUXT-Polaris/lua_vendor.git
+      version: main
+    status: developed
   resource_retriever:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `repository_name` to `0.0.1-1`:

- upstream repository: https://github.com/OUXT-Polaris/lua_vendor.git
- release repository: https://github.com/OUXT-Polaris/lua_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## lua_vendor

```
* Merge branch 'main' of https://github.com/OUXT-Polaris/lua_vendor into workflow/foxy
* Merge pull request #2 <https://github.com/OUXT-Polaris/lua_vendor/issues/2> from OUXT-Polaris/workflow/dashing
  update CI workflow for dashing
* update CMakeLists.txt
* add CONTRIBUTING.md
* update .github/workflows/ROS2-Dashing.yaml
* update dependency.repos
* update .github/workflows/ROS2-Foxy.yaml
* update dependency.repos
* Fix CmakeLists.txt
* Add package.xml
* Initial commit
* Contributors: HansRobo, Kotaro Yoshimoto, Masaya Kataoka, robotx_buildfarm
```
