### PR TITLE
sol_vendor: 0.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4419,6 +4419,22 @@ repositories:
       url: https://github.com/oKermorgant/slider_publisher.git
       version: ros2
     status: maintained
+  sol_vendor:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/sol_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/OUXT-Polaris/sol_vendor-release.git
+      version: 0.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/OUXT-Polaris/sol_vendor.git
+      version: main
+    status: developed
   sophus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sol_vendor` to `0.0.1-1`:

- upstream repository: https://github.com/OUXT-Polaris/sol_vendor.git
- release repository: https://github.com/OUXT-Polaris/sol_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## sol_vendor

```
* Add package description
* Merge pull request #1 <https://github.com/OUXT-Polaris/sol_vendor/issues/1> from OUXT-Polaris/workflow/foxy
  update CI workflow for foxy
* Add CONTRIBUTING.md
* update .github/workflows/ROS2-Foxy.yaml
* update dependency.repos
* Add CMakeLists.txt
* Add package.xml
* Initial commit
* Contributors: HansRobo, Kotaro Yoshimoto, robotx_buildfarm
```
