### PR TITLE
cascade_lifecycle: 0.0.8-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -464,7 +464,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/fmrico/cascade_lifecycle.git
-      version: master
+      version: foxy-devel
     release:
       packages:
       - cascade_lifecycle_msgs
@@ -476,7 +476,7 @@ repositories:
     source:
       type: git
       url: https://github.com/fmrico/cascade_lifecycle.git
-      version: master
+      version: foxy-devel
     status: developed
   class_loader:
     doc:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -472,7 +472,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/fmrico/cascade_lifecycle-release.git
-      version: 0.0.7-4
+      version: 0.0.8-1
     source:
       type: git
       url: https://github.com/fmrico/cascade_lifecycle.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cascade_lifecycle` to `0.0.8-1`:

- upstream repository: https://github.com/fmrico/cascade_lifecycle.git
- release repository: https://github.com/fmrico/cascade_lifecycle-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.7-4`

## cascade_lifecycle_msgs

- No changes

## rclcpp_cascade_lifecycle

```
* Add support for namespace&Fix CI
  1. add support for namespace & test code
  2. fix CI config to v0.2
* Contributors: Francisco Martín Rico, Homalozoa
```
