### PR TITLE
cascade_lifecycle: 1.0.0-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -368,6 +368,24 @@ repositories:
       url: https://github.com/ros2/cartographer_ros.git
       version: dashing
     status: maintained
+  cascade_lifecycle:
+    doc:
+      type: git
+      url: https://github.com/fmrico/cascade_lifecycle.git
+      version: master
+    release:
+      packages:
+      - cascade_lifecycle_msgs
+      - rclcpp_cascade_lifecycle
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/fmrico/cascade_lifecycle-release.git
+      version: 1.0.0-2
+    source:
+      type: git
+      url: https://github.com/fmrico/cascade_lifecycle.git
+      version: master
+    status: developed
   class_loader:
     doc:
       type: git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -372,7 +372,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/fmrico/cascade_lifecycle.git
-      version: master
+      version: galactic-devel
     release:
       packages:
       - cascade_lifecycle_msgs
@@ -384,7 +384,7 @@ repositories:
     source:
       type: git
       url: https://github.com/fmrico/cascade_lifecycle.git
-      version: master
+      version: galactic-devel
     status: developed
   class_loader:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `cascade_lifecycle` to `1.0.0-2`:

- upstream repository: https://github.com/fmrico/cascade_lifecycle.git
- release repository: https://github.com/fmrico/cascade_lifecycle-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## cascade_lifecycle_msgs

- No changes

## rclcpp_cascade_lifecycle

```
* Add support for namespace&Fix CI
  1. add support for namespace & test code
  2. fix CI config to v0.2
* Dynamic add/remove deps
* Contributors: Francisco Martin Rico, Francisco Martín Rico, Homalozoa
```
