### PR TITLE
popf: 0.0.13-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1871,6 +1871,21 @@ repositories:
       url: https://gitlab.com/ApexAI/point_cloud_msg_wrapper
       version: galactic
     status: developed
+  popf:
+    doc:
+      type: git
+      url: https://github.com/fmrico/popf.git
+      version: galactic-devel
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/fmrico/popf-release.git
+      version: 0.0.13-1
+    source:
+      type: git
+      url: https://github.com/fmrico/popf.git
+      version: galactic-devel
+    status: maintained
   pybind11_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `popf` to `0.0.13-1`:

- upstream repository: https://github.com/fmrico/popf.git
- release repository: https://github.com/fmrico/popf-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## popf

- No changes
