### PR TITLE
ros2_planning_system: 2.0.0-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2593,7 +2593,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system.git
-      version: master
+      version: galactic-devel
     release:
       packages:
       - plansys2_bringup
@@ -2611,11 +2611,11 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release.git
-      version: 2.0.0-1
+      version: 2.0.0-2
     source:
       type: git
       url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system.git
-      version: master
+      version: galactic-devel
     status: developed
   ros2_socketcan:
     doc:

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2589,6 +2589,34 @@ repositories:
       url: https://github.com/SteveMacenski/ros2_ouster_drivers.git
       version: foxy-devel
     status: maintained
+  ros2_planning_system:
+    doc:
+      type: git
+      url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system.git
+      version: master
+    release:
+      packages:
+      - plansys2_bringup
+      - plansys2_bt_actions
+      - plansys2_core
+      - plansys2_domain_expert
+      - plansys2_executor
+      - plansys2_lifecycle_manager
+      - plansys2_msgs
+      - plansys2_pddl_parser
+      - plansys2_planner
+      - plansys2_popf_plan_solver
+      - plansys2_problem_expert
+      - plansys2_terminal
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system.git
+      version: master
+    status: developed
   ros2_socketcan:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_planning_system` to `2.0.0-1`:

- upstream repository: https://github.com/IntelligentRoboticsLabs/ros2_planning_system.git
- release repository: https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## plansys2_bringup

```
* Compile for ROS2 Galactic
* Contributors: Francisco Martín Rico, Jonatan Olofsson
```

## plansys2_bt_actions

- No changes

## plansys2_core

- No changes

## plansys2_domain_expert

```
* Compile for ROS2 Galactic
* Contributors: Francisco Martín Rico, Jonatan Olofsson
```

## plansys2_executor

```
* Fix default param
* Solve statically parameter error
* Fix compile issues for galactic
* Compile for ROS2 Galactic
* Contributors: Francisco Martín Rico, Jonatan Olofsson, bjnjo
```

## plansys2_lifecycle_manager

- No changes

## plansys2_msgs

- No changes

## plansys2_pddl_parser

- No changes

## plansys2_planner

```
* Solve statically parameter error
* Compile for ROS2 Galactic
* Contributors: Francisco Martín Rico, Jonatan Olofsson
```

## plansys2_popf_plan_solver

- No changes

## plansys2_problem_expert

```
* Compile for ROS2 Galactic
* Contributors: Francisco Martín Rico, Jonatan Olofsson
```

## plansys2_terminal

```
* Fix compile issues for galactic
* Compile for ROS2 Galactic
* Contributors: Francisco Martín Rico, Jonatan Olofsson, bjnjo
```
