### PR TITLE
rosdep: add opencascade

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3897,12 +3897,6 @@ libnss3-dev:
   gentoo: [=dev-libs/nss-3*]
   nixos: [nss]
   ubuntu: [libnss3-dev]
-liboce-modeling-dev:
-  debian: [liboce-modeling-dev]
-  ubuntu: [liboce-modeling-dev]
-liboce-visualization-dev:
-  debian: [liboce-visualization-dev]
-  ubuntu: [liboce-visualization-dev]
 libogg:
   arch: [libogg]
   debian: [libogg-dev]
@@ -6205,6 +6199,15 @@ omniorb:
   macports: [omniORB]
   nixos: [omniorb]
   ubuntu: [omniorb, omniidl, omniorb-idl, omniorb-nameserver, libomniorb4-dev]
+opencascade:
+  debian:
+    buster: [libocct-data-exchange-dev, libocct-draw-dev]
+    stretch: [liboce-visualization-dev]
+  fedora: [opencascade-devel]
+  gentoo: [sci-libs/opencascade]
+  ubuntu:
+    bionic: [liboce-visualization-dev]
+    focal: [libocct-data-exchange-dev, libocct-draw-dev]
 opencl-headers:
   arch: [opencl-headers]
   debian: [opencl-headers]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3897,6 +3897,12 @@ libnss3-dev:
   gentoo: [=dev-libs/nss-3*]
   nixos: [nss]
   ubuntu: [libnss3-dev]
+liboce-modeling-dev:
+  debian: [liboce-modeling-dev]
+  ubuntu: [liboce-modeling-dev]
+liboce-visualization-dev:
+  debian: [liboce-visualization-dev]
+  ubuntu: [liboce-visualization-dev]
 libogg:
   arch: [libogg]
   debian: [libogg-dev]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

liboce-modeling-dev
liboce-visualization-dev

## Package Upstream Source:

https://github.com/tpaviot/oce

## Purpose of using this:

oce (Open Cascade community Edition) is a fork of the Open Cascade 3D c++ modeling library. 
OpenCASCADE is a suite for 3D surface and solid modeling, visualization, data exchange and rapid application development.

Among other things, one specific feature of this library is parsing [step](https://en.wikipedia.org/wiki/ISO_10303-21) files and triangulating them into meshes.

## Links to Distribution Packages

- Debian: 
  -  liboce-modeling-dev
     -  https://packages.debian.org/stretch/liboce-modeling-dev
     -  https://packages.debian.org/buster/liboce-modeling-dev
  - liboce-visualization-dev
     - https://packages.debian.org/stretch/liboce-visualization-dev
     - https://packages.debian.org/buster/liboce-visualization-dev 
- Ubuntu:
  -  liboce-modeling-dev
     -  https://packages.ubuntu.com/bionic/liboce-modeling-dev
     -  https://packages.ubuntu.com/focal/liboce-modeling-dev
  - liboce-visualization-dev
     - https://packages.ubuntu.com/bionic/liboce-visualization-dev
     - https://packages.ubuntu.com/focal/liboce-visualization-dev
