### PR TITLE
cv_camera: 0.6.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1285,7 +1285,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/OTL/cv_camera-release.git
-      version: 0.5.0-3
+      version: 0.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cv_camera` to `0.6.0-1`:

- upstream repository: https://github.com/OTL/cv_camera
- release repository: https://github.com/OTL/cv_camera-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.5.0-3`

## cv_camera

```
* Adding MONO8 format if number of channels is 1
* Contributors: Servando
```
