### PR TITLE
rmf_simulation: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2290,6 +2290,28 @@ repositories:
       url: https://github.com/open-rmf/rmf_ros2.git
       version: main
     status: developed
+  rmf_simulation:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_simulation.git
+      version: main
+    release:
+      packages:
+      - rmf_building_sim_common
+      - rmf_building_sim_gazebo_plugins
+      - rmf_building_sim_ignition_plugins
+      - rmf_robot_sim_common
+      - rmf_robot_sim_gazebo_plugins
+      - rmf_robot_sim_ignition_plugins
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_simulation-release.git
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_simulation.git
+      version: main
+    status: developed
   rmf_task:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_simulation` to `1.2.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_simulation.git
- release repository: https://github.com/ros2-gbp/rmf_simulation-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## rmf_building_sim_common

```
* Add animation switch to crowd simulation plugin (#238 <https://github.com/osrf/traffic_editor/pull/238>)
* Add pausing feature to slotcar plugin: [#267 <https://github.com/osrf/traffic_editor/pull/267>]
* undo features
* dropping eloquent support (#277 <https://github.com/osrf/traffic_editor/issues/277>)
* Fix undefined initialization of _old_ang_vel and _old_lin_vel (#274 <https://github.com/osrf/traffic_editor/issues/274>)
* idle mode when slotcar is stationary (#264 <https://github.com/osrf/traffic_editor/issues/264>)
* Add pausing feature (#267 <https://github.com/osrf/traffic_editor/issues/267>)
* Debug/slotcar battery and mode (#261 <https://github.com/osrf/traffic_editor/issues/261>)
* Added ament exports for crowd simulation common (#260 <https://github.com/osrf/traffic_editor/issues/260>)
* Merge branch 'release-1.1'
* Make slotcar rotations follow trajectory yaw angle (#254 <https://github.com/osrf/traffic_editor/issues/254>)
* Fixed RobotMode (#252 <https://github.com/osrf/traffic_editor/issues/252>)
* Fix namespace for rmf charging plugin (#253 <https://github.com/osrf/traffic_editor/issues/253>)
* Control slotcar with model velocity cmds in place of joint velocity cmds (#236 <https://github.com/osrf/traffic_editor/issues/236>)
* Implement battery drain and recharge for slotcars (#242 <https://github.com/osrf/traffic_editor/issues/242>)
* Implement animation switching in crowd simulation (#238 <https://github.com/osrf/traffic_editor/issues/238>)
* Contributors: Geoffrey Biggs, Grey, Guoliang (Fred) Shao, Luca Della Vedova, Marco A. Gutiérrez, Morgan Quigley, Rushyendra Maganty, Yadu, youliang
```

## rmf_building_sim_gazebo_plugins

```
* Merge branch 'release-1.1'
* Control slotcar with model velocity cmds in place of joint velocity cmds (#236 <https://github.com/osrf/traffic_editor/issues/236>)
* Implement battery drain and recharge for slotcars (#242 <https://github.com/osrf/traffic_editor/issues/242>)
* Implement animation switching in crowd simulation (#238 <https://github.com/osrf/traffic_editor/issues/238>)
* Building_crowdsim for generating the navmesh file and required configuration files for menge (#224 <https://github.com/osrf/traffic_editor/issues/224>)
* Contributors: Geoffrey Biggs, Guoliang (Fred) Shao, Marco A. Gutierrez, Marco A. Gutiérrez, Rushyendra Maganty
* Add animation switch to crowd simulation plugin (#238 <https://github.com/osrf/traffic_editor/pull/238>)
```

## rmf_building_sim_ignition_plugins

```
* Remove Slotcar/Lift AABB component when not required to speed up demos (#271 <https://github.com/osrf/traffic_editor/issues/271>)
* Migrate ignition plugins to ament_target_dependencies (#262 <https://github.com/osrf/traffic_editor/issues/262>)
* Enable lifts to work with TPE (#250 <https://github.com/osrf/traffic_editor/issues/250>)
  Modifies lift plugin to issue either joint or model velocity commands
  based on the physics engine used.
* Control slotcar with model velocity cmds in place of joint velocity cmds (#236 <https://github.com/osrf/traffic_editor/issues/236>)
* Implement battery drain and recharge for slotcars (#242 <https://github.com/osrf/traffic_editor/issues/242>)
* Implement animation switching in crowd simulation (#238 <https://github.com/osrf/traffic_editor/issues/238>)
* Add first pass of quality declarations for all packages (#235 <https://github.com/osrf/traffic_editor/issues/235>)
* Building_crowdsim for generating the navmesh file and required configuration files for menge (#224 <https://github.com/osrf/traffic_editor/issues/224>)
* Add animation switch to crowd simulation plugin (#238 <https://github.com/osrf/traffic_editor/pull/238>)
* Contributors: Geoffrey Biggs, Guoliang (Fred) Shao, Luca Della Vedova, Marco A. Gutierrez, Marco A. Gutiérrez, Rushyendra Maganty
```

## rmf_robot_sim_ignition_plugins

```
* Provides TeleportDispenserPlugin Ignition plugin that is attached to the TeleportDispenser model in rmf_demo_assets. When loaded into Ignition Gazebo along side a "payload" model, the plugin will teleport the payload onto the nearest robot when it registers a rmf_dispenser_msgs::DispenserRequest message with target_guid matching its model name.
* Provides TeleportIngestorPlugin Ignition plugin that is attached to the TeleportIngestor model in rmf_demo_assets. When loaded into Ignition Gazebo, the plugin will teleport the payload off the nearest robot and onto its location, when it registers a rmf_ingestor_msgs::IngestorRequest message with target_guid matching its model name.
* Provides ReadonlyPlugin Readonly plugin that emulates the behavior of a read_only fleet type. When attached to a steerable vehicle that operates on a known traffic graph, the plugin publishes a prediction of the vehicle's intended path to the rmf traffic database via its configured read_only_fleet_adapter. Other fleets operating in the space can plan routes to avoid the path of this vehicle.
* Contributors: Aaron Chong, Luca Della Vedova, Yadunund, Rushyendra Maganty
```
