### PR TITLE
heifu: 0.8.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4141,19 +4141,28 @@ repositories:
       version: releasePackage
     release:
       packages:
+      - bev_mavros
+      - collision_avoidance
+      - control_bringup
+      - gcs_interface
+      - gimbal
+      - gnss_utils
+      - gpu_voxels_ros
       - heifu
-      - heifu_bringup
-      - heifu_description
-      - heifu_diagnostic
-      - heifu_mavros
-      - heifu_msgs
-      - heifu_safety
-      - heifu_simple_waypoint
-      - heifu_tools
+      - heifu-bringup
+      - mavros_commands
+      - navigation_controller
+      - planner
+      - planners_manager
+      - priority_manager
+      - rrt
+      - status_diagnostic
+      - uav_msgs
+      - waypoints_manager
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/BV-OpenSource/heifu-release.git
-      version: 0.7.7-2
+      version: 0.8.1-1
     source:
       type: git
       url: https://gitlab.pdmfc.com/drones/ros1/heifu.git


### PR DESCRIPTION
Increasing version of package(s) in repository `heifu` to `0.8.1-1`:

- upstream repository: https://gitlab.pdmfc.com/drones/ros1/heifu-uav/heifu.git
- release repository: https://github.com/BV-OpenSource/heifu-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.7-2`

## bev_mavros

- No changes

## collision_avoidance

- No changes

## control_bringup

- No changes

## gcs_interface

- No changes

## gimbal

- No changes

## gnss_utils

- No changes

## gpu_voxels_ros

- No changes

## heifu

- No changes

## heifu-bringup

```
* Fix node naming.
* Add Endpoint argument for interface.
* Add gimbal control.
* Change launch order. Fix missing parameter on launch call.
* Add Heifu bringup launch.
* Contributors: André Filipe
```

## mavros_commands

- No changes

## navigation_controller

- No changes

## planner

- No changes

## planners_manager

- No changes

## priority_manager

- No changes

## rrt

- No changes

## status_diagnostic

- No changes

## uav_msgs

- No changes

## waypoints_manager

- No changes
