### PR TITLE
Update Galactic branch for domain_bridge

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -582,7 +582,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/domain_bridge.git
-      version: main
+      version: galactic
     release:
       tags:
         release: release/galactic/{package}/{version}
@@ -592,7 +592,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/domain_bridge.git
-      version: main
+      version: galactic
     status: developed
   dynamixel_sdk:
     doc:


### PR DESCRIPTION
Since the `main` branch is diverging in https://github.com/ros2/domain_bridge/pull/32