### PR TITLE
rosidl_typesupport_gurumdds: 2.0.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3012,7 +3012,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_gurumdds-release.git
-      version: 2.0.0-3
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ros2/rosidl_typesupport_gurumdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_gurumdds` to `2.0.1-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_gurumdds.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_gurumdds-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-3`

## gurumdds_cmake_module

```
* Modify cmake according to library path format
* Contributors: Youngjin Yun
```
