### PR TITLE
rosidl_typesupport_gurumdds: 1.0.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3865,7 +3865,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_gurumdds-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/ros2/rosidl_typesupport_gurumdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_gurumdds` to `1.0.4-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_gurumdds.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_gurumdds-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.3-1`

## gurumdds_cmake_module

```
* Modify cmake according to library path format
* Change maintainer
* Contributors: Youngjin Yun
```
