### PR TITLE
rosbag2: 0.9.1-3 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2837,7 +2837,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.9.0-1
+      version: 0.9.1-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.9.1-3`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.9.0-1`

## ros2bag

```
* [backport galactic] Add delay option (#789 <https://github.com/ros2/rosbag2/issues/789>) (#812 <https://github.com/ros2/rosbag2/issues/812>)
  Backport #789 <https://github.com/ros2/rosbag2/issues/789> to galactic
  * Add delay option
* Contributors: Kosuke Takeuchi
```

## rosbag2

- No changes

## rosbag2_compression

- No changes

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

- No changes

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_py

```
* [backport galactic] Handle SIGTERM gracefully in recording (#792 <https://github.com/ros2/rosbag2/issues/792>) (#807 <https://github.com/ros2/rosbag2/issues/807>)
  Backport #792 <https://github.com/ros2/rosbag2/issues/792> to galactic
  * Handle SIGTERM gracefully in recording
* [backport galactic] Add delay option (#789 <https://github.com/ros2/rosbag2/issues/789>) (#812 <https://github.com/ros2/rosbag2/issues/812>)
  Backport #789 <https://github.com/ros2/rosbag2/issues/789> to galactic
  * Add delay option
* Contributors: Emerson Knapp, Kosuke Takeuchi
```

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

```
* [backport galactic] Handle SIGTERM gracefully in recording (#792 <https://github.com/ros2/rosbag2/issues/792>) (#807 <https://github.com/ros2/rosbag2/issues/807>)
  Backport #792 <https://github.com/ros2/rosbag2/issues/792> to galactic
  * Handle SIGTERM gracefully in recording
* Contributors: Emerson Knapp
```

## rosbag2_tests

```
* [backport galactic] Handle SIGTERM gracefully in recording (#792 <https://github.com/ros2/rosbag2/issues/792>) (#807 <https://github.com/ros2/rosbag2/issues/807>)
  Backport #792 <https://github.com/ros2/rosbag2/issues/792> to galactic
  * Handle SIGTERM gracefully in recording
* Contributors: Emerson Knapp
```

## rosbag2_transport

```
* [backport galactic] Add delay option (#789 <https://github.com/ros2/rosbag2/issues/789>) (#812 <https://github.com/ros2/rosbag2/issues/812>)
  Backport #789 <https://github.com/ros2/rosbag2/issues/789> to galactic
  * Add delay option
* Copy recorder QoS profile to local variable so that temporary value isn't cleared (#803 <https://github.com/ros2/rosbag2/issues/803>) (#805 <https://github.com/ros2/rosbag2/issues/805>)
* Contributors: Emerson Knapp, Kosuke Takeuchi
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
