### PR TITLE
Adding cyglidar_d1 to documentation index for distro

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2074,11 +2074,6 @@ repositories:
       type: git
       url: https://github.com/CygLiDAR-ROS/cyglidar_d1.git
       version: v0.1.1
-    release:
-      tags:
-        release: release/melodic/{package}/{version}
-      url: https://github.com/CygLiDAR-ROS/cyglidar_d1.git
-      version: v0.1.1
     source:
       type: git
       url: https://github.com/CygLiDAR-ROS/cyglidar_d1.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2069,6 +2069,21 @@ repositories:
       url: https://github.com/OTL/cv_camera.git
       version: master
     status: maintained
+  cyglidar_d1:
+    doc:
+      type: git
+      url: https://github.com/CygLiDAR-ROS/cyglidar_d1.git
+      version: v0.1.1
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/CygLiDAR-ROS/cyglidar_d1.git
+      version: v0.1.1
+    source:
+      type: git
+      url: https://github.com/CygLiDAR-ROS/cyglidar_d1.git
+      version: v0.1.1
+    status: maintained
   dataspeed_can:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2073,12 +2073,12 @@ repositories:
     doc:
       type: git
       url: https://github.com/CygLiDAR-ROS/cyglidar_d1.git
-      version: v0.1.1
+      version: v0.1.2
     release:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/CygLiDAR-ROS/cyglidar_d1.git
-      version: v0.1.1
+      version: v0.1.2
     status: maintained
   dataspeed_can:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2074,8 +2074,9 @@ repositories:
       type: git
       url: https://github.com/CygLiDAR-ROS/cyglidar_d1.git
       version: v0.1.1
-    source:
-      type: git
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
       url: https://github.com/CygLiDAR-ROS/cyglidar_d1.git
       version: v0.1.1
     status: maintained


### PR DESCRIPTION
I'd like cyglidar_d1 to be indexed and documented on ros.org.