### PR TITLE
kvh_geo_fog_3d to 1.5.1-1

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5406,7 +5406,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/MITRE/kvh_geo_fog_3d-release.git
-      version: 1.3.3-1
+      version: 1.5.1-1
     source:
       type: git
       url: https://github.com/MITRE/kvh_geo_fog_3d.git


### PR DESCRIPTION
Update version to 1.5.1-1 on Melodic. Has been pushed to release repo.