### PR TITLE
color_names: 0.0.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -402,6 +402,21 @@ repositories:
       url: https://github.com/ros/class_loader.git
       version: galactic
     status: maintained
+  color_names:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/color_names.git
+      version: master
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/OUXT-Polaris/color_names-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/color_names-release.git
+      version: master
+    status: developed
   common_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `color_names` to `0.0.2-1`:

- upstream repository: https://github.com/OUXT-Polaris/color_names.git
- release repository: https://github.com/OUXT-Polaris/color_names-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## color_names

```
* Merge pull request #12 <https://github.com/OUXT-Polaris/color_names/issues/12> from OUXT-Polaris/workflow/galactic
  update CI workflow for galactic
* update .github/workflows/ROS2-Galactic.yaml
* Merge pull request #10 <https://github.com/OUXT-Polaris/color_names/issues/10> from OUXT-Polaris/workflow/foxy
  update CI workflow for foxy
* update .github/workflows/ROS2-Foxy.yaml
* Merge pull request #9 <https://github.com/OUXT-Polaris/color_names/issues/9> from OUXT-Polaris/workflow/dashing
  update CI workflow for dashing
* update .github/workflows/ROS2-Dashing.yaml
* update dependency.repos
* Merge pull request #7 <https://github.com/OUXT-Polaris/color_names/issues/7> from OUXT-Polaris/feature/foxy
  enable pass colcon test
* enable pass colcon test
* Contributors: Masaya Kataoka, robotx_buildfarm
```
