### PR TITLE
rtabmap: 0.20.13-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4267,6 +4267,21 @@ repositories:
       url: https://github.com/rt-net/rt_usb_9axisimu_driver.git
       version: foxy-devel
     status: maintained
+  rtabmap:
+    doc:
+      type: git
+      url: https://github.com/introlab/rtabmap.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/introlab/rtabmap-release.git
+      version: 0.20.13-1
+    source:
+      type: git
+      url: https://github.com/introlab/rtabmap.git
+      version: foxy-devel
+    status: maintained
   rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap` to `0.20.13-1`:

- upstream repository: https://github.com/introlab/rtabmap.git
- release repository: https://github.com/introlab/rtabmap-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
