### PR TITLE
urg_stamped: 0.0.12-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13895,7 +13895,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/seqsense/urg_stamped-release.git
-      version: 0.0.11-1
+      version: 0.0.12-2
     source:
       type: git
       url: https://github.com/seqsense/urg_stamped.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_stamped` to `0.0.12-2`:

- upstream repository: https://github.com/seqsense/urg_stamped.git
- release repository: https://github.com/seqsense/urg_stamped-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.11-1`

## urg_stamped

```
* Fix gpg key source in prerelease test (#111 <https://github.com/seqsense/urg_stamped/issues/111>)
* Reboot sensor if time sync error count exceeded limit and never succeeded (#108 <https://github.com/seqsense/urg_stamped/issues/108>)
* Rotate bot token (#106 <https://github.com/seqsense/urg_stamped/issues/106>)
* Drop Kinetic (#105 <https://github.com/seqsense/urg_stamped/issues/105>)
* Contributors: Atsushi Watanabe
```
