### PR TITLE
ublox_dgnss: 0.1.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3826,9 +3826,8 @@ repositories:
     source:
       type: git
       url: https://github.com/aussierobots/ublox_dgnss.git
-      version: master
+      version: main
     status: developed
-    status_description: functional against Ublox ZED-F9P
   udp_msgs:
     doc:
       type: git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3812,6 +3812,23 @@ repositories:
       url: https://github.com/KumarRobotics/ublox.git
       version: foxy-devel
     status: maintained
+  ublox_dgnss:
+    release:
+      packages:
+      - ublox_dgnss
+      - ublox_dgnss_node
+      - ublox_ubx_interfaces
+      - ublox_ubx_msgs
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/aussierobots/ublox_dgnss-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/aussierobots/ublox_dgnss.git
+      version: master
+    status: developed
+    status_description: functional against Ublox ZED-F9P
   udp_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ublox_dgnss` to `0.1.0-1`:

- upstream repository: https://github.com/aussierobots/ublox_dgnss
- release repository: https://github.com/aussierobots/ublox_dgnss-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
