### PR TITLE
librealsense2: 2.48.0-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1226,7 +1226,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/IntelRealSense/librealsense2-release.git
-      version: 2.48.0-1
+      version: 2.48.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense2` to `2.48.0-2`:

- upstream repository: https://github.com/IntelRealSense/librealsense.git
- release repository: https://github.com/IntelRealSense/librealsense2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.48.0-1`
