### PR TITLE
quaternion_operation: 0.0.6-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1985,6 +1985,21 @@ repositories:
       url: https://github.com/ros-visualization/qt_gui_core.git
       version: galactic-devel
     status: maintained
+  quaternion_operation:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/quaternion_operation.git
+      version: master
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/OUXT-Polaris/quaternion_operation-release.git
+      version: 0.0.6-1
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/quaternion_operation.git
+      version: ros2
+    status: maintained
   radar_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `quaternion_operation` to `0.0.6-1`:

- upstream repository: https://github.com/OUXT-Polaris/quaternion_operation.git
- release repository: https://github.com/OUXT-Polaris/quaternion_operation-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## quaternion_operation

```
* add gtest to the depends
* Merge pull request #26 <https://github.com/OUXT-Polaris/quaternion_operation/issues/26> from OUXT-Polaris/workflow/galactic
  update CI workflow for galactic
* update .github/workflows/ROS2-Galactic.yaml
* Contributors: Masaya Kataoka, robotx_buildfarm
```
