### PR TITLE
embree_vendor: 0.0.7-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -954,7 +954,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/OUXT-Polaris/embree_vendor-release.git
-      version: 0.0.6-1
+      version: 0.0.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `embree_vendor` to `0.0.7-1`:

- upstream repository: https://github.com/OUXT-Polaris/embree_vendor.git
- release repository: https://github.com/OUXT-Polaris/embree_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.6-1`

## embree_vendor

```
* remove test lines
* Merge pull request #3 <https://github.com/OUXT-Polaris/embree_vendor/issues/3> from OUXT-Polaris/workflow/galactic
  update CI workflow for galactic
* update .github/workflows/ROS2-Galactic.yaml
* Merge pull request #2 <https://github.com/OUXT-Polaris/embree_vendor/issues/2> from OUXT-Polaris/workflow/foxy
  update CI workflow for foxy
* update .github/workflows/ROS2-Foxy.yaml
* update dependency.repos
* add workflow_dispatch trigger
* Contributors: Masaya Kataoka, robotx_buildfarm
```
