### PR TITLE
pmb2_robot: 4.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2458,6 +2458,26 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: foxy
     status: maintained
+  pmb2_robot:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pmb2_robot.git
+      version: foxy-devel
+    release:
+      packages:
+      - pmb2_bringup
+      - pmb2_controller_configuration
+      - pmb2_description
+      - pmb2_robot
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/pal-gbp/pmb2_robot-gbp.git
+      version: 4.0.0-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pmb2_robot.git
+      version: foxy-devel
+    status: developed
   point_cloud_msg_wrapper:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2505,6 +2505,8 @@ repositories:
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_navigation.git
+      version: foxy-devel
+    status: developed
   pmb2_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_robot` to `4.0.0-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_robot.git
- release repository: https://github.com/pal-gbp/pmb2_robot-gbp.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## pmb2_bringup

```
* Cleanup unused files
* Add linters and fix errors
* Cleanup pmb2_bringup
* Remove old joystick_teleop.launch
* Use unstamped topic in mobile_base_controller
* Migrate pmb2_bringup to ROS2
* First working version
* Contributors: Victor Lopez
```

## pmb2_controller_configuration

```
* Correct dependency name
* Using joint_state_broadcaster instead of controller
* Adapt to proper parameter naming
* Add linters to pmb2_bringup and apply fixes
* use_sim_time in controllers and cleanup
* Split default_controllers launch file
* Fixes to gazebo ros2 control param changes
* More fixes to default_controllers
* Add default_controllers.launch.py
* Update default_controllers.yaml
  Update gazebo controller name
* Add pmb2_controller_configuration
* First working version
* Contributors: Jordan Palacios, Victor Lopez
```

## pmb2_description

```
* Set back old version number before release
* Restructuring code and add description test
* No laser value is 'no-laser', change rgbd_sensors to courier_rgbd_sensors
* Tune a bit physics to avoid joint slippage, specially in TIAGo
* Correct physic property names for newer gazebo
* Add ROS2 control imu
* Add imu plugin
* Migrate rest of lasers to ROS2
* Renamed end_effector argument
* Format
* Fixed some tiago arguments
* Add linters to pmb2_description and apply fixes
* Move param utils to launch_pal
* Add show.launch.py
* Remove gazebo laser plugin namespace
* Merge branch 'single_ros2_control_system' into 'foxy-devel'
  Single ROS2 control system
  See merge request robots/pmb2_robot!65
* All joints now form part of a single ros2_control system
* Fixes to gazebo ros2 control param changes
* Update how ros2 gazebo plugin is loaded
* Add wheel ros2_control file
* First working version
* Remove comments to workaround https://github.com/ros2/launch_ros/issues/214
* First WIP of upload.py
* Contributors: Jordan Palacios, Victor Lopez, victor
```

## pmb2_robot

```
* Set back old version number before release
* Cleanup unused files
* First working version
* First WIP of upload.py
* Contributors: Victor Lopez
```
