### PR TITLE
pmb2_navigation: 3.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2458,6 +2458,25 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: foxy
     status: maintained
+  pmb2_navigation:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pmb2_navigation.git
+      version: foxy-devel
+    release:
+      packages:
+      - pmb2_2dnav
+      - pmb2_maps
+      - pmb2_navigation
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/pal-gbp/pmb2_navigation-gbp.git
+      version: 3.0.0-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pmb2_navigation.git
+      version: foxy-devel
+    status: developed
   point_cloud_msg_wrapper:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_navigation` to `3.0.0-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_navigation.git
- release repository: https://github.com/pal-gbp/pmb2_navigation-gbp.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## pmb2_2dnav

```
* Remove ROS1 launch files
* Comment dependencies pending to be migrated to ROS2
* Fix costmaps and increase max velocity
* Revert "Fix usage of map argument"
  This reverts commit 22d9e4a02b93fa5e9016738312538740a8c7e376.
  Specifying full path is more work but more flexible
* Fix usage of map argument
* Reduce max speeds to avoid crashing into walls
  A similara issue seems to be reported in:
  https://github.com/ros-planning/navigation2/issues/938
  Probably we need more tunning for our robot and/or a different
  controller
* Fixes for slam
* More linter fixes
* Remove hard coded map
* First working pmb2_nav_bringup launch file
* Contributors: Victor Lopez
```

## pmb2_maps

```
* Create pal_office map with nav2
* Remove hard coded map
* Contributors: Victor Lopez
```

## pmb2_navigation

```
* Comment dependencies pending to be migrated to ROS2
* Migrate pmb2_navigation to ros2
* Contributors: Victor Lopez
```
