### PR TITLE
moveit: 2.2.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1914,7 +1914,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/moveit/moveit2-release.git
-      version: 2.2.0-1
+      version: 2.2.1-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.2.1-1`:

- upstream repository: https://github.com/ros-planning/moveit2.git
- release repository: https://github.com/moveit/moveit2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.2.0-1`

## moveit

- No changes

## moveit_common

```
* Set project VERSION in moveit_common, fix sonames (#532 <https://github.com/ros-planning/moveit2/issues/532>)
* Contributors: Henning Kayser
```

## moveit_core

```
* Pluginlib Deprecation Fix (#542 <https://github.com/ros-planning/moveit2/issues/542>)
* Set project VERSION in moveit_common, fix sonames (#532 <https://github.com/ros-planning/moveit2/issues/532>)
* Contributors: David V. Lu!!, Henning Kayser
```

## moveit_kinematics

```
* Pluginlib Deprecation Fix (#542 <https://github.com/ros-planning/moveit2/issues/542>)
* Contributors: David V. Lu!!
```

## moveit_planners

- No changes

## moveit_planners_ompl

```
* Fix test dependencies (#539 <https://github.com/ros-planning/moveit2/issues/539>)
* Add persistent planner support back (#537 <https://github.com/ros-planning/moveit2/issues/537>)
* Contributors: Jochen Sprickerhof, Michael Görner
```

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_move_group

- No changes

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

- No changes

## moveit_ros_planning

```
* Fix unwanted override of URDF joint limit defaults (#546 <https://github.com/ros-planning/moveit2/issues/546>)
* Contributors: Jafar Abdi
```

## moveit_ros_planning_interface

```
* Fix test dependencies (#539 <https://github.com/ros-planning/moveit2/issues/539>)
* Contributors: Jochen Sprickerhof
```

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

- No changes

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_servo

```
* moveit_servo: Add a parameter to halt only joints that violate position limits  (#515 <https://github.com/ros-planning/moveit2/issues/515>)
  Add halt_all_joints_in_joint_mode & halt_all_joints_in_cartesian_mode parameters to decide whether to halt all joints or some of them in case of joint limit violation
* Contributors: Jafar Abdi
```

## moveit_simple_controller_manager

- No changes

## run_move_group

- No changes

## run_moveit_cpp

- No changes

## run_ompl_constrained_planning

- No changes
