### PR TITLE
pilz_industrial_motion: 0.4.13-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8544,15 +8544,13 @@ repositories:
       version: melodic-devel
     release:
       packages:
-      - pilz_extensions
       - pilz_industrial_motion
       - pilz_robot_programming
       - pilz_store_positions
-      - pilz_trajectory_generation
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_industrial_motion-release.git
-      version: 0.4.12-1
+      version: 0.4.13-2
     source:
       type: git
       url: https://github.com/PilzDE/pilz_industrial_motion.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_industrial_motion` to `0.4.13-2`:

- upstream repository: https://github.com/PilzDE/pilz_industrial_motion.git
- release repository: https://github.com/PilzDE/pilz_industrial_motion-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.12-1`

## pilz_industrial_motion

```
* Merge our trajectory_generation as moveit planner
  * move sequence related pilz msgs to moveit
  * remove pilz_extensions
  * update README.md
  * update package.xml
  * update industrial_ci_action.yml
* Contributors: Pilz GmbH and Co. KG
```

## pilz_robot_programming

```
* Merge our trajectory_generation as moveit planner
  * update all references to the planner
  * move sequence related pilz msgs to moveit
  * change blend radius in test data to not cause blend radius to large error
* Prevent misunderstandings in acceptance-tests
* Contributors: Pilz GmbH and Co. KG
```

## pilz_store_positions

- No changes
