### PR TITLE
rosidl: 2.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2897,7 +2897,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 2.3.0-1
+      version: 2.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `2.4.0-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.0-1`

## rosidl_adapter

- No changes

## rosidl_cli

```
* Support passing keyword arguments to rosidl CLI extensions (#597 <https://github.com/ros2/rosidl/issues/597>)
* Add missing f for format string (#600 <https://github.com/ros2/rosidl/issues/600>)
* Contributors: Michel Hidalgo, Shane Loretz
```

## rosidl_cmake

```
* Bundle and ensure the exportation of rosidl generated targets (#601 <https://github.com/ros2/rosidl/issues/601>)
* Contributors: Michel Hidalgo
```

## rosidl_generator_c

```
* Bundle and ensure the exportation of rosidl generated targets (#601 <https://github.com/ros2/rosidl/issues/601>)
* Contributors: Michel Hidalgo
```

## rosidl_generator_cpp

```
* Bundle and ensure the exportation of rosidl generated targets (#601 <https://github.com/ros2/rosidl/issues/601>)
* Contributors: Michel Hidalgo
```

## rosidl_parser

- No changes

## rosidl_runtime_c

- No changes

## rosidl_runtime_cpp

- No changes

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

```
* Bundle and ensure the exportation of rosidl generated targets (#601 <https://github.com/ros2/rosidl/issues/601>)
* Update function prefix (#596 <https://github.com/ros2/rosidl/issues/596>)
* Contributors: Michel Hidalgo, Pablo Garrido
```

## rosidl_typesupport_introspection_cpp

```
* Bundle and ensure the exportation of rosidl generated targets (#601 <https://github.com/ros2/rosidl/issues/601>)
* Contributors: Michel Hidalgo
```
