### PR TITLE
embree_vendor: 0.0.9-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -644,6 +644,21 @@ repositories:
       url: https://github.com/ros/eigen_stl_containers.git
       version: dashing
     status: maintained
+  embree_vendor:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/embree_vendor.git
+      version: master
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/OUXT-Polaris/embree_vendor-release.git
+      version: 0.0.9-1
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/embree_vendor.git
+      version: master
+    status: developed
   example_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `embree_vendor` to `0.0.9-1`:

- upstream repository: https://github.com/OUXT-Polaris/embree_vendor.git
- release repository: https://github.com/OUXT-Polaris/embree_vendor-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## embree_vendor

- No changes
