### PR TITLE
er_public_msgs: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2841,6 +2841,17 @@ repositories:
       url: https://github.com/uos/epos2_motor_controller.git
       version: master
     status: maintained
+  er_public_msgs:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/enabled-robotics/er_public_msgs-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/enabled-robotics/er_public_msgs.git
+      version: 1.0.0
+    status: maintained
   ethercat_grant:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `er_public_msgs` to `1.0.0-1`:

- upstream repository: https://github.com/enabled-robotics/er_public_msgs.git
- release repository: https://github.com/enabled-robotics/er_public_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
