### PR TITLE
tf2_2d: 0.6.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13070,6 +13070,18 @@ repositories:
       url: https://github.com/Terabee/teraranger_array.git
       version: master
     status: maintained
+  tf2_2d:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/locusrobotics/tf2_2d-release.git
+      version: 0.6.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/locusrobotics/tf2_2d.git
+      version: devel
+    status: developed
   tf2_server:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf2_2d` to `0.6.3-1`:

- upstream repository: https://github.com/locusrobotics/tf2_2d.git
- release repository: https://github.com/locusrobotics/tf2_2d-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## tf2_2d

```
* Fixing package license
* Contributors: Tom Moore
```
