### PR TITLE
tf2_2d: 0.6.3-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8274,6 +8274,18 @@ repositories:
       url: https://github.com/ros-industrial-consortium/tesseract.git
       version: master
     status: developed
+  tf2_2d:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/locusrobotics/tf2_2d-release.git
+      version: 0.6.3-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/locusrobotics/tf2_2d.git
+      version: devel
+    status: developed
   tf2_web_republisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf2_2d` to `0.6.3-2`:

- upstream repository: https://github.com/locusrobotics/tf2_2d.git
- release repository: https://github.com/locusrobotics/tf2_2d-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## tf2_2d

```
* Fixing package license
* Contributors: Tom Moore
```
