### PR TITLE
raptor_dbw_ros2: 1.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2763,7 +2763,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/NewEagleRaptor/raptor-dbw-ros2-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/NewEagleRaptor/raptor-dbw-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `raptor_dbw_ros2` to `1.1.1-1`:

- upstream repository: https://github.com/NewEagleRaptor/raptor-dbw-ros2.git
- release repository: https://github.com/NewEagleRaptor/raptor-dbw-ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.0-1`

## can_dbc_parser

```
* Fix compile warnings
* Contributors: neweagleraptor
```

## raptor_dbw_can

- No changes

## raptor_dbw_joystick

- No changes

## raptor_dbw_msgs

- No changes

## raptor_pdu

- No changes

## raptor_pdu_msgs

- No changes
