### PR TITLE
rclcpp: 11.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2146,7 +2146,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 11.0.0-1
+      version: 11.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `11.1.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `11.0.0-1`

## rclcpp

```
* Removed left over ``is_initialized()`` implementation (#1711 <https://github.com/ros2/rclcpp/issues/1711>)
  Leftover from https://github.com/ros2/rclcpp/pull/1622
* Fixed declare parameter methods for int and float vectors (#1696 <https://github.com/ros2/rclcpp/issues/1696>)
* Cleaned up implementation of the intra-process manager (#1695 <https://github.com/ros2/rclcpp/issues/1695>)
* Added the node name to an executor ``runtime_error`` (#1686 <https://github.com/ros2/rclcpp/issues/1686>)
* Fixed a typo "Attack" -> "Attach" (#1687 <https://github.com/ros2/rclcpp/issues/1687>)
* Removed use of std::allocator<>::rebind (#1678 <https://github.com/ros2/rclcpp/issues/1678>)
  rebind is deprecated in c++17 and removed in c++20
* Contributors: Alberto Soragna, Chen Lihui, Chris Lalancette, Petter Nilsson, Steve Macenski, William Woodall
```

## rclcpp_action

```
* Fixed occasionally missing goal result caused by race condition (#1677 <https://github.com/ros2/rclcpp/issues/1677>)
* Contributors: Kaven Yau
```

## rclcpp_components

```
* Added a hook to generate node options in ComponentManager (#1702 <https://github.com/ros2/rclcpp/issues/1702>)
* Contributors: Rebecca Butler
```

## rclcpp_lifecycle

- No changes
