### PR TITLE
Update image_transport_plugins dev branches

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1395,7 +1395,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/image_transport_plugins.git
-      version: ros2
+      version: foxy-devel
     release:
       packages:
       - compressed_depth_image_transport
@@ -1410,7 +1410,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/image_transport_plugins.git
-      version: ros2
+      version: foxy-devel
     status: maintained
   interactive_markers:
     doc:


### PR DESCRIPTION
For foxy so that rolling and galactic can continue with ros2 as a dev branch.

Signed-off-by: Michael Carroll <michael@openrobotics.org>