### PR TITLE
fuse: 0.4.1-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3471,6 +3471,35 @@ repositories:
       url: https://github.com/FUJISOFT-Robotics/fsrobo_r.git
       version: master
     status: developed
+  fuse:
+    doc:
+      type: git
+      url: https://github.com/locusrobotics/fuse.git
+      version: devel
+    release:
+      packages:
+      - fuse
+      - fuse_constraints
+      - fuse_core
+      - fuse_doc
+      - fuse_graphs
+      - fuse_loss
+      - fuse_models
+      - fuse_msgs
+      - fuse_optimizers
+      - fuse_publishers
+      - fuse_variables
+      - fuse_viz
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/locusrobotics/fuse-release.git
+      version: 0.4.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/locusrobotics/fuse.git
+      version: devel
+    status: developed
   gazebo_ros_pkgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fuse` to `0.4.1-2`:

- upstream repository: https://github.com/locusrobotics/fuse.git
- release repository: https://github.com/locusrobotics/fuse-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## fuse

```
* Add support for sphinx documentation (#228 <https://github.com/locusrobotics/fuse/issues/228>)
  * Adding tutorial for basic configuration
* Add fuse_viz pkg with rviz SerializedGraph display (#99 <https://github.com/locusrobotics/fuse/issues/99>)
* [RST-2340] Add serialization support to fuse (#98 <https://github.com/locusrobotics/fuse/issues/98>)
* Renaming package to fuse_models
* Contributors: Enrique Fernandez Perdomo, Stephen Williams, Tom Moore
```

## fuse_constraints

```
* Use analytic relative pose 2d cost function (#193 <https://github.com/locusrobotics/fuse/issues/193>)
  * Use analytic relative pose 2d cost function
  * Add analytic NormalDeltaPose2D cost function
  * Use analytic NormalDeltaPose2D cost function in
  RelativePose2DStampedConstraint
  * Test NormalDeltaPose2D jacobians are correct, comparing against
  NormalDeltaPose2DCostFunctor using automatic differentiation
  * Benchmark NormalDeltaPose2D vs NormalDeltaPose2DCostFunctor using
  automatic differentiation for 1, 2 and 3 residuals. The latency
  speedup is approximately 1.35, 1.49 and 1.55, respectively.
* Use analytic absolute pose 2d cost function (#192 <https://github.com/locusrobotics/fuse/issues/192>)
  * Add analytic NormalPriorPose2D cost function
  * Use analytic NormalPriorPose2D cost function in
  AbsolutePose2DStampedConstraint
  * Test NormalPriorPose2D jacobians are correct, comparing against
  NormalPriorPose2DCostFunctor using automatic differentiation
  * Benchmark NormalPriorPose2D vs NormalPriorPose2DCostFunctor using
  automatic differentiation for 1, 2 and 3 residuals. The latency
  speedup is approximately 2.36, 2.76 and 3.44, respectively.
* Fix roslint 0.12.0 (#186 <https://github.com/locusrobotics/fuse/issues/186>)
  * Fix roslint 0.12.0 include_what_you_use warnings
  Mostly for:
  * std::move -> #include <utility>
  * std::make_shared and similar -> #include <memory>
  * Remove static string variable not permitted by roslint 0.12.0, using a test fixture where needed.
* Fix Unicycle2DIgnition set_pose (#154 <https://github.com/locusrobotics/fuse/issues/154>)
  * Initialize StateHistoryElement::velocity_yaw
  * Process ignition transactions individually
  * Call motion model generator with last stamp
  * Skip optimization cycle if transaction is empty
* Fix compute elimination order with orphan variables (#136 <https://github.com/locusrobotics/fuse/issues/136>)
  * Test computeEliminationOrder with orphan variables
  * Fix computeEliminationOrder with orphan variables
* Fix get constraints with lvalue iterator input (#134 <https://github.com/locusrobotics/fuse/issues/134>)
  * Change getConstraints signature to return iterator
  * Update marginalize code to fix the previous usage error
* Support printing VariableConstraints objects (#132 <https://github.com/locusrobotics/fuse/issues/132>)
* Add fuse_loss pkg with plugin-based loss functions (#118 <https://github.com/locusrobotics/fuse/issues/118>)
* Removed the explicit '-std=c++14' compile flag (#119 <https://github.com/locusrobotics/fuse/issues/119>)
  * Removed the explicit '-std=c++14' compile flag
  * Changed the CXX_STANDARD setting to be per-target instead of global
  * Added the CXX_STANDARD_REQUIRED setting to all targets
* Revert "Fix build with ceres 2.0 with CMake < 3.8 (#106 <https://github.com/locusrobotics/fuse/issues/106>)" (#120 <https://github.com/locusrobotics/fuse/issues/120>)
  This reverts commit 9933456ecc24ba9b649a8a2885be3f852306efee.
* Wrap normal delta pose 2d orientation angle error (#122 <https://github.com/locusrobotics/fuse/issues/122>)
* fix compilation in Kinetic (#112 <https://github.com/locusrobotics/fuse/issues/112>)
* Support empty linear terms in marginalizeNext (#111 <https://github.com/locusrobotics/fuse/issues/111>)
  * Enforce constness
  * Unshadow variable_uuid in inner for loop
  * Support empty linear terms in marginalizeNext
* Fix build with ceres 2.0 with CMake < 3.8 (#106 <https://github.com/locusrobotics/fuse/issues/106>)
  * Note that while the Ceres 2.0 build completes, there may still be some lingering issues.
* [RST-1951] speed optimizations (#100 <https://github.com/locusrobotics/fuse/issues/100>)
  * Improved random UUID generator
  * Minor Eigen assignment speed improvements
* [RST-2427] Added a 'source' field to the constraints. This is an API-breaking change. (#101 <https://github.com/locusrobotics/fuse/issues/101>)
* [RST-2340] Add serialization support to fuse (#98 <https://github.com/locusrobotics/fuse/issues/98>)
* Fix -Wall -Wextra warnings in tests (#80 <https://github.com/locusrobotics/fuse/issues/80>)
* Fix -Wall -Wextra warnings (#77 <https://github.com/locusrobotics/fuse/issues/77>)
* Contributors: Davide Faconti, Enrique Fernandez Perdomo, Stephen Williams
```

## fuse_core

```
* Support throttling serialized graph publisher (#204 <https://github.com/locusrobotics/fuse/issues/204>)
  * Change sensor proc from gtest to gmock target
  * Move ThrottledCallback to fuse_core
  * Support generic callbacks in ThrottledCallback
  * Throttle graph publishing
  * Overload getPositiveParam for ros::Duration
  * Use getPositiveParam for ros::Duration parameters
* Use std::enable_if_t (#187 <https://github.com/locusrobotics/fuse/issues/187>)
* Fix roslint 0.12.0 (#186 <https://github.com/locusrobotics/fuse/issues/186>)
  * Fix roslint 0.12.0 include_what_you_use warnings
  Mostly for:
  * std::move -> #include <utility>
  * std::make_shared and similar -> #include <memory>
  * Remove static string variable not permitted by roslint 0.12.0, using a test fixture where needed.
* Remove variables on hold (#185 <https://github.com/locusrobotics/fuse/issues/185>)
  * Test variables on hold are removed when removing a variable
  * Erase variable on hold when removing variable
* Filter out transactions older than the lag window (#173 <https://github.com/locusrobotics/fuse/issues/173>)
  * Filter out transactions older than the lag window
  * Fix expiration time computation
  * Reset the lag expiration time when the smoother is reset
  * Reorganize class variables by their mutex guard
  * Add a mutex guard for start_time_; use start_time_ as a min time in the lag expiation computation
  * Add minStamp() and maxStamp() accessors to the Transaction class
  * Use the minStamp() and maxStamp() accessors to filter and purge transactions correctly
* Call onStop() directly if !ros::ok() in stop() (#182 <https://github.com/locusrobotics/fuse/issues/182>)
  * Call onStop() directly if !ros::ok() in stop()
  * Stop spinner before calling onStop()
* Only call generator if motion model history empty (#181 <https://github.com/locusrobotics/fuse/issues/181>)
  * Only call generator if motion model history empty
  * Handle dt == 0 special case in motion model
  * Revert test_timestamp_manager.cpp #154 <https://github.com/locusrobotics/fuse/issues/154>
  * Add EmptySingleStamp test
* Fix doxygen comment (#177 <https://github.com/locusrobotics/fuse/issues/177>)
* Delay throttle no valid state message (#175 <https://github.com/locusrobotics/fuse/issues/175>)
  This requires rosconsole >=1.13.8.
* Replace ignition_sensors list param with ignition field (#163 <https://github.com/locusrobotics/fuse/issues/163>)
  * Remove ignition_sensors param and use a per-sensor ignition field
* Throttle (#162 <https://github.com/locusrobotics/fuse/issues/162>)
  * Support throttling sensor model inputs
  * Add ThrottledCallback rostest
* Use a static Boost random UUID generator (#171 <https://github.com/locusrobotics/fuse/issues/171>)
* Fix motion model history (#168 <https://github.com/locusrobotics/fuse/issues/168>)
  * Fix the motion model history to maintain *at least* the requested time interval
  * Apply a similar fix to the MessageBuffer class
* Get positive param API change (#169 <https://github.com/locusrobotics/fuse/issues/169>)
  * Change getPositiveParam API
  In order to match the getParam and getRequiredParam, so the value is
  not returned, but set in an in/out argument.
  * Move getPositiveParam and other param related functions to
  parameter.h from util.h, and updated the ros/unit tests accordingly.
  * Fix wrapAngle2D expected range to [-Pi, +Pi)
  Instead of (-Pi, +Pi], and update unit test to reflect that.
* Fix thread issue with UUID generation (#167 <https://github.com/locusrobotics/fuse/issues/167>)
  * Add a mutex lock to the random UUID generation. The STL random number generator is not thread-safe.
* Patch Tukey loss for Ceres < 2.0.0 (#159 <https://github.com/locusrobotics/fuse/issues/159>)
  * Patch Tukey loss for Ceres < 2.0.0
  * Create ceres_macros.h header
* Fix Unicycle2DIgnition set_pose (#154 <https://github.com/locusrobotics/fuse/issues/154>)
  * Initialize StateHistoryElement::velocity_yaw
  * Process ignition transactions individually
  * Call motion model generator with last stamp
  * Skip optimization cycle if transaction is empty
* Add evaluate method to graph (#151 <https://github.com/locusrobotics/fuse/issues/151>)
* Support ScaledLoss (#141 <https://github.com/locusrobotics/fuse/issues/141>)
* Const deserialize (#148 <https://github.com/locusrobotics/fuse/issues/148>)
  * Make TransactionDeserializer::deserialize const
  * Make GraphDeserializer::deserialize const
  This requires the graph_loader_ to be mutable.
* Cleanup validation checks (#139 <https://github.com/locusrobotics/fuse/issues/139>)
  * Add getCovarianceDiagonalParam helper
  This allows to load a covariance matrix from the parameter server,
  provided in a list with the diagonal values.
  * Add isSymmetric and isPositiveDefinite helper functions
* Better validation of partial measurement output (#131 <https://github.com/locusrobotics/fuse/issues/131>)
  * Relax the default precision when validating the covariance matrix is
  symmetric.
  * Print the covariance matrix with Eigen::FullPrecision when the
  symmetry test fails with isApprox, so we can see the magnitude of
  the error.
  * Show source if validation fails
  * Changes from throwing/crashing to ROS_ERROR.
  * Add eigenvalues to non-PSD error check
  * Add disable_checks param to sensor models
* Add fuse_loss pkg with plugin-based loss functions (#118 <https://github.com/locusrobotics/fuse/issues/118>)
* Validate partial measurements (#125 <https://github.com/locusrobotics/fuse/issues/125>)
* Removed the explicit '-std=c++14' compile flag (#119 <https://github.com/locusrobotics/fuse/issues/119>)
  * Removed the explicit '-std=c++14' compile flag
  * Changed the CXX_STANDARD setting to be per-target instead of global
  * Added the CXX_STANDARD_REQUIRED setting to all targets
* Revert "Fix build with ceres 2.0 with CMake < 3.8 (#106 <https://github.com/locusrobotics/fuse/issues/106>)" (#120 <https://github.com/locusrobotics/fuse/issues/120>)
  This reverts commit 9933456ecc24ba9b649a8a2885be3f852306efee.
* Predict jacobians per parameter block (#115 <https://github.com/locusrobotics/fuse/issues/115>)
* fix compilation in Kinetic (#112 <https://github.com/locusrobotics/fuse/issues/112>)
* Support ceres 2.0 in tests (#117 <https://github.com/locusrobotics/fuse/issues/117>)
  In Ceres 2.0 we should call AutoDifferentiate<...>(...) instead of
  AutoDiff<...>::Differentiate(...).
* Fix build with ceres 2.0 with CMake < 3.8 (#106 <https://github.com/locusrobotics/fuse/issues/106>)
  * Note that while the Ceres 2.0 build completes, there may still be some lingering issues.
* [RST-2438] Make ceres params loaders reusable (#104 <https://github.com/locusrobotics/fuse/issues/104>)
  * Moved the Ceres loadFromROS functions into reusable functions in fuse_core
  * Load solver parameters for the batch optimizer
* [RST-1951] speed optimizations (#100 <https://github.com/locusrobotics/fuse/issues/100>)
  * Improved random UUID generator
  * Minor Eigen assignment speed improvements
* [RST-2437] Ensure that all variables are updated by the motion model (#103 <https://github.com/locusrobotics/fuse/issues/103>)
* Expose Ceres Solver, Problem and Covariance Options as ROS parameters (#78 <https://github.com/locusrobotics/fuse/issues/78>)
* [RST-2427] Added a 'source' field to the constraints. This is an API-breaking change. (#101 <https://github.com/locusrobotics/fuse/issues/101>)
* [RST-2340] Add serialization support to fuse (#98 <https://github.com/locusrobotics/fuse/issues/98>)
* Fix -Wall -Wextra warnings in tests (#80 <https://github.com/locusrobotics/fuse/issues/80>)
* Stamp merged transaction (#79 <https://github.com/locusrobotics/fuse/issues/79>)
  Set stamp in merged transactions
  Otherwise, merged transactions don't have a stamp.
  The stamp used is the maximum stamp of the two transactions merged.
* [RST-2148] Added start() and stop() methods to the MotionModel, SensorModel, and Publisher API (#75 <https://github.com/locusrobotics/fuse/issues/75>)
  * Added start() and stop() methods to the MotionModel, SensorModel, and Publisher API
  * Added the ability to clear the callback queue of the optimizer
  * Refactor the fixed-lag reset callback to use the plugins' stop() and start() methods
* Fix -Wall -Wextra warnings (#77 <https://github.com/locusrobotics/fuse/issues/77>)
* Contributors: Davide Faconti, Enrique Fernandez Perdomo, Stephen Williams
```

## fuse_doc

```
* Changelogs
* Add support for sphinx documentation (#228 <https://github.com/locusrobotics/fuse/issues/228>)
  * Adding tutorial for basic configuration
* Contributors: Tom Moore
* Add support for sphinx documentation (#228 <https://github.com/locusrobotics/fuse/issues/228>)
  * Adding tutorial for basic configuration
* Contributors: Tom Moore
```

## fuse_graphs

```
* Improve logs on graph update exception thrown (#227 <https://github.com/locusrobotics/fuse/issues/227>)
  * Catch graph update exceptions and log fatal msg
  When the graph update method throws an exception the node crashes and
  there is no way to know what transaction caused the exception because we
  call notify after successfully updating the graph.
  This catches any exception thrown by the graph update method and logs a
  FATAL message that includes the current graph and the new transaction.
  * Add full stop to exception messages
  This homogenizes the exception messages from all exceptions thrown by
  the HashGraph class.
* Move parameter blocks vector outside loop (#215 <https://github.com/locusrobotics/fuse/issues/215>)
  This reduces the amount of allocations required, since the same vector
  and its previously allocated memory is reused among all the graph
  constraints when the ceres::Problem is created.
* Add HashGraph::createProblem benchmark (#214 <https://github.com/locusrobotics/fuse/issues/214>)
* Fix roslint 0.12.0 (#186 <https://github.com/locusrobotics/fuse/issues/186>)
  * Fix roslint 0.12.0 include_what_you_use warnings
  Mostly for:
  * std::move -> #include <utility>
  * std::make_shared and similar -> #include <memory>
  * Remove static string variable not permitted by roslint 0.12.0, using a test fixture where needed.
* Remove variables on hold (#185 <https://github.com/locusrobotics/fuse/issues/185>)
  * Test variables on hold are removed when removing a variable
  * Erase variable on hold when removing variable
* Add evaluate method to graph (#151 <https://github.com/locusrobotics/fuse/issues/151>)
* Add fuse_loss pkg with plugin-based loss functions (#118 <https://github.com/locusrobotics/fuse/issues/118>)
* Removed the explicit '-std=c++14' compile flag (#119 <https://github.com/locusrobotics/fuse/issues/119>)
  * Removed the explicit '-std=c++14' compile flag
  * Changed the CXX_STANDARD setting to be per-target instead of global
  * Added the CXX_STANDARD_REQUIRED setting to all targets
* fix compilation in Kinetic (#112 <https://github.com/locusrobotics/fuse/issues/112>)
* [RST-2438] Make ceres params loaders reusable (#104 <https://github.com/locusrobotics/fuse/issues/104>)
  * Moved the Ceres loadFromROS functions into reusable functions in fuse_core
  * Load solver parameters for the batch optimizer
* Expose Ceres Solver, Problem and Covariance Options as ROS parameters (#78 <https://github.com/locusrobotics/fuse/issues/78>)
* [RST-2427] Added a 'source' field to the constraints. This is an API-breaking change. (#101 <https://github.com/locusrobotics/fuse/issues/101>)
* [RST-2340] Add serialization support to fuse (#98 <https://github.com/locusrobotics/fuse/issues/98>)
* Fix -Wall -Wextra warnings in tests (#80 <https://github.com/locusrobotics/fuse/issues/80>)
* Contributors: Davide Faconti, Enrique Fernandez Perdomo, Stephen Williams
```

## fuse_loss

```
* Changelogs
* Fix roslint 0.12.0 (#186 <https://github.com/locusrobotics/fuse/issues/186>)
  * Fix roslint 0.12.0 include_what_you_use warnings
  Mostly for:
  * std::move -> #include <utility>
  * std::make_shared and similar -> #include <memory>
  * Remove static string variable not permitted by roslint 0.12.0, using a test fixture where needed.
* Replace ignition_sensors list param with ignition field (#163 <https://github.com/locusrobotics/fuse/issues/163>)
  * Remove ignition_sensors param and use a per-sensor ignition field
* Add ComposedLoss (#170 <https://github.com/locusrobotics/fuse/issues/170>)
* Patch Tukey loss for Ceres < 2.0.0 (#159 <https://github.com/locusrobotics/fuse/issues/159>)
  * Patch Tukey loss for Ceres < 2.0.0
  * Create ceres_macros.h header
* Plot loss (#143 <https://github.com/locusrobotics/fuse/issues/143>)
  * Add test to plot loss rho, influence and weight
  * Add BUILD_WITH_PLOT_TESTS option (defaults OFF)
* Remove Pseudo-Huber loss, it duplicates SoftLOne (#152 <https://github.com/locusrobotics/fuse/issues/152>)
  * Remove Pseudo-Huber loss, it duplicates SoftLOne
* Add new loss functions (#142 <https://github.com/locusrobotics/fuse/issues/142>)
  The following loss functions, not available in Ceres solver are
  provided:
  * Geman-McClure
  * DCS (Dynamic Covariance Scaling)
  * Fair
  * Pseudo-Huber
  * Welsch
* Support ScaledLoss (#141 <https://github.com/locusrobotics/fuse/issues/141>)
* Add fuse_loss pkg with plugin-based loss functions (#118 <https://github.com/locusrobotics/fuse/issues/118>)
* Contributors: Enrique Fernandez Perdomo, Stephen Williams, Tom Moore
* Fix roslint 0.12.0 (#186 <https://github.com/locusrobotics/fuse/issues/186>)
  * Fix roslint 0.12.0 include_what_you_use warnings
  Mostly for:
  * std::move -> #include <utility>
  * std::make_shared and similar -> #include <memory>
  * Remove static string variable not permitted by roslint 0.12.0, using a test fixture where needed.
* Replace ignition_sensors list param with ignition field (#163 <https://github.com/locusrobotics/fuse/issues/163>)
  * Remove ignition_sensors param and use a per-sensor ignition field
* Add ComposedLoss (#170 <https://github.com/locusrobotics/fuse/issues/170>)
* Patch Tukey loss for Ceres < 2.0.0 (#159 <https://github.com/locusrobotics/fuse/issues/159>)
  * Patch Tukey loss for Ceres < 2.0.0
  * Create ceres_macros.h header
* Plot loss (#143 <https://github.com/locusrobotics/fuse/issues/143>)
  * Add test to plot loss rho, influence and weight
  * Add BUILD_WITH_PLOT_TESTS option (defaults OFF)
* Remove Pseudo-Huber loss, it duplicates SoftLOne (#152 <https://github.com/locusrobotics/fuse/issues/152>)
  * Remove Pseudo-Huber loss, it duplicates SoftLOne
* Add new loss functions (#142 <https://github.com/locusrobotics/fuse/issues/142>)
  The following loss functions, not available in Ceres solver are
  provided:
  * Geman-McClure
  * DCS (Dynamic Covariance Scaling)
  * Fair
  * Pseudo-Huber
  * Welsch
* Support ScaledLoss (#141 <https://github.com/locusrobotics/fuse/issues/141>)
* Add fuse_loss pkg with plugin-based loss functions (#118 <https://github.com/locusrobotics/fuse/issues/118>)
* Contributors: Enrique Fernandez Perdomo, Stephen Williams
```

## fuse_models

```
* Getting versions in sync
* Substract minimum twist covariance from twist covariance (#222 <https://github.com/locusrobotics/fuse/issues/222>)
  * Substract min twist cov from twist cov
  If the twist covariance already had a minimum twist covariance added to
  it to prevent ill-conditioned covariance matrices, we need a way to
  substract that minimum twist covariance from it before we compute the
  pose relative covariance. Otherwise, we cannot get the original pose
  relative covariance because the minimum twist covariance term is
  multiplies by the time delta, which could actually make the resulting
  pose relative covariance ill-conditioned or very small, i.e.
  overconfident.
* [Issue #223 <https://github.com/locusrobotics/fuse/issues/223>] Add an optional tf_timeout parameter to the sensor models (#224 <https://github.com/locusrobotics/fuse/issues/224>)
* Factorize differential mode processing (#219 <https://github.com/locusrobotics/fuse/issues/219>)
  * Factorize differential mode processing
  * Throttle log message when transform message fails
* Target frame optional (#217 <https://github.com/locusrobotics/fuse/issues/217>)
  * Make target_frame optional
  * Remove optional target_frame parameters in tests
* Transform message in differential mode (#216 <https://github.com/locusrobotics/fuse/issues/216>)
  * Transform message in differential mode
  This is important because the relative transformation is not the same if
  the sensor and target frame are different.
  Consider for example the case of an IMU sensor upside down:
  * The robot base frame is base_link
  * The IMU sensor frame is imu_link
  * The imu_link transformation wrt base_link is 180 degrees wrt the y or
  x axis
  * The angular velocity around the z axis has opposite sign in the
  sensor frame wrt the target frame
  * Require pose_target_frame in differential mode
  * Roslint
  * Add pose_target_frame to optimizer test config
* Use fuse_core::getPositiveParam for all ros::Duration parameters (#212 <https://github.com/locusrobotics/fuse/issues/212>)
  * Use fuse_core::getPositiveParam for ros::Duration
  * Use fuse_core::getPositiveParam for TF durations
* Add tcp_no_delay parameter to sensor models (#211 <https://github.com/locusrobotics/fuse/issues/211>)
* Add ability to throttle covariance computation (#209 <https://github.com/locusrobotics/fuse/issues/209>)
* Add invert_tf to Odometry2DPublisher (#206 <https://github.com/locusrobotics/fuse/issues/206>)
  This allows to publish the inverse TF transform.
  This can be useful to skip the odom->base_link lookupTransform() when
  braodcasting map->base_link, which must be broadcasted as map->odom
  because TF tree doesn't support more than a single parent per frame,
  base_link in this case. This is particular relevant when
  predict_to_current_time is enabled, because the lookupTransform() could
  take a while, causing delays.
* Support throttling serialized graph publisher (#204 <https://github.com/locusrobotics/fuse/issues/204>)
  * Change sensor proc from gtest to gmock target
  * Move ThrottledCallback to fuse_core
  * Support generic callbacks in ThrottledCallback
  * Throttle graph publishing
  * Overload getPositiveParam for ros::Duration
  * Use getPositiveParam for ros::Duration parameters
* Add linear acceleration to synchronizer (#205 <https://github.com/locusrobotics/fuse/issues/205>)
* Use local latest_stamp in notifyCallback (#203 <https://github.com/locusrobotics/fuse/issues/203>)
* Use dedicated spinner for publish timer callback (#201 <https://github.com/locusrobotics/fuse/issues/201>)
  * Use dedicated spinner for publishTimerCallback
  * This reduces the jitter in the output topics and TF transform stamp
  because it allows the notifyCallback and publishTimerCallback to run
  concurrently. The notifyCallback might take longer than the timer
  period sometimes, mostly because the covariance computation is an
  expensive operation.
  * There is a subtle change of behaviour with this implementation!
  Before, the publishTimerCallback overwrote the odom_output_ and
  acceleration_output_ with the predicted state. Now it does not, and
  if it gets called twice or more times consecutively, it predicts since
  the last time the state was computed and updated in the
  notifyCallback. With the notifyCallback and publishTimerCallback
  running concurrently it is not trivial to keep the previous behaviour
  efficiently, because we would have to lock the entire callbacks to
  avoid the publishTimerCallback to overwrite a new state being computed
  concurrently in the notifyCallback. That being said, the predicted
  state is likely the same in both implementation. That is, the result
  is likely the same if we use multiple steps or a single one to predict
  the last state forward to the current time.
* Add fuse_models::GraphIgnition sensor model (#196 <https://github.com/locusrobotics/fuse/issues/196>)
* Add fuse_models::Transaction sensor model (#195 <https://github.com/locusrobotics/fuse/issues/195>)
* Fix Unicycle2D constructor doxygen (#198 <https://github.com/locusrobotics/fuse/issues/198>)
* Remove deprecated ::Model models leftovers (#194 <https://github.com/locusrobotics/fuse/issues/194>)
  * Remove fuse_models::twist_2d::Model plugin declaration
  * Remove empty space in fuse_plugins.xml
  * Update ::Model names to new names in doxygen comments
* Conditionally test_depend on benchmark (#189 <https://github.com/locusrobotics/fuse/issues/189>)
* Fix typo in jacobian comments (#191 <https://github.com/locusrobotics/fuse/issues/191>)
* Fix throttle (#190 <https://github.com/locusrobotics/fuse/issues/190>)
  * Update last called time adding throttle period
  Instead of setting to now, which could be larger than the expected call
  time.
  * Init last called time to now the first time
  * Fix check for init/zero last called time
  We cannot use isValid because that does not check the last called time
  is zero, but a completely different thing. We must use isZero.
* Check canTransform output and show error if false (#188 <https://github.com/locusrobotics/fuse/issues/188>)
  * Check canTransform output and show error if false
  * Fix pose -> twist typo
  * Lookup transform directly
* Use std::enable_if_t (#187 <https://github.com/locusrobotics/fuse/issues/187>)
* Fix roslint 0.12.0 (#186 <https://github.com/locusrobotics/fuse/issues/186>)
  * Fix roslint 0.12.0 include_what_you_use warnings
  Mostly for:
  * std::move -> #include <utility>
  * std::make_shared and similar -> #include <memory>
  * Remove static string variable not permitted by roslint 0.12.0, using a test fixture where needed.
* Only call generator if motion model history empty (#181 <https://github.com/locusrobotics/fuse/issues/181>)
  * Only call generator if motion model history empty
  * Handle dt == 0 special case in motion model
  * Revert test_timestamp_manager.cpp #154 <https://github.com/locusrobotics/fuse/issues/154>
  * Add EmptySingleStamp test
* Add use_twist_covariance ROS param and logic to Imu2D differential orientation measurements (#178 <https://github.com/locusrobotics/fuse/issues/178>)
  * Move pose into previous_pose_
  This makes the Odometry2D do the same as the Imu2D.
  * Allow Imu2D to use twist covariance
  For differential orientation measurements.
  * Move pose relative covariance closer to use
* Validate unicycle 2d (#180 <https://github.com/locusrobotics/fuse/issues/180>)
  * Remove unused EPSILON constexpr
  * Validate Unicyle2D state and process noise
  * Add disable_checks param (defaults to false)
  * Validate state1 and state2 are finite
  * Validate process noise covariance (after it's been scaled and
  multiplied by dt)
* Fix doxygen comment (#177 <https://github.com/locusrobotics/fuse/issues/177>)
* Delay throttle no valid state message (#175 <https://github.com/locusrobotics/fuse/issues/175>)
  This requires rosconsole >=1.13.8.
* Throttle (#162 <https://github.com/locusrobotics/fuse/issues/162>)
  * Support throttling sensor model inputs
  * Add ThrottledCallback rostest
* Fix motion model history (#168 <https://github.com/locusrobotics/fuse/issues/168>)
  * Fix the motion model history to maintain *at least* the requested time interval
  * Apply a similar fix to the MessageBuffer class
* Get positive param API change (#169 <https://github.com/locusrobotics/fuse/issues/169>)
  * Change getPositiveParam API
  In order to match the getParam and getRequiredParam, so the value is
  not returned, but set in an in/out argument.
  * Move getPositiveParam and other param related functions to
  parameter.h from util.h, and updated the ros/unit tests accordingly.
  * Fix wrapAngle2D expected range to [-Pi, +Pi)
  Instead of (-Pi, +Pi], and update unit test to reflect that.
* Don't require frame if empty indices (#166 <https://github.com/locusrobotics/fuse/issues/166>)
* Fix Unicycle2DIgnition set_pose (#154 <https://github.com/locusrobotics/fuse/issues/154>)
  * Initialize StateHistoryElement::velocity_yaw
  * Process ignition transactions individually
  * Call motion model generator with last stamp
  * Skip optimization cycle if transaction is empty
* C++14 for test_unicycle_2d_state_cost_function (#157 <https://github.com/locusrobotics/fuse/issues/157>)
* Print state history (#156 <https://github.com/locusrobotics/fuse/issues/156>)
  * Add print method to StateHistoryElement
  * Add print method to Unicycle2D
  It only prints the history state for now though.
* Minor typo fixes (#155 <https://github.com/locusrobotics/fuse/issues/155>)
* Get minimum_pose_relative_covariance_diagonal (#150 <https://github.com/locusrobotics/fuse/issues/150>)
  Regardless of the value of independent, because the
  fuse_models::Odometry2D sensor model checks for use_twist_covariance
  before independent, and we could end up with an uninitialized
  minimum_pose_relative_covariance_diagonal.
* Support ScaledLoss (#141 <https://github.com/locusrobotics/fuse/issues/141>)
* Remove duplicated roslint build_depend (#146 <https://github.com/locusrobotics/fuse/issues/146>)
* Remove old acceleration_2d folder (#145 <https://github.com/locusrobotics/fuse/issues/145>)
* Cleanup validation checks (#139 <https://github.com/locusrobotics/fuse/issues/139>)
  * Add getCovarianceDiagonalParam helper
  This allows to load a covariance matrix from the parameter server,
  provided in a list with the diagonal values.
  * Add isSymmetric and isPositiveDefinite helper functions
* Use twist covariance for differential dependent (#138 <https://github.com/locusrobotics/fuse/issues/138>)
  In the fuse_models::Odometry2D sensor model, when differential: true
  and independent: false, the relative pose covariance should NOT be
  computed from the consecutive absolute pose covariance matrices because
  they grow unbounded, so the resulting relative pose covariance suffers
  from numerical issues.
  Instead, we can use the twist covariance of the last pose to compute the
  relative pose covariance, using the time difference between the
  consecutive absolute poses.
  The only limitation is that we cannot throttle the input topics, because
  otherwise the twist covariance from the intermediate/throttled messages
  is missed. We'll have to throttle inside the sensor model, by
  integrating the intermediate messages.
* Support dependent relative pose measurements (#137 <https://github.com/locusrobotics/fuse/issues/137>)
  * Added a "dependent" covariance calculation option to the "differential" mode
  * Added an independent param that defaults to true to keep the current behaviour
  * Added a minimum_pose_relative_covariance_diagonal param that is added to the
  resulting pose relative covariance in order to guarantee that it's not zero or ill-conditioned.
* Scale process noise covariance (#130 <https://github.com/locusrobotics/fuse/issues/130>)
  * Scale process noise covariance
  This scales the process noise covariance pose by the norm of the current
  state velocity.
  A new parameter velocity_norm_min is added, that prevents the process
  noise scaling from setting the pose components to zero or a very small
  value that could lead to NaN or a rank deficient Jacobian in the problem
  solved, due to an ill-condition covariance for the process noise.
* Better validation of partial measurement output (#131 <https://github.com/locusrobotics/fuse/issues/131>)
  * Relax the default precision when validating the covariance matrix is
  symmetric.
  * Print the covariance matrix with Eigen::FullPrecision when the
  symmetry test fails with isApprox, so we can see the magnitude of
  the error.
  * Show source if validation fails
  * Changes from throwing/crashing to ROS_ERROR.
  * Add eigenvalues to non-PSD error check
  * Add disable_checks param to sensor models
* Publish linear acceleration (#129 <https://github.com/locusrobotics/fuse/issues/129>)
  * Publish linear acceleration
  * Also use linear acceleration if predicting to the current time if the
  new param predict_with_acceleration is true (default value).
* Explicitly call boost::range::join (#128 <https://github.com/locusrobotics/fuse/issues/128>)
  Otherwise we could get a compilation error due to an ambiguous overloaded join function when  some additional boost/algorithm headers are included.
* Add fuse_loss pkg with plugin-based loss functions (#118 <https://github.com/locusrobotics/fuse/issues/118>)
* Validate partial measurements (#125 <https://github.com/locusrobotics/fuse/issues/125>)
* Don't read pose_target_frame if differential (#126 <https://github.com/locusrobotics/fuse/issues/126>)
  If differential is true, the pose_target_frame is not used.
* Only allow exact timestamp transformations (#123 <https://github.com/locusrobotics/fuse/issues/123>)
* Benchmark unicycle_2d state cost function (#121 <https://github.com/locusrobotics/fuse/issues/121>)
  The benchmark targets are now only build if CATKIN_ENABLE_TESTING is ON,
  which means that benchmark is now a test_depend and not a depend.
  However, the benchmarks are NOT gtests, so they are built directly on
  catkin build, i.e. there is no need to run make run_tests after. For
  this reason, the find_package on benchmark is no longer REQUIRED,
  but QUIET instead. The benchmark is built only if the benchmark package
  is FOUND.
* Removed the explicit '-std=c++14' compile flag (#119 <https://github.com/locusrobotics/fuse/issues/119>)
  * Removed the explicit '-std=c++14' compile flag
  * Changed the CXX_STANDARD setting to be per-target instead of global
  * Added the CXX_STANDARD_REQUIRED setting to all targets
* Predict jacobians per parameter block (#115 <https://github.com/locusrobotics/fuse/issues/115>)
* fix compilation in Kinetic (#112 <https://github.com/locusrobotics/fuse/issues/112>)
* Wait for reset service existence (#116 <https://github.com/locusrobotics/fuse/issues/116>)
* Publish odometry with timer and allow to predict it (#109 <https://github.com/locusrobotics/fuse/issues/109>)
* Use measurement stamps for transformed variables (#113 <https://github.com/locusrobotics/fuse/issues/113>)
* [RST-2149] Added the configured device_id to the log message (#110 <https://github.com/locusrobotics/fuse/issues/110>)
* [RST-2438] Make ceres params loaders reusable (#104 <https://github.com/locusrobotics/fuse/issues/104>)
  * Moved the Ceres loadFromROS functions into reusable functions in fuse_core
  * Load solver parameters for the batch optimizer
* Expose Ceres Solver, Problem and Covariance Options as ROS parameters (#78 <https://github.com/locusrobotics/fuse/issues/78>)
* [RST-2427] Added a 'source' field to the constraints. This is an API-breaking change. (#101 <https://github.com/locusrobotics/fuse/issues/101>)
* [RST-2340] Add serialization support to fuse (#98 <https://github.com/locusrobotics/fuse/issues/98>)
* RST-2390 Renaming unicycle_2d (#90 <https://github.com/locusrobotics/fuse/issues/90>)
  * Renaming unicycle_2d
* Renaming twist_2d (#89 <https://github.com/locusrobotics/fuse/issues/89>)
* Renaming pose_2d (#88 <https://github.com/locusrobotics/fuse/issues/88>)
* Renaming odometry_2d (#87 <https://github.com/locusrobotics/fuse/issues/87>)
* Renaming imu_2d (#86 <https://github.com/locusrobotics/fuse/issues/86>)
* RST-2390 Renaming acceleration_2d (#85 <https://github.com/locusrobotics/fuse/issues/85>)
  * Renaming acceleration_2d
* Renaming package to fuse_models
* Preparing for move
* Contributors: Davide Faconti, Enrique Fernandez Perdomo, Stephen Williams, Tom Moore, sjphilli
```

## fuse_msgs

```
* Changelogs
* [RST-2340] Add serialization support to fuse (#98 <https://github.com/locusrobotics/fuse/issues/98>)
* Contributors: Stephen Williams, Tom Moore
* [RST-2340] Add serialization support to fuse (#98 <https://github.com/locusrobotics/fuse/issues/98>)
* Contributors: Stephen Williams
```

## fuse_optimizers

```
* Improve logs on graph update exception thrown (#227 <https://github.com/locusrobotics/fuse/issues/227>)
  * Catch graph update exceptions and log fatal msg
  When the graph update method throws an exception the node crashes and
  there is no way to know what transaction caused the exception because we
  call notify after successfully updating the graph.
  This catches any exception thrown by the graph update method and logs a
  FATAL message that includes the current graph and the new transaction.
  * Add full stop to exception messages
  This homogenizes the exception messages from all exceptions thrown by
  the HashGraph class.
* Fix diagnostics typo (#218 <https://github.com/locusrobotics/fuse/issues/218>)
* Target frame optional (#217 <https://github.com/locusrobotics/fuse/issues/217>)
  * Make target_frame optional
  * Remove optional target_frame parameters in tests
* Transform message in differential mode (#216 <https://github.com/locusrobotics/fuse/issues/216>)
  * Transform message in differential mode
  This is important because the relative transformation is not the same if
  the sensor and target frame are different.
  Consider for example the case of an IMU sensor upside down:
  * The robot base frame is base_link
  * The IMU sensor frame is imu_link
  * The imu_link transformation wrt base_link is 180 degrees wrt the y or
  x axis
  * The angular velocity around the z axis has opposite sign in the
  sensor frame wrt the target frame
  * Require pose_target_frame in differential mode
  * Roslint
  * Add pose_target_frame to optimizer test config
* Check empty transaction with empty() method (#210 <https://github.com/locusrobotics/fuse/issues/210>)
* Add solver summary info to diagnostics (#208 <https://github.com/locusrobotics/fuse/issues/208>)
  * Add solver summary info to diagnostics
  * Abort if optimization failed
* Support throttling serialized graph publisher (#204 <https://github.com/locusrobotics/fuse/issues/204>)
  * Change sensor proc from gtest to gmock target
  * Move ThrottledCallback to fuse_core
  * Support generic callbacks in ThrottledCallback
  * Throttle graph publishing
  * Overload getPositiveParam for ros::Duration
  * Use getPositiveParam for ros::Duration parameters
* Fix optimizer test config (#202 <https://github.com/locusrobotics/fuse/issues/202>)
  * Add dimensions to the sensor models, so we do not get these warnings:
  ``` bash
  [ WARN] [/Optimizer] [1604556511.895230377]: No dimensions were specified. Data from topic /imu will be ignored.
  [ WARN] [/Optimizer] [1604556511.899319309]: No dimensions were specified. Data from topic /pose will be ignored.
  [ WARN] [/Optimizer] [1604556511.905227451]: No dimensions were specified. Data from topic /odom will be ignored.
  ```
  * Add twist_target_frame to imu sensor model, so we do not get this
  error:
  ``` bash
  [FATAL] [/Optimizer] [1604557006.977288017]: Could not find required parameter twist_target_frame in namespace /Optimizer/imu
  ```
* Purge transactions older than ignition max stamp (#183 <https://github.com/locusrobotics/fuse/issues/183>)
* Fix roslint 0.12.0 (#186 <https://github.com/locusrobotics/fuse/issues/186>)
  * Fix roslint 0.12.0 include_what_you_use warnings
  Mostly for:
  * std::move -> #include <utility>
  * std::make_shared and similar -> #include <memory>
  * Remove static string variable not permitted by roslint 0.12.0, using a test fixture where needed.
* Filter out transactions older than the lag window (#173 <https://github.com/locusrobotics/fuse/issues/173>)
  * Filter out transactions older than the lag window
  * Fix expiration time computation
  * Reset the lag expiration time when the smoother is reset
  * Reorganize class variables by their mutex guard
  * Add a mutex guard for start_time_; use start_time_ as a min time in the lag expiation computation
  * Add minStamp() and maxStamp() accessors to the Transaction class
  * Use the minStamp() and maxStamp() accessors to filter and purge transactions correctly
* The started/ignited variables are accessed from multiple threads. (#172 <https://github.com/locusrobotics/fuse/issues/172>)
* Replace ignition_sensors list param with ignition field (#163 <https://github.com/locusrobotics/fuse/issues/163>)
  * Remove ignition_sensors param and use a per-sensor ignition field
* Get positive param API change (#169 <https://github.com/locusrobotics/fuse/issues/169>)
  * Change getPositiveParam API
  In order to match the getParam and getRequiredParam, so the value is
  not returned, but set in an in/out argument.
  * Move getPositiveParam and other param related functions to
  parameter.h from util.h, and updated the ros/unit tests accordingly.
  * Fix wrapAngle2D expected range to [-Pi, +Pi)
  Instead of (-Pi, +Pi], and update unit test to reflect that.
* Add missed fuse_models dependencies (#164 <https://github.com/locusrobotics/fuse/issues/164>)
* From a usage standpoint, the 'element' variable is getting modified and should not be const. The const was not causing compilation issues before because of some pointer indirection. (#160 <https://github.com/locusrobotics/fuse/issues/160>)
* Added unit test to illustrate variable initialization bug (#158 <https://github.com/locusrobotics/fuse/issues/158>)
* Fix Unicycle2DIgnition set_pose (#154 <https://github.com/locusrobotics/fuse/issues/154>)
  * Initialize StateHistoryElement::velocity_yaw
  * Process ignition transactions individually
  * Call motion model generator with last stamp
  * Skip optimization cycle if transaction is empty
* Support YAML struct for models and publishers (#149 <https://github.com/locusrobotics/fuse/issues/149>)
  * Support YAML struct for models and publishers
  This allows to compound multiple YAML files that provide additional
  models or publishers. This cannot be done with a list/array, because the
  previous values get overwritten/lost.
* Throttle optimization duration exceeded warning (#140 <https://github.com/locusrobotics/fuse/issues/140>)
* Add fuse_loss pkg with plugin-based loss functions (#118 <https://github.com/locusrobotics/fuse/issues/118>)
* Removed the explicit '-std=c++14' compile flag (#119 <https://github.com/locusrobotics/fuse/issues/119>)
  * Removed the explicit '-std=c++14' compile flag
  * Changed the CXX_STANDARD setting to be per-target instead of global
  * Added the CXX_STANDARD_REQUIRED setting to all targets
* fix compilation in Kinetic (#112 <https://github.com/locusrobotics/fuse/issues/112>)
* Initialize diagnostic_updater_timer_period_ (#114 <https://github.com/locusrobotics/fuse/issues/114>)
* Add diagnostic updater (#108 <https://github.com/locusrobotics/fuse/issues/108>)
* [RST-2438] Make ceres params loaders reusable (#104 <https://github.com/locusrobotics/fuse/issues/104>)
  * Moved the Ceres loadFromROS functions into reusable functions in fuse_core
  * Load solver parameters for the batch optimizer
* Expose Ceres Solver, Problem and Covariance Options as ROS parameters (#78 <https://github.com/locusrobotics/fuse/issues/78>)
* [RST-2427] Added a 'source' field to the constraints. This is an API-breaking change. (#101 <https://github.com/locusrobotics/fuse/issues/101>)
* [RST-2432] Reworked the transaction queue to skip transactions on a per-sensor basis (#102 <https://github.com/locusrobotics/fuse/issues/102>)
* [RST-2340] Add serialization support to fuse (#98 <https://github.com/locusrobotics/fuse/issues/98>)
* Fix -Wall -Wextra warnings in tests (#80 <https://github.com/locusrobotics/fuse/issues/80>)
* [RST-2148] Added start() and stop() methods to the MotionModel, SensorModel, and Publisher API (#75 <https://github.com/locusrobotics/fuse/issues/75>)
  * Added start() and stop() methods to the MotionModel, SensorModel, and Publisher API
  * Added the ability to clear the callback queue of the optimizer
  * Refactor the fixed-lag reset callback to use the plugins' stop() and start() methods
* Fix -Wall -Wextra warnings (#77 <https://github.com/locusrobotics/fuse/issues/77>)
* Contributors: Davide Faconti, Enrique Fernandez Perdomo, Stephen Williams
```

## fuse_publishers

```
* Fixing license
* Support throttling serialized graph publisher (#204 <https://github.com/locusrobotics/fuse/issues/204>)
  * Change sensor proc from gtest to gmock target
  * Move ThrottledCallback to fuse_core
  * Support generic callbacks in ThrottledCallback
  * Throttle graph publishing
  * Overload getPositiveParam for ros::Duration
  * Use getPositiveParam for ros::Duration parameters
* Set latch param in serialized publisher to false by default (#184 <https://github.com/locusrobotics/fuse/issues/184>)
* Add latch param to serialized publisher (#165 <https://github.com/locusrobotics/fuse/issues/165>)
* Use transaction stamp in SerializedPublisher (#147 <https://github.com/locusrobotics/fuse/issues/147>)
  By using the transaction stamp instead of ros::Time::now() it's
  possible to replay things with the same transaction and compare the
  original and new generated graphs.
* Removed the explicit '-std=c++14' compile flag (#119 <https://github.com/locusrobotics/fuse/issues/119>)
  * Removed the explicit '-std=c++14' compile flag
  * Changed the CXX_STANDARD setting to be per-target instead of global
  * Added the CXX_STANDARD_REQUIRED setting to all targets
* fix compilation in Kinetic (#112 <https://github.com/locusrobotics/fuse/issues/112>)
* [RST-2149] Added the configured device_id to the log message (#110 <https://github.com/locusrobotics/fuse/issues/110>)
* [RST-2427] Added a 'source' field to the constraints. This is an API-breaking change. (#101 <https://github.com/locusrobotics/fuse/issues/101>)
* [RST-2340] Add serialization support to fuse (#98 <https://github.com/locusrobotics/fuse/issues/98>)
* [RST-2148] Added start() and stop() methods to the MotionModel, SensorModel, and Publisher API (#75 <https://github.com/locusrobotics/fuse/issues/75>)
  * Added start() and stop() methods to the MotionModel, SensorModel, and Publisher API
  * Added the ability to clear the callback queue of the optimizer
  * Refactor the fixed-lag reset callback to use the plugins' stop() and start() methods
* Fix -Wall -Wextra warnings (#77 <https://github.com/locusrobotics/fuse/issues/77>)
* Contributors: Davide Faconti, Enrique Fernandez Perdomo, Stephen Williams, Tom Moore
```

## fuse_variables

```
* Removed the explicit '-std=c++14' compile flag (#119 <https://github.com/locusrobotics/fuse/issues/119>)
  * Removed the explicit '-std=c++14' compile flag
  * Changed the CXX_STANDARD setting to be per-target instead of global
  * Added the CXX_STANDARD_REQUIRED setting to all targets
* fix compilation in Kinetic (#112 <https://github.com/locusrobotics/fuse/issues/112>)
* [RST-2340] Add serialization support to fuse (#98 <https://github.com/locusrobotics/fuse/issues/98>)
* Fix -Wall -Wextra warnings in tests (#80 <https://github.com/locusrobotics/fuse/issues/80>)
* Fix -Wall -Wextra warnings (#77 <https://github.com/locusrobotics/fuse/issues/77>)
* Contributors: Davide Faconti, Enrique Fernandez Perdomo, Stephen Williams
```

## fuse_viz

```
* Changelogs
* Adding QT5 dependency in package.xml (#229 <https://github.com/locusrobotics/fuse/issues/229>)
  * Adding QT5 dependency in package.xml
  * Fixing viz build issues in noetic (#230 <https://github.com/locusrobotics/fuse/issues/230>)
* Fixed compile error when using the latest version of rviz (#220 <https://github.com/locusrobotics/fuse/issues/220>)
* Fix roslint 0.12.0 (#186 <https://github.com/locusrobotics/fuse/issues/186>)
  * Fix roslint 0.12.0 include_what_you_use warnings
  Mostly for:
  * std::move -> #include <utility>
  * std::make_shared and similar -> #include <memory>
  * Remove static string variable not permitted by roslint 0.12.0, using a test fixture where needed.
* Replace ignition_sensors list param with ignition field (#163 <https://github.com/locusrobotics/fuse/issues/163>)
  * Remove ignition_sensors param and use a per-sensor ignition field
* Keep constraint properties sorted by source (#161 <https://github.com/locusrobotics/fuse/issues/161>)
* Visualize loss (#144 <https://github.com/locusrobotics/fuse/issues/144>)
  * Visualize error scaled by loss cost factor
  If a constraint has a loss function, the cost is computed with and
  without loss, and the quotient of the cost with loss by the cost without
  loss is used to scale the error line. This is used to draw a "loss"
  error line, so we can see the contribution of the loss function to the
  constraint.
* Set QT_INCLUDE_DIRS and QT_LIBRARIES properly (#153 <https://github.com/locusrobotics/fuse/issues/153>)
* Removed the explicit '-std=c++14' compile flag (#119 <https://github.com/locusrobotics/fuse/issues/119>)
  * Removed the explicit '-std=c++14' compile flag
  * Changed the CXX_STANDARD setting to be per-target instead of global
  * Added the CXX_STANDARD_REQUIRED setting to all targets
* Draw RelativePose2DStampedConstraint constraints (#107 <https://github.com/locusrobotics/fuse/issues/107>)
  * Draw RelativePose2DStampedConstraint constraints
  * Dynamically generate display properties for the constraint sources
  * Cache the constraint sources properties config so it's applied when
  the properties are later created
  * Create Variable visual + property, as we do for the Constraint
* fix compilation in Kinetic (#112 <https://github.com/locusrobotics/fuse/issues/112>)
* Add fuse_viz pkg with rviz SerializedGraph display (#99 <https://github.com/locusrobotics/fuse/issues/99>)
* Contributors: Davide Faconti, Enrique Fernandez Perdomo, Stephen Williams, Tom Moore
* Adding QT5 dependency in package.xml (#229 <https://github.com/locusrobotics/fuse/issues/229>)
  * Adding QT5 dependency in package.xml
  * Fixing viz build issues in noetic (#230 <https://github.com/locusrobotics/fuse/issues/230>)
* Fixed compile error when using the latest version of rviz (#220 <https://github.com/locusrobotics/fuse/issues/220>)
* Fix roslint 0.12.0 (#186 <https://github.com/locusrobotics/fuse/issues/186>)
  * Fix roslint 0.12.0 include_what_you_use warnings
  Mostly for:
  * std::move -> #include <utility>
  * std::make_shared and similar -> #include <memory>
  * Remove static string variable not permitted by roslint 0.12.0, using a test fixture where needed.
* Replace ignition_sensors list param with ignition field (#163 <https://github.com/locusrobotics/fuse/issues/163>)
  * Remove ignition_sensors param and use a per-sensor ignition field
* Keep constraint properties sorted by source (#161 <https://github.com/locusrobotics/fuse/issues/161>)
* Visualize loss (#144 <https://github.com/locusrobotics/fuse/issues/144>)
  * Visualize error scaled by loss cost factor
  If a constraint has a loss function, the cost is computed with and
  without loss, and the quotient of the cost with loss by the cost without
  loss is used to scale the error line. This is used to draw a "loss"
  error line, so we can see the contribution of the loss function to the
  constraint.
* Set QT_INCLUDE_DIRS and QT_LIBRARIES properly (#153 <https://github.com/locusrobotics/fuse/issues/153>)
* Removed the explicit '-std=c++14' compile flag (#119 <https://github.com/locusrobotics/fuse/issues/119>)
  * Removed the explicit '-std=c++14' compile flag
  * Changed the CXX_STANDARD setting to be per-target instead of global
  * Added the CXX_STANDARD_REQUIRED setting to all targets
* Draw RelativePose2DStampedConstraint constraints (#107 <https://github.com/locusrobotics/fuse/issues/107>)
  * Draw RelativePose2DStampedConstraint constraints
  * Dynamically generate display properties for the constraint sources
  * Cache the constraint sources properties config so it's applied when
  the properties are later created
  * Create Variable visual + property, as we do for the Constraint
* fix compilation in Kinetic (#112 <https://github.com/locusrobotics/fuse/issues/112>)
* Add fuse_viz pkg with rviz SerializedGraph display (#99 <https://github.com/locusrobotics/fuse/issues/99>)
* Contributors: Davide Faconti, Enrique Fernandez Perdomo, Stephen Williams, Tom Moore
```
