### PR TITLE
image_transport_plugins: 2.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1075,7 +1075,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 2.3.0-4
+      version: 2.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `2.3.1-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.0-4`

## compressed_depth_image_transport

- No changes

## compressed_image_transport

```
* [ros2] Fix RCLCPP_* logs, a string literal must be the first argument (#72 <https://github.com/ros-perception/image_transport_plugins/issues/72>)
* Contributors: Ivan Santiago Paunovic, Łukasz Mitka
```

## image_transport_plugins

- No changes

## theora_image_transport

```
* Fix ament_export_dependencies syntax in CMake (#65 <https://github.com/ros-perception/image_transport_plugins/issues/65>)
* Contributors: Chen Bainian
```
