### PR TITLE
quanergy_client: 5.0.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9479,6 +9479,12 @@ repositories:
       url: https://github.com/stonier/qt_ros.git
       version: indigo
     status: maintained
+  quanergy_client:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/QuanergySystems/quanergy_client-release.git
+      version: 5.0.0-2
   quaternion_operation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `quanergy_client` to `5.0.0-2`:

- upstream repository: https://github.com/QuanergySystems/quanergy_client.git
- release repository: https://github.com/QuanergySystems/quanergy_client-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
