### PR TITLE
quanergy_client: 5.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5818,6 +5818,12 @@ repositories:
       url: https://github.com/ros-visualization/qt_gui_core.git
       version: melodic-devel
     status: maintained
+  quanergy_client:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/QuanergySystems/quanergy_client-release.git
+      version: 5.0.0-1
   qwt_dependency:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `quanergy_client` to `5.0.0-1`:

- upstream repository: https://github.com/QuanergySystems/quanergy_client.git
- release repository: https://github.com/QuanergySystems/quanergy_client-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
