### PR TITLE
embree_vendor: 0.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -969,7 +969,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/OUXT-Polaris/embree_vendor-release.git
-      version: 0.0.9-1
+      version: 0.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `embree_vendor` to `0.1.0-1`:

- upstream repository: https://github.com/OUXT-Polaris/embree_vendor.git
- release repository: https://github.com/OUXT-Polaris/embree_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.9-1`

## embree_vendor

```
* Merge branch 'master' of https://github.com/OUXT-Polaris/embree_vendor
* Merge pull request #4 <https://github.com/OUXT-Polaris/embree_vendor/issues/4> from OUXT-Polaris/feature/onetbb_src
  Feature/onetbb src
* change build order
* remove unused action
* add tbb build command
* fix version
* Contributors: Masaya Kataoka
```
