### PR TITLE
pmb2_navigation: 3.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2501,7 +2501,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_navigation-gbp.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_navigation` to `3.0.1-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_navigation.git
- release repository: https://github.com/pal-gbp/pmb2_navigation-gbp.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.0.0-1`

## pmb2_2dnav

```
* Add missing ament_cmake_auto dependency
* Contributors: Victor Lopez
```

## pmb2_maps

```
* Add missing ament_cmake_auto dependency
* Contributors: Victor Lopez
```

## pmb2_navigation

- No changes
