### PR TITLE
backward_ros: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -288,7 +288,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/pal-gbp/backward_ros-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/backward_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `backward_ros` to `1.0.1-1`:

- upstream repository: git@github.com:pal-robotics/backward_ros.git
- release repository: https://github.com/pal-gbp/backward_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.0-1`

## backward_ros

```
* Add missing ament_cmake dependency
* Contributors: Victor Lopez
```
