### PR TITLE
tf2_2d: 0.6.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13075,7 +13075,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/locusrobotics/tf2_2d-release.git
-      version: 0.6.3-1
+      version: 0.6.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf2_2d` to `0.6.4-1`:

- upstream repository: https://github.com/locusrobotics/tf2_2d.git
- release repository: https://github.com/locusrobotics/tf2_2d-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.3-1`

## tf2_2d

```
* Handling issue with tf2 circular dependency (#4 <https://github.com/locusrobotics/tf2_2d/issues/4>)
  * Handling issue with tf2 circular dependency and other warnings
* Contributors: Tom Moore
```
