### PR TITLE
tf2_2d: 0.6.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8279,7 +8279,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/locusrobotics/tf2_2d-release.git
-      version: 0.6.3-2
+      version: 0.6.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf2_2d` to `0.6.4-1`:

- upstream repository: https://github.com/locusrobotics/tf2_2d.git
- release repository: https://github.com/locusrobotics/tf2_2d-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.3-2`

## tf2_2d

```
* Handling issue with tf2 circular dependency (#4 <https://github.com/locusrobotics/tf2_2d/issues/4>)
  * Handling issue with tf2 circular dependency and other warnings
* Contributors: Tom Moore
```
