### PR TITLE
backward_ros: 1.0.1-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -279,6 +279,21 @@ repositories:
       url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
       version: master
     status: developed
+  backward_ros:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/backward_ros.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/pal-gbp/backward_ros-release.git
+      version: 1.0.1-2
+    source:
+      type: git
+      url: https://github.com/pal-robotics/backward_ros.git
+      version: foxy-devel
+    status: maintained
   behaviortree_cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `backward_ros` to `1.0.1-2`:

- upstream repository: git@github.com:pal-robotics/backward_ros.git
- release repository: https://github.com/pal-gbp/backward_ros-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## backward_ros

```
* Add missing ament_cmake dependency
* Contributors: Victor Lopez
```
