### PR TITLE
filters: 2.1.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -731,7 +731,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/filters-release.git
-      version: 2.0.0-3
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `filters` to `2.1.0-1`:

- upstream repository: https://github.com/ros/filters.git
- release repository: https://github.com/ros2-gbp/filters-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-3`

## filters

```
* Fix compiler warnings+test failures on CI (#56 <https://github.com/ros/filters/issues/56>)
* Solve statically parameter error (#48 <https://github.com/ros/filters/issues/48>)
* Contributors: Jon Binney, Patrick Lascombz
```
