### PR TITLE
Add libdw-dev rule for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2805,6 +2805,7 @@ libdw-dev:
   nixos: [elfutils]
   openembedded: [elfutils@openembedded-core]
   opensuse: [libdw-devel]
+  rhel: [elfutils-devel]
   ubuntu: [libdw-dev]
 libdxflib-dev:
   debian: [libdxflib-dev]


### PR DESCRIPTION
For both RHEL 7 and 8, the elfutils-devel package is provided in the BaseOS repository.

According to the [Ubuntu package page](https://packages.ubuntu.com/focal/libdw-dev), the `elfutils-devel` package provides the same headers as `libdw-dev` does on Ubuntu.

http://mirror.centos.org/centos-7/7/os/x86_64/Packages/elfutils-devel-0.176-5.el7.i686.rpm
http://mirror.centos.org/centos-8/8/BaseOS/x86_64/os/Packages/elfutils-devel-0.182-3.el8.i686.rpm