### PR TITLE
[galactic] Update image_transport_plugins to use foxy-devel

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1035,7 +1035,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/image_transport_plugins.git
-      version: ros2
+      version: foxy-devel
     release:
       packages:
       - compressed_depth_image_transport
@@ -1050,7 +1050,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/image_transport_plugins.git
-      version: ros2
+      version: foxy-devel
     status: maintained
   interactive_markers:
     doc:


### PR DESCRIPTION
Follow up to #30185

Signed-off-by: Michael Carroll <michael@openrobotics.org>
