### PR TITLE
turtlebot3_simulations: 1.3.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13407,7 +13407,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release.git
-      version: 1.3.1-1
+      version: 1.3.2-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_simulations` to `1.3.2-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.3.1-1`

## turtlebot3_fake

```
* update catkin minimum requirement
* fix bugs
* Contributors: Kerui, Elvis Dowson, Will Son
```

## turtlebot3_gazebo

```
* update catkin minimum requirement
* fix bugs
* Contributors: Kerui, Elvis Dowson, Will Son
```

## turtlebot3_simulations

```
* update catkin minimum requirement
* fix bugs
* Contributors: Kerui, Elvis Dowson, Will Son
```
