### PR TITLE
hls_lfcd_lds_driver: 2.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -967,7 +967,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/robotis-ros2-release/hls_lfcd_lds_driver-release.git
-      version: 2.0.2-1
+      version: 2.0.4-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hls_lfcd_lds_driver` to `2.0.4-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
- release repository: https://github.com/robotis-ros2-release/hls_lfcd_lds_driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.2-1`

## hls_lfcd_lds_driver

```
* fix linker error
* Contributors: goekce, Will Son
```
