### PR TITLE
rcdiscover: 1.1.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6046,7 +6046,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/roboception-gbp/rcdiscover-release.git
-      version: 1.1.2-1
+      version: 1.1.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcdiscover` to `1.1.4-1`:

- upstream repository: https://github.com/roboception/rcdiscover.git
- release repository: https://github.com/roboception-gbp/rcdiscover-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.2-1`

## rcdiscover

```
* fix version in package.xml
```
