### PR TITLE
python_qt_binding: 0.4.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9305,7 +9305,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/python_qt_binding-release.git
-      version: 0.4.3-1
+      version: 0.4.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `0.4.4-1`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros-gbp/python_qt_binding-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.3-1`

## python_qt_binding

```
* add check for sip binding install directory on archlinux (#95 <https://github.com/ros-visualization/python_qt_binding/issues/95>)
* Update maintainers (#96 <https://github.com/ros-visualization/python_qt_binding/issues/96>)
* Contributors: Akash Patel, Shane Loretz
```
