### PR TITLE
gmcl: 1.0.1-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2480,7 +2480,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/adler-1994/gmcl-release.git
-      version: 1.0.1-1
+      version: 1.0.1-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gmcl` to `1.0.1-3`:

- upstream repository: https://github.com/adler-1994/gmcl.git
- release repository: https://github.com/adler-1994/gmcl-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.1-1`

## gmcl

```
* avoid dividing by zero when setting either of energy map resolutions to zero.
* change message names to be more appropriate.
```
