### PR TITLE
rosidl_python: 0.13.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2967,7 +2967,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.12.0-1
+      version: 0.13.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_python` to `0.13.0-1`:

- upstream repository: https://github.com/ros2/rosidl_python.git
- release repository: https://github.com/ros2-gbp/rosidl_python-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.12.0-1`

## rosidl_generator_py

```
* Support available typesupport specification in CLI extension (#133 <https://github.com/ros2/rosidl_python/issues/133>)
* Use python_d for test_cli_extension in Debug mode (#136 <https://github.com/ros2/rosidl_python/issues/136>)
* Add missing float/double bounds check (#128 <https://github.com/ros2/rosidl_python/issues/128>)
* Contributors: Michel Hidalgo, Seulbae Kim, Shane Loretz
```
