### PR TITLE
webots_ros: 4.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -14540,7 +14540,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/cyberbotics/webots_ros-release.git
-      version: 4.0.1-1
+      version: 4.1.0-1
     source:
       type: git
       url: https://github.com/cyberbotics/webots_ros.git


### PR DESCRIPTION
The packages in the `webots_ros` repository were released into the `melodic` distro by running `/usr/bin/bloom-release --rosdistro melodic --track melodic webots_ros --edit` on `Fri, 16 Jul 2021 15:11:13 -0000`

The `webots_ros` package was released.

Version of package(s) in repository `webots_ros`:

- upstream repository: https://github.com/cyberbotics/webots_ros.git
- release repository: https://github.com/cyberbotics/webots_ros-release.git
- rosdistro version: `4.0.1-1`
- old version: `4.0.1-1`
- new version: `4.1.0-1`

Versions of tools used:

- bloom version: `0.10.7`
- catkin_pkg version: `0.4.23`
- rosdep version: `0.21.0`
- rosdistro version: `0.8.3`
- vcstools version: `0.1.42`