### PR TITLE
Added python3 version of cairosvg

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5940,6 +5940,13 @@ python3-cairo:
     slackpkg:
       packages: [py3cairo]
   ubuntu: [python3-cairo]
+python3-cairosvg:
+  arch: [python-cairosvg]
+  debian: [python3-cairosvg]
+  fedora: [python-cairosvg]
+  gentoo: [media-gfx/cairosvg]
+  opensuse: [python3-CairoSVG]
+  ubuntu: [python3-cairosvg]
 python3-can:
   debian: [python3-can]
   fedora: [python3-can]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5943,7 +5943,7 @@ python3-cairo:
 python3-cairosvg:
   arch: [python-cairosvg]
   debian: [python3-cairosvg]
-  fedora: [python-cairosvg]
+  fedora: [python3-cairosvg]
   gentoo: [media-gfx/cairosvg]
   opensuse: [python3-CairoSVG]
   ubuntu: [python3-cairosvg]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-cairosvg

## Package Upstream Source:

https://github.com/Kozea/CairoSVG 

## Purpose of using this:

Converting SVG into PDF and PNG, the python2 version is already in use by aruco_detect for marker generation.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/stable/python3-cairosvg
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/focal/python3-cairosvg
   - REQUIRED
- Fedora: https://src.fedoraproject.org/rpms/python-cairosvg
  - IF AVAILABLE
- Arch: https://archlinux.org/packages/community/any/python-cairosvg/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/packages/media-gfx/cairosvg
  - IF AVAILABLE
