### PR TITLE
quanergy_client_ros: 4.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9485,6 +9485,12 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/QuanergySystems/quanergy_client-release.git
       version: 5.0.0-2
+  quanergy_client_ros:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/QuanergySystems/quanergy_client_ros-release.git
+      version: 4.0.0-1
   quaternion_operation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `quanergy_client_ros` to `4.0.0-1`:

- upstream repository: https://github.com/QuanergySystems/quanergy_client_ros.git
- release repository: https://github.com/QuanergySystems/quanergy_client_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
