### PR TITLE
quanergy_client_ros: 4.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5824,6 +5824,12 @@ repositories:
         release: release/noetic/{package}/{version}
       url: https://github.com/QuanergySystems/quanergy_client-release.git
       version: 5.0.0-1
+  quanergy_client_ros:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/QuanergySystems/quanergy_client_ros-release.git
+      version: 4.0.0-1
   qwt_dependency:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `quanergy_client_ros` to `4.0.0-1`:

- upstream repository: https://github.com/QuanergySystems/quanergy_client_ros.git
- release repository: https://github.com/QuanergySystems/quanergy_client_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
