### PR TITLE
nao_interfaces: 0.0.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1490,10 +1490,13 @@ repositories:
       url: https://github.com/ijnek/nao_interfaces.git
       version: main
     release:
+      packages:
+      - nao_command_msgs
+      - nao_sensor_msgs
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ijnek/nao_interfaces-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/ijnek/nao_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_interfaces` to `0.0.3-1`:

- upstream repository: https://github.com/ijnek/nao_interfaces.git
- release repository: https://github.com/ijnek/nao_interfaces-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.2-1`

## nao_command_msgs

```
* move all nao_command_msgs files that were in wrong directory
* separated msgs into two different packages, sensor and command packages
* Contributors: Kenji Brameld
```

## nao_sensor_msgs

```
* separated msgs into two different packages, sensor and command packages
* Contributors: Kenji Brameld
```
