### PR TITLE
jsk_demos: 0.0.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5113,6 +5113,29 @@ repositories:
       url: https://github.com/jsk-ros-pkg/jsk_control.git
       version: master
     status: developed
+  jsk_demos:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_demos.git
+      version: master
+    release:
+      packages:
+      - diabolo_pr2_201806
+      - drc_com_common
+      - elevator_move_base_pr2
+      - jsk_2019_10_semi
+      - jsk_demo_common
+      - jsk_maps
+      - welcome_to_jsk_fetch
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/jsk_demos-release.git
+      version: 0.0.5-1
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_demos.git
+      version: master
+    status: developed
   jsk_model_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_demos` to `0.0.5-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_demos.git
- release repository: https://github.com/tork-a/jsk_demos-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## diabolo_pr2_201806

```
* Add .rviz and stop feedback controly from teleop device (#1260 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1260>)
  
    * modify indent of euslisp file
    * add a function for stoping a feedback controller with button 'x' of a remote controller, for showing that diabolo demo is difficult without a feedback controller
    * add .rviz file for visualizing result of recognitino
  
* add diabolo_pr2 in jsk_demos (#1257 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1257>)
* Contributors: Takayuki Murooka
```

## drc_com_common

- No changes

## elevator_move_base_pr2

```
* elevator_move_base_pr2: fix for testing (#1238 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1238>)
  
    * elevator_move_base_pr2: remove old files
    * elevator_move_base_pr2: fix for indigo
    * elevator_move_base_pr2: minor bugfix
  
* travis: drop hydro (#1231 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1231>)
* Contributors: Yuki Furuta
```

## jsk_2019_10_semi

```
* edit how to get parameter in 2019 semi (#1313 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1313>)
* add jsk_2019_10_semi (#1273 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1273>)
* Contributors: Naoaki Kanazawan, Miyabi Tanemoto, YoshiaAbe, Yoshiki Obinata, Affonso Guilherme, Shingo Kitagawa
```

## jsk_demo_common

```
* [jsk_demo_common] use :stop-grasp in open fridge (#1275 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1275>)
* Refine 73B2 fridge demo motion (#1264 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1264>)
* add fridge demo with voice command (#1263 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1263>)
  
    * refine fridge move motion
    * add app-utils.l to jsk_demo_common
  
* 2019/04/10 Fridge demo (#1262 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1262>)
  
    * jsk_demo_common: pr2-action.l: wait for openning gripper before approaching to cans
    * use new color histogram
  
* [jsk_demo_common] some bugfix (#1222 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1222>)
  
    * [jsk_demo_common][pr2-action.l] add missing move-arm
    * [jsk_demo_common][pr2-action.l] fix docstring order
  
* Contributors: Kei Okada, Shingo Kitagawa, Yuki Furuta
```

## jsk_maps

```
* add fetch dock2 (#1329 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1329>)
* [jsk_maps] update change-floor.l to set *tfl* when it is not set (#1301 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1301>)
* fix slant and fetch place (#1300 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1300>)
  * update 73b2 kitchen map
  * change 3f-map origin
  * update eng2-3f-0.05_keepout.xcf
  * fix the elevator in eng2 3th floor
  * remove fetch dock in 73b2
  * update 73b2 map
  * update eng2 7f maps to add vending machine
  * make *tfl* when there is no *tfl*
  * remove unused mux key
  * remap static_map to static_map_keepout
  * publish map_keepout topic
  * resize and rotate eng2 8f map
  * set keepout arg default false
  * add eng6 and eng8 keepout arg
  * add eng8 keepout maps
  * add eng6 keepout maps
  * update eng2 1f and 2f keepout
  * remove unnecessary return
  * use group tag
  * add keepout arg in launch/start_map_eng2.launch
  * add eng2 8f keepout
  * add eng2/8f keepout map
  * add keepout arg for eng2 building
  * generate keepout yaml
  * remove eng2-7f-0.05_keepout.yaml
  * update eng2 1f map
  * Merge branch 'master' into update-maps
  * update eng2 3f map
  * update eng2 7f map
  * update eng2 2f maps
  * remove unnecessary space in jsk_maps/CMakeLists.txt
  * Update eng2/7f map
  * Update eng2/2f map
* [jsk_maps] use rospy.logerr in initialpose3d (#1298 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1298>)
  
    * remove unnecessary ;
    * use rospy.logerr instead of print
  
* Update map of eng2-8f, add room 83A3 (#1247 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1247>)
* update fetch dock spot (#1274 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1274>)
* remove pr2 from eng2 7f map (#1265 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1265>)
* fix a typo in REAME.md of jsk_maps (#1269 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1269>)
* [jsk_maps] Add change-floor server to change map (#1251 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1251>)
* Refine 73B2 fridge demo motion (#1264 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1264>)
  
    * remove pr2 from eng2 7f map
    * update 73b2 fridge front spot
    * [jsk_maps/change-floor.l] Modified key value of change-costmap-publish-frequency
    * [jsk_maps/change-floor.l] Fixed typo. inamenitialpose3d  -> initialpose3d
    * [jsk_maps/change-floor.l] Remove shebang
    * [jsk_maps/change-floor-server.l] Refactor unix:usleep -> unix:sleep
    * [jsk_maps/change-floor-server.l] Change publish_frequncy of costmap to reload it
    * [jsk_maps/change-floor.l] Add change-costmap-publish-frequency function
    * [jsk_maps/change-floor.l] Return t in change-floor function
    * [jsk_maps/change-floor.l] Refactor
    * [jsk_maps/change-floor.l] Fixed lookup transform
    * [jsk_maps/change-floor-server.l] Add comments
    * [jsk_maps/change-floor-server.l] Add *tfl* initialization
    * [jsk_maps/change-floor.l] Add *tfl* error exception
    * [jsk_maps] Add change-floor server
    * update map of eng2-8f, add room 83A3
  
* update position of fetch's charge dock (#1245 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1245>)
* Add fetch's dock spot to /spots_marker_array (#1244 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1244>)
* update map of 73B2, set gray pixels to white (#1243 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1243>)
* change map of eng2-7f (#1233 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1233>)
* elevator_move_base_pr2: Fixes for pr2 indigo demo (#1238 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1238>)
  
    * jsk_maps: cleanup old codes
  
* [jsk_maps] refactor publish_spot.l & add test (#1227 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1227>)
  
    * jsk_maps: disable test on hydro
    * jsk_maps: cleanup old codes
    * jsk_maps: add test
    * jsk_maps: publish_spots.l: refactor / add option to select using pictograms or pins
  
* jsk_maps/tools/publish_spot.l: add message when map is selected (#1214 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1214>)
* [jsk_maps][building-model.l] add :rooms / :current-room (#1221 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1221>)
  
    * jsk_maps/tools/publish_spot.l: add emssage when map is selected
  
* Contributors: Naoaki Kanazawa, Kei Okada, Koki Shinjo, Naoya Yamaguchi, Shingo Kitagawa, Yuki Furuta, Yuto Uchimi, Taichi Higashide, Iory Yanokura, Yoshiki Obinata
```

## welcome_to_jsk_fetch

```
* Add demo programs for visitors using fetch (#1235 <https://github.com/jsk-ros-pkg/jsk_demos/issues/1235>)
  
    * add JSK navigation node with fetch
    * add author and dependency to package.xml
    * add README
    * rename launch file
    * add demo programs for visitors using fetch
  
* Contributors: Kei Okada, Naoya Yamaguchi
```
