### PR TITLE
jackal: 0.7.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4816,7 +4816,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.7.5-1
+      version: 0.7.6-1
     source:
       type: git
       url: https://github.com/jackal/jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.7.6-1`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.5-1`

## jackal_control

```
* Add envar support for adding a GX5 family IMU (#85 <https://github.com/jackal/jackal/issues/85>)
  * Add an alternate EKF file that uses the secondary IMU.  Add the GX5 link to the URDF if necessary. Standard mounting location TBD, so don't merge this yet.
  * Add a sane default we can use for mounting the GX5.  RSCI-10 is low-priority, so we may not finalize the default position. But this way Integration can at least start using the envars and ensure they set the xyz/rpy offsets correctly.
  * Don't disable the default IMU configuration, just load the GX5 settings as a secondary IMU
* Contributors: Chris I-B
```

## jackal_description

```
* cpr urdf extras
* Contributors: Ebrahim Shahrivar
```

## jackal_msgs

- No changes

## jackal_navigation

- No changes
