### PR TITLE
dingo: 0.1.9-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2361,7 +2361,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/dingo-release.git
-      version: 0.1.8-1
+      version: 0.1.9-2
     source:
       type: git
       url: https://github.com/dingo-cpr/dingo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo` to `0.1.9-2`:

- upstream repository: https://github.com/dingo-cpr/dingo.git
- release repository: https://github.com/clearpath-gbp/dingo-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.8-1`

## dingo_control

```
* Change where we load the joy_dev argument so it loads correctly
* Contributors: Chris Iverach-Brereton
```

## dingo_description

- No changes

## dingo_msgs

- No changes

## dingo_navigation

- No changes
