### PR TITLE
webots_ros2: 1.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5235,11 +5235,14 @@ repositories:
       packages:
       - webots_ros2
       - webots_ros2_abb
+      - webots_ros2_control
       - webots_ros2_core
       - webots_ros2_demos
+      - webots_ros2_driver
       - webots_ros2_epuck
       - webots_ros2_examples
       - webots_ros2_importer
+      - webots_ros2_mavic
       - webots_ros2_msgs
       - webots_ros2_tesla
       - webots_ros2_tiago
@@ -5250,7 +5253,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/cyberbotics/webots_ros2-release.git
-      version: 1.0.6-1
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `webots_ros2` to `1.1.0-1`:

- upstream repository: https://github.com/cyberbotics/webots_ros2.git
- release repository: https://github.com/cyberbotics/webots_ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.6-1`

## webots_ros2

```
* Included the 'webots_ros2_driver' package as a C++ alternative to the 'webots_ros2_core' package.
* Integrated ros2_control.
* Included a Mavic drone simulation example
```

## webots_ros2_control

```
* Initial version
```

## webots_ros2_driver

```
* Initial version
```

## webots_ros2_importer

```
* Upgraded to urdf2webots 1.0.10
```

## webots_ros2_mavic

```
* Initial version
```

## webots_ros2_msgs

```
* Added camera recognition object messages
```
