### PR TITLE
Add libfcl-dev rule for RHEL 8

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2884,6 +2884,9 @@ libfcl-dev:
   gentoo: [sci-libs/fcl]
   nixos: [fcl]
   openembedded: [fcl@meta-ros-common]
+  rhel:
+    '*': [fcl-devel]
+    '7': null
   ubuntu:
     '*': [libfcl-dev]
     wily: [libfcl-0.5-dev]


### PR DESCRIPTION
This package recently became available in EPEL 8. It is not available in RHEL 7 as far as I know.

https://src.fedoraproject.org/rpms/fcl#bodhi_updates