### PR TITLE
Add flex rule for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1027,6 +1027,7 @@ flex:
   nixos: [flex]
   openembedded: [flex@openembedded-core]
   opensuse: [flex]
+  rhel: [flex]
   ubuntu: [flex]
 fltk:  # Consider using the libfltk-dev and fluid (fltk runtime) keys instead.
   arch: [fltk]


### PR DESCRIPTION
This package is part of the OS repository for RHEL 7, and AppStream for RHEL 8:

* RHEL 7: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/flex-2.5.37-6.el7.x86_64.rpm
* RHEL 8: http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/Packages/flex-2.6.1-9.el8.x86_64.rpm