### PR TITLE
Add libomp-dev rule for RHEL 8

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3990,6 +3990,9 @@ libomp-dev:
   debian: [libomp-dev]
   fedora: [libomp-devel]
   nixos: [llvmPackages.openmp]
+  rhel:
+    '*': [libomp-devel]
+    '7': null
   ubuntu: [libomp-dev]
 libopal-dev:
   debian: [libopal-dev]


### PR DESCRIPTION
This package is part of AppStream in RHEL 8, and is not available in RHEL 7 at the moment.

http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/Packages/libomp-devel-11.0.0-1.module_el8.4.0+587+5187cac0.i686.rpm