### PR TITLE
xacro: 1.13.12-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -14691,7 +14691,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.13.11-1
+      version: 1.13.12-1
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.13.12-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.13.11-1`

## xacro

```
* Improve macro arg parsing (#278 <https://github.com/ros/xacro/issues/278>) to support:
  - $(substitution args)
  - ${python expressions}
  - single or double quoting of spaces
* Contributors: Robert Haschke
```
