### PR TITLE
xacro: 1.14.8-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9237,7 +9237,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.14.7-1
+      version: 1.14.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.14.8-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.14.7-1`

## xacro

```
* Improve macro arg parsing (#278 <https://github.com/ros/xacro/issues/278>) to support:
  - $(substitution args)
  - ${python expressions}
  - single or double quoting of spaces
* Contributors: Robert Haschke
```
