### PR TITLE
ublox_dgnss: 0.2.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3925,6 +3925,21 @@ repositories:
       url: https://github.com/KumarRobotics/ublox.git
       version: foxy-devel
     status: maintained
+  ublox_dgnss:
+    release:
+      packages:
+      - ublox_dgnss
+      - ublox_dgnss_node
+      - ublox_ubx_interfaces
+      - ublox_ubx_msgs
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/aussierobots/ublox_dgnss-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/aussierobots/ublox_dgnss.git
+      version: main
   udp_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ublox_dgnss` to `0.2.0-1`:

- upstream repository: https://github.com/aussierobots/ublox_dgnss
- release repository: https://github.com/aussierobots/ublox_dgnss-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
