### PR TITLE
nao_lola: 0.0.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1576,6 +1576,7 @@ repositories:
       type: git
       url: https://github.com/ijnek/nao_lola.git
       version: main
+    status: developed
   naosoccer_sim:
     doc:
       type: git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1575,6 +1575,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ijnek/nao_lola.git
+      version: main
   naosoccer_sim:
     doc:
       type: git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1562,6 +1562,21 @@ repositories:
       url: https://github.com/ijnek/nao_interfaces.git
       version: main
     status: developed
+  nao_lola:
+    doc:
+      type: git
+      url: https://github.com/ijnek/nao_lola.git
+      version: main
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ijnek/nao_lola-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/ijnek/nao_lola.git
+      version: main
+    status: developed
   navigation2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_lola` to `0.0.2-1`:

- upstream repository: https://github.com/ijnek/nao_lola.git
- release repository: https://github.com/ijnek/nao_lola-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
