### PR TITLE
naosoccer_sim: 0.0.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1562,6 +1562,24 @@ repositories:
       url: https://github.com/ijnek/nao_interfaces.git
       version: main
     status: developed
+  naosoccer_sim:
+    doc:
+      type: git
+      url: https://github.com/ijnek/naosoccer_sim.git
+      version: main
+    release:
+      packages:
+      - nao_button_sim
+      - rcss3d_agent
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ijnek/naosoccer_sim-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/ijnek/naosoccer_sim.git
+      version: main
+    status: developed
   navigation2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `naosoccer_sim` to `0.0.2-1`:

- upstream repository: https://github.com/ijnek/naosoccer_sim.git
- release repository: https://github.com/ijnek/naosoccer_sim-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
