### PR TITLE
pmb2_simulation: 3.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2527,6 +2527,25 @@ repositories:
       url: https://github.com/pal-robotics/pmb2_robot.git
       version: foxy-devel
     status: developed
+  pmb2_simulation:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pmb2_simulation.git
+      version: foxy-devel
+    release:
+      packages:
+      - pmb2_2dnav_gazebo
+      - pmb2_gazebo
+      - pmb2_simulation
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/pal-gbp/pmb2_simulation-gbp.git
+      version: 3.0.0-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pmb2_simulation.git
+      version: foxy-devel
+    status: developed
   point_cloud_msg_wrapper:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_simulation` to `3.0.0-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_simulation.git
- release repository: https://github.com/pal-gbp/pmb2_simulation-gbp.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## pmb2_2dnav_gazebo

```
* Add ament and apply corrections
* Migrate pmb2_2dnav_gazebo to ROS2
* First gazebo launch with ROS2
* Contributors: Victor Lopez
```

## pmb2_gazebo

```
* Cleanup old launch files
* Correct python launch file
* Add ament and apply corrections
* Cleanup
* Cleanup pmb2_gazebo spawn
* Path fixes for gazebo
* First gazebo launch with ROS2
* Contributors: Victor Lopez
```

## pmb2_simulation

```
* Add ament and apply corrections
* Remove pmb2_controller_configuration_gazebo, use default one for gazebo
  For now we can use the default one
* First gazebo launch with ROS2
* Contributors: Victor Lopez
```
