### PR TITLE
rclc: 3.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2122,10 +2122,11 @@ repositories:
       - rclc
       - rclc_examples
       - rclc_lifecycle
+      - rclc_parameter
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
-      version: 1.0.1-1
+      version: 3.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclc` to `3.0.1-1`:

- upstream repository: https://github.com/ros2/rclc.git
- release repository: https://github.com/ros2-gbp/rclc-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.1-1`

## rclc

```
* Added rclc_parameter package
* Added quality of service entity creation API
* Added executor prepare API
* Added support for removing subscription from executor
* Added support for subscription with context
* Added quality declaration statement
* Updated compatability function for sleep
* Removed duplicate NOTICE files
```

## rclc_examples

```
* Added example for parameter server
* Added example for executor prepare API
* Added example for quality of service entity creation API
* Added example for subscription with context
```

## rclc_lifecycle

```
* Added quality declaration statement
```

## rclc_parameter

```
* Removed shared from rclc_parameter
* Ensure clean message when set_parameter
* Added QoS entity creation API
* Updated CMakeLists.txt
* Major vesion bump was neccessary because API change in rcl_lifecycle package
```
