### PR TITLE
rclc: 2.0.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2261,10 +2261,11 @@ repositories:
       - rclc
       - rclc_examples
       - rclc_lifecycle
+      - rclc_parameter
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclc` to `2.0.2-1`:

- upstream repository: https://github.com/ros2/rclc.git
- release repository: https://github.com/ros2-gbp/rclc-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.1-1`

## rclc

```
* Added rclc_parameter package
* Added quality of service entity creation API
* Addded executor_prepare API
* Added support for removing subscription from executor
* Added support for subscription with context
* Updated compatability function for sleep
* Removed duplicate NOTICE files
```

## rclc_examples

```
* Added example for parameter server
* Added example for quality of service entity creation API
* Added example for subscription with context
* Added example for executor_prepare API
```

## rclc_lifecycle

```
* Bumped version
```

## rclc_parameter

```
* Removed shared from rclc_parameter
* Ensure clean message when set_parameter
* Added QoS entity creation API
* Updated CMakeLists.txt
* Major vesion bump was neccessary because API change in rcl_lifecycle package
```
