### PR TITLE
rclc: 1.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3019,7 +3019,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
-      version: 1.0.0-1
+      version: 1.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclc` to `1.0.2-1`:

- upstream repository: https://github.com/ros2/rclc.git
- release repository: https://github.com/ros2-gbp/rclc-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.0-1`

## rclc

```
* Bumped version (tag with version 1.0.1 already exists)
```

## rclc_examples

```
* Bumped version (tag with version 1.0.1 already exists)
```

## rclc_lifecycle

```
* Bumped version (tag with version 1.0.1 already exists)
```
