### PR TITLE
Revert "heifu: 0.8.1-1 in 'melodic/distribution.yaml' [bloom] (#30127)"

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4177,28 +4177,19 @@ repositories:
       version: releasePackage
     release:
       packages:
-      - bev_mavros
-      - collision_avoidance
-      - control_bringup
-      - gcs_interface
-      - gimbal
-      - gnss_utils
-      - gpu_voxels_ros
       - heifu
-      - heifu-bringup
-      - mavros_commands
-      - navigation_controller
-      - planner
-      - planners_manager
-      - priority_manager
-      - rrt
-      - status_diagnostic
-      - uav_msgs
-      - waypoints_manager
+      - heifu_bringup
+      - heifu_description
+      - heifu_diagnostic
+      - heifu_mavros
+      - heifu_msgs
+      - heifu_safety
+      - heifu_simple_waypoint
+      - heifu_tools
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/BV-OpenSource/heifu-release.git
-      version: 0.8.1-1
+      version: 0.7.7-2
     source:
       type: git
       url: https://gitlab.pdmfc.com/drones/ros1/heifu.git


### PR DESCRIPTION
This reverts commit cc525aba57fb794837cec8496dfaa1e255af5f4b.

Many of the packages in the 0.8.1 release of heifu are failing to build; see https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__heifu__ubuntu_bionic_amd64__binary/ for the tip of the iceberg.  @BV-OpenSource FYI.