### PR TITLE
Revert "jsk_3rdparty: 2.1.22-1 in 'melodic/distribution.yaml' [bloom]…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5000,17 +5000,14 @@ repositories:
       version: master
     release:
       packages:
-      - aques_talk
       - assimp_devel
       - bayesian_belief_networks
-      - chaplus_ros
       - collada_urdf_jsk_patch
       - dialogflow_task_executive
       - downward
       - ff
       - ffha
       - gdrive_ros
-      - google_cloud_texttospeech
       - jsk_3rdparty
       - julius
       - julius_ros
@@ -5033,7 +5030,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
-      version: 2.1.22-1
+      version: 2.1.21-3
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git


### PR DESCRIPTION
… (#29830)"

This reverts commit 69f42050b0a30586c6f8511846d3c1bb9551d1f5.

gdrive_ros hasn't built properly since this was merged; see https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__gdrive_ros__ubuntu_bionic_amd64__binary/ .  @k-okada FYI