### PR TITLE
Release kvh_geo_fog_3d to noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3365,6 +3365,26 @@ repositories:
       url: https://github.com/yujinrobot/kobuki_msgs.git
       version: noetic
     status: maintained
+   kvh_geo_fog_3d:
+    doc:
+      type: git
+      url: https://github.com/MITRE/kvh_geo_fog_3d.git
+      version: master
+    release:
+      packages:
+      - kvh_geo_fog_3d
+      - kvh_geo_fog_3d_driver
+      - kvh_geo_fog_3d_msgs
+      - kvh_geo_fog_3d_rviz
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/MITRE/kvh_geo_fog_3d-release.git
+      version: 1.5.1-1
+    source:
+      type: git
+      url: https://github.com/MITRE/kvh_geo_fog_3d.git
+      version: noetic-devel
+     status: maintained
   lanelet2:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3365,7 +3365,7 @@ repositories:
       url: https://github.com/yujinrobot/kobuki_msgs.git
       version: noetic
     status: maintained
-   kvh_geo_fog_3d:
+  kvh_geo_fog_3d:
     doc:
       type: git
       url: https://github.com/MITRE/kvh_geo_fog_3d.git
@@ -3384,7 +3384,7 @@ repositories:
       type: git
       url: https://github.com/MITRE/kvh_geo_fog_3d.git
       version: noetic-devel
-     status: maintained
+    status: maintained
   lanelet2:
     doc:
       type: git


### PR DESCRIPTION
Releasing to noetic. Can't use pull request because oath token isn't working within firewall.
