### PR TITLE
fuse: 0.4.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2218,7 +2218,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/locusrobotics/fuse-release.git
-      version: 0.4.1-1
+      version: 0.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fuse` to `0.4.2-1`:

- upstream repository: https://github.com/locusrobotics/fuse.git
- release repository: https://github.com/locusrobotics/fuse-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.1-1`

## fuse

```
* Adding roslint dependency to fuse_viz (#231 <https://github.com/locusrobotics/fuse/issues/231>)
  * Adding roslint dependency to fuse_viz
  * Silence CMP0048 warnings
* Contributors: Tom Moore
```

## fuse_constraints

```
* Adding roslint dependency to fuse_viz (#231 <https://github.com/locusrobotics/fuse/issues/231>)
  * Adding roslint dependency to fuse_viz
  * Silence CMP0048 warnings
* Contributors: Tom Moore
```

## fuse_core

```
* Adding roslint dependency to fuse_viz (#231 <https://github.com/locusrobotics/fuse/issues/231>)
  * Adding roslint dependency to fuse_viz
  * Silence CMP0048 warnings
* Contributors: Tom Moore
```

## fuse_doc

```
* Adding roslint dependency to fuse_viz (#231 <https://github.com/locusrobotics/fuse/issues/231>)
  * Adding roslint dependency to fuse_viz
  * Silence CMP0048 warnings
* Contributors: Tom Moore
```

## fuse_graphs

```
* Adding roslint dependency to fuse_viz (#231 <https://github.com/locusrobotics/fuse/issues/231>)
  * Adding roslint dependency to fuse_viz
  * Silence CMP0048 warnings
* Contributors: Tom Moore
```

## fuse_loss

```
* Adding roslint dependency to fuse_viz (#231 <https://github.com/locusrobotics/fuse/issues/231>)
  * Adding roslint dependency to fuse_viz
  * Silence CMP0048 warnings
* Contributors: Tom Moore
```

## fuse_models

```
* Adding roslint dependency to fuse_viz (#231 <https://github.com/locusrobotics/fuse/issues/231>)
  * Adding roslint dependency to fuse_viz
  * Silence CMP0048 warnings
* Contributors: Tom Moore
```

## fuse_msgs

```
* Adding roslint dependency to fuse_viz (#231 <https://github.com/locusrobotics/fuse/issues/231>)
  * Adding roslint dependency to fuse_viz
  * Silence CMP0048 warnings
* Contributors: Tom Moore
```

## fuse_optimizers

```
* Adding roslint dependency to fuse_viz (#231 <https://github.com/locusrobotics/fuse/issues/231>)
  * Adding roslint dependency to fuse_viz
  * Silence CMP0048 warnings
* Contributors: Tom Moore
```

## fuse_publishers

```
* Adding roslint dependency to fuse_viz (#231 <https://github.com/locusrobotics/fuse/issues/231>)
  * Adding roslint dependency to fuse_viz
  * Silence CMP0048 warnings
* Contributors: Tom Moore
```

## fuse_variables

```
* Adding roslint dependency to fuse_viz (#231 <https://github.com/locusrobotics/fuse/issues/231>)
  * Adding roslint dependency to fuse_viz
  * Silence CMP0048 warnings
* Contributors: Tom Moore
```

## fuse_viz

```
* Adding roslint dependency to fuse_viz (#231 <https://github.com/locusrobotics/fuse/issues/231>)
  * Adding roslint dependency to fuse_viz
  * Silence CMP0048 warnings
* Contributors: Tom Moore
```
