### PR TITLE
rosbag2: 0.3.8-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3727,7 +3727,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.3.7-1
+      version: 0.3.8-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.3.8-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.7-1`

## ros2bag

- No changes

## rosbag2

- No changes

## rosbag2_compression

- No changes

## rosbag2_converter_default_plugins

- No changes

## rosbag2_cpp

- No changes

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

```
* Handle SIGTERM gracefully in recording (#809 <https://github.com/ros2/rosbag2/issues/809>)
* Contributors: Emerson Knapp
```

## rosbag2_tests

```
* Disable SIGTERM test on Windows in Foxy due to shutdown behavior in tests on that platform. (#818 <https://github.com/ros2/rosbag2/issues/818>)
* Handle SIGTERM gracefully in recording (#809 <https://github.com/ros2/rosbag2/issues/809>)
* Contributors: Emerson Knapp
```

## rosbag2_transport

```
* [backport Foxy] Fixed playing if unknown message types exist (backports #592 <https://github.com/ros2/rosbag2/issues/592>) (#686 <https://github.com/ros2/rosbag2/issues/686>)
* [backport Foxy] More reliable topic remapping test (backports #456 <https://github.com/ros2/rosbag2/issues/456>) (#817 <https://github.com/ros2/rosbag2/issues/817>)
* [backport Foxy] Handle SIGTERM gracefully in recording (#809 <https://github.com/ros2/rosbag2/issues/809>)
* Contributors: Emerson Knapp
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
