### PR TITLE
ros_ign: 0.221.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3668,10 +3668,11 @@ repositories:
       - ros_ign_gazebo
       - ros_ign_gazebo_demos
       - ros_ign_image
+      - ros_ign_interfaces
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 0.221.1-1
+      version: 0.221.2-1
     source:
       test_pull_requests: true
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3660,7 +3660,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ignitionrobotics/ros_ign.git
-      version: ros2
+      version: foxy
     release:
       packages:
       - ros_ign
@@ -3677,7 +3677,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ignitionrobotics/ros_ign.git
-      version: ros2
+      version: foxy
     status: developed
   ros_testing:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_ign` to `0.221.2-1`:

- upstream repository: https://github.com/ignitionrobotics/ros_ign
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.221.1-1`

## ros_ign

- No changes

## ros_ign_bridge

```
* Ignore local publications for ROS 2 subscriber (#146 <https://github.com/osrf/ros_ign/issues/146>)
  - Note: Does not work with all rmw implementations (e.g.: FastRTPS)
* [ros2] Update documentation for installation instructions and bridge examples (#142 <https://github.com/osrf/ros_ign/issues/142>)
* [foxy] Edifice support (#140 <https://github.com/osrf/ros_ign/issues/140>)
* [ros2] Add JointTrajectory message conversion (#121 <https://github.com/osrf/ros_ign/issues/121>)
  Conversion between
  - ignition::msgs::JointTrajectory
  - trajectory_msgs::msg::JointTrajectory
* Add TFMessage / Pose_V and Float64 / Double conversions (#117 <https://github.com/osrf/ros_ign/issues/117>)
  Addresses issue #116 <https://github.com/osrf/ros_ign/issues/116>
* updated prereq & branch name (#113 <https://github.com/osrf/ros_ign/issues/113>)
* [ros2] Update releases (#108 <https://github.com/osrf/ros_ign/issues/108>)
* Updated README.md (#104 <https://github.com/osrf/ros_ign/issues/104>)
* Add support for Dome (#103 <https://github.com/osrf/ros_ign/issues/103>)
* Contributors: Alejandro Hernández Cordero, Andrej Orsula, Florent Audonnet, Jenn, Louise Poubel, Luca Della Vedova
```

## ros_ign_gazebo

```
* [foxy] Edifice support (#140 <https://github.com/osrf/ros_ign/issues/140>)
* Add topic flag to create robot  (#128 <https://github.com/osrf/ros_ign/issues/128>)
  Now it is possible to run ros_ign_gazebo create specifying a topic as
  source of the robot description
  Add a launch file starting a ignition gazebo world and spawn a sphere in it.
  Additionally a rviz2 interface is loaded to show that also Rviz can load
  the robot description
  The newly created demo introduce a dependency on the robot_state_publisher package
* Add default value for plugin path in launch script (#125 <https://github.com/osrf/ros_ign/issues/125>)
* Fix overwriting of plugin path in launch script (#122 <https://github.com/osrf/ros_ign/issues/122>)
  - IGN_GAZEBO_SYSTEM_PLUGIN_PATH was overwritten by LD_LIBRARY_PATH
  - Now it is instead extended by LD_LIBRARY_PATH
  - This allows use of ign_gazebo.launch.py with custom gazebo plugins
* Changed for loading xml from ROS param(#119 <https://github.com/osrf/ros_ign/issues/119>) (#120 <https://github.com/osrf/ros_ign/issues/120>)
* ros_ign_gazebo exec depend on ign-gazebo (#110 <https://github.com/osrf/ros_ign/issues/110>)
* [ros2] Update releases (#108 <https://github.com/osrf/ros_ign/issues/108>)
* Add support for Dome (#103 <https://github.com/osrf/ros_ign/issues/103>)
* Contributors: Andrej Orsula, Louise Poubel, Luca Della Vedova, Valerio Magnago, chama1176
```

## ros_ign_gazebo_demos

```
* Joint states tutorial (#156 <https://github.com/osrf/ros_ign/issues/156>)
  Adds an rrbot model to demos and shows the usage of joint_states plugin.
* [ros2] Minor updates for demos (#144 <https://github.com/osrf/ros_ign/issues/144>)
  * Re-enable air pressure demo
  - Resolves https://github.com/ignitionrobotics/ros_ign/issues/78
  * Add RQt topic viewer to IMU demo
  * Add image_topic argument for image_bridge demo
  * Do not normalize depth image in RViz2
* [foxy] Edifice support (#140 <https://github.com/osrf/ros_ign/issues/140>)
* Add topic flag to create robot  (#128 <https://github.com/osrf/ros_ign/issues/128>)
  Now it is possible to run ros_ign_gazebo create specifying a topic as
  source of the robot description
  Add a launch file starting a ignition gazebo world and spawn a sphere in it.
  Additionally a rviz2 interface is loaded to show that also Rviz can load
  the robot description
  The newly created demo introduce a dependency on the robot_state_publisher package
* [ros2] Update releases (#108 <https://github.com/osrf/ros_ign/issues/108>)
* Contributors: Andrej Orsula, Louise Poubel, Valerio Magnago, Vatan Aksoy Tezer
```

## ros_ign_image

```
* Fix Deprecation Warning (#158 <https://github.com/osrf/ros_ign/issues/158>)
* [foxy] Edifice support (#140 <https://github.com/osrf/ros_ign/issues/140>)
* [ros2] Update releases (#108 <https://github.com/osrf/ros_ign/issues/108>)
* Add support for Dome (#103 <https://github.com/osrf/ros_ign/issues/103>)
* Contributors: David V. Lu!!, Louise Poubel, Luca Della Vedova
```

## ros_ign_interfaces

```
* [ros2]  new package ros_ign_interfaces, provide some  Ignition-specific ROS messages. (#152 <https://github.com/osrf/ros_ign/issues/152>)
  * add new package ros_ign_interfaces,provide some Ignition-specific ros .msg and .srv files
* Contributors: gezp
```
