### PR TITLE
ros_ign: 0.233.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2903,10 +2903,11 @@ repositories:
       - ros_ign_gazebo
       - ros_ign_gazebo_demos
       - ros_ign_image
+      - ros_ign_interfaces
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 0.233.1-5
+      version: 0.233.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_ign` to `0.233.2-1`:

- upstream repository: https://github.com/ignitionrobotics/ros_ign
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.233.1-5`

## ros_ign

- No changes

## ros_ign_bridge

```
* [ros2] Update version docs, add Galactic and Fortress (#164 <https://github.com/osrf/ros_ign/issues/164>)
* Contributors: Louise Poubel
```

## ros_ign_gazebo

```
* [ros2] Update version docs, add Galactic and Fortress (#164 <https://github.com/osrf/ros_ign/issues/164>)
* Contributors: Louise Poubel
```

## ros_ign_gazebo_demos

```
* [ros2] Add exec depend on xacro for demos (#170 <https://github.com/osrf/ros_ign/issues/170>)
* [ros2] Update version docs, add Galactic and Fortress (#164 <https://github.com/osrf/ros_ign/issues/164>)
* Joint states tutorial (#156 <https://github.com/osrf/ros_ign/issues/156>)
  Adds an rrbot model to demos and shows the usage of joint_states plugin.
* Contributors: Louise Poubel, Vatan Aksoy Tezer
```

## ros_ign_image

```
* [ros2] Update version docs, add Galactic and Fortress (#164 <https://github.com/osrf/ros_ign/issues/164>)
* Fix Deprecation Warning (#158 <https://github.com/osrf/ros_ign/issues/158>)
* Contributors: David V. Lu!!, Louise Poubel
```

## ros_ign_interfaces

```
* [ros2]  new package ros_ign_interfaces, provide some  Ignition-specific ROS messages. (#152 <https://github.com/osrf/ros_ign/issues/152>)
  * add new package ros_ign_interfaces,provide some Ignition-specific ros .msg and .srv files
  * modify to match ign-msgs
  * add author info
  * modify comments
  * update code and doc style
* Contributors: gezp
```
