### PR TITLE
ackermann_msgs: 2.0.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -19,6 +19,17 @@ repositories:
       url: https://gitlab.com/autowarefoundation/autoware.auto/acado_vendor.git
       version: main
     status: maintained
+  ackermann_msgs:
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/ackermann_msgs-release.git
+      version: 2.0.2-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/ackermann_msgs.git
+      version: ros2
+    status: maintained
   ament_cmake:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ackermann_msgs` to `2.0.2-1`:

- upstream repository: https://github.com/ros-drivers/ackermann_msgs.git
- release repository: https://github.com/ros-drivers-gbp/ackermann_msgs-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ackermann_msgs

```
* missing std msg dependency
* Contributors: Rousseau Vincent
```
