### PR TITLE
pilz_robots: 0.5.23-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8600,7 +8600,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_robots-release.git
-      version: 0.5.22-1
+      version: 0.5.23-1
     source:
       type: git
       url: https://github.com/PilzDE/pilz_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_robots` to `0.5.23-1`:

- upstream repository: https://github.com/PilzDE/pilz_robots.git
- release repository: https://github.com/PilzDE/pilz_robots-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.5.22-1`

## pilz_control

- No changes

## pilz_robots

- No changes

## pilz_status_indicator_rqt

- No changes

## prbt_gazebo

- No changes

## prbt_hardware_support

- No changes

## prbt_ikfast_manipulator_plugin

- No changes

## prbt_moveit_config

```
* Allow usage of deprecated pilz_command_planner
* Contributors: Pilz GmbH and Co. KG
```

## prbt_support

- No changes
