### PR TITLE
four_wheel_steering_msgs: 2.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -775,6 +775,17 @@ repositories:
       url: https://github.com/eProsima/foonathan_memory_vendor.git
       version: master
     status: maintained
+  four_wheel_steering_msgs:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/four_wheel_steering_msgs-release.git
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/four_wheel_steering_msgs.git
+      version: ros2
+    status: maintained
   gazebo_ros_pkgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `four_wheel_steering_msgs` to `2.0.1-1`:

- upstream repository: https://github.com/ros-drivers/four_wheel_steering_msgs.git
- release repository: https://github.com/ros-drivers-gbp/four_wheel_steering_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## four_wheel_steering_msgs

```
* 2.0.0
* Add architecture_independent tag
* Remove linter tests directive
* Migrate to ROS2
* Contributors: Marcel Zeilinger
```
