### PR TITLE
realsense_hardware_interface: 0.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3137,6 +3137,21 @@ repositories:
       url: https://github.com/IntelRealSense/realsense-ros.git
       version: ros2
     status: developed
+  realsense_hardware_interface:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/realsense_hardware_interface.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/OUXT-Polaris/realsense_hardware_interface-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/realsense_hardware_interface.git
+      version: master
+    status: developed
   realtime_support:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense_hardware_interface` to `0.0.1-1`:

- upstream repository: https://github.com/OUXT-Polaris/realsense_hardware_interface.git
- release repository: https://github.com/OUXT-Polaris/realsense_hardware_interface-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## realsense_hardware_interface

```
* add depends
* enable pass test
* enable print device infomation
* fix error
* enable specify serial
* apply reformat
* enable encode as color image
* fix error
* fix errors
* add qos option
* rename rviz package
* update rviz
* enable get image
* enable subscribe image
* fix size
* add util.cpp
* apply reformat
* enable transport image as shared memory
* add poco key param
* add frameToSet function
* update depends
* add poco to the depends
* enable get w value
* apply reformat
* fix problems in getting angular velocity
* add rviz file
* enable publish odom
* enable get odom message
* add depends
* apply reformat
* add angular acceleration interface
* enable passing rs2_pose
* enable load controller plugin
* add rs2_pose_publisher
* add getValue memnber function
* remove reference from member
* add handler to the interface
* enable export interface from handle struct
* add PoseHandle
* add data handle
* remove proto files
* add proto definition
* add toMsg functions
* modify cmake
* remove unused process
* use librealsense
* add some configuration
* add URDF
* apply reformat
* add .gitignore
* enable recieve values
* initial commit
* Contributors: Masaya Kataoka
```
