### PR TITLE
data_buffer: 0.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -646,6 +646,21 @@ repositories:
       url: https://github.com/eclipse-cyclonedds/cyclonedds.git
       version: releases/0.7.x
     status: maintained
+  data_buffer:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/data_buffer.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/OUXT-Polaris/data_buffer-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/data_buffer.git
+      version: master
+    status: developed
   demos:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `data_buffer` to `0.0.1-1`:

- upstream repository: https://github.com/OUXT-Polaris/data_buffer.git
- release repository: https://github.com/OUXT-Polaris/data_buffer-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## data_buffer

```
* Merge pull request #8 <https://github.com/OUXT-Polaris/data_buffer/issues/8> from OUXT-Polaris/workflow/galactic
  update CI workflow for galactic
* update .github/workflows/ROS2-Galactic.yaml
* Merge pull request #7 <https://github.com/OUXT-Polaris/data_buffer/issues/7> from OUXT-Polaris/fix/test
  enable pass cpplint
* enable pass cpplint
* Merge pull request #6 <https://github.com/OUXT-Polaris/data_buffer/issues/6> from OUXT-Polaris/workflow/dashing
  update CI workflow for dashing
* update .github/workflows/ROS2-Dashing.yaml
* Merge pull request #5 <https://github.com/OUXT-Polaris/data_buffer/issues/5> from OUXT-Polaris/workflow/dashing
  update CI workflow for dashing
* Merge pull request #4 <https://github.com/OUXT-Polaris/data_buffer/issues/4> from OUXT-Polaris/workflow/foxy
* update .github/workflows/ROS2-Dashing.yaml
* update dependency.repos
* update .github/workflows/ROS2-Foxy.yaml
* update dependency.repos
* update buffer base
* add .gitignore
* add code check
* Create main.yml
* Delete main.yml
* Create main.yml
* change to shared_ptr
* fix constructor
* update ERROR function
* add ament_export_include_directories(include)
* porting to ROS2
* add exception
* initial commit
* Contributors: HansRobo, Masaya Kataoka, robotx_buildfarm
```
