### PR TITLE
rclcpp: 11.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2147,7 +2147,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 11.1.0-1
+      version: 11.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `11.2.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `11.1.0-1`

## rclcpp

```
* Support to defer to send a response in services. (#1709 <https://github.com/ros2/rclcpp/issues/1709>)
  Signed-off-by: Ivan Santiago Paunovic <mailto:ivanpauno@ekumenlabs.com>
* Fix documentation bug. (#1719 <https://github.com/ros2/rclcpp/issues/1719>)
  Signed-off-by: William Woodall <mailto:william@osrfoundation.org>
* Contributors: Ivan Santiago Paunovic, William Woodall
```

## rclcpp_action

- No changes

## rclcpp_components

```
* Deprecate method names that use CamelCase in rclcpp_components. (#1716 <https://github.com/ros2/rclcpp/issues/1716>)
* Contributors: Rebecca Butler
```

## rclcpp_lifecycle

- No changes
