### PR TITLE
udp_com: 1.1.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8598,7 +8598,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/flynneva/udp_com-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/continental/udp_com.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8593,7 +8593,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/continental/udp_com.git
-      version: ros1/main
+      version: main
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -8602,7 +8602,7 @@ repositories:
     source:
       type: git
       url: https://github.com/continental/udp_com.git
-      version: ros1/main
+      version: main
     status: maintained
   ueye_cam:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `udp_com` to `1.1.2-1`:

- upstream repository: https://github.com/continental/udp_com.git
- release repository: https://github.com/flynneva/udp_com-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.1-1`

## udp_com

```
* update release ci
* update ros1 ci
* fix launch file, use namespace arg
* add note about future work
* remove note about open PRs
* added ros buildfarm status to readme
* update package description
* remove unnecessary step
* update doxyfile
* add note about releases
* fix ubuntu links
* update README with other ROS distros
* trying a different checkout method
* Contributors: Evan Flynn
```
