### PR TITLE
ros: 1.15.8-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6413,7 +6413,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.15.7-1
+      version: 1.15.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.15.8-1`:

- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.15.7-1`

## mk

```
* Update maintainers (#272 <https://github.com/ros/ros/issues/272>)
* Contributors: Jacob Perron
```

## rosbash

```
* Fix variable name (from $arg to $argv) in rosfish (#279 <https://github.com/ros/ros/issues/279>)
* Update maintainers (#272 <https://github.com/ros/ros/issues/272>)
* Contributors: Jacob Perron, Yuma Hiramatsu
```

## rosboost_cfg

```
* Update maintainers (#272 <https://github.com/ros/ros/issues/272>)
* Contributors: Jacob Perron
```

## rosbuild

```
* Fix spelling (#277 <https://github.com/ros/ros/issues/277>)
* Update maintainers (#272 <https://github.com/ros/ros/issues/272>)
* Contributors: Jacob Perron, freddii
```

## rosclean

```
* Update maintainers (#272 <https://github.com/ros/ros/issues/272>)
* Contributors: Jacob Perron
```

## roscreate

```
* Update maintainers (#272 <https://github.com/ros/ros/issues/272>)
* Contributors: Jacob Perron
```

## roslang

```
* Update maintainers (#272 <https://github.com/ros/ros/issues/272>)
* Contributors: Jacob Perron
```

## roslib

```
* Fix spelling (#277 <https://github.com/ros/ros/issues/277>)
* Update maintainers (#272 <https://github.com/ros/ros/issues/272>)
* Contributors: Jacob Perron, freddii
```

## rosmake

```
* Fix spelling (#277 <https://github.com/ros/ros/issues/277>)
* Update maintainers (#272 <https://github.com/ros/ros/issues/272>)
* Contributors: Jacob Perron, freddii
```

## rosunit

```
* Gracefully handle missing time attribute in testcase XML element (#283 <https://github.com/ros/ros/issues/283>)
* Fix spelling (#277 <https://github.com/ros/ros/issues/277>)
* Update maintainers (#272 <https://github.com/ros/ros/issues/272>)
* Contributors: Jacob Perron, Romain Reignier, freddii
```
