### PR TITLE
view_controller_msgs: 0.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -14195,7 +14195,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/view_controller_msgs.git
-      version: lunar-devel
+      version: noetic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -14205,7 +14205,7 @@ repositories:
       type: git
       url: https://github.com/ros-visualization/view_controller_msgs.git
       version: noetic-devel
-    status: unmaintained
+    status: maintained
   vision_msgs:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -14200,7 +14200,11 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/view_controller_msgs-release.git
-      version: 0.1.3-0
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/view_controller_msgs.git
+      version: noetic-devel
     status: unmaintained
   vision_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `view_controller_msgs` to `0.2.0-1`:

- upstream repository: https://github.com/ros-visualization/view_controller_msgs.git
- release repository: https://github.com/ros-gbp/view_controller_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.3-0`

## view_controller_msgs

```
* add new status badge
* remove ci badge for now
* add gh actions for noetic and melodic
* major version bump since added new msgs
* Merge pull request #8 <https://github.com/ros-visualization/view_controller_msgs/issues/8> from Razlaw/camera_trajectories
  add messages to support moving view camera along trajectory
* add CameraMovement and CameraTrajectory messages to support moving view camera along trajectory
* take over maintenance from orphaned package group (#7 <https://github.com/ros-visualization/view_controller_msgs/issues/7>)
* Contributors: Evan Flynn, razlaw
```
