### PR TITLE
view_controller_msgs: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8950,7 +8950,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/view_controller_msgs-release.git
-      version: 0.1.3-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/view_controller_msgs.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8945,7 +8945,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/view_controller_msgs.git
-      version: lunar-devel
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -8954,8 +8954,8 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/view_controller_msgs.git
-      version: lunar-devel
-    status: unmaintained
+      version: noetic-devel
+    status: maintained
   vision_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `view_controller_msgs` to `0.2.0-1`:

- upstream repository: https://github.com/ros-visualization/view_controller_msgs.git
- release repository: https://github.com/ros-gbp/view_controller_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.3-1`

## view_controller_msgs

```
* add new status badge
* remove ci badge for now
* add gh actions for noetic and melodic
* major version bump since added new msgs
* Merge pull request #8 <https://github.com/ros-visualization/view_controller_msgs/issues/8> from Razlaw/camera_trajectories
  add messages to support moving view camera along trajectory
* add CameraMovement and CameraTrajectory messages to support moving view camera along trajectory
* take over maintenance from orphaned package group (#7 <https://github.com/ros-visualization/view_controller_msgs/issues/7>)
* Contributors: Evan Flynn, razlaw
```
