### PR TITLE
rmw_gurumdds: 1.0.8-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3314,7 +3314,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
-      version: 1.0.7-1
+      version: 1.0.8-1
     source:
       type: git
       url: https://github.com/ros2/rmw_gurumdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_gurumdds` to `1.0.8-1`:

- upstream repository: https://github.com/ros2/rmw_gurumdds.git
- release repository: https://github.com/ros2-gbp/rmw_gurumdds-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.7-1`

## rmw_gurumdds_cpp

```
* Remove datareader listener patch
* Remove unnecessary operation
* Contributors: Kumazuma, Youngjin Yun
```

## rmw_gurumdds_shared_cpp

```
* Remove datareader listener patch
* Remove attached waitset conditions on destructor
* Remove unnecessary operation
* Contributors: Kumazuma, Youngjin Yun
```
