### PR TITLE
usb_cam: 0.4.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5140,6 +5140,21 @@ repositories:
       url: https://github.com/ros-drivers/urg_node_msgs.git
       version: master
     status: maintained
+  usb_cam:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/usb_cam.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros-gbp/usb_cam-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/usb_cam.git
+      version: ros2
+    status: maintained
   v4l2_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `usb_cam` to `0.4.0-1`:

- upstream repository: https://github.com/ros-drivers/usb_cam.git
- release repository: https://github.com/ros-gbp/usb_cam-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## usb_cam

```
* bump version for ros2 first release
* add galactic to ci, closes #157 <https://github.com/ros-drivers/usb_cam/issues/157>
  update camera name
* Merge pull request #158 <https://github.com/ros-drivers/usb_cam/issues/158> from wep21/feature/add_camera_info
  Feature/add camera info
* Add sample camera info yaml
* Add camera info
* Merge pull request #156 <https://github.com/ros-drivers/usb_cam/issues/156> from wep21/feature/composable_node
* Make usb_cam_node composable
* Merge pull request #153 <https://github.com/ros-drivers/usb_cam/issues/153> from flynneva/lint/make-utils-file
* add utils file, fix lint errors
* Merge pull request #151 <https://github.com/ros-drivers/usb_cam/issues/151> from flynneva/fix/remove-boost
* replace boost lexical_cast with snprintf
* Merge pull request #149 <https://github.com/ros-drivers/usb_cam/issues/149> from flynneva/fix/update-readme
  fix readme headers
* fix readme headers
* Merge pull request #148 <https://github.com/ros-drivers/usb_cam/issues/148> from flynneva/update-ros2-readme-and-lint
  Update ros2 readme and lint
* fix most lint errors
* update readme, fix linter errors
* Merge pull request #146 <https://github.com/ros-drivers/usb_cam/issues/146> from flynneva/ros2-clean-up
  Ros2 clean up
* fix show_image script lag
* run, launch and params file working
* add service, install launch, separate header
* Merge pull request #139 <https://github.com/ros-drivers/usb_cam/issues/139> from flynneva/cmake-cleanup
  consolidate srcs, use ament_auto macros, closes #138 <https://github.com/ros-drivers/usb_cam/issues/138>
* consolidate srcs, use ament_auto macros, closes #137 <https://github.com/ros-drivers/usb_cam/issues/137> #138 <https://github.com/ros-drivers/usb_cam/issues/138>
* Merge pull request #132 <https://github.com/ros-drivers/usb_cam/issues/132> from flynneva/foxy
  updates for foxy
* add myself to authors
* fixing lint errors
* add ros2 github actions
* minor updates to foxy
* adding launch file
  try to fix low framerate #103 <https://github.com/ros-drivers/usb_cam/issues/103>
  add ros parameters
  loading more parameters from parameter server #103 <https://github.com/ros-drivers/usb_cam/issues/103>
  use argparse to get arguments from command line
  untested correction to args
  ignore unknown args
  set proper default device and look for more bad return values
  trying to find why framerate is limited to about 8 fps
  framerate ok for low-exposure settings
  print list of valid formats #105 <https://github.com/ros-drivers/usb_cam/issues/105>
* use the v4l2_buffer timestamp if available. #75 <https://github.com/ros-drivers/usb_cam/issues/75>
  usb_cam.cpp is building but untested #103 <https://github.com/ros-drivers/usb_cam/issues/103>
  Builds but crashes immediately after running
  data is getting published, no image shown
  image shown, frame rate is very slow #103 <https://github.com/ros-drivers/usb_cam/issues/103>
* move the timestamping closer to when the image was acquired. #75 <https://github.com/ros-drivers/usb_cam/issues/75>
* Merge pull request #136 <https://github.com/ros-drivers/usb_cam/issues/136> from flynneva/patch-1
  add myself as a maintainer for ros2
* add myself as a maintainer for ros2
* Merge pull request #124 <https://github.com/ros-drivers/usb_cam/issues/124> from k-okada/add_noetic
  add noetic .travis.yml
* add noetic .travis.yml
* Contributors: Evan Flynn, Kei Okada, Lucas Walter, flynneva, wep21
```
