### PR TITLE
pilz_industrial_motion: 0.4.14-1 in 'melodic/distribution.yaml' [bloom][EOL]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8580,7 +8580,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_industrial_motion-release.git
-      version: 0.4.12-1
+      version: 0.4.14-1
     source:
       type: git
       url: https://github.com/PilzDE/pilz_industrial_motion.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8585,7 +8585,8 @@ repositories:
       type: git
       url: https://github.com/PilzDE/pilz_industrial_motion.git
       version: melodic-devel
-    status: developed
+    status: end-of-life
+    status_description: The pilz planner has been integrated into moveit. See https://moveit.ros.org/documentation/planners/
   pilz_robots:
     doc:
       type: git
@@ -8609,7 +8610,7 @@ repositories:
       type: git
       url: https://github.com/PilzDE/pilz_robots.git
       version: melodic-devel
-    status: developed
+    status: end-of-life
   pincher_arm:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_industrial_motion` to `0.4.14-1`:

- upstream repository: https://github.com/PilzDE/pilz_industrial_motion.git
- release repository: https://github.com/PilzDE/pilz_industrial_motion-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.12-1`

Change status to `end-of-life` for `pilz_industrial_motion `& `pilz_robots`

## pilz_extensions

```
* Deprecate this package since the planner has been integrated into [moveit](https://moveit.ros.org/documentation/planners/).
* Contributors: Pilz GmbH and Co. KG
```

## pilz_industrial_motion

```
* Revert removing pilz_extension and pilz_trajectory_generation, but deprecate it.
* Contributors: Pilz GmbH and Co. KG
```

## pilz_robot_programming

- No changes

## pilz_store_positions

- No changes

## pilz_trajectory_generation

```
* Deprecate this package since the planner has been integrated into [moveit](https://moveit.ros.org/documentation/planners/).
* Contributors: Pilz GmbH and Co. KG
```
