### PR TITLE
Added python3-smbus rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7773,6 +7773,13 @@ python3-sklearn:
     pip:
       packages: [scikit-learn]
   ubuntu: [python3-sklearn]
+python3-smbus:
+  arch: [i2c-tools]
+  debian: [python3-smbus]
+  fedora: [i2c-tools]
+  gentoo: [i2c-tools]
+  opensuse: [i2c-tools]
+  ubuntu: [python3-smbus]
 python3-smbus2-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7777,7 +7777,6 @@ python3-smbus:
   arch: [i2c-tools]
   debian: [python3-smbus]
   fedora: [python3-i2c-tools]
-  gentoo: [i2c-tools]
   opensuse: [python3-smbus]
   ubuntu: [python3-smbus]
 python3-smbus2-pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7776,7 +7776,7 @@ python3-sklearn:
 python3-smbus:
   arch: [i2c-tools]
   debian: [python3-smbus]
-  fedora: [i2c-tools]
+  fedora: [python3-i2c-tools]
   gentoo: [i2c-tools]
   opensuse: [i2c-tools]
   ubuntu: [python3-smbus]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7778,7 +7778,7 @@ python3-smbus:
   debian: [python3-smbus]
   fedora: [python3-i2c-tools]
   gentoo: [i2c-tools]
-  opensuse: [i2c-tools]
+  opensuse: [python3-smbus]
   ubuntu: [python3-smbus]
 python3-smbus2-pip:
   debian:


### PR DESCRIPTION
-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-smbus

## Package Upstream Source:

https://git.kernel.org/pub/scm/utils/i2c-tools/i2c-tools.git/

## Purpose of using this:

To enable i2c communication using Python. 

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/buster/python3-smbus
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/focal/python3-smbus
   - REQUIRED
- Fedora: https://src.fedoraproject.org/rpms/i2c-tools
  - IF AVAILABLE
- Arch: https://archlinux.org/packages/community/x86_64/i2c-tools/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/packages/sys-apps/i2c-tools
  - IF AVAILABLE

It appears that only Debian and Ubuntu package this separately, other distros seem to have the Python bindings as part of the `i2c-tools` package, so I depended on that.
