### PR TITLE
web_video_server: 0.2.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9159,6 +9159,21 @@ repositories:
       url: https://github.com/ros-planning/warehouse_ros_mongo.git
       version: noetic-devel
     status: maintained
+  web_video_server:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/web_video_server.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/RobotWebTools-release/web_video_server-release.git
+      version: 0.2.2-1
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/web_video_server.git
+      version: master
+    status: unmaintained
   webkit_dependency:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `web_video_server` to `0.2.2-1`:

- upstream repository: https://github.com/RobotWebTools/web_video_server.git
- release repository: https://github.com/RobotWebTools-release/web_video_server-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## web_video_server

```
* fix vp9 and h264, support for opencv4 and ffmpeg 4 (#103 <https://github.com/RobotWebTools/web_video_server/issues/103>)
* add a mention of mjpegcanvasjs in the readme (#100 <https://github.com/RobotWebTools/web_video_server/issues/100>)
* fix multipart_stream.cpp HttpHeader values in order to solve DOMException(cross origin) CORS issue (#92 <https://github.com/RobotWebTools/web_video_server/issues/92>)
* Contributors: Gady, okapi1125, randoms
```
