### PR TITLE
Remove failing release of marti_messages.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1359,7 +1359,6 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/marti_messages-release.git
-      version: 1.1.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
This repository's packages are failing to build due to the upstream issue https://github.com/swri-robotics/marti_messages/issues/112. A future release is likely to resolve the issue allowing this package to be built again.