### PR TITLE
rosidl_typesupport_fastrtps: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3090,7 +3090,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-      version: 1.2.1-1
+      version: 2.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_fastrtps` to `2.0.0-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.1-1`

## fastrtps_cmake_module

- No changes

## rosidl_typesupport_fastrtps_c

```
* Bundle and ensure the exportation of rosidl generated targets (#73 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/73>)
* Fix Fast-RTPS C++ typesupport CLI extension (#72 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/72>)
* Fastdds type support extensions (#67 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/67>)
* Remove fastrtps dependency (#68 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/68>)
* Contributors: Andrea Sorbini, Michel Hidalgo, Miguel Company
```

## rosidl_typesupport_fastrtps_cpp

```
* Bundle and ensure the exportation of rosidl generated targets (#73 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/73>)
* Fix Fast-RTPS C++ typesupport CLI extension (#72 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/72>)
* Fastdds type support extensions (#67 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/67>)
* Remove fastrtps dependency (#68 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/68>)
* Contributors: Andrea Sorbini, Michel Hidalgo, Miguel Company
```
