### PR TITLE
Disable plotjuggler_ros release in Rolling.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1828,7 +1828,6 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
-      version: 1.5.0-1
     source:
       type: git
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git


### PR DESCRIPTION
This release is failing due to the upstream issue. https://github.com/PlotJuggler/plotjuggler-ros-plugins/issues/26

A future release will likely resolve this issue.