### PR TITLE
robot_localization: 2.6.11-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10191,7 +10191,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/cra-ros-pkg/robot_localization-release.git
-      version: 2.6.10-1
+      version: 2.6.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `2.6.11-1`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/cra-ros-pkg/robot_localization-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.6.10-1`

## robot_localization

```
* Prevent node from crashing on invalid UTM zone, but throw ROS_ERROR to notify user (#683 <https://github.com/cra-ros-pkg/robot_localization/issues/683>)
* Contributors: MCFurry
```
