### PR TITLE
robot_localization: 2.7.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6253,7 +6253,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/cra-ros-pkg/robot_localization-release.git
-      version: 2.7.2-1
+      version: 2.7.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `2.7.3-1`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/cra-ros-pkg/robot_localization-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.7.2-1`

## robot_localization

```
* Prevent node from crashing on invalid UTM zone, but throw ROS_ERROR to notify user (#682 <https://github.com/cra-ros-pkg/robot_localization/issues/682>)
* changed geographiclib to <depend> tag (#684 <https://github.com/cra-ros-pkg/robot_localization/issues/684>)
* Small formatting and content change (#677 <https://github.com/cra-ros-pkg/robot_localization/issues/677>)
* Fixed state transition for sigma points. The state transition function for each sigma point now uses its sigma point's posteriori state instead of always the posteriori state. (#628 <https://github.com/cra-ros-pkg/robot_localization/issues/628>)
  Co-authored-by: jola6897 <mailto:jola6897@users.noreply.github.com>
* Contributors: John Stechschulte, Jonas, MCFurry, Vivek Mhatre
```
