### PR TITLE
Add python3-flask rule for RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6366,6 +6366,7 @@ python3-flask:
   fedora: [python3-flask]
   gentoo: [dev-python/flask]
   nixos: [python3Packages.flask]
+  rhel: [python3-flask]
   ubuntu: [python3-flask]
 python3-flask-cors:
   debian: [python3-flask-cors]


### PR DESCRIPTION
This package is provided in EPEL for both RHEL 7 and 8: https://src.fedoraproject.org/rpms/python3-flask#bodhi_updates