### PR TITLE
soccer_visualization: 0.0.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3607,6 +3607,23 @@ repositories:
       url: https://github.com/ijnek/soccer_interfaces.git
       version: main
     status: developed
+  soccer_visualization:
+    doc:
+      type: git
+      url: https://github.com/ijnek/soccer_visualization.git
+      version: main
+    release:
+      packages:
+      - soccer_marker_generation
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ijnek/soccer_visualization-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/ijnek/soccer_visualization.git
+      version: main
+    status: developed
   spdlog_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `soccer_visualization` to `0.0.1-1`:

- upstream repository: https://github.com/ijnek/soccer_visualization.git
- release repository: https://github.com/ijnek/soccer_visualization-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
