### PR TITLE
ublox_dgnss: 0.2.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3977,7 +3977,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/aussierobots/ublox_dgnss-release.git
-      version: 0.2.2-1
+      version: 0.2.3-1
     source:
       type: git
       url: https://github.com/aussierobots/ublox_dgnss.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ublox_dgnss` to `0.2.3-1`:

- upstream repository: https://github.com/aussierobots/ublox_dgnss
- release repository: https://github.com/aussierobots/ublox_dgnss-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.2-1`
