### PR TITLE
realsense2_camera: 3.2.2-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2394,7 +2394,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
-      version: 3.2.2-1
+      version: 3.2.2-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `3.2.2-2`:

- upstream repository: https://github.com/IntelRealSense/realsense-ros.git
- release repository: https://github.com/IntelRealSense/realsense-ros-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.2.2-1`

## realsense2_camera

```
* Support Galactic and Rolling
* Fix reading yaml config file
* No tf broadcaster object if publish_tf is set to false
* Add udev-rules installation to debian
* update ros2 launch examples (demo_t265_launch.py, rs_t265_launch.py, demo_pointcloud_launch.py)
* fix rs_multi_camera_launch.py to include default separate node names.
* Add support for L535
* QoS parameters to be applied for all publishers
* Imu_default QoS changed to hid_default
* Pointcloud_default and info_default QoS changed to qos_default
* Contributors: Guillaume Doisy, TSC21, anaelle, doronhi
```

## realsense2_camera_msgs

- No changes

## realsense2_description

```
* Added imu frames to _l515.urdf.xacro
* Add conditional param use_mesh
* Add demo_pointcloud_launch.py
* Contributors: Simon Honigmann, doronhi
```
