### PR TITLE
rtcm_msgs: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12054,6 +12054,17 @@ repositories:
       url: https://github.com/introlab/rtabmap_ros.git
       version: melodic-devel
     status: maintained
+  rtcm_msgs:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/nobleo/rtcm_msgs-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/tilk/rtcm_msgs.git
+      version: master
+    status: maintained
   rtctree:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtcm_msgs` to `1.0.0-1`:

- upstream repository: https://github.com/tilk/rtcm_msgs.git
- release repository: https://github.com/nobleo/rtcm_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
