### PR TITLE
rclcpp: 12.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2167,7 +2167,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 11.2.0-1
+      version: 12.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `12.0.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `11.2.0-1`

## rclcpp

```
* Remove unsafe get_callback_groups API.
  Callers should change to using for_each_callback_group(), or
  store the callback groups they need internally.
* Add in callback_groups_for_each.
  The main reason to add this method in is to make accesses to the
  callback_groups_ vector thread-safe.  By having a
  callback_groups_for_each that accepts a std::function, we can
  just have the callers give us the callback they are interested
  in, and we can take care of the locking.
  The rest of this fairly large PR is cleaning up all of the places
  that use get_callback_groups() to instead use
  callback_groups_for_each().
* Use a different mechanism to avoid timers being scheduled multiple times by the MultiThreadedExecutor (#1692 <https://github.com/ros2/rclcpp/issues/1692>)
* Fix windows CI (#1726 <https://github.com/ros2/rclcpp/issues/1726>)
  Fix bug in AnyServiceCallback introduced in #1709 <https://github.com/ros2/rclcpp/issues/1709>.
* Contributors: Chris Lalancette, Ivan Santiago Paunovic
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* Remove unsafe get_callback_groups API.
  Callers should change to using for_each_callback_group(), or
  store the callback groups they need internally.
* Add in callback_groups_for_each.
  The main reason to add this method in is to make accesses to the
  callback_groups_ vector thread-safe.  By having a
  callback_groups_for_each that accepts a std::function, we can
  just have the callers give us the callback they are interested
  in, and we can take care of the locking.
  The rest of this fairly large PR is cleaning up all of the places
  that use get_callback_groups() to instead use
  callback_groups_for_each().
* Contributors: Chris Lalancette
```
