### PR TITLE
ros2_tracing: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2770,7 +2770,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 2.3.0-1
+      version: 3.0.0-1
     source:
       type: git
       url: https://gitlab.com/ros-tracing/ros2_tracing.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `3.0.0-1`:

- upstream repository: https://gitlab.com/ros-tracing/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.0-1`

## tracetools

```
* Export target on Windows and export an interface if TRACETOOLS_DISABLED
* Remove deprecated utility functions
* Contributors: Christophe Bedard, Ivan Santiago Paunovic
```
