### PR TITLE
turtlebot3_simulations: 2.2.4-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3935,7 +3935,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/robotis-ros2-release/turtlebot3_simulations-release.git
-      version: 2.2.4-1
+      version: 2.2.4-2
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_simulations` to `2.2.4-2`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
- release repository: https://github.com/robotis-ros2-release/turtlebot3_simulations-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.2.4-1`

## turtlebot3_fake_node

```
* Release for ROS2 Galactic
* Clean up unncessary files
* Use turtlebot3_common mesh modeling
* Independent turtlebot3_simulations package
* Contributors: Will Son
```

## turtlebot3_gazebo

```
* Release for ROS2 Galactic
* Separate world and robot models(#162)
* Clean up unncessary files
* Use turtlebot3_common mesh modeling
* Independent turtlebot3_simulations package
* Contributors: Joep Tool, Will Son
```

## turtlebot3_simulations

```
* Release for ROS2 Galactic
* Separate world and robot models(#162)
* Clean up unncessary files
* Use turtlebot3_common mesh modeling
* Independent turtlebot3_simulations package
* Contributors: Joep Tool, Will Son
```
