### PR TITLE
cyglidar_d1: 0.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2069,6 +2069,23 @@ repositories:
       url: https://github.com/OTL/cv_camera.git
       version: master
     status: maintained
+  cyglidar_d1:
+    doc:
+      type: git
+      url: https://github.com/CygLiDAR-ROS/cyglidar_d1.git
+      version: v0.1.2
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/CygLiDAR-ROS/cyglidar_d1-release.git
+      version: 0.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/CygLiDAR-ROS/cyglidar_d1.git
+      version: v0.1.2
+    status: maintained
+    status_description: end-of-life
   dataspeed_can:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cyglidar_d1` to `0.0.2-1`:

- upstream repository: https://github.com/CygLiDAR-ROS/cyglidar_d1.git
- release repository: https://github.com/CygLiDAR-ROS/cyglidar_d1-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
