### PR TITLE
[Python] Voluptous Python 3

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5449,6 +5449,11 @@ python-voluptuous:
   gentoo: [dev-python/voluptuous]
   nixos: [pythonPackages.voluptuous]
   ubuntu: [python-voluptuous]
+python3-voluptuous:
+  debian: [python-voluptuous]
+  fedora: [python-voluptuous]
+  gentoo: [dev-python/voluptuous]
+  ubuntu: [python3-voluptuous]
 python-vtk:
   arch: [vtk]
   debian: [python-vtk]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8041,8 +8041,8 @@ python3-virtualserialports-pip:
     pip:
       packages: [PyVirtualSerialPorts]
 python3-voluptuous:
-  debian: [python-voluptuous]
-  fedora: [python-voluptuous]
+  debian: [python3-voluptuous]
+  fedora: [python3-voluptuous]
   gentoo: [dev-python/voluptuous]
   opensuse: [python-voluptuous]
   rhel:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8045,7 +8045,9 @@ python3-voluptuous:
   fedora: [python-voluptuous]
   gentoo: [dev-python/voluptuous]
   opensuse: [python-voluptuous]
-  rhel: [python3-voluptuous]
+  rhel:
+    '*': [python3-voluptuous]
+    '7': null
   ubuntu: [python3-voluptuous]
 python3-watchdog:
   debian: [python3-watchdog]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5449,11 +5449,6 @@ python-voluptuous:
   gentoo: [dev-python/voluptuous]
   nixos: [pythonPackages.voluptuous]
   ubuntu: [python-voluptuous]
-python3-voluptuous:
-  debian: [python-voluptuous]
-  fedora: [python-voluptuous]
-  gentoo: [dev-python/voluptuous]
-  ubuntu: [python3-voluptuous]
 python-vtk:
   arch: [vtk]
   debian: [python-vtk]
@@ -8045,6 +8040,12 @@ python3-virtualserialports-pip:
   ubuntu:
     pip:
       packages: [PyVirtualSerialPorts]
+python3-voluptuous:
+  debian: [python-voluptuous]
+  fedora: [python-voluptuous]
+  gentoo: [dev-python/voluptuous]
+  opensuse: [python-voluptuous]
+  ubuntu: [python3-voluptuous]
 python3-watchdog:
   debian: [python3-watchdog]
   fedora: [python3-watchdog]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8045,6 +8045,7 @@ python3-voluptuous:
   fedora: [python-voluptuous]
   gentoo: [dev-python/voluptuous]
   opensuse: [python-voluptuous]
+  rhel: [python3-voluptuous]
   ubuntu: [python3-voluptuous]
 python3-watchdog:
   debian: [python3-watchdog]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

Voluptous for python3, update to https://github.com/ros/rosdistro/pull/17079

## Package Upstream Source:

https://github.com/alecthomas/voluptuous

## Purpose of using this:

PR to add the JSON validation library Voluptuous. We use this to validate JSON commands coming from external sources (laptop, cloud etc).


## Links to Distribution Packages
Ubuntu: https://packages.ubuntu.com/focal/python3-voluptuous
Fedora: https://src.fedoraproject.org/rpms/python-voluptuous
Debian: https://packages.debian.org/buster/python-voluptuous
Gentoo: https://packages.gentoo.org/packages/dev-python/voluptuous


# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
