### PR TITLE
nao_lola: 0.0.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1593,7 +1593,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ijnek/nao_lola-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/ijnek/nao_lola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_lola` to `0.0.3-1`:

- upstream repository: https://github.com/ijnek/nao_lola.git
- release repository: https://github.com/ijnek/nao_lola-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.2-1`

## nao_lola

```
* add ament_cmake_gtest and boost dependency in package.xml and CMakeLists.txt
* Contributors: Kenji Brameld
```
