### PR TITLE
dynamixel-workbench: 2.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1603,6 +1603,26 @@ repositories:
       url: https://github.com/ros/dynamic_reconfigure.git
       version: noetic-devel
     status: maintained
+  dynamixel-workbench:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
+      version: noetic-devel
+    release:
+      packages:
+      - dynamixel_workbench
+      - dynamixel_workbench_controllers
+      - dynamixel_workbench_operators
+      - dynamixel_workbench_toolbox
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release.git
+      version: 2.2.1-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
+      version: noetic-devel
+    status: maintained
   dynamixel-workbench-msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel-workbench` to `2.2.1-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
- release repository: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## dynamixel_workbench

```
* Added 2XC430-W250, XL330 series
* Contributors: Will Son, t-kitajima, Hye-jong KIM
```

## dynamixel_workbench_controllers

```
* Added 2XC430-W250, XL330 series
* Contributors: Will Son, t-kitajima, Hye-jong KIM
```

## dynamixel_workbench_operators

```
* Added 2XC430-W250, XL330 series
* Contributors: Will Son, t-kitajima, Hye-jong KIM
```

## dynamixel_workbench_toolbox

```
* Added 2XC430-W250, XL330 series
* Contributors: Will Son, t-kitajima, Hye-jong KIM
```
