### PR TITLE
added urdfpy python dep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7991,6 +7991,13 @@ python3-ubjson:
   ubuntu:
     '*': [python3-ubjson]
     xenial: null
+python3-urdfpy-pip:
+  debian:
+    pip:
+      packages: [urdfpy]
+  ubuntu:
+    pip:
+      packages: [urdfpy]
 python3-urllib3:
   debian: [python3-urllib3]
   fedora: [python3-urllib3]


### PR DESCRIPTION


Please add the following dependency to the rosdep database.

## Package name:

urdfpy

## Package Upstream Source:

https://github.com/mmatl/urdfpy

## Purpose of using this:

Urdfpy is a simple and easy-to-use library for loading, manipulating, saving, and visualizing URDF files.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

Available using PIP
- Debian: https://packages.debian.org/
  - pip: urdfpy
- Ubuntu: https://packages.ubuntu.com/
   - pip: urdfpy
- Fedora: https://src.fedoraproject.org/browse/projects/
  - IF AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL



# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
