### PR TITLE
Adding python3 version of gpxpy [python]

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6456,6 +6456,11 @@ python3-gnupg:
   opensuse: [python3-python-gnupg]
   ubuntu: [python3-gnupg]
 python3-google-cloud-texttospeech-pip: *migrate_eol_2025_04_30_python3_google_cloud_texttospeech_pip
+python3-gpxpy:
+  debian: [python3-gpxpy]
+  fedora: [python3-gpxpy]
+  opensuse: [python3-gpxpy]
+  ubuntu: [python3-gpxpy]
 python3-gql-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-gpxpy

## Package Upstream Source:

https://github.com/tkrajina/gpxpy

## Purpose of using this:

We use for this package for reading and writing GPX files in python.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/buster/python3-gpxpy
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/focal/python3-gpxpy
- Fedora: https://src.fedoraproject.org/browse/projects/
  - https://src.fedoraproject.org/rpms/python-gpxpy
- OpenSUSE:
  - https://software.opensuse.org/package/python3-gpxpy


# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
