### PR TITLE
Disable embree_vendor repo in Galactic

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -694,7 +694,6 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/OUXT-Polaris/embree_vendor-release.git
-      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/OUXT-Polaris/embree_vendor.git


### PR DESCRIPTION
It appears that this package did not Bloom successfully, and tags for neither of the supported binary platforms (Ubuntu Focal and RHEL 8) are present.
    
The maintainer of this package can probably just re-release them with a 'debinc' bump. Until then, removing the 'release' version will stop the buildfarm from attempting to build the source package in vain.

The broken release was made in #30197. @hakuturu583, please re-release your package and ensure that the debian generator successfully completes. The RPM generator is not required to complete successfully.