### PR TITLE
robot_body_filter: 1.2.0-4 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6203,7 +6203,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/peci1/robot_body_filter-release.git
-      version: 1.1.9-1
+      version: 1.2.0-4
     source:
       type: git
       url: https://github.com/peci1/robot_body_filter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_body_filter` to `1.2.0-4`:

- upstream repository: https://github.com/peci1/robot_body_filter
- release repository: https://github.com/peci1/robot_body_filter-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.9-1`

## robot_body_filter

```
* Merge pull request #11 <https://github.com/peci1/robot_body_filter/issues/11> from peci1/correct-pointcloud-transforms
  Add possibility to specify pointcloud channels that should be transformed together with positional data.
* Merge pull request #14 <https://github.com/peci1/robot_body_filter/issues/14> from peci1/per_link_scaling
  Add support for scaling/padding each link differently
* Short-circuit classification of NaN points.
* Warn about missing collision elements only for non-ignored links and only if they have at least one visual.
* Fixed bounding shapes computation
* Added filter/max_shadow_distance for great performance increase
* Added possibility to scale/pad collisions separately for computation of bounding box and sphere.
* Unique-ify test target name to allow building with geometric_shapes.
* Use correct Eigen allocator.
* Reflected the newly added support for non-uniformly scaled meshes.
* Contributors: Martin Pecka
```
