### PR TITLE
move_basic: 0.4.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4140,6 +4140,12 @@ repositories:
       url: https://github.com/MarkNaeem/move_base_sequence.git
       version: main
     status: maintained
+  move_basic:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/UbiquityRobotics-release/move_basic-release.git
+      version: 0.4.2-1
   moveit:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_basic` to `0.4.2-1`:

- upstream repository: https://github.com/UbiquityRobotics/move_basic.git
- release repository: https://github.com/UbiquityRobotics-release/move_basic-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## move_basic

```
* Fixes dependencies
* Contributors: Rohan Agrawal, Teo Podobnik
```
