### PR TITLE
Add python3-flask-cors rules for Fedora and RHEL 8

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6370,6 +6370,10 @@ python3-flask:
   ubuntu: [python3-flask]
 python3-flask-cors:
   debian: [python3-flask-cors]
+  fedora: [python3-flask-cors]
+  rhel:
+    '*': [python3-flask-cors]
+    '7': null
   ubuntu: [python3-flask-cors]
 python3-flask-restplus-pip:
   ubuntu:


### PR DESCRIPTION
This package is provided by EPEL for RHEL 8, but is not available for RHEL 7.

https://src.fedoraproject.org/rpms/python-flask-cors#bodhi_updates