### PR TITLE
[python] Adding python3 of pynmea2

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7282,6 +7282,14 @@ python3-pymongo:
   nixos: [python3Packages.pymongo]
   openembedded: [python3-pymongo@meta-python]
   ubuntu: [python3-pymongo]
+python3-pynmea2:
+  debian:
+    pip:
+      packages: [pynmea2]
+  fedora:
+    pip:
+      packages: [pynmea2]
+  ubuntu: [python3-nmea2]
 python3-pyosmium:
   debian: [python3-pyosmium]
   fedora: [python3-osmium]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7283,9 +7283,7 @@ python3-pymongo:
   openembedded: [python3-pymongo@meta-python]
   ubuntu: [python3-pymongo]
 python3-pynmea2:
-  debian:
-    pip:
-      packages: [pynmea2]
+  debian: [python3-nmea2]
   fedora:
     pip:
       packages: [pynmea2]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

pynmea2

## Package Upstream Source:

https://github.com/Knio/pynmea2

## Purpose of using this:

This library is used to parse raw NMEA strings coming from GNSS receivers.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - via pip, https://packages.debian.org/buster/python-nmea2 is way to old and has only python2 support
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/focal/python3-nmea2
- Fedora: https://src.fedoraproject.org/browse/projects/
  - via pip


# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
