### PR TITLE
ROS-MSCL: 1.1.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10,6 +10,23 @@ release_platforms:
   ubuntu:
   - focal
 repositories:
+  ROS-MSCL:
+    release:
+      packages:
+      - mscl_msgs
+      - ros_mscl
+      - ros_mscl_cpp_example
+      - ros_mscl_py_example
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/LORD-MicroStrain/ROS-MSCL-release.git
+      version: 1.1.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/LORD-MicroStrain/ROS-MSCL.git
+      version: develop
+    status: developed
   abb_robot_driver_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ROS-MSCL` to `1.1.4-1`:

- upstream repository: https://github.com/LORD-MicroStrain/ROS-MSCL.git
- release repository: https://github.com/LORD-MicroStrain/ROS-MSCL-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## mscl_msgs

```
* Please see changelog
* Added aiding measurement summary for each GNSS (GQ7 only)
  Added MSCL version output when node starts
* Merge pull request #54 <https://github.com/LORD-MicroStrain/ROS-MSCL/issues/54> from civerachb-cpr/master
  Explicitly name the mscl_msgs package
* Explicitly name the mscl_msgs package instead of using the directory name; the dir name isn't reliable on some build-farms that extract each package into a separate working directory
* Contributors: Chris Iverach-Brereton, Nathan Miller, nathanmillerparker
```

## ros_mscl

```
* Installs MSCL from CMake to hopefully allow this package to be built in the buildfarm
* Merge pull request #70 <https://github.com/LORD-MicroStrain/ROS-MSCL/issues/70> from ori-drs/master
  [ros_mscl] Turn filter_data_rate and imu_data_rate into an argument
* [ros_mscl] Turn filter_data_rate and imu_data_rate into an argument
* Eliminated build warnings
* Fixed a bug that wouldn't allow the rtk dongle to be enabled as it was using the wrong variable to enable it.
* See changelog
* Added aiding measurement summary for each GNSS (GQ7 only)
  Added MSCL version output when node starts
* Merge pull request #50 <https://github.com/LORD-MicroStrain/ROS-MSCL/issues/50> from civerachb-cpr/master
  Add an arg to enable setting NED/ENU frame parameter
* Add an arg to enable setting NED/ENU frame parameter
* Contributors: Chris Iverach-Brereton, Nathan Miller, Wolfgang Merkt, nathanmillerparker, robbiefish
```

## ros_mscl_cpp_example

```
* Merge branch 'master' of https://github.com/LORD-MicroStrain/ROS-MSCL into develop
* Properly installs examples to match instructions
* Contributors: robbiefish
```

## ros_mscl_py_example

```
* Merge branch 'master' of https://github.com/LORD-MicroStrain/ROS-MSCL into develop
* Properly installs examples to match instructions
* Contributors: robbiefish
```
