### PR TITLE
plotjuggler_ros: 1.5.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1827,6 +1827,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
+      version: 1.5.1-1
     source:
       type: git
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler_ros` to `1.5.1-1`:

- upstream repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
- release repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## plotjuggler_ros

```
* Merge branch 'rolling' of github.com:PlotJuggler/plotjuggler-ros-plugins into rolling
* rosbag2 logging hpp change
* compile with rolling
* Last galactic API build (#19 <https://github.com/PlotJuggler/plotjuggler-ros-plugins/issues/19>)
  * compile with rolling
  * rosbag2 logging hpp change
  * compils with galactic API
  Co-authored-by: Davide Faconti <mailto:davide.faconti@gmail.com>
* rosbag2 logging hpp change
* compile with rolling
* Contributors: Davide Faconti, G.Doisy, Guillaume Doisy
```
