### PR TITLE
plotjuggler_ros: 1.5.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1970,7 +1970,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
-      version: 1.5.0-1
+      version: 1.5.1-1
     source:
       type: git
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler_ros` to `1.5.1-1`:

- upstream repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
- release repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.5.0-1`

## plotjuggler_ros

```
* Merge branch 'rolling' of github.com:PlotJuggler/plotjuggler-ros-plugins into rolling
* rosbag2 logging hpp change
* compile with rolling
* Last galactic API build (#19 <https://github.com/PlotJuggler/plotjuggler-ros-plugins/issues/19>)
  * compile with rolling
  * rosbag2 logging hpp change
  * compils with galactic API
  Co-authored-by: Davide Faconti <mailto:davide.faconti@gmail.com>
* rosbag2 logging hpp change
* compile with rolling
* Contributors: Davide Faconti, G.Doisy, Guillaume Doisy
```
