### PR TITLE
lanelet2: 1.1.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1208,6 +1208,32 @@ repositories:
       url: https://github.com/ros/kdl_parser.git
       version: galactic
     status: maintained
+  lanelet2:
+    doc:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git
+      version: master
+    release:
+      packages:
+      - lanelet2
+      - lanelet2_core
+      - lanelet2_examples
+      - lanelet2_io
+      - lanelet2_maps
+      - lanelet2_projection
+      - lanelet2_python
+      - lanelet2_routing
+      - lanelet2_traffic_rules
+      - lanelet2_validation
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/fzi-forschungszentrum-informatik/lanelet2-release.git
+      version: 1.1.1-1
+    source:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git
+      version: master
+    status: maintained
   laser_geometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lanelet2` to `1.1.1-1`:

- upstream repository: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git
- release repository: https://github.com/fzi-forschungszentrum-informatik/lanelet2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## lanelet2

```
* Add missing dependency to ros_environment
* Contributors: Fabian Poggenhans
```

## lanelet2_core

- No changes

## lanelet2_examples

- No changes

## lanelet2_io

- No changes

## lanelet2_maps

- No changes

## lanelet2_projection

- No changes

## lanelet2_python

- No changes

## lanelet2_routing

- No changes

## lanelet2_traffic_rules

- No changes

## lanelet2_validation

- No changes
