### PR TITLE
Add RHEL rule and fix Fedora rule for pugixml-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6589,8 +6589,9 @@ psutils:
   ubuntu: [psutils]
 pugixml-dev:
   debian: [libpugixml-dev]
-  fedora: [pugixml]
+  fedora: [pugixml-devel]
   openembedded: [pugixml@meta-oe]
+  rhel: [pugixml-devel]
   ubuntu: [libpugixml-dev]
 pybind11-dev:
   arch: [pybind11]


### PR DESCRIPTION
This package is provided by EPEL for both RHEL 7 and 8: https://src.fedoraproject.org/rpms/pugixml#bodhi_updates
The Fedora rule needed to be updated to include the headers and such.