### PR TITLE
sr_hand_detector: 0.0.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8157,6 +8157,21 @@ repositories:
       url: https://github.com/ros-perception/sparse_bundle_adjustment.git
       version: melodic-devel
     status: maintained
+  sr_hand_detector:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/sr_hand_detector.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/shadow-robot/sr_hand_detector-release.git
+      version: 0.0.4-1
+    source:
+      type: git
+      url: https://github.com/shadow-robot/sr_hand_detector.git
+      version: noetic-devel
+    status: maintained
   srdfdom:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8166,7 +8166,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/shadow-robot/sr_hand_detector-release.git
-      version: 0.0.4-1
+      version: 0.0.4-2
     source:
       type: git
       url: https://github.com/shadow-robot/sr_hand_detector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sr_hand_detector` to `0.0.4-2`:

- upstream repository: https://github.com/shadow-robot/sr_hand_detector.git
- release repository: https://github.com/shadow-robot/sr_hand_detector-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## sr_hand_detector

- No changes
