### PR TITLE
rtabmap: 0.20.13-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3511,6 +3511,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_topic.git
       version: foxy-devel
     status: maintained
+  rtabmap:
+    doc:
+      type: git
+      url: https://github.com/introlab/rtabmap.git
+      version: rolling-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/introlab/rtabmap-release.git
+      version: 0.20.13-1
+    source:
+      type: git
+      url: https://github.com/introlab/rtabmap.git
+      version: rolling-devel
+    status: maintained
   rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap` to `0.20.13-1`:

- upstream repository: https://github.com/introlab/rtabmap.git
- release repository: https://github.com/introlab/rtabmap-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
