### PR TITLE
rosmon: 2.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7031,7 +7031,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/xqms/rosmon-release.git
-      version: 2.3.2-1
+      version: 2.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosmon` to `2.4.0-1`:

- upstream repository: https://github.com/xqms/rosmon.git
- release repository: https://github.com/xqms/rosmon-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.2-1`

## rosmon

```
* Increase cmake minimum version to 3.4
* Contributors: Max Schwarz
```

## rosmon_core

```
* Support YAML merge keys inside arrays (Issue #150, PR #153)
* Clear ONLCR o_flag on pty to avoid converting n into rn (PR #152)
* Inidicate when a node is actually Idle (e.g. stopped) (PR #144)
* Add missing dependency on libboost-python-dev (PR #149)
* Use a second PTY for stderr (Issue #147, PR #148)
* Provide number of restarts threshold per node via ROS-launch arguments (Issue #145, PR #146)
* Install tests (necessary for testing with colcon)
* Warning for type= attrs on <param> tags on Kinetic + whitespace fixes (Issue #138, PR #141)
* Use double precision for auto type parameters (PR #141)
* Monitor: do not leak stderr file descriptors
* Added option to prepend node name to stdout when using --disable-ui (Issue #139, PR #140)
* bytes_parser: add missing include (PR #137)
* Start all and stop all keybindings (Issue #127, PR #133)
* Display & search full name including namespace
* Follow symbolic links during file name suggestion (fixes completion with colcon)
* Fix problems identified with -Wfloat-conversion
* Respect leading slashes in rosparam YAML keys (Issue #130, PR #131)
* Contributors: Ferry Schoenmakers, Kutay YILMAZ, Max Schwarz, Romain Reignier, Steve Golton, Tim Clephas, mcfurry
```

## rosmon_msgs

```
* Increase cmake minimum version to 3.4
* Contributors: Max Schwarz
```

## rqt_rosmon

```
* Fix -Wfloat-conversion warnings
* Increase cmake minimum version to 3.4
* Contributors: Max Schwarz
```
