### PR TITLE
teleop_twist_joy: 2.4.3-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3689,7 +3689,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_twist_joy-release.git
-      version: 2.4.2-1
+      version: 2.4.3-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_joy` to `2.4.3-2`:

- upstream repository: https://github.com/ros2/teleop_twist_joy.git
- release repository: https://github.com/ros2-gbp/teleop_twist_joy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.4.2-1`

## teleop_twist_joy

```
* Fix the launch file to use 'executable'. (#28 <https://github.com/ros2/teleop_twist_joy/issues/28>)
* fix launch notation (#26 <https://github.com/ros2/teleop_twist_joy/issues/26>)
* Contributors: Chris Lalancette, Shigeki Kobayashi
```
