### PR TITLE
robot_state_publisher: 2.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2687,7 +2687,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/robot_state_publisher-release.git
-      version: 2.5.0-1
+      version: 2.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `2.6.0-1`:

- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros2-gbp/robot_state_publisher-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.5.0-1`

## robot_state_publisher

```
* Cleanup the documentation in the RobotStatePublisher class. (#172 <https://github.com/ros/robot_state_publisher/issues/172>)
* Always publish fixed frames to /tf_static (#158 <https://github.com/ros/robot_state_publisher/issues/158>)
* corrected publish_frequency default in README (#166 <https://github.com/ros/robot_state_publisher/issues/166>)
* Contributors: Chris Lalancette, Jacob Perron, Nils Schulte
```
