### PR TITLE
robot_state_publisher: 2.4.4-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2790,7 +2790,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/robot_state_publisher-release.git
-      version: 2.4.3-2
+      version: 2.4.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `2.4.4-1`:

- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros2-gbp/robot_state_publisher-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.4.3-2`

## robot_state_publisher

```
* Restore tf frame prefix support for ROS 2 (#159 <https://github.com/ros/robot_state_publisher/issues/159>) (#171 <https://github.com/ros/robot_state_publisher/issues/171>)
* Contributors: Chris Lalancette
```
