### PR TITLE
phidgets_drivers: 2.2.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1965,7 +1965,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/phidgets_drivers-release.git
-      version: 2.2.0-1
+      version: 2.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `2.2.1-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros2-gbp/phidgets_drivers-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.2.0-1`

## libphidget22

```
* Update to the latest libphidgets 1.6 library. (#91 <https://github.com/ros-drivers/phidgets_drivers/issues/91>)
* Contributors: Chris Lalancette
```

## phidgets_accelerometer

```
* Update the ROS 2 readme files. (#93 <https://github.com/ros-drivers/phidgets_drivers/issues/93>)
* Contributors: Chris Lalancette
```

## phidgets_analog_inputs

```
* Update the ROS 2 readme files. (#93 <https://github.com/ros-drivers/phidgets_drivers/issues/93>)
* Contributors: Chris Lalancette
```

## phidgets_api

- No changes

## phidgets_digital_inputs

```
* Update the ROS 2 readme files. (#93 <https://github.com/ros-drivers/phidgets_drivers/issues/93>)
* Contributors: Chris Lalancette
```

## phidgets_digital_outputs

```
* Update the ROS 2 readme files. (#93 <https://github.com/ros-drivers/phidgets_drivers/issues/93>)
* Contributors: Chris Lalancette
```

## phidgets_drivers

- No changes

## phidgets_gyroscope

```
* Update the ROS 2 readme files. (#93 <https://github.com/ros-drivers/phidgets_drivers/issues/93>)
* Contributors: Chris Lalancette
```

## phidgets_high_speed_encoder

```
* Update the ROS 2 readme files. (#93 <https://github.com/ros-drivers/phidgets_drivers/issues/93>)
* Contributors: Chris Lalancette
```

## phidgets_ik

```
* Update the ROS 2 readme files. (#93 <https://github.com/ros-drivers/phidgets_drivers/issues/93>)
* Contributors: Chris Lalancette
```

## phidgets_magnetometer

```
* Make the magnetometer corrections optional again. (#95 <https://github.com/ros-drivers/phidgets_drivers/issues/95>)
* Update the ROS 2 readme files. (#93 <https://github.com/ros-drivers/phidgets_drivers/issues/93>)
* Contributors: Chris Lalancette
```

## phidgets_motors

```
* Update the ROS 2 readme files. (#93 <https://github.com/ros-drivers/phidgets_drivers/issues/93>)
* Contributors: Chris Lalancette
```

## phidgets_msgs

- No changes

## phidgets_spatial

```
* Make the magnetometer corrections optional again. (#95 <https://github.com/ros-drivers/phidgets_drivers/issues/95>)
* Update the ROS 2 readme files. (#93 <https://github.com/ros-drivers/phidgets_drivers/issues/93>)
* Contributors: Chris Lalancette
```

## phidgets_temperature

```
* Update the ROS 2 readme files. (#93 <https://github.com/ros-drivers/phidgets_drivers/issues/93>)
* Contributors: Chris Lalancette
```
