### PR TITLE
[dep] inxi

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1946,6 +1946,16 @@ intltool:
   nixos: [intltool]
   opensuse: [intltool]
   ubuntu: [intltool]
+inxi:
+  debian: [inxi]
+  fedora: [inxi]
+  gentoo: [sys-apps/inxi]
+  opensuse: [inxi]
+  osx:
+    homebrew:
+      packages: [inxi]
+  rhel: [inxi]
+  ubuntu: [inxi]
 iperf:
   debian: [iperf]
   fedora: [iperf]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`inxi`

## Package Upstream Source:

https://smxi.org/docs/inxi.htm

## Purpose of using this:

Get computer hardware info (and use in downstream app e.g. ROS diagnostics)

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/buster/misc/inxi
- Ubuntu: https://packages.ubuntu.com/
   - [packages.ubuntu.com](https://packages.ubuntu.com/search?keywords=%20inxi)
- Fedora: https://src.fedoraproject.org/browse/projects/
  - https://src.fedoraproject.org/rpms/inxi
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/sys-apps/inxi
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/inxi#default
- opensuse https://software.opensuse.org/package/inxi
- rhel https://src.fedoraproject.org/rpms/inxi#bodhi_updates