### PR TITLE
diagnostics: 2.0.8-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -711,7 +711,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 2.0.7-1
+      version: 2.0.8-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `2.0.8-2`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.7-1`

## diagnostic_aggregator

- No changes

## diagnostic_updater

```
* [ROS2] Time Diagnostics can be used with Simulated Time (#201 <https://github.com/ros/diagnostics/issues/201>) (#205 <https://github.com/ros/diagnostics/issues/205>)
* Contributors: Marco Lampacrescia
```

## self_test

- No changes
