### PR TITLE
diagnostics: 2.1.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -612,7 +612,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 2.1.2-2
+      version: 2.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `2.1.3-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.2-2`

## diagnostic_aggregator

- No changes

## diagnostic_updater

```
* Time Diagnostics can be used with Simulated Time. (#201 <https://github.com/ros/diagnostics/issues/201>)
* Contributors: Marco Lampacrescia
```

## self_test

- No changes
