### PR TITLE
robot_state_publisher: 2.4.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3385,7 +3385,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/robot_state_publisher-release.git
-      version: 2.4.2-1
+      version: 2.4.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `2.4.5-1`:

- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros2-gbp/robot_state_publisher-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.4.2-1`

## robot_state_publisher

```
* Restore tf frame prefix support for ROS 2 (#159 <https://github.com/ros/robot_state_publisher/issues/159>) (#170 <https://github.com/ros/robot_state_publisher/issues/170>)
* Contributors: Chris Lalancette
```
