### PR TITLE
mrt_cmake_modules: 1.0.8-3 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1601,7 +1601,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/KIT-MRT/mrt_cmake_modules-release.git
-      version: 1.0.8-2
+      version: 1.0.8-3
     source:
       type: git
       url: https://github.com/KIT-MRT/mrt_cmake_modules.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrt_cmake_modules` to `1.0.8-3`:

- upstream repository: https://github.com/KIT-MRT/mrt_cmake_modules.git
- release repository: https://github.com/KIT-MRT/mrt_cmake_modules-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.8-2`

## mrt_cmake_modules

```
* Fix finding boost python on versions with old cmake but new boost
* Contributors: Fabian Poggenhans
```
