### PR TITLE
mrt_cmake_modules: 1.0.8-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1571,7 +1571,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/KIT-MRT/mrt_cmake_modules-release.git
-      version: 1.0.8-1
+      version: 1.0.8-2
     source:
       type: git
       url: https://github.com/KIT-MRT/mrt_cmake_modules.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrt_cmake_modules` to `1.0.8-2`:

- upstream repository: https://github.com/KIT-MRT/mrt_cmake_modules.git
- release repository: https://github.com/KIT-MRT/mrt_cmake_modules-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.8-1`

## mrt_cmake_modules

```
* Fix finding boost python on versions with old cmake but new boost
* Contributors: Fabian Poggenhans
```
