### PR TITLE
fiducials: 0.12.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2040,6 +2040,22 @@ repositories:
       url: https://github.com/fetchrobotics/fetch_tools.git
       version: ros1
     status: maintained
+  fiducials:
+    release:
+      packages:
+      - aruco_detect
+      - fiducial_msgs
+      - fiducial_slam
+      - fiducials
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/UbiquityRobotics-release/fiducials-release.git
+      version: 0.12.0-1
+    source:
+      type: git
+      url: https://github.com/UbiquityRobotics/fiducials.git
+      version: noetic-devel
+    status: maintained
   filters:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fiducials` to `0.12.0-1`:

- upstream repository: https://github.com/UbiquityRobotics/fiducials
- release repository: https://github.com/UbiquityRobotics-release/fiducials-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## aruco_detect

```
* Deps python2 -> python3
* Updated marker generation script to work with Python3  (#254 <https://github.com/UbiquityRobotics/fiducials/issues/254>)
  * Updated create marker script for python3
  * Updated to use Python 3 cairosvg module
  * Added argument to change fiducial length and scaling the marker based on it
  * Change to Python 3
  * Fixed string format
  * Changed argument name for passing in fiducial length
  * Updated marker generation script to work with Python3
  * Added a comment about why marker_gen is a separate module
  * gitignore bagfiles, we don't want them to be checked in generally
  Co-authored-by: Ajith Thomas <mailto:ajiththomas152@gmail.com>
* Use newer constant for imread in aruco tests
* Add missing dependencies on transport plugins
* Merge pull request #236 <https://github.com/UbiquityRobotics/fiducials/issues/236> from UbiquityRobotics/bugfix-aruco-detect-relative-topics
  fixed aruco detect remaps to relative topic names to suport namespaces
* Dynamic Reconfigure rosparam integration completed
* Splitted aruco vertices detection and pose estimation.
* Splitted detection and pose estimation.
* Make fiducial_tf_publish a param
* Moved fiducial tf publishing to aruco_detect node
* Add mutex to image callback
* Public node handle instead of leading / for namespace support
  This allows someone to start the node in a namespace and have all the
  topics remapped into the namespace automatically. Parameters are still
  kept in a private node handle so they come up in aruco_detect/*
  Fixes: https://github.com/UbiquityRobotics/fiducials/issues/183
* Fix fiducial_len_override bug (#180 <https://github.com/UbiquityRobotics/fiducials/issues/180>)
* Make ignored fiducials dynamically reconfigurable (#170 <https://github.com/UbiquityRobotics/fiducials/issues/170>)
  * Make ignored fiducials dynamically reconfigurable
* Contributors: Caio Amaral, Canberk S. Gurel, Janez Cimerman, Jim Vaughan, MoffKalast, Rohan Agrawal, Teodor, Vid Rijavec, canberkgurel
```

## fiducial_msgs

- No changes

## fiducial_slam

```
* Merge pull request #259 <https://github.com/UbiquityRobotics/fiducials/issues/259> from ivan140/feature/pose_publish_rate
  Added pose_publish_rate which controls the rate of /fiducial_pose
* added feature pose_publish_rate which controls the rate of topic /fiducial_pose
* Merge pull request #258 <https://github.com/UbiquityRobotics/fiducials/issues/258> from UbiquityRobotics/opencv-deprecated-constant
  Replace deprecated OpenCV constant in fiducial_slam test
* Replace deprecated OpenCV constant in fiducial_slam test
* Merge pull request #244 <https://github.com/UbiquityRobotics/fiducials/issues/244> from agutenkunst/fix/remove_unused_subs
  I think this is sensible to merge, since it does not affect the workings of the package and it removes some confusion, so merging
* Remove non-functional doPoseEstimation from fiducial_slam
* Remove unused subscriber
* Merge pull request #221 <https://github.com/UbiquityRobotics/fiducials/issues/221> from UbiquityRobotics/bugfix-#220 <https://github.com/UbiquityRobotics/bugfix-/issues/220>
  Allow covariance to be overridden by launch file
* Allow covariance to be overriden by launch file
  Uses YAML interpretation for the parameter so that it becomes an array
  instead of a string. Fix a comparison issue in the code to make the
  override actually warn on 0 values.
* Return early from auto init when no fiducials
* Merge pull request #214 <https://github.com/UbiquityRobotics/fiducials/issues/214> from UbiquityRobotics/publish_fids
  Moved fiducial tf publishing to aruco_detect node
* Moved fiducial tf publishing to aruco_detect node
* Address #204 <https://github.com/UbiquityRobotics/fiducials/issues/204> (#205 <https://github.com/UbiquityRobotics/fiducials/issues/205>)
* Revert "Address #204 <https://github.com/UbiquityRobotics/fiducials/issues/204>"
  This reverts commit ba13b567ca71a33202547dd6df03d61b94a90d45.
* Address #204 <https://github.com/UbiquityRobotics/fiducials/issues/204>
* Use FrameId in rviz markers (#195 <https://github.com/UbiquityRobotics/fiducials/issues/195>)
  * FrameId used in the rviz markers
  * FrameId used in rviz markers
* Removed multi-fiducial code (#184 <https://github.com/UbiquityRobotics/fiducials/issues/184>)
* Add service call to add a fiducial to the map (#176 <https://github.com/UbiquityRobotics/fiducials/issues/176>)
  * Add service call to add a fiducial to the map
  * Abort auto-init when add fiducial service is called.
* Merge pull request #175 <https://github.com/UbiquityRobotics/fiducials/issues/175> from UbiquityRobotics/fix-#173 <https://github.com/UbiquityRobotics/fix-/issues/173>
  Cleanup for fiducial_slam
* add and run clang-format
* Get rid of observation.positon, it was only being used in 1 place
* Links to other fiducials uses set instead map<int,int>
  We only care if the element exists or not, so a set is a
  clearer data structure to use.
* Unused sum_in_qudrature removed, holdover from Alexy stuff
* Use clearer ranged for where possible
  Ranged for provides an easier way to interate over every
  element in a containter.
  NOTE: This commit changes what I consider to be buggy behavior
  in the autoInit and findClosestObs code, which was not properly
  iterating over every elemnent, using obs[0] every time.
* Remove using namespace declarations
  These are generally considered dangerous, due to the potential
  for namespace collisions and unclarity when using types.
* Contributors: Alexander Gutenkunst, David Alejo Teissière, Ivan Shalnov, Janez Cimerman, Jim Vaughan, Rohan Agrawal
```

## fiducials

- No changes
