### PR TITLE
ubiquity_motor: 0.13.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8657,6 +8657,17 @@ repositories:
       url: https://github.com/ros-teleop/twist_mux_msgs.git
       version: melodic-devel
     status: maintained
+  ubiquity_motor:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
+      version: 0.13.2-1
+    source:
+      type: git
+      url: https://github.com/UbiquityRobotics/ubiquity_motor.git
+      version: noetic-devel
+    status: maintained
   ublox:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ubiquity_motor` to `0.13.2-1`:

- upstream repository: https://github.com/UbiquityRobotics/ubiquity_motor.git
- release repository: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ubiquity_motor

```
* Added ros noetic github action
* Install the shared lib for our custom serial
* Check for mininum hardware version before reading option switch
* Contributors: Rohan Agrawal
```
