### PR TITLE
Add python-monotonic

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2673,6 +2673,7 @@ python-monotonic:
   debian: [python-monotonic]
   fedora: [python-monotonic]
   nixos: [pythonPackages.monotonic]
+  opensuse: [python2-monotonic]
   ubuntu: [python-monotonic]
 python-more-itertools:
   arch: [python-more-itertools]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2668,6 +2668,11 @@ python-mock:
     xenial_python3: [python3-mock]
     yakkety: [python-mock]
     zesty: [python-mock]
+python-monotonic:
+  arch: [python-monotonic]
+  debian: [python-monotonic]
+  fedora: [python-monotonic]
+  ubuntu: [python-monotonic]
 python-more-itertools:
   arch: [python-more-itertools]
   debian: [python-more-itertools]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2672,7 +2672,6 @@ python-monotonic:
   arch: [python-monotonic]
   debian: [python-monotonic]
   fedora: [python-monotonic]
-  gentoo: [dev-python/monotonic]
   ubuntu: [python-monotonic]
 python-more-itertools:
   arch: [python-more-itertools]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2672,6 +2672,7 @@ python-monotonic:
   arch: [python-monotonic]
   debian: [python-monotonic]
   fedora: [python-monotonic]
+  gentoo: [dev-python/monotonic]
   ubuntu: [python-monotonic]
 python-more-itertools:
   arch: [python-more-itertools]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2671,7 +2671,7 @@ python-mock:
 python-monotonic:
   arch: [python-monotonic]
   debian: [python-monotonic]
-  fedora: [python-monotonic]
+  nixos: [pythonPackages.monotonic]
   ubuntu: [python-monotonic]
 python-more-itertools:
   arch: [python-more-itertools]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2671,6 +2671,7 @@ python-mock:
 python-monotonic:
   arch: [python-monotonic]
   debian: [python-monotonic]
+  fedora: [python-monotonic]
   nixos: [pythonPackages.monotonic]
   ubuntu: [python-monotonic]
 python-more-itertools:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python-monotonic

## Package Upstream Source:

python-monotonic

## Purpose of using this:

monotonic time is not available for python2. It can be usefull for dt calculations on systems where the clock can be modified by the operating system.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - `python-monotonic`
- Ubuntu: https://packages.ubuntu.com/
   - `python-monotonic`
- Fedora: https://src.fedoraproject.org/browse/projects/
  - `python-monotonic`
- Arch: https://www.archlinux.org/packages/
  - `python-monotonic`
- Gentoo: https://packages.gentoo.org/
  - `dev-python/monotonic`
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available

