### PR TITLE
libstatistics_collector: 1.1.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1350,7 +1350,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/libstatistics_collector-release.git
-      version: 1.1.0-3
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libstatistics_collector` to `1.1.1-1`:

- upstream repository: https://github.com/ros-tooling/libstatistics_collector.git
- release repository: https://github.com/ros2-gbp/libstatistics_collector-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.0-3`

## libstatistics_collector

```
* Remove cloudwatch reporting (#110 <https://github.com/ros-tooling/libstatistics_collector/issues/110>)
* Replace index.ros.org links -> docs.ros.org. (#94 <https://github.com/ros-tooling/libstatistics_collector/issues/94>)
* Use latest versions of CI actions (#92 <https://github.com/ros-tooling/libstatistics_collector/issues/92>)
* Contributors: Chris Lalancette, Emerson Knapp
```
