### PR TITLE
ros_controllers_cartesian: 0.1.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10667,7 +10667,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release.git
-      version: 0.1.3-1
+      version: 0.1.4-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers_cartesian` to `0.1.4-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian.git
- release repository: https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.3-1`

## cartesian_interface

```
* Add websites to package.xml files
* Update image paths of partner logos (#4 <https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian/issues/4>)
* Contributors: Felix Exner
```

## cartesian_trajectory_controller

```
* Make control update open-loop without active action (#5 <https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian/issues/5>)
* Add websites to package.xml files
* Update image paths of partner logos (#4 <https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian/issues/4>)
* Contributors: Felix Exner, Stefan Scherzinger
```

## cartesian_trajectory_interpolation

```
* Add websites to package.xml files
* Update image paths of partner logos (#4 <https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian/issues/4>)
* Contributors: Felix Exner
```

## ros_controllers_cartesian

```
* Add websites to package.xml files
* Contributors: Felix Exner
```

## twist_controller

```
* Add websites to package.xml files
* Update image paths of partner logos (#4 <https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian/issues/4>)
* Contributors: Felix Exner
```
