### PR TITLE
urg_stamped: 0.0.13-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13975,7 +13975,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/seqsense/urg_stamped-release.git
-      version: 0.0.12-2
+      version: 0.0.13-2
     source:
       type: git
       url: https://github.com/seqsense/urg_stamped.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_stamped` to `0.0.13-2`:

- upstream repository: https://github.com/seqsense/urg_stamped.git
- release repository: https://github.com/seqsense/urg_stamped-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.12-2`

## urg_stamped

```
* Remove doubled QT command request (#112 <https://github.com/seqsense/urg_stamped/issues/112>)
* Contributors: Atsushi Watanabe
```
