### PR TITLE
franka_ros: 0.8.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3896,6 +3896,7 @@ repositories:
       - franka_control
       - franka_description
       - franka_example_controllers
+      - franka_gazebo
       - franka_gripper
       - franka_hw
       - franka_msgs
@@ -3904,7 +3905,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/frankaemika/franka_ros-release.git
-      version: 0.6.0-1
+      version: 0.8.0-1
     source:
       type: git
       url: https://github.com/frankaemika/franka_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `franka_ros` to `0.8.0-1`:

- upstream repository: https://github.com/frankaemika/franka_ros.git
- release repository: https://github.com/frankaemika/franka_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.0-1`
