### PR TITLE
robot_body_filter: 1.2.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10138,7 +10138,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/peci1/robot_body_filter-release.git
-      version: 1.2.0-2
+      version: 1.2.1-1
     source:
       type: git
       url: https://github.com/peci1/robot_body_filter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_body_filter` to `1.2.1-1`:

- upstream repository: https://github.com/peci1/robot_body_filter
- release repository: https://github.com/peci1/robot_body_filter-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.0-2`

## robot_body_filter

```
* Merge pull request #15 <https://github.com/peci1/robot_body_filter/issues/15> from universal-field-robots/master
  TFFramesWatchdog and RayCastingShapeMask need to be installed in the CMakeLists.txt
* Added RayCastingShapeMask and TFFramesWatchdog to install targets in cmake
* Contributors: Josh Owen, Martin Pecka
```
