### PR TITLE
robot_body_filter: 1.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6230,7 +6230,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/peci1/robot_body_filter-release.git
-      version: 1.2.0-4
+      version: 1.2.1-1
     source:
       type: git
       url: https://github.com/peci1/robot_body_filter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_body_filter` to `1.2.1-1`:

- upstream repository: https://github.com/peci1/robot_body_filter
- release repository: https://github.com/peci1/robot_body_filter-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.0-4`

## robot_body_filter

```
* Merge pull request #15 <https://github.com/peci1/robot_body_filter/issues/15> from universal-field-robots/master
  TFFramesWatchdog and RayCastingShapeMask need to be installed in the CMakeLists.txt
* Added RayCastingShapeMask and TFFramesWatchdog to install targets in cmake
* Contributors: Josh Owen, Martin Pecka
```
