### PR TITLE
ruckig: 0.3.3-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3601,6 +3601,12 @@ repositories:
       url: https://github.com/introlab/rtabmap.git
       version: galactic-devel
     status: maintained
+  ruckig:
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/pantor/ruckig-release.git
+      version: 0.3.3-2
   rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ruckig` to `0.3.3-2`:

- upstream repository: https://github.com/pantor/ruckig.git
- release repository: https://github.com/pantor/ruckig-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
