### PR TITLE
ruckig: 0.3.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3527,6 +3527,12 @@ repositories:
       url: https://github.com/introlab/rtabmap.git
       version: rolling-devel
     status: maintained
+  ruckig:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/pantor/ruckig-release.git
+      version: 0.3.3-1
   rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ruckig` to `0.3.3-1`:

- upstream repository: https://github.com/pantor/ruckig.git
- release repository: https://github.com/pantor/ruckig-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
