### PR TITLE
Set libstatistics_collector doc & source branches to galactic for Galactic

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1345,7 +1345,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git
-      version: master
+      version: galactic
     release:
       tags:
         release: release/galactic/{package}/{version}
@@ -1354,7 +1354,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git
-      version: master
+      version: galactic
     status: developed
   libyaml_vendor:
     release:


### PR DESCRIPTION
After changing the Galactic track to point to `galactic`.

Follow-up to #30411

Relates to https://github.com/ros2/ros2/pull/1166

cc @emersonknapp

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>