### PR TITLE
ira_laser_tools: 1.0.5-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3055,6 +3055,13 @@ repositories:
       url: https://github.com/ros-visualization/interactive_markers.git
       version: noetic-devel
     status: maintained
+  ira_laser_tools:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/iralabdisco/ira_laser_tools-release.git
+      version: 1.0.5-2
+    status: developed
   iris_lama:
     release:
       tags:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3061,6 +3061,10 @@ repositories:
         release: release/noetic/{package}/{version}
       url: https://github.com/iralabdisco/ira_laser_tools-release.git
       version: 1.0.5-2
+    source:
+      type: git
+      url: https://github.com/iralabdisco/ira_laser_tools.git
+      version: noetic
     status: developed
   iris_lama:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `ira_laser_tools` to `1.0.5-2`:

- upstream repository: https://github.com/iralabdisco/ira_laser_tools.git
- release repository: https://github.com/iralabdisco/ira_laser_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ira_laser_tools

```
* add new mantainer email
* fix launch before laser scan is available
* add a try catch for first non valid tf
* Retrying compare topics between ROS master and Token
* Contributors: JackFrost67
```
