### PR TITLE
ira_laser_tools: 1.0.5-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4733,7 +4733,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/iralabdisco/ira_laser_tools-release.git
-      version: 1.0.4-1
+      version: 1.0.5-2
     source:
       type: git
       url: https://github.com/iralabdisco/ira_laser_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ira_laser_tools` to `1.0.5-2`:

- upstream repository: https://github.com/iralabdisco/ira_laser_tools.git
- release repository: https://github.com/iralabdisco/ira_laser_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.4-1`

## ira_laser_tools

```
* add new mantainer email
* fix launch before laser scan is available
* add a try catch for first non valid tf
* Retrying compare topics between ROS master and Token
* Contributors: JackFrost67
```
