### PR TITLE
usb_cam: 0.4.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5149,7 +5149,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros-gbp/usb_cam-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/ros-drivers/usb_cam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `usb_cam` to `0.4.1-1`:

- upstream repository: https://github.com/ros-drivers/usb_cam.git
- release repository: https://github.com/ros-gbp/usb_cam-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.0-1`

## usb_cam

```
* update README, add compression section
* update package.xml to include image_transport_plugins
* clean up README instructions
* update README ros2 run executable name
* Contributors: Evan Flynn
```
