### PR TITLE
add v4l-utils rhel key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7594,6 +7594,8 @@ v4l-utils:
   gentoo: [media-tv/v4l-utils]
   nixos: [v4l-utils]
   openembedded: [v4l-utils@meta-oe]
+  rhel:
+    '7': [v4l-utils]
   ubuntu: [v4l-utils]
 valgrind:
   debian: [valgrind]


### PR DESCRIPTION
`v4l-utils` was missing a key for `rhel` so just adding it in as discussed over at [this PR for the `usb_cam` package](https://github.com/ros/rosdistro/pull/30306).

https://rpms.remirepo.net/rpmphp/zoom.php?rpm=v4l-utils



