### PR TITLE
python3-pyproj-pip: add dep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7309,6 +7309,16 @@ python3-pyproj:
     '*': ['python%{python3_pkgversion}-pyproj']
     '7': null
   ubuntu: [python3-pyproj]
+python3-pyproj-pip:
+  debian:
+    pip:
+      packages: [pyproj]
+  fedora:
+    pip:
+      packages: [pyproj]
+  ubuntu:
+    pip:
+      packages: [pyproj]
 python3-pyqrcode:
   arch: [python-qrcode]
   debian: [python3-pyqrcode]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

pyproj via pip

## Package Upstream Source:

https://github.com/pyproj4/pyproj

## Purpose of using this:

Focal's version of pyproj is out of date (the proj dependency is multiple major point releases out of date) and is missing features such as `database`. 


## Links to Distribution Packages

https://pypi.org/project/pyproj/