### PR TITLE
rmw_fastrtps: 5.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2638,7 +2638,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 5.2.1-1
+      version: 5.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `5.2.2-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `5.2.1-1`

## rmw_fastrtps_cpp

```
* Correctly recalculate serialized size on bounded sequences. (#540 <https://github.com/ros2/rmw_fastrtps/issues/540>)
* Fix type size alignment. (#550 <https://github.com/ros2/rmw_fastrtps/issues/550>)
* Contributors: Miguel Company
```

## rmw_fastrtps_dynamic_cpp

```
* Correctly recalculate serialized size on bounded sequences. (#540 <https://github.com/ros2/rmw_fastrtps/issues/540>)
* Fix type size alignment. (#550 <https://github.com/ros2/rmw_fastrtps/issues/550>)
* Contributors: Miguel Company
```

## rmw_fastrtps_shared_cpp

```
* Pass the CRL down to Fast-DDS if available. (#546 <https://github.com/ros2/rmw_fastrtps/issues/546>)
* Contributors: Chris Lalancette
```
