### PR TITLE
rosidl_typesupport_fastrtps: 2.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3131,7 +3131,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-      version: 1.2.1-1
+      version: 2.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_fastrtps` to `2.0.2-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.1-1`

## fastrtps_cmake_module

- No changes

## rosidl_typesupport_fastrtps_c

```
* Revert rosidl targets and dependencies exportation (#76 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/76>)
  * Revert "Export rosidl_typesupport_fastrtps_c* dependencies (#75 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/75>)"
  * Revert "Bundle and ensure the exportation of rosidl generated targets (#73 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/73>)"
* Correctly inform that a BoundedSequence is bounded (#71 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/71>)
* Contributors: Michel Hidalgo, Miguel Company
```

## rosidl_typesupport_fastrtps_cpp

```
* Revert rosidl targets and dependencies exportation (#76 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/76>)
  * Revert "Export rosidl_typesupport_fastrtps_c* dependencies (#75 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/75>)"
  * Revert "Bundle and ensure the exportation of rosidl generated targets (#73 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/73>)"
* Correctly inform that a BoundedSequence is bounded (#71 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/71>)
* Contributors: Michel Hidalgo, Miguel Company
```
