### PR TITLE
espeak_ros: 0.1.0-6 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -976,6 +976,15 @@ repositories:
       url: https://github.com/OUXT-Polaris/embree_vendor.git
       version: master
     status: developed
+  espeak_ros:
+    release:
+      packages:
+      - espeak_interfaces
+      - espeak_ros
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://gitlab.com/espeak-ros2/espeak-ros2-release.git
+      version: 0.1.0-6
   example_interfaces:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -985,6 +985,11 @@ repositories:
         release: release/foxy/{package}/{version}
       url: https://gitlab.com/espeak-ros2/espeak-ros2-release.git
       version: 0.1.0-6
+    source:
+      type: git
+      url: https://gitlab.com/espeak-ros2/espeak-ros2.git
+      version: master
+    status: developed
   example_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `espeak_ros` to `0.1.0-6`:

- upstream repository: https://gitlab.com/espeak-ros2/espeak-ros2.git
- release repository: https://gitlab.com/espeak-ros2/espeak-ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
