### PR TITLE
geometry_tutorials: 0.3.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -932,6 +932,25 @@ repositories:
       url: https://github.com/ros2/geometry2.git
       version: galactic
     status: maintained
+  geometry_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros/geometry_tutorials.git
+      version: ros2
+    release:
+      packages:
+      - geometry_tutorials
+      - turtle_tf2_cpp
+      - turtle_tf2_py
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros-gbp/geometry_tutorials-release.git
+      version: 0.3.2-1
+    source:
+      type: git
+      url: https://github.com/ros/geometry_tutorials.git
+      version: ros2
+    status: maintained
   google_benchmark_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_tutorials` to `0.3.2-1`:

- upstream repository: https://github.com/ros/geometry_tutorials
- release repository: https://github.com/ros-gbp/geometry_tutorials-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## geometry_tutorials

- No changes

## turtle_tf2_cpp

```
* turtle_tf2_cpp tutorial package (#44 <https://github.com/ros/geometry_tutorials/issues/44>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: kurshakuz
```

## turtle_tf2_py

```
* Add fixed and dynamic frame broadcaster nodes (#40 <https://github.com/ros/geometry_tutorials/issues/40>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Add target frame parameter to the listener node (#41 <https://github.com/ros/geometry_tutorials/issues/41>)
* fix linter style issues and remove spin_thread=False statement (#39 <https://github.com/ros/geometry_tutorials/issues/39>)
* Contributors: kurshakuz
```
