### PR TITLE
ruckig: 0.3.3-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3528,6 +3528,17 @@ repositories:
       url: https://github.com/introlab/rtabmap.git
       version: rolling-devel
     status: maintained
+  ruckig:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/pantor/ruckig-release.git
+      version: 0.3.3-2
+    source:
+      type: git
+      url: https://github.com/pantor/ruckig.git
+      version: v0.3.3
+    status: developed
   rviz:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3537,7 +3537,7 @@ repositories:
     source:
       type: git
       url: https://github.com/pantor/ruckig.git
-      version: v0.3.3
+      version: master
     status: developed
   rviz:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ruckig` to `0.3.3-2`:

- upstream repository: https://github.com/pantor/ruckig.git
- release repository: https://github.com/pantor/ruckig-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
