### PR TITLE
ruckig: 0.3.3-3 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3619,6 +3619,17 @@ repositories:
       url: https://github.com/introlab/rtabmap.git
       version: galactic-devel
     status: maintained
+  ruckig:
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/pantor/ruckig-release.git
+      version: 0.3.3-3
+    source:
+      type: git
+      url: https://github.com/pantor/ruckig.git
+      version: v0.3.3
+    status: developed
   rviz:
     doc:
       type: git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3628,7 +3628,7 @@ repositories:
     source:
       type: git
       url: https://github.com/pantor/ruckig.git
-      version: v0.3.3
+      version: master
     status: developed
   rviz:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ruckig` to `0.3.3-3`:

- upstream repository: https://github.com/pantor/ruckig.git
- release repository: https://github.com/pantor/ruckig-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
