### PR TITLE
ruckig: 0.3.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4405,6 +4405,17 @@ repositories:
       url: https://github.com/introlab/rtabmap.git
       version: foxy-devel
     status: maintained
+  ruckig:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/pantor/ruckig-release.git
+      version: 0.3.3-1
+    source:
+      type: git
+      url: https://github.com/pantor/ruckig.git
+      version: v0.3.3
+    status: developed
   rviz:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4414,7 +4414,7 @@ repositories:
     source:
       type: git
       url: https://github.com/pantor/ruckig.git
-      version: v0.3.3
+      version: master
     status: developed
   rviz:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ruckig` to `0.3.3-1`:

- upstream repository: https://github.com/pantor/ruckig.git
- release repository: https://github.com/pantor/ruckig-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
