### PR TITLE
ruckig: 0.3.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12186,7 +12186,7 @@ repositories:
     source:
       type: git
       url: https://github.com/pantor/ruckig.git
-      version: v0.3.3
+      version: master
     status: developed
   rviz:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12177,6 +12177,17 @@ repositories:
       url: https://github.com/gbiggs/rtsprofile.git
       version: master
     status: maintained
+  ruckig:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/pantor/ruckig-release.git
+      version: 0.3.3-1
+    source:
+      type: git
+      url: https://github.com/pantor/ruckig.git
+      version: v0.3.3
+    status: developed
   rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ruckig` to `0.3.3-1`:

- upstream repository: https://github.com/pantor/ruckig.git
- release repository: https://github.com/pantor/ruckig-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
