### PR TITLE
ruckig: 0.3.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7728,6 +7728,17 @@ repositories:
       url: https://github.com/tilk/rtcm_msgs.git
       version: master
     status: maintained
+  ruckig:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/pantor/ruckig-release.git
+      version: 0.3.3-1
+    source:
+      type: git
+      url: https://github.com/pantor/ruckig.git
+      version: v0.3.3
+    status: developed
   rviz:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7737,7 +7737,7 @@ repositories:
     source:
       type: git
       url: https://github.com/pantor/ruckig.git
-      version: v0.3.3
+      version: master
     status: developed
   rviz:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ruckig` to `0.3.3-1`:

- upstream repository: https://github.com/pantor/ruckig.git
- release repository: https://github.com/pantor/ruckig-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
