### PR TITLE
Added dcraw for most common distributions

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -755,6 +755,7 @@ dcraw:
   debian: [dcraw]
   fedora: [dcraw]
   gentoo: [media-gfx/dcraw]
+  opensuse: [dcraw]
   ubuntu: [dcraw]
 debhelper:
   debian: [debhelper]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -750,6 +750,12 @@ daemontools:
   nixos: [daemontools]
   openembedded: [daemontools@meta-oe]
   ubuntu: [daemontools]
+dcraw:
+  arch: [dcraw]
+  debian: [dcraw]
+  fedora: [dcraw]
+  gentoo: [media-gfx/dcraw]
+  ubuntu: [dcraw]
 debhelper:
   debian: [debhelper]
   fedora: [debhelper]


### PR DESCRIPTION

Please add the following dependency to the rosdep database.

## Package name:
dcraw

## Package Upstream Source:

https://dechifro.org/dcraw/

## Purpose of using this:

We need to handle raw images for a SLAM project from a panocam and use dcraw for image conversions.

Distro packaging links:

## Links to Distribution Packages


- Debian: https://packages.debian.org/
  https://packages.debian.org/search?keywords=dcraw
- Ubuntu: https://packages.ubuntu.com/
  https://packages.ubuntu.com/search?keywords=dcraw
- Fedora: https://src.fedoraproject.org/browse/projects/
  https://src.fedoraproject.org/rpms/dcraw
- Arch: https://www.archlinux.org/packages/
  https://archlinux.org/packages/community/x86_64/dcraw/
- Gentoo: https://packages.gentoo.org/
  https://packages.gentoo.org/packages/media-gfx/dcraw
