### PR TITLE
rosidl: 2.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3022,7 +3022,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 2.4.0-1
+      version: 2.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `2.5.0-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.4.0-1`

## rosidl_adapter

- No changes

## rosidl_cli

- No changes

## rosidl_cmake

```
* Revert "Bundle and ensure the exportation of rosidl generated targets" (#611 <https://github.com/ros2/rosidl/issues/611>)
* Add rosidl_get_typesupport_target and deprecate rosidl_target_interfaces (#606 <https://github.com/ros2/rosidl/issues/606>)
* Contributors: Michel Hidalgo, Shane Loretz
```

## rosidl_generator_c

```
* Revert "Bundle and ensure the exportation of rosidl generated targets" (#611 <https://github.com/ros2/rosidl/issues/611>)
* Contributors: Michel Hidalgo
```

## rosidl_generator_cpp

```
* Support flow style YAML printing (#613 <https://github.com/ros2/rosidl/issues/613>)
* Revert "Bundle and ensure the exportation of rosidl generated targets" (#611 <https://github.com/ros2/rosidl/issues/611>)
* Relocate to_yaml() under message namespace (#609 <https://github.com/ros2/rosidl/issues/609>)
* Contributors: Michel Hidalgo
```

## rosidl_parser

- No changes

## rosidl_runtime_c

- No changes

## rosidl_runtime_cpp

- No changes

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

```
* Revert "Bundle and ensure the exportation of rosidl generated targets" (#611 <https://github.com/ros2/rosidl/issues/611>)
* Contributors: Michel Hidalgo
```

## rosidl_typesupport_introspection_cpp

```
* Revert "Bundle and ensure the exportation of rosidl generated targets" (#611 <https://github.com/ros2/rosidl/issues/611>)
* Contributors: Michel Hidalgo
```
