### PR TITLE
Add python3-gpiozero to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6460,6 +6460,10 @@ python3-gnupg:
   opensuse: [python3-python-gnupg]
   ubuntu: [python3-gnupg]
 python3-google-cloud-texttospeech-pip: *migrate_eol_2025_04_30_python3_google_cloud_texttospeech_pip
+python3-gpiozero:
+  debian: [python3-gpiozero]
+  fedora: [python3-gpiozero]
+  ubuntu: [python3-gpiozero]
 python3-gpxpy:
   debian: [python3-gpxpy]
   fedora: [python3-gpxpy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6463,7 +6463,9 @@ python3-google-cloud-texttospeech-pip: *migrate_eol_2025_04_30_python3_google_cl
 python3-gpiozero:
   debian: [python3-gpiozero]
   fedora: [python3-gpiozero]
-  ubuntu: [python3-gpiozero]
+  ubuntu:
+    '*': [python3-gpiozero]
+    bionic: null
 python3-gpxpy:
   debian: [python3-gpxpy]
   fedora: [python3-gpxpy]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-gpiozero

## Purpose of using this:

This library is able to read CPU temperature data from the Raspberry Pi and is useful for measuring sensor changes.

## Links to Distribution Packages

- Debian: https://packages.debian.org/buster/python3-gpiozero
- Ubuntu: https://packages.ubuntu.com/bionic/python3-gpiozero
- Fedora: https://src.fedoraproject.org/rpms/python-gpiozero
