### PR TITLE
Add python3-spidev-pip to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4776,7 +4776,7 @@ python-sphinx-rtd-theme:
     yakkety_python3: [python3-sphinx-rtd-theme]
     zesty: [python-sphinx-rtd-theme]
     zesty_python3: [python3-sphinx-rtd-theme]
-python-spidev-pip:
+python-spidev-pip: &migrate_eol_2025_04_30_python3_spidev_pip
   debian:
     pip:
       packages: [spidev]
@@ -7834,6 +7834,7 @@ python3-sphinx-rtd-theme:
   nixos: [python3Packages.sphinx_rtd_theme]
   rhel: ['python%{python3_pkgversion}-sphinx_rtd_theme']
   ubuntu: [python3-sphinx-rtd-theme]
+python3-spidev-pip: *migrate_eol_2025_04_30_python3_spidev_pip
 python3-sqlalchemy:
   arch: [python-sqlalchemy]
   debian: [python3-sqlalchemy]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-spidev-pip

## Package Upstream Source:

https://github.com/doceme/py-spidev

## Purpose of using this:

This PR is simply bringing python3 support to the preexisting python-spidev-pip via aliasing per the rosdep guidelines.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- PyPi: https://pypi.org/project/spidev/
- Debian: not available
  - REQUIRED
- Ubuntu: not available
   - REQUIRED
