### PR TITLE
Add rm_control to documentation index

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10069,19 +10069,19 @@ repositories:
       url: https://github.com/RoboJackets/rj-ros-common.git
       version: master
     status: developed
-  rm_infrastructure:
+  rm_control:
     doc:
       type: git
-      url: https://github.com/rm-controls/rm_infrastructure
+      url: https://github.com/rm-controls/rm_control
       version: master
     release:
       tags:
         release: release/noetic/{package}/{version}
-      url: https://github.com/rm-controls/rm_infrastructure-release
+      url: https://github.com/rm-controls/rm_control-release
       version: 1.0.35-1
     source:
       type: git
-      url: https://github.com/rm-controls/rm_infrastructure
+      url: https://github.com/rm-controls/rm_control
       version: master
     status: maintained
   robosense:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10069,6 +10069,21 @@ repositories:
       url: https://github.com/RoboJackets/rj-ros-common.git
       version: master
     status: developed
+  rm_infrastructure:
+    doc:
+      type: git
+      url: https://github.com/rm-controls/rm_infrastructure
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/rm-controls/rm_infrastructure-release
+      version: 1.0.35-1
+    source:
+      type: git
+      url: https://github.com/rm-controls/rm_infrastructure
+      version: master
+    status: maintained
   robosense:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6232,19 +6232,19 @@ repositories:
       url: https://github.com/osu-uwrt/riptide_controllers.git
       version: dev
     status: maintained
-  rm_infrastructure:
+  rm_control:
     doc:
       type: git
-      url: https://github.com/rm-controls/rm_infrastructure
+      url: https://github.com/rm-controls/rm_control
       version: master
     release:
       tags:
         release: release/noetic/{package}/{version}
-      url: https://github.com/rm-controls/rm_infrastructure-release
+      url: https://github.com/rm-controls/rm_control-release
       version: 1.0.35-1
     source:
       type: git
-      url: https://github.com/rm-controls/rm_infrastructure
+      url: https://github.com/rm-controls/rm_control
       version: master
     status: maintained
   robot_body_filter:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6232,6 +6232,21 @@ repositories:
       url: https://github.com/osu-uwrt/riptide_controllers.git
       version: dev
     status: maintained
+  rm_infrastructure:
+    doc:
+      type: git
+      url: https://github.com/rm-controls/rm_infrastructure
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/rm-controls/rm_infrastructure-release
+      version: 1.0.35-1
+    source:
+      type: git
+      url: https://github.com/rm-controls/rm_infrastructure
+      version: master
+    status: maintained
   robot_body_filter:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

rm_control

# The source is here: 
https://github.com/rm-controls/rm_control

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
