### PR TITLE
demos: 0.16.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -543,7 +543,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.15.0-1
+      version: 0.16.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.16.0-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.15.0-1`

## action_tutorials_cpp

- No changes

## action_tutorials_interfaces

- No changes

## action_tutorials_py

- No changes

## composition

- No changes

## demo_nodes_cpp

```
* Update talker_loaned_message.cpp (#518 <https://github.com/ros2/demos/issues/518>)
* Contributors: Zongbao Feng
```

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

- No changes

## dummy_map_server

- No changes

## dummy_robot_bringup

- No changes

## dummy_sensors

- No changes

## image_tools

```
* ambigulity: unknown type name 'nullptr_t' (#528 <https://github.com/ros2/demos/issues/528>)
* Add type masquerading demos (#482 <https://github.com/ros2/demos/issues/482>)
* Contributors: Audrow Nash, William Woodall, xwnb
```

## intra_process_demo

```
* Revert "Add type masquerading demos (#482 <https://github.com/ros2/demos/issues/482>)" (#520 <https://github.com/ros2/demos/issues/520>)
* Add type masquerading demos (#482 <https://github.com/ros2/demos/issues/482>)
* Contributors: Audrow Nash, William Woodall
```

## lifecycle

- No changes

## logging_demo

```
* Use rosidl_get_typesupport_target() (#529 <https://github.com/ros2/demos/issues/529>)
* Contributors: Shane Loretz
```

## pendulum_control

- No changes

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

```
* Initialize message correctly (#522 <https://github.com/ros2/demos/issues/522>)
* Contributors: Ivan Santiago Paunovic
```

## quality_of_service_demo_py

- No changes

## topic_monitor

```
* Small cleanups to the topic monitor. (#517 <https://github.com/ros2/demos/issues/517>)
* Contributors: Chris Lalancette
```

## topic_statistics_demo

- No changes
