### PR TITLE
rviz: 8.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3557,7 +3557,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 8.6.0-2
+      version: 8.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `8.7.0-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `8.6.0-2`

## rviz2

```
* Change links index.ros.org -> docs.ros.org. (#698 <https://github.com/ros2/rviz/issues/698>)
* Contributors: Chris Lalancette
```

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Update window close icon (#734 <https://github.com/ros2/rviz/issues/734>)
* Fix missing "X" icon in panel close button (#731 <https://github.com/ros2/rviz/issues/731>)
* Add rviz_rendering dependency to rviz_common (#727 <https://github.com/ros2/rviz/issues/727>)
* Remove the word "Alpha" from the splash screen. (#696 <https://github.com/ros2/rviz/issues/696>)
* Removed some memory leaks in rviz_rendering and rviz_rendering_tests (#710 <https://github.com/ros2/rviz/issues/710>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Rebecca Butler
```

## rviz_default_plugins

```
* Fix path message orientation error (#736 <https://github.com/ros2/rviz/issues/736>)
* Set topic namespace in interactive markers display (#725 <https://github.com/ros2/rviz/issues/725>)
* mass property visualization (#714 <https://github.com/ros2/rviz/issues/714>)
* Export InteractiveMarker (#718 <https://github.com/ros2/rviz/issues/718>)
* Yuv to rgb changes (#701 <https://github.com/ros2/rviz/issues/701>)
* Extract message type in ImageTransportDisplay (#711 <https://github.com/ros2/rviz/issues/711>)
* Duplicated code RobotJoint (#702 <https://github.com/ros2/rviz/issues/702>)
* Don't attempt to moc generate files that don't have QOBJECT. (#690 <https://github.com/ros2/rviz/issues/690>)
* Switch to including tf2_geometry_msgs.hpp (#689 <https://github.com/ros2/rviz/issues/689>)
* Contributors: Akash, Alejandro Hernández Cordero, Chris Lalancette, Paul, Rebecca Butler, brian soe, cturcotte-qnx
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Removed some memory leaks in rviz_rendering and rviz_rendering_tests (#710 <https://github.com/ros2/rviz/issues/710>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_rendering_tests

```
* Removed some memory leaks in rviz_rendering and rviz_rendering_tests (#710 <https://github.com/ros2/rviz/issues/710>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_visual_testing_framework

- No changes
