### PR TITLE
nodl_to_policy: 1.0.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1774,6 +1774,22 @@ repositories:
       url: https://github.com/ubuntu-robotics/nodl.git
       version: master
     status: developed
+  nodl_to_policy:
+    doc:
+      type: git
+      url: https://github.com/osrf/nodl_to_policy.git
+      version: master
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/nodl_to_policy-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/osrf/nodl_to_policy.git
+      version: master
+    status: maintained
   ntpd_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodl_to_policy` to `1.0.0-1`:

- upstream repository: https://github.com/osrf/nodl_to_policy.git
- release repository: https://github.com/ros2-gbp/nodl_to_policy-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
