### PR TITLE
ros2launch_security: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2883,6 +2883,25 @@ repositories:
       url: https://github.com/ros2/ros2cli_common_extensions.git
       version: galactic
     status: maintained
+  ros2launch_security:
+    doc:
+      type: git
+      url: https://github.com/osrf/ros2launch_security.git
+      version: main
+    release:
+      packages:
+      - ros2launch_security
+      - ros2launch_security_examples
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2launch_security-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/osrf/ros2launch_security.git
+      version: main
+    status: maintained
   ros_canopen:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2launch_security` to `1.0.0-1`:

- upstream repository: https://github.com/osrf/ros2launch_security.git
- release repository: https://github.com/ros2-gbp/ros2launch_security-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
