### PR TITLE
ros2launch_security: 1.0.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2974,6 +2974,25 @@ repositories:
       url: https://github.com/ros2-gbp/ros2cli_common_extensions-release.git
       version: 0.1.1-2
     status: maintained
+  ros2launch_security:
+    doc:
+      type: git
+      url: https://github.com/osrf/ros2launch_security.git
+      version: main
+    release:
+      packages:
+      - ros2launch_security
+      - ros2launch_security_examples
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2launch_security-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/osrf/ros2launch_security.git
+      version: main
+    status: maintained
   ros_canopen:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2launch_security` to `1.0.0-1`:

- upstream repository: https://github.com/osrf/ros2launch_security.git
- release repository: https://github.com/ros2-gbp/ros2launch_security-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
