### PR TITLE
ira_laser_tools: 1.0.6-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3064,7 +3064,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/iralabdisco/ira_laser_tools-release.git
-      version: 1.0.6-1
+      version: 1.0.6-2
     source:
       type: git
       url: https://github.com/iralabdisco/ira_laser_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ira_laser_tools` to `1.0.6-2`:

- upstream repository: https://github.com/iralabdisco/ira_laser_tools.git
- release repository: https://github.com/iralabdisco/ira_laser_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.6-1`

## ira_laser_tools

```
* add check for PCL version
* add new mantainer email
* fix launch before laser scan is available
* add a try catch for first non valid tf
* Retrying compare topics between ROS master and Token
* Contributors: JackFrost67
```
