### PR TITLE
ros2_tracing: 3.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2830,7 +2830,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 3.0.0-1
+      version: 3.1.0-1
     source:
       type: git
       url: https://gitlab.com/ros-tracing/ros2_tracing.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `3.1.0-1`:

- upstream repository: https://gitlab.com/ros-tracing/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.0.0-1`

## tracetools

```
* Correctly handle calls to TRACEPOINT() macro with no tracepoint args
* Move publisher handle tracepoint argument from rclcpp_publish to rcl_publish
* Add support for rmw init/pub, take, and executor instrumentation
* Contributors: Christophe Bedard
```

## tracetools_test

```
* Add tests for rmw init/pub, take, and executor instrumentation
* Add field type assertion utilities to TraceTestCase
* Fixing deprecated subscriber callback warnings
* Contributors: Abrar Rahman Protyasha, Christophe Bedard
```

## tracetools_trace

```
* Add support for rmw init/pub, take, and executor tracepoints
* Contributors: Christophe Bedard
```
