### PR TITLE
soccer_interfaces: 0.0.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3717,7 +3717,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ijnek/soccer_interfaces-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/ijnek/soccer_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `soccer_interfaces` to `0.0.3-1`:

- upstream repository: https://github.com/ijnek/soccer_interfaces.git
- release repository: https://github.com/ijnek/soccer_interfaces-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.2-1`

## soccer_vision_msgs

```
* add Ball msg
* Contributors: Kenji Brameld
```
