### PR TITLE
rm_control: 0.1.1-5 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6236,6 +6236,28 @@ repositories:
       url: https://github.com/osu-uwrt/riptide_controllers.git
       version: dev
     status: maintained
+  rm_control:
+    doc:
+      type: git
+      url: https://github.com/rm-controls/rm_control.git
+      version: master
+    release:
+      packages:
+      - rm_base
+      - rm_common
+      - rm_control
+      - rm_description
+      - rm_gazebo
+      - rm_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/rm-controls/rm_control-release.git
+      version: 0.1.1-5
+    source:
+      type: git
+      url: https://github.com/rm-controls/rm_control.git
+      version: master
+    status: developed
   robot_body_filter:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6308,6 +6308,7 @@ repositories:
     source:
       type: git
       url: https://github.com/rm-controls/rm_control.git
+      version: master
   rm_controllers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rm_control` to `0.1.1-5`:

- upstream repository: https://github.com/rm-controls/rm_control.git
- release repository: https://github.com/rm-controls/rm_control-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## rm_base

```
* Reset all version to 0.1.0
* Contributors: qiayuan
```

## rm_common

```
* Reset all version to 0.1.0
* Contributors: qiayuan
```

## rm_control

```
* Reset all version to 0.1.0
* Remove exec_depend rm_base of rm_control for ros_controllers CI
* Remove exec_depend: rm_description, rm_gazebo of rm_control
* Update package.xml url of rm_control
* Contributors: qiayuan
```

## rm_description

```
* Reset all version to 0.1.0
* Contributors: qiayuan
```

## rm_gazebo

```
* Reset all version to 0.1.0
* Contributors: qiayuan
```

## rm_msgs

```
* Reset all version to 0.1.0
* Contributors: qiayuan
```
