### PR TITLE
object_msgs_test: 0.3.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7662,6 +7662,14 @@ repositories:
       url: https://github.com/vooon/ntpd_driver.git
       version: master
     status: maintained
+  object_msgs_test:
+    release:
+      packages:
+      - object_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/GuoliangShi/object_msgs_test_release.git
+      version: 0.3.0-2
   object_recognition_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `object_msgs_test` to `0.3.0-2`:

- upstream repository: https://github.com/GuoliangShi/object_msgs_test.git
- release repository: https://github.com/GuoliangShi/object_msgs_test_release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## object_msgs

- No changes
