### PR TITLE
Add python3-mediapipe-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2632,19 +2632,6 @@ python-mechanize:
   gentoo: [dev-python/mechanize]
   nixos: [pythonPackages.mechanize]
   ubuntu: [python-mechanize]
-python3-mediapipe-pip:
-  debian:
-    pip:
-      packages: [mediapipe]
-  fedora:
-    pip:
-      packages: [mediapipe]
-  osx:
-    pip:
-      packages: [mediapipe]
-  ubuntu:
-    pip:
-      packages: [mediapipe]
 python-mock:
   alpine: [py-mock]
   arch: [python2-mock]
@@ -6753,6 +6740,19 @@ python3-mechanize:
     '*': [python3-mechanize]
     bionic: null
     xenial: null
+python3-mediapipe-pip:
+  debian:
+    pip:
+      packages: [mediapipe]
+  fedora:
+    pip:
+      packages: [mediapipe]
+  osx:
+    pip:
+      packages: [mediapipe]
+  ubuntu:
+    pip:
+      packages: [mediapipe]
 python3-meshio:
   arch: [python-meshio]
   debian: [python3-meshio]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2632,7 +2632,7 @@ python-mechanize:
   gentoo: [dev-python/mechanize]
   nixos: [pythonPackages.mechanize]
   ubuntu: [python-mechanize]
-python-mediapipe-pip:
+python3-mediapipe-pip:
   debian:
     pip:
       packages: [mediapipe]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2632,6 +2632,19 @@ python-mechanize:
   gentoo: [dev-python/mechanize]
   nixos: [pythonPackages.mechanize]
   ubuntu: [python-mechanize]
+python-mediapipe-pip:
+  debian:
+    pip:
+      packages: [mediapipe]
+  fedora:
+    pip:
+      packages: [mediapipe]
+  osx:
+    pip:
+      packages: [mediapipe]
+  ubuntu:
+    pip:
+      packages: [mediapipe]
 python-mock:
   alpine: [py-mock]
   arch: [python2-mock]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python-mediapipe-pip

## Package Upstream Source:

https://github.com/google/mediapipe

## Purpose of using this:

This adds mediapipe solutions to rosdep. Mediapipe solutions offer an easy and performant way to build pose tracking and other ml based applications.

Distro packaging links:

## Links to Distribution Packages

PyPi: https://pypi.org/project/mediapipe/