### PR TITLE
Add rqt_paramedit to documentation index for melodic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11708,6 +11708,12 @@ repositories:
       url: https://github.com/ros-visualization/rqt_nav_view.git
       version: master
     status: maintained
+  rqt_paramedit:
+    doc:
+      type: git
+      url: https://github.com/dornhege/rqt_paramedit.git
+      version: melodic-devel
+    status: maintained
   rqt_plot:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11713,6 +11713,10 @@ repositories:
       type: git
       url: https://github.com/dornhege/rqt_paramedit.git
       version: melodic-devel
+    source:
+      type: git
+      url: https://github.com/dornhege/rqt_paramedit.git
+      version: melodic-devel
     status: maintained
   rqt_plot:
     doc:


### PR DESCRIPTION
# Please Add rqt_paramedit to be indexed in the rosdistro.

melodic

# The source is here: 

https://github.com/dornhege/rqt_paramedit/tree/melodic-devel

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
