### PR TITLE
picknik_ament_copyright: 0.0.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2006,6 +2006,12 @@ repositories:
       url: https://github.com/ros-drivers/phidgets_drivers.git
       version: galactic
     status: maintained
+  picknik_ament_copyright:
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/PickNikRobotics/picknik_ament_copyright-release.git
+      version: 0.0.1-1
   plotjuggler:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `picknik_ament_copyright` to `0.0.1-1`:

- upstream repository: git@github.com:PickNikRobotics/picknik_ament_copyright.git
- release repository: https://github.com/PickNikRobotics/picknik_ament_copyright-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## picknik_ament_copyright

```
* use PickNik Inc. as copyright name (#1 <https://github.com/PickNikRobotics/picknik_ament_copyright/issues/1>)
* add readme with instructions
* update license in setup.py file
* initial commit for PickNik proprietary license
* Contributors: Joe Schornak, Joseph Schornak
```
