### PR TITLE
picknik_ament_copyright: 0.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1847,6 +1847,12 @@ repositories:
       url: https://github.com/ros-drivers/phidgets_drivers.git
       version: galactic
     status: maintained
+  picknik_ament_copyright:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/PickNikRobotics/picknik_ament_copyright-release.git
+      version: 0.0.2-1
   plotjuggler:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `picknik_ament_copyright` to `0.0.2-1`:

- upstream repository: git@github.com:PickNikRobotics/picknik_ament_copyright.git
- release repository: https://github.com/PickNikRobotics/picknik_ament_copyright-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## picknik_ament_copyright

```
* add name for the SPDX identifier argument (#2 <https://github.com/PickNikRobotics/picknik_ament_copyright/issues/2>)
* Contributors: Joe Schornak
```
