### PR TITLE
rosbridge_suite: 1.0.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3822,6 +3822,18 @@ repositories:
       url: https://github.com/ros2/rosbag2_bag_v2.git
       version: foxy
     status: maintained
+  rosbridge_suite:
+    release:
+      packages:
+      - rosapi
+      - rosbridge_library
+      - rosbridge_msgs
+      - rosbridge_server
+      - rosbridge_suite
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/rosbridge_suite-release.git
+      version: 1.0.5-1
   rosidl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `1.0.5-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## rosapi

- No changes

## rosbridge_library

- No changes

## rosbridge_msgs

- No changes

## rosbridge_server

```
* Fix globs in launch xml for ROS 2 pre-Galactic (#589 <https://github.com/foxglove/rosbridge_suite/issues/589>)
* Remove authentication features and rosauth dependency (#586 <https://github.com/foxglove/rosbridge_suite/issues/586>)
  [rosauth](http://wiki.ros.org/rosauth) is not maintained for ROS 2, and has not been released for Galactic (https://github.com/GT-RAIL/rosauth/issues/35). Since the authentication feature is old and not commonly used, and since rosbridge_suite has not yet been released in Eloquent, Foxy, or Galactic, we decided to just remove the authentication features to unblock us from pushing releases.
  To avoid breaking backwards compatibility, we will not publish the new version of rosbridge_suite for Dashing.
* The server now allows choosing port:=0 to select an ephemeral port, and sets the port number in the actual_port ROS param. (#585 <https://github.com/foxglove/rosbridge_suite/issues/585>)
* Contributors: Jacob Bandes-Storch
```

## rosbridge_suite

- No changes
