### PR TITLE
soccer_interfaces: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3636,6 +3636,23 @@ repositories:
       url: https://github.com/ros/sdformat_urdf.git
       version: ros2
     status: maintained
+  soccer_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ijnek/soccer_interfaces.git
+      version: rolling
+    release:
+      packages:
+      - soccer_vision_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ijnek/soccer_interfaces-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ijnek/soccer_interfaces.git
+      version: rolling
+    status: developed
   spdlog_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `soccer_interfaces` to `1.0.0-1`:

- upstream repository: https://github.com/ijnek/soccer_interfaces.git
- release repository: https://github.com/ijnek/soccer_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## soccer_vision_msgs

```
* bumping version to 1.0.0 to reach a mature state and follow semver's specifications
```
