### PR TITLE
soccer_interfaces: 1.0.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3754,7 +3754,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ijnek/soccer_interfaces-release.git
-      version: 0.0.3-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/ijnek/soccer_interfaces.git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3747,7 +3747,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ijnek/soccer_interfaces.git
-      version: main
+      version: rolling
     release:
       packages:
       - soccer_vision_msgs
@@ -3758,7 +3758,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ijnek/soccer_interfaces.git
-      version: main
+      version: rolling
     status: developed
   soccer_visualization:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `soccer_interfaces` to `1.0.0-1`:

- upstream repository: https://github.com/ijnek/soccer_interfaces.git
- release repository: https://github.com/ijnek/soccer_interfaces-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.3-1`

## soccer_vision_msgs

```
* bumping version to 1.0.0 to reach a mature state and follow semver's specifications
```
