### PR TITLE
soccer_interfaces: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4600,6 +4600,23 @@ repositories:
       url: https://github.com/oKermorgant/slider_publisher.git
       version: ros2
     status: maintained
+  soccer_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ijnek/soccer_interfaces.git
+      version: rolling
+    release:
+      packages:
+      - soccer_vision_msgs
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ijnek/soccer_interfaces-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ijnek/soccer_interfaces.git
+      version: rolling
+    status: developed
   sophus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `soccer_interfaces` to `1.0.0-1`:

- upstream repository: https://github.com/ijnek/soccer_interfaces.git
- release repository: https://github.com/ijnek/soccer_interfaces-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## soccer_vision_msgs

```
* bumping version to 1.0.0 to reach a mature state and follow semver's specifications
```
