### PR TITLE
lanelet2: 1.1.1-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1246,7 +1246,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/fzi-forschungszentrum-informatik/lanelet2-release.git
-      version: 1.1.1-1
+      version: 1.1.1-2
     source:
       type: git
       url: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lanelet2` to `1.1.1-2`:

- upstream repository: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git
- release repository: https://github.com/fzi-forschungszentrum-informatik/lanelet2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.1-1`

## lanelet2

```
* Add missing dependency to ros_environment
* Contributors: Fabian Poggenhans
```

## lanelet2_core

- No changes

## lanelet2_examples

- No changes

## lanelet2_io

- No changes

## lanelet2_maps

- No changes

## lanelet2_projection

- No changes

## lanelet2_python

- No changes

## lanelet2_routing

- No changes

## lanelet2_traffic_rules

- No changes

## lanelet2_validation

- No changes
