### PR TITLE
ignition_cmake2_vendor: 0.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1039,6 +1039,22 @@ repositories:
       url: https://github.com/ignitionrobotics/ign-rviz.git
       version: main
     status: developed
+  ignition_cmake2_vendor:
+    doc:
+      type: git
+      url: https://github.com/ignition-release/ignition_cmake2_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ignition_cmake2_vendor-release.git
+      version: 0.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ignition-release/ignition_cmake2_vendor.git
+      version: main
+    status: maintained
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ignition_cmake2_vendor` to `0.0.1-1`:

- upstream repository: https://github.com/ignition-release/ignition_cmake2_vendor.git
- release repository: https://github.com/ros2-gbp/ignition_cmake2_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ignition_cmake2_vendor

```
* Initial package
* Contributors: Scott K Logan
```
