### PR TITLE
knowledge_representation: 0.9.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3375,7 +3375,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/knowledge_representation-release.git
-      version: 0.9.3-1
+      version: 0.9.4-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `knowledge_representation` to `0.9.4-1`:

- upstream repository: https://github.com/utexas-bwi/knowledge_representation.git
- release repository: https://github.com/utexas-bwi-gbp/knowledge_representation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.9.3-1`

## knowledge_representation

```
* Add lock capability to LTMC
* Improve support for SVG transforms in map annotations
* Document map annotation process
* Improve example annotated map
* Contributors: Nick Walker, Yuqian Jiang, Tobias Fischer
```
