### PR TITLE
sol_vendor: 0.0.2-3 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4617,6 +4617,21 @@ repositories:
       url: https://github.com/ijnek/soccer_interfaces.git
       version: rolling
     status: developed
+  sol_vendor:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/sol_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/OUXT-Polaris/sol_vendor-release.git
+      version: 0.0.2-3
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/sol_vendor.git
+      version: main
+    status: developed
   sophus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sol_vendor` to `0.0.2-3`:

- upstream repository: https://github.com/OUXT-Polaris/sol_vendor.git
- release repository: https://github.com/OUXT-Polaris/sol_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## sol_vendor

```
* Merge branch 'main' of https://github.com/OUXT-Polaris/sol_vendor into main
* update CHANGELOG
* Setup scenario test workflow (#6 <https://github.com/OUXT-Polaris/sol_vendor/issues/6>)
* Merge pull request #4 <https://github.com/OUXT-Polaris/sol_vendor/issues/4> from OUXT-Polaris/workflow/scenario_test
  [Bot] Update workflow
* Setup scenario test workflow
* Merge pull request #3 <https://github.com/OUXT-Polaris/sol_vendor/issues/3> from OUXT-Polaris/workflow/galactic
  update CI workflow for galactic
* update .github/workflows/ROS2-Galactic.yaml
* Contributors: Masaya Kataoka, robotx_buildfarm, wam-v-tan
* Merge pull request #3 <https://github.com/OUXT-Polaris/sol_vendor/issues/3> from OUXT-Polaris/workflow/galactic
  update CI workflow for galactic
* update .github/workflows/ROS2-Galactic.yaml
* Contributors: Masaya Kataoka, robotx_buildfarm
```
