### PR TITLE
rosbridge_suite: 1.0.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3075,6 +3075,10 @@ repositories:
       version: master
     status: maintained
   rosbridge_suite:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/rosbridge_suite.git
+      version: ros2
     release:
       packages:
       - rosapi
@@ -3085,7 +3089,12 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 1.0.5-1
+      version: 1.0.6-1
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/rosbridge_suite.git
+      version: ros2
+    status: maintained
   rosidl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `1.0.6-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.5-1`

## rosapi

```
* Include /msg/ in type names (#591 <https://github.com/RobotWebTools/rosbridge_suite/issues/591>)
* Fix broken links in changelogs
* Contributors: Jacob Bandes-Storch
```

## rosbridge_library

```
* Fix broken links in changelogs
* Contributors: Jacob Bandes-Storch
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* Fix broken links in changelogs
* Contributors: Jacob Bandes-Storch
```

## rosbridge_suite

- No changes
