### PR TITLE
apriltag: 3.1.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -260,7 +260,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/AprilRobotics/apriltag-release.git
-      version: 3.1.2-2
+      version: 3.1.5-1
     source:
       type: git
       url: https://github.com/AprilRobotics/apriltag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag` to `3.1.5-1`:

- upstream repository: https://github.com/AprilRobotics/apriltag.git
- release repository: https://github.com/AprilRobotics/apriltag-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.1.2-2`
