### PR TITLE
Add python3-sounddevice-pip to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4709,12 +4709,14 @@ python-sortedcontainers-pip:
     pip:
       packages: [sortedcontainers]
 python-sounddevice-pip:
+  arch: [python-sounddevice]
   debian:
     pip:
       packages: [sounddevice]
   fedora:
     pip:
       packages: [sounddevice]
+  nixos: [python39Packages.sounddevice]
   osx:
     pip:
       packages: [sounddevice]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4708,21 +4708,6 @@ python-sortedcontainers-pip:
   ubuntu:
     pip:
       packages: [sortedcontainers]
-python-sounddevice-pip:
-  arch: [python-sounddevice]
-  debian:
-    pip:
-      packages: [sounddevice]
-  fedora:
-    pip:
-      packages: [sounddevice]
-  nixos: [python39Packages.sounddevice]
-  osx:
-    pip:
-      packages: [sounddevice]
-  ubuntu:
-    pip:
-      packages: [sounddevice]
 python-sparqlwrapper:
   debian: [python-sparqlwrapper]
   gentoo: [dev-python/sparql-wrapper]
@@ -7874,6 +7859,19 @@ python3-sqlalchemy:
   nixos: [python3Packages.sqlalchemy]
   opensuse: [python3-SQLAlchemy]
   ubuntu: [python3-sqlalchemy]
+python3-sounddevice-pip:
+  debian:
+    pip:
+      packages: [sounddevice]
+  fedora:
+    pip:
+      packages: [sounddevice]
+  osx:
+    pip:
+      packages: [sounddevice]
+  ubuntu:
+    pip:
+      packages: [sounddevice]
 python3-stable-baselines3-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4708,6 +4708,19 @@ python-sortedcontainers-pip:
   ubuntu:
     pip:
       packages: [sortedcontainers]
+python-sounddevice-pip:
+  debian:
+    pip:
+      packages: [sounddevice]
+  fedora:
+    pip:
+      packages: [sounddevice]
+  osx:
+    pip:
+      packages: [sounddevice]
+  ubuntu:
+    pip:
+      packages: [sounddevice]
 python-sparqlwrapper:
   debian: [python-sparqlwrapper]
   gentoo: [dev-python/sparql-wrapper]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-sounddevice-pip

## Package Upstream Source:

https://github.com/spatialaudio/python-sounddevice

## Purpose of using this:

This [Python](https://www.python.org/) module provides bindings for the [PortAudio](http://www.portaudio.com/) library and a few convenience functions to play and record [NumPy](https://numpy.org/) arrays containing audio signals.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- PyPi: https://pypi.org/project/sounddevice/
- Debian: not available
- Ubuntu: not available
- Arch: https://archlinux.org/packages/community/any/python-sounddevice/
- Gentoo: not available
- macOS: not available
- Alpine: not available
- NixOS/nixpkgs: https://search.nixos.org/packages?query=sounddevice