### PR TITLE
webots_ros2: 1.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4324,13 +4324,17 @@ repositories:
       packages:
       - webots_ros2
       - webots_ros2_abb
+      - webots_ros2_control
       - webots_ros2_core
       - webots_ros2_demos
+      - webots_ros2_driver
       - webots_ros2_epuck
       - webots_ros2_examples
       - webots_ros2_importer
+      - webots_ros2_mavic
       - webots_ros2_msgs
       - webots_ros2_tesla
+      - webots_ros2_tests
       - webots_ros2_tiago
       - webots_ros2_turtlebot
       - webots_ros2_tutorials
@@ -4339,7 +4343,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/cyberbotics/webots_ros2-release.git
-      version: 1.0.6-1
+      version: 1.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `webots_ros2` to `1.1.1-1`:

- upstream repository: https://github.com/cyberbotics/webots_ros2.git
- release repository: https://github.com/cyberbotics/webots_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.6-1`
