### PR TITLE
slider_publisher: 2.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4590,11 +4590,15 @@ repositories:
       version: foxy-devel
     status: maintained
   slider_publisher:
+    doc:
+      type: git
+      url: https://github.com/oKermorgant/slider_publisher.git
+      version: ros2
     release:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/oKermorgant/slider_publisher-release.git
-      version: 1.0.2-2
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/oKermorgant/slider_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `slider_publisher` to `2.0.0-1`:

- upstream repository: https://github.com/oKermorgant/slider_publisher.git
- release repository: https://github.com/oKermorgant/slider_publisher-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.2-2`

## slider_publisher

```
* add service and detects value type (float / int / bool)
* can pick default value
* Contributors: Olivier Kermorgant
```
