### PR TITLE
rmw_gurumdds: 3.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2712,7 +2712,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
-      version: 3.0.2-1
+      version: 3.0.3-1
     source:
       type: git
       url: https://github.com/ros2/rmw_gurumdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_gurumdds` to `3.0.3-1`:

- upstream repository: https://github.com/ros2/rmw_gurumdds.git
- release repository: https://github.com/ros2-gbp/rmw_gurumdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.0.2-1`

## rmw_gurumdds_cpp

```
* Remove datareader listener patch
* Remove unnecessary operation
* Contributors: Youngjin Yun
```

## rmw_gurumdds_shared_cpp

```
* Wait for state change of topic cache
* Remove datareader listener patch
* Remove attached waitset conditions on destructor
* Remove unnecessary operation
* Contributors: Youngjin Yun
```
