### PR TITLE
rmw_gurumdds: 2.1.8-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2789,7 +2789,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
-      version: 2.1.7-1
+      version: 2.1.8-1
     source:
       type: git
       url: https://github.com/ros2/rmw_gurumdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_gurumdds` to `2.1.8-1`:

- upstream repository: https://github.com/ros2/rmw_gurumdds.git
- release repository: https://github.com/ros2-gbp/rmw_gurumdds-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.7-1`

## rmw_gurumdds_cpp

```
* Remove datareader listener patch
* Remove unnecessary operation
* Contributors: Youngjin Yun
```

## rmw_gurumdds_shared_cpp

```
* Wait for state change of topic cache
* Remove datareader listener patch
* Remove attached waitset conditions on destructor
* Remove unnecessary operation
* Contributors: Youngjin Yun
```
