### PR TITLE
rc_genicam_api: 2.5.6-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2262,7 +2262,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rc_genicam_api-release.git
-      version: 2.5.0-2
+      version: 2.5.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_api` to `2.5.6-1`:

- upstream repository: https://github.com/roboception/rc_genicam_api.git
- release repository: https://github.com/ros2-gbp/rc_genicam_api-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.5.0-2`

## rc_genicam_api

```
* Changed ImageList::find with tolerance > 0 to return the closest within tolerance
```
