### PR TITLE
rc_genicam_driver: 0.2.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2278,7 +2278,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rc_genicam_driver_ros2-release.git
-      version: 0.1.3-2
+      version: 0.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_driver` to `0.2.0-1`:

- upstream repository: https://github.com/roboception/rc_genicam_driver_ros2.git
- release repository: https://github.com/ros2-gbp/rc_genicam_driver_ros2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.3-2`

## rc_genicam_driver

```
For supporting rc_sgm_producer:
* Extend color format to RGB8 for ros foxy
* Using parameter PtpEnable instead of deprecated parameter GevIEEE1588
```
