### PR TITLE
slider_publisher: 1.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8105,11 +8105,15 @@ repositories:
       version: noetic-devel
     status: maintained
   slider_publisher:
+    doc:
+      type: git
+      url: https://github.com/oKermorgant/slider_publisher.git
+      version: ros1
     release:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/oKermorgant/slider_publisher-release.git
-      version: 1.0.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/oKermorgant/slider_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `slider_publisher` to `1.1.1-1`:

- upstream repository: https://github.com/oKermorgant/slider_publisher.git
- release repository: https://github.com/oKermorgant/slider_publisher-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.0-1`

## slider_publisher

```
* allow service calls / different control for double,int,bool
* can pick default value
* Contributors: Olivier Kermorgant
```
