### PR TITLE
neo_simulation2: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1629,6 +1629,21 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: ros2
     status: maintained
+  neo_simulation2:
+    doc:
+      type: git
+      url: https://github.com/neobotix/neo_simulation2.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/neobotix/neo_simulation2-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/neobotix/neo_simulation2.git
+      version: main
+    status: maintained
   nmea_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `neo_simulation2` to `1.0.0-1`:

- upstream repository: https://github.com/neobotix/neo_simulation2.git
- release repository: https://github.com/neobotix/neo_simulation2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
