### PR TITLE
rclc: 2.0.4-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2401,7 +2401,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
-      version: 2.0.3-3
+      version: 2.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclc` to `2.0.4-1`:

- upstream repository: https://github.com/ros2/rclc.git
- release repository: https://github.com/ros2-gbp/rclc-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.3-3`

## rclc

```
* Refactoring: remove callback_type
* Improvement: Checking for valid ROS context in spin_some
* Bug fix: Ignoring unsuccessful SERVICE_TAKE
* Bug fix: Updated ci workflow dependency on galactic
* Improvement: Updated codecov configuration to ignore unit tests
```

## rclc_examples

```
* Added pingpong example (example for C++ support)
```

## rclc_lifecycle

```
* Provide lifecycle services in the rclc lifecycle nodes
```

## rclc_parameter

```
* Added Quality Declaration Statement
```
