### PR TITLE
catch_ros: 0.5.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -579,7 +579,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/AIS-Bonn/catch_ros-release.git
-      version: 0.4.0-1
+      version: 0.5.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catch_ros` to `0.5.0-2`:

- upstream repository: https://github.com/AIS-Bonn/catch_ros
- release repository: https://github.com/AIS-Bonn/catch_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.0-1`

## catch_ros

```
* Update Catch to version v2.13.7 (PR #15)
* Update CMakeLists.txt to pass catkin_lint (PR #14)
* Contributors: Jorge Nicho, Martin Jansa, Max Schwarz, augustinmanecy, sven-herrmann
```
