### PR TITLE
dynamic-graph: 4.4.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2489,7 +2489,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/stack-of-tasks/dynamic-graph-ros-release.git
-      version: 4.3.4-1
+      version: 4.4.0-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/dynamic-graph.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic-graph` to `4.4.0-1`:

- upstream repository: https://github.com/stack-of-tasks/dynamic-graph.git
- release repository: https://github.com/stack-of-tasks/dynamic-graph-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `4.3.4-1`
