### PR TITLE
rviz: 1.13.19-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12210,7 +12210,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.13.18-1
+      version: 1.13.19-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.13.19-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.13.18-1`

## rviz

```
* IntensityPCTransformer: make min/max values read-only if auto-compute is off
* Smoothly move PCL given a moving frame_id (#1655 <https://github.com/ros-visualization/rviz/issues/1655>)
* Smoothly move an Odometry's path given a moving frame_id (#1631 <https://github.com/ros-visualization/rviz/issues/1631>)
* TF display: Correctly reparent root frame property (#1647 <https://github.com/ros-visualization/rviz/issues/1647>)
* Fix memory leak
* Contributors: Robert Haschke, anre
```
