### PR TITLE
rviz: 1.14.9-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7799,7 +7799,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.14.8-1
+      version: 1.14.9-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.14.9-2`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.14.8-1`

## rviz

```
* Revert #1639 <https://github.com/ros-visualization/rviz/issues/1639> as it strongly delayed showing dialogs under heavy (rendering) load
* Smoothly move PCL given a moving frame_id (#1655 <https://github.com/ros-visualization/rviz/issues/1655>)
* Smoothly move an Odometry's path given a moving frame_id (#1631 <https://github.com/ros-visualization/rviz/issues/1631>)
* TF display: Correctly reparent root frame property (#1647 <https://github.com/ros-visualization/rviz/issues/1647>)
* DepthCloudDisplay: remove mutex for PointCloudCommon
* Fix memory leak
* Contributors: Robert Haschke, Institute for Autonomous Systems Technology, anre
```
