### PR TITLE
gazebo_video_monitors: 0.7.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2305,11 +2305,12 @@ repositories:
       packages:
       - gazebo_video_monitor_msgs
       - gazebo_video_monitor_plugins
+      - gazebo_video_monitor_utils
       - gazebo_video_monitors
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/nlamprian/gazebo_video_monitors-release.git
-      version: 0.6.0-1
+      version: 0.7.0-1
     source:
       type: git
       url: https://github.com/nlamprian/gazebo_video_monitors.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_video_monitors` to `0.7.0-1`:

- upstream repository: https://github.com/nlamprian/gazebo_video_monitors.git
- release repository: https://github.com/nlamprian/gazebo_video_monitors-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.0-1`

## gazebo_video_monitor_msgs

```
* Resolve catkin lint errors
```

## gazebo_video_monitor_plugins

```
* Resolve catkin lint errors
* Add service for deferred initialization
  Launching a simulation with a robot that has ray sensors may make
  Gazebo/ODE crash. The part that makes the difference is the creation
  of the scene (if skipped, the crash goes away). Having found no
  sensible reason why this is, I add this service to give control to
  the user when to initialize the plugin.
```

## gazebo_video_monitor_utils

```
* Resolve catkin lint errors
* Add wait_for_model utility
  - Add utils package
  - Provide script that waits for model to appear and then triggers
  initialization of a gvm plugin
```

## gazebo_video_monitors

- No changes
