### PR TITLE
paho-mqtt-c: 1.3.9-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1935,6 +1935,17 @@ repositories:
       url: https://github.com/osrf/osrf_testing_tools_cpp.git
       version: master
     status: maintained
+  paho-mqtt-c:
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/nobleo/paho.mqtt.c-release.git
+      version: 1.3.9-2
+    source:
+      type: git
+      url: https://github.com/eclipse/paho.mqtt.c.git
+      version: master
+    status: maintained
   pcl_msgs:
     release:
       tags:

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1940,7 +1940,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/nobleo/paho.mqtt.c-release.git
-      version: 1.3.9-2
+      version: 1.3.9-3
     source:
       type: git
       url: https://github.com/eclipse/paho.mqtt.c.git


### PR DESCRIPTION
Increasing version of package(s) in repository `paho-mqtt-c` to `1.3.9-2`:

- upstream repository: https://github.com/eclipse/paho.mqtt.c.git
- release repository: https://github.com/nobleo/paho.mqtt.c-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

As per request here: https://github.com/nobleo/paho.mqtt.cpp-release/issues/1