### PR TITLE
ruckig: 0.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3618,7 +3618,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/pantor/ruckig-release.git
-      version: 0.3.3-2
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/pantor/ruckig.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ruckig` to `0.4.0-1`:

- upstream repository: https://github.com/pantor/ruckig.git
- release repository: https://github.com/pantor/ruckig-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.3-2`
