### PR TITLE
paho-mqtt-cpp: 1.2.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5133,6 +5133,17 @@ repositories:
       url: https://github.com/eclipse/paho.mqtt.c.git
       version: master
     status: maintained
+  paho-mqtt-cpp:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/nobleo/paho.mqtt.cpp-release.git
+      version: 1.2.0-2
+    source:
+      type: git
+      url: https://github.com/eclipse/paho.mqtt.cpp.git
+      version: master
+    status: maintained
   panda_moveit_config:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `paho-mqtt-cpp` to `1.2.0-2`:

- upstream repository: https://github.com/eclipse/paho.mqtt.cpp.git
- release repository: https://github.com/nobleo/paho.mqtt.cpp-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
