### PR TITLE
ruckig: 0.4.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3686,7 +3686,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/pantor/ruckig-release.git
-      version: 0.3.3-3
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/pantor/ruckig.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ruckig` to `0.4.0-1`:

- upstream repository: https://github.com/pantor/ruckig.git
- release repository: https://github.com/pantor/ruckig-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.3-3`
