### PR TITLE
ruckig: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7784,7 +7784,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/pantor/ruckig-release.git
-      version: 0.3.3-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/pantor/ruckig.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ruckig` to `0.4.0-1`:

- upstream repository: https://github.com/pantor/ruckig.git
- release repository: https://github.com/pantor/ruckig-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.3-1`
