### PR TITLE
espeak_ros: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -984,7 +984,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://gitlab.com/espeak-ros2/espeak-ros2-release.git
-      version: 0.1.0-6
+      version: 1.0.0-1
     source:
       type: git
       url: https://gitlab.com/espeak-ros2/espeak-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `espeak_ros` to `1.0.0-1`:

- upstream repository: https://gitlab.com/espeak-ros2/espeak-ros2.git
- release repository: https://gitlab.com/espeak-ros2/espeak-ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.0-6`

## espeak_interfaces

```
* Fix issues detected by linters
* Contributors: Thibaud Chupin
```

## espeak_ros

```
* Better detect when the call to espeak fails
  If the audio device does not exist, espeak will just print a bunch of
  warnings to stderr but still return 0. Now if any test is present
  in stderr we interpret it as a failure.
* Fix issues detected by linters
* Fix install directory of espeak_ros nodes
* Contributors: Thibaud Chupin
```
