### PR TITLE
rclcpp: 13.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2265,7 +2265,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 12.0.0-1
+      version: 13.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `13.0.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `12.0.0-1`

## rclcpp

```
* Remove can_be_nullptr assignment check for QNX case. (#1752 <https://github.com/ros2/rclcpp/issues/1752>)
* Update client API to be able to remove pending requests. (#1734 <https://github.com/ros2/rclcpp/issues/1734>)
* Fix: Allow to add a node while spinning in the StaticSingleThreadedExecutor. (#1690 <https://github.com/ros2/rclcpp/issues/1690>)
* Add tracing instrumentation for executor and message taking. (#1738 <https://github.com/ros2/rclcpp/issues/1738>)
* Fix: Reset timer trigger time before execute in StaticSingleThreadedExecutor. (#1739 <https://github.com/ros2/rclcpp/issues/1739>)
* Use FindPython3 and make python3 dependency explicit. (#1745 <https://github.com/ros2/rclcpp/issues/1745>)
* Use rosidl_get_typesupport_target(). (#1729 <https://github.com/ros2/rclcpp/issues/1729>)
* Fix returning invalid namespace if sub_namespace is empty. (#1658 <https://github.com/ros2/rclcpp/issues/1658>)
* Add free function to wait for a subscription message. (#1705 <https://github.com/ros2/rclcpp/issues/1705>)
* Use rcpputils/scope_exit.hpp and remove rclcpp/scope_exit.hpp. (#1727 <https://github.com/ros2/rclcpp/issues/1727>)
* Contributors: Ahmed Sobhy, Christophe Bedard, Ivan Santiago Paunovic, Karsten Knese, M. Hofstätter, Mauro Passerino, Shane Loretz, mauropasse
```

## rclcpp_action

```
* Use rcpputils/scope_exit.hpp and remove rclcpp/scope_exit.hpp. (#1727 <https://github.com/ros2/rclcpp/issues/1727>)
* Contributors: Christophe Bedard
```

## rclcpp_components

```
* Update client API to be able to remove pending requests. (#1734 <https://github.com/ros2/rclcpp/issues/1734>)
* Contributors: Ivan Santiago Paunovic
```

## rclcpp_lifecycle

```
* Update client API to be able to remove pending requests. (#1734 <https://github.com/ros2/rclcpp/issues/1734>)
* Change log level for lifecycle_publisher. (#1715 <https://github.com/ros2/rclcpp/issues/1715>)
* Fix: RCLCPP_PUBLIC -> RCLCPP_LIFECYCLE_PUBLIC (#1732 <https://github.com/ros2/rclcpp/issues/1732>)
* Use rcpputils/scope_exit.hpp and remove rclcpp/scope_exit.hpp (#1727 <https://github.com/ros2/rclcpp/issues/1727>)
* Contributors: Alberto Soragna, Christophe Bedard, Ivan Santiago Paunovic, Shane Loretz
```
