### PR TITLE
paho-mqtt-c: 1.3.9-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2380,6 +2380,17 @@ repositories:
       url: https://github.com/osrf/osrf_testing_tools_cpp.git
       version: foxy
     status: maintained
+  paho-mqtt-c:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/nobleo/paho.mqtt.c-release.git
+      version: 1.3.9-2
+    source:
+      type: git
+      url: https://github.com/eclipse/paho.mqtt.c.git
+      version: master
+    status: maintained
   pal_gazebo_worlds:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `paho-mqtt-c` to `1.3.9-2`:

- upstream repository: https://github.com/eclipse/paho.mqtt.c.git
- release repository: https://github.com/nobleo/paho.mqtt.c-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
