### PR TITLE
rviz_animated_view_controller: 0.2.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7822,6 +7822,21 @@ repositories:
       url: https://github.com/ros-visualization/rviz.git
       version: noetic-devel
     status: maintained
+  rviz_animated_view_controller:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rviz_animated_view_controller.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rviz_animated_view_controller-release.git
+      version: 0.2.0-2
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rviz_animated_view_controller.git
+      version: noetic-devel
+    status: maintained
   rviz_satellite:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_animated_view_controller` to `0.2.0-2`:

- upstream repository: https://github.com/ros-visualization/rviz_animated_view_controller.git
- release repository: https://github.com/ros-gbp/rviz_animated_view_controller-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## rviz_animated_view_controller

```
* add license file
* fix typo in README image link
* clip gif a bit shorter
* add README and demo gif
* Add option to pause the current animation
* Publish camera view images
* accidentally deleted cv_bridge and image_transport
* fix dependencies in package.xml
* Add publisher for the current view camera pose
* Add properties showing view window size in panel
* Add support for camera trajectories messages
* switch ci to use noetic-devel branch
* add bool property allowing the user to activate publishing of the view images in the view controller
  Is automatically activated when a trajectory is requested to be rendered frame by frame.
* add image publisher for rviz camera's view
  Publish what the user sees in the rviz visualization window.
  Publishing is only active when the render_frame_by_frame parameter is set to true in the CameraTrajectory message requesting the trajectory.
  Otherwise there is a lag on slower computers when the resolution of the view image is large.
* add publisher for a message to indicate the animation is finished
* add functionality to render the trajectory frame by frame with a specified number of frames per second
* add support for view_controller_msgs::CameraTrajectory messages
  First, the movements requested using the CameraPlacement or CameraTrajectory messages are stored in a movement buffer.
  Then, animation is enabled, causing the update method to use the movements from the buffer to perform camera movements.
* convert transformCameraPlacementToAttachedFrame method's parameter from whole CameraPlacement to only the relevant eye, focus and up
  this way the method is more general
* add gh actions and gitignore
* compile on kinetic Qt5
* add myself as maintainer (#8 <https://github.com/ros-visualization/rviz_animated_view_controller/issues/8>)
* Contributors: Evan Flynn, Gene Merewether, Razlaw, razlaw
```
