### PR TITLE
microstrain_inertial: 2.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4112,6 +4112,22 @@ repositories:
       url: https://github.com/ros-drivers/microstrain_3dmgx2_imu.git
       version: indigo-devel
     status: maintained
+  microstrain_inertial:
+    release:
+      packages:
+      - microstrain_inertial_driver
+      - microstrain_inertial_examples
+      - microstrain_inertial_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/LORD-MicroStrain/microstrain_inertial-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/LORD-MicroStrain/microstrain_inertial.git
+      version: 2.0.0
+    status: developed
   mir_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `2.0.0-1`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/LORD-MicroStrain/microstrain_inertial-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## microstrain_inertial_driver

```
* Optionally polls and waits for device to exist before trying to connect
* Adds tolerance for streaming devices on startup by retrying connections until the device can be communicated with
* Moves common code to submodule to reduce code duplication
* Renames packages to be compatible with ROS build farm
* Gracefully exits on device disconnect
* Contributors: Rob Fisher
```

## microstrain_inertial_examples

```
* Consolidates examples to single package
* Contributors: Rob Fisher
```

## microstrain_inertial_msgs

```
* Moves service messages to msgs package
* Contributors: Rob Fisher
```
