### PR TITLE
cmvision: 0.5.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -650,6 +650,21 @@ repositories:
       url: https://github.com/ros/cmake_modules.git
       version: 0.4-devel
     status: maintained
+  cmvision:
+    doc:
+      type: git
+      url: https://github.com/teshanshanuka/cmvision.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/teshanshanuka/cmvision-release.git
+      version: 0.5.0-1
+    source:
+      type: git
+      url: https://github.com/teshanshanuka/cmvision.git
+      version: noetic-devel
+    status: maintained
   cnpy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cmvision` to `0.5.0-1`:

- upstream repository: https://github.com/teshanshanuka/cmvision.git
- release repository: https://github.com/teshanshanuka/cmvision-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## cmvision

```
* Updated cmvision for OpenCV4 and ros-noetic
```
