### PR TITLE
common_interfaces: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -433,7 +433,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 2.3.0-1
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_interfaces` to `3.0.0-1`:

- upstream repository: https://github.com/ros2/common_interfaces.git
- release repository: https://github.com/ros2-gbp/common_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.0-1`

## actionlib_msgs

- No changes

## common_interfaces

- No changes

## diagnostic_msgs

- No changes

## geometry_msgs

- No changes

## nav_msgs

- No changes

## sensor_msgs

- No changes

## sensor_msgs_py

- No changes

## shape_msgs

- No changes

## std_msgs

- No changes

## std_srvs

- No changes

## stereo_msgs

- No changes

## trajectory_msgs

- No changes

## visualization_msgs

```
* Marker Textures (#153 <https://github.com/ros2/common_interfaces/issues/153>)
* Contributors: Greg Balke
```
