### PR TITLE
Adding python3 support for RPi.GPIO

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4336,6 +4336,7 @@ python-rpi.gpio-pip:
       packages: [RPi.GPIO]
 python3-rpi.gpio:
   debian:
+    bullseye: [python3-rpi.gpio]
     buster: [python3-rpi.gpio]
     jessie:
       pip:
@@ -4345,8 +4346,8 @@ python3-rpi.gpio:
         packages: [RPi.GPIO]
   fedora: [python3-RPi.GPIO]
   ubuntu:
+    '*': [python3-rpi.gpio]    
     artful: [python3-rpi.gpio]
-    '*': [python3-rpi.gpio]
     trusty:
       pip:
         packages: [RPi.GPIO]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4334,7 +4334,48 @@ python-rpi.gpio-pip:
   ubuntu:
     pip:
       packages: [RPi.GPIO]
-python-rrdtool:
+python3-rpi.gpio:
+  debian:
+    buster: [python3-rpi.gpio]
+    jessie:
+      pip:
+        packages: [RPi.GPIO]
+    stretch:
+      pip:
+        packages: [RPi.GPIO]
+  ubuntu:
+    artful: [python3-rpi.gpio]
+    bionic: [python3-rpi.gpio]
+    trusty:
+      pip:
+        packages: [RPi.GPIO]
+    utopic:
+      pip:
+        packages: [RPi.GPIO]
+    vivid:
+      pip:
+        packages: [RPi.GPIO]
+    wily:
+      pip:
+        packages: [RPi.GPIO]
+    xenial:
+      pip:
+        packages: [RPi.GPIO]
+    yakkety:
+      pip:
+        packages: [RPi.GPIO]
+    zesty: [python3-rpi.gpio]
+python3-rpi.gpio-pip:
+  debian:
+    pip:
+      packages: [RPi.GPIO]
+  fedora:
+    pip:
+      packages: [RPi.GPIO]
+  ubuntu:
+    pip:
+      packages: [RPi.GPIO]
+python3-rrdtool:
   debian: [python-rrdtool]
   fedora: [rrdtool-python]
   gentoo: [net-analyzer/rrdtool]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4375,7 +4375,7 @@ python3-rpi.gpio-pip:
   ubuntu:
     pip:
       packages: [RPi.GPIO]
-python3-rrdtool:
+python-rrdtool:
   debian: [python-rrdtool]
   fedora: [rrdtool-python]
   gentoo: [net-analyzer/rrdtool]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4334,49 +4334,6 @@ python-rpi.gpio-pip:
   ubuntu:
     pip:
       packages: [RPi.GPIO]
-python3-rpi.gpio:
-  debian:
-    bullseye: [python3-rpi.gpio]
-    buster: [python3-rpi.gpio]
-    jessie:
-      pip:
-        packages: [RPi.GPIO]
-    stretch:
-      pip:
-        packages: [RPi.GPIO]
-  fedora: [python3-RPi.GPIO]
-  ubuntu:
-    '*': [python3-rpi.gpio]    
-    artful: [python3-rpi.gpio]
-    trusty:
-      pip:
-        packages: [RPi.GPIO]
-    utopic:
-      pip:
-        packages: [RPi.GPIO]
-    vivid:
-      pip:
-        packages: [RPi.GPIO]
-    wily:
-      pip:
-        packages: [RPi.GPIO]
-    xenial:
-      pip:
-        packages: [RPi.GPIO]
-    yakkety:
-      pip:
-        packages: [RPi.GPIO]
-    zesty: [python3-rpi.gpio]
-python3-rpi.gpio-pip:
-  debian:
-    pip:
-      packages: [RPi.GPIO]
-  fedora:
-    pip:
-      packages: [RPi.GPIO]
-  ubuntu:
-    pip:
-      packages: [RPi.GPIO]
 python-rrdtool:
   debian: [python-rrdtool]
   fedora: [rrdtool-python]
@@ -7635,6 +7592,49 @@ python3-rospkg-modules:
     pip:
       packages: [rospkg]
   ubuntu: [python3-rospkg-modules]
+python3-rpi.gpio:
+  debian:
+    bullseye: [python3-rpi.gpio]
+    buster: [python3-rpi.gpio]
+    jessie:
+      pip:
+        packages: [RPi.GPIO]
+    stretch:
+      pip:
+        packages: [RPi.GPIO]
+  fedora: [python3-RPi.GPIO]
+  ubuntu:
+    '*': [python3-rpi.gpio]   
+    artful: [python3-rpi.gpio]
+    trusty:
+      pip:
+        packages: [RPi.GPIO]
+    utopic:
+      pip:
+        packages: [RPi.GPIO]
+    vivid:
+      pip:
+        packages: [RPi.GPIO]
+    wily:
+      pip:
+        packages: [RPi.GPIO]
+    xenial:
+      pip:
+        packages: [RPi.GPIO]
+    yakkety:
+      pip:
+        packages: [RPi.GPIO]
+    zesty: [python3-rpi.gpio]
+python3-rpi.gpio-pip:
+  debian:
+    pip:
+      packages: [RPi.GPIO]
+  fedora:
+    pip:
+      packages: [RPi.GPIO]
+  ubuntu:
+    pip:
+      packages: [RPi.GPIO]
 python3-rtree:
   debian: [python3-rtree]
   ubuntu: [python3-rtree]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4346,7 +4346,7 @@ python3-rpi.gpio:
   fedora: [python3-RPi.GPIO]
   ubuntu:
     artful: [python3-rpi.gpio]
-    bionic: [python3-rpi.gpio]
+    '*': [python3-rpi.gpio]
     trusty:
       pip:
         packages: [RPi.GPIO]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4343,6 +4343,7 @@ python3-rpi.gpio:
     stretch:
       pip:
         packages: [RPi.GPIO]
+  fedora: [python3-RPi.GPIO]
   ubuntu:
     artful: [python3-rpi.gpio]
     bionic: [python3-rpi.gpio]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

RPi.GPIO (python3 support)

## Package Upstream Source:

https://sourceforge.net/p/raspberry-gpio-python/wiki/Home/

## Purpose of using this:

Adds python3 support to useful package. Set GPIO pins high or low on Raspberry Pi. 

Distro packaging links:

## Links to Distribution Packages


More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/
   - REQUIRED
- Fedora: https://src.fedoraproject.org/browse/projects/
  - IF AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL


<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

ROSDISTRO NAME

# The source is here: 

http://sourcecode_url



# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
