### PR TITLE
turtlebot3_simulations: 2.2.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3969,6 +3969,25 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
       version: rolling-devel
     status: developed
+  turtlebot3_simulations:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
+      version: ros2
+    release:
+      packages:
+      - turtlebot3_fake_node
+      - turtlebot3_gazebo
+      - turtlebot3_simulations
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/robotis-ros2-release/turtlebot3_simulations-release.git
+      version: 2.2.5-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
+      version: ros2
+    status: maintained
   turtlesim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_simulations` to `2.2.5-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
- release repository: https://github.com/robotis-ros2-release/turtlebot3_simulations-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## turtlebot3_fake_node

```
* Release for ROS2 Rolling
* Contributors: Will Son
```

## turtlebot3_gazebo

```
* Release for ROS2 Rolling
* Contributors: Will Son
```

## turtlebot3_simulations

```
* Release for ROS2 Rolling
* Contributors: Will Son
```
