### PR TITLE
add anytree python package via pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5800,6 +5800,16 @@ python3-ansible-runner-pip:
   ubuntu:
     pip:
       packages: [ansible-runner]
+python3-anytree-pip:
+  debian:
+    pip:
+      packages: [anytree]
+  fedora:
+    pip:
+      packages: [anytree]
+  ubuntu:
+    pip:
+      packages: [anytree]
 python3-argcomplete:
   alpine: [py3-argcomplete]
   arch: [python-argcomplete]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

anytree

## Package Upstream Source:

https://pypi.org/project/anytree/

## Purpose of using this:

`anytree` is a "simple, lightweight and extensible Tree data structure." Essentially it's a python package that is used for building, rendering, searching and iterating over trees. The basic node class they provide can be extended with extra attributes or you can extend your own classes into tree classes. It prevents us from having to write our own tree boilerplate.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - pip: anytree
- Ubuntu: https://packages.ubuntu.com/
   - pip: anytree
- Fedora: https://src.fedoraproject.org/browse/projects/
  - pip: anytree
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL

