### PR TITLE
aws-robomaker-small-warehouse-world: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -341,6 +341,19 @@ repositories:
       url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
       version: master
     status: developed
+  aws-robomaker-small-warehouse-world:
+    release:
+      packages:
+      - aws_robomaker_small_warehouse_world
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/aws-gbp/aws_robomaker_small_warehouse_world-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/aws-robotics/aws-robomaker-small-warehouse-world.git
+      version: ros2
+    status: maintained
   backward_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aws-robomaker-small-warehouse-world` to `1.0.0-1`:

- upstream repository: https://github.com/aws-robotics/aws-robomaker-small-warehouse-world.git
- release repository: https://github.com/aws-gbp/aws_robomaker_small_warehouse_world-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
