### PR TITLE
Add filetype to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1648,13 +1648,6 @@ python-fcn-pip: &migrate_eol_2025_04_30_python3_fcn_pip
     pip:
       depends: [liblapack-dev]
       packages: [fcn]
-python-filetype-pip:
-  debian:
-    pip:
-      packages: [filetype]
-  ubuntu:
-    pip:
-      packages: [filetype]
 python-filterpy-pip:
   debian:
     pip:
@@ -6311,6 +6304,13 @@ python3-fastnumbers-pip:
     pip:
       packages: [fastnumbers]
 python3-fcn-pip: *migrate_eol_2025_04_30_python3_fcn_pip
+python-filetype-pip:
+  debian:
+    pip:
+      packages: [filetype]
+  ubuntu:
+    pip:
+      packages: [filetype]
 python3-filterpy-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -157,10 +157,6 @@ exhale-pip:
   ubuntu:
     pip:
       packages: [exhale]
-python-filetype-pip:
-  ubuntu:
-    pip:
-      packages: [filetype]
 gunicorn:
   debian: [gunicorn]
   fedora: [python-gunicorn]
@@ -1652,6 +1648,13 @@ python-fcn-pip: &migrate_eol_2025_04_30_python3_fcn_pip
     pip:
       depends: [liblapack-dev]
       packages: [fcn]
+python-filetype-pip:
+  debian:
+    pip:
+      packages: [filetype]
+  ubuntu:
+    pip:
+      packages: [filetype]
 python-filterpy-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -157,7 +157,7 @@ exhale-pip:
   ubuntu:
     pip:
       packages: [exhale]
-filetype:
+python-filetype-pip:
   ubuntu:
     pip:
       packages: [filetype]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -157,6 +157,10 @@ exhale-pip:
   ubuntu:
     pip:
       packages: [exhale]
+filetype:
+  ubuntu:
+    pip:
+      packages: [filetype]
 gunicorn:
   debian: [gunicorn]
   fedora: [python-gunicorn]


### PR DESCRIPTION
I propose to add the "filetype" lib

<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

filetype

## Package Upstream Source:

https://pypi.org/project/filetype/

## Purpose of using this:

This dependency is being used to infer file type and MIME type checking the magic numbers signature of a file or buffer. This is why I think it's valuable to be added to the rosdep database. 

Distro packaging links:

filetype-1.0.7-py2.py3-none-any.whl

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/
   - REQUIRED
- Fedora: https://src.fedoraproject.org/browse/projects/
  - IF AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL


# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
