### PR TITLE
rosbridge_suite: 1.0.8-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3159,7 +3159,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 1.0.7-1
+      version: 1.0.8-1
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `1.0.8-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.7-1`

## rosapi

```
* Add missing test_depends and buildtool_depends (#617 <https://github.com/RobotWebTools/rosbridge_suite/issues/617>)
* Fix various Python code style and lint issues
* Contributors: Christian Clauss, Jacob Bandes-Storch
```

## rosbridge_library

```
* Fix various Python code style and lint issues
* Contributors: Christian Clauss, Jacob Bandes-Storch
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* Add missing test_depends and buildtool_depends
* Fix various Python code style and lint issues
* Contributors: Christian Clauss, Jacob Bandes-Storch
```

## rosbridge_suite

- No changes
