### PR TITLE
qb_device: 2.2.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11211,6 +11211,7 @@ repositories:
       - qb_device_control
       - qb_device_description
       - qb_device_driver
+      - qb_device_gazebo
       - qb_device_hardware_interface
       - qb_device_msgs
       - qb_device_srvs
@@ -11218,7 +11219,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
-      version: 2.1.1-1
+      version: 2.2.1-1
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbdevice-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_device` to `2.2.1-1`:

- upstream repository: https://bitbucket.org/qbrobotics/qbdevice-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.1-1`

## qb_device

- No changes

## qb_device_bringup

- No changes

## qb_device_control

- No changes

## qb_device_description

- No changes

## qb_device_driver

- No changes

## qb_device_gazebo

- No changes

## qb_device_hardware_interface

```
* Fix qbhand movement at startup
* Fix qb SoftHands startup
```

## qb_device_msgs

- No changes

## qb_device_srvs

- No changes

## qb_device_utils

- No changes
