### PR TITLE
nixos: Add some missing packages

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5565,6 +5565,7 @@ libxmlrpc-c++:
   debian: [libxmlrpc-c++8-dev]
   fedora: [xmlrpc-c-devel]
   gentoo: [dev-libs/xmlrpc-c]
+  nixos: [xmlrpc_c]
   openembedded: [xmlrpc-c@meta-oe]
   rhel: [xmlrpc-c-devel]
   ubuntu: [libxmlrpc-c++8-dev]
@@ -6607,6 +6608,7 @@ psutils:
 pugixml-dev:
   debian: [libpugixml-dev]
   fedora: [pugixml-devel]
+  nixos: [pugixml]
   openembedded: [pugixml@meta-oe]
   rhel: [pugixml-devel]
   ubuntu: [libpugixml-dev]
@@ -7100,6 +7102,7 @@ spirv-headers:
   debian: [spirv-headers]
   fedora: [spirv-headers-devel]
   gentoo: [dev-util/spirv-headers]
+  nixos: [spirv-headers]
   openembedded: [spirv-headers@openembedded-core]
   rhel: [spirv-headers-devel]
   ubuntu:
@@ -7111,6 +7114,7 @@ spirv-tools:
   debian: [spirv-tools]
   fedora: [spirv-tools, spirv-tools-devel, spirv-tools-libs]
   gentoo: [dev-util/spirv-tools]
+  nixos: [spirv-tools]
   openembedded: [spirv-tools@openembedded-core]
   rhel: [spirv-tools, spirv-tools-devel, spirv-tools-libs]
   ubuntu:


### PR DESCRIPTION
Adds missing nixos keys for libxmlrpc-c++, pugixml-dev, spirv-headers and spirv-tools

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=21.05&from=0&size=50&sort=relevance&type=packages&query=xmlrpc_c
  - https://search.nixos.org/packages?channel=21.05&show=pugixml&from=0&size=50&sort=relevance&type=packages&query=pugixml
  - https://search.nixos.org/packages?channel=21.05&show=spirv-headers&from=0&size=50&sort=relevance&type=packages&query=spirv-headers
  - https://search.nixos.org/packages?channel=21.05&show=spirv-headers&from=0&size=50&sort=relevance&type=packages&query=spirv-tools

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
