### PR TITLE
multi_object_tracking_lidar: 1.0.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4453,7 +4453,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/praveen-palanisamy/multi_object_tracking_lidar-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `multi_object_tracking_lidar` to `1.0.4-1`:

- upstream repository: https://github.com/praveen-palanisamy/multiple-object-tracking-lidar.git
- release repository: https://github.com/praveen-palanisamy/multi_object_tracking_lidar-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `1.0.3-1`

## multi_object_tracking_lidar

```
* Merge pull request #46 <https://github.com/praveen-palanisamy/multiple-object-tracking-lidar/issues/46> from praveen-palanisamy/rm-topic-slash-prefix
  Remove topic slash prefix
* Apply clang-format-10
* Rm slash prefix (deprecated in TF2)
* Add note to filter NaNs in input point clouds
* Contributors: Praveen Palanisamy
```
