### PR TITLE
micro_ros_msgs: 1.0.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1524,11 +1524,20 @@ repositories:
       version: galactic
     status: maintained
   micro_ros_msgs:
+    doc:
+      type: git
+      url: https://github.com/micro-ROS/micro_ros_msgs.git
+      version: galactic
     release:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/micro_ros_msgs-release.git
       version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/micro-ROS/micro_ros_msgs.git
+      version: galactic
+    status: maintained
   mimick_vendor:
     doc:
       type: git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1523,6 +1523,12 @@ repositories:
       url: https://github.com/ros2/message_filters.git
       version: galactic
     status: maintained
+  micro_ros_msgs:
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/micro_ros_msgs-release.git
+      version: 1.0.0-1
   mimick_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `micro_ros_msgs` to `1.0.0-1`:

- upstream repository: https://github.com/micro-ROS/micro_ros_msgs
- release repository: https://github.com/ros2-gbp/micro_ros_msgs-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## micro_ros_msgs

```
* Remove not necessary dependencies (#1 <https://github.com/micro-ROS/micro_ros_msgs/issues/1>)
* Add issue template
* Add msg definitions used by micro-ROS graph manager
* Update README.md
```
