### PR TITLE
micro_ros_msgs: 1.0.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1919,11 +1919,20 @@ repositories:
       version: foxy
     status: maintained
   micro_ros_msgs:
+    doc:
+      type: git
+      url: https://github.com/micro-ROS/micro_ros_msgs.git
+      version: foxy
     release:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/micro_ros_msgs-release.git
       version: 1.0.0-2
+    source:
+      type: git
+      url: https://github.com/micro-ROS/micro_ros_msgs.git
+      version: foxy
+    status: maintained
   mimick_vendor:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1918,6 +1918,12 @@ repositories:
       url: https://github.com/ros2/message_filters.git
       version: foxy
     status: maintained
+  micro_ros_msgs:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/micro_ros_msgs-release.git
+      version: 1.0.0-2
   mimick_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `micro_ros_msgs` to `1.0.0-2`:

- upstream repository: https://github.com/micro-ROS/micro_ros_msgs
- release repository: https://github.com/ros2-gbp/micro_ros_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## micro_ros_msgs

```
* Remove not necessary dependencies (#1 <https://github.com/micro-ROS/micro_ros_msgs/issues/1>)
* Add issue template
* Add msg definitions used by micro-ROS graph manager
* Update README.md
```
