### PR TITLE
qb_move: 2.2.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9445,11 +9445,12 @@ repositories:
       - qb_move
       - qb_move_control
       - qb_move_description
+      - qb_move_gazebo
       - qb_move_hardware_interface
       tags:
         release: release/melodic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbmove-ros-release.git
-      version: 2.0.0-1
+      version: 2.2.1-1
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbmove-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_move` to `2.2.1-1`:

- upstream repository: https://bitbucket.org/qbrobotics/qbmove-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbmove-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-1`

## qb_move

- No changes

## qb_move_control

- No changes

## qb_move_description

- No changes

## qb_move_gazebo

- No changes

## qb_move_hardware_interface

- No changes
