### PR TITLE
qb_move: 2.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5945,6 +5945,27 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: melodic-devel
     status: maintained
+  qb_move:
+    doc:
+      type: git
+      url: https://bitbucket.org/qbrobotics/qbmove-ros.git
+      version: production-noetic
+    release:
+      packages:
+      - qb_move
+      - qb_move_control
+      - qb_move_description
+      - qb_move_gazebo
+      - qb_move_hardware_interface
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://bitbucket.org/qbrobotics/qbmove-ros-release.git
+      version: 2.2.1-1
+    source:
+      type: git
+      url: https://bitbucket.org/qbrobotics/qbmove-ros.git
+      version: production-noetic
+    status: developed
   qpoases_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_move` to `2.2.1-1`:

- upstream repository: https://bitbucket.org/qbrobotics/qbmove-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbmove-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## qb_move

- No changes

## qb_move_control

- No changes

## qb_move_description

- No changes

## qb_move_gazebo

- No changes

## qb_move_hardware_interface

- No changes
