### PR TITLE
qb_chain: 2.2.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9380,11 +9380,13 @@ repositories:
       packages:
       - qb_chain
       - qb_chain_control
+      - qb_chain_controllers
       - qb_chain_description
+      - qb_chain_msgs
       tags:
         release: release/melodic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbchain-ros-release.git
-      version: 2.0.0-0
+      version: 2.2.2-1
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbchain-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_chain` to `2.2.2-1`:

- upstream repository: https://bitbucket.org/qbrobotics/qbchain-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbchain-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-0`

## qb_chain

- No changes

## qb_chain_control

- No changes

## qb_chain_controllers

- No changes

## qb_chain_description

- No changes

## qb_chain_msgs

```
* Fix version tag in some packages.
```
