### PR TITLE
qb_hand: 2.2.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5945,6 +5945,27 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: melodic-devel
     status: maintained
+  qb_hand:
+    doc:
+      type: git
+      url: https://bitbucket.org/qbrobotics/qbhand-ros.git
+      version: production-noetic
+    release:
+      packages:
+      - qb_hand
+      - qb_hand_control
+      - qb_hand_description
+      - qb_hand_gazebo
+      - qb_hand_hardware_interface
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://bitbucket.org/qbrobotics/qbhand-ros-release.git
+      version: 2.2.2-1
+    source:
+      type: git
+      url: https://bitbucket.org/qbrobotics/qbhand-ros.git
+      version: production-noetic
+    status: developed
   qpoases_vendor:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5971,6 +5971,32 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: melodic-devel
     status: maintained
+  qb_device:
+    doc:
+      type: git
+      url: https://bitbucket.org/qbrobotics/qbdevice-ros.git
+      version: production-noetic
+    release:
+      packages:
+      - qb_device
+      - qb_device_bringup
+      - qb_device_control
+      - qb_device_description
+      - qb_device_driver
+      - qb_device_gazebo
+      - qb_device_hardware_interface
+      - qb_device_msgs
+      - qb_device_srvs
+      - qb_device_utils
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
+      version: 2.2.2-1
+    source:
+      type: git
+      url: https://bitbucket.org/qbrobotics/qbdevice-ros.git
+      version: production-noetic
+    status: developed
   qb_hand:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_hand` to `2.2.2-1`:

- upstream repository: https://bitbucket.org/qbrobotics/qbhand-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbhand-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## qb_hand

- No changes

## qb_hand_control

- No changes

## qb_hand_description

- No changes

## qb_hand_hardware_interface

- No changes
