### PR TITLE
udp_msgs: 0.0.3-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5073,7 +5073,7 @@ repositories:
     source:
       type: git
       url: https://github.com/flynneva/udp_msgs.git
-      version: devel
+      version: main
     status: maintained
   uncrustify_vendor:
     release:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5069,7 +5069,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/flynneva/udp_msgs-release.git
-      version: 0.0.3-1
+      version: 0.0.3-2
     source:
       type: git
       url: https://github.com/flynneva/udp_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `udp_msgs` to `0.0.3-2`:

- upstream repository: https://github.com/flynneva/udp_msgs.git
- release repository: https://github.com/flynneva/udp_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.3-1`

## udp_msgs

```
* update release CI
* update CI
* Contributors: flynneva
```
