### PR TITLE
rosdep: add rhel package for clang

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -518,6 +518,9 @@ clang:
   gentoo: [sys-devel/clang]
   nixos: [clang]
   ubuntu: [clang]
+  rhel:
+    '*': [clang]
+    '7': null
 clang-format:
   alpine: [clang]
   debian:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -517,10 +517,10 @@ clang:
   fedora: [clang]
   gentoo: [sys-devel/clang]
   nixos: [clang]
-  ubuntu: [clang]
   rhel:
     '*': [clang]
     '7': null
+  ubuntu: [clang]
 clang-format:
   alpine: [clang]
   debian:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

clang

## Package Upstream Source:

https://github.com/llvm/llvm-project/

## Purpose of using this:

`clang` key already exists in [rosdep/base.yaml](https://github.com/ros/rosdistro/blob/5192944639c35d498b155790e6d9231efb8f85cf/rosdep/base.yaml#L515).  
However it lacks an `rhel` package, leading `bloom-release` 0.10.7 to such warning when releasing a package that depends on `clang`:

```bash
==> git-bloom-generate -y rosrpm --prefix release/rolling rolling -i 1 --os-name rhel
Generating source RPMs for the packages: ['zenoh-bridge-dds']
RPM Incremental Version: 1
RPM OS: rhel
RPM Distributions: ['8']
Releasing for rosdistro: rolling

Pre-verifying RPM dependency keys...
Running 'rosdep update'...
ROS Distro index file associate with commit '5192944639c35d498b155790e6d9231efb8f85cf'
New ROS Distro index url: 'https://raw.githubusercontent.com/ros/rosdistro/5192944639c35d498b155790e6d9231efb8f85cf/index-v4.yaml'
Could not resolve rosdep key 'clang' for distro '8':
No definition of [clang] for OS [rhel]
	rosdep key : clang
	OS name    : rhel
	OS version : 8
	Data:
debian:
		- clang
		fedora:
		- clang
		gentoo:
		- sys-devel/clang
		nixos:
		- clang
		ubuntu:
		- clang
		
Failed to resolve clang on rhel:8 with: Error running generator: Failed to resolve rosdep key 'clang', aborting.
clang is depended on by these packages: ['zenoh-bridge-dds']
<== Failed
Some of the dependencies for packages in this repository could not be resolved by rosdep.
<== The following generator action reported that it is missing one or more
    rosdep keys, but that the key exists in other platforms:
'['/usr/bin/git-bloom-generate', '-y', 'rosrpm', '--prefix', 'release/rolling', 'rolling', '-i', '1', '--os-name', 'rhel']'

If you are absolutely sure that this key is unavailable for the platform in
question, the generator can be skipped and you can proceed with the release.
Skip generator action and continue with release [y/N]? y
```

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- RHEL/CentOS: 
  - https://centos.pkgs.org/8/centos-appstream-x86_64/clang-11.0.0-1.module_el8.4.0+587+5187cac0.i686.rpm.html
