### PR TITLE
neonavigation: 0.11.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4617,7 +4617,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.10.11-1
+      version: 0.11.0-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.11.0-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.10.11-1`

## costmap_cspace

```
* Rename PointcloudAccumurator to PointcloudAccumulator (#608 <https://github.com/at-wat/neonavigation/issues/608>)
* Apply clang-format-11 with new setting (#605 <https://github.com/at-wat/neonavigation/issues/605>)
* Contributors: Naotaka Hatao, f-fl0
```

## joystick_interrupt

- No changes

## map_organizer

- No changes

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

- No changes

## obj_to_pointcloud

- No changes

## planner_cspace

```
* Apply clang-format-11 with new setting (#605 <https://github.com/at-wat/neonavigation/issues/605>)
* Contributors: Naotaka Hatao
```

## safety_limiter

```
* Apply clang-format-11 with new setting (#605 <https://github.com/at-wat/neonavigation/issues/605>)
* Contributors: Naotaka Hatao
```

## track_odometry

- No changes

## trajectory_tracker

```
* trajectory_tracker: add velocity tolerance parameters (#607 <https://github.com/at-wat/neonavigation/issues/607>)
* Apply clang-format-11 with new setting (#605 <https://github.com/at-wat/neonavigation/issues/605>)
* Contributors: Naotaka Hatao
```
