### PR TITLE
sbg_driver: 3.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14879,7 +14879,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/SBG-Systems/sbg_ros_driver-release.git
-      version: 2.0.3-1
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/SBG-Systems/sbg_ros_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sbg_driver` to `3.0.0-1`:

- upstream repository: https://github.com/SBG-Systems/sbg_ros_driver.git
- release repository: https://github.com/SBG-Systems/sbg_ros_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.3-1`

## sbg_driver

```
* Merge pull request #62 <https://github.com/SBG-Systems/sbg_ros_driver/issues/62> from SBG-Systems/devel
  Devel
* Merge pull request #61 <https://github.com/SBG-Systems/sbg_ros_driver/issues/61> from SBG-Systems/fix-frame-convention
  Fix frame convention errors
* Make sure only delta angles/velocities are used
  + syntax fixes
* Improved comments & README file
* Fix missing checks on UTC / Unix time computation
* Updated sbgECom messages definitions
* Update README.md and releasePackage.md
* Clean up readme
* Fix position accuracy
* Replace pow by multiplication
* Complete README.md
* Fix bugs in message wrapper and complete message definitions
* Fix Z GPS velocity
* Fix frame convention errors
* Merge pull request #59 <https://github.com/SBG-Systems/sbg_ros_driver/issues/59> from SBG-Systems/fix-frame-id
  Fix param name
* Fix param name
* Fix inconsistent tab and spaces usages.
  Now all files are using spaces
* Add wrap 2PI
* Fix bugs
* Fix matrix accuracy
* Fix course
* wrapper: Fix ENU->NED for GPS messages
* warpper: Change createrVector3 names
* wrapper: Fix setter
* wrapper: Fix missing ENU conversion an add comment for cov
* wrapper: Fix regresion
* coding style : Remove tables
* publisher: Configure the wrapper before init the publisher
* main: Fix loopFrequency type
* config: Restore output configuration
* config: Replace enu by use_enu
* enu: Replace enu by use_enu and rename frame convertion function
* frame_id: Change default value
* clean up
* #51 <https://github.com/SBG-Systems/sbg_ros_driver/issues/51> - Correctly fill convariances parameters
* project: Update maintainer
* config: Update parameters
* #45 <https://github.com/SBG-Systems/sbg_ros_driver/issues/45>-#50 <https://github.com/SBG-Systems/sbg_ros_driver/issues/50> - Add parameters to set frame ID and ENU convention
* #48 <https://github.com/SBG-Systems/sbg_ros_driver/issues/48> - # 52 Add a parameter to select header stamp source and read ROS time when publishing the message
* #47 <https://github.com/SBG-Systems/sbg_ros_driver/issues/47> Remove node ros::Rate period auto computation and only read it from a node parameter
* clean up: Remove blank spaces
* Merge pull request #35 <https://github.com/SBG-Systems/sbg_ros_driver/issues/35> from ShepelIlya/patch-1
  Fixed time_stamp value initializing in SbgEkfNavMessage.
* Added/updated license to MIT
* Updated maintainer
* Fixed timeStamp value initializing in SbgEkfNavMessage.
* Contributors: Michael Zemb, Raphael Siryani, ShepelIlya, bsaussay, rsiryani
```
