### PR TITLE
SMACC2: 0.1.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -8,6 +8,24 @@ release_platforms:
   ubuntu:
   - focal
 repositories:
+  SMACC2:
+    doc:
+      type: git
+      url: https://github.com/robosoft-ai/SMACC2.git
+      version: master
+    release:
+      packages:
+      - smacc2
+      - smacc2_msgs
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/robosoft-ai/SMACC2-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/robosoft-ai/SMACC2.git
+      version: master
+    status: developed
   acado_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `SMACC2` to `0.1.0-1`:

- upstream repository: https://github.com/robosoft-ai/SMACC2.git
- release repository: https://github.com/robosoft-ai/SMACC2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## smacc2

```
* Initial release of SMACC2 core
* Contributors: Brett Aldrich, Pablo Inigo Blasco, Denis Štogl
```

## smacc2_msgs

```
* Initial release of SMACC2 core
* Contributors: Brett Aldrich, Pablo Inigo Blasco, Denis Štogl
```
