### PR TITLE
osrf_pycommon: 0.1.11-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2355,7 +2355,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/osrf_pycommon-release.git
-      version: 0.1.10-1
+      version: 0.1.11-1
     source:
       type: git
       url: https://github.com/osrf/osrf_pycommon.git


### PR DESCRIPTION
Increasing version of package(s) in repository `osrf_pycommon` to `0.1.11-1`:

- upstream repository: https://github.com/osrf/osrf_pycommon.git
- release repository: https://github.com/ros2-gbp/osrf_pycommon-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.10-1`

## osrf_pycommon

```
* Fix osrf.py_common.process_utils.get_loop() implementation (#70 <https://github.com/osrf/osrf_pycommon/issues/70>) (#75 <https://github.com/osrf/osrf_pycommon/issues/75>)
* Contributors: Michel Hidalgo
```
