### PR TITLE
osrf_testing_tools_cpp: 1.3.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2367,13 +2367,10 @@ repositories:
       url: https://github.com/osrf/osrf_testing_tools_cpp.git
       version: foxy
     release:
-      packages:
-      - osrf_testing_tools_cpp
-      - test_osrf_testing_tools_cpp
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/osrf_testing_tools_cpp-release.git
-      version: 1.3.2-1
+      version: 1.3.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `osrf_testing_tools_cpp` to `1.3.4-1`:

- upstream repository: https://github.com/osrf/osrf_testing_tools_cpp.git
- release repository: https://github.com/ros2-gbp/osrf_testing_tools_cpp-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.3.2-1`

## osrf_testing_tools_cpp

```
* Update cmake minimum version to 2.8.12 (#61 <https://github.com/osrf/osrf_testing_tools_cpp/issues/61>) (#63 <https://github.com/osrf/osrf_testing_tools_cpp/issues/63>)
* Contributors: Louise Poubel, Stephen Brawner
```
