### PR TITLE
qt_gui_core: 1.1.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2801,7 +2801,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 1.1.2-2
+      version: 1.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `1.1.3-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.2-2`

## qt_dotgraph

- No changes

## qt_gui

```
* Fix 'dict_keys' object not subscriptable (#243 <https://github.com/ros-visualization/qt_gui_core/issues/243>)
* Contributors: Michael Jeronimo
```

## qt_gui_app

- No changes

## qt_gui_cpp

```
* Fix duplicated QMap to QMultiMap (#244 <https://github.com/ros-visualization/qt_gui_core/issues/244>)
* Contributors: Chris Lalancette, Homalozoa X
```

## qt_gui_py_common

- No changes
