### PR TITLE
rqt: 1.1.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4131,7 +4131,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `1.1.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros2-gbp/rqt-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.1-1`

## rqt

- No changes

## rqt_gui

- No changes

## rqt_gui_cpp

```
* Declare dependency to pluginlib (#251 <https://github.com/ros-visualization/rqt/issues/251>)
* Contributors: Chris Lalancette
```

## rqt_gui_py

```
* Use underscores instead of dashes in setup.cfg (#254 <https://github.com/ros-visualization/rqt/issues/254>)
* Contributors: Abrar Rahman Protyasha
```

## rqt_py_common

- No changes
