### PR TITLE
rqt_plot: 1.1.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3523,7 +3523,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_plot-release.git
-      version: 1.0.10-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_plot` to `1.1.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_plot.git
- release repository: https://github.com/ros2-gbp/rqt_plot-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.10-1`

## rqt_plot

```
* Automatically match QoS (#76 <https://github.com/ros-visualization/rqt_plot/issues/76>)
* Fix modern setuptools warning about dashes instead of underscores (#74 <https://github.com/ros-visualization/rqt_plot/issues/74>)
* Fix matplotlib exception on Windows (#73 <https://github.com/ros-visualization/rqt_plot/issues/73>)
* Contributors: Chris Lalancette, Gonzo
```
