### PR TITLE
rqt_srv: 1.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3595,7 +3595,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_srv-release.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_srv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_srv` to `1.0.3-1`:

- upstream repository: https://github.com/ros-visualization/rqt_srv.git
- release repository: https://github.com/ros2-gbp/rqt_srv-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.2-1`

## rqt_srv

```
* Fix modern setuptools warning about dashes instead of underscores (#7 <https://github.com/ros-visualization/rqt_srv/issues/7>)
* Contributors: Chris Lalancette
```
