### PR TITLE
rqt_shell: 1.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4375,7 +4375,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_shell-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_shell.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_shell` to `1.0.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_shell.git
- release repository: https://github.com/ros2-gbp/rqt_shell-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.1-1`

## rqt_shell

```
* Fix modern setuptools warning about dashes instead of underscores (#14 <https://github.com/ros-visualization/rqt_shell/issues/14>)
* Contributors: Chris Lalancette
```
