### PR TITLE
rqt_topic: 1.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3625,7 +3625,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_topic-release.git
-      version: 1.2.1-1
+      version: 1.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_topic` to `1.2.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_topic.git
- release repository: https://github.com/ros2-gbp/rqt_topic-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.1-1`

## rqt_topic

```
* Fix modern setuptools warning about dashes instead of underscores (#34 <https://github.com/ros-visualization/rqt_topic/issues/34>)
* Remove obsolete warnings (#31 <https://github.com/ros-visualization/rqt_topic/issues/31>)
* Contributors: Chris Lalancette, Michael Jeronimo
```
