### PR TITLE
geometry2: 0.13.11-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1238,7 +1238,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.13.10-1
+      version: 0.13.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.13.11-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.13.10-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* Fix a TOCTTOU race in tf2 (#307 <https://github.com/ros2/geometry2/issues/307>) (#449 <https://github.com/ros2/geometry2/issues/449>)
* Contributors: Chris Lalancette, Louise Poubel
```

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Fix tf2_echo does not work with ros-args (#407 <https://github.com/ros2/geometry2/issues/407>) (#408 <https://github.com/ros2/geometry2/issues/408>) (#411 <https://github.com/ros2/geometry2/issues/411>)
* Avoid using invalid std::list iterators (#293 <https://github.com/ros2/geometry2/issues/293>) (#419 <https://github.com/ros2/geometry2/issues/419>)
* Fix accessing free'd resources (#386 <https://github.com/ros2/geometry2/issues/386>) (#419 <https://github.com/ros2/geometry2/issues/419>)
* Contributors: Chris Lalancette, Kazunari Tanaka, Michael Carroll, PGotzmann, simutisernestas
```

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
