### PR TITLE
launch: 0.10.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1640,7 +1640,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.10.5-1
+      version: 0.10.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.10.6-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.10.5-1`

## launch

```
* Handle signals within the asyncio loop (#506 <https://github.com/ros2/launch/issues/506>)
  * Handle signals within the asyncio loop (#476 <https://github.com/ros2/launch/issues/476>)
  * Workaround asyncio signal handling on Unix (#479 <https://github.com/ros2/launch/issues/479>)
  * Remove is_winsock_handle() and instead test if wrapping the handle in a socket.socket() works (#494 <https://github.com/ros2/launch/issues/494>)
  * Close the socket pair used for signal management (#497 <https://github.com/ros2/launch/issues/497>)
  * Only try to wrap the fd in a socket on Windows (#498 <https://github.com/ros2/launch/issues/498>)
* Contributors: Michael Jeronimo
```

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
