### PR TITLE
rclpy: 1.0.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3126,7 +3126,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 1.0.5-1
+      version: 1.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `1.0.6-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.5-1`

## rclpy

```
* Reject cancel request if failed to transit to CANCEL_GOAL state (#791 <https://github.com/ros2/rclpy/issues/791>) (#796 <https://github.com/ros2/rclpy/issues/796>)
* Break log function execution ASAP if configured severity is too high (#776 <https://github.com/ros2/rclpy/issues/776>) (#784 <https://github.com/ros2/rclpy/issues/784>)
* Contributors: Jacob Perron, Tomoya Fujita, ksuszka
```
