### PR TITLE
rcpputils: 1.3.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3142,7 +3142,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 1.3.1-1
+      version: 1.3.2-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `1.3.2-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.3.1-1`

## rcpputils

```
* Add stream operator for paths to make it easier to log (#120 <https://github.com/ros2/rcpputils/issues/120>) (#121 <https://github.com/ros2/rcpputils/issues/121>)
* Removed Github Actions (#105 <https://github.com/ros2/rcpputils/issues/105>) (#106 <https://github.com/ros2/rcpputils/issues/106>)
* Updating quality declaration links (ros2/docs.ros2.org#52 <https://github.com/ros2/docs.ros2.org/issues/52>) (#131 <https://github.com/ros2/rcpputils/issues/131>)
* Update to quality level 1 (#115 <https://github.com/ros2/rcpputils/issues/115>)
* Update maintainer list for Foxy (#109 <https://github.com/ros2/rcpputils/issues/109>)
* Contributors: Alejandro Hernández Cordero, Emerson Knapp, Michael Jeronimo, Stephen Brawner, shonigmann
```
