### PR TITLE
audio_common: 0.3.12-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -678,7 +678,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/audio_common-release.git
-      version: 0.3.11-1
+      version: 0.3.12-1
     source:
       type: git
       url: https://github.com/ros-drivers/audio_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common` to `0.3.12-1`:

- upstream repository: https://github.com/ros-drivers/audio_common.git
- release repository: https://github.com/ros-gbp/audio_common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.3.11-1`

## audio_capture

```
* Merge branch 'master' into master
* Contributors: Shingo Kitagawa
```

## audio_common

```
* Merge branch 'master' into master
* Contributors: Shingo Kitagawa
```

## audio_common_msgs

```
* Merge branch 'master' into master
* Contributors: Shingo Kitagawa
```

## audio_play

```
* Merge branch 'master' into master
* Contributors: Shingo Kitagawa
```

## sound_play

```
* Merge pull request #175 <https://github.com/ros-drivers/audio_common/issues/175> from iory/rate
  Modified loop rate for action execution
* Modified loop rate for action execution
* Merge pull request #131 <https://github.com/ros-drivers/audio_common/issues/131> from yann-bourrigault/master
  Handle playing sound in loop
* import GObject in try section
* Merge pull request #174 <https://github.com/ros-drivers/audio_common/issues/174> from iory/cache
  Add arg2 information for cache
* Add arg2 information for cache
* Merge pull request #173 <https://github.com/ros-drivers/audio_common/issues/173> from knorth55/replace-sound-client
* Merge pull request #172 <https://github.com/ros-drivers/audio_common/issues/172> from knorth55/start-action-after-init
  [sound_play] start ActionServer after initialize in soundplay_node.py
* Merge pull request #171 <https://github.com/ros-drivers/audio_common/issues/171> from knorth55/set-aborted
  [sound_play] add proper set_aborted in soundplay_node.py
* add replace in sendMsg
* start actionserver after initialize in soundplay_node.py
* add proper set_aborted in soundplay_node.py
* Merge branch 'master' into master
* Handle playing sound repeatedly
* Contributors: Shingo Kitagawa, Yann BOURRIGAULT, iory
```
