### PR TITLE
qb_device: 2.2.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5985,7 +5985,7 @@ repositories:
       - qb_move_hardware_interface
       tags:
         release: release/noetic/{package}/{version}
-      url: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
+      url: https://bitbucket.org/qbrobotics/qbmove-ros-release.git
       version: 2.2.2-1
     source:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5981,7 +5981,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
-      version: 2.2.1-1
+      version: 2.2.2-1
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbdevice-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_device` to `2.2.2-1`:

- upstream repository: https://bitbucket.org/qbrobotics/qbdevice-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.2.1-1`

## qb_device

- No changes

## qb_device_bringup

- No changes

## qb_device_control

- No changes

## qb_device_description

- No changes

## qb_device_driver

- No changes

## qb_device_gazebo

```
* Set c++ standard 17 in gazebo packages
```

## qb_device_hardware_interface

- No changes

## qb_device_msgs

- No changes

## qb_device_srvs

- No changes

## qb_device_utils

- No changes
