### PR TITLE
rmw_cyclonedds: 0.7.7-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3318,7 +3318,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 0.7.6-1
+      version: 0.7.7-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `0.7.7-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.6-1`

## rmw_cyclonedds_cpp

```
* Add -latomic for RISC-V (#332 <https://github.com/ros2/rmw_cyclonedds/issues/332>) (#333 <https://github.com/ros2/rmw_cyclonedds/issues/333>)
* Contributors: guillaume-pais-siemens
```
