### PR TITLE
rosidl_typesupport_fastrtps: 1.0.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4033,7 +4033,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_fastrtps` to `1.0.4-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.3-1`

## fastrtps_cmake_module

- No changes

## rosidl_typesupport_fastrtps_c

- No changes

## rosidl_typesupport_fastrtps_cpp

```
* Replace connext with fastrtps in comments (#74 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/74>)
* Contributors: VictorLee
```
