### PR TITLE
rviz: 8.2.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4498,7 +4498,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 8.2.2-1
+      version: 8.2.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `8.2.3-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `8.2.2-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Update message_filter_display.hpp (#708 <https://github.com/ros2/rviz/issues/708>)
* Contributors: Nisala Kalupahana
```

## rviz_default_plugins

```
* YUV to RGB changes (#732 <https://github.com/ros2/rviz/issues/732>)
* Export InteractiveMarker (#728 <https://github.com/ros2/rviz/issues/728>)
* Contributors: Akash, cturcotte-qnx
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
