### PR TITLE
rclcpp: 2.4.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3121,7 +3121,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 2.3.1-1
+      version: 2.4.0-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `2.4.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.1-1`

## rclcpp

```
* Guard against integer overflow in duration conversion (#1584 <https://github.com/ros2/rclcpp/issues/1584>) (#1761 <https://github.com/ros2/rclcpp/issues/1761>)
* Update for checking correct variable (#1534 <https://github.com/ros2/rclcpp/issues/1534>) (#1760 <https://github.com/ros2/rclcpp/issues/1760>)
* Fix SEGV caused by order of destruction of Node sub-interfaces (#1469 <https://github.com/ros2/rclcpp/issues/1469>) (#1736 <https://github.com/ros2/rclcpp/issues/1736>)
* Add wait for message API (#1705 <https://github.com/ros2/rclcpp/issues/1705>) (#1737 <https://github.com/ros2/rclcpp/issues/1737>)
* Fix documentation bug (#1719 <https://github.com/ros2/rclcpp/issues/1719>) (#1721 <https://github.com/ros2/rclcpp/issues/1721>)
* Fix clock thread issue (#1266 <https://github.com/ros2/rclcpp/issues/1266>) (#1267 <https://github.com/ros2/rclcpp/issues/1267>) (#1685 <https://github.com/ros2/rclcpp/issues/1685>)
* Allow timers to keep up the intended rate in MultiThreadedExecutor #1516 <https://github.com/ros2/rclcpp/issues/1516> (#1636 <https://github.com/ros2/rclcpp/issues/1636>)
  Backports #1516 <https://github.com/ros2/rclcpp/issues/1516> and follow-up fix #1628 <https://github.com/ros2/rclcpp/issues/1628>
* Contributors: Chen Lihui, Colin MacKenzie, Daisuke Sato, Jacob Perron, Karsten Knese, Tomoya Fujita, hsgwa, William Woodall
```

## rclcpp_action

```
* Fix occasionally missing goal result caused by race condition (#1677 <https://github.com/ros2/rclcpp/issues/1677>) (#1682 <https://github.com/ros2/rclcpp/issues/1682>)
* Returns CancelResponse::REJECT while goal handle failed to transit to CANCELING state (#1641 <https://github.com/ros2/rclcpp/issues/1641>) (#1659 <https://github.com/ros2/rclcpp/issues/1659>)
* Fix action server deadlock issue that caused by other mutexes locked in CancelCallback (#1635 <https://github.com/ros2/rclcpp/issues/1635>) (#1654 <https://github.com/ros2/rclcpp/issues/1654>)
* Contributors: Kaven Yau, Tomoya Fujita
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* Fix SEGV caused by order of destruction of Node sub-interfaces (#1469 <https://github.com/ros2/rclcpp/issues/1469>) (#1736 <https://github.com/ros2/rclcpp/issues/1736>)
* Contributors: Colin MacKenzie
```
