### PR TITLE
rmf_task: 1.0.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2669,7 +2669,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_task.git
-      version: main
+      version: galactic
     release:
       tags:
         release: release/galactic/{package}/{version}
@@ -2678,7 +2678,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_task.git
-      version: main
+      version: galactic
     status: developed
   rmf_traffic:
     doc:

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2665,6 +2665,21 @@ repositories:
       url: https://github.com/open-rmf/rmf_internal_msgs.git
       version: galactic
     status: developed
+  rmf_task:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_task.git
+      version: main
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_task-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_task.git
+      version: main
+    status: developed
   rmf_traffic:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_task` to `1.0.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_task.git
- release repository: https://github.com/ros2-gbp/rmf_task-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
