### PR TITLE
rosdep: add libmnl-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3759,8 +3759,11 @@ libmlpack-dev:
   fedora: [mlpack-devel]
   ubuntu: [libmlpack-dev]
 libmnl-dev:
+  alpine: [libmnl-dev]
   debian: [libmnl-dev]
   fedora: [libmnl-devel]
+  opensuse: [libmnl-devel]
+  rhel: [libmnl-devel]
   ubuntu: [libmnl-dev]
 libmockito-java:
   arch: [mockito]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3758,6 +3758,10 @@ libmlpack-dev:
   debian: [libmlpack-dev]
   fedora: [mlpack-devel]
   ubuntu: [libmlpack-dev]
+libmnl-dev:
+  debian: [libmnl-dev]
+  fedora: [libmnl-devel]
+  ubuntu: [libmnl-dev]
 libmockito-java:
   arch: [mockito]
   debian: [libmockito-java]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

libmnl-dev

## Package Upstream Source:

https://git.netfilter.org/libmnl/tree/

## Purpose of using this:

It's a convenient library to communicate using the Linux kernel Netlink communication system.

## Links to Distribution Packages

- Debian: https://packages.debian.org/bullseye/libmnl-dev
- Ubuntu: https://packages.ubuntu.com/bionic/libmnl-dev
- Fedora: DOWN ATM
