### PR TITLE
rcl: 3.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2226,7 +2226,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 3.1.2-1
+      version: 3.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `3.2.0-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.1.2-1`

## rcl

```
* Add rcl_publisher_wait_for_all_acked support. (#913 <https://github.com/ros2/rcl/issues/913>)
* Add tracing instrumentation for rcl_take. (#930 <https://github.com/ros2/rcl/issues/930>)
* Fix #include in C++ typesupport example in rcl_subscription_init docblock. (#927 <https://github.com/ros2/rcl/issues/927>)
* Update includes after rcutils/get_env.h deprecation. (#917 <https://github.com/ros2/rcl/issues/917>)
* Use proper rcl_logging return value type and compare to constant. (#916 <https://github.com/ros2/rcl/issues/916>)
* Contributors: Barry Xu, Christophe Bedard
```

## rcl_action

```
* Wait for action server in rcl_action comm tests. (#919 <https://github.com/ros2/rcl/issues/919>)
* Contributors: Michel Hidalgo
```

## rcl_lifecycle

```
* Rename variable to fix name shadowing warning. (#929 <https://github.com/ros2/rcl/issues/929>)
* Contributors: Alberto Soragna
```

## rcl_yaml_param_parser

- No changes
