### PR TITLE
Adding amr_interop_bridge to documentation index for melodic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -168,6 +168,12 @@ repositories:
       url: https://github.com/AinsteinAI/ainstein_radar.git
       version: master
     status: maintained
+  amr_interop_bridge:
+    source:
+      type: git
+      url: https://github.com/LexxPluss/amr_interop_bridge.git
+      version: main
+    status: developed
   angles:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -169,6 +169,10 @@ repositories:
       version: master
     status: maintained
   amr_interop_bridge:
+    doc:
+      type: git
+      url: https://github.com/LexxPluss/amr_interop_bridge.git
+      version: main
     source:
       type: git
       url: https://github.com/LexxPluss/amr_interop_bridge.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -85,6 +85,16 @@ repositories:
       url: https://github.com/AinsteinAI/ainstein_radar.git
       version: master
     status: maintained
+  amr_interop_bridge:
+    doc:
+      type: git
+      url: https://github.com/LexxPluss/amr_interop_bridge.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/LexxPluss/amr_interop_bridge.git
+      version: main
+    status: developed
   angles:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

noetic
melodic

# The source is here: 

https://github.com/LexxPluss/amr_interop_bridge



# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
