### PR TITLE
add rom_msgs package to documentation index for noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6604,24 +6604,10 @@ repositories:
     status: maintained
   rom_msgs:
     doc:
-      depends:
-      - actionlib
-      - robot_state_publisher
-      - std_msgs
-      type: git
-      url: https://github.com/greenghostman/rom_msgs.git
-      version: master
-    release:
-      packages:
-      - rom_motor_msgs
-      tags:
-        release: release/noetic/{package}/{version}
-      url: https://github.com/greenghostman/rom_msgs.git
-      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/greenghostman/rom_msgs.git
-      version: master
+      version: main
     status: developed
   ros:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6602,6 +6602,27 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/robotis_manipulator.git
       version: noetic-devel
     status: maintained
+  rom_msgs:
+    doc:
+      depends:
+      - actionlib
+      - robot_state_publisher
+      - std_msgs
+      type: git
+      url: https://github.com/greenghostman/rom_msgs.git
+      version: master
+    release:
+      packages:
+      - rom_motor_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/greenghostman/rom_msgs.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/greenghostman/rom_msgs.git
+      version: master
+    status: developed
   ros:
     doc:
       type: git


### PR DESCRIPTION
I'd like my rom_msgs package to be indexed and document on ros.org.