### PR TITLE
xacro: 1.13.13-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -14801,7 +14801,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.13.12-1
+      version: 1.13.13-1
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.13.13-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.13.12-1`

## xacro

```
* Allow more builtin symbols: sorted, set
* Don't import hidden symbols from math package
* Fix eval security vulnerability
  - safe_eval()
  - unit tests validating the protection mechanism
* Generalize yaml !degrees constructors: Enable expressions as well
* Contributors: Robert Haschke
```
