### PR TITLE
Use a more stable method to detect rosdep changes

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -10,8 +10,6 @@ jobs:
         python-version: [3.8]
     steps:
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: 5
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
@@ -19,8 +17,7 @@ jobs:
     - name: Fetch upstream (to enable diff)
       run: |
         git remote add unittest_upstream_comparision https://github.com/ros/rosdistro.git || git remote set-url unittest_upstream_comparision https://github.com/ros/rosdistro.git
-        git fetch --no-tags --depth=5 unittest_upstream_comparision master
-        git fetch --no-tags --depth=5 origin $GITHUB_BASE_REF
+        git fetch --no-tags --depth=1 unittest_upstream_comparision master
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/test/rosdep_repo_check/test_rosdep_repo_check.py
+++ b/test/rosdep_repo_check/test_rosdep_repo_check.py
@@ -57,10 +57,25 @@ def detect_lines(diffstr):
 
 
 def get_changed_line_numbers():
-    base_ref = ''
-    GITHUB_BASE_REF = os.environ.get('GITHUB_BASE_REF')
-    if GITHUB_BASE_REF:
-        base_ref = 'remotes/origin/' + GITHUB_BASE_REF + '...'
+    UPSTREAM_NAME = 'unittest_upstream_comparision'
+    DIFF_BRANCH = 'master'
+    DIFF_REPO = 'https://github.com/ros/rosdistro.git'
+
+    # See if UPSTREAM_NAME remote is available and use it as it's expected to be setup by CI
+    # Otherwise fall back to origin/master
+    cmd = 'git config --get remote.%s.url' % UPSTREAM_NAME
+    try:
+        remote_url = subprocess.check_output(cmd.split()).decode('utf-8').strip()
+        # Remote exists
+        # Check url
+        assert remote_url != DIFF_REPO, \
+            '%s remote url [%s] is different than %s' % (UPSTREAM_NAME, remote_url, DIFF_REPO)
+        base_ref = '%s/%s' % (UPSTREAM_NAME, DIFF_BRANCH)
+    except subprocess.CalledProcessError:
+        # No remote so fall back to origin/master
+        print('WARNING: No remote %s detected, falling back to origin master. Make sure it is up to date.' % UPSTREAM_NAME, file=sys.stderr)
+        base_ref = 'origin/master'
+
     cmd = 'git diff --unified=0 %s -- rosdep' % (base_ref,)
     print("Detecting changed rules with '%s'" % (cmd,))
     diff = subprocess.check_output(cmd.split()).decode('utf-8')
@@ -76,6 +91,10 @@ class TestRosdepRepositoryCheck(unittest.TestCase):
         cls._full_data = {}
         cls._isolated_data = {}
         cls._repo_root = os.path.join(os.path.dirname(__file__), '..', '..')
+
+        # For clarity in the logs, show as 'skipped' rather than 'passed'
+        if not cls._changed_lines:
+            raise unittest.SkipTest('No rosdep changes were detected')
 
         for path in ('rosdep/base.yaml', 'rosdep/python.yaml'):
             if path not in cls._changed_lines:

--- a/test/rosdep_repo_check/test_rosdep_repo_check.py
+++ b/test/rosdep_repo_check/test_rosdep_repo_check.py
@@ -68,7 +68,7 @@ def get_changed_line_numbers():
         remote_url = subprocess.check_output(cmd.split()).decode('utf-8').strip()
         # Remote exists
         # Check url
-        assert remote_url != DIFF_REPO, \
+        assert remote_url == DIFF_REPO, \
             '%s remote url [%s] is different than %s' % (UPSTREAM_NAME, remote_url, DIFF_REPO)
         base_ref = '%s/%s' % (UPSTREAM_NAME, DIFF_BRANCH)
     except subprocess.CalledProcessError:


### PR DESCRIPTION
The method for detecting rosdep changes in the repository checking system doesn't seem to work very well under all circumstances, and sometimes fails to determine the differences resulting in a failed job.

This change switches the test to use a line change detection mechanism already in use in another test, so it should be more stable.

Based on: https://github.com/ros/rosdistro/blob/004707217a790e8f378def5d5c7fa3d8f2237d0e/test/test_url_validity.py#L314-L330

Reverts #30032
Should fix #29964