### PR TITLE
xacro: 2.0.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4445,7 +4445,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/xacro-release.git
-      version: 2.0.6-1
+      version: 2.0.7-1
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `2.0.7-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros2-gbp/xacro-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.6-1`

## xacro

```
* Allow more builtin symbols: sorted, set
* Don't import hidden symbols from math package
* Fix eval security vulnerability
  - safe_eval()
  - unit tests validating the protection mechanism
* Generalize yaml !degrees constructors: Enable expressions as well
* Improve macro arg parsing (#278 <https://github.com/ros/xacro/issues/278>) to support:
  - $(substitution args)
  - ${python expressions}
  - single or double quoting of spaces
* Contributors: Robert Haschke
```
