### PR TITLE
rom_motor_msgs: 0.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6602,6 +6602,22 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/robotis_manipulator.git
       version: noetic-devel
     status: maintained
+  rom_motor_msgs:
+    doc:
+      type: git
+      url: https://github.com/GreenGhostMan/rom_motor_msgs-doc.git
+      version: main
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/GreenGhostMan/rom_motor_msgs-release.git
+      version: 0.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/GreenGhostMan/rom_msgs.git
+      version: noetic-devel
+    status: maintained
   ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rom_motor_msgs` to `0.0.2-1`:

- upstream repository: https://github.com/GreenGhostMan/rom_msgs.git
- release repository: https://github.com/GreenGhostMan/rom_motor_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
