### PR TITLE
ros2_control / ros2_controllers: Change source branch to foxy

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3504,7 +3504,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/ros2_control.git
-      version: master
+      version: foxy
     release:
       packages:
       - controller_interface
@@ -3522,13 +3522,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git
-      version: master
+      version: foxy
     status: developed
   ros2_controllers:
     doc:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git
-      version: master
+      version: foxy
     release:
       packages:
       - diff_drive_controller
@@ -3550,7 +3550,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git
-      version: master
+      version: foxy
     status: developed
   ros2_intel_realsense:
     doc:


### PR DESCRIPTION
We branched from `master` to `foxy` in `ros2_control` and `ros2_controllers` *after* the last release. Updating entries now