### PR TITLE
ament_cmake_catch2: 1.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -70,6 +70,21 @@ repositories:
       url: https://github.com/ament/ament_cmake.git
       version: foxy
     status: developed
+  ament_cmake_catch2:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/ament_cmake_catch2.git
+      version: foxy
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_cmake_catch2-release.git
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/ament_cmake_catch2.git
+      version: foxy
+    status: developed
   ament_cmake_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake_catch2` to `1.2.0-1`:

- upstream repository: https://github.com/open-rmf/ament_cmake_catch2.git
- release repository: https://github.com/ros2-gbp/ament_cmake_catch2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
