### PR TITLE
menge_vendor: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1919,6 +1919,21 @@ repositories:
       url: https://github.com/mavlink/mavros.git
       version: ros2
     status: developed
+  menge_vendor:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/menge_vendor.git
+      version: foxy
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/menge_vendor-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/menge_vendor.git
+      version: foxy
+    status: developed
   message_filters:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `menge_vendor` to `1.0.0-1`:

- upstream repository: https://github.com/open-rmf/menge_vendor.git
- release repository: https://github.com/ros2-gbp/menge_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## menge_vendor

```
* fix find_package problem when installed (#1 <https://github.com/osrf/menge_core/issues/1>)
* menge core
* Contributors: Marco A. Gutiérrez, Shao Guoliang, flooshao
```
