### PR TITLE
rmf_building_map_msgs: 1.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3284,6 +3284,21 @@ repositories:
       url: https://github.com/ros/resource_retriever.git
       version: foxy
     status: maintained
+  rmf_building_map_msgs:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_building_map_msgs.git
+      version: foxy
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_building_map_msgs-release.git
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_building_map_msgs.git
+      version: foxy
+    status: developed
   rmw:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_building_map_msgs` to `1.2.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_building_map_msgs.git
- release repository: https://github.com/ros2-gbp/rmf_building_map_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## rmf_building_map_msgs

```
* Add first pass of quality declarations for all packages (#235 <https://github.com/osrf/traffic_editor/issues/235>)
* Contributors: Geoffrey Biggs, Marco A. Gutierrez, Marco A. Gutiérrez
```
