### PR TITLE
stubborn_buddies: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4732,6 +4732,24 @@ repositories:
       url: https://github.com/ros2/sros2.git
       version: foxy
     status: developed
+  stubborn_buddies:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/stubborn_buddies.git
+      version: foxy
+    release:
+      packages:
+      - stubborn_buddies
+      - stubborn_buddies_msgs
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/stubborn_buddies-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/stubborn_buddies.git
+      version: foxy
+    status: developed
   system_metrics_collector:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `stubborn_buddies` to `1.0.0-1`:

- upstream repository: https://github.com/open-rmf/stubborn_buddies.git
- release repository: https://github.com/ros2-gbp/stubborn_buddies-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
