### PR TITLE
rmf_internal_msgs: 1.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2526,7 +2526,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
-      version: 1.3.0-2
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_internal_msgs.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2511,7 +2511,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_internal_msgs.git
-      version: rolling
+      version: main
     release:
       packages:
       - rmf_charger_msgs
@@ -2530,7 +2530,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_internal_msgs.git
-      version: rolling
+      version: main
     status: developed
   rmf_ros2:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_internal_msgs` to `1.4.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_internal_msgs.git
- release repository: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.3.0-2`
