### PR TITLE
Adding dynamixel_interface to documentation index for melodic and noetic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2605,6 +2605,16 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
       version: melodic-devel
     status: developed
+  dynamixel_interface:
+    doc:
+      type: git
+      url: https://github.com/csiro-robotics/dynamixel_interface
+      version: noetic-devel
+    source:
+      type: git
+      url: https://github.com/csiro-robotics/dynamixel_interface
+      version: noetic-devel
+    status: maintained
   dynamixel_sdk:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2608,11 +2608,11 @@ repositories:
   dynamixel_interface:
     doc:
       type: git
-      url: https://github.com/csiro-robotics/dynamixel_interface
+      url: https://github.com/csiro-robotics/dynamixel_interface.git
       version: noetic-devel
     source:
       type: git
-      url: https://github.com/csiro-robotics/dynamixel_interface
+      url: https://github.com/csiro-robotics/dynamixel_interface.git
       version: noetic-devel
     status: maintained
   dynamixel_sdk:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1650,6 +1650,16 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
       version: noetic-devel
     status: maintained
+  dynamixel_interface:
+    doc:
+      type: git
+      url: https://github.com/csiro-robotics/dynamixel_interface
+      version: noetic-devel
+    source:
+      type: git
+      url: https://github.com/csiro-robotics/dynamixel_interface
+      version: noetic-devel
+    status: maintained
   dynamixel_sdk:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1653,11 +1653,11 @@ repositories:
   dynamixel_interface:
     doc:
       type: git
-      url: https://github.com/csiro-robotics/dynamixel_interface
+      url: https://github.com/csiro-robotics/dynamixel_interface.git
       version: noetic-devel
     source:
       type: git
-      url: https://github.com/csiro-robotics/dynamixel_interface
+      url: https://github.com/csiro-robotics/dynamixel_interface.git
       version: noetic-devel
     status: maintained
   dynamixel_sdk:


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

Melodic
Noetic

# The source is here: 

https://github.com/csiro-robotics/dynamixel_interface/tree/noetic-devel

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
