### PR TITLE
rqt_runtime_monitor: 0.5.8-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3589,6 +3589,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_robot_steering.git
       version: dashing-devel
     status: maintained
+  rqt_runtime_monitor:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_runtime_monitor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_runtime_monitor-release.git
+      version: 0.5.8-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_runtime_monitor.git
+      version: rolling
+    status: maintained
   rqt_service_caller:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_runtime_monitor` to `0.5.8-1`:

- upstream repository: https://github.com/ros-visualization/rqt_runtime_monitor.git
- release repository: https://github.com/ros2-gbp/rqt_runtime_monitor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## rqt_runtime_monitor

```
* use conditional dependencies for Python 3 (#3 <https://github.com/ros-visualization/rqt_runtime_monitor/issues/3>)
* bump CMake minimum version to avoid CMP0048 warning
```
