### PR TITLE
rmf_traffic: 1.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2598,7 +2598,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic-release.git
-      version: 1.3.0-2
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2593,7 +2593,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_traffic.git
-      version: rolling
+      version: main
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2602,7 +2602,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic.git
-      version: rolling
+      version: main
     status: developed
   rmf_traffic_editor:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_traffic` to `1.4.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_traffic.git
- release repository: https://github.com/ros2-gbp/rmf_traffic-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.3.0-2`
