### PR TITLE
zenoh_bridge_dds: 0.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4463,5 +4463,20 @@ repositories:
       url: https://github.com/ros2/yaml_cpp_vendor.git
       version: master
     status: maintained
+  zenoh_bridge_dds:
+    doc:
+      type: git
+      url: https://github.com/eclipse-zenoh/zenoh-plugin-dds.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/atolab/zenoh_bridge_dds-release.git
+      version: 0.5.0-1
+    source:
+      type: git
+      url: https://github.com/eclipse-zenoh/zenoh-plugin-dds.git
+      version: master
+    status: developed
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `zenoh_bridge_dds` to `0.5.0-1`:

- upstream repository: https://github.com/eclipse-zenoh/zenoh-plugin-dds.git
- release repository: https://github.com/atolab/zenoh_bridge_dds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
