### PR TITLE
Adding clober_msgs to documentation index for noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -644,6 +644,16 @@ repositories:
       url: https://github.com/CLOBOT-Co-Ltd/clober.git
       version: noetic-devel
     status: developed
+  clober_msgs:
+    doc:
+      type: git
+      url: https://github.com/CLOBOT-Co-Ltd/clober_msgs.git
+      version: noetic-devel
+    source:
+      type: git
+      url: https://github.com/CLOBOT-Co-Ltd/clober_msgs.git
+      version: noetic-devel
+    status: developed
   cmake_modules:
     doc:
       type: git


### PR DESCRIPTION
I'd like my repository to be indexed and documented on ros.org