### PR TITLE
keyboard_handler: 0.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1249,6 +1249,22 @@ repositories:
       url: https://github.com/ros/kdl_parser.git
       version: ros2
     status: maintained
+  keyboard_handler:
+    doc:
+      type: git
+      url: https://github.com/ros-tooling/keyboard_handler.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/keyboard_handler-release.git
+      version: 0.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-tooling/keyboard_handler.git
+      version: main
+    status: developed
   lanelet2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `keyboard_handler` to `0.0.2-1`:

- upstream repository: https://github.com/ros-tooling/keyboard_handler.git
- release repository: https://github.com/ros2-gbp/keyboard_handler-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## keyboard_handler

```
* Merge pull request #5 <https://github.com/ros-tooling/keyboard_handler/issues/5> from lihui815/sonia-str2code
  added enum_str_to_key_code
* Unified keyboard handler (#1 <https://github.com/ros-tooling/keyboard_handler/issues/1>)
  * Initial implementation for Keyboard handler
* Contributors: Emerson Knapp, Michael Orlov, Sonia Jin
```
