### PR TITLE
nixos: Add missing packages

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -313,8 +313,8 @@ benchmark:
     '*': [libbenchmark-dev]
     stretch: null
   fedora: [google-benchmark-devel]
-  openembedded: [google-benchmark@meta-ros2]
   nixos: [gbenchmark]
+  openembedded: [google-benchmark@meta-ros2]
   rhel: [google-benchmark-devel]
   ubuntu:
     '*': [libbenchmark-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -269,6 +269,7 @@ avr-libc:
   debian: [avr-libc]
   fedora: [avr-libc]
   gentoo: [dev-embedded/avr-libc]
+  nixos: [avrlibc]
   ubuntu: [avr-libc]
 avrdude:
   arch: [avrdude]
@@ -313,6 +314,7 @@ benchmark:
     stretch: null
   fedora: [google-benchmark-devel]
   openembedded: [google-benchmark@meta-ros2]
+  nixos: [gbenchmark]
   rhel: [google-benchmark-devel]
   ubuntu:
     '*': [libbenchmark-dev]
@@ -723,6 +725,7 @@ curl:
 curlpp-dev:
   debian: [libcurlpp-dev]
   fedora: [curlpp-devel]
+  nixos: [curlpp]
   openembedded: [curlpp@meta-networking]
   ubuntu: [libcurlpp-dev]
 cvs:
@@ -4904,6 +4907,7 @@ libspnav-dev:
   debian: [libspnav-dev, libx11-dev]
   fedora: [libspnav-devel, libX11-devel]
   gentoo: [dev-libs/libspnav]
+  nixos: [libspnav]
   rhel: [libspnav-devel, libX11-devel]
   ubuntu: [libspnav-dev, libx11-dev]
 libsqlite3-dev:
@@ -5278,6 +5282,7 @@ libuvc-dev:
     '*': [libuvc-dev]
     stretch: null
   gentoo: [media-libs/libuvc]
+  nixos: [libuvc]
   ubuntu:
     '*': [libuvc-dev]
     xenial: null
@@ -5430,6 +5435,7 @@ libvulkan-dev:
   debian: [libvulkan-dev]
   fedora: [vulkan-devel]
   gentoo: [media-libs/vulkan-loader]
+  nixos: [vulkan-loader]
   openembedded: [vulkan-headers@openembedded-core]
   rhel:
     '7': [vulkan-devel]
@@ -6780,6 +6786,7 @@ qttools5-dev:
 qttools5-dev-tools:
   debian: [qttools5-dev-tools]
   fedora: [qt5-qttools-devel]
+  nixos: [qt5.qttools.dev]
   openembedded: [qttools@meta-qt5]
   rhel: [qt5-qttools-devel]
   ubuntu: [qttools5-dev-tools]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6754,7 +6754,7 @@ python3-mapbox-earcut-pip:
       packages: [mapbox-earcut]
 python3-mapnik:
   debian: [python3-mapnik]
-  nixos:  [python3Packages.python-mapnik]
+  nixos: [python3Packages.python-mapnik]
   ubuntu: [python3-mapnik]
 python3-markdown:
   debian: [python3-markdown]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5970,6 +5970,7 @@ python3-cairosvg:
   debian: [python3-cairosvg]
   fedora: [python3-cairosvg]
   gentoo: [media-gfx/cairosvg]
+  nixos: [python3Packages.cairosvg]
   opensuse: [python3-CairoSVG]
   ubuntu: [python3-cairosvg]
 python3-can:
@@ -6032,6 +6033,7 @@ python3-cffi:
 python3-chainer-pip: *migrate_eol_2025_04_30_python3_chainer_pip
 python3-cherrypy3:
   debian: [python3-cherrypy3]
+  nixos: [python3Packages.cherrypy]
   ubuntu: [python3-cherrypy3]
 python3-click:
   debian: [python3-click]
@@ -6052,6 +6054,7 @@ python3-collada:
     buster: null
     stretch: null
   fedora: [python3-collada]
+  nixos: [python3Packages.pycollada]
   rhel: ['python%{python3_pkgversion}-collada']
   ubuntu:
     '*': [python3-collada]
@@ -6466,6 +6469,7 @@ python3-github:
   debian: [python3-github]
   fedora: [python3-github]
   gentoo: [dev-python/PyGithub]
+  nixos: [python3Packages.PyGithub]
   rhel: ['python%{python3_pkgversion}-pygithub']
   ubuntu: [python3-github]
 python3-gitlab:
@@ -6655,6 +6659,7 @@ python3-joblib:
   debian: [python3-joblib]
   fedora: [python-joblib]
   gentoo: [dev-python/joblib]
+  nixos: [python3Packages.joblib]
   opensuse: [python3-joblib]
   ubuntu: [python3-joblib]
 python3-jsonpickle:
@@ -6749,6 +6754,7 @@ python3-mapbox-earcut-pip:
       packages: [mapbox-earcut]
 python3-mapnik:
   debian: [python3-mapnik]
+  nixos:  [python3Packages.python-mapnik]
   ubuntu: [python3-mapnik]
 python3-markdown:
   debian: [python3-markdown]
@@ -7396,6 +7402,7 @@ python3-pyqrcode:
 python3-pyqt5.qtwebengine:
   debian: [python3-pyqt5.qtwebengine]
   fedora: [python3-qt5-webengine]
+  nixos: [python3Packages.pyqtwebengine]
   openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
   opensuse: [python3-qtwebengine-qt5]
   ubuntu: [python3-pyqt5.qtwebengine]
@@ -7539,6 +7546,7 @@ python3-qt5-bindings-webkit:
   debian: [python3-pyqt5.qtwebkit]
   fedora: [python3-qt5-webkit]
   gentoo: ['dev-python/PyQt5[webkit]']
+  nixos: [python3Packages.pyqt5_with_qtwebkit]
   openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python3-qt5]
   ubuntu: [python3-pyqt5.qtwebkit]
@@ -7578,6 +7586,7 @@ python3-requests-oauthlib:
   debian: [python3-requests-oauthlib]
   fedora: [python3-requests-oauthlib]
   gentoo: [dev-python/requests-oauthlib]
+  nixos: [python3Packages.requests_oauthlib]
   openembedded: [python3-requests-oauthlib@meta-python]
   rhel:
     '*': ['python%{python3_pkgversion}-requests-oauthlib']


### PR DESCRIPTION
Adds missing keys packages for:

* avr-libc
* benchmark
*  curlpp-dev
*   libspnav-dev
*  libuvc-dev
*  libvulcan-dev
*  qttools5-dev
*  python3-cairosvg
*  python3-cherrypy
*  python3-pycollada
*  python3-github
*  python3-joblib
*  python3-mapnik
*  python3-pyqt5.qtwebengine
*  python3-qt5-bindings-webkit
*  python3-requests-oauthlib

Distro packaging links:

## Links to Distribution Packages

- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=21.05&show=avrlibc&from=0&size=50&sort=relevance&type=packages&query=avrlibc
  - https://search.nixos.org/packages?channel=21.05&show=gbenchmark&from=0&size=50&sort=relevance&type=packages&query=benchmark
  - https://search.nixos.org/packages?channel=21.05&from=0&size=50&sort=relevance&type=packages&query=curlpp
  - https://search.nixos.org/packages?channel=21.05&from=0&size=50&sort=relevance&type=packages&query=libspnav
  - https://search.nixos.org/packages?channel=21.05&from=0&size=50&sort=relevance&type=packages&query=libuvc
  - https://search.nixos.org/packages?channel=21.05&from=0&size=50&sort=relevance&type=packages&query=vulkan-loader
  - https://search.nixos.org/packages?channel=21.05&from=0&size=50&sort=relevance&type=packages&query=qt5.qttools
    - The `.dev` target here can be validated with `nix-shell -p qt5.qttools.dev` but does not show on the web page
  - https://search.nixos.org/packages?channel=21.05&from=0&size=50&sort=relevance&type=packages&query=cairosvg
  - https://search.nixos.org/packages?channel=21.05&from=0&size=50&sort=relevance&type=packages&query=cherrypy
  - https://search.nixos.org/packages?channel=21.05&from=0&size=50&sort=relevance&type=packages&query=pycollada
  - https://search.nixos.org/packages?channel=21.05&from=0&size=50&sort=relevance&type=packages&query=pygithub
  - https://search.nixos.org/packages?channel=21.05&from=0&size=50&sort=relevance&type=packages&query=joblib
  - https://search.nixos.org/packages?channel=21.05&from=0&size=50&sort=relevance&type=packages&query=python-mapnik
  - https://search.nixos.org/packages?channel=21.05&from=0&size=50&sort=relevance&type=packages&query=pyqtwebengine
  - https://search.nixos.org/packages?channel=21.05&from=0&size=50&sort=relevance&type=packages&query=pyqt5_with_qtwebkit
  - https://search.nixos.org/packages?channel=21.05&from=0&size=50&sort=relevance&type=packages&query=requests_oauthlib


# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
