### PR TITLE
rmf_utils: 1.3.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3344,6 +3344,21 @@ repositories:
       url: https://github.com/open-rmf/rmf_cmake_uncrustify.git
       version: foxy
     status: developed
+  rmf_utils:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_utils.git
+      version: foxy
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_utils-release.git
+      version: 1.3.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_utils.git
+      version: foxy
+    status: developed
   rmf_visualization_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_utils` to `1.3.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_utils.git
- release repository: https://github.com/ros2-gbp/rmf_utils-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## rmf_utils

```
* Adding missing string include for test, only shows up when building with clang (#9 <https://github.com/open-rmf/rmf_utils/issues/9>)
* Add quality declaration documents (#1 <https://github.com/open-rmf/rmf_utils/issues/1>)
* Changed package requirement to QUIET to allow use in non-ROS 2 packages (#6 <https://github.com/open-rmf/rmf_utils/issues/6>)
* install rmf_code_style.cfg in rmf_utils_DIR (#4 <https://github.com/open-rmf/rmf_utils/issues/4>)
* change to catch2 test, uncrustify everything (#3 <https://github.com/open-rmf/rmf_utils/issues/3>)
* Contributors: Aaron Chong, Geoffrey Biggs, ddengster
```
