### PR TITLE
rmf_battery: 0.1.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2622,7 +2622,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_battery-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_battery.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_battery` to `0.1.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_battery.git
- release repository: https://github.com/ros2-gbp/rmf_battery-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.0-1`
