### PR TITLE
rospy_message_converter: 0.5.7-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11312,7 +11312,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uos-gbp/rospy_message_converter-release.git
-      version: 0.5.6-1
+      version: 0.5.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospy_message_converter` to `0.5.7-1`:

- upstream repository: https://github.com/uos/rospy_message_converter.git
- release repository: https://github.com/uos-gbp/rospy_message_converter-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.5.6-1`

## rospy_message_converter

```
* Handle None values in dictionary
* Add tests for None
* Dockerfile-kinetic: Add --include-eol-distros
* Contributors: Martin Günther
```
