### PR TITLE
franka_ros: 0.8.1-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3460,7 +3460,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/frankaemika/franka_ros-release.git
-      version: 0.8.0-1
+      version: 0.8.1-2
     source:
       type: git
       url: https://github.com/frankaemika/franka_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `franka_ros` to `0.8.1-2`:

- upstream repository: https://github.com/frankaemika/franka_ros.git
- release repository: https://github.com/frankaemika/franka_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.8.0-1`
