### PR TITLE
microstrain_inertial: 2.0.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4151,7 +4151,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/LORD-MicroStrain/microstrain_inertial-release.git
-      version: 2.0.3-1
+      version: 2.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `2.0.4-1`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/LORD-MicroStrain/microstrain_inertial-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.3-1`

## microstrain_inertial_driver

```
* Upgrade CMake version and removes unused include in examples
* Contributors: robbiefish
```

## microstrain_inertial_examples

```
* Upgrade CMake version and removes unused include in examples
* Contributors: robbiefish
```

## microstrain_inertial_msgs

```
* Upgrade CMake version and removes unused include in examples
* Contributors: robbiefish
```
