### PR TITLE
rmf_simulation: 1.3.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2703,6 +2703,28 @@ repositories:
       url: https://github.com/open-rmf/rmf_ros2.git
       version: galactic
     status: developed
+  rmf_simulation:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_simulation.git
+      version: galactic
+    release:
+      packages:
+      - rmf_building_sim_common
+      - rmf_building_sim_gazebo_plugins
+      - rmf_building_sim_ignition_plugins
+      - rmf_robot_sim_common
+      - rmf_robot_sim_gazebo_plugins
+      - rmf_robot_sim_ignition_plugins
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_simulation-release.git
+      version: 1.3.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_simulation.git
+      version: galactic
+    status: developed
   rmf_task:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_simulation` to `1.3.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_simulation.git
- release repository: https://github.com/ros2-gbp/rmf_simulation-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## rmf_building_sim_common

```
* Fix dependencies (#26 <https://github.com/open-rmf/rmf_simulation/issues/26>)
* Changes for galactic (#25 <https://github.com/open-rmf/rmf_simulation/issues/25>)
* Removing unnecessary qt5 dependency from CMakeLists (#22 <https://github.com/open-rmf/rmf_simulation/issues/22>)
* Make menge mandatory and fix building_sim dependencies (#19 <https://github.com/open-rmf/rmf_simulation/issues/19>)
* Start using ros-tooling for build and test workflow, added coverage, tsan (#14 <https://github.com/open-rmf/rmf_simulation/issues/14>)
* Add quality declaration documents (#1 <https://github.com/open-rmf/rmf_simulation/issues/1>)
* Crowd step size fix for large physics step sizes (#10 <https://github.com/open-rmf/rmf_simulation/issues/10>)
* Add build and style actions (#11 <https://github.com/open-rmf/rmf_simulation/issues/11>)
* Slotcar plugin package move and utils cleanup (#5 <https://github.com/open-rmf/rmf_simulation/issues/5>)
* Refactor and cleanup utils (#6 <https://github.com/open-rmf/rmf_simulation/issues/6>)
* account for renaming from building_map_msgs to rmf_building_map_msgs (#3 <https://github.com/open-rmf/rmf_simulation/issues/3>)
* Contributors: Aaron Chong, Charayaphan Nakorn Boon Han, Geoffrey Biggs, Luca Della Vedova, Marco A. Gutiérrez, Yadu
```

## rmf_building_sim_gazebo_plugins

```
* Fix dependencies (#26 <https://github.com/open-rmf/rmf_simulation/issues/26>)
* fix compile error on qt > 5.14 (#27 <https://github.com/open-rmf/rmf_simulation/issues/27>)
* Changes for galactic (#25 <https://github.com/open-rmf/rmf_simulation/issues/25>)
* Make menge mandatory and fix building_sim dependencies (#19 <https://github.com/open-rmf/rmf_simulation/issues/19>)
* Add quality declaration documents (#1 <https://github.com/open-rmf/rmf_simulation/issues/1>)
* Crowd step size fix for large physics step sizes (#10 <https://github.com/open-rmf/rmf_simulation/issues/10>)
* Slotcar plugin package move and utils cleanup (#5 <https://github.com/open-rmf/rmf_simulation/issues/5>)
* account for renaming to rmf_building_map_tools (#4 <https://github.com/open-rmf/rmf_simulation/issues/4>)
* account for renaming from building_map_msgs to rmf_building_map_msgs (#3 <https://github.com/open-rmf/rmf_simulation/issues/3>)
* Contributors: Charayaphan Nakorn Boon Han, Geoffrey Biggs, Luca Della Vedova, Marco A. Gutiérrez, Teo Koon Peng, Yadu
```

## rmf_building_sim_ignition_plugins

```
* Added rosdep key for ignition-edifice, made it a mandatory dependency (#31 <https://github.com/open-rmf/rmf_simulation/issues/31>)
* Skip updating ignition plugins when simulation is paused (#34 <https://github.com/open-rmf/rmf_simulation/issues/34>)
* updating for galactic and rolling compatibility (#29 <https://github.com/open-rmf/rmf_simulation/issues/29>)
* Fix dependencies (#26 <https://github.com/open-rmf/rmf_simulation/issues/26>)
* Make menge mandatory and fix building_sim dependencies (#19 <https://github.com/open-rmf/rmf_simulation/issues/19>)
* Add quality declaration documents (#1 <https://github.com/open-rmf/rmf_simulation/issues/1>)
* Crowd step size fix for large physics step sizes (#10 <https://github.com/open-rmf/rmf_simulation/issues/10>)
* Update to Ignition Edifice (#8 <https://github.com/open-rmf/rmf_simulation/issues/8>)
* Slotcar plugin package move and utils cleanup (#5 <https://github.com/open-rmf/rmf_simulation/issues/5>)
* account for renaming from building_map_msgs to rmf_building_map_msgs (#3 <https://github.com/open-rmf/rmf_simulation/issues/3>)
* Contributors: Charayaphan Nakorn Boon Han, Geoffrey Biggs, Luca Della Vedova, Marco A. Gutiérrez
```

## rmf_robot_sim_common

```
* support reversible slotcar (#38 <https://github.com/open-rmf/rmf_simulation/issues/38>)
* Nonholonomic slotcar turning fixes, add turning multiplier offset parameter, rename compute_ds variables (#41 <https://github.com/open-rmf/rmf_simulation/issues/41>)
* Support nonholonomic movement for slotcar (#33 <https://github.com/open-rmf/rmf_simulation/issues/33>)
* Fix/dependencies (#26 <https://github.com/open-rmf/rmf_simulation/issues/26>)
* Changes and corrections to support ROS 2 Galactic (#23 <https://github.com/open-rmf/rmf_simulation/issues/23>)
* Start using ros-tooling for build and test workflow, added coverage, tsan (#14 <https://github.com/open-rmf/rmf_simulation/issues/14>)
* Add quality declaration documents (#1 <https://github.com/open-rmf/rmf_simulation/issues/1>)
* Do not drain battery when robot is in the vicinity of the charger (#18 <https://github.com/open-rmf/rmf_simulation/issues/18>)
* Skip RobotState if level_name is empty (#16 <https://github.com/open-rmf/rmf_simulation/issues/16>)
* Log as debug (#12 <https://github.com/open-rmf/rmf_simulation/issues/12>)
* Add build and style actions (#11 <https://github.com/open-rmf/rmf_simulation/issues/11>)
* Slotcar plugin package move and utils cleanup (#5 <https://github.com/open-rmf/rmf_simulation/issues/5>)
* account for renaming from building_map_msgs to rmf_building_map_msgs (#3 <https://github.com/open-rmf/rmf_simulation/issues/3>)
* Package Renames (#2 <https://github.com/open-rmf/rmf_simulation/issues/2>)
* Contributors: Aaron Chong, Charayaphan Nakorn Boon Han, Geoffrey Biggs, Luca Della Vedova, Marco A. Gutiérrez, Yadu, chianfern, ddengster
```

## rmf_robot_sim_gazebo_plugins

```
* Change parameter tag from holonomic to steering (#46 <https://github.com/open-rmf/rmf_simulation/issues/46>)
* Nonholonomic slotcar turning fixes, add turning multiplier offset parameter, rename compute_ds variables (#41 <https://github.com/open-rmf/rmf_simulation/issues/41>)
* fix typo on gazebo_dev dependency (#28 <https://github.com/open-rmf/rmf_simulation/issues/28>)
* Fix dependencies (#26 <https://github.com/open-rmf/rmf_simulation/issues/26>)
* Changes and corrections to support ROS 2 Galactic (#23 <https://github.com/open-rmf/rmf_simulation/issues/23>)
* Add quality declaration documents (#1 <https://github.com/open-rmf/rmf_simulation/issues/1>)
* Add build and style actions (#11 <https://github.com/open-rmf/rmf_simulation/issues/11>)
* Slotcar plugin package move and utils cleanup (#5 <https://github.com/open-rmf/rmf_simulation/issues/5>)
* account for renaming from building_map_msgs to rmf_building_map_msgs (#3 <https://github.com/open-rmf/rmf_simulation/issues/3>)
* Package renames (#2 <https://github.com/open-rmf/rmf_simulation/issues/2>)
* Contributors: Charayaphan Nakorn Boon Han, Geoffrey Biggs, Luca Della Vedova, Marco A. Gutiérrez, ddengster
```

## rmf_robot_sim_ignition_plugins

```
* Make Ignition Edifice dependency mandatory to fix binary builds(#45 <https://github.com/open-rmf/rmf_simulation/issues/45>)
* Change parameter tag from holonomic to steering (#46 <https://github.com/open-rmf/rmf_simulation/issues/46>)
* Change slotcar control to explicitly open loop (#43 <https://github.com/open-rmf/rmf_simulation/issues/43>)
* Nonholonomic slotcar turning fixes, add turning multiplier offset parameter, rename compute_ds variables (#41 <https://github.com/open-rmf/rmf_simulation/issues/41>)
* Support nonholonomic movement for slotcar (#33 <https://github.com/open-rmf/rmf_simulation/issues/33>)
* Skip updating ignition plugins when simulation is paused (#34 <https://github.com/open-rmf/rmf_simulation/issues/34>)
* Fix/dependencies (#26 <https://github.com/open-rmf/rmf_simulation/issues/26>)
* Add quality declaration documents (#1 <https://github.com/open-rmf/rmf_simulation/issues/1>)
* Add build and style actions (#11 <https://github.com/open-rmf/rmf_simulation/issues/11>)
* Update to Ignition Edifice (#8 <https://github.com/open-rmf/rmf_simulation/issues/8>)
* Slotcar plugin package move and utils cleanup (#5 <https://github.com/open-rmf/rmf_simulation/issues/5>)
* account for renaming from building_map_msgs to rmf_building_map_msgs (#3 <https://github.com/open-rmf/rmf_simulation/issues/3>)
* Package renames (#2 <https://github.com/open-rmf/rmf_simulation/issues/2>)
* Contributors: Charayaphan Nakorn Boon Han, Geoffrey Biggs, Luca Della Vedova, Marco A. Gutiérrez, ddengster
```
