### PR TITLE
rmf_visualization: 1.2.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2768,6 +2768,27 @@ repositories:
       url: https://github.com/open-rmf/rmf_utils.git
       version: galactic
     status: developed
+  rmf_visualization:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_visualization.git
+      version: galactic
+    release:
+      packages:
+      - rmf_visualization
+      - rmf_visualization_building_systems
+      - rmf_visualization_fleet_states
+      - rmf_visualization_rviz2_plugins
+      - rmf_visualization_schedule
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_visualization-release.git
+      version: 1.2.1-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_visualization.git
+      version: galactic
+    status: developed
   rmf_visualization_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_visualization` to `1.2.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_visualization.git
- release repository: https://github.com/ros2-gbp/rmf_visualization-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
