### PR TITLE
rmf_demos: 1.3.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2503,7 +2503,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_demos-release.git
-      version: 1.3.0-1
+      version: 1.3.0-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_demos.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_demos` to `1.3.0-2`:

- upstream repository: https://github.com/open-rmf/rmf_demos.git
- release repository: https://github.com/ros2-gbp/rmf_demos-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.3.0-1`
