### PR TITLE
sr_hand_detector: 0.0.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8391,7 +8391,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/shadow-robot/sr_hand_detector-release.git
-      version: 0.0.6-1
+      version: 0.0.7-1
     source:
       type: git
       url: https://github.com/shadow-robot/sr_hand_detector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sr_hand_detector` to `0.0.7-1`:

- upstream repository: https://github.com/shadow-robot/sr_hand_detector.git
- release repository: https://github.com/shadow-robot/sr_hand_detector-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.6-1`

## sr_hand_detector

```
* Adding executables to package lib (#26 <https://github.com/shadow-robot/sr_hand_detector/issues/26>)
  * Adding executables to package lib
  * Update CMakeLists.txt
  * fixing build
* Contributors: mikramarc
```
