### PR TITLE
mavros: 1.9.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3969,7 +3969,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 1.8.0-1
+      version: 1.9.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `1.9.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.8.0-1`

## libmavconn

- No changes

## mavros

```
* Merge pull request #1616 <https://github.com/mavlink/mavros/issues/1616> from amilcarlucas/pr/RC_CHANNELS-mavlink2-extensions
  Mavlink v2.0 specs for RC_CHANNELS_OVERRIDE accepts upto 18 channels.…
* Changed OverrideRCIn to 18 channels
* Merge pull request #1617 <https://github.com/mavlink/mavros/issues/1617> from amilcarlucas/pr/NAV_CONTROLLER_OUTPUT-plugin
  Added NAV_CONTROLLER_OUTPUT Plugin
* Merge pull request #1619 <https://github.com/mavlink/mavros/issues/1619> from amilcarlucas/pr/BATTERY2-topic
  publish BATTERY2 message as /mavros/battery2 topic
* publish BATTERY2 message as /mavros/battery2 topic
* Mavlink v2.0 specs for RC_CHANNELS_OVERRIDE accepts upto 18 channels. The plugin publishes channels 9 to 18 if the FCU protocol version is 2.0
* Added NAV_CONTROLLER_OUTPUT Plugin
* Merge branch 'master' into master
* plugins: reformat xml
* Exclude changes to launch files.
* Delete debug files.
* Apply uncrustify changes.
* Move Compass calibration report to extras. Rewrite code based on instructions.
* Add compass calibration feedback status. Add service to call the 'Next' button in calibrations.
* Contributors: André Filipe, BV-OpenSource, Karthik Desai, Vladimir Ermakov
```

## mavros_extras

```
* Merge pull request #1621 <https://github.com/mavlink/mavros/issues/1621> from amilcarlucas/pr/mount-control-spelling
  Spelling corrections
* Spelling corrections
* Merge pull request #1615 <https://github.com/mavlink/mavros/issues/1615> from amilcarlucas/pr/erase-logs
  This adds functionality to erase all logs on the SD card via mavlink
* Merge pull request #1618 <https://github.com/mavlink/mavros/issues/1618> from amilcarlucas/pr/GPS_INPUT-plugin
  Added GPS_INPUT plugin
* This adds functionality to erase all logs on the SD card via mavlink
* Added GPS_INPUT plugin
* Merge pull request #1606 <https://github.com/mavlink/mavros/issues/1606> from BV-OpenSource/master
  Add Mount angles message for communications with ardupilotmega.
* Merge branch 'master' into master
* Update esc_status plugin with datatype change on MAVLink.
  ESC_INFO MAVLink message was updated to have negative temperates and also at a different resolution. This commit updates those changes on this side.
* Convert status data from cdeg to rad.
* Publish quaternion information with Mount Status mavlink message.
* Add missing subscription.
* Remove Mount_Status plugin. Add Status data to Mount_Control plugin. Remove Mount_Status message.
* extras: esc_telemetry: fix build
* extras: fix esc_telemetry centi-volt/amp conversion
* extras: uncrustify all plugins
* extras: reformat plugins xml
* extras: fix apm esc_telemetry
* actually allocate memory for the telemetry information
* fixed some compile errors
* added esc_telemetry plugin
* Add Mount angles message for communications with ardupilotmega.
* Reset calibration flag when re-calibrating. Prevent wrong data output.
* Delete debug files.
* Apply uncrustify changes.
* Set progress array to global to prevent erasing data.
* Move Compass calibration report to extras. Rewrite code based on instructions.
* Contributors: Abhijith Thottumadayil Jagadeesh, André Filipe, Dr.-Ing. Amilcar do Carmo Lucas, Karthik Desai, Ricardo Marques, Russell, Vladimir Ermakov
```

## mavros_msgs

```
* Merge pull request #1616 <https://github.com/mavlink/mavros/issues/1616> from amilcarlucas/pr/RC_CHANNELS-mavlink2-extensions
  Mavlink v2.0 specs for RC_CHANNELS_OVERRIDE accepts upto 18 channels.…
* Changed OverrideRCIn to 18 channels
* Merge pull request #1617 <https://github.com/mavlink/mavros/issues/1617> from amilcarlucas/pr/NAV_CONTROLLER_OUTPUT-plugin
  Added NAV_CONTROLLER_OUTPUT Plugin
* Merge pull request #1618 <https://github.com/mavlink/mavros/issues/1618> from amilcarlucas/pr/GPS_INPUT-plugin
  Added GPS_INPUT plugin
* Mavlink v2.0 specs for RC_CHANNELS_OVERRIDE accepts upto 18 channels. The plugin publishes channels 9 to 18 if the FCU protocol version is 2.0
* Added NAV_CONTROLLER_OUTPUT Plugin
* Added GPS_INPUT plugin
* Merge branch 'master' into master
* Update esc_status plugin with datatype change on MAVLink.
  ESC_INFO MAVLink message was updated to have negative temperates and also at a different resolution. This commit updates those changes on this side.
* Remove Mount_Status plugin. Add Status data to Mount_Control plugin. Remove Mount_Status message.
* msgs: fix types for apm's esc telemetry
* actually allocate memory for the telemetry information
* added esc_telemetry plugin
* Add Mount angles message for communications with ardupilotmega.
* Remove extra message from CMakeLists.
* Add message and service definition.
* Contributors: Abhijith Thottumadayil Jagadeesh, André Filipe, Dr.-Ing. Amilcar do Carmo Lucas, Karthik Desai, Ricardo Marques, Russell, Vladimir Ermakov
```

## test_mavros

- No changes
