### PR TITLE
Add python3 falcon

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6304,6 +6304,12 @@ python3-ezdxf:
     focal:
       pip:
         packages: [ezdxf]
+python3-falcon:
+  arch: [python-falcon]
+  debian: [python3-falcon]
+  fedora: [python3-falcon]
+  opensuse: [python3-falcon]
+  ubuntu: [python3-falcon]
 python3-fastnumbers-pip:
   arch:
     pip:


### PR DESCRIPTION
bionic: https://packages.ubuntu.com/bionic/python3-falcon
focal: https://packages.ubuntu.com/focal/python3-falcon

focal does not contain a version without the `python3`-prefix.

Looking at the distribution file I was unsure whether to solve it the way I did or whether to create a new entry `python3-falcon`. However, I assume that allowing users not to change their packages is preferrable.