### PR TITLE
rmf_demos: 1.3.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2659,6 +2659,30 @@ repositories:
       url: https://github.com/open-rmf/rmf_cmake_uncrustify.git
       version: galactic
     status: developed
+  rmf_demos:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_demos.git
+      version: galactic
+    release:
+      packages:
+      - rmf_demos
+      - rmf_demos_assets
+      - rmf_demos_dashboard_resources
+      - rmf_demos_gz
+      - rmf_demos_ign
+      - rmf_demos_maps
+      - rmf_demos_panel
+      - rmf_demos_tasks
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_demos-release.git
+      version: 1.3.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_demos.git
+      version: galactic
+    status: developed
   rmf_internal_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_demos` to `1.3.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_demos.git
- release repository: https://github.com/ros2-gbp/rmf_demos-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
