### PR TITLE
rmf_traffic: 1.4.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3369,6 +3369,21 @@ repositories:
       url: https://github.com/open-rmf/rmf_internal_msgs.git
       version: foxy
     status: developed
+  rmf_traffic:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_traffic.git
+      version: foxy
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_traffic-release.git
+      version: 1.4.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_traffic.git
+      version: foxy
+    status: developed
   rmf_utils:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_traffic` to `1.4.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_traffic.git
- release repository: https://github.com/ros2-gbp/rmf_traffic-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
