### PR TITLE
rmf_traffic_editor: 1.4.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3369,6 +3369,26 @@ repositories:
       url: https://github.com/open-rmf/rmf_internal_msgs.git
       version: foxy
     status: developed
+  rmf_traffic_editor:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_traffic_editor.git
+      version: foxy
+    release:
+      packages:
+      - rmf_building_map_tools
+      - rmf_traffic_editor
+      - rmf_traffic_editor_assets
+      - rmf_traffic_editor_test_maps
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
+      version: 1.4.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_traffic_editor.git
+      version: foxy
+    status: developed
   rmf_utils:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_traffic_editor` to `1.4.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_traffic_editor.git
- release repository: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## rmf_building_map_tools

```
* Feature/map generator using global coordinates (#379 <https://github.com/open-rmf/rmf_traffic_editor/issues/379>)
* added support for ceilings with texture (#383 <https://github.com/open-rmf/rmf_traffic_editor/issues/383>)
* Feature/wall graph (#377 <https://github.com/open-rmf/rmf_traffic_editor/issues/377>)
* added scaling features to wall texture (#382 <https://github.com/open-rmf/rmf_traffic_editor/issues/382>)
* fix crowdsim map generation when there are no robots (#380 <https://github.com/open-rmf/rmf_traffic_editor/issues/380>)
* Fix crash when level has no floors (#370 <https://github.com/open-rmf/rmf_traffic_editor/issues/370>)
* adding maintainer for buildfarm notifications (#368 <https://github.com/open-rmf/rmf_traffic_editor/issues/368>)
* Fix issues with building map tools using Ignition tools (#362 <https://github.com/open-rmf/rmf_traffic_editor/issues/362>)
* Contributors: Luca Della Vedova, Marco A. Gutiérrez, Matthew Booker, Morgan Quigley, Nicholas, Xiyu
```

## rmf_traffic_editor

```
* Feature/graph names and widths (#384 <https://github.com/open-rmf/rmf_traffic_editor/issues/384>)
  * Graph data structure: default lane widths and a step towards #378 <https://github.com/open-rmf/rmf_traffic_editor/issues/378>
* added support for ceilings with texture (#383 <https://github.com/open-rmf/rmf_traffic_editor/issues/383>)
* added scaling features to wall texture (#382 <https://github.com/open-rmf/rmf_traffic_editor/issues/382>)
* resolve build error on some systems with size_t namespace (#374 <https://github.com/open-rmf/rmf_traffic_editor/issues/374>)
  fix build error on some compilers/systems reported in https://github.com/open-rmf/rmf/discussions/85   by adding std:: prefix to size_t
* sort list by model name, not Fuel group name (#373 <https://github.com/open-rmf/rmf_traffic_editor/issues/373>)
* Feature: align vertices colinear (#372 <https://github.com/open-rmf/rmf_traffic_editor/issues/372>)
* adding maintainer for buildfarm notifications (#368 <https://github.com/open-rmf/rmf_traffic_editor/issues/368>)
* hotfix for #366 <https://github.com/open-rmf/rmf_traffic_editor/issues/366>, avoid exploding transform for 1 fudicual (#367 <https://github.com/open-rmf/rmf_traffic_editor/issues/367>)
* Minor tweak to how empty crowd_sim and lift structures are serialized in YAML (#364 <https://github.com/open-rmf/rmf_traffic_editor/issues/364>)
* Contributors: Marco A. Gutiérrez, Morgan Quigley, Xiyu
```

## rmf_traffic_editor_assets

```
* add ambulance icon to model_list (#376 <https://github.com/open-rmf/rmf_traffic_editor/issues/376>)
* adding maintainer for buildfarm notifications (#368 <https://github.com/open-rmf/rmf_traffic_editor/issues/368>)
* Contributors: Marco A. Gutiérrez, ddengster
```

## rmf_traffic_editor_test_maps

```
* adding maintainer for buildfarm notifications (#368 <https://github.com/open-rmf/rmf_traffic_editor/issues/368>)
* Contributors: Marco A. Gutiérrez
```
