### PR TITLE
clober_msgs: 1.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -649,6 +649,11 @@ repositories:
       type: git
       url: https://github.com/CLOBOT-Co-Ltd/clober_msgs.git
       version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/CLOBOT-Co-Ltd-release/clober_msgs-release.git
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/CLOBOT-Co-Ltd/clober_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clober_msgs` to `1.0.1-1`:

* upstream repository: https://github.com/CLOBOT-Co-Ltd/clober_msgs.git
* release repository: https://github.com/CLOBOT-Co-Ltd-release/clober_msgs-release.git
* distro file: `noetic/distribution.yaml`
* bloom version: `0.10.0`
* previous version for package: `null`