### PR TITLE
rmf_battery: 0.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3314,6 +3314,21 @@ repositories:
       url: https://github.com/ros/resource_retriever.git
       version: foxy
     status: maintained
+  rmf_battery:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_battery.git
+      version: foxy
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_battery-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_battery.git
+      version: foxy
+    status: developed
   rmf_building_map_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_battery` to `0.1.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_battery.git
- release repository: https://github.com/ros2-gbp/rmf_battery-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
