### PR TITLE
Adding python2 and 3 J1939 library

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2353,7 +2353,7 @@ python-itsdangerous:
   ubuntu:
     '*': null
     bionic: [python-itsdangerous]
-python-j1939-pip:
+python-j1939-pip: &migrate_eol_2025_04_30_python3_j1939_pip
   debian:
     pip:
       packages: [j1939]
@@ -6679,19 +6679,7 @@ python3-interpreter:
   rhel: [python3]
   slackware: [python3]
   ubuntu: [python3-minimal]
-python3-j1939-pip:
-  debian:
-    pip:
-      packages: [j1939]
-  fedora:
-    pip:
-      packages: [j1939]
-  gentoo:
-    pip:
-      packages: [j1939]
-  ubuntu:
-    pip:
-      packages: [j1939]
+python3-j1939-pip: *migrate_eol_2025_04_30_python3_j1939_pip
 python3-jinja2:
   alpine: [py3-jinja2]
   debian: [python3-jinja2]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2353,6 +2353,19 @@ python-itsdangerous:
   ubuntu:
     '*': null
     bionic: [python-itsdangerous]
+python-j1939-pip:
+  debian:
+    pip:
+      packages: [j1939]
+  fedora:
+    pip:
+      packages: [j1939]
+  gentoo:
+    pip:
+      packages: [j1939]
+  ubuntu:
+    pip:
+      packages: [j1939]
 python-jasmine-pip:
   ubuntu:
     pip:
@@ -6666,6 +6679,19 @@ python3-interpreter:
   rhel: [python3]
   slackware: [python3]
   ubuntu: [python3-minimal]
+python3-j1939-pip:
+  debian:
+    pip:
+      packages: [j1939]
+  fedora:
+    pip:
+      packages: [j1939]
+  gentoo:
+    pip:
+      packages: [j1939]
+  ubuntu:
+    pip:
+      packages: [j1939]
 python3-jinja2:
   alpine: [py3-jinja2]
   debian: [python3-jinja2]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

j1939

## Package Upstream Source:

https://github.com/benkfra/j1939
https://pypi.org/project/j1939/ (There are a few similarly named libraries but this is registered as j1939 in pypi index)

## Purpose of using this:

We are using this library as a convenience wrapped to talk to ECUs and a few other devices via J1939.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - not available
- Ubuntu: https://packages.ubuntu.com/
   - not available
- Fedora: https://src.fedoraproject.org/browse/projects/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
