### PR TITLE
rmf_task: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3406,6 +3406,21 @@ repositories:
       url: https://github.com/open-rmf/rmf_simulation.git
       version: foxy
     status: developed
+  rmf_task:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_task.git
+      version: foxy
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_task-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_task.git
+      version: foxy
+    status: developed
   rmf_traffic:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_task` to `1.0.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_task.git
- release repository: https://github.com/ros2-gbp/rmf_task-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
