### PR TITLE
qb_chain: 2.2.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5976,6 +5976,27 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: melodic-devel
     status: maintained
+  qb_chain:
+    doc:
+      type: git
+      url: https://bitbucket.org/qbrobotics/qbchain-ros.git
+      version: production-noetic
+    release:
+      packages:
+      - qb_chain
+      - qb_chain_control
+      - qb_chain_controllers
+      - qb_chain_description
+      - qb_chain_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://bitbucket.org/qbrobotics/qbchain-ros-release.git
+      version: 2.2.2-1
+    source:
+      type: git
+      url: https://bitbucket.org/qbrobotics/qbchain-ros.git
+      version: production-noetic
+    status: developed
   qb_move:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_chain` to `2.2.2-1`:

- upstream repository: https://bitbucket.org/qbrobotics/qbchain-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbchain-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## qb_chain

- No changes

## qb_chain_control

- No changes

## qb_chain_controllers

- No changes

## qb_chain_description

- No changes

## qb_chain_msgs

```
* Fix version tag in some packages.
```
