### PR TITLE
rmf_ros2: 1.4.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3384,6 +3384,26 @@ repositories:
       url: https://github.com/open-rmf/rmf_internal_msgs.git
       version: foxy
     status: developed
+  rmf_ros2:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_ros2.git
+      version: foxy
+    release:
+      packages:
+      - rmf_fleet_adapter
+      - rmf_fleet_adapter_python
+      - rmf_task_ros2
+      - rmf_traffic_ros2
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_ros2-release.git
+      version: 1.4.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_ros2.git
+      version: foxy
+    status: developed
   rmf_simulation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_ros2` to `1.4.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_ros2.git
- release repository: https://github.com/ros2-gbp/rmf_ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
