### PR TITLE
micro-ROS-Agent-release: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1544,6 +1544,22 @@ repositories:
       url: https://github.com/ros2/message_filters.git
       version: master
     status: maintained
+  micro-ROS-Agent-release:
+    doc:
+      type: git
+      url: https://github.com/micro-ROS/micro-ROS-Agent.git
+      version: main
+    release:
+      packages:
+      - micro_ros_agent
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/micro-ROS-Agent-release.git
+      version: 3.0.0-1
+    source:
+      type: git
+      url: https://github.com/micro-ROS/micro-ROS-Agent.git
+      version: main
   micro_ros_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `micro-ROS-Agent-release` to `3.0.0-1`:

- upstream repository: https://github.com/micro-ROS/micro-ROS-Agent/
- release repository: https://github.com/ros2-gbp/micro-ROS-Agent-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## micro_ros_agent

- No changes
