### PR TITLE
micro-ROS-Agent-release: 2.0.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1542,6 +1542,22 @@ repositories:
       url: https://github.com/ros2/message_filters.git
       version: galactic
     status: maintained
+  micro-ROS-Agent-release:
+    doc:
+      type: git
+      url: https://github.com/micro-ROS/micro-ROS-Agent.git
+      version: galactic
+    release:
+      packages:
+      - micro_ros_agent
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/micro-ROS-Agent-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/micro-ROS/micro-ROS-Agent.git
+      version: galactic
   micro_ros_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `micro-ROS-Agent-release` to `2.0.0-1`:

- upstream repository: https://github.com/micro-ROS/micro-ROS-Agent/
- release repository: https://github.com/ros2-gbp/micro-ROS-Agent-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## micro_ros_agent

```
* Remove XRCE dependency and add superbuild (#97 <https://github.com/micro-ROS/micro-ROS-Agent/issues/97>)
* Fixed launch file by using a list for arguments. Ensures order of items is kept. (#93 <https://github.com/micro-ROS/micro-ROS-Agent/issues/93>) (#94 <https://github.com/micro-ROS/micro-ROS-Agent/issues/94>)
* Modify argument type (#91 <https://github.com/micro-ROS/micro-ROS-Agent/issues/91>)
* Fix graph manager datawriters behaviour (#84 <https://github.com/micro-ROS/micro-ROS-Agent/issues/84>)
* Graph manager: Fix participant mask for listener callbacks (#81 <https://github.com/micro-ROS/micro-ROS-Agent/issues/81>)
* Fix agent launch (#78 <https://github.com/micro-ROS/micro-ROS-Agent/issues/78>)
* Fix graph manager node namespaces (#75 <https://github.com/micro-ROS/micro-ROS-Agent/issues/75>)
* Fix Rolling agent (#61 <https://github.com/micro-ROS/micro-ROS-Agent/issues/61>)
* Add multi domain graph manager (#69 <https://github.com/micro-ROS/micro-ROS-Agent/issues/69>)
* Add ros2 launch capabilities and example launch file (#47 <https://github.com/micro-ROS/micro-ROS-Agent/issues/47>)
* Snap build for the micro-ROS-Agent (#43 <https://github.com/micro-ROS/micro-ROS-Agent/issues/43>)
* Create graph manager after checking passed CLI arguments and launch xrce-dds server (#41 <https://github.com/micro-ROS/micro-ROS-Agent/issues/41>)
* Contributors: Antonio Cuadros, Jose Antonio Moral, Pablo Garrido, mergify[bot]
```
