### PR TITLE
rviz_visual_tools: 4.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4768,11 +4768,12 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/PickNikRobotics/rviz_visual_tools-release.git
-      version: 4.0.0-1
+      version: 4.0.1-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/rviz_visual_tools.git
       version: foxy-devel
+    status: maintained
   sbg_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `4.0.1-1`:

- upstream repository: https://github.com/PickNikRobotics/rviz_visual_tools.git
- release repository: https://github.com/PickNikRobotics/rviz_visual_tools-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `4.0.0-1`

## rviz_visual_tools

```
* Remove executor namespace from rclcpp (#190 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/190>)
* Fixes & improvements for deleting markers (#188 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/188>)
  * Added RvizVisualTools method to delete all markers in a namespace
  * Fixed deleteAllMarkers for all namespaces
  * Added getters for marker ID's
* Move waitForSubscriber function to header file (#185 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/185>)
* Create LICENSE (#183 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/183>)
* Contributors: Jafar Abdi, Nathan Brooks, Vatan Aksoy Tezer, Wyatt Rees
```
