### PR TITLE
graph_msgs: 0.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1343,6 +1343,21 @@ repositories:
       url: https://github.com/swri-robotics/gps_umd.git
       version: dashing-devel
     status: developed
+  graph_msgs:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/graph_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/PickNikRobotics/graph_msgs-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/graph_msgs.git
+      version: ros2
+    status: maintained
   grasping_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `graph_msgs` to `0.2.0-1`:

- upstream repository: https://github.com/PickNikRobotics/graph_msgs.git
- release repository: https://github.com/PickNikRobotics/graph_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## graph_msgs

```
* Port to ROS 2 (#5 <https://github.com/PickNikRobotics/graph_msgs/issues/5>)
* Contributors: Dave Coleman, Henning Kayser, Tyler Weaver, Vatan Aksoy Tezer
```
