### PR TITLE
graph_msgs: 0.2.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1035,6 +1035,21 @@ repositories:
       url: https://github.com/swri-robotics/gps_umd.git
       version: dashing-devel
     status: developed
+  graph_msgs:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/graph_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/PickNikRobotics/graph_msgs-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/graph_msgs.git
+      version: ros2
+    status: maintained
   grbl_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `graph_msgs` to `0.2.0-1`:

- upstream repository: https://github.com/PickNikRobotics/graph_msgs.git
- release repository: https://github.com/PickNikRobotics/graph_msgs-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## graph_msgs

```
* Port to ROS 2 (#5 <https://github.com/PickNikRobotics/graph_msgs/issues/5>)
* Contributors: Dave Coleman, Henning Kayser, Tyler Weaver, Vatan Aksoy Tezer
```
