### PR TITLE
rviz_visual_tools: 4.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3750,6 +3750,21 @@ repositories:
       url: https://github.com/ros2/rviz.git
       version: ros2
     status: maintained
+  rviz_visual_tools:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/rviz_visual_tools.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/PickNikRobotics/rviz_visual_tools-release.git
+      version: 4.1.0-1
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/rviz_visual_tools.git
+      version: ros2
+    status: maintained
   sdformat_urdf:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `4.1.0-1`:

- upstream repository: https://github.com/PickNikRobotics/rviz_visual_tools.git
- release repository: https://github.com/PickNikRobotics/rviz_visual_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## rviz_visual_tools

```
* Fixes for new ros2 branch (#198 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/198>)
* Fix include deprecation warning
* Enable Galactic and Rolling CI (#190 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/190>)
  * minor compile fixes
* Fixes & improvements for deleting markers (#188 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/188>)
  * Added RvizVisualTools method to delete all markers in a namespace
  * Fixed deleteAllMarkers for all namespaces
  * Added getters for marker ID's
* Move waitForSubscriber function to header file (#185 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/185>)
* Contributors: Henning Kayser, Jafar Abdi, Nathan Brooks, Vatan Aksoy Tezer, Wyatt Rees
```
