### PR TITLE
radar_msgs: 0.2.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2883,6 +2883,12 @@ repositories:
       url: https://github.com/OUXT-Polaris/quaternion_operation.git
       version: ros2
     status: maintained
+  radar_msgs:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/radar_msgs-release.git
+      version: 0.2.1-1
   random_numbers:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2889,6 +2889,10 @@ repositories:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/radar_msgs-release.git
       version: 0.2.1-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/radar_msgs.git
+      version: ros2
   random_numbers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `radar_msgs` to `0.2.1-1`:

- upstream repository: https://github.com/ros-perception/radar_msgs.git
- release repository: https://github.com/ros2-gbp/radar_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
