### PR TITLE
slam_toolbox: 1.5.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8305,7 +8305,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/SteveMacenski/slam_toolbox-release.git
-      version: 1.5.5-1
+      version: 1.5.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_toolbox` to `1.5.6-1`:

- upstream repository: https://github.com/SteveMacenski/slam_toolbox.git
- release repository: https://github.com/SteveMacenski/slam_toolbox-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.5.5-1`
