### PR TITLE
ur_client_library: 0.3.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9003,7 +9003,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `0.3.2-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.1-1`

## ur_client_library

```
* Removed console_bridge dependency (#74 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/74>)
  As log handlers for the client library has been created in the drivers, the console bridge dependency is no longer needed.
* Added "On behalf of Universal Robots A/S" notice (#81 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/81>)
  to all files that have been created by FZI
* Contributors: Felix Exner, Mads Holm Peters
```
