### PR TITLE
robot_localization: 3.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2820,6 +2820,12 @@ repositories:
       url: https://github.com/ros2/rmw_implementation.git
       version: master
     status: developed
+  robot_localization:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/cra-ros-pkg/robot_localization-release.git
+      version: 3.3.0-1
   robot_state_publisher:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2826,6 +2826,10 @@ repositories:
         release: release/rolling/{package}/{version}
       url: https://github.com/cra-ros-pkg/robot_localization-release.git
       version: 3.3.0-1
+    source:
+      type: git
+      url: https://github.com/cra-ros-pkg/robot_localization.git
+      version: ros2
   robot_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `3.3.0-1`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/cra-ros-pkg/robot_localization-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
