### PR TITLE
navigation2: 1.0.7-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1759,8 +1759,10 @@ repositories:
       - nav2_recoveries
       - nav2_regulated_pure_pursuit_controller
       - nav2_rviz_plugins
+      - nav2_simple_commander
       - nav2_smac_planner
       - nav2_system_tests
+      - nav2_theta_star_planner
       - nav2_util
       - nav2_voxel_grid
       - nav2_waypoint_follower
@@ -1770,7 +1772,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/SteveMacenski/navigation2-release.git
-      version: 1.0.6-1
+      version: 1.0.7-1
     source:
       type: git
       url: https://github.com/ros-planning/navigation2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation2` to `1.0.7-1`:

- upstream repository: https://github.com/ros-planning/navigation2.git
- release repository: https://github.com/SteveMacenski/navigation2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.6-1`
