### PR TITLE
rmw_fastrtps: 6.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2779,7 +2779,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 5.2.2-1
+      version: 6.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `6.0.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `5.2.2-1`

## rmw_fastrtps_cpp

- No changes

## rmw_fastrtps_dynamic_cpp

- No changes

## rmw_fastrtps_shared_cpp

```
* Update rmw_context_impl_t definition. (#558 <https://github.com/ros2/rmw_fastrtps/issues/558>)
* Update the LoanManager to do internal locking. (#552 <https://github.com/ros2/rmw_fastrtps/issues/552>)
* Contributors: Chris Lalancette, Michel Hidalgo
```
