### PR TITLE
psen_scan_v2: 0.3.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9246,7 +9246,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/psen_scan_v2-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/PilzDE/psen_scan_v2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `psen_scan_v2` to `0.3.2-1`:

- upstream repository: https://github.com/PilzDE/psen_scan_v2.git
- release repository: https://github.com/PilzDE/psen_scan_v2-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.1-1`

## psen_scan_v2

```
* Improve performance of standalone part
  
  Introduce RawDataPtr
  
  Write to std::stringstream instead of constructing from std::string
  
  Pass by reference wherever possible
* Make release build the default
* Calculate timestamp as the time of the first ray (udp communication time is neglected)
* API: Add timestamp (nanoseconds since epoch) to LaserScan
* API: Add scan counter to LaserScan
* API: remove LaserScan equality operator
* Contributors: Pilz GmbH and Co. KG
```
