### PR TITLE
rcl_logging: 2.1.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2301,13 +2301,12 @@ repositories:
     release:
       packages:
       - rcl_logging_interface
-      - rcl_logging_log4cxx
       - rcl_logging_noop
       - rcl_logging_spdlog
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 2.1.2-1
+      version: 2.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `2.1.3-1`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.2-1`

## rcl_logging_interface

```
* Add Doxyfile to rcl_logging_interface package (#80 <https://github.com/ros2/rcl_logging/issues/80>)
* Update includes after rcutils/get_env.h deprecation (#75 <https://github.com/ros2/rcl_logging/issues/75>)
* Contributors: Christophe Bedard, Michel Hidalgo
```

## rcl_logging_noop

- No changes

## rcl_logging_spdlog

```
* Update includes after rcutils/get_env.h deprecation (#75 <https://github.com/ros2/rcl_logging/issues/75>)
* Contributors: Christophe Bedard
```
