### PR TITLE
rcl: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2261,7 +2261,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 3.2.0-1
+      version: 4.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `4.0.0-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.2.0-1`

## rcl

```
* Fix up documentation build for rcl when using rosdoc2 (#932 <https://github.com/ros2/rcl/issues/932>)
* Include rmw_event_t instead of forward declaring it (#933 <https://github.com/ros2/rcl/issues/933>)
* Contributors: Michel Hidalgo
```

## rcl_action

```
* Fix expired goals capacity of action server (#931 <https://github.com/ros2/rcl/issues/931>)
* Contributors: spiralray
```

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

- No changes
