### PR TITLE
moveit_resources: 2.0.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2091,7 +2091,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/moveit/moveit_resources-release.git
-      version: 2.0.2-1
+      version: 2.0.3-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_resources.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `2.0.3-1`:

- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/moveit/moveit_resources-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.2-1`

## moveit_resources

- No changes

## moveit_resources_fanuc_description

- No changes

## moveit_resources_fanuc_moveit_config

```
* Migrate to joint state broadcaster
* Contributors: Vatan Aksoy Tezer
```

## moveit_resources_panda_description

- No changes

## moveit_resources_panda_moveit_config

```
* Migrate to joint state broadcaster
* Add panda_hand_controller to demo.launch.py (#87 <https://github.com/ros-planning/moveit_resources/issues/87>)
* Add fake controller for panda_hand (#73 <https://github.com/ros-planning/moveit_resources/issues/73>)
* Contributors: Jafar Abdi, Marq Rasmussen, Vatan Aksoy Tezer
```

## moveit_resources_pr2_description

- No changes
