### PR TITLE
rmw_dds_common: 1.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2759,7 +2759,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_dds_common-release.git
-      version: 1.3.0-1
+      version: 1.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_dds_common` to `1.4.0-1`:

- upstream repository: https://github.com/ros2/rmw_dds_common.git
- release repository: https://github.com/ros2-gbp/rmw_dds_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.3.0-1`

## rmw_dds_common

```
* Fix up rmw_dds_common documentation when using rosdoc2 (#54 <https://github.com/ros2/rmw_dds_common/issues/54>)
* Add support for Certificate Revocation List files (#52 <https://github.com/ros2/rmw_dds_common/issues/52>)
* Silence clang warning (range-loop-construct) (#53 <https://github.com/ros2/rmw_dds_common/issues/53>)
* Contributors: Chris Lalancette, Karsten Knese, Michel Hidalgo
```
