### PR TITLE
rclcpp: 9.2.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2486,7 +2486,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 9.1.0-1
+      version: 9.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `9.2.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `9.1.0-1`

## rclcpp

```
* Added thread safe for_each_callback_group method (#1741 <https://github.com/ros2/rclcpp/issues/1741>)
* Added a function rclcpp::wait_for_message() convenience function (#1705 <https://github.com/ros2/rclcpp/issues/1705>) (#1740 <https://github.com/ros2/rclcpp/issues/1740>)
* Fixed a documentation bug (#1719 <https://github.com/ros2/rclcpp/issues/1719>) (#1720 <https://github.com/ros2/rclcpp/issues/1720>)
* Contributors: Aditya Pande, Karsten Knese, mergify[bot]
```

## rclcpp_action

```
* Fixed a bug where it would occasionally miss a goal result, which was caused by race condition (#1677 <https://github.com/ros2/rclcpp/issues/1677>) (#1683 <https://github.com/ros2/rclcpp/issues/1683>)
  * Co-authored-by: Kaven Yau <mailto:kavenyau@foxmail.com>
* Contributors: Tomoya Fujita
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* Added thread safe for_each_callback_group method (#1741 <https://github.com/ros2/rclcpp/issues/1741>)
* Contributors: Aditya Pande
```
