### PR TITLE
rosdep: add google-cloud-storage to rosdep pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1953,6 +1953,16 @@ python-google-cloud-speech-pip:
   ubuntu:
     pip:
       packages: [google-cloud-speech]
+python-google-cloud-storage-pip: &migrate_eol_2025_04_30_python3_google_cloud_storage_pip
+  debian:
+    pip:
+      packages: [google-cloud-storage]
+  fedora:
+    pip:
+      packages: [google-cloud-storage]
+  ubuntu:
+    pip:
+      packages: [google-cloud-storage]
 python-google-cloud-texttospeech-pip: &migrate_eol_2025_04_30_python3_google_cloud_texttospeech_pip
   debian:
     pip:
@@ -6507,6 +6517,7 @@ python3-gnupg:
   openembedded: [python3-gnupg@meta-python]
   opensuse: [python3-python-gnupg]
   ubuntu: [python3-gnupg]
+python3-google-cloud-storage-pip: *migrate_eol_2025_04_30_python3_google_cloud_storage_pip
 python3-google-cloud-texttospeech-pip: *migrate_eol_2025_04_30_python3_google_cloud_texttospeech_pip
 python3-gpiozero:
   debian: [python3-gpiozero]


### PR DESCRIPTION


<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

google-cloud-storage

## Package Upstream Source:

https://pypi.org/project/google-cloud-storage/

## Purpose of using this:

Provides google cloud storage API for uploading files to google storage using python google cloud client.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->


https://pypi.org/project/google-cloud-storage/



# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
