### PR TITLE
aws-robomaker-small-warehouse-world: 1.0.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -327,6 +327,19 @@ repositories:
       url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
       version: master
     status: developed
+  aws-robomaker-small-warehouse-world:
+    release:
+      packages:
+      - aws_robomaker_small_warehouse_world
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/aws-gbp/aws_robomaker_small_warehouse_world-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/aws-robotics/aws-robomaker-small-warehouse-world.git
+      version: ros2
+    status: maintained
   backward_ros:
     doc:
       type: git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -328,6 +328,10 @@ repositories:
       version: master
     status: developed
   aws-robomaker-small-warehouse-world:
+    doc:
+      type: git
+      url: https://github.com/aws-robotics/aws-robomaker-small-warehouse-world.git
+      version: ros2
     release:
       packages:
       - aws_robomaker_small_warehouse_world


### PR DESCRIPTION
Increasing version of package(s) in repository `aws-robomaker-small-warehouse-world` to `1.0.1-1`:

- upstream repository: https://github.com/aws-robotics/aws-robomaker-small-warehouse-world.git
- release repository: https://github.com/aws-gbp/aws_robomaker_small_warehouse_world-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
