### PR TITLE
computer_status_msgs: 2.1.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1844,9 +1844,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/kinetic/{package}/{version}
+        release: release/melodic/{package}/{version}
       url: https://github.com/130s/computer_status_msgs-release.git
-      version: 2.0.0-2
+      version: 2.1.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `computer_status_msgs` to `2.1.0-2`:

- upstream repository: https://github.com/plusone-robotics/computer_status_msgs
- release repository: https://github.com/130s/computer_status_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-2`

## computer_status_msgs

```
* [fix] Remove invalid, PR2 specific msgs #4 <https://github.com/plusone-robotics/computer_status_msgs/issues/4>
```
