### PR TITLE
computer_status_msgs: 2.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1168,9 +1168,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/kinetic/{package}/{version}
+        release: release/noetic/{package}/{version}
       url: https://github.com/130s/computer_status_msgs-release.git
-      version: 2.0.0-2
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `computer_status_msgs` to `2.1.0-1`:

- upstream repository: https://github.com/plusone-robotics/computer_status_msgs.git
- release repository: https://github.com/130s/computer_status_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-2`

## computer_status_msgs

```
* [fix] Remove invalid, PR2 specific msgs #4 <https://github.com/plusone-robotics/computer_status_msgs/issues/4>
```
