### PR TITLE
Revert "qb_chain: 2.2.2-1 in 'melodic/distribution.yaml' [bloom] (#30…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9390,13 +9390,11 @@ repositories:
       packages:
       - qb_chain
       - qb_chain_control
-      - qb_chain_controllers
       - qb_chain_description
-      - qb_chain_msgs
       tags:
         release: release/melodic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbchain-ros-release.git
-      version: 2.2.2-1
+      version: 2.0.0-0
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbchain-ros.git


### PR DESCRIPTION
…602)"

This reverts commit 0ee042ab11468dbd76477db4898d8ae98ccc5699.

This has been failing since #30602 was merged.  Since we want to do a Melodic sync soon, back it out to an older version.  @umbertofontana93 FYI.