### PR TITLE
Revert "qb_device: 2.2.1-3 in 'melodic/distribution.yaml' [bloom] (#3…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9412,7 +9412,6 @@ repositories:
       - qb_device_control
       - qb_device_description
       - qb_device_driver
-      - qb_device_gazebo
       - qb_device_hardware_interface
       - qb_device_msgs
       - qb_device_srvs
@@ -9420,7 +9419,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
-      version: 2.2.1-3
+      version: 2.0.1-0
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbdevice-ros.git


### PR DESCRIPTION
…0583)"

This reverts commit 24fbad41ceb01e8d0892dac51f58bd8a09187ba1.

This hasn't built since it was merged in #30583 .  @umbertofontana93 FYI.