### PR TITLE
Revert "qb_hand: 2.2.2-1 in 'melodic/distribution.yaml' [bloom] (#306…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9435,12 +9435,11 @@ repositories:
       - qb_hand
       - qb_hand_control
       - qb_hand_description
-      - qb_hand_gazebo
       - qb_hand_hardware_interface
       tags:
         release: release/melodic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbhand-ros-release.git
-      version: 2.2.2-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbhand-ros.git


### PR DESCRIPTION
…04)"

This reverts commit 021787912d77d18ecca7bec0ec098473dd812829.

This hasn't built properly since #30604 (and friends) was merged.  @umbertofontana93 FYI.