### PR TITLE
Revert "qb_move: 2.2.1-1 in 'melodic/distribution.yaml' [bloom] (#306…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9455,12 +9455,11 @@ repositories:
       - qb_move
       - qb_move_control
       - qb_move_description
-      - qb_move_gazebo
       - qb_move_hardware_interface
       tags:
         release: release/melodic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbmove-ros-release.git
-      version: 2.2.1-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbmove-ros.git


### PR DESCRIPTION
…00)"

This reverts commit af1b8cdd1cb2e62ee283e94c943fd30fc3e5d3ec.

This hasn't built properly since #30600 and friends were merged.  @umbertofontana93 FYI.