### PR TITLE
rosee_msg: 1.0.1-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11149,6 +11149,21 @@ repositories:
       url: https://github.com/ros-infrastructure/rosdoc_lite.git
       version: master
     status: maintained
+  rosee_msg:
+    doc:
+      type: git
+      url: https://github.com/ADVRHumanoids/rosee_msg.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ADVRHumanoids/rosee_msg-release.git
+      version: 1.0.1-2
+    source:
+      type: git
+      url: https://github.com/ADVRHumanoids/rosee_msg.git
+      version: master
+    status: maintained
   rosflight:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosee_msg` to `1.0.1-2`:

- upstream repository: https://github.com/ADVRHumanoids/rosee_msg.git
- release repository: https://github.com/ADVRHumanoids/rosee_msg-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## rosee_msg

- No changes
