### PR TITLE
ros_comm: 1.15.12-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6753,7 +6753,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.15.11-1
+      version: 1.15.12-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.15.12-1`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.15.11-1`

## message_filters

- No changes

## ros_comm

- No changes

## rosbag

- No changes

## rosbag_storage

- No changes

## roscpp

```
* Fix warning related to Boost bind placeholders declared in global namespace (#2169 <https://github.com/ros/ros_comm/issues/2169>)
* Contributors: Elvis Dowson
```

## rosgraph

```
* Fix memory leak in rosgraph for kernel < 4.16 and Python 3 (#2165 <https://github.com/ros/ros_comm/issues/2165>)
* Contributors: Alexis Schad
```

## roslaunch

- No changes

## roslz4

- No changes

## rosmaster

- No changes

## rosmsg

- No changes

## rosnode

- No changes

## rosout

- No changes

## rosparam

- No changes

## rospy

```
* Document current_real in timer.py (#2178 <https://github.com/ros/ros_comm/issues/2178>)
* Do not set self.transport unless persistent in ServiceProxy (#2171 <https://github.com/ros/ros_comm/issues/2171>)
* Fix #2123 <https://github.com/ros/ros_comm/issues/2123>:  Do not raise exception if socket is busy in TCPROSTransport (#2131 <https://github.com/ros/ros_comm/issues/2131>)
* Contributors: Kevin Chang, Shingo Kitagawa, 金梦磊
```

## rosservice

- No changes

## rostest

- No changes

## rostopic

- No changes

## roswtf

- No changes

## topic_tools

- No changes

## xmlrpcpp

```
* Fix XMLRPC endless loop (#2185 <https://github.com/ros/ros_comm/issues/2185>)
* Fix build when gtest is not available (#2177 <https://github.com/ros/ros_comm/issues/2177>)
* Contributors: Chris Lalancette, Wolfgang Merkt
```
