### PR TITLE
dbw_fca_ros: 1.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1412,7 +1412,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_fca_ros-release.git
-      version: 1.2.0-1
+      version: 1.2.1-1
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/dbw_fca_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_fca_ros` to `1.2.1-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/dbw_fca_ros.git
- release repository: https://github.com/DataspeedInc-release/dbw_fca_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.0-1`

## dbw_fca

- No changes

## dbw_fca_can

```
* Bump firmware versions
* Add reserved bits
* Improve printing of license info
* Add ignition status to ThrottleInfoReport
* Add user control of alert
* Contributors: Kevin Hallenbeck
```

## dbw_fca_description

```
* Modify rear wheel link inertial parameters to prevent wobbling in Gazebo
* Contributors: Micho Radovnikovich
```

## dbw_fca_joystick_demo

- No changes

## dbw_fca_msgs

```
* Add ignition status to ThrottleInfoReport
* Add user control of alert
* Contributors: Kevin Hallenbeck
```
