### PR TITLE
dbw_mkz_ros: 1.4.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1433,7 +1433,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_mkz_ros-release.git
-      version: 1.4.0-1
+      version: 1.4.1-1
     source:
       type: git
       url: https://bitbucket.org/dataspeedinc/dbw_mkz_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_mkz_ros` to `1.4.1-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/dbw_mkz_ros.git
- release repository: https://github.com/DataspeedInc-release/dbw_mkz_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.4.0-1`

## dbw_mkz

- No changes

## dbw_mkz_can

```
* Bump firmware versions
* Add reserved bits
* Improve printing of license info
* Add ignition status to ThrottleInfoReport
* Add user control of alert
* Contributors: Kevin Hallenbeck
```

## dbw_mkz_description

- No changes

## dbw_mkz_joystick_demo

- No changes

## dbw_mkz_msgs

```
* Add ignition status to ThrottleInfoReport
* Add user control of alert
* Contributors: Kevin Hallenbeck
```
