### PR TITLE
moveit_opw_kinematics_plugin: 0.3.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4342,6 +4342,17 @@ repositories:
       url: https://github.com/ros-planning/moveit_msgs.git
       version: master
     status: maintained
+  moveit_opw_kinematics_plugin:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/JeroenDM/moveit_opw_kinematics_plugin-release.git
+      version: 0.3.1-2
+    source:
+      type: git
+      url: https://github.com/JeroenDM/moveit_opw_kinematics_plugin.git
+      version: noetic-devel
+    status: maintained
   moveit_python:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_opw_kinematics_plugin` to `0.3.1-2`:

- upstream repository: https://github.com/JeroenDM/moveit_opw_kinematics_plugin.git
- release repository: https://github.com/JeroenDM/moveit_opw_kinematics_plugin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## moveit_opw_kinematics_plugin

```
* First release in noetic.
* update to new opw_kinematics API (with std::array)
* Add opw_kinematics dependency to package.xml and CMakeLists.txt.
* Remove opw_kinematics submodule.
* Change moveit_resources to more specific moveit_resources_fanuc_moveit_config
* Minor changes:
  - It's not a service based IK solver.
  - Parameters don't always come from 'kinematics.yaml'.
* Contributors: JeroenDM, gavanderhoorn.
```
