### PR TITLE
marti_common: 3.3.2-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1480,7 +1480,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 3.3.2-1
+      version: 3.3.2-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `3.3.2-2`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.3.2-1`

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

- No changes

## swri_image_util

- No changes

## swri_math_util

- No changes

## swri_opencv_util

- No changes

## swri_prefix_tools

- No changes

## swri_roscpp

```
* Fix topic services under ros2 (#604 <https://github.com/swri-robotics/marti_common/issues/604>)
* Fix bugs related to subscription age and setting timeout (#609 <https://github.com/swri-robotics/marti_common/issues/609>, #611 <https://github.com/swri-robotics/marti_common/issues/611>) (#612 <https://github.com/swri-robotics/marti_common/issues/612>)
* Contributors: David Anthony, mschickler
```

## swri_route_util

- No changes

## swri_serial_util

```
* Make SerialPort's functions virtual (#608 <https://github.com/swri-robotics/marti_common/issues/608>)
* Contributors: Ryan DelGizzi
```

## swri_system_util

- No changes

## swri_transform_util

- No changes
