### PR TITLE
hello_world_bloom: 0.1.0-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4225,6 +4225,13 @@ repositories:
       url: https://gitlab.pdmfc.com/drones/ros1/heifu.git
       version: releasePackage
     status: maintained
+  hello_world_bloom:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://tochtli8@bitbucket.org/tochtli8/hello_world_bloom-release.git
+      version: 0.1.0-3
+    status: developed
   heron:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hello_world_bloom` to `0.1.0-3`:

- upstream repository: https://tochtli8@bitbucket.org/tochtli8/hello_world_bloom.git
- release repository: https://tochtli8@bitbucket.org/tochtli8/hello_world_bloom-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## hello_world_bloom

```
* First initial development release.
```
