### PR TITLE
neo_simulation2: 1.0.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1828,6 +1828,21 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: galactic
     status: maintained
+  neo_simulation2:
+    doc:
+      type: git
+      url: https://github.com/neobotix/neo_simulation2.git
+      version: galactic
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/neobotix/neo_simulation2-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/neobotix/neo_simulation2.git
+      version: galactic
+    status: maintained
   nmea_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `neo_simulation2` to `1.0.1-1`:

- upstream repository: https://github.com/neobotix/neo_simulation2.git
- release repository: https://github.com/neobotix/neo_simulation2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
