### PR TITLE
rqt_runtime_monitor: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4693,7 +4693,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_runtime_monitor-release.git
-      version: 0.5.8-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_runtime_monitor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_runtime_monitor` to `1.0.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_runtime_monitor.git
- release repository: https://github.com/ros2-gbp/rqt_runtime_monitor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.5.8-1`

## rqt_runtime_monitor

```
* added LICENSE file
* Ported to ROS 2 (#5 <https://github.com/ros-visualization/rqt_runtime_monitor/issues/5>)
```
