### PR TITLE
Revert "jderobot_drones: 1.4.1-2 in 'noetic/distribution.yaml' [bloom…

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3218,17 +3218,14 @@ repositories:
     release:
       packages:
       - drone_assets
-      - drone_circuit_assets
       - drone_wrapper
       - jderobot_drones
       - rqt_drone_teleop
       - rqt_ground_robot_teleop
-      - tello_driver
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/JdeRobot/drones-release.git
-      version: 1.4.1-2
-    status: maintained
+      version: 1.4.0-1
   joint_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
…] (#30811)"

This reverts commit 467748740fbd5f2e3a8635d97ff619e495f4bcbd.

This hasn't built since #30811 was merged.  @pariaspe FYI.