### PR TITLE
toposens: 2.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8770,6 +8770,7 @@ repositories:
       - toposens_bringup
       - toposens_description
       - toposens_driver
+      - toposens_echo_driver
       - toposens_markers
       - toposens_msgs
       - toposens_pointcloud
@@ -8777,7 +8778,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 2.2.1-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toposens` to `2.3.0-1`:

- upstream repository: https://gitlab.com/toposens/public/ros-packages.git
- release repository: https://gitlab.com/toposens/public/toposens-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.2.1-1`

## toposens

```
* Introduce toposens_echo_driver package
* Update maintainers
* Minor bug fixes
* Contributors: Baris Yazici, Dennis Maier
```

## toposens_bringup

```
* Introduce toposens_echo_driver package
* Update maintainers
* Minor bug fixes
* Contributors: Baris Yazici, Dennis Maier
```

## toposens_description

```
* Introduce toposens_echo_driver package
* Update maintainers
* Minor bug fixes
* Contributors: Baris Yazici, Dennis Maier
```

## toposens_driver

```
* Introduce toposens_echo_driver package
* Update maintainers
* Minor bug fixes
* Contributors: Baris Yazici, Dennis Maier
```

## toposens_echo_driver

```
* Introduce toposens_echo_driver package
* Update maintainers
* Minor bug fixes
* Contributors: Baris Yazici, Dennis Maier
```

## toposens_markers

```
* Introduce toposens_echo_driver package
* Update maintainers
* Minor bug fixes
* Contributors: Baris Yazici, Dennis Maier
```

## toposens_msgs

```
* Introduce toposens_echo_driver package
* Update maintainers
* Minor bug fixes
* Contributors: Baris Yazici, Dennis Maier
```

## toposens_pointcloud

```
* Introduce toposens_echo_driver package
* Update maintainers
* Minor bug fixes
* Contributors: Baris Yazici, Dennis Maier
```

## toposens_sync

```
* Introduce toposens_echo_driver package
* Update maintainers
* Minor bug fixes
* Contributors: Baris Yazici, Dennis Maier
```
