### PR TITLE
Add python3-pygments to rosdep

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -583,6 +583,10 @@ python-vtk:
   osx:
     homebrew:
       depends: [libvtk]
+python3-pygments:
+  osx:
+    homebrew:
+      packages: [pygments]
 qt5-qmake:
   osx:
     homebrew:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7320,8 +7320,8 @@ python3-pygments:
   fedora: [python3-pygments]
   gentoo: [dev-python/pygments]
   openembedded: [python3-pygments@openembedded-core]
-  rhel: [python3-pygments]
   opensuse: [python3-Pygments]
+  rhel: [python3-pygments]
   ubuntu: [python3-pygments]
 python3-pygraphviz:
   alpine: [py3-graphviz]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7313,6 +7313,16 @@ python3-pygit2:
       packages: [pygit2]
   rhel: ['python%{python3_pkgversion}-pygit2']
   ubuntu: [python3-pygit2]
+python3-pygments:
+  alpine: [py3-pygments]
+  arch: [python-pygments]
+  debian: [python3-pygments]
+  fedora: [python3-pygments]
+  gentoo: [dev-python/pygments]
+  openembedded: [python3-pygments@openembedded-core]
+  rhel: [python3-pygments]
+  opensuse: [python3-Pygments]
+  ubuntu: [python3-pygments]
 python3-pygraphviz:
   alpine: [py3-graphviz]
   arch: [python2-pygraphviz]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7321,7 +7321,9 @@ python3-pygments:
   gentoo: [dev-python/pygments]
   openembedded: [python3-pygments@openembedded-core]
   opensuse: [python3-Pygments]
-  rhel: [python3-pygments]
+  rhel:
+    '*': [python3-pygments]
+    '7': null
   ubuntu: [python3-pygments]
 python3-pygraphviz:
   alpine: [py3-graphviz]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

## Package name:

Pygments

## Package Upstream Source:

https://github.com/pygments/pygments

## Purpose of using this:

Though designed as a syntax highlighting library, Pygments includes a ton of useful lexers which are quite handy when parsing or post-processing source code.

## Links to Distribution Packages

- Debian: https://packages.debian.org
  - https://packages.debian.org/search?keywords=python3-pygments&searchon=names&suite=all&section=all
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=python3-pygments&searchon=names
- Fedora: https://src.fedoraproject.org/browse/projects/
  - https://src.fedoraproject.org/rpms/python3-pygments
  - Can also be found in https://pkgs.org/search/?q=pygments
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/community/any/python-pygments/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/pygments
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/pygments#default
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.org/search/?q=pygments
- OpenEmbedded
  - https://layers.openembedded.org/layerindex/recipe/181220/
- OpenSUSE:
  - https://pkgs.org/search/?q=pygments
- RHEL
  - https://pkgs.org/search/?q=pygments 