### PR TITLE
ros_inorbit_samples: 0.2.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10767,6 +10767,19 @@ repositories:
       type: git
       url: https://github.com/shadow-robot/ros_ethercat_eml.git
       version: melodic-devel
+  ros_inorbit_samples:
+    release:
+      packages:
+      - inorbit_republisher
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/inorbit-ai/ros_inorbit_samples-release.git
+      version: 0.2.1-1
+    source:
+      type: git
+      url: https://github.com/inorbit-ai/ros_inorbit_samples.git
+      version: melodic-devel
+    status: maintained
   ros_led:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_inorbit_samples` to `0.2.1-1`:

- upstream repository: https://github.com/inorbit-ai/ros_inorbit_samples.git
- release repository: https://github.com/inorbit-ai/ros_inorbit_samples-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## inorbit_republisher

```
* Initial Implementation
* Contributors: Leandro Pineda
```
