### PR TITLE
leo_robot: 1.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3648,6 +3648,25 @@ repositories:
       url: https://github.com/LeoRover/leo_desktop.git
       version: master
     status: maintained
+  leo_robot:
+    doc:
+      type: git
+      url: https://github.com/LeoRover/leo_robot.git
+      version: master
+    release:
+      packages:
+      - leo_bringup
+      - leo_fw
+      - leo_robot
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/fictionlab-gbp/leo_robot-release.git
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://github.com/LeoRover/leo_robot.git
+      version: master
+    status: maintained
   leo_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_robot` to `1.2.0-1`:

- upstream repository: https://github.com/LeoRover/leo_robot.git
- release repository: https://github.com/fictionlab-gbp/leo_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## leo_bringup

```
* Core2 parameters: change input_timeout to float, add robot and odom frame_id parameters
* Delete launch prefix from serial_node
* Avoid deprecation warnings from xacro and robot_state_publisher
* Update author and maintainer info
```

## leo_fw

```
* Bundle a new firmware binary release (v1.2.0)
* Add flash script to CMakeLists
* Add flash script for flashing custom firmware
* Add arguments to the flash_firmware function
* Update author and maintainer info
```

## leo_robot

```
* Update author and maintainer info
```
