### PR TITLE
Update joint_state_publisher Galactic and Rolling devel branches

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1241,7 +1241,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/joint_state_publisher.git
-      version: foxy
+      version: galactic
     release:
       packages:
       - joint_state_publisher
@@ -1254,7 +1254,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/joint_state_publisher.git
-      version: foxy
+      version: galactic
     status: maintained
   joystick_drivers:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1227,7 +1227,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/joint_state_publisher.git
-      version: foxy
+      version: ros2
     release:
       packages:
       - joint_state_publisher
@@ -1240,7 +1240,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/joint_state_publisher.git
-      version: foxy
+      version: ros2
     status: maintained
   joystick_drivers:
     doc:


### PR DESCRIPTION
Instead of using the `foxy` branch, use the existing `ros2` branch and the newly created `galactic` branch.