### PR TITLE
python-itsdangerous is not available since Bionic

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2350,7 +2350,9 @@ python-itsdangerous:
     stretch: [python-itsdangerous]
   fedora: [python-itsdangerous]
   gentoo: [dev-python/itsdangerous]
-  ubuntu: [python-itsdangerous]
+  ubuntu:
+    '*': null
+    bionic: [python-itsdangerous]
 python-jasmine-pip:
   ubuntu:
     pip:


### PR DESCRIPTION
Follow-up from https://github.com/ros/rosdistro/pull/30763#issuecomment-926192678

https://packages.ubuntu.com/search?keywords=python-itsdangerous