### PR TITLE
Disable PR and commit testing for MoveIt 2

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2056,6 +2056,8 @@ repositories:
       url: https://github.com/moveit/moveit2-release.git
       version: 2.2.1-1
     source:
+      test_commits: false
+      test_pull_requests: false
       type: git
       url: https://github.com/ros-planning/moveit2.git
       version: main

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1639,6 +1639,8 @@ repositories:
       url: https://github.com/moveit/moveit2-release.git
       version: 2.2.1-1
     source:
+      test_commits: false
+      test_pull_requests: false
       type: git
       url: https://github.com/ros-planning/moveit2.git
       version: main

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1641,6 +1641,8 @@ repositories:
       url: https://github.com/moveit/moveit2-release.git
       version: 2.2.1-1
     source:
+      test_commits: false
+      test_pull_requests: false
       type: git
       url: https://github.com/ros-planning/moveit2.git
       version: main


### PR DESCRIPTION
These jobs keep failing / timing out, and we already have CI based on GHA over at `ros-planning/moveit2` (targetting the different active ROS 2 versions, including Rolling).

As MoveIt builds can take a *really* long time (without the extensive caching we do at `ros-planning/moveit2`), this PR suggests to save resources by removing the `source` entries for Foxy, Galactic and Rolling respectively, so the buildfarm can do something else.
