### PR TITLE
Switch rolling urdfdom to use the master branch

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4291,7 +4291,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/urdfdom.git
-      version: ros2
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -4301,7 +4301,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/urdfdom.git
-      version: ros2
+      version: master
     status: maintained
   urdfdom_headers:
     doc:


### PR DESCRIPTION
We've merged all of the necessary changes to the master branch,
so we should start using that instead of the ros2 branch.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>