### PR TITLE
Update python-numpy key for opensuse

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2927,7 +2927,7 @@ python-numpy:
   macports: [py27-numpy]
   nixos: [pythonPackages.numpy]
   openembedded: ['${PYTHON_PN}-numpy@openembedded-core']
-  opensuse: [python2-numpy]
+  opensuse: [python2-numpy-devel]
   osx:
     pip:
       packages: [numpy]


### PR DESCRIPTION
Need python2-numpy-devel not just python2-numpy for openSUSE 

https://software.opensuse.org/package/python2-numpy-devel?search_term=python2-numpy-devel