### PR TITLE
Updating boost key for opensuse

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -382,7 +382,7 @@ boost:
   macports: [boost]
   nixos: [boost]
   openembedded: [boost@openembedded-core]
-  opensuse: [libboost_headers1_66_0-devel, libboost_system1_66_0-devel, libboost_thread1_66_0-devel, libboost_chrono1_66_0-devel, libboost_date_time1_66_0-devel, libboost_serialization1_66_0-devel, libboost_filesystem1_66_0-devel, libboost_program_options1_66_0-devel, libboost_signals1_66_0-devel, libboost_regex1_66_0-devel]
+  opensuse: [libboost_atomic1_66_0-devel, libboost_headers1_66_0-devel, libboost_system1_66_0-devel, libboost_thread1_66_0-devel, libboost_chrono1_66_0-devel, libboost_date_time1_66_0-devel, libboost_serialization1_66_0-devel, libboost_filesystem1_66_0-devel, libboost_program_options1_66_0-devel, libboost_python-py2_7-1_66_0-devel, libboost_python-py3-1_66_0-devel, libboost_signals1_66_0-devel, libboost_regex1_66_0-devel, libboost_iostreams1_66_0-devel]
   rhel: [boost-devel, 'boost-python%{python3_pkgversion}-devel']
   slackware:
     slackpkg:


### PR DESCRIPTION
Updated the boost key with the following additional devel libs:
libboost_atomic1_66_0-devel
libboost_python-py2_7-1_66_0-devel
libboost_python-py3-1_66_0-devel
libboost_iostreams1_66_0-devel

https://software.opensuse.org/package/libboost_atomic1_66_0-devel
https://software.opensuse.org/package/libboost_python-py2_7-1_66_0-devel
https://software.opensuse.org/package/libboost_python-py3-1_66_0-devel
https://software.opensuse.org/package/libboost_iostreams1_66_0-devel
