### PR TITLE
Update python-qt5-bindings key for opensuse

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4033,7 +4033,7 @@ python-qt5-bindings:
   gentoo: ['dev-python/PyQt5[gui,widgets]']
   nixos: [pythonPackages.pyqt5]
   openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
-  opensuse: [python2-qt5-devel,python2-sip-devel]
+  opensuse: [python2-qt5-devel, python2-sip-devel]
   slackware: [PyQt5]
   ubuntu:
     artful: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4033,7 +4033,7 @@ python-qt5-bindings:
   gentoo: ['dev-python/PyQt5[gui,widgets]']
   nixos: [pythonPackages.pyqt5]
   openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
-  opensuse: [python2-qt5]
+  opensuse: [python2-qt5-devel,python2-sip-devel]
   slackware: [PyQt5]
   ubuntu:
     artful: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev]


### PR DESCRIPTION
Need python2-qt5-devel and python2-sip-devel for opensuse.

https://software.opensuse.org/package/python2-qt5-devel
https://software.opensuse.org/package/python2-sip-devel