### PR TITLE
rviz: 1.13.20-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12255,7 +12255,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.13.19-1
+      version: 1.13.20-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.13.20-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.13.19-1`

## rviz

```
* Revert "Smoothly move PCL given a moving frame_id (#1655 <https://github.com/ros-visualization/rviz/issues/1655>)"
* Revert "Smoothly move an Odometry's path given a moving frame_id (#1631 <https://github.com/ros-visualization/rviz/issues/1631>)"
* Restore workaround for https://github.com/ros/geometry2/pull/402
* BillboardLine: Fix handling of many points (> 16384) (#1662 <https://github.com/ros-visualization/rviz/issues/1662>)
* DisplayPanel: Simplify selection of current item after Remove (#1661 <https://github.com/ros-visualization/rviz/issues/1661>), fixes #1658 <https://github.com/ros-visualization/rviz/issues/1658>
* Contributors: Robert Haschke
```
