### PR TITLE
Add rosdep key for libboost-numpy-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2407,6 +2407,14 @@ libboost-math-dev:
   opensuse: [libboost_math1_66_0-devel]
   rhel: [boost-devel]
   ubuntu: [libboost-math-dev]
+libboost-numpy-dev:
+  debian: [libboost-numpy-dev]
+  fedora: [boost-devel]
+  gentoo: [dev-libs/boost]
+  nixos: [boost]
+  opensuse: [libboost_numpy-py2_7-1_66_0, libboost_numpy-py3-1_66_0]
+  rhel: [boost-devel]
+  ubuntu: [libboost-numpy-dev]
 libboost-program-options:
   debian:
     buster: [libboost-program-options1.67.0]


### PR DESCRIPTION
Please add libboost-numpy-dev to the rosdep database. I chose the distributions in the style of the other libboost-* rosdep keys and checked the values using the distributions package search websites.

Signed-off-by: Dennis Nienhüser <dennis.nienhueser@de.bosch.com>
