### PR TITLE
moveit_msgs: 2.1.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1652,7 +1652,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/moveit/moveit_msgs-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_msgs` to `2.1.1-1`:

- upstream repository: https://github.com/ros-planning/moveit_msgs.git
- release repository: https://github.com/moveit/moveit_msgs-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.0-1`

## moveit_msgs

```
* Add jerk to JointLimits.msg (#132 <https://github.com/ros-planning/moveit_msgs/issues/132>)
* Contributors: AndyZe
```
