### PR TITLE
srdfdom: 2.0.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4052,7 +4052,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/moveit/srdfdom-release.git
-      version: 2.0.2-1
+      version: 2.0.3-1
     source:
       type: git
       url: https://github.com/ros-planning/srdfdom.git


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom` to `2.0.3-1`:

- upstream repository: https://github.com/ros-planning/srdfdom.git
- release repository: https://github.com/moveit/srdfdom-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.2-1`

## srdfdom

```
* Use modern cmake (#96 <https://github.com/ros-planning/srdfdom/issues/96>)
* Fix unit tests & setup.py file (#94 <https://github.com/ros-planning/srdfdom/issues/94>)
* Fix use of tinyxml2_vendor (#95 <https://github.com/ros-planning/srdfdom/issues/95>)
* Fixes for usage on windows (#91 <https://github.com/ros-planning/srdfdom/issues/91>)
* Contributors: Akash, Jafar Abdi, Vatan Aksoy Tezer
```
