### PR TITLE
srdfdom: 2.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3853,7 +3853,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/moveit/srdfdom-release.git
-      version: 2.0.2-1
+      version: 2.0.3-1
     source:
       type: git
       url: https://github.com/ros-planning/srdfdom.git


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom` to `2.0.3-1`:

- upstream repository: https://github.com/ros-planning/srdfdom.git
- release repository: https://github.com/moveit/srdfdom-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.2-1`

## srdfdom

```
* Use modern cmake (#96 <https://github.com/ros-planning/srdfdom/issues/96>)
* Fix unit tests & setup.py file (#94 <https://github.com/ros-planning/srdfdom/issues/94>)
* Fix use of tinyxml2_vendor (#95 <https://github.com/ros-planning/srdfdom/issues/95>)
* Fixes for usage on windows (#91 <https://github.com/ros-planning/srdfdom/issues/91>)
* Contributors: Akash, Jafar Abdi, Vatan Aksoy Tezer
```
