### PR TITLE
geometric_shapes: 2.1.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -949,7 +949,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/moveit/geometric_shapes-release.git
-      version: 2.1.0-2
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `2.1.1-1`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/moveit/geometric_shapes-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.0-2`

## geometric_shapes

```
* Changed retriever.h to retriever.hpp in mesh_operations.cpp in order to align with resource_retriever ros2 branch (#200 <https://github.com/ros-planning/geometric_shapes/issues/200>)
* Add Copyright and LICENSE files
* Fix building on Windows with MSVC (#189 <https://github.com/ros-planning/geometric_shapes/issues/189>)
* Contributors: Akash, Diego Rojas, Mark Moll, Tyler Weaver, Vatan Aksoy Tezer
```
