### PR TITLE
warehouse_ros_mongo: 2.0.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4696,7 +4696,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/moveit/warehouse_ros_mongo-release.git
-      version: 2.0.2-1
+      version: 2.0.3-1
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros_mongo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros_mongo` to `2.0.3-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros_mongo.git
- release repository: https://github.com/moveit/warehouse_ros_mongo-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.2-1`

## warehouse_ros_mongo

```
* Clean OpenSSL dependencies (#67 <https://github.com/ros-planning/warehouse_ros_mongo/issues/67>)
* Add Copyright and LICENSE files (#65 <https://github.com/ros-planning/warehouse_ros_mongo/issues/65>)
* Contributors: Vatan Aksoy Tezer
```
