### PR TITLE
moveit_visual_tools: 4.0.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1680,6 +1680,21 @@ repositories:
       url: https://github.com/ros-planning/moveit_resources.git
       version: ros2
     status: developed
+  moveit_visual_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_visual_tools.git
+      version: ros2
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/moveit/moveit_visual_tools-release.git
+      version: 4.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_visual_tools.git
+      version: ros2
+    status: maintained
   mrpt2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `4.0.0-1`:

- upstream repository: https://github.com/ros-planning/moveit_visual_tools.git
- release repository: https://github.com/moveit/moveit_visual_tools-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## moveit_visual_tools

```
* Port to ros2 (#92 <https://github.com/ros-planning/moveit_visual_tools/issues/92>)
* Fix typo in package.xml (#87 <https://github.com/ros-planning/moveit_visual_tools/issues/87>)
* Contributors: Davide Faconti, Felix von Drigalski, Vatan Aksoy Tezer
```
