### PR TITLE
moveit_visual_tools: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1682,6 +1682,21 @@ repositories:
       url: https://github.com/ros-planning/moveit_resources.git
       version: ros2
     status: developed
+  moveit_visual_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_visual_tools.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/moveit/moveit_visual_tools-release.git
+      version: 4.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_visual_tools.git
+      version: ros2
+    status: maintained
   mrpt2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `4.0.0-1`:

- upstream repository: https://github.com/ros-planning/moveit_visual_tools.git
- release repository: https://github.com/moveit/moveit_visual_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## moveit_visual_tools

```
* Port to ros2 (#92 <https://github.com/ros-planning/moveit_visual_tools/issues/92>)
* Fix typo in package.xml (#87 <https://github.com/ros-planning/moveit_visual_tools/issues/87>)
* Contributors: Davide Faconti, Felix von Drigalski, Vatan Aksoy Tezer
```
