### PR TITLE
ros2_control: 1.0.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3068,6 +3068,30 @@ repositories:
       url: https://github.com/ros2/ros1_bridge.git
       version: galactic
     status: maintained
+  ros2_control:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/ros2_control.git
+      version: master
+    release:
+      packages:
+      - controller_interface
+      - controller_manager
+      - controller_manager_msgs
+      - hardware_interface
+      - ros2_control
+      - ros2_control_test_assets
+      - ros2controlcli
+      - transmission_interface
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_control-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/ros2_control.git
+      version: master
+    status: developed
   ros2_ouster_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `1.0.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## controller_interface

```
* Per controller update rate (#513 <https://github.com/ros-controls/ros2_control/issues/513>)
  * add update_rate member field to controller manager
* added dt to controller interface and controller manager #438 <https://github.com/ros-controls/ros2_control/issues/438> (#520 <https://github.com/ros-controls/ros2_control/issues/520>)
* Methods controlling the lifecycle of controllers all have on_ prefix
* Do not manually set C++ version to 14 (#516 <https://github.com/ros-controls/ros2_control/issues/516>)
* rename get_current_state() to get_state() (#512 <https://github.com/ros-controls/ros2_control/issues/512>)
* Contributors: Bence Magyar, Denis Štogl, Dmitri Ignakov, Márk Szitanics, bailaC
```

## controller_manager

```
* Use ControllerManager node clock for control loop timepoints (#542 <https://github.com/ros-controls/ros2_control/issues/542>)
* Per controller update rate(#513 <https://github.com/ros-controls/ros2_control/issues/513>)
* added dt to controller interface and controller manager #438 <https://github.com/ros-controls/ros2_control/issues/438> (#520 <https://github.com/ros-controls/ros2_control/issues/520>)
* Update nomenclature in CM for better code and output understanding (#517 <https://github.com/ros-controls/ros2_control/issues/517>)
* Methods controlling the lifecycle of controllers all have on_ prefix
* Controller Manager should not crash when trying to start finalized or unconfigured controller (#461 <https://github.com/ros-controls/ros2_control/issues/461>)
* Fix deprecation warning from rclcpp::Duration (#511 <https://github.com/ros-controls/ros2_control/issues/511>)
* Remove BOOST compiler definitions for pluginlib from CMakeLists (#514 <https://github.com/ros-controls/ros2_control/issues/514>)
* Do not manually set C++ version to 14 (#516 <https://github.com/ros-controls/ros2_control/issues/516>)
* Refactor INSTANTIATE_TEST_CASE_P -> INSTANTIATE_TEST_SUITE_P (#515 <https://github.com/ros-controls/ros2_control/issues/515>)
  Also removed the duplicated format & compiler fixes as on Galactic this shouldn't be an issue
* rename get_current_state() to get_state() (#512 <https://github.com/ros-controls/ros2_control/issues/512>)
* Fix spawner tests (#509 <https://github.com/ros-controls/ros2_control/issues/509>)
* Removed deprecated CLI verbs (#420 <https://github.com/ros-controls/ros2_control/issues/420>)
* Remove extensions from executable nodes (#453 <https://github.com/ros-controls/ros2_control/issues/453>)
* Contributors: Bence Magyar, Denis Štogl, Dmitri Ignakov, Joseph Schornak, Márk Szitanics, Tim Clephas, bailaC, Mathias Aarbo
```

## controller_manager_msgs

```
* Do not manually set C++ version to 14 (#516 <https://github.com/ros-controls/ros2_control/issues/516>)
* Contributors: Bence Magyar
```

## hardware_interface

```
* Hardware components extension for lifecycle support (#503 <https://github.com/ros-controls/ros2_control/issues/503>)
* add M_PI macro for windows in test_component_parser.cpp (#502 <https://github.com/ros-controls/ros2_control/issues/502>)
* Extend GenericSystem by adding mapping of position with offset to custom interface. (#469 <https://github.com/ros-controls/ros2_control/issues/469>)
* Remove BOOST compiler definitions for pluginlib from CMakeLists (#514 <https://github.com/ros-controls/ros2_control/issues/514>)
* Do not manually set C++ version to 14 (#516 <https://github.com/ros-controls/ros2_control/issues/516>)
* Contributors: Bence Magyar, Denis Štogl, dzyGIT
```

## ros2_control

```
* Add missing packages in the metapackage (#534 <https://github.com/ros-controls/ros2_control/issues/534>)
* Contributors: Denis Štogl
```

## ros2_control_test_assets

```
* Remove unnecessary includes (#518 <https://github.com/ros-controls/ros2_control/issues/518>)
* Do not manually set C++ version to 14 (#516 <https://github.com/ros-controls/ros2_control/issues/516>)
* Contributors: Bence Magyar, Denis Štogl
```

## ros2controlcli

```
* Removed deprecated CLI verbs (#420 <https://github.com/ros-controls/ros2_control/issues/420>)
* Contributors: Mathias Aarbo
```

## transmission_interface

```
* Do not manually set C++ version to 14 (#516 <https://github.com/ros-controls/ros2_control/issues/516>)
* Refactor INSTANTIATE_TEST_CASE_P -> INSTANTIATE_TEST_SUITE_P (#515 <https://github.com/ros-controls/ros2_control/issues/515>)
* Contributors: Bence Magyar
```
