### PR TITLE
phidgets_drivers: 1.0.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5371,6 +5371,7 @@ repositories:
       - libphidget22
       - phidgets_accelerometer
       - phidgets_analog_inputs
+      - phidgets_analog_outputs
       - phidgets_api
       - phidgets_digital_inputs
       - phidgets_digital_outputs
@@ -5386,7 +5387,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `1.0.3-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.2-1`

## libphidget22

- No changes

## phidgets_accelerometer

- No changes

## phidgets_analog_inputs

- No changes

## phidgets_analog_outputs

```
* Add Analog Outputs (#103 <https://github.com/ros-drivers/phidgets_drivers/issues/103>)
* Contributors: Carsten Plasberg
```

## phidgets_api

```
* Fix typo in error message
* Add Analog Outputs (#103 <https://github.com/ros-drivers/phidgets_drivers/issues/103>)
* Contributors: Carsten Plasberg, Martin Günther
```

## phidgets_digital_inputs

```
* Add missing license headers
* Contributors: Martin Günther
```

## phidgets_digital_outputs

```
* Add missing license headers
* Contributors: Martin Günther
```

## phidgets_drivers

- No changes

## phidgets_gyroscope

- No changes

## phidgets_high_speed_encoder

- No changes

## phidgets_ik

- No changes

## phidgets_magnetometer

- No changes

## phidgets_motors

- No changes

## phidgets_msgs

```
* Add Analog Outputs (#103 <https://github.com/ros-drivers/phidgets_drivers/issues/103>)
* Contributors: Carsten Plasberg
```

## phidgets_spatial

- No changes

## phidgets_temperature

- No changes
