### PR TITLE
Add source entry for rosbridge_suite.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3203,6 +3203,10 @@ repositories:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
       version: 1.0.5-1
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/rosbridge_suite.git
+      version: ros2
   rosidl:
     doc:
       type: git


### PR DESCRIPTION
This will allow rosinstall_generator to work with the --upstream and --upstream-development options as well as enable commit testing on changes to the ros2 branch. Pull request testing can be enabled as well, if desired.

I'd like approval from @jtbandes or @amacneil since this will likely trigger build farm notifications for them.