### PR TITLE
Remove self_test package while build is broken.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -629,7 +629,6 @@ repositories:
       packages:
       - diagnostic_aggregator
       - diagnostic_updater
-      - self_test
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git


### PR DESCRIPTION
This package is not currently building.
The issue is ticketed upstream https://github.com/ros/diagnostics/issues/206

A future release of diagnostics will re-add this package and thus attempt to build it again. This change will not prevent self_test from being built and tested during devel jobs.