### PR TITLE
Adding new repository for indexing: stair_step_detector

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4103,6 +4103,12 @@ repositories:
       url: https://github.com/ros2/sros2.git
       version: galactic
     status: developed
+  stair_step_detector:
+    doc:
+      type: git
+      url: https://github.com/peter-nebe/stair-step-detector.git
+      version: master
+    status: developed
   stubborn_buddies:
     doc:
       type: git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4108,6 +4108,10 @@ repositories:
       type: git
       url: https://github.com/peter-nebe/stair-step-detector.git
       version: master
+    source:
+      type: git
+      url: https://github.com/peter-nebe/stair-step-detector.git
+      version: master
     status: developed
   stubborn_buddies:
     doc:


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

galactic

# The source is here: 

https://github.com/peter-nebe/stair-step-detector


# Checks
 - [y] All packages have a declared license in the package.xml
 - [y] This repository has a LICENSE file
 - [y] This package is expected to build on the submitted rosdistro


Hello Maintainers,
the stair-step-detector could perhaps become a useful ROS package. It allows the detection of stair steps using a LiDAR depth camera. I hope the criteria for inclusion in the ROS Index have been met. I am happy to answer your questions.
Best regards,
Peter