### PR TITLE
plotjuggler_msgs: 0.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2590,11 +2590,20 @@ repositories:
       version: foxy
     status: developed
   plotjuggler_msgs:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/plotjuggler_msgs.git
+      version: ros2
     release:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler_msgs-release.git
-      version: 0.1.2-1
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/facontidavide/plotjuggler_msgs.git
+      version: ros2
+    status: developed
   plotjuggler_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler_msgs` to `0.2.0-1`:

- upstream repository: https://github.com/facontidavide/plotjuggler_msgs.git
- release repository: https://github.com/facontidavide/plotjuggler_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.2-1`
