### PR TITLE
plotjuggler_msgs: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2027,7 +2027,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler_msgs-release.git
-      version: 0.1.2-2
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/facontidavide/plotjuggler_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler_msgs` to `0.2.0-1`:

- upstream repository: https://github.com/facontidavide/plotjuggler_msgs.git
- release repository: https://github.com/facontidavide/plotjuggler_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.2-2`
