### PR TITLE
[dep] systemd

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7338,7 +7338,9 @@ systemd:
   debian: [systemd]
   fedora: [systemd]
   gentoo: [sys-apps/systemd]
-  macports: [systemd]
+  osx:
+    homebrew:
+      packages: [systemd]
   opensuse: [systemd]
   rhel: [systemd]
   ubuntu: [systemd]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7333,6 +7333,15 @@ sysstat:
   nixos: [sysstat]
   openembedded: [sysstat@openembedded-core]
   ubuntu: [sysstat]
+systemd:
+  arch: [systemd]
+  debian: [systemd]
+  fedora: [systemd]
+  gentoo: [sys-apps/systemd]
+  macports: [systemd]
+  opensuse: [systemd]
+  rhel: [systemd]
+  ubuntu: [systemd]
 tango-icon-theme:
   alpine: [tango-icon-theme]
   arch: [tango-icon-theme]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7338,10 +7338,10 @@ systemd:
   debian: [systemd]
   fedora: [systemd]
   gentoo: [sys-apps/systemd]
+  opensuse: [systemd]
   osx:
     homebrew:
       packages: [systemd]
-  opensuse: [systemd]
   rhel: [systemd]
   ubuntu: [systemd]
 tango-icon-theme:


### PR DESCRIPTION
## Package name:

`systemd`

## Purpose of using this:

- The pkg contains `systemctl`, which is operational interface for OS daemon on some Linux distros.
   - There already seems to be a rosdep key `libsystemd-dev`, which doesn't seem to include `systemctl`.
- Usecase e.g. My team is making a tool that controls daemon. This pkg doesn't seem to come with Docker image of Ubuntu so the dependency on it needs to be defined.

# Distro packaging links:

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->
- Debian: https://packages.debian.org/
  - REQUIRED
  - https://packages.debian.org/stretch/systemd
- Ubuntu: https://packages.ubuntu.com/
   - REQUIRED
   - https://packages.ubuntu.com/search?keywords=systemd
- Fedora: https://src.fedoraproject.org/browse/projects/
  - IF AVAILABLE
  - https://src.fedoraproject.org/rpms/systemd#bodhi_updates
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
  - https://archlinux.org/packages/core/x86_64/systemd/
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
  - https://packages.gentoo.org/packages/sys-apps/systemd
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
  - https://formulae.brew.sh/formula-linux/systemd
- RHEL http://mirror.centos.org/centos-8/8/BaseOS/x86_64/os/Packages/systemd-239-45.el8.i686.rpm
- OpenSuse https://software.opensuse.org/package/systemd