### PR TITLE
jackal: 0.7.7-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4854,7 +4854,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.7.6-1
+      version: 0.7.7-1
     source:
       type: git
       url: https://github.com/jackal/jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.7.7-1`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.6-1`

## jackal_control

```
* Enable roslaunch_add_file_check when CATKIN_ENABLE_TESTING=true
* Contributors: PN:Ruichao Wu2
```

## jackal_description

```
* Fix the custom_example URDF file to the LMS1xx sensors don't throw errors
* Enable roslaunch_add_file_check when CATKIN_ENABLE_TESTING=true
* Added velodyne towers and HDL-32E sensor (#88)
* Contributors: Chris I-B, Luis Camero, PN:Ruichao Wu2
```

## jackal_msgs

- No changes

## jackal_navigation

```
* Enable roslaunch_add_file_check when CATKIN_ENABLE_TESTING=true
* Contributors: PN:Ruichao Wu2
```
