### PR TITLE
cpu_temperature_diagnostics: 0.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2032,6 +2032,11 @@ repositories:
       type: git
       url: https://github.com/yotabits/cpu_temperature_diagnostics.git
       version: melodic-release
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/yotabits/cpu_temperature_diagnostics-release.git
+      version: 0.0.1-1
     source:
       type: git
       url: https://github.com/yotabits/cpu_temperature_diagnostics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpu_temperature_diagnostics` to `0.0.1-1`:

- upstream repository: https://github.com/yotabits/cpu_temperature_diagnostics.git
- release repository: https://github.com/yotabits/cpu_temperature_diagnostics-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
