### PR TITLE
rosee_msg: 1.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11158,7 +11158,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ADVRHumanoids/rosee_msg-release.git
-      version: 1.0.1-2
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ADVRHumanoids/rosee_msg.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosee_msg` to `1.0.2-1`:

- upstream repository: https://github.com/ADVRHumanoids/rosee_msg.git
- release repository: https://github.com/ADVRHumanoids/rosee_msg-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.1-2`

## rosee_msg

```
* roscpp and rospy dependencies && authors and urls in package
* Contributors: Davide Torielli
```
