### PR TITLE
plotjuggler: 3.3.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8755,7 +8755,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.3.0-1
+      version: 3.3.1-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.3.1-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.3.0-1`

## plotjuggler

```
* fix #527 <https://github.com/facontidavide/PlotJuggler/issues/527>
* avoid shared libraries in libkissFFT
* Fix #524 <https://github.com/facontidavide/PlotJuggler/issues/524> and #529 <https://github.com/facontidavide/PlotJuggler/issues/529>
* Fix bug with Outlier Removal (#532 <https://github.com/facontidavide/PlotJuggler/issues/532>)
* minor changes
* Implement Moving RMS filter #510 <https://github.com/facontidavide/PlotJuggler/issues/510>
* Fix issue #516 <https://github.com/facontidavide/PlotJuggler/issues/516>
  - Don't show more than once "Do you want to delete old data" when
  loading multiple files.
  - Correctly clean all the data, including _loaded_datafiles
* Update README.md
* Contributors: Davide Faconti
```
