### PR TITLE
plotjuggler_msgs: 0.2.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2598,7 +2598,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler_msgs-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/facontidavide/plotjuggler_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler_msgs` to `0.2.1-1`:

- upstream repository: https://github.com/facontidavide/plotjuggler_msgs.git
- release repository: https://github.com/facontidavide/plotjuggler_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.0-1`
