### PR TITLE
urdfdom_py: 0.4.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9188,7 +9188,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/urdfdom_py-release.git
-      version: 0.4.5-1
+      version: 0.4.6-1
     source:
       type: git
       url: https://github.com/ros/urdf_parser_py.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_py` to `0.4.6-1`:

- upstream repository: https://github.com/ros/urdf_parser_py.git
- release repository: https://github.com/ros-gbp/urdfdom_py-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.5-1`

## urdfdom_py

```
* Support name attribute for collisions (#67 <https://github.com/ros/urdf_parser_py/issues/67>)
* Contributors: Nick Lamprianidis
```
