### PR TITLE
ros_end_effector: 1.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2844,6 +2844,17 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/eml-release.git
       version: 1.8.15-2
+  end_effector:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ADVRHumanoids/ROSEndEffector-release.git
+      version: 1.0.3-1
+    source:
+      type: git
+      url: https://github.com/ADVRHumanoids/ROSEndEffector.git
+      version: master
+    status: maintained
   ensenso_driver:
     doc:
       type: git
@@ -10755,17 +10766,6 @@ repositories:
     source:
       type: git
       url: https://github.com/code-iai/ros_emacs_utils.git
-      version: master
-    status: maintained
-  ros_end_effector:
-    release:
-      tags:
-        release: release/melodic/{package}/{version}
-      url: https://github.com/ADVRHumanoids/ROSEndEffector-release.git
-      version: 1.0.2-1
-    source:
-      type: git
-      url: https://github.com/ADVRHumanoids/ROSEndEffector.git
       version: master
     status: maintained
   ros_environment:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10757,6 +10757,17 @@ repositories:
       url: https://github.com/code-iai/ros_emacs_utils.git
       version: master
     status: maintained
+  ros_end_effector:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ADVRHumanoids/ROSEndEffector-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/ADVRHumanoids/ROSEndEffector.git
+      version: master
+    status: maintained
   ros_environment:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_end_effector` to `1.0.2-1`:

- upstream repository: https://github.com/ADVRHumanoids/ROSEndEffector.git
- release repository: https://github.com/ADVRHumanoids/ROSEndEffector-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ros_end_effector

```
* package info url & authors
* Contributors: Davide Torielli
```
