### PR TITLE
jderobot_drones: 1.4.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3273,14 +3273,17 @@ repositories:
     release:
       packages:
       - drone_assets
+      - drone_circuit_assets
       - drone_wrapper
       - jderobot_drones
       - rqt_drone_teleop
       - rqt_ground_robot_teleop
+      - tello_driver
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/JdeRobot/drones-release.git
-      version: 1.4.0-1
+      version: 1.4.2-1
+    status: developed
   joint_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_drones` to `1.4.2-1`:

- upstream repository: https://github.com/JdeRobot/drones.git
- release repository: https://github.com/JdeRobot/drones-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.4.0-1`

## drone_assets

```
* Added gazebo_ros dependency to drone_assets
* Contributors: pariaspe
```

## drone_circuit_assets

```
* Removed drone_assets reference from drone_circuit_assets CMakeLists
* Contributors: pariaspe
```

## drone_wrapper

```
* Removed old file from drone_wrapper CMakeLists
* corrected maintainer
* Contributors: Nikhil Khedekar, pariaspe
```

## jderobot_drones

```
* Fixing Jenkins Build errors
* Contributors: pariaspe
```

## rqt_drone_teleop

```
* python-rospkg doesn't exist in noetic release, replacing with python3-rospkg
* corrected maintainer
* Contributors: Nikhil Khedekar, pariaspe
```

## rqt_ground_robot_teleop

```
* python-rospkg doesn't exist in noetic release, replacing with python3-rospkg
* corrected maintainer
* Contributors: Nikhil Khedekar, pariaspe
```

## tello_driver

```
* Tello driver is not used as python package, fixed
* Contributors: pariaspe
```
