### PR TITLE
xacro: 1.14.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9722,7 +9722,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.14.9-1
+      version: 1.14.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.14.10-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.14.9-1`

## xacro

```
* Allow property names to be evaluated from an expression
  This allows to turn macros into a function that can compute an arbitrary property:
  
      <xacro:macro name="square" params="name args">
    <!-- Perform some complex computation and set the property within the parent's scope -->
    <xacro:property name="${name}" value="${[float(x)**2 for x in args]}" scope="parent" />
  </xacro:macro>
  <xacro:square name="result" args="${python.range(5)}" />
  
* Fix error reporting for invalid symbols in NameSpaces
* Allow removal of a property definition (#288 <https://github.com/ros/xacro/issues/288>)<xacro:property name="prop" remove="true"/>
* Allow greedy property evaluation (#284 <https://github.com/ros/xacro/issues/284>)
  This can be used, to redefine a property from its previous value, e.g. for normalization:
  
      <xacro:property name="prop" value="${prop.lower()}" lazy_eval="false"/>
  
* Correctly expose XML namespaces imported via ``xacro:include`` within a macro (#287 <https://github.com/ros/xacro/issues/287>)
* Throw when attempting to declare a property starting with *double* underscore (#286 <https://github.com/ros/xacro/issues/286>)
* Improve global symbols (#283 <https://github.com/ros/xacro/issues/283>)
  
    * Expose most builtin symbols of python
    * Expose xacro functions into ``xacro`` namespace
      
        * ``xacro.print_location()`` to print the current filestack
        * ``tokenize(string, sep=',; ', skip_empty=True)`` to facilitate string tokenization
        * ``message()``, ``warning()``, ``error()``, and ``fatal()`` to output messages on ``stderr``.
          All but ``message()`` print the error location (macro call and file hierarchy) by default:
          
              ${xacro.message('message', 'text', 2, 3.14, color=32, print_location=True)}
          ${xacro.warning('warning')}
          ${xacro.error('error', print_location=False)}
          ${xacro.fatal('fatal')}
          
      
    * Rework handling of file and macro stack, such that print_location() works from anywhere
    * Unit tests: Reduce reported ``stdout``/``stderr`` output
    * Rework definition of ``global_symbols`` to expose functions into namespaces python, math, xacro
  
* Contributors: Robert Haschke
```
