### PR TITLE
end-effector: 1.0.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2844,6 +2844,19 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/eml-release.git
       version: 1.8.15-2
+  end-effector:
+    release:
+      packages:
+      - end_effector
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ADVRHumanoids/ROSEndEffector-release.git
+      version: 1.0.4-1
+    source:
+      type: git
+      url: https://github.com/ADVRHumanoids/ROSEndEffector.git
+      version: master
+    status: maintained
   ensenso_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `end-effector` to `1.0.4-1`:

- upstream repository: https://github.com/ADVRHumanoids/ROSEndEffector.git
- release repository: https://github.com/ADVRHumanoids/ROSEndEffector-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## end_effector

```
* hotfix after the change of package name
* Contributors: Davide Torielli
```
