### PR TITLE
rviz: 8.2.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4845,7 +4845,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 8.2.3-1
+      version: 8.2.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `8.2.4-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `8.2.3-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Removed traces in renderPanel (#777 <https://github.com/ros2/rviz/issues/777>) (#779 <https://github.com/ros2/rviz/issues/779>)
* Ensure rviz_common::MessageFilterDisplay processes messages in the main thread (#620 <https://github.com/ros2/rviz/issues/620>) (#765 <https://github.com/ros2/rviz/issues/765>)
* Update displays_panel.cpp (#745 <https://github.com/ros2/rviz/issues/745>) (#772 <https://github.com/ros2/rviz/issues/772>)
* Fix byte indexing for depth patch pixels (#661 <https://github.com/ros2/rviz/issues/661>) (#759 <https://github.com/ros2/rviz/issues/759>)
* Fix toolbar vanishing when pressing escape (#656 <https://github.com/ros2/rviz/issues/656>) (#758 <https://github.com/ros2/rviz/issues/758>)
* Efficiently handle 3-bytes pixel formats (#743 <https://github.com/ros2/rviz/issues/743>)
* Contributors: Alejandro Hernández Cordero, Jacob Perron, Vojtech Spurny, Michel Hidalgo, Greg Balke, Joseph Schornak, ipa-fez
```

## rviz_default_plugins

```
* Fixed crash when changing rendering parameters for pointcloud2 while 'Selectable' box is unchecked (#768 <https://github.com/ros2/rviz/issues/768>) (#770 <https://github.com/ros2/rviz/issues/770>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Reset current line width when calculating text width (#655 <https://github.com/ros2/rviz/issues/655>) (#757 <https://github.com/ros2/rviz/issues/757>)
* Contributors: Jacob Perron, ipa-fez
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
