### PR TITLE
launch_ros: 0.11.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1722,7 +1722,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.11.3-1
+      version: 0.11.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.11.4-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.11.3-1`

## launch_ros

- No changes

## launch_testing_ros

- No changes

## ros2launch

```
* Simplify logic for mode switch (#245 <https://github.com/ros2/launch_ros/issues/245>)
* Contributors: rob-clarke
```
