### PR TITLE
ros2_controllers: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2931,7 +2931,6 @@ repositories:
       - gripper_controllers
       - imu_sensor_broadcaster
       - joint_state_broadcaster
-      - joint_state_controller
       - joint_trajectory_controller
       - position_controllers
       - ros2_controllers
@@ -2939,7 +2938,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 0.5.0-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `1.0.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.5.0-1`

## diff_drive_controller

```
* Add time and period to update function (#241 <https://github.com/ros-controls/ros2_controllers/issues/241>)
* Unify style of controllers. (#236 <https://github.com/ros-controls/ros2_controllers/issues/236>)
* ros2_controllers code changes to support ros2_controls issue #489 <https://github.com/ros-controls/ros2_controllers/issues/489> (#233 <https://github.com/ros-controls/ros2_controllers/issues/233>)
* Removing Boost from controllers. (#235 <https://github.com/ros-controls/ros2_controllers/issues/235>)
* refactor get_current_state to get_state (#232 <https://github.com/ros-controls/ros2_controllers/issues/232>)
* Contributors: Bence Magyar, Denis Štogl, Márk Szitanics, bailaC
```

## effort_controllers

```
* Add time and period to update function (#241 <https://github.com/ros-controls/ros2_controllers/issues/241>)
* Unify style of controllers. (#236 <https://github.com/ros-controls/ros2_controllers/issues/236>)
* ros2_controllers code changes to support ros2_controls issue #489 <https://github.com/ros-controls/ros2_controllers/issues/489> (#233 <https://github.com/ros-controls/ros2_controllers/issues/233>)
* Removing Boost from controllers. (#235 <https://github.com/ros-controls/ros2_controllers/issues/235>)
* Contributors: Bence Magyar, Denis Štogl, bailaC
```

## force_torque_sensor_broadcaster

```
* Add time and period to update function (#241 <https://github.com/ros-controls/ros2_controllers/issues/241>)
* ros2_controllers code changes to support ros2_controls issue #489 <https://github.com/ros-controls/ros2_controllers/issues/489> (#233 <https://github.com/ros-controls/ros2_controllers/issues/233>)
* Removing Boost from controllers. (#235 <https://github.com/ros-controls/ros2_controllers/issues/235>)
* Contributors: Bence Magyar, bailaC
```

## forward_command_controller

```
* Reset and test of command buffer for forwarding controllers. (#246 <https://github.com/ros-controls/ros2_controllers/issues/246>)
* Remove compile warnings. (#245 <https://github.com/ros-controls/ros2_controllers/issues/245>)
* Add time and period to update function (#241 <https://github.com/ros-controls/ros2_controllers/issues/241>)
* ros2_controllers code changes to support ros2_controls issue #489 <https://github.com/ros-controls/ros2_controllers/issues/489> (#233 <https://github.com/ros-controls/ros2_controllers/issues/233>)
* Removing Boost from controllers. (#235 <https://github.com/ros-controls/ros2_controllers/issues/235>)
* Contributors: Bence Magyar, Denis Štogl, bailaC
```

## gripper_controllers

```
* Remove compile warnings. (#245 <https://github.com/ros-controls/ros2_controllers/issues/245>)
* Add time and period to update function (#241 <https://github.com/ros-controls/ros2_controllers/issues/241>)
* Unify style of controllers. (#236 <https://github.com/ros-controls/ros2_controllers/issues/236>)
* ros2_controllers code changes to support ros2_controls issue #489 <https://github.com/ros-controls/ros2_controllers/issues/489> (#233 <https://github.com/ros-controls/ros2_controllers/issues/233>)
* Removing Boost from controllers. (#235 <https://github.com/ros-controls/ros2_controllers/issues/235>)
* Contributors: Bence Magyar, Denis Štogl, bailaC
```

## imu_sensor_broadcaster

```
* Add time and period to update function (#241 <https://github.com/ros-controls/ros2_controllers/issues/241>)
* ros2_controllers code changes to support ros2_controls issue #489 <https://github.com/ros-controls/ros2_controllers/issues/489> (#233 <https://github.com/ros-controls/ros2_controllers/issues/233>)
* Removing Boost from controllers. (#235 <https://github.com/ros-controls/ros2_controllers/issues/235>)
* Contributors: Bence Magyar, bailaC
```

## joint_state_broadcaster

```
* Add time and period to update function (#241 <https://github.com/ros-controls/ros2_controllers/issues/241>)
* Unify style of controllers. (#236 <https://github.com/ros-controls/ros2_controllers/issues/236>)
* ros2_controllers code changes to support ros2_controls issue #489 <https://github.com/ros-controls/ros2_controllers/issues/489> (#233 <https://github.com/ros-controls/ros2_controllers/issues/233>)
* Removing Boost from controllers. (#235 <https://github.com/ros-controls/ros2_controllers/issues/235>)
* Contributors: Bence Magyar, Denis Štogl, bailaC
```

## joint_trajectory_controller

```
* Remove compile warnings. (#245 <https://github.com/ros-controls/ros2_controllers/issues/245>)
* Add time and period to update function (#241 <https://github.com/ros-controls/ros2_controllers/issues/241>)
* Quickfix 🛠: Correct confusing variable name (#240 <https://github.com/ros-controls/ros2_controllers/issues/240>)
* Unify style of controllers. (#236 <https://github.com/ros-controls/ros2_controllers/issues/236>)
* Change test to work with Foxy and posterior action API (#237 <https://github.com/ros-controls/ros2_controllers/issues/237>)
* ros2_controllers code changes to support ros2_controls issue #489 <https://github.com/ros-controls/ros2_controllers/issues/489> (#233 <https://github.com/ros-controls/ros2_controllers/issues/233>)
* Removing Boost from controllers. (#235 <https://github.com/ros-controls/ros2_controllers/issues/235>)
* refactor get_current_state to get_state (#232 <https://github.com/ros-controls/ros2_controllers/issues/232>)
* Contributors: Bence Magyar, Denis Štogl, Márk Szitanics, Tyler Weaver, bailaC
```

## position_controllers

```
* Add time and period to update function (#241 <https://github.com/ros-controls/ros2_controllers/issues/241>)
* Unify style of controllers. (#236 <https://github.com/ros-controls/ros2_controllers/issues/236>)
* ros2_controllers code changes to support ros2_controls issue #489 <https://github.com/ros-controls/ros2_controllers/issues/489> (#233 <https://github.com/ros-controls/ros2_controllers/issues/233>)
* Removing Boost from controllers. (#235 <https://github.com/ros-controls/ros2_controllers/issues/235>)
* Contributors: Bence Magyar, Denis Štogl, bailaC
```

## ros2_controllers

```
* Remove joint_state_controller, use joint_state_broadcaster instead (#230 <https://github.com/ros-controls/ros2_controllers/issues/230>)
* Contributors: Bence Magyar
```

## velocity_controllers

```
* Add time and period to update function (#241 <https://github.com/ros-controls/ros2_controllers/issues/241>)
* Unify style of controllers. (#236 <https://github.com/ros-controls/ros2_controllers/issues/236>)
* ros2_controllers code changes to support ros2_controls issue #489 <https://github.com/ros-controls/ros2_controllers/issues/489> (#233 <https://github.com/ros-controls/ros2_controllers/issues/233>)
* Removing Boost from controllers. (#235 <https://github.com/ros-controls/ros2_controllers/issues/235>)
* Contributors: Bence Magyar, Denis Štogl, bailaC
```
