### PR TITLE
sbg_driver: 3.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12434,7 +12434,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/SBG-Systems/sbg_ros_driver-release.git
-      version: 3.0.0-1
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/SBG-Systems/sbg_ros_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sbg_driver` to `3.1.0-1`:

- upstream repository: https://github.com/SBG-Systems/sbg_ros_driver.git
- release repository: https://github.com/SBG-Systems/sbg_ros_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.0.0-1`

## sbg_driver

```
* Feature #44 <https://github.com/SBG-Systems/sbg_ros_driver/issues/44> - odometry output
* fix #66 <https://github.com/SBG-Systems/sbg_ros_driver/issues/66> - status description for SbgGpsHdt msg
* fix #66 <https://github.com/SBG-Systems/sbg_ros_driver/issues/66> - missing heading and pitch accuracies in sbgGpsHdt msg
* add ellipse D default configuration
* update README
* Contributors: Michael Zemb
```
