### PR TITLE
sbg_driver: 3.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8157,6 +8157,20 @@ repositories:
       url: https://bitbucket.org/DataspeedInc/sainsmart_relay_usb.git
       version: master
     status: maintained
+  sbg_driver:
+    doc:
+      type: git
+      url: https://github.com/SBG-Systems/sbg_ros_driver.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/SBG-Systems/sbg_ros_driver-release.git
+      version: 3.1.0-1
+    source:
+      type: git
+      url: https://github.com/SBG-Systems/sbg_ros_driver.git
+      version: 3.1.0
   sbpl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sbg_driver` to `3.1.0-1`:

- upstream repository: https://github.com/SBG-Systems/sbg_ros_driver.git
- release repository: https://github.com/SBG-Systems/sbg_ros_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## sbg_driver

```
* Feature #44 <https://github.com/SBG-Systems/sbg_ros_driver/issues/44> - odometry output
* fix #66 <https://github.com/SBG-Systems/sbg_ros_driver/issues/66> - status description for SbgGpsHdt msg
* fix #66 <https://github.com/SBG-Systems/sbg_ros_driver/issues/66> - missing heading and pitch accuracies in sbgGpsHdt msg
* add ellipse D default configuration
* update README
* Contributors: Michael Zemb
```
