### PR TITLE
bota_driver: 0.6.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -488,7 +488,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.com/botasys/bota_driver-release.git
-      version: 0.6.1-1
+      version: 0.6.1-2
     source:
       type: git
       url: https://gitlab.com/botasys/bota_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bota_driver` to `0.6.1-2`:

- upstream repository: https://gitlab.com/botasys/bota_driver.git
- release repository: https://gitlab.com/botasys/bota_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.1-1`

## bota_driver

- No changes

## bota_driver_testing

```
* Remove gmock dependency
* Let pipeline fail if tests fail
* remove calibration matrix values and change sensor config files
* Feature - Add more async tests in the hardware tests step of CI
* change serial sensor name in CI
* Feature/ethercat grant
* Feature/add hardware testing
* Contributors: Martin Wermelinger, Mike Karamousadakis
```

## bota_node

- No changes

## bota_signal_handler

- No changes

## bota_worker

- No changes

## rokubimini

```
* Set imu angular rate.
* add missing files in install space
* Contributors: Martin, Mike Karam, Mike Karamousadakis
```

## rokubimini_bus_manager

- No changes

## rokubimini_description

```
* Fix/simplify collision mesh
* Contributors: Lefteris Kotsonis, Martin Wermelinger, Mike Karamousadakis
```

## rokubimini_ethercat

```
* Feature/ethercat grant
* add missing files in install space
* fix S/N wrongly displayed in ethercat
* Show serial number in boot
* Contributors: Ilias Patsiaouras, Lefteris Kotsonis, Martin, Martin Wermelinger, Mike Karamousadakis
```

## rokubimini_msgs

- No changes

## rokubimini_serial

```
* Throttle error message, set max attempts to open serial port.
* remove shutting down because of too many timeouts
* Handle time stamp as uint and not float
* add missing files in install space
* Show serial number in boot
* Contributors: Ilias Patsiaouras, Lefteris Kotsonis, Martin Wermelinger, Mike Karam, Mike Karamousadakis
```
