### PR TITLE
Add python3-funcsigs to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6454,6 +6454,11 @@ python3-flask-restplus-pip:
 python3-flask-socketio:
   debian: [python3-flask-socketio]
   ubuntu: [python3-flask-socketio]
+python3-funcsigs:
+  debian: [python3-funcsigs]
+  fedora: [python3-funcsigs]
+  ubuntu: [python3-funcsigs]
+  opensuse: [python3-funcsigs]
 python3-future:
   debian: [python3-future]
   fedora: [python3-future]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6458,7 +6458,6 @@ python3-funcsigs:
   debian: [python3-funcsigs]
   fedora: [python3-funcsigs]
   ubuntu: [python3-funcsigs]
-  opensuse: [python3-funcsigs]
 python3-future:
   debian: [python3-future]
   fedora: [python3-future]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-funcsigs

## Package Upstream Source:

https://github.com/aliles/funcsigs

## Purpose of using this:

Funcsigs is a backport of inspect.signature to python2. However, it is also useful to have in python3 if one wants to write code that works for both python2 and python3.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/python/python3-funcsigs
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/focal/python/python3-funcsigs
- Fedora: https://src.fedoraproject.org/browse/projects/
  - https://fedora.pkgs.org/33/fedora-x86_64/python3-funcsigs-1.0.2-22.fc33.noarch.rpm.html
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available


# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
