### PR TITLE
launch_ros: 0.15.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1388,7 +1388,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.14.2-1
+      version: 0.15.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.15.0-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.14.2-1`

## launch_ros

```
* Handle substitutions in RosTimer (#264 <https://github.com/ros2/launch_ros/issues/264>)
* Add SetParametersFromFile action (#260 <https://github.com/ros2/launch_ros/issues/260>)
* Properly support ros_args attribute through launch frontends (#253 <https://github.com/ros2/launch_ros/issues/253>)
* Add 'push_ros_namespace' alias to 'push-ros-namespace' (#250 <https://github.com/ros2/launch_ros/issues/250>)
* Add ros_arguments option to Node action (#249 <https://github.com/ros2/launch_ros/issues/249>)
* Refactor RosTimer to extend TimerAction (#248 <https://github.com/ros2/launch_ros/issues/248>)
* ROS Timer Action (#244 <https://github.com/ros2/launch_ros/issues/244>)
* Support container in frontend (#235 <https://github.com/ros2/launch_ros/issues/235>)
* Fix a small typo in a comment (#237 <https://github.com/ros2/launch_ros/issues/237>)
* Better document parameter handling in Node (#234 <https://github.com/ros2/launch_ros/issues/234>)
* Contributors: Aditya Pande, Chris Lalancette, Christophe Bedard, Felix Divo, Jacob Perron, Kenji Miyake, Rebecca Butler
```

## launch_testing_ros

```
* Add WaitForTopics utility for waiting on publishers (#274 <https://github.com/ros2/launch_ros/issues/274>)
* Remove unused code, Future.result() already raises (#270 <https://github.com/ros2/launch_ros/issues/270>)
* Add timeout to wait for service response in example (#271 <https://github.com/ros2/launch_ros/issues/271>)
* Add examples (#263 <https://github.com/ros2/launch_ros/issues/263>)
* Contributors: Aditya Pande, Shane Loretz
```

## ros2launch

```
* Add regex filter for selective launch-prefix application (#261 <https://github.com/ros2/launch_ros/issues/261>)
* Resolves #37 <https://github.com/ros2/launch_ros/issues/37> - Added --launch-prefix argument for 'ros2 launch' command (#254 <https://github.com/ros2/launch_ros/issues/254>)
* Use sets of file extensions provided by parser extensions (#252 <https://github.com/ros2/launch_ros/issues/252>)
* Simplify logic to fix absolute paths (#230 <https://github.com/ros2/launch_ros/issues/230>)
* Contributors: Cameron Miller, Christophe Bedard, rob-clarke
```
