### PR TITLE
nodelet_core: 1.10.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4871,7 +4871,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/nodelet_core-release.git
-      version: 1.10.1-1
+      version: 1.10.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.10.2-1`:

- upstream repository: https://github.com/ros/nodelet_core.git
- release repository: https://github.com/ros-gbp/nodelet_core-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.10.1-1`

## nodelet

```
* add version.h for nodelet (#105 <https://github.com/ros/nodelet_core/issues/105>)
* Fix missing num_threads call when NODELET_QUEUE_DEBUG (#112 <https://github.com/ros/nodelet_core/issues/112>)
* Contributors: Matthijs van der Burgh, Shingo Kitagawa
```

## nodelet_core

- No changes

## nodelet_topic_tools

- No changes
