### PR TITLE
mppic: 0.2.1-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2099,6 +2099,21 @@ repositories:
       url: https://github.com/ros-planning/moveit_resources.git
       version: ros2
     status: developed
+  mppic:
+    doc:
+      type: git
+      url: https://github.com/FastSense/mppic.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/artofnothingness/mppic-release.git
+      version: 0.2.1-2
+    source:
+      type: git
+      url: https://github.com/FastSense/mppic.git
+      version: master
+    status: developed
   mrpt2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mppic` to `0.2.1-2`:

- upstream repository: https://github.com/FastSense/mppic.git
- release repository: https://github.com/artofnothingness/mppic-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## mppic

```
* add functional tests
* dev tools upgrade
* fix control sequence propagation
```
