### PR TITLE
rviz_visual_tools: 4.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4861,7 +4861,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/PickNikRobotics/rviz_visual_tools-release.git
-      version: 4.0.1-1
+      version: 4.0.2-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/rviz_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `4.0.2-1`:

- upstream repository: https://github.com/PickNikRobotics/rviz_visual_tools.git
- release repository: https://github.com/PickNikRobotics/rviz_visual_tools-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `4.0.1-1`

## rviz_visual_tools

```
* Re-enable RemoteControl functionality (#204 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/204>)
  * use condition_variable to be more thread safe
  * Drop executor from constructor, deprecate old one
  * Fix RemoteControl usage in demo
  * Use SystemDefaultsQOS for RemoteControl subscriber
  * Add RvizVisualToolsGui dashboard to rviz config, correct view
* Rename node_executable to executable (#201 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/201>)
* Contributors: Jafar Abdi, Davide Faconti, Henning Kayser, Vatan Aksoy Tezer
```
