### PR TITLE
people: 1.4.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5398,7 +5398,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/OSUrobotics/people-release.git
-      version: 1.4.0-1
+      version: 1.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `people` to `1.4.2-1`:

- upstream repository: https://github.com/wg-perception/people.git
- release repository: https://github.com/OSUrobotics/people-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.4.0-1`
