### PR TITLE
Revert "plotjuggler_ros: 1.6.0-1 in 'foxy/distribution.yaml' [bloom] (#30918)"

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2613,7 +2613,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
-      version: 1.6.0-1
+      version: 1.5.0-1
     source:
       type: git
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git


### PR DESCRIPTION
This reverts commit adf8deb0b90f58182e05489d3833d8c76b220ea7 (#30918)

Attempt to fix a regression in Foxy.

@facontidavide FYI.