### PR TITLE
rqt_paramedit: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11790,6 +11790,14 @@ repositories:
       type: git
       url: https://github.com/dornhege/rqt_paramedit.git
       version: melodic-devel
+    release:
+      packages:
+      - qt_paramedit
+      - rqt_paramedit
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/dornhege/rqt_paramedit-release.git
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/dornhege/rqt_paramedit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_paramedit` to `1.0.1-1`:

- upstream repository: https://github.com/dornhege/rqt_paramedit.git
- release repository: https://github.com/dornhege/rqt_paramedit-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
