### PR TITLE
rviz_visual_tools: 4.1.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4009,7 +4009,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/PickNikRobotics/rviz_visual_tools-release.git
-      version: 4.1.0-1
+      version: 4.1.1-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/rviz_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `4.1.1-1`:

- upstream repository: https://github.com/PickNikRobotics/rviz_visual_tools.git
- release repository: https://github.com/PickNikRobotics/rviz_visual_tools-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `4.1.0-1`

## rviz_visual_tools

```
* Re-enable RemoteControl functionality (#205 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/205>)
  * use condition_variable to be more thread safe
  * Drop executor from constructor, deprecate old one
  * Fix RemoteControl usage in demo
  * Use SystemDefaultsQOS for RemoteControl subscriber
  * Add RvizVisualToolsGui dashboard to rviz config, correct view
* Add pluginlib dependency. (#203 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/203>)
* Fix package dependencies and cmake export (#202 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/202>)
* Rename node_executable to executable (#200 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/200>)
* Contributors: Davide Faconti, Henning Kayser, Jafar Abdi, Steven! Ragnarök, Vatan Aksoy Tezer
```
