### PR TITLE
lvr2: 20.11.3-4 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3908,7 +3908,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/uos-gbp/lvr2-release.git
-      version: 20.11.2-1
+      version: 20.11.3-4
     source:
       type: git
       url: https://github.com/uos/lvr2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lvr2` to `20.11.3-4`:

- upstream repository: https://github.com/uos/lvr2.git
- release repository: https://github.com/uos-gbp/lvr2-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `20.11.2-1`

## lvr2

```
* add libgdal-dev to package.xml, resolves #10 <https://github.com/uos/lvr2/issues/10>
```
