### PR TITLE
rosidl_python: 0.11.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3498,7 +3498,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.11.0-2
+      version: 0.11.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_python` to `0.11.1-1`:

- upstream repository: https://github.com/ros2/rosidl_python.git
- release repository: https://github.com/ros2-gbp/rosidl_python-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.11.0-2`

## rosidl_generator_py

```
* Added optimization for copying arrays of simple types from python to C using buffer protocol (#129 <https://github.com/ros2/rosidl_python/issues/129>) (#145 <https://github.com/ros2/rosidl_python/issues/145>)
* Contributors: ksuszka
```
