### PR TITLE
mavlink: 2021.10.10-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1518,7 +1518,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/mavlink/mavlink-gbp-release.git
-      version: 2021.9.9-1
+      version: 2021.10.10-1
     source:
       type: git
       url: https://github.com/mavlink/mavlink-gbp-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavlink` to `2021.10.10-1`:

- upstream repository: https://github.com/mavlink/mavlink.git
- release repository: https://github.com/mavlink/mavlink-gbp-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2021.9.9-1`
