### PR TITLE
dolly: 0.4.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -673,6 +673,27 @@ repositories:
       url: https://github.com/ros/diagnostics.git
       version: ros2-devel
     status: maintained
+  dolly:
+    doc:
+      type: git
+      url: https://github.com/chapulina/dolly.git
+      version: galactic
+    release:
+      packages:
+      - dolly
+      - dolly_follow
+      - dolly_gazebo
+      - dolly_ignition
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/chapulina/dolly-release.git
+      version: 0.4.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/chapulina/dolly.git
+      version: galactic
+    status: developed
   domain_bridge:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dolly` to `0.4.0-1`:

- upstream repository: https://github.com/chapulina/dolly.git
- release repository: https://github.com/chapulina/dolly-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## dolly

- No changes

## dolly_follow

```
* Galactic + Edifice support
* Contributors: Louise Poubel
```

## dolly_gazebo

```
* Galactic + Edifice support
* Contributors: Louise Poubel
```

## dolly_ignition

```
* Galactic + Edifice support
* Make ros_ign_gazebo more than exec_depend (#26 <https://github.com/chapulina/dolly/issues/26>)
* Contributors: Louise Poubel
```
