### PR TITLE
add pylibdmtx

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2493,6 +2493,20 @@ python-levenshtein:
   fedora: [python-Levenshtein]
   gentoo: [dev-python/python-levenshtein]
   ubuntu: [python-levenshtein]
+python-pylibdmtx-pip: &migrate_eol_2025_04_30_python3_pylibdmtx_pip
+  debian:
+    pip:
+      packages: [pylibdmtx]
+  fedora:
+    pip:
+      packages: [pylibdmtx]
+  osx:
+    pip:
+      packages: [pylibdmtx]
+  ubuntu:
+    pip:
+      packages: [pylibdmtx]
+python3-pylibdmtx-pip: *migrate_eol_2025_04_30_python3_pylibdmtx_pip
 python-libpcap:
   debian: [python-libpcap]
   fedora: [pylibpcap]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2502,7 +2502,7 @@ python3-pylibdmtx:
     pip:
       packages: [pylibdmtx]
   ubuntu:
-    "*":
+    '*':
       packages: [python3-pylibdmtx]
     focal:
       pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2494,7 +2494,18 @@ python-levenshtein:
   gentoo: [dev-python/python-levenshtein]
   ubuntu: [python-levenshtein]
 python3-pylibdmtx:
-  debian: [python3-pylibdmtx]
+  debian:
+    '*':
+      packages: [python3-pylibdmtx]
+    buster:
+      pip:
+        packages: [pylibdmtx]
+    jessie:
+      pip:
+        packages: [pylibdmtx]
+    stretch:
+      pip:
+        packages: [pylibdmtx]
   fedora:
     pip:
       packages: [pylibdmtx]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2500,12 +2500,6 @@ python3-pylibdmtx:
     buster:
       pip:
         packages: [pylibdmtx]
-    jessie:
-      pip:
-        packages: [pylibdmtx]
-    stretch:
-      pip:
-        packages: [pylibdmtx]
   fedora:
     pip:
       packages: [pylibdmtx]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2493,29 +2493,6 @@ python-levenshtein:
   fedora: [python-Levenshtein]
   gentoo: [dev-python/python-levenshtein]
   ubuntu: [python-levenshtein]
-python3-pylibdmtx:
-  debian:
-    '*':
-      packages: [python3-pylibdmtx]
-    buster:
-      pip:
-        packages: [pylibdmtx]
-  fedora:
-    pip:
-      packages: [pylibdmtx]
-  osx:
-    pip:
-      packages: [pylibdmtx]
-  ubuntu:
-    '*':
-      packages: [python3-pylibdmtx]
-    bionic:
-      pip:
-        packages: [pylibdmtx]
-    focal:
-      pip:
-        packages: [pylibdmtx]
-
 python-libpcap:
   debian: [python-libpcap]
   fedora: [pylibpcap]
@@ -7405,6 +7382,28 @@ python3-pykdl:
     '*': [python3-pykdl]
     bionic: null
     xenial: null
+python3-pylibdmtx:
+  debian:
+    '*':
+      packages: [python3-pylibdmtx]
+    buster:
+      pip:
+        packages: [pylibdmtx]
+  fedora:
+    pip:
+      packages: [pylibdmtx]
+  osx:
+    pip:
+      packages: [pylibdmtx]
+  ubuntu:
+    '*':
+      packages: [python3-pylibdmtx]
+    bionic:
+      pip:
+        packages: [pylibdmtx]
+    focal:
+      pip:
+        packages: [pylibdmtx]
 python3-pymesh2-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2493,6 +2493,12 @@ python-levenshtein:
   fedora: [python-Levenshtein]
   gentoo: [dev-python/python-levenshtein]
   ubuntu: [python-levenshtein]
+python3-pylibdmtx:
+  debian: [python3-pylibdmtx]
+  ubuntu:
+    "*": [python3-pylibdmtx]
+    focal: null
+    bionic: null
 python-pylibdmtx-pip: &migrate_eol_2025_04_30_python3_pylibdmtx_pip
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2509,12 +2509,13 @@ python3-pylibdmtx:
   ubuntu:
     '*':
       packages: [python3-pylibdmtx]
-    focal:
-      pip:
-        packages: [pylibdmtx]
     bionic:
       pip:
         packages: [pylibdmtx]
+    focal:
+      pip:
+        packages: [pylibdmtx]
+
 python-libpcap:
   debian: [python-libpcap]
   fedora: [pylibpcap]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7417,8 +7417,7 @@ python3-pykdl:
     xenial: null
 python3-pylibdmtx:
   debian:
-    '*':
-      packages: [python3-pylibdmtx]
+    '*': [python3-pylibdmtx]
     buster:
       pip:
         packages: [pylibdmtx]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2495,14 +2495,6 @@ python-levenshtein:
   ubuntu: [python-levenshtein]
 python3-pylibdmtx:
   debian: [python3-pylibdmtx]
-  ubuntu:
-    "*": [python3-pylibdmtx]
-    focal: null
-    bionic: null
-python-pylibdmtx-pip: &migrate_eol_2025_04_30_python3_pylibdmtx_pip
-  debian:
-    pip:
-      packages: [pylibdmtx]
   fedora:
     pip:
       packages: [pylibdmtx]
@@ -2510,9 +2502,14 @@ python-pylibdmtx-pip: &migrate_eol_2025_04_30_python3_pylibdmtx_pip
     pip:
       packages: [pylibdmtx]
   ubuntu:
-    pip:
-      packages: [pylibdmtx]
-python3-pylibdmtx-pip: *migrate_eol_2025_04_30_python3_pylibdmtx_pip
+    "*":
+      packages: [python3-pylibdmtx]
+    focal:
+      pip:
+        packages: [pylibdmtx]
+    bionic:
+      pip:
+        packages: [pylibdmtx]
 python-libpcap:
   debian: [python-libpcap]
   fedora: [pylibpcap]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7428,8 +7428,7 @@ python3-pylibdmtx:
     pip:
       packages: [pylibdmtx]
   ubuntu:
-    '*':
-      packages: [python3-pylibdmtx]
+    '*': [python3-pylibdmtx]
     bionic:
       pip:
         packages: [pylibdmtx]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

pylibdmtx

## Package Upstream Source:

https://pypi.org/project/pylibdmtx/

## Purpose of using this:

Datamatrix generation/reading for python scripts, pylibdmtx is a python wrapper for libdmtx.
Useful for any time you wish to work with datamatrix tags and you do not need the more performant aspects of c++ code.
I am currently using this to update textures in gazebo models to allow easy testing of different tag sizes and to generate labelled printable versions all datamatrix tags. I could do this task in c++ as libdmtx already exists in this repository, but a task like this lends itself better to python in my eyes.

## Links to Distribution Packages:

* Debian, Fedora, OSX, Ubuntu:
  * https://pypi.org/project/pylibdmtx/
