### PR TITLE
warehouse_ros_sqlite: 1.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4517,6 +4517,21 @@ repositories:
       url: https://github.com/ros-planning/warehouse_ros_mongo.git
       version: ros2
     status: maintained
+  warehouse_ros_sqlite:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros_sqlite.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/moveit/warehouse_ros_sqlite-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros_sqlite.git
+      version: ros2
+    status: maintained
   webots_ros2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros_sqlite` to `1.0.2-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros_sqlite.git
- release repository: https://github.com/moveit/warehouse_ros_sqlite-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## warehouse_ros_sqlite

```
* Update CMakeLists.txt
* Adapt github URLs in README
* Fix whitespaces in codecov script
* Enable pre-commit in CI
* Enable prerelease tests
* Add pre-commit config
* Switch to upstream warehouse_ros
* Contributors: Bjar Ne, Nisala Kalupahana
```
