### PR TITLE
warehouse_ros_sqlite: 1.0.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4787,6 +4787,21 @@ repositories:
       url: https://github.com/ros-planning/warehouse_ros_mongo.git
       version: ros2
     status: maintained
+  warehouse_ros_sqlite:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros_sqlite.git
+      version: ros2
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/moveit/warehouse_ros_sqlite-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros_sqlite.git
+      version: ros2
+    status: maintained
   webots_ros2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros_sqlite` to `1.0.2-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros_sqlite.git
- release repository: https://github.com/moveit/warehouse_ros_sqlite-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## warehouse_ros_sqlite

```
* Update CMakeLists.txt
* Adapt github URLs in README
* Fix whitespaces in codecov script
* Enable pre-commit in CI
* Enable prerelease tests
* Add pre-commit config
* Switch to upstream warehouse_ros
* Contributors: Bjar Ne, Nisala Kalupahana
```
