### PR TITLE
rviz: 8.2.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4860,7 +4860,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 8.2.4-1
+      version: 8.2.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `8.2.5-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `8.2.4-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Revert "Ensure rviz_common::MessageFilterDisplay processes messages in the main thread (#620 <https://github.com/ros2/rviz/issues/620>) (#765 <https://github.com/ros2/rviz/issues/765>)" (#783 <https://github.com/ros2/rviz/issues/783>)
* Contributors: Greg Balke
```

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
