### PR TITLE
Fix some macOS dependencies

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1441,6 +1441,9 @@ google-mock:
   nixos: [gtest]
   openembedded: [gtest@meta-oe]
   opensuse: [gmock]
+  osx:
+    homebrew:
+      packages: [googletest]
   rhel: [gmock-devel]
   ubuntu: [google-mock]
 gpac:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -546,9 +546,6 @@ clang-tidy:
   fedora: [clang-tools-extra]
   gentoo: [sys-devel/clang]
   nixos: [clang]
-  osx:
-    homebrew:
-      packages: [llvm]
   rhel:
     '*': [clang-tools-extra]
     '7': null

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7701,6 +7701,9 @@ wget:
   nixos: [wget]
   openembedded: [wget@openembedded-core]
   opensuse: [wget]
+  osx:
+    homebrew:
+      packages: [wget]
   ubuntu: [wget]
 wireless-tools:
   debian: [wireless-tools]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7617,7 +7617,7 @@ usbutils:
   openembedded: [usbutils@openembedded-core]
   osx:
     homebrew:
-      packages: [mikhailai/misc/usbutils]
+      packages: [lsusb]
   ubuntu: [usbutils]
 util-linux:
   arch: [util-linux]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5611,9 +5611,6 @@ libxml2-utils:
   gentoo: [dev-libs/libxml2]
   nixos: [libxml2]
   openembedded: [libxml2@openembedded-core]
-  osx:
-    homebrew:
-      packages: [libxml2]
   rhel: [libxml2]
   ubuntu: [libxml2-utils]
 libxmlrpc-c++:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -154,7 +154,7 @@ graphviz:
 gtest:
   osx:
     homebrew:
-      packages: [gtest]
+      packages: [googletest]
 gtk2:
   osx:
     homebrew:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -207,6 +207,10 @@ libfcl-dev:
   osx:
     homebrew:
       packages: [dartsim/dart/fcl]
+libffi-dev:
+  osx:
+    homebrew:
+      packages: []
 libflann:
   osx:
     homebrew:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -447,6 +447,10 @@ libxml2:
   osx:
     homebrew:
       packages: []
+libxml2-utils:
+  osx:
+    homebrew:
+      packages: []
 libxrandr:
   osx:
     homebrew:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -50,6 +50,10 @@ checkinstall:
   osx:
     homebrew:
       packages: []
+clang-tidy:
+  osx:
+    homebrew:
+      packages: []
 cmake:
   osx:
     homebrew:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7260,6 +7260,9 @@ python3-pycodestyle:
   nixos: [python3Packages.pycodestyle]
   openembedded: [python3-pycodestyle@meta-python]
   opensuse: [python3-pycodestyle]
+  osx:
+    pip:
+      packages: [pycodestyle]
   rhel: ['python%{python3_pkgversion}-pycodestyle']
   ubuntu: [python3-pycodestyle]
 python3-pycryptodome:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6662,6 +6662,9 @@ python3-importlib-resources:
   gentoo: [dev-python/importlib_resources]
   nixos: [python3Packages.importlib-resources]
   openembedded: [python3@openembedded-core]
+  osx:
+    pip:
+      packages: [importlib-resources]
   rhel:
     '*': ['python%{python3_pkgversion}-importlib-resources']
     '7': null

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6638,6 +6638,9 @@ python3-importlib-metadata:
   gentoo: [dev-python/importlib_metadata]
   nixos: [python3Packages.importlib-metadata]
   openembedded: [python3-importlib-metadata@openembedded-core]
+  osx:
+    pip:
+      packages: [importlib_metadata]
   rhel:
     '*': ['python%{python3_pkgversion}-importlib-metadata']
     '7': null

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6955,6 +6955,9 @@ python3-nose:
   nixos: [python3Packages.nose]
   openembedded: [python3-nose@openembedded-core]
   opensuse: [python3-nose]
+  osx:
+    pip:
+      packages: [nose]
   rhel: ['python%{python3_pkgversion}-nose']
   ubuntu: [python3-nose]
 python3-nose-parameterized:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8254,6 +8254,9 @@ python3-vcstool:
   macports:
     pip:
       packages: [vcstool]
+  osx:
+    pip:
+      packages: [vcstool]
   ubuntu: [python3-vcstool]
 python3-vedo-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7583,6 +7583,9 @@ python3-pytest-mock:
   nixos: [python3Packages.pytest-mock]
   openembedded: [python3-pytest-mock@meta-ros-common]
   opensuse: [python3-pytest-mock]
+  osx:
+    pip:
+      packages: [pytest-mock]
   rhel: ['python%{python3_pkgversion}-pytest-mock']
   ubuntu: [python3-pytest-mock]
 python3-pytest-timeout:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8291,6 +8291,9 @@ python3-venv:
   fedora: [python3-libs]
   nixos: [python3]
   opensuse: [python3-virtualenv]
+  osx:
+    pip:
+      packages: []
   ubuntu: [python3-venv]
 python3-virtualserialports-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6907,6 +6907,9 @@ python3-mypy:
   nixos: [python3Packages.mypy]
   openembedded: [python3-mypy@meta-ros-common]
   opensuse: [mypy]
+  osx:
+    pip:
+      packages: [mypy]
   ubuntu: [python3-mypy]
 python3-nclib-pip:
   arch:


### PR DESCRIPTION
Hi all. It seems building on and for macOS is not officially supported in the latest release. Some packages are missing for ```osx```, while a few others are special because they are already shipped with macOS or Xcode. At least these changes need to be made to make ```rosdep``` happy. 