### PR TITLE
sbg_driver: 3.1.1-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8173,6 +8173,21 @@ repositories:
       url: https://bitbucket.org/DataspeedInc/sainsmart_relay_usb.git
       version: master
     status: maintained
+  sbg_driver:
+    doc:
+      type: git
+      url: https://github.com/SBG-Systems/sbg_ros_driver.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/SBG-Systems/sbg_ros_driver-release.git
+      version: 3.1.1-3
+    source:
+      type: git
+      url: https://github.com/SBG-Systems/sbg_ros_driver.git
+      version: master
+    status: maintained
   sbpl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sbg_driver` to `3.1.1-3`:

- upstream repository: https://github.com/SBG-Systems/sbg_ros_driver.git
- release repository: https://github.com/SBG-Systems/sbg_ros_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## sbg_driver

```
* update build status icon
* fix missing dependencies
* update doc with odometry message
* Contributors: Michael Zemb
```
