### PR TITLE
Revert "toposens: 2.3.0-1 in 'melodic/distribution.yaml' [bloom] (#30…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13394,7 +13394,6 @@ repositories:
       - toposens_bringup
       - toposens_description
       - toposens_driver
-      - toposens_echo_driver
       - toposens_markers
       - toposens_msgs
       - toposens_pointcloud
@@ -13402,7 +13401,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 2.3.0-1
+      version: 2.2.1-1
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git


### PR DESCRIPTION
…854)"

This reverts commit 4070e9e5520aecbf0fd0eff3070957fe3ec29187.

Toposens hasn't built on Melodic since this was merged: https://build.ros.org/job/Mbin_uB64__toposens_echo_driver__ubuntu_bionic_amd64__binary/

@maiertopo FYI
