### PR TITLE
filters: 1.8.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3278,7 +3278,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/filters-release.git
-      version: 1.8.1-0
+      version: 1.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `filters` to `1.8.2-1`:

- upstream repository: https://github.com/ros/filters.git
- release repository: https://github.com/ros-gbp/filters-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.8.1-0`

## filters

```
* Make FilterBase::getName() const.
* Make getParam() functions of FilterBase const
* [Windows][lunar] Fix run_tests build breaks on WindowsMSVC (#26 <https://github.com/ros/filters/issues/26>)
  * fix test build break. (#2 <https://github.com/ros/filters/issues/2>)
  * use c standard lib.
* Merge pull request #29 <https://github.com/ros/filters/issues/29> from mvieth/lunar-devel
  Fix problem with illegal xml characters
* Fix problem with illegal xml characters
* Contributors: Jonathan Binney, Markus Vieth, Martin Pecka, Sean Yen, Tully Foote
```
