### PR TITLE
laser_filters: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1343,6 +1343,17 @@ repositories:
       url: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git
       version: master
     status: maintained
+  laser_filters:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/laser_filters-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/laser_filters
+      version: ros2
+    status: maintained
   laser_geometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters` to `2.0.0-1`:

- upstream repository: https://github.com/ros-perception/laser_filters
- release repository: https://github.com/ros2-gbp/laser_filters-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## laser_filters

```
* Enable CI for foxy, galactic and rolling distros
* Remove unneeded find_package of pcl_conversions
* Port speckle filter to ros2
* Remove pointcloud footprint filter
  It has been deprecated for years, and is the only filter that depends on
  pcl_ros. Removing it means we don't have to install the 500MB of
  dependencies that pcl brings in on CI.
* ROS2 migration (foxy)
* Make laser_filters build for ros2 (on windows 10)
* Updated deprecated pluginlib macros to avoid warning messages
* Contributors: Brian Fjeldstad, Jon Binney, Jonathan Binney, Nick Lamprianidis, Nicolas Limpert, Patrick Lascombe, Rein Appeldoorn, hang
```
