### PR TITLE
rmw_gurumdds: 3.0.8-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2852,7 +2852,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
-      version: 3.0.7-1
+      version: 3.0.8-1
     source:
       type: git
       url: https://github.com/ros2/rmw_gurumdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_gurumdds` to `3.0.8-1`:

- upstream repository: https://github.com/ros2/rmw_gurumdds.git
- release repository: https://github.com/ros2-gbp/rmw_gurumdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.0.7-1`

## rmw_gurumdds_cpp

- No changes

## rmw_gurumdds_shared_cpp

```
* Fix bug: condition of dw/dr seq delete
* Support static discovery
* Contributors: Youngjin Yun
```
