### PR TITLE
Add rosdep rules for python3-fiona

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6382,6 +6382,15 @@ python3-filterpy-pip:
   ubuntu:
     pip:
       packages: [filterpy]
+python3-fiona:
+  arch: [python-fiona]
+  debian: [python3-fiona]
+  fedora: [python3-fiona]
+  nixos: [python3Packages.fiona]
+  rhel:
+    '*': [python3-fiona]
+    '7': null
+  ubuntu: [python3-fiona]
 python3-flake8:
   alpine: [py3-flake8]
   debian:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-fiona

## Package Upstream Source:

https://github.com/Toblerity/Fiona

## Purpose of using this:

Fiona reads and writes geographic data files and thereby helps Python programmers integrate geographic information systems with other computer systems. Fiona contains extension modules that link the Geospatial Data Abstraction Library (GDAL).

## Links to Distribution Packages

- Debian: https://packages.debian.org/search?keywords=python3-fiona&searchon=names&exact=1&suite=all&section=all
- Ubuntu: https://packages.ubuntu.com/search?keywords=python3-fiona&searchon=names&exact=1&suite=all&section=all
- Fedora: https://src.fedoraproject.org/rpms/python-fiona#bodhi_updates
- RHEL: https://src.fedoraproject.org/rpms/python-fiona#bodhi_updates (via EPEL, not available for 7)
- Arch: https://archlinux.org/packages/community/x86_64/python-fiona/
- Gentoo: NOT AVAILABLE
- macOS: NOT AVAILABLE
- Alpine: NOT AVAILABLE
- openSUSE: NOT AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=21.05&from=0&size=50&sort=relevance&type=packages&query=fiona

FYI @marcoag