### PR TITLE
ublox: 1.5.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13825,7 +13825,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/KumarRobotics/ublox-release.git
-      version: 1.4.1-1
+      version: 1.5.0-1
     source:
       type: git
       url: https://github.com/KumarRobotics/ublox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ublox` to `1.5.0-1`:

- upstream repository: https://github.com/KumarRobotics/ublox.git
- release repository: https://github.com/KumarRobotics/ublox-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.4.1-1`

## ublox

- No changes

## ublox_gps

```
* Add rtcm_msgs dependency
* Add RTK support via rtcm
* GPS coordinate precision corrected for high accuracy.
* Diagonstics for Differential GNSS updated.
* Add a new parameter to set the search path for the param_file_name. Add a default to the node_name parameter.
* Add zed-f9p configuration
* Contributors: Balamurugan Kandan, Chris Iverach-Brereton, Igor
```

## ublox_msgs

```
* Fixed reconfig value in UBX_CFG_ANT.
* Contributors: ito-san
```

## ublox_serialization

- No changes
