### PR TITLE
pal_statistics: 2.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2508,6 +2508,24 @@ repositories:
       url: https://github.com/pal-robotics/pal_gazebo_worlds.git
       version: foxy-devel
     status: developed
+  pal_statistics:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pal_statistics.git
+      version: foxy-devel
+    release:
+      packages:
+      - pal_statistics
+      - pal_statistics_msgs
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/pal-gbp/pal_statistics-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pal_statistics.git
+      version: foxy-devel
+    status: maintained
   pcl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_statistics` to `2.0.0-1`:

- upstream repository: https://github.com/pal-robotics/pal_statistics.git
- release repository: https://github.com/pal-gbp/pal_statistics-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## pal_statistics

```
* Comment out tests that require galactic rclpcpp API
* Use ament_cmake_auto
* Update package.xml
* Add comment about ament_cmake_pal
* Change license to BSD-3 Clause
* Flake8 and pep257 compliance
* Add ament dependencies
* More formatting and header ordering
* Apply ament_link_cmake
* Cpplint compliance
* Rename headers to .h and uncrustify them
* Fix double comparisons in test
* Reorganize code to remove boost from include files
* Tests passing in ROS2
* Update license on headers
  refs #5 <https://github.com/pal-robotics/pal_statistics/issues/5>
* Change License to MIT
  fixes #5 <https://github.com/pal-robotics/pal_statistics/issues/5>
* Contributors: Victor Lopez
```

## pal_statistics_msgs

```
* Remove ROS1 dependency
* Migrate pal_statistics_msgs to ROS2
* Change License to MIT
  fixes #5 <https://github.com/pal-robotics/pal_statistics/issues/5>
* Contributors: Victor Lopez
```
