### PR TITLE
pal_statistics: 2.1.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2072,6 +2072,24 @@ repositories:
       url: https://github.com/eclipse/paho.mqtt.c.git
       version: master
     status: maintained
+  pal_statistics:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pal_statistics.git
+      version: galactic-devel
+    release:
+      packages:
+      - pal_statistics
+      - pal_statistics_msgs
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/pal-gbp/pal_statistics-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pal_statistics.git
+      version: galactic-devel
+    status: maintained
   pcl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_statistics` to `2.1.0-1`:

- upstream repository: https://github.com/pal-robotics/pal_statistics.git
- release repository: https://github.com/pal-gbp/pal_statistics-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## pal_statistics

```
* Revert "Comment out tests that require galactic rclpcpp API"
  This reverts commit 6642f6a743e5d5be210f7e59191153746b296866.
* Fix cmake lint
* Contributors: Victor Lopez
```

## pal_statistics_msgs

- No changes
