### PR TITLE
jderobot_drones: 1.3.9-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4988,10 +4988,11 @@ repositories:
       - jderobot_drones
       - rqt_drone_teleop
       - rqt_ground_robot_teleop
+      - tello_driver
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/JdeRobot/drones-release.git
-      version: 1.3.8-1
+      version: 1.3.9-1
     source:
       type: git
       url: https://github.com/JdeRobot/drones.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_drones` to `1.3.9-1`:

- upstream repository: https://github.com/JdeRobot/drones.git
- release repository: https://github.com/JdeRobot/drones-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.3.8-1`

## drone_assets

```
* Fix path of custom_box_target
* Added new ocean model
* Added a new model slab
* Added new simple_labyrinth_green
* Added plugins
* Added gas_station model
* Contributors: Arka, RUFFY-369, iamarkaj, pariaspe
```

## drone_wrapper

```
* Removed old reference to non-existing file
* Drone wrapper takeoff adjusted. Added precision error to decided when takeoff is over.
* Added get_battery to drone_warpper api
* Added drone_model rosparam to drone_wrapper cam topics
* Removed unused dependency
* Added battery state
* Reduced to minimum drone model dependencies
* Drone wrapper can be also invoke now as node
* Added Tello compatibility basics
* Contributors: Diego Martín, Nikhil Khedekar, pariaspe
```

## jderobot_drones

```
* Added tello driver
* Drone wrapper is now compatible with tello driver
* New models in drone_assets
* Corrected maintainer for drone packages
* Contributors: pariaspe
```

## rqt_drone_teleop

```
* Added default values to ensure retro-compatibility
* Added takeoff config to rqt_pos_teleop
* Customizable takeoff height and precision from launch and during running
* RQT widgets are model dependant free.
* Added Tello compatibility basics
* Contributors: Diego Martín, Nikhil Khedekar, pariaspe
```

## rqt_ground_robot_teleop

```
* Corrected maintainer
* Contributors: Nikhil Khedekar, pariaspe
```

## tello_driver

```
* Tello driver is not used anymore as python package
* Added tello_driver
* Contributors: pariaspe
```
