### PR TITLE
sbg_driver: 3.1.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4037,6 +4037,21 @@ repositories:
       url: https://github.com/PickNikRobotics/rviz_visual_tools.git
       version: ros2
     status: maintained
+  sbg_driver:
+    doc:
+      type: git
+      url: https://github.com/SBG-Systems/sbg_ros2.git
+      version: master
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/SBG-Systems/sbg_ros2-release.git
+      version: 3.1.0-1
+    source:
+      type: git
+      url: https://github.com/SBG-Systems/sbg_ros2.git
+      version: master
+    status: developed
   sdformat_urdf:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sbg_driver` to `3.1.0-1`:

- upstream repository: https://github.com/SBG-Systems/sbg_ros2.git
- release repository: https://github.com/SBG-Systems/sbg_ros2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## sbg_driver

```
* Add imu/odometry publisher
  * Fix dependencies
  * Fix wrong SbgGpsHdt description
  * Update doc
  * Add missing MIT licences
  * Based on release 3.1 of ros1 driver
* Add ENU/NED option, rework frame IDs, time stamps and driver frequency.
  * Add parameters to set frame ID and ENU convention
  * Add a parameter to select header stamp source and read ROS time when publishing the message
  * Remove node ros::Rate period auto computation and only read it from a node parameter
  * Update documentation and messages definitions
  * Fix timeStamp value initializing in SbgEkfNavMessage
  * Based on release 3.0.0 of ros1 driver
* update maintainer
* print interface details at startup
* fix configuration files
* Contributors: Michael Zemb, Raphael Siryani
```
