### PR TITLE
sbg_driver: 3.1.1-7 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8182,7 +8182,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/SBG-Systems/sbg_ros_driver-release.git
-      version: 3.1.0-2
+      version: 3.1.1-7
     source:
       type: git
       url: https://github.com/SBG-Systems/sbg_ros_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sbg_driver` to `3.1.1-7`:

- upstream repository: https://github.com/SBG-Systems/sbg_ros_driver.git
- release repository: https://github.com/SBG-Systems/sbg_ros_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.1.0-2`

## sbg_driver

```
* fix missing dependencies and build status link
  - missing dep on nav_msgs, tf2_geometry_msgs, tf2_ros and tf2_msgs
  - fix build status link in readme
* update doc with odometry message
* Contributors: Michael Zemb
```
