### PR TITLE
pmb2_simulation: 3.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2720,7 +2720,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_simulation-gbp.git
-      version: 3.0.1-1
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_simulation` to `3.0.2-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_simulation.git
- release repository: https://github.com/pal-gbp/pmb2_simulation-gbp.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.0.1-1`

## pmb2_2dnav_gazebo

- No changes

## pmb2_gazebo

```
* Add gazebo_ros2_control dependency
* Contributors: Victor Lopez
```

## pmb2_simulation

- No changes
