### PR TITLE
pmb2_robot: 4.0.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2701,7 +2701,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_robot-gbp.git
-      version: 4.0.2-1
+      version: 4.0.4-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_robot` to `4.0.4-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_robot.git
- release repository: https://github.com/pal-gbp/pmb2_robot-gbp.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `4.0.2-1`

## pmb2_bringup

- No changes

## pmb2_controller_configuration

- No changes

## pmb2_description

```
* Add missing exec dependency
* Contributors: Victor Lopez
```

## pmb2_robot

- No changes
