### PR TITLE
pointcloud_to_laserscan: 2.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2128,6 +2128,21 @@ repositories:
       url: https://gitlab.com/ApexAI/point_cloud_msg_wrapper
       version: rolling
     status: developed
+  pointcloud_to_laserscan:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/pointcloud_to_laserscan.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/pointcloud_to_laserscan-release.git
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/pointcloud_to_laserscan.git
+      version: rolling
+    status: maintained
   pybind11_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pointcloud_to_laserscan` to `2.0.1-1`:

- upstream repository: https://github.com/ros-perception/pointcloud_to_laserscan.git
- release repository: https://github.com/ros2-gbp/pointcloud_to_laserscan-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## pointcloud_to_laserscan

```
* Replace deprecated launch api (#56 <https://github.com/ros-perception/pointcloud_to_laserscan/issues/56>)
* Fix linting errors in the code (#52 <https://github.com/ros-perception/pointcloud_to_laserscan/issues/52>)
* Update README.md
* Contributors: Chris Lalancette, Daisuke Nishimatsu, Paul Bovbel
```
