### PR TITLE
laser_filters: 2.0.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1342,6 +1342,21 @@ repositories:
       url: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git
       version: master
     status: maintained
+  laser_filters:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/laser_filters.git
+      version: ros2
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/laser_filters-release.git
+      version: 2.0.2-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/laser_filters.git
+      version: ros2
+    status: maintained
   laser_geometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters` to `2.0.2-1`:

- upstream repository: https://github.com/ros-perception/laser_filters.git
- release repository: https://github.com/ros2-gbp/laser_filters-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## laser_filters

```
* Add top level license file
  The license is the same as it always has been; this commmit just copies
  the license text from the source files into a top level LICENSE file to
  make it clear.
* Contributors: Jon Binney
```
