### PR TITLE
rc_genicam_driver: 0.6.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6365,7 +6365,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_genicam_driver_ros-release.git
-      version: 0.6.1-1
+      version: 0.6.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_driver` to `0.6.2-1`:

- upstream repository: https://github.com/roboception/rc_genicam_driver_ros.git
- release repository: https://github.com/roboception-gbp/rc_genicam_driver_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.1-1`

## rc_genicam_driver

```
* Controlling PtpEnable as optional so that this driver also works for rc_cube
```
