### PR TITLE
uos_tools: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13957,7 +13957,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uos-gbp/uos-tools.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/uos/uos_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `uos_tools` to `1.0.1-1`:

- upstream repository: https://github.com/uos/uos_tools.git
- release repository: https://github.com/uos-gbp/uos-tools.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.0-1`

## uos_common_urdf

```
* Add missing xacro tag to property
  find . -iname "*.xacro" | xargs sed -i 's#<([/]?)(if|unless|include|arg|property|macro|insert_block)#<1xacro:2#g'
* Add missing xacro tags for inertials with origin (#25 <https://github.com/uos/uos_tools/issues/25>)
```

## uos_diffdrive_teleop

- No changes

## uos_freespace

- No changes

## uos_gazebo_worlds

- No changes

## uos_maps

- No changes

## uos_tools

- No changes
