### PR TITLE
microstrain_inertial: 2.0.5-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1625,6 +1625,22 @@ repositories:
       url: https://github.com/micro-ROS/micro_ros_msgs.git
       version: galactic
     status: maintained
+  microstrain_inertial:
+    release:
+      packages:
+      - microstrain_inertial_driver
+      - microstrain_inertial_examples
+      - microstrain_inertial_msgs
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release.git
+      version: 2.0.5-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/LORD-MicroStrain/microstrain_inertial.git
+      version: ros2
+    status: developed
   mimick_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `2.0.5-1`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## microstrain_inertial_driver

```
* Updates maintainers and dependencies in preparation for ROS build farm
* Updates submodule to check for correct architecture
* Moves submodules to subdirectory to get bloom working
* Renames packages to be more consistent with ROS naming conventions
* Contributors: Rob Fisher, robbiefish
```

## microstrain_inertial_examples

```
* Updates maintainers and dependencies in preparation for ROS build farm
* Renames packages to be more consistent with ROS naming conventions
* Contributors: Rob Fisher, robbiefish
```

## microstrain_inertial_msgs

```
* Updates maintainers and dependencies in preparation for ROS build farm
* Moves submodules to subdirectory to get bloom working
* Renames packages to be more consistent with ROS naming conventions
* Contributors: Rob Fisher, robbiefish
```
