### PR TITLE
uos_tools: 1.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9118,6 +9118,28 @@ repositories:
       url: https://github.com/ros-geographic-info/unique_identifier-release.git
       version: 1.0.6-1
     status: maintained
+  uos_tools:
+    doc:
+      type: git
+      url: https://github.com/uos/uos_tools.git
+      version: master
+    release:
+      packages:
+      - uos_common_urdf
+      - uos_diffdrive_teleop
+      - uos_freespace
+      - uos_gazebo_worlds
+      - uos_maps
+      - uos_tools
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/uos-gbp/uos-tools.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/uos/uos_tools.git
+      version: master
+    status: maintained
   ur_client_library:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `uos_tools` to `1.0.2-1`:

- upstream repository: https://github.com/uos/uos_tools.git
- release repository: https://github.com/uos-gbp/uos-tools.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## uos_common_urdf

- No changes

## uos_diffdrive_teleop

```
* rename ps3joy to joy and remove ps3joy run depend
```

## uos_freespace

- No changes

## uos_gazebo_worlds

- No changes

## uos_maps

- No changes

## uos_tools

- No changes
