### PR TITLE
plotjuggler_ros: 1.6.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8821,7 +8821,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
-      version: 1.5.0-1
+      version: 1.6.2-1
     source:
       type: git
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler_ros` to `1.6.2-1`:

- upstream repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
- release repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.5.0-1`

## plotjuggler_ros

```
* parse a ROSBAG even if some topic types are not recognized
* Update ros2.yaml
* segmentation fault off (#30 <https://github.com/PlotJuggler/plotjuggler-ros-plugins/issues/30>)
* Contributors: Davide Faconti, simulacrus
```
