### PR TITLE
rclpy: 3.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2462,7 +2462,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 3.0.1-1
+      version: 3.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `3.1.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.0.1-1`

## rclpy

```
* Handle sigterm. (#830 <https://github.com/ros2/rclpy/issues/830>)
* Use pybind11 for signal handling, and delete now unused rclpy_common, pycapsule, and handle code. (#814 <https://github.com/ros2/rclpy/issues/814>)
* Fix memory leak in Service::take_request() and Client::take_response(). (#828 <https://github.com/ros2/rclpy/issues/828>)
* Add Publisher.wait_for_all_acked(). (#793 <https://github.com/ros2/rclpy/issues/793>)
* Only add one done callback to a future in Executor. (#816 <https://github.com/ros2/rclpy/issues/816>)
* Add convert function from ParameterValue to Python builtin. (#819 <https://github.com/ros2/rclpy/issues/819>)
* Call Context._logging_fini() in Context.try_shutdown(). (#800 <https://github.com/ros2/rclpy/issues/800>)
* Lift LoggingSeverity enum as common dependency to logging and rcutils_logger modules (#785 <https://github.com/ros2/rclpy/issues/785>)
* Set Context.__context to None in __init__(). (#812 <https://github.com/ros2/rclpy/issues/812>)
* Remove unused function make_mock_subscription. (#809 <https://github.com/ros2/rclpy/issues/809>)
* Contributors: Barry Xu, Chris Lalancette, Ivan Santiago Paunovic, Jacob Perron, Lei Liu, Louise Poubel, Shane Loretz, ksuszka
```
