### PR TITLE
rosbridge_suite: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3270,18 +3270,21 @@ repositories:
     release:
       packages:
       - rosapi
+      - rosapi_msgs
       - rosbridge_library
       - rosbridge_msgs
       - rosbridge_server
       - rosbridge_suite
+      - rosbridge_test_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 1.0.5-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git
       version: ros2
+    status: developed
   rosidl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `1.1.0-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.5-1`

## rosapi

```
* Move msg/srv from rosapi and rosbridge_library into separate packages; enable Rolling in CI (#665 <https://github.com/RobotWebTools/rosbridge_suite/issues/665>)
* Exit cleanly on SIGINT; remove sleep in test (#667 <https://github.com/RobotWebTools/rosbridge_suite/issues/667>)
* Remove unused service_host and search_param services (#660 <https://github.com/RobotWebTools/rosbridge_suite/issues/660>)
* Migrate remaining linters to pre-commit (#657 <https://github.com/RobotWebTools/rosbridge_suite/issues/657>)
* Add pre-commit, format with black and isort (#648 <https://github.com/RobotWebTools/rosbridge_suite/issues/648>)
* Contributors: Adrian Macneil, Jacob Bandes-Storch, Kenji Miyake
```

## rosapi_msgs

```
* Move msg/srv from rosapi and rosbridge_library into separate packages; enable Rolling in CI (#665 <https://github.com/RobotWebTools/rosbridge_suite/issues/665>)
* Contributors: Jacob Bandes-Storch
```

## rosbridge_library

```
* Fix test imports from rosbridge_test_msgs (#668 <https://github.com/RobotWebTools/rosbridge_suite/issues/668>)
* Move msg/srv from rosapi and rosbridge_library into separate packages; enable Rolling in CI (#665 <https://github.com/RobotWebTools/rosbridge_suite/issues/665>)
* Fix test_services.py (#653 <https://github.com/RobotWebTools/rosbridge_suite/issues/653>)
* Fix unused variables: flake8 --select=F841 (#623 <https://github.com/RobotWebTools/rosbridge_suite/issues/623>)
* Remove get_service_instance from ros_loader (#647 <https://github.com/RobotWebTools/rosbridge_suite/issues/647>)
* Fix test settings for rosbridge_library (#643 <https://github.com/RobotWebTools/rosbridge_suite/issues/643>)
* Fix DOS line endings (#658 <https://github.com/RobotWebTools/rosbridge_suite/issues/658>)
* Port #464 <https://github.com/RobotWebTools/rosbridge_suite/issues/464>, #478 <https://github.com/RobotWebTools/rosbridge_suite/issues/478>, #496 <https://github.com/RobotWebTools/rosbridge_suite/issues/496>, and #502 <https://github.com/RobotWebTools/rosbridge_suite/issues/502> from ROS1 branch (#663 <https://github.com/RobotWebTools/rosbridge_suite/issues/663>)
* Add pre-commit, format with black and isort (#648 <https://github.com/RobotWebTools/rosbridge_suite/issues/648>)
* Contributors: Adrian Macneil, Christian Clauss, Domenic Rodriguez, Jacob Bandes-Storch, Kenji Miyake
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* Exit cleanly on SIGINT; remove sleep in test (#667 <https://github.com/RobotWebTools/rosbridge_suite/issues/667>)
* Fix unused variables: flake8 --select=F841 (#623 <https://github.com/RobotWebTools/rosbridge_suite/issues/623>)
* Fix undefined name in rosbridge_websocket (#659 <https://github.com/RobotWebTools/rosbridge_suite/issues/659>)
* Port #464 <https://github.com/RobotWebTools/rosbridge_suite/issues/464>, #478 <https://github.com/RobotWebTools/rosbridge_suite/issues/478>, #496 <https://github.com/RobotWebTools/rosbridge_suite/issues/496>, and #502 <https://github.com/RobotWebTools/rosbridge_suite/issues/502> from ROS1 branch (#663 <https://github.com/RobotWebTools/rosbridge_suite/issues/663>)
* Add pre-commit, format with black and isort (#648 <https://github.com/RobotWebTools/rosbridge_suite/issues/648>)
* Contributors: Adrian Macneil, Christian Clauss, Domenic Rodriguez, Jacob Bandes-Storch, Kenji Miyake
```

## rosbridge_suite

- No changes

## rosbridge_test_msgs

```
* Move msg/srv from rosapi and rosbridge_library into separate packages; enable Rolling in CI (#665 <https://github.com/RobotWebTools/rosbridge_suite/issues/665>)
* Contributors: Jacob Bandes-Storch
```
