### PR TITLE
microstrain_inertial: 2.0.6-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1634,7 +1634,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release.git
-      version: 2.0.5-1
+      version: 2.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `2.0.6-1`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.5-1`

## microstrain_inertial_driver

```
* Fixes CMake build errors experienced on the build farm
* Contributors: Rob Fisher, robbiefish
```

## microstrain_inertial_examples

```
* Fixes CMake build errors experienced on the build farm
* Contributors: Rob Fisher, robbiefish
```
