### PR TITLE
ros2_control: 1.1.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3189,7 +3189,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `1.1.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.0-1`

## controller_interface

```
* Quick fix 🏎: make doc on helpers clearer (#553 <https://github.com/ros-controls/ros2_control/issues/553>)
* Contributors: Denis Štogl
```

## controller_manager

```
* feat: add colored output into spawner.py (#560 <https://github.com/ros-controls/ros2_control/issues/560>)
* Added timeout argument for service_caller timeout (#552 <https://github.com/ros-controls/ros2_control/issues/552>)
* controller_manager: Use command_interface_configuration for the claimed interfaces when calling list_controllers (#544 <https://github.com/ros-controls/ros2_control/issues/544>)
* Clean up test_load_controller (#532 <https://github.com/ros-controls/ros2_control/issues/532>)
* Contributors: Jack Center, Jafar Abdi, Michael, Nour Saeed
```

## controller_manager_msgs

```
* controller_manager: Use command_interface_configuration for the claimed interfaces when calling list_controllers (#544 <https://github.com/ros-controls/ros2_control/issues/544>)
* Contributors: Jafar Abdi, Denis Štogl
```

## hardware_interface

```
* Handle errors of hardware that happen on read and write. (#546 <https://github.com/ros-controls/ros2_control/issues/546>)
* Contributors: Denis Štogl, Mathias Aarbo
```

## ros2_control

- No changes

## ros2_control_test_assets

```
* Moving diffbot_urdf to ros2_control_test_assets. (#558 <https://github.com/ros-controls/ros2_control/issues/558>)
* Contributors: bailaC
```

## ros2controlcli

```
* Fixup formatting 🔧 of "list_controllers.py" and do not check formating on build stage. (#555 <https://github.com/ros-controls/ros2_control/issues/555>)
  * Do not check formating on build stage.
  * Change formatting of strings.
  * Make output a bit easier to read.
* controller_manager: Use command_interface_configuration for the claimed interfaces when calling list_controllers (#544 <https://github.com/ros-controls/ros2_control/issues/544>)
* Contributors: Denis Štogl, Jafar Abdi
```

## transmission_interface

- No changes
