### PR TITLE
ros2_controllers: 1.1.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3216,7 +3216,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `1.1.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.0-1`

## diff_drive_controller

```
* Use common test URDF from descriptions.hpp (#258 <https://github.com/ros-controls/ros2_controllers/issues/258>)
* Fix header include on Fedora <https://github.com/ros-controls/ros2_controllers/issues/255>`_ (#256 <https://github.com/ros-controls/ros2_controllers/issues/256>)
* Fix diff_drive accel limit (#242 <https://github.com/ros-controls/ros2_controllers/issues/242>) (#252 <https://github.com/ros-controls/ros2_controllers/issues/252>)
* Contributors: Denis Štogl, Josh Newans, Noeël Moeskops, bailaC
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

```
* Move interface sorting into ControllerInterface (#259 <https://github.com/ros-controls/ros2_controllers/issues/259>)
* Revise for-loop style (#254 <https://github.com/ros-controls/ros2_controllers/issues/254>)
* Contributors: bailaC
```

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

```
* Revise for-loop style (#254 <https://github.com/ros-controls/ros2_controllers/issues/254>)
* Contributors: bailaC
```

## joint_trajectory_controller

```
* Move interface sorting into ControllerInterface (#259 <https://github.com/ros-controls/ros2_controllers/issues/259>)
* Revise for-loop style (#254 <https://github.com/ros-controls/ros2_controllers/issues/254>)
* Contributors: bailaC
```

## position_controllers

- No changes

## ros2_controllers

- No changes

## velocity_controllers

- No changes
