### PR TITLE
ros2_control: 0.8.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3866,7 +3866,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `0.8.1-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.8.0-1`

## controller_interface

- No changes

## controller_manager

```
* [ControllerManager] Fix method name upon fetching state of controller(s) (#526 <https://github.com/ros-controls/ros2_control/issues/526>)
* Controller Manager should not crash when trying to start finalized or unconfigured controller (#461 <https://github.com/ros-controls/ros2_control/issues/461>) (#524 <https://github.com/ros-controls/ros2_control/issues/524>)
* Contributors: Denis Štogl, Lovro Ivanov
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* add M_PI macro for windows foxy in test_component_parser.cpp (#545 <https://github.com/ros-controls/ros2_control/issues/545>)
* Extend GenericSystem by adding mapping of position with offset to custom interface. (#469 <https://github.com/ros-controls/ros2_control/issues/469>) (#523 <https://github.com/ros-controls/ros2_control/issues/523>)
* Contributors: BenjaminHug8, Denis Štogl
```

## ros2_control

- No changes

## ros2_control_test_assets

```
* Remove unnecessary includes (#518 <https://github.com/ros-controls/ros2_control/issues/518>) (#522 <https://github.com/ros-controls/ros2_control/issues/522>)
* Contributors: mergify[bot]
```

## ros2controlcli

- No changes

## transmission_interface

- No changes
