### PR TITLE
[dep] Update: ruamel.yaml for newer Ubuntu distro

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4391,6 +4391,7 @@ python-ruamel.yaml:
   fedora: [python-ruamel-yaml]
   nixos: [pythonPackages.ruamel_yaml]
   ubuntu:
+    '*': [python-ruamel.yaml]
     artful: [python-ruamel.yaml]
     bionic: [python-ruamel.yaml]
     xenial: [python-ruamel.yaml]


### PR DESCRIPTION
The package is [available on Ubuntu 20.04 (packages.ubuntu.com)](https://packages.ubuntu.com/source/focal/ruamel.yaml) and on newer distros. But the current rosdep key doesn't seem to cover those distros.