### PR TITLE
moveit_sim_controller: 0.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4505,6 +4505,21 @@ repositories:
       url: https://github.com/ros-planning/moveit_resources.git
       version: master
     status: maintained
+  moveit_sim_controller:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/moveit_sim_controller.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/PickNikRobotics/moveit_sim_controller-release.git
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/moveit_sim_controller.git
+      version: noetic-devel
+    status: maintained
   moveit_visual_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_sim_controller` to `0.3.0-1`:

- upstream repository: https://github.com/PickNikRobotics/moveit_sim_controller.git
- release repository: https://github.com/PickNikRobotics/moveit_sim_controller-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## moveit_sim_controller

```
* Fix shared pointer conversion bug (#9 <https://github.com/PickNikRobotics/moveit_sim_controller/issues/9>)
* Fixup SFINAE detection of boilerplate API (#6 <https://github.com/PickNikRobotics/moveit_sim_controller/issues/6>)
* Cleanup & Fix main executable (#4 <https://github.com/PickNikRobotics/moveit_sim_controller/issues/4>)
  * if the pose does not exist, still initialize joints Otherwise this warning should be fatal...
  * conditionally call loop only when available
* Contributors: Dave Coleman, Henning Kayser, Jafar Abdi, Michael Görner, Rick Staa
```
