### PR TITLE
move_base_flex: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4351,7 +4351,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/uos-gbp/move_base_flex-release.git
-      version: 0.3.4-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/magazino/move_base_flex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_flex` to `0.4.0-1`:

- upstream repository: https://github.com/magazino/move_base_flex.git
- release repository: https://github.com/uos-gbp/move_base_flex-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.4-1`

## mbf_abstract_core

- No changes

## mbf_abstract_nav

```
* Fixes planner execution API compatibility, see #279 and https://github.com/uos/mesh_navigation/issues/18
* return empty footprint if partly outside of the map, see #272
* Allow the controller to handle cancel if properly implemented, see #274
* Do not reset cancel_, as that will invalidate ongoing canceling
* Run replanning in its own thread, fixes #223, see #267
* enable max retries logic for controller execution test, see #264
* fix controller termination, see #263
* abstract controller execution unit tests, see #261
* planner action unit tests, see #244
* Fix number of retries check, see #262
* transform pose to global frame before calling planner in costmap planner execution, see #256
* Use ROS rates for sleeping to support simulation time, see #257
* wait for timeout in abstract eecution base, since cancel call could be missed, see #255
* add unit test for the abstract execution base, see #249
* fix race-condition in the test, see #254
* AbstractPlannerExecution refactoring and unit tests, see #237
* add documentation, missing includes, joinable check, and fixup and test the abstract_action_base
```

## mbf_costmap_core

- No changes

## mbf_costmap_nav

```
* make the costmaps used for planning and controlling configurable, see #278
* return empty footprint if partly outside of the map, see #272
* add tf_transform_ptr to the abstract planner execution, see #256
* transform pose to global frame before calling planner in costmap planner execution, see #256
```

## mbf_msgs

```
* return empty footprint if partly outside of the map, see #272
```

## mbf_simple_nav

- No changes

## mbf_utility

```
* return empty footprint if partly outside of the map, see #272
```

## move_base_flex

- No changes
