### PR TITLE
gazebo_ros2_control: 0.0.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1184,7 +1184,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.0.3-1
+      version: 0.0.5-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1176,7 +1176,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git
-      version: master
+      version: foxy
     release:
       packages:
       - gazebo_ros2_control
@@ -1188,7 +1188,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git
-      version: master
+      version: foxy
     status: maintained
   gazebo_ros_pkgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros2_control` to `0.0.5-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros2_control/
- release repository: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.3-1`
