### PR TITLE
microstrain_inertial: 2.0.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1995,6 +1995,22 @@ repositories:
       url: https://github.com/micro-ROS/micro_ros_msgs.git
       version: foxy
     status: maintained
+  microstrain_inertial:
+    release:
+      packages:
+      - microstrain_inertial_driver
+      - microstrain_inertial_examples
+      - microstrain_inertial_msgs
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release.git
+      version: 2.0.6-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/LORD-MicroStrain/microstrain_inertial.git
+      version: ros2
+    status: developed
   mimick_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `2.0.6-1`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## microstrain_inertial_driver

```
* Fixes CMake build errors experienced on the build farm
* Contributors: Rob Fisher, robbiefish
```

## microstrain_inertial_examples

```
* Fixes CMake build errors experienced on the build farm
* Contributors: Rob Fisher, robbiefish
```
