### PR TITLE
rqt_console: 2.0.2-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3787,7 +3787,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_console-release.git
-      version: 2.0.1-1
+      version: 2.0.2-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_console` to `2.0.2-2`:

- upstream repository: https://github.com/ros-visualization/rqt_console.git
- release repository: https://github.com/ros2-gbp/rqt_console-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.1-1`

## rqt_console

```
* Use a custom QoS profile based on the default rosout QoS profile (#37 <https://github.com/ros-visualization/rqt_console/issues/37>)
* Contributors: Arne Hitzmann, Cole Tucker
```
