### PR TITLE
mesh_tools: 1.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4181,11 +4181,10 @@ repositories:
       - mesh_msgs_transform
       - mesh_tools
       - rviz_map_plugin
-      - rviz_mesh_plugin
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/uos-gbp/mesh-tools.git
-      version: 1.0.1-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/uos/mesh_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mesh_tools` to `1.1.0-1`:

- upstream repository: https://github.com/uos/mesh_tools.git
- release repository: https://github.com/uos-gbp/mesh-tools.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.1-1`

## hdf5_map_io

```
* added publishing of mesh_msgs to mesh_msgs_hdf5 package
* fixed mpi error
* resolved catkin lint problems
* update label in hdf5 file
```

## label_manager

```
* resolved catkin lint problems
```

## mesh_msgs

```
* added publishing of mesh_msgs to mesh_msgs_hdf5 package
* removed unused messages
* correct wiki address for mesh_tools
```

## mesh_msgs_conversions

```
* removed unused messages
* resolved catkin lint problems
```

## mesh_msgs_hdf5

```
* added publishing of mesh_msgs to mesh_msgs_hdf5 package
* fixed hdf5 to mesh_msgs publisher node
* resolved catkin lint problems
```

## mesh_msgs_transform

```
* removed unused messages
* Contributors: Malte kl. Piening
```

## mesh_tools

- No changes

## rviz_map_plugin

```
* fixed GetUUIDs service call in MeshDisplay
* added option to visualize vertex costs using the rviz Map Visuslization
* removed unused messages
* added support for multiple meshes to be visualized at the same time
* added cleaning of generalmesh before adding new data
* removed old plugin and displays
* fixed thin wireframe
* fixed normals shading
* improved normals performance
* fixed rainbow-redgreen cost color type change
* fixed duplicate vertex cost types
* fixed map3d and fixed loading Vertex colors when updating the VertexColors topic
* MeshDisplay: removed visual access from topic and service callbacks
* added option to stop MeshDisplay listening to MeshMsgs
* MeshDisplay now woring with MeshMap
* added properties to MeshDisplay
* added Map3D file dialog property
* added textured mesh display for mesh msgs visualization to rviz_map_plugin
* combined mesh-plugin and map-plugin texture mesh visuals
* fixed mpi error
* resolved catkin lint problems
```
