### PR TITLE
camera_aravis: 4.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -526,6 +526,11 @@ repositories:
       type: git
       url: https://github.com/FraunhoferIOSB/camera_aravis.git
       version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/FraunhoferIOSB/camera_aravis-release.git
+      version: 4.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_aravis` to `4.0.0-1`:

- upstream repository: https://github.com/FraunhoferIOSB/camera_aravis.git
- release repository: https://github.com/FraunhoferIOSB/camera_aravis-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## camera_aravis

```
* Major refactoring
* Add support for ROS Noetic and aravis-0.6
* Fix several bugs (see git history)
* Add new features:
  
    * Support for multisource cameras
    * Zero-copy transport with ROS nodelets
    * Camera time synchronization
    * Example launch files
  
* Update package author and maintainer
* Contributors: Dominik Klein, Floris van Breugel, Gaël Écorchard, Thomas Emter, Peter Mortimer, Dominik Kleiser
```
