### PR TITLE
micro_ros_diagnostics: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1609,6 +1609,24 @@ repositories:
       url: https://github.com/ros2/message_filters.git
       version: master
     status: maintained
+  micro_ros_diagnostics:
+    doc:
+      type: git
+      url: https://github.com/micro-ROS/micro_ros_diagnostics.git
+      version: master
+    release:
+      packages:
+      - micro_ros_diagnostic_bridge
+      - micro_ros_diagnostic_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/micro_ros_diagnostics-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/micro-ROS/micro_ros_diagnostics.git
+      version: master
+    status: developed
   micro_ros_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `micro_ros_diagnostics` to `0.2.0-1`:

- upstream repository: https://github.com/micro-ROS/micro_ros_diagnostics.git
- release repository: https://github.com/ros2-gbp/micro_ros_diagnostics-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
