### PR TITLE
micro_ros_diagnostics: 0.2.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1980,6 +1980,24 @@ repositories:
       url: https://github.com/ros2/message_filters.git
       version: foxy
     status: maintained
+  micro_ros_diagnostics:
+    doc:
+      type: git
+      url: https://github.com/micro-ROS/micro_ros_diagnostics.git
+      version: master
+    release:
+      packages:
+      - micro_ros_diagnostic_bridge
+      - micro_ros_diagnostic_msgs
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/micro_ros_diagnostics-release.git
+      version: 0.2.0-2
+    source:
+      type: git
+      url: https://github.com/micro-ROS/micro_ros_diagnostics.git
+      version: master
+    status: developed
   micro_ros_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `micro_ros_diagnostics` to `0.2.0-2`:

- upstream repository: https://github.com/micro-ROS/micro_ros_diagnostics.git
- release repository: https://github.com/ros2-gbp/micro_ros_diagnostics-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
