### PR TITLE
roswww: 0.1.13-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11493,7 +11493,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/roswww-release.git
-      version: 0.1.12-0
+      version: 0.1.13-1
     source:
       type: git
       url: https://github.com/tork-a/roswww.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roswww` to `0.1.13-1`:

- upstream repository: https://github.com/tork-a/roswww.git
- release repository: https://github.com/ros-gbp/roswww-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.12-0`

## roswww

```
* add basic authentication (#57 <https://github.com/tork-a/roswww/issues/57>
* add single package mode (#56 <https://github.com/tork-a/roswww/issues/56>)
  
    * original PR #54 <https://github.com/tork-a/roswww/issues/54>
  
* add more test on listener.html / talker .html #55 <https://github.com/tork-a/roswww/issues/55>
  
    * make python 2/3 compatible
    * use .travis.sh to compile with --install option
    * drop indigo/jade/lunar
    * add test for listner/talker
  
* fix travis build and add melodic and noetic test (#53 <https://github.com/tork-a/roswww/issues/53>)
  
    * use add_arguent('-headless') to disable display
    * python3 returns bytes in subproces.Popen.communicate
  c.f. https://stackoverflow.com/questions/33054527/typeerror-a-bytes-like-object-is-required-not-str-when-writing-to-a-file-in
  https://stackoverflow.com/questions/15374211/why-does-popen-communicate-return-bhi-n-instead-of-hi
  * use python3-selenium instead of pip
  * add python3 compile test
  * python3 support for noetic
  * remove phantomjs dependency
  * use latest geckodriver version
  * use firefox instead of phantomjs
  * add noetic, melodic and allow failure for jade, lunar
  * install wget in BEFORE_INIT
  * use BEFORE_INIT instead of BEFORE_SCRIPT
* Contributors: Kai-Uwe Hermann, Kei Okada, Shingo Kitagawa, Takashi Ogura
```
