### PR TITLE
add `charisma-sdk` to rosdep database

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6057,6 +6057,9 @@ python3-cffi:
   ubuntu: [python3-cffi]
 python3-chainer-pip: *migrate_eol_2025_04_30_python3_chainer_pip
 python3-charisma-sdk-pip:
+  debian:
+    pip:
+      packages: [charisma-sdk]
   ubuntu:
     pip:
       packages: [charisma-sdk]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6056,6 +6056,10 @@ python3-cffi:
   rhel: ['python%{python3_pkgversion}-cffi']
   ubuntu: [python3-cffi]
 python3-chainer-pip: *migrate_eol_2025_04_30_python3_chainer_pip
+python3-charisma-sdk-pip:
+  ubuntu:
+    pip:
+      packages: [charisma-sdk]
 python3-cherrypy3:
   debian: [python3-cherrypy3]
   nixos: [python3Packages.cherrypy]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

charisma-sdk

## Package Upstream Source:

https://github.com/charisma-ai/charisma-sdk-python

## Purpose of using this:

We're starting to hook Charisma (an interactive narrative system) up to robots, so ideally we need to access our python SDK in ROS packages.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://pypi.org/project/charisma-sdk/
- Ubuntu: https://packages.ubuntu.com/
   - https://pypi.org/project/charisma-sdk/
- Fedora: https://src.fedoraproject.org/browse/projects/
  - IF AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL


# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
