### PR TITLE
paho-mqtt-cpp: 1.2.0-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5330,7 +5330,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/nobleo/paho.mqtt.cpp-release.git
-      version: 1.2.0-2
+      version: 1.2.0-3
     source:
       type: git
       url: https://github.com/eclipse/paho.mqtt.cpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `paho-mqtt-cpp` to `1.2.0-3`:

- upstream repository: https://github.com/eclipse/paho.mqtt.cpp.git
- release repository: https://github.com/nobleo/paho.mqtt.cpp-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.0-2`
