### PR TITLE
[dep] inputtimeout-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6683,6 +6683,19 @@ python3-influxdb-client-pip:
   ubuntu:
     pip:
       packages: [influxdb-client]
+python3-inputimeout-pip:
+  debian:
+    pip:
+      packages: [inputimeout]
+  fedora:
+    pip:
+      packages: [inputimeout]
+  osx:
+    pip:
+      packages: [inputimeout]
+  ubuntu:
+    pip:
+      packages: [inputimeout]
 python3-interpreter:
   arch: [python]
   debian: [python3-minimal]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

inputtimeout

## Package Upstream Source:

Dev repo listed in pypi.org, http://github.com/johejo/inutimeout, is not found.

## Purpose of using this:

- Programming the CLI application.

Distro packaging links:

## Links to Distribution Packages

https://pypi.org/project/inputimeout/

