### PR TITLE
cartographer_ros: 1.0.9004-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -441,7 +441,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/cartographer_ros-release.git
-      version: 1.0.9003-3
+      version: 1.0.9004-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cartographer_ros` to `1.0.9004-1`:

- upstream repository: https://github.com/ros2/cartographer_ros.git
- release repository: https://github.com/ros2-gbp/cartographer_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.9003-3`

## cartographer_ros

```
* add pbstream_to_ros_map_node (#54 <https://github.com/ros2/cartographer_ros/issues/54>)
* Use the non-deprecated tf2_eigen.hpp header. (#55 <https://github.com/ros2/cartographer_ros/issues/55>)
* Contributors: Chris Lalancette, Liangqian
```

## cartographer_ros_msgs

- No changes
