### PR TITLE
neonavigation: 0.11.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7465,7 +7465,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.11.0-1
+      version: 0.11.1-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.11.1-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.11.0-1`

## costmap_cspace

- No changes

## joystick_interrupt

- No changes

## map_organizer

- No changes

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

- No changes

## obj_to_pointcloud

- No changes

## planner_cspace

```
* planner_cspace: refactor distance map generator (#617 <https://github.com/at-wat/neonavigation/issues/617>)
* planner_cspace: recover error on FINISHING state (#615 <https://github.com/at-wat/neonavigation/issues/615>)
* planner_cspace: fix flaky actionlib tests (#616 <https://github.com/at-wat/neonavigation/issues/616>)
* planner_cspace: remove unused variable (#614 <https://github.com/at-wat/neonavigation/issues/614>)
* Contributors: Atsushi Watanabe
```

## safety_limiter

- No changes

## track_odometry

- No changes

## trajectory_tracker

```
* trajectory_tracker: increase SwitchBackWithPathUpdate test timeout (#611 <https://github.com/at-wat/neonavigation/issues/611>)
* Contributors: Atsushi Watanabe
```
