### PR TITLE
ament_cmake: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -65,6 +65,7 @@ repositories:
       - ament_cmake_export_libraries
       - ament_cmake_export_link_flags
       - ament_cmake_export_targets
+      - ament_cmake_gen_version_h
       - ament_cmake_gmock
       - ament_cmake_google_benchmark
       - ament_cmake_gtest
@@ -79,7 +80,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 1.1.4-1
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake` to `1.2.0-1`:

- upstream repository: https://github.com/ament/ament_cmake.git
- release repository: https://github.com/ros2-gbp/ament_cmake-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.4-1`

## ament_cmake

```
* Add ament_cmake_gen_version_h package (#198 <https://github.com/ament/ament_cmake/issues/198>)
* Use FindPython3 instead of FindPythonInterp (#355 <https://github.com/ament/ament_cmake/issues/355>)
* Update maintainers (#336 <https://github.com/ament/ament_cmake/issues/336>)
* Contributors: Chris Lalancette, Shane Loretz, serge-nikulin
```

## ament_cmake_auto

```
* Add ament_auto_add_gtest (#344 <https://github.com/ament/ament_cmake/issues/344>)
* Use FindPython3 instead of FindPythonInterp (#355 <https://github.com/ament/ament_cmake/issues/355>)
* Update maintainers (#336 <https://github.com/ament/ament_cmake/issues/336>)
* Contributors: Chris Lalancette, Joshua Whitley, Shane Loretz
```

## ament_cmake_core

```
* Use FindPython3 instead of FindPythonInterp (#355 <https://github.com/ament/ament_cmake/issues/355>)
* Support commands with executable targets (#352 <https://github.com/ament/ament_cmake/issues/352>)
* doc/resource_index: Indent list subitems correctly (#342 <https://github.com/ament/ament_cmake/issues/342>)
* Update maintainers (#336 <https://github.com/ament/ament_cmake/issues/336>)
* Contributors: Chris Lalancette, Michal Sojka, Shane Loretz
```

## ament_cmake_export_definitions

```
* Use FindPython3 instead of FindPythonInterp (#355 <https://github.com/ament/ament_cmake/issues/355>)
* Update maintainers (#336 <https://github.com/ament/ament_cmake/issues/336>)
* Contributors: Chris Lalancette, Shane Loretz
```

## ament_cmake_export_dependencies

```
* Use FindPython3 instead of FindPythonInterp (#355 <https://github.com/ament/ament_cmake/issues/355>)
* Update maintainers (#336 <https://github.com/ament/ament_cmake/issues/336>)
* Contributors: Chris Lalancette, Shane Loretz
```

## ament_cmake_export_include_directories

```
* Use FindPython3 instead of FindPythonInterp (#355 <https://github.com/ament/ament_cmake/issues/355>)
* Update maintainers (#336 <https://github.com/ament/ament_cmake/issues/336>)
* Contributors: Chris Lalancette, Shane Loretz
```

## ament_cmake_export_interfaces

```
* Use FindPython3 instead of FindPythonInterp (#355 <https://github.com/ament/ament_cmake/issues/355>)
* Update maintainers (#336 <https://github.com/ament/ament_cmake/issues/336>)
* Contributors: Chris Lalancette, Shane Loretz
```

## ament_cmake_export_libraries

```
* Use FindPython3 instead of FindPythonInterp (#355 <https://github.com/ament/ament_cmake/issues/355>)
* Add note regarding interface libraries (#339 <https://github.com/ament/ament_cmake/issues/339>)
* Update maintainers (#336 <https://github.com/ament/ament_cmake/issues/336>)
* Contributors: Bjar Ne, Chris Lalancette, Shane Loretz
```

## ament_cmake_export_link_flags

```
* Use FindPython3 instead of FindPythonInterp (#355 <https://github.com/ament/ament_cmake/issues/355>)
* Update maintainers (#336 <https://github.com/ament/ament_cmake/issues/336>)
* Contributors: Chris Lalancette, Shane Loretz
```

## ament_cmake_export_targets

```
* Use FindPython3 instead of FindPythonInterp (#355 <https://github.com/ament/ament_cmake/issues/355>)
* Update maintainers (#336 <https://github.com/ament/ament_cmake/issues/336>)
* Contributors: Chris Lalancette, Shane Loretz
```

## ament_cmake_gen_version_h

```
* Add ament_cmake_gen_version_h package (#198 <https://github.com/ament/ament_cmake/issues/198>)
* Contributors: serge-nikulin
```

## ament_cmake_gmock

```
* Use FindPython3 instead of FindPythonInterp (#355 <https://github.com/ament/ament_cmake/issues/355>)
* Update maintainers (#336 <https://github.com/ament/ament_cmake/issues/336>)
* Contributors: Chris Lalancette, Shane Loretz
```

## ament_cmake_google_benchmark

```
* Use FindPython3 instead of FindPythonInterp (#355 <https://github.com/ament/ament_cmake/issues/355>)
* Update maintainers (#336 <https://github.com/ament/ament_cmake/issues/336>)
* Contributors: Chris Lalancette, Shane Loretz
```

## ament_cmake_gtest

```
* Use FindPython3 instead of FindPythonInterp (#355 <https://github.com/ament/ament_cmake/issues/355>)
* Update maintainers (#336 <https://github.com/ament/ament_cmake/issues/336>)
* Contributors: Chris Lalancette, Shane Loretz
```

## ament_cmake_include_directories

```
* Use FindPython3 instead of FindPythonInterp (#355 <https://github.com/ament/ament_cmake/issues/355>)
* Update maintainers (#336 <https://github.com/ament/ament_cmake/issues/336>)
* Contributors: Chris Lalancette, Shane Loretz
```

## ament_cmake_libraries

```
* Use FindPython3 instead of FindPythonInterp (#355 <https://github.com/ament/ament_cmake/issues/355>)
* Update maintainers (#336 <https://github.com/ament/ament_cmake/issues/336>)
* Contributors: Chris Lalancette, Shane Loretz
```

## ament_cmake_nose

```
* Use FindPython3 instead of FindPythonInterp (#355 <https://github.com/ament/ament_cmake/issues/355>)
* Support commands with executable targets (#352 <https://github.com/ament/ament_cmake/issues/352>)
* Update maintainers (#336 <https://github.com/ament/ament_cmake/issues/336>)
* Contributors: Chris Lalancette, Shane Loretz
```

## ament_cmake_pytest

```
* Use FindPython3 instead of FindPythonInterp (#355 <https://github.com/ament/ament_cmake/issues/355>)
* Support commands with executable targets (#352 <https://github.com/ament/ament_cmake/issues/352>)
* Mention other platforms in 'pytest/pytest-cov not found' warning (#337 <https://github.com/ament/ament_cmake/issues/337>)
* Update maintainers (#336 <https://github.com/ament/ament_cmake/issues/336>)
* Contributors: Chris Lalancette, Christophe Bedard, Shane Loretz
```

## ament_cmake_python

```
* Make ament_cmake_python symlink for symlink installs only (#357 <https://github.com/ament/ament_cmake/issues/357>)
* Use FindPython3 instead of FindPythonInterp (#355 <https://github.com/ament/ament_cmake/issues/355>)
* Make ament_python_install_package() match setuptools' egg names. (#338 <https://github.com/ament/ament_cmake/issues/338>)
* Drop ament_cmake_python outdated tests. (#340 <https://github.com/ament/ament_cmake/issues/340>)
* Update maintainers (#336 <https://github.com/ament/ament_cmake/issues/336>)
* Make ament_python_install_package() install console_scripts (#328 <https://github.com/ament/ament_cmake/issues/328>)
* Contributors: Chris Lalancette, Michel Hidalgo, Shane Loretz
```

## ament_cmake_target_dependencies

```
* Use FindPython3 instead of FindPythonInterp (#355 <https://github.com/ament/ament_cmake/issues/355>)
* Fix bug packages with multiple configurations (#318 <https://github.com/ament/ament_cmake/issues/318>)
* Update maintainers (#336 <https://github.com/ament/ament_cmake/issues/336>)
* Contributors: Chris Lalancette, Shane Loretz
```

## ament_cmake_test

```
* Use FindPython3 instead of FindPythonInterp (#355 <https://github.com/ament/ament_cmake/issues/355>)
* Update maintainers (#336 <https://github.com/ament/ament_cmake/issues/336>)
* Contributors: Chris Lalancette, Shane Loretz
```

## ament_cmake_version

```
* Use FindPython3 instead of FindPythonInterp (#355 <https://github.com/ament/ament_cmake/issues/355>)
* Update maintainers (#336 <https://github.com/ament/ament_cmake/issues/336>)
* Contributors: Chris Lalancette, Shane Loretz
```
