### PR TITLE
robot_calibration: 0.6.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10280,7 +10280,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/robot_calibration-release.git
-      version: 0.6.4-1
+      version: 0.6.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_calibration` to `0.6.5-1`:

- upstream repository: https://github.com/mikeferguson/robot_calibration.git
- release repository: https://github.com/ros-gbp/robot_calibration-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.6.4-1`

## robot_calibration

```
* add support for static camera calibration (#101 <https://github.com/mikeferguson/robot_calibration/issues/101>)
* remove references to chain3d_to_arm (#99 <https://github.com/mikeferguson/robot_calibration/issues/99>)
* Contributors: Michael Ferguson
```

## robot_calibration_msgs

- No changes
