### PR TITLE
plotjuggler: 3.3.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5640,7 +5640,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.3.2-1
+      version: 3.3.3-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.3.3-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.3.2-1`

## plotjuggler

```
* Fix critical bug when loading a file twice
* change order of removal
* fix crash when one of the source of XY is deleted
* fix issue #549 <https://github.com/facontidavide/PlotJuggler/issues/549> (comma decima separator)
* Fix issue #545 <https://github.com/facontidavide/PlotJuggler/issues/545>
* Contributors: Davide Faconti
```
