### PR TITLE
ira_laser_tools: 1.0.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3222,7 +3222,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/iralabdisco/ira_laser_tools-release.git
-      version: 1.0.6-2
+      version: 1.0.7-1
     source:
       type: git
       url: https://github.com/iralabdisco/ira_laser_tools.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3217,7 +3217,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/iralabdisco/ira_laser_tools.git
-      version: noetic
+      version: ros1-master
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -3226,7 +3226,7 @@ repositories:
     source:
       type: git
       url: https://github.com/iralabdisco/ira_laser_tools.git
-      version: noetic
+      version: ros1-master
     status: developed
   iris_lama:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `ira_laser_tools` to `1.0.7-1`:

- upstream repository: https://github.com/iralabdisco/ira_laser_tools.git
- release repository: https://github.com/iralabdisco/ira_laser_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.6-2`

## ira_laser_tools

```
* Use the same header in published scan as the published cloud
* Fix a concurrency issue
* Contributors: JackFrost67, MikHut, Auri
```
