### PR TITLE
ira_laser_tools: 1.0.7-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4821,7 +4821,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/iralabdisco/ira_laser_tools-release.git
-      version: 1.0.6-1
+      version: 1.0.7-1
     source:
       type: git
       url: https://github.com/iralabdisco/ira_laser_tools.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4816,7 +4816,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/iralabdisco/ira_laser_tools.git
-      version: melodic
+      version: ros1-master
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -4825,7 +4825,7 @@ repositories:
     source:
       type: git
       url: https://github.com/iralabdisco/ira_laser_tools.git
-      version: melodic
+      version: ros1-master
     status: developed
   iris_lama:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `ira_laser_tools` to `1.0.7-1`:

- upstream repository: https://github.com/iralabdisco/ira_laser_tools.git
- release repository: https://github.com/iralabdisco/ira_laser_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.6-1`

## ira_laser_tools

```
* Use the same header in published scan as the published cloud
* Fix a concurrency issue
* Contributors: JackFrost67, MikHut, Auri
```
