### PR TITLE
rcutils: 5.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2509,7 +2509,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 4.0.2-1
+      version: 5.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `5.0.0-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `4.0.2-1`

## rcutils

```
* Fixing up documentation build when using rosdoc2 (#344 <https://github.com/ros2/rcutils/issues/344>)
* Stop double-defining structs. (#333 <https://github.com/ros2/rcutils/issues/333>)
* Use FindPython3 explicitly instead of FindPythonInterp implicitly (#345 <https://github.com/ros2/rcutils/issues/345>)
* Fix build on Android (#342 <https://github.com/ros2/rcutils/issues/342>)
* Deprecate get_env.h and move content to env.{h,c} (#340 <https://github.com/ros2/rcutils/issues/340>)
* Contributors: Chris Lalancette, Christophe Bedard, Ivan Santiago Paunovic, Shane Loretz, William Woodall
```
