### PR TITLE
Adding sciurus17 to documentation index for noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8335,6 +8335,12 @@ repositories:
       url: https://github.com/ipa320/schunk_modular_robotics.git
       version: kinetic_dev
     status: maintained
+  sciurus17:
+    doc:
+      type: git
+      url: https://github.com/rt-net/sciurus17_ros.git
+      version: master
+    status: maintained
   sdhlibrary_cpp:
     doc:
       type: git


### PR DESCRIPTION
I'd like my repository to be indexed and documented on ros.org
