### PR TITLE
Adding crane_x7 to documentation index for noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1313,6 +1313,12 @@ repositories:
       url: https://github.com/rst-tu-dortmund/costmap_converter.git
       version: master
     status: maintained
+  crane_x7:
+    doc:
+      type: git
+      url: https://github.com/rt-net/crane_x7_ros.git
+      version: master
+    status: maintained
   criutils:
     doc:
       type: git


### PR DESCRIPTION
I'd like my repository to be indexed and documented on ros.org
