### PR TITLE
turtlebot3_autorace_2020: 1.1.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9018,7 +9018,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace_2020_release.git
-      version: 1.1.0-7
+      version: 1.1.1-2
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_autorace_2020.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_autorace_2020` to `1.1.1-2`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_autorace_2020.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace_2020_release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.0-7`

## turtlebot3_autorace_2020

```
* Modified opencv packages (#6)
* Contributors: Ashe Kim, Will Son
```

## turtlebot3_autorace_camera

```
* Modified opencv packages (#6)
* Contributors: Ashe Kim, Will Son
```

## turtlebot3_autorace_detect

```
* Modified opencv packages (#6)
* Contributors: Ashe Kim, Will Son
```

## turtlebot3_autorace_driving

```
* Modified opencv packages (#6)
* Contributors: Ashe Kim, Will Son
```

## turtlebot3_autorace_msgs

```
* Modified opencv packages (#6)
* Contributors: Ashe Kim, Will Son
```
