### PR TITLE
simple_launch: 1.2.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4188,6 +4188,21 @@ repositories:
       url: https://github.com/ros/sdformat_urdf.git
       version: ros2
     status: maintained
+  simple_launch:
+    doc:
+      type: git
+      url: https://github.com/oKermorgant/simple_launch.git
+      version: 1.0.2
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/oKermorgant/simple_launch-release.git
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://github.com/oKermorgant/simple_launch.git
+      version: devel
+    status: maintained
   slam_toolbox:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_launch` to `1.2.0-1`:

- upstream repository: https://github.com/oKermorgant/simple_launch.git
- release repository: https://github.com/oKermorgant/simple_launch-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## simple_launch

```
* make it clearer for the prefix_gz_plugins param
* Contributors: Olivier Kermorgant
```
