### PR TITLE
python_qt_binding: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2198,7 +2198,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/python_qt_binding-release.git
-      version: 1.0.7-1
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `1.1.0-1`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros2-gbp/python_qt_binding-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.7-1`

## python_qt_binding

```
* Make FindPythonInterp dependency explicit (#107 <https://github.com/ros-visualization/python_qt_binding/issues/107>)
* Add note about galactic branch (#104 <https://github.com/ros-visualization/python_qt_binding/issues/104>)
* fuerte-devel is too new for ROS Electric (#101 <https://github.com/ros-visualization/python_qt_binding/issues/101>)
* Contributors: Shane Loretz
```
