### PR TITLE
heifu: 0.8.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4246,19 +4246,26 @@ repositories:
       version: releasePackage
     release:
       packages:
+      - collision_avoidance
+      - control_bringup
+      - gcs_interface
+      - gimbal
+      - gnss_utils
+      - gpu_voxels_ros
+      - gstreamer
       - heifu
-      - heifu_bringup
-      - heifu_description
-      - heifu_diagnostic
-      - heifu_mavros
-      - heifu_msgs
-      - heifu_safety
-      - heifu_simple_waypoint
-      - heifu_tools
+      - heifu-bringup
+      - heifu-gpu
+      - planner
+      - planners_manager
+      - rrt
+      - status_diagnostic
+      - uav_msgs
+      - waypoints_manager
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/BV-OpenSource/heifu-release.git
-      version: 0.7.7-2
+      version: 0.8.3-1
     source:
       type: git
       url: https://gitlab.pdmfc.com/drones/ros1/heifu.git


### PR DESCRIPTION
Increasing version of package(s) in repository `heifu` to `0.8.3-1`:

- upstream repository: https://gitlab.pdmfc.com/drones/ros1/heifu-uav/heifu.git
- release repository: https://github.com/BV-OpenSource/heifu-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.7-2`

## collision_avoidance

- No changes

## control_bringup

- No changes

## gcs_interface

- No changes

## gimbal

- No changes

## gnss_utils

- No changes

## gpu_voxels_ros

- No changes

## gstreamer

- No changes

## heifu

- No changes

## heifu-bringup

- No changes

## heifu-gpu

- No changes

## planner

```
* 0.8.2
* Updated changelog.
* Contributors: André Filipe
```

## planners_manager

```
* 0.8.2
* Updated changelog.
* Contributors: André Filipe
```

## rrt

- No changes

## status_diagnostic

```
* 0.8.2
* Updated changelogs.
* Contributors: André Filipe
```

## uav_msgs

- No changes

## waypoints_manager

- No changes
