### PR TITLE
Add pigpiod

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6453,6 +6453,8 @@ php:
     xenial: [php7.0]
     yakkety: [php7.0]
     zesty: [php7.0]
+pigpiod:
+  ubuntu: [pigpiod]
 pigz:
   debian: [pigz]
   fedora: [pigz]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6453,8 +6453,8 @@ php:
     xenial: [php7.0]
     yakkety: [php7.0]
     zesty: [php7.0]
-pigpiod:
-  ubuntu: [pigpiod]
+pigpio:
+  ubuntu: [pigpio]
 pigz:
   debian: [pigz]
   fedora: [pigz]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.


## Package name:

`pigpio`

## Package Upstream Source:

[Github: joan2937/pigpio](https://github.com/joan2937/pigpio)

## Purpose of using this:

It is a GPIO tool available on the [Ubuntu flavors for the Raspberry Pi](https://www.raspberrypi.com/software/operating-systems/). It allows for remote access and easy GPIO interaction.

## Links to Distribution Packages

Is this the correct way of specifying such a dependency?

- Debian: https://packages.debian.org/
  - REQUIRED -> None?
- Ubuntu: https://packages.ubuntu.com/
   - REQUIRED -> Only on raspberry-pi flavours
- Fedora: https://src.fedoraproject.org/browse/projects/
  - IF AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL