### PR TITLE
Revert "jderobot_drones: 1.3.9-1 in 'melodic/distribution.yaml' [bloo…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5018,11 +5018,10 @@ repositories:
       - jderobot_drones
       - rqt_drone_teleop
       - rqt_ground_robot_teleop
-      - tello_driver
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/JdeRobot/drones-release.git
-      version: 1.3.9-1
+      version: 1.3.8-1
     source:
       type: git
       url: https://github.com/JdeRobot/drones.git


### PR DESCRIPTION
…m] (#30999)"

This reverts commit 88bcc806a72b56a69dfd92b76b63b58268af2d54.

This has been failing to build on the buildfarm since it was merged: https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__drone_assets__ubuntu_bionic_amd64__binary/20/console .  @pariaspe FYI