### PR TITLE
webots_ros2: 1.1.2-3 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5870,13 +5870,10 @@ repositories:
     release:
       packages:
       - webots_ros2
-      - webots_ros2_abb
       - webots_ros2_control
       - webots_ros2_core
-      - webots_ros2_demos
       - webots_ros2_driver
       - webots_ros2_epuck
-      - webots_ros2_examples
       - webots_ros2_importer
       - webots_ros2_mavic
       - webots_ros2_msgs
@@ -5884,13 +5881,11 @@ repositories:
       - webots_ros2_tests
       - webots_ros2_tiago
       - webots_ros2_turtlebot
-      - webots_ros2_tutorials
       - webots_ros2_universal_robot
-      - webots_ros2_ur_e_description
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/cyberbotics/webots_ros2-release.git
-      version: 1.1.1-1
+      version: 1.1.2-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of packages in repository webots_ros2 to 1.1.2-2 for Foxy:

- upstream repository: https://github.com/cyberbotics/webots_ros2.git
- release repository: https://github.com/cyberbotics/webots_ros2-release.git
- rosdistro version: `1.1.1-1`
- old version: `1.1.2-1`
- new version: `1.1.2-2`

Versions of tools used:

- bloom version: `0.10.7`
- catkin_pkg version: `0.4.24`
- rosdep version: `0.21.0`
- rosdistro version: `0.8.3`
- vcstools version: `0.1.42`
