### PR TITLE
realtime_tools: 2.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3404,7 +3404,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros-gbp/realtime_tools-release.git
-      version: 2.1.1-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `2.2.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros-gbp/realtime_tools-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.1-1`

## realtime_tools

```
* Adding new reset() function for Issue-247.
* Contributors: bailaC
```
