### PR TITLE
rviz: 1.13.21-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12365,7 +12365,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.13.20-1
+      version: 1.13.21-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.13.21-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.13.20-1`

## rviz

```
* Fix scaling of PointVisual's sphere (#1678 <https://github.com/ros-visualization/rviz/issues/1678>)
* Fix assertion in billboard_line.cpp (#1674 <https://github.com/ros-visualization/rviz/issues/1674>)
* Drop unused rosbag dependency
* Contributors: Jochen Sprickerhof, Robert Haschke
```
