### PR TITLE
webots_ros2: 1.1.2-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4957,23 +4957,22 @@ repositories:
     release:
       packages:
       - webots_ros2
-      - webots_ros2_abb
+      - webots_ros2_control
       - webots_ros2_core
-      - webots_ros2_demos
+      - webots_ros2_driver
       - webots_ros2_epuck
-      - webots_ros2_examples
       - webots_ros2_importer
+      - webots_ros2_mavic
       - webots_ros2_msgs
       - webots_ros2_tesla
+      - webots_ros2_tests
       - webots_ros2_tiago
       - webots_ros2_turtlebot
-      - webots_ros2_tutorials
       - webots_ros2_universal_robot
-      - webots_ros2_ur_e_description
       tags:
         release: release/galactic/{package}/{version}
-      url: https://github.com/ros2-gbp/webots_ros2-release.git
-      version: 1.0.6-2
+      url: https://github.com/cyberbotics/webots_ros2-release.git
+      version: 1.1.2-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `webots_ros2` to `1.1.2-2`:

- upstream repository: https://github.com/cyberbotics/webots_ros2.git
- release repository: https://github.com/cyberbotics/webots_ros2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.6-2`

## webots_ros2

```
* Adapted the 'webots_ros2_driver' package to be also a python alternative to the 'webots_ros2_core' package.
* Replaced the use of the deprecated 'webots_ros2_core' package by the 'webots_ros2_driver' package.
* Removed the 'webots_ros2_example', 'webots_ros2_tutorials' and 'webots_ros2_abb' packages.
* Replaced the 'webots_ros2_tiago' package.
```

## webots_ros2_control

```
* Added code compliance for 'ROS Foxy'.
```

## webots_ros2_core

```
* This package is now deprecated.
```

## webots_ros2_driver

```
* Adapted the 'webots_ros2_driver' package to be also a python alternative to the 'webots_ros2_core' package.
```

## webots_ros2_epuck

```
* Utilize the 'webots_ros2_driver' and 'ros2_control' instead of 'webots_ros2_core'.
```

## webots_ros2_mavic

```
* Utilize the 'webots_ros2_driver' instead of 'webots_ros2_core'.
```

## webots_ros2_tesla

```
* Utilize the 'webots_ros2_driver' instead of 'webots_ros2_core'.
* Added code compliance for 'ROS Foxy'.
```

## webots_ros2_tiago

```
* Initial version (package replaced).
```

## webots_ros2_turtlebot

```
* Utilize the 'webots_ros2_driver' and 'ros2_control' instead of 'webots_ros2_core'.
```

## webots_ros2_universal_robot

```
* Utilize the 'webots_ros2_driver' and 'ros2_control' instead of 'webots_ros2_core'.
* Add MoveIt2 example.
* Upgrade the multi-robot example.
* Remove non-useful simulations.
```
