### PR TITLE
mavros: 1.10.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4113,7 +4113,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 1.9.0-1
+      version: 1.10.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `1.10.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.9.0-1`

## libmavconn

```
* Merge pull request #1626 <https://github.com/mavlink/mavros/issues/1626> from valbok/crash_on_shutdown
  Show ENOTCONN error instead of crash on socket's shutdown
* Show ENOTCONN error instead of crash
  When a client suddenly drops the connection,
  socket.shutdown() will throw an exception:
  boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::system::system_error> >
  what():  shutdown: Transport endpoint is not connected
  Showing an error in this common case looks more reasonable than crashing.
* Contributors: Val Doroshchuk, Vladimir Ermakov
```

## mavros

```
* Merge pull request #1626 <https://github.com/mavlink/mavros/issues/1626> from valbok/crash_on_shutdown
  Show ENOTCONN error instead of crash on socket's shutdown
* Merge pull request #1627 <https://github.com/mavlink/mavros/issues/1627> from marcelino-pensa/bug/ma-prevent-race-condition
  Node dying when calling /mavros/param/pull
* Remove reference
* Catch std::length_error in send_message
  Instead of crashing the process
* Merge pull request #1623 <https://github.com/mavlink/mavros/issues/1623> from amilcarlucas/pr/more-typo-fixes
  More typo fixes
* sys_time.cpp: typo
* Merge pull request #1622 <https://github.com/mavlink/mavros/issues/1622> from dayjaby/sys_time_pub_clock
  sys_time: publish /clock for simulation times
* sys_time: publish /clock for simulation times
* Contributors: David Jablonski, Dr.-Ing. Amilcar do Carmo Lucas, Marcelino Almeida, Val Doroshchuk, Vladimir Ermakov
```

## mavros_extras

```
* Merge pull request #1625 <https://github.com/mavlink/mavros/issues/1625> from scoutdi/tunnel-plugin
  Plugin for TUNNEL messages
* Tunnel: Check for invalid payload length
* mavros_extras: Create tunnel plugin
* Contributors: Morten Fyhn Amundsen, Vladimir Ermakov
```

## mavros_msgs

```
* msgs: update gpsraw to have yaw field
* Merge pull request #1625 <https://github.com/mavlink/mavros/issues/1625> from scoutdi/tunnel-plugin
  Plugin for TUNNEL messages
* Tunnel.msg: Generate enum with cog
* mavros_msgs: Add Tunnel message
* Merge pull request #1623 <https://github.com/mavlink/mavros/issues/1623> from amilcarlucas/pr/more-typo-fixes
  More typo fixes
* MountControl.msg: fix copy-paste
* Contributors: Dr.-Ing. Amilcar do Carmo Lucas, Morten Fyhn Amundsen, Vladimir Ermakov
```

## test_mavros

- No changes
