### PR TITLE
mavros: 2.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1569,11 +1569,12 @@ repositories:
       packages:
       - libmavconn
       - mavros
+      - mavros_extras
       - mavros_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 2.0.3-1
+      version: 2.0.4-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `2.0.4-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.3-1`

## libmavconn

```
* Merge branch 'master' into ros2
  * master:
  1.10.0
  prepare release
* 1.10.0
* prepare release
* mavconn: update to use std::error_code
* Merge branch 'master' into ros2
  * master: (25 commits)
  Remove reference
  Catch std::length_error in send_message
  Show ENOTCONN error instead of crash
  Tunnel: Check for invalid payload length
  Tunnel.msg: Generate enum with cog
  mavros_extras: Create tunnel plugin
  mavros_msgs: Add Tunnel message
  MountControl.msg: fix copy-paste
  sys_time.cpp: typo
  sys_time: publish /clock for simulation times
  1.9.0
  update changelog
  Spelling corrections
  Changed OverrideRCIn to 18 channels
  This adds functionality to erase all logs on the SD card via mavlink
  publish BATTERY2 message as /mavros/battery2 topic
  Mavlink v2.0 specs for RC_CHANNELS_OVERRIDE accepts upto 18 channels. The plugin publishes channels 9 to 18 if the FCU protocol version is 2.0
  Added NAV_CONTROLLER_OUTPUT Plugin
  Added GPS_INPUT plugin
  Update esc_status plugin with datatype change on MAVLink.
  ...
* Merge pull request #1626 <https://github.com/mavlink/mavros/issues/1626> from valbok/crash_on_shutdown
  Show ENOTCONN error instead of crash on socket's shutdown
* Show ENOTCONN error instead of crash
  When a client suddenly drops the connection,
  socket.shutdown() will throw an exception:
  boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::system::system_error> >
  what():  shutdown: Transport endpoint is not connected
  Showing an error in this common case looks more reasonable than crashing.
* 1.9.0
* update changelog
* Contributors: Val Doroshchuk, Vladimir Ermakov
```

## mavros

```
* Merge branch 'master' into ros2
  * master:
  1.10.0
  prepare release
* 1.10.0
* prepare release
* extras: port esc_status plugin
* plugins: update metadata xml
* mavros: port mav_controller_output plugin
* Merge branch 'master' into ros2
  * master: (25 commits)
  Remove reference
  Catch std::length_error in send_message
  Show ENOTCONN error instead of crash
  Tunnel: Check for invalid payload length
  Tunnel.msg: Generate enum with cog
  mavros_extras: Create tunnel plugin
  mavros_msgs: Add Tunnel message
  MountControl.msg: fix copy-paste
  sys_time.cpp: typo
  sys_time: publish /clock for simulation times
  1.9.0
  update changelog
  Spelling corrections
  Changed OverrideRCIn to 18 channels
  This adds functionality to erase all logs on the SD card via mavlink
  publish BATTERY2 message as /mavros/battery2 topic
  Mavlink v2.0 specs for RC_CHANNELS_OVERRIDE accepts upto 18 channels. The plugin publishes channels 9 to 18 if the FCU protocol version is 2.0
  Added NAV_CONTROLLER_OUTPUT Plugin
  Added GPS_INPUT plugin
  Update esc_status plugin with datatype change on MAVLink.
  ...
* Merge pull request #1631 <https://github.com/mavlink/mavros/issues/1631> from shubham-shahh/ros2
  rectified spelling and gramatical errors
* Update mission_protocol_base.cpp
* Update test_uas.cpp
* Update setpoint_raw.cpp
* Update param.cpp
* Update param.cpp
* Update mission_protocol_base.cpp
* Update ftp.cpp
* Update command.cpp
* Update param.py
* Merge pull request #1626 <https://github.com/mavlink/mavros/issues/1626> from valbok/crash_on_shutdown
  Show ENOTCONN error instead of crash on socket's shutdown
* Merge pull request #1627 <https://github.com/mavlink/mavros/issues/1627> from marcelino-pensa/bug/ma-prevent-race-condition
  Node dying when calling /mavros/param/pull
* Remove reference
* Catch std::length_error in send_message
  Instead of crashing the process
* Merge pull request #1623 <https://github.com/mavlink/mavros/issues/1623> from amilcarlucas/pr/more-typo-fixes
  More typo fixes
* sys_time.cpp: typo
* Merge pull request #1622 <https://github.com/mavlink/mavros/issues/1622> from dayjaby/sys_time_pub_clock
  sys_time: publish /clock for simulation times
* sys_time: publish /clock for simulation times
* 1.9.0
* update changelog
* Merge pull request #1616 <https://github.com/mavlink/mavros/issues/1616> from amilcarlucas/pr/RC_CHANNELS-mavlink2-extensions
  Mavlink v2.0 specs for RC_CHANNELS_OVERRIDE accepts upto 18 channels.…
* Changed OverrideRCIn to 18 channels
* Merge pull request #1617 <https://github.com/mavlink/mavros/issues/1617> from amilcarlucas/pr/NAV_CONTROLLER_OUTPUT-plugin
  Added NAV_CONTROLLER_OUTPUT Plugin
* Merge pull request #1619 <https://github.com/mavlink/mavros/issues/1619> from amilcarlucas/pr/BATTERY2-topic
  publish BATTERY2 message as /mavros/battery2 topic
* publish BATTERY2 message as /mavros/battery2 topic
* Mavlink v2.0 specs for RC_CHANNELS_OVERRIDE accepts upto 18 channels. The plugin publishes channels 9 to 18 if the FCU protocol version is 2.0
* Added NAV_CONTROLLER_OUTPUT Plugin
* Merge branch 'master' into master
* plugins: fix lint error
* extras: fix build, add UAS::send_massage(msg, compid)
* extras: port companion_process_status
* style: apply ament_uncrustify --reformat
* Merge branch 'master' into ros2
  * master:
  extras: esc_telemetry: fix build
  extras: fix esc_telemetry centi-volt/amp conversion
  extras: uncrustify all plugins
  plugins: reformat xml
  extras: reformat plugins xml
  extras: fix apm esc_telemetry
  msgs: fix types for apm's esc telemetry
  actually allocate memory for the telemetry information
  fixed some compile errors
  added esc_telemetry plugin
  Reset calibration flag when re-calibrating. Prevent wrong data output.
  Exclude changes to launch files.
  Delete debug files.
  Apply uncrustify changes.
  Set progress array to global to prevent erasing data.
  Move Compass calibration report to extras. Rewrite code based on instructions.
  Remove extra message from CMakeLists.
  Add message and service definition.
  Add compass calibration feedback status. Add service to call the 'Next' button in calibrations.
* plugins: reformat xml
* mavros_extras: ported landing_target plugin to ros2
* sanitized code
* Exclude changes to launch files.
* Delete debug files.
* Apply uncrustify changes.
* Move Compass calibration report to extras. Rewrite code based on instructions.
* Add compass calibration feedback status. Add service to call the 'Next' button in calibrations.
* Contributors: André Filipe, BV-OpenSource, David Jablonski, Dr.-Ing. Amilcar do Carmo Lucas, Karthik Desai, Marcelino Almeida, Shubham Shah, Val Doroshchuk, Vladimir Ermakov
```

## mavros_extras

```
* Merge branch 'master' into ros2
  * master:
  1.10.0
  prepare release
* 1.10.0
* prepare release
* extras: remove safety_area as outdated
* extras: port esc_telemetry
* extras: port esc_status plugin
* extras: porting gps_status
* Merge branch 'master' into ros2
  * master: (25 commits)
  Remove reference
  Catch std::length_error in send_message
  Show ENOTCONN error instead of crash
  Tunnel: Check for invalid payload length
  Tunnel.msg: Generate enum with cog
  mavros_extras: Create tunnel plugin
  mavros_msgs: Add Tunnel message
  MountControl.msg: fix copy-paste
  sys_time.cpp: typo
  sys_time: publish /clock for simulation times
  1.9.0
  update changelog
  Spelling corrections
  Changed OverrideRCIn to 18 channels
  This adds functionality to erase all logs on the SD card via mavlink
  publish BATTERY2 message as /mavros/battery2 topic
  Mavlink v2.0 specs for RC_CHANNELS_OVERRIDE accepts upto 18 channels. The plugin publishes channels 9 to 18 if the FCU protocol version is 2.0
  Added NAV_CONTROLLER_OUTPUT Plugin
  Added GPS_INPUT plugin
  Update esc_status plugin with datatype change on MAVLink.
  ...
* Merge pull request #1625 <https://github.com/mavlink/mavros/issues/1625> from scoutdi/tunnel-plugin
  Plugin for TUNNEL messages
* Tunnel: Check for invalid payload length
* mavros_extras: Create tunnel plugin
* Merge pull request #1605 <https://github.com/mavlink/mavros/issues/1605> from Peter010103/ros2
  mavros_extras: Ported vision_pose_estimate plugin for ROS2
* 1.9.0
* update changelog
* Merge pull request #1621 <https://github.com/mavlink/mavros/issues/1621> from amilcarlucas/pr/mount-control-spelling
  Spelling corrections
* Spelling corrections
* Merge pull request #1615 <https://github.com/mavlink/mavros/issues/1615> from amilcarlucas/pr/erase-logs
  This adds functionality to erase all logs on the SD card via mavlink
* Merge pull request #1618 <https://github.com/mavlink/mavros/issues/1618> from amilcarlucas/pr/GPS_INPUT-plugin
  Added GPS_INPUT plugin
* This adds functionality to erase all logs on the SD card via mavlink
* Added GPS_INPUT plugin
* Merge pull request #1606 <https://github.com/mavlink/mavros/issues/1606> from BV-OpenSource/master
  Add Mount angles message for communications with ardupilotmega.
* Merge branch 'master' into master
* Update esc_status plugin with datatype change on MAVLink.
  ESC_INFO MAVLink message was updated to have negative temperates and also at a different resolution. This commit updates those changes on this side.
* Convert status data from cdeg to rad.
* Publish quaternion information with Mount Status mavlink message.
* Add missing subscription.
* extras: port cam_imu_sync
* extras: re-generate cog
* extras: port debug_value
* Remove Mount_Status plugin. Add Status data to Mount_Control plugin. Remove Mount_Status message.
* extras: fix build, add UAS::send_massage(msg, compid)
* extras: port companion_process_status
* msgs: re-generate file lists
* style: apply ament_uncrustify --reformat
* Merge branch 'master' into ros2
  * master:
  extras: esc_telemetry: fix build
  extras: fix esc_telemetry centi-volt/amp conversion
  extras: uncrustify all plugins
  plugins: reformat xml
  extras: reformat plugins xml
  extras: fix apm esc_telemetry
  msgs: fix types for apm's esc telemetry
  actually allocate memory for the telemetry information
  fixed some compile errors
  added esc_telemetry plugin
  Reset calibration flag when re-calibrating. Prevent wrong data output.
  Exclude changes to launch files.
  Delete debug files.
  Apply uncrustify changes.
  Set progress array to global to prevent erasing data.
  Move Compass calibration report to extras. Rewrite code based on instructions.
  Remove extra message from CMakeLists.
  Add message and service definition.
  Add compass calibration feedback status. Add service to call the 'Next' button in calibrations.
* extras: esc_telemetry: fix build
* extras: fix esc_telemetry centi-volt/amp conversion
* extras: uncrustify all plugins
* extras: reformat plugins xml
* extras: fix apm esc_telemetry
* actually allocate memory for the telemetry information
* fixed some compile errors
* added esc_telemetry plugin
* Add Mount angles message for communications with ardupilotmega.
* Added subscriber callback function for ROS2
* Added initialise function in vision_pose_estimate
* Boilerplate vision_pose_estimate plugin
* extras: landing_target: disable tf listener, it segfaults
* extras: regenerate plugins xml, ament_uncrustify
* mavros_extras: improve landing_target logging
* mavros_extras: ported landing_target plugin to ros2
* Reset calibration flag when re-calibrating. Prevent wrong data output.
* Delete debug files.
* Apply uncrustify changes.
* Set progress array to global to prevent erasing data.
* Move Compass calibration report to extras. Rewrite code based on instructions.
* extras: port 3dr radio
* extras: add urdf package
* extras: adsb: begin porting to ros2
* Contributors: Abhijith Thottumadayil Jagadeesh, André Filipe, David Jablonski, Dr.-Ing. Amilcar do Carmo Lucas, Karthik Desai, Morten Fyhn Amundsen, Peter010103, Ricardo Marques, Russell, Vladimir Ermakov
```

## mavros_msgs

```
* Merge branch 'master' into ros2
  * master:
  1.10.0
  prepare release
* 1.10.0
* prepare release
* Merge branch 'master' into ros2
  * master:
  msgs: update gpsraw to have yaw field
* msgs: update gpsraw to have yaw field
* Merge branch 'master' into ros2
  * master: (25 commits)
  Remove reference
  Catch std::length_error in send_message
  Show ENOTCONN error instead of crash
  Tunnel: Check for invalid payload length
  Tunnel.msg: Generate enum with cog
  mavros_extras: Create tunnel plugin
  mavros_msgs: Add Tunnel message
  MountControl.msg: fix copy-paste
  sys_time.cpp: typo
  sys_time: publish /clock for simulation times
  1.9.0
  update changelog
  Spelling corrections
  Changed OverrideRCIn to 18 channels
  This adds functionality to erase all logs on the SD card via mavlink
  publish BATTERY2 message as /mavros/battery2 topic
  Mavlink v2.0 specs for RC_CHANNELS_OVERRIDE accepts upto 18 channels. The plugin publishes channels 9 to 18 if the FCU protocol version is 2.0
  Added NAV_CONTROLLER_OUTPUT Plugin
  Added GPS_INPUT plugin
  Update esc_status plugin with datatype change on MAVLink.
  ...
* Merge pull request #1625 <https://github.com/mavlink/mavros/issues/1625> from scoutdi/tunnel-plugin
  Plugin for TUNNEL messages
* Tunnel.msg: Generate enum with cog
* mavros_msgs: Add Tunnel message
* Merge pull request #1623 <https://github.com/mavlink/mavros/issues/1623> from amilcarlucas/pr/more-typo-fixes
  More typo fixes
* MountControl.msg: fix copy-paste
* 1.9.0
* update changelog
* Merge pull request #1616 <https://github.com/mavlink/mavros/issues/1616> from amilcarlucas/pr/RC_CHANNELS-mavlink2-extensions
  Mavlink v2.0 specs for RC_CHANNELS_OVERRIDE accepts upto 18 channels.…
* Changed OverrideRCIn to 18 channels
* Merge pull request #1617 <https://github.com/mavlink/mavros/issues/1617> from amilcarlucas/pr/NAV_CONTROLLER_OUTPUT-plugin
  Added NAV_CONTROLLER_OUTPUT Plugin
* Merge pull request #1618 <https://github.com/mavlink/mavros/issues/1618> from amilcarlucas/pr/GPS_INPUT-plugin
  Added GPS_INPUT plugin
* Mavlink v2.0 specs for RC_CHANNELS_OVERRIDE accepts upto 18 channels. The plugin publishes channels 9 to 18 if the FCU protocol version is 2.0
* Added NAV_CONTROLLER_OUTPUT Plugin
* Added GPS_INPUT plugin
* Merge branch 'master' into master
* Update esc_status plugin with datatype change on MAVLink.
  ESC_INFO MAVLink message was updated to have negative temperates and also at a different resolution. This commit updates those changes on this side.
* Remove Mount_Status plugin. Add Status data to Mount_Control plugin. Remove Mount_Status message.
* msgs: re-generate file lists
* Merge branch 'master' into ros2
  * master:
  extras: esc_telemetry: fix build
  extras: fix esc_telemetry centi-volt/amp conversion
  extras: uncrustify all plugins
  plugins: reformat xml
  extras: reformat plugins xml
  extras: fix apm esc_telemetry
  msgs: fix types for apm's esc telemetry
  actually allocate memory for the telemetry information
  fixed some compile errors
  added esc_telemetry plugin
  Reset calibration flag when re-calibrating. Prevent wrong data output.
  Exclude changes to launch files.
  Delete debug files.
  Apply uncrustify changes.
  Set progress array to global to prevent erasing data.
  Move Compass calibration report to extras. Rewrite code based on instructions.
  Remove extra message from CMakeLists.
  Add message and service definition.
  Add compass calibration feedback status. Add service to call the 'Next' button in calibrations.
* msgs: fix types for apm's esc telemetry
* actually allocate memory for the telemetry information
* added esc_telemetry plugin
* Add Mount angles message for communications with ardupilotmega.
* Remove extra message from CMakeLists.
* Add message and service definition.
* Contributors: Abhijith Thottumadayil Jagadeesh, André Filipe, Dr.-Ing. Amilcar do Carmo Lucas, Karthik Desai, Morten Fyhn Amundsen, Ricardo Marques, Russell, Vladimir Ermakov
```
