### PR TITLE
jderobot_drones: 1.3.10-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5018,10 +5018,11 @@ repositories:
       - jderobot_drones
       - rqt_drone_teleop
       - rqt_ground_robot_teleop
+      - tello_driver
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/JdeRobot/drones-release.git
-      version: 1.3.8-1
+      version: 1.3.10-1
     source:
       type: git
       url: https://github.com/JdeRobot/drones.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_drones` to `1.3.10-1`:

- upstream repository: https://github.com/JdeRobot/drones.git
- release repository: https://github.com/JdeRobot/drones-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.3.8-1`

## drone_assets

```
* Adding gazebo_ros dependency
* Contributors: pariaspe
```

## drone_wrapper

```
* Takeoff returns if drone is flying or taking off
* Contributors: pariaspe
```

## jderobot_drones

```
* Fix jenkins builb in drone_assets
* Made takeoff idempotent
* Contributors: pariaspe
```

## rqt_drone_teleop

- No changes

## rqt_ground_robot_teleop

- No changes

## tello_driver

- No changes
