### PR TITLE
ros2_control: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2997,7 +2997,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `1.2.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.0-1`

## controller_interface

- No changes

## controller_manager

- No changes

## controller_manager_msgs

- No changes

## hardware_interface

```
* Import and Initialize components (#566 <https://github.com/ros-controls/ros2_control/issues/566>)
* Contributors: Alejandro Hernández Cordero
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Add verbose flag to CLI command list_controllers (#569 <https://github.com/ros-controls/ros2_control/issues/569>)
* Contributors: Xi-Huang
```

## transmission_interface

- No changes
