### PR TITLE
mesh_navigation: 1.0.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4173,6 +4173,7 @@ repositories:
       version: master
     release:
       packages:
+      - cvp_mesh_planner
       - dijkstra_mesh_planner
       - mbf_mesh_core
       - mbf_mesh_nav
@@ -4181,11 +4182,10 @@ repositories:
       - mesh_layers
       - mesh_map
       - mesh_navigation
-      - wave_front_planner
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/uos-gbp/mesh_navigation-release.git
-      version: 1.0.0-2
+      version: 1.0.1-2
     source:
       type: git
       url: https://github.com/uos/mesh_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mesh_navigation` to `1.0.1-2`:

- upstream repository: https://github.com/uos/mesh_navigation.git
- release repository: https://github.com/uos-gbp/mesh_navigation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.0-2`

## cvp_mesh_planner

```
* rename to cvp_mesh_planner
```

## dijkstra_mesh_planner

- No changes

## mbf_mesh_core

- No changes

## mbf_mesh_nav

- No changes

## mesh_client

- No changes

## mesh_controller

- No changes

## mesh_layers

- No changes

## mesh_map

- No changes

## mesh_navigation

```
* rename to cvp_mesh_planner
```
