### PR TITLE
rviz: 1.14.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8166,7 +8166,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.14.10-1
+      version: 1.14.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.14.11-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.14.10-1`

## rviz

```
* AxisDisplay: allow ribbon trail (#1677 <https://github.com/ros-visualization/rviz/issues/1677>)
* Silent warning about .skeleton files not found (#1679 <https://github.com/ros-visualization/rviz/issues/1679>)
* Fix scaling of PointVisual's sphere (#1678 <https://github.com/ros-visualization/rviz/issues/1678>)
* Fix assertion in billboard_line.cpp (#1674 <https://github.com/ros-visualization/rviz/issues/1674>)
* Fix cross-platform compatibility (#1636 <https://github.com/ros-visualization/rviz/issues/1636>)
* Fix compilation with OGRE 1.12
* Drop unused rosbag dependency
* Contributors: Christian Rauch, Jochen Sprickerhof, Robert Haschke, Timo Röhling, Tobias Fischer
```
