### PR TITLE
rosmsg_cpp: 1.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7448,6 +7448,21 @@ repositories:
       url: https://github.com/xqms/rosmon.git
       version: master
     status: developed
+  rosmsg_cpp:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/rosmsg_cpp.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ctu-vras/rosmsg_cpp-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ctu-vras/rosmsg_cpp.git
+      version: master
+    status: developed
   rospack:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosmsg_cpp` to `1.0.1-1`:

- upstream repository: https://github.com/ctu-vras/rosmsg_cpp.git
- release repository: https://github.com/ctu-vras/rosmsg_cpp-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
