### PR TITLE
rosidl: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3326,7 +3326,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 2.5.0-1
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `3.0.0-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.5.0-1`

## rosidl_adapter

```
* Update package maintainers (#624 <https://github.com/ros2/rosidl/issues/624>)
* Make rosidl packages use FindPython3 instead of FindPythonInterp (#612 <https://github.com/ros2/rosidl/issues/612>)
* Contributors: Michel Hidalgo, Shane Loretz
```

## rosidl_cli

```
* Update package maintainers (#624 <https://github.com/ros2/rosidl/issues/624>)
* Contributors: Michel Hidalgo
```

## rosidl_cmake

```
* Update package maintainers (#624 <https://github.com/ros2/rosidl/issues/624>)
* Contributors: Michel Hidalgo
```

## rosidl_generator_c

```
* Update package maintainers (#624 <https://github.com/ros2/rosidl/issues/624>)
* Make rosidl packages use FindPython3 instead of FindPythonInterp (#612 <https://github.com/ros2/rosidl/issues/612>)
* Contributors: Michel Hidalgo, Shane Loretz
```

## rosidl_generator_cpp

```
* Update package maintainers (#624 <https://github.com/ros2/rosidl/issues/624>)
* Make rosidl packages use FindPython3 instead of FindPythonInterp (#612 <https://github.com/ros2/rosidl/issues/612>)
* Contributors: Michel Hidalgo, Shane Loretz
```

## rosidl_parser

```
* Update package maintainers (#624 <https://github.com/ros2/rosidl/issues/624>)
* Contributors: Michel Hidalgo
```

## rosidl_runtime_c

```
* Update package maintainers (#624 <https://github.com/ros2/rosidl/issues/624>)
* Contributors: Michel Hidalgo
```

## rosidl_runtime_cpp

```
* Update package maintainers (#624 <https://github.com/ros2/rosidl/issues/624>)
* Contributors: Michel Hidalgo
```

## rosidl_typesupport_interface

```
* Update package maintainers (#624 <https://github.com/ros2/rosidl/issues/624>)
* Contributors: Michel Hidalgo
```

## rosidl_typesupport_introspection_c

```
* Fix up the documentation for rosidl_typesupport_introspection_c (#628 <https://github.com/ros2/rosidl/issues/628>)
* Update package maintainers (#624 <https://github.com/ros2/rosidl/issues/624>)
* Quality Declaration for typesupport_introspection (#621 <https://github.com/ros2/rosidl/issues/621>)
* Make rosidl packages use FindPython3 instead of FindPythonInterp (#612 <https://github.com/ros2/rosidl/issues/612>)
* Contributors: Chris Lalancette, Michel Hidalgo, Shane Loretz, eboasson
```

## rosidl_typesupport_introspection_cpp

```
* Fix up the documentation for rosidl_typesupport_introspection_cpp (#627 <https://github.com/ros2/rosidl/issues/627>)
* Update package maintainers (#624 <https://github.com/ros2/rosidl/issues/624>)
* Quality Declaration for typesupport_introspection (#621 <https://github.com/ros2/rosidl/issues/621>)
* Make rosidl packages use FindPython3 instead of FindPythonInterp (#612 <https://github.com/ros2/rosidl/issues/612>)
* Contributors: Chris Lalancette, Michel Hidalgo, Shane Loretz, eboasson
```
