### PR TITLE
ros1_bridge: 0.10.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2972,7 +2972,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros1_bridge-release.git
-      version: 0.10.1-1
+      version: 0.10.2-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros1_bridge` to `0.10.2-1`:

- upstream repository: https://github.com/ros2/ros1_bridge.git
- release repository: https://github.com/ros2-gbp/ros1_bridge-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.10.1-1`

## ros1_bridge

```
* Example for parameter_bridge (#330 <https://github.com/ros2/ros1_bridge/issues/330>)
* Use rcpputils/scope_exit.hpp instead of rclcpp/scope_exit.hpp (#324 <https://github.com/ros2/ros1_bridge/issues/324>)
* Use FindPython3 and make Python dependency explicit (#322 <https://github.com/ros2/ros1_bridge/issues/322>)
* Bump mailto:ros-tooling/setup-ros@v0.2 (#323 <https://github.com/ros2/ros1_bridge/issues/323>)
* Add GitHub workflow for CI (#310 <https://github.com/ros2/ros1_bridge/issues/310>)
* Update includes after rcutils/get_env.h deprecation (#311 <https://github.com/ros2/ros1_bridge/issues/311>)
* Contributors: Christophe Bedard, Harsh Deshpande, Loy, Shane Loretz
```
