### PR TITLE
paho-mqtt-cpp: 1.2.0-4 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5369,7 +5369,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/nobleo/paho.mqtt.cpp-release.git
-      version: 1.2.0-3
+      version: 1.2.0-4
     source:
       type: git
       url: https://github.com/eclipse/paho.mqtt.cpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `paho-mqtt-cpp` to `1.2.0-4`:

- upstream repository: https://github.com/eclipse/paho.mqtt.cpp.git
- release repository: https://github.com/nobleo/paho.mqtt.cpp-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.0-3`
