### PR TITLE
moveit_resources: 0.8.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4523,7 +4523,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit_resources-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_resources.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `0.8.1-1`:

- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros-gbp/moveit_resources-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.8.0-1`

## moveit_resources

- No changes

## moveit_resources_fanuc_description

- No changes

## moveit_resources_fanuc_moveit_config

```
* Rename launch parameter ``execution_type`` -> ``fake_execution_type`` to clarify that it is only used for fake controllers
* Replace ``$(find moveit_resources\_*_moveit_config)/launch/*`` -> ``$(dirname)/*``
* Introduce ``prbt_moveit_config/launch/test_environment.launch``
* Minor fixes (#90 <https://github.com/ros-planning/moveit_resources/issues/90>)
  * CHOMP parameter ``collision_clearance`` got renamed (fixed typo)
  * Fix empty sensors_3d.yaml
  * ``setup_assistant.launch``: require MSA node
* Contributors: Michael Görner, Robert Haschke
```

## moveit_resources_panda_description

- No changes

## moveit_resources_panda_moveit_config

```
* Recreated moveit_resources_panda_moveit_config with latest MSA (#92 <https://github.com/ros-planning/moveit_resources/issues/92>)
* Rename launch parameter ``execution_type`` -> ``fake_execution_type`` to clarify that it is only used for fake controllers
* Replace ``$(find moveit_resources\_*_moveit_config)/launch/*`` -> ``$(dirname)/*``
* Introduce ``prbt_moveit_config/launch/test_environment.launch``
* Remove TrajOpt planner config from OMPL pipeline (#85 <https://github.com/ros-planning/moveit_resources/issues/85>)
* Minor fixes (#90 <https://github.com/ros-planning/moveit_resources/issues/90>)
  * CHOMP parameter ``collision_clearance`` got renamed (fixed typo)
  * Fix empty sensors_3d.yaml
  * ``setup_assistant.launch``: require MSA node
* Contributors: Captain Yoshi, Michael Görner, Robert Haschke
```

## moveit_resources_pr2_description

- No changes

## moveit_resources_prbt_ikfast_manipulator_plugin

```
* Disable clang-tidy for ikfast package
* Contributors: Robert Haschke
```

## moveit_resources_prbt_moveit_config

```
* Remove deprecated xacro ``--inorder`` flag
* Rename launch parameter ``execution_type`` -> ``fake_execution_type`` to clarify that it is only used for fake controllers
* Replace ``$(find moveit_resources\_*_moveit_config)/launch/*`` -> ``$(dirname)/*``
* Introduce ``prbt_moveit_config/launch/test_environment.launch``
* Contributors: Robert Haschke
```

## moveit_resources_prbt_pg70_support

```
* Rename launch parameter ``execution_type`` -> ``fake_execution_type`` to clarify that it is only used for fake controllers
* Contributors: Robert Haschke
```

## moveit_resources_prbt_support

```
* Drop all test code
* Contributors: Michael Görner, Robert Haschke
```
