### PR TITLE
moveit: 1.1.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4442,7 +4442,11 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 1.1.5-1
+      version: 1.1.6-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit.git
+      version: master
     status: maintained
   moveit_calibration:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `1.1.6-1`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.5-1`

## chomp_motion_planner

```
* Use newly introduced cmake macro ``moveit_build_options()`` from ``moveit_core``
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* CHOMP: Rename param 'clearence' to 'clearance' (#2702 <https://github.com/ros-planning/moveit/issues/2702>, #2707 <https://github.com/ros-planning/moveit/issues/2707>)
* Contributors: Martin Günther, Michael Görner, Robert Haschke, pvanlaar
```

## moveit

- No changes

## moveit_chomp_optimizer_adapter

```
* Use newly introduced cmake macro ``moveit_build_options()`` from ``moveit_core``
* CHOMP: Rename param 'clearence' to 'clearance' (#2702 <https://github.com/ros-planning/moveit/issues/2702>, #2707 <https://github.com/ros-planning/moveit/issues/2707>)
* Contributors: Martin Günther, Michael Görner, Robert Haschke
```

## moveit_commander

```
* Use relative imports (#2912 <https://github.com/ros-planning/moveit/issues/2912>)
* Fix trajectory constraints (#2429 <https://github.com/ros-planning/moveit/issues/2429>)
* Fix ``get_planning_pipeline_id`` in Python MGI (#2753 <https://github.com/ros-planning/moveit/issues/2753>)
* Contributors: Felix von Drigalski, Kevin Chang, Michael Görner, Robert Haschke
```

## moveit_core

```
* Silent warning about invalid ``virtual_joint`` in Gazebo setups
* Add ``RobotState::getRigidlyConnectedParentLinkModel`` #2918 <https://github.com/ros-planning/moveit/issues/2918> (add RobotState::getRigidlyAttachedParentLink)
* Normalize incoming transforms (#2920 <https://github.com/ros-planning/moveit/issues/2920>)
* Reworked compiler flags and fixed various warnings (#2915 <https://github.com/ros-planning/moveit/issues/2915>)
  
    * Remove unused arguments from global_adjustment_factor()
    * Simplify API: Remove obviously unused arguments
    * Introduced cmake macro ``moveit_build_options()`` in ``moveit_core`` to centrally define
      common build options like ``CMAKE_CXX_STANDARD``, ``CMAKE_BUILD_TYPE``, and compiler warning flags
  
* Fix uninitialized orientation in default shape pose (#2896 <https://github.com/ros-planning/moveit/issues/2896>)
* Drop the minimum velocity/acceleration limits for TOTG (#2937 <https://github.com/ros-planning/moveit/issues/2937>)
* Readability and consistency improvements in TOTG (#2882 <https://github.com/ros-planning/moveit/issues/2882>)
* Bullet collision: Consider ACM defaults using ``getAllowedCollision()`` (#2871 <https://github.com/ros-planning/moveit/issues/2871>)
* ``PlanningScene::getPlanningSceneDiffMsg()``: Do not list an object as destroyed when it got attached (#2864 <https://github.com/ros-planning/moveit/issues/2864>)The information in the diff is redundant because attaching implies the removal from the PlanningScene.
  In the unlikely case, you relied on the ``REMOVE`` entry in the diff message,
  use the newly attached collision object to indicate the same instead.
* Fix Bullet collision: Register ``notify`` function to receive world updates (#2830 <https://github.com/ros-planning/moveit/issues/2830>)
* Split CollisionPluginLoader (#2834 <https://github.com/ros-planning/moveit/issues/2834>)To avoid circular dependencies, but enable reuse of the ``CollisionPluginLoader``, the non-ROS part was moved into ``moveit_core/moveit_collision_detection.so``
  and the ROS part (reading the plugin name from the parameter server) into ``moveit_ros_planning/moveit_collision_plugin_loader.so`` (as before).
* Use default copy constructor to clone attached objects (#2855 <https://github.com/ros-planning/moveit/issues/2855>)
* Fix pose-not-set-bug (#2852 <https://github.com/ros-planning/moveit/issues/2852>)
* Add API for passing a ``RNG`` to ``setToRandomPositionsNearBy()`` (#2799 <https://github.com/ros-planning/moveit/issues/2799>)
* Fix backwards compatibility for specifying poses for a single collision shape (#2816 <https://github.com/ros-planning/moveit/issues/2816>)
* Fix Bullet collision returning wrong contact type (#2829 <https://github.com/ros-planning/moveit/issues/2829>)
* Add ``RobotState::setToDefaultValues(string group)`` (#2828 <https://github.com/ros-planning/moveit/issues/2828>)
* Fix confusion of tolerance limits in JointConstraint (#2815 <https://github.com/ros-planning/moveit/issues/2815>)
* Fix RobotState constructor segfault (#2790 <https://github.com/ros-planning/moveit/issues/2790>)
* Preserve metadata (color, type) when detaching objects (#2814 <https://github.com/ros-planning/moveit/issues/2814>)
* Introduce a reference frame for collision objects (#2037 <https://github.com/ros-planning/moveit/issues/2037>)``CollisionObject`` messages are now defined with a ``Pose``. Shapes and subframes are defined relative to that pose.
  This makes it easier to place objects with subframes and multiple shapes in the scene.
  This causes several changes:
  
    * ``getFrameTransform()`` now returns this pose instead of the first shape's pose.
    * The Rviz plugin's manipulation tab now uses the object's pose instead of the shape pose to evaluate if object's are in the region of interest.
    * PlanningScene geometry text files (``.scene``) have changed format.Add a line ``0 0 0 0 0 0 1`` under each line with an asterisk to upgrade old files if required.
  
* Fix bullet plugin library path name (#2783 <https://github.com/ros-planning/moveit/issues/2783>)
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* ``RobotTrajectory``: convenience constructor + chain setter support (#2751 <https://github.com/ros-planning/moveit/issues/2751>)
* Fix Windows build (#2604 <https://github.com/ros-planning/moveit/issues/2604>, #2776 <https://github.com/ros-planning/moveit/issues/2776>)
* Allow axis-angle representation for orientation constraints (#2402 <https://github.com/ros-planning/moveit/issues/2402>)
* Optimization: ``reserve()`` vector in advance (#2732 <https://github.com/ros-planning/moveit/issues/2732>)
* Use same padding/scale for attached collision objects as for parent link (#2721 <https://github.com/ros-planning/moveit/issues/2721>)
* Optimize ``FCL distanceCallback()``: use thread_local vars, avoid copying (#2698 <https://github.com/ros-planning/moveit/issues/2698>)
* Remove octomap from catkin_packages ``LIBRARIES`` entry (#2700 <https://github.com/ros-planning/moveit/issues/2700>)
* Remove deprecated header ``deprecation.h`` (#2693 <https://github.com/ros-planning/moveit/issues/2693>)
* ``collision_detection_fcl``: Report link_names in correct order (#2682 <https://github.com/ros-planning/moveit/issues/2682>)
* Move ``OccMapTree`` to ``moveit_core/collision_detection`` (#2684 <https://github.com/ros-planning/moveit/issues/2684>)
* Contributors: 0Nel, AndyZe, Captain Yoshi, Felix von Drigalski, Jafar Abdi, Jeroen, Jochen Sprickerhof, John Stechschulte, Jonathan Grebe, Max Schwarz, Michael Görner, Michael Wiznitzer, Peter Mitrano, Robert Haschke, Silvio Traversaro, Simon Schmeisser, Tobias Fischer, Tyler Weaver, Wolf Vollprecht, Yuri Rocha, pvanlaar, toru-kuga, v4hn, werner291
```

## moveit_fake_controller_manager

```
* Use newly introduced cmake macro ``moveit_build_options()`` from ``moveit_core``
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Contributors: Robert Haschke, pvanlaar
```

## moveit_kinematics

```
* Use newly introduced cmake macro ``moveit_build_options()`` from ``moveit_core``
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Contributors: Robert Haschke, pvanlaar
```

## moveit_planners

- No changes

## moveit_planners_chomp

```
* Use test_environment.launch in unittests (#2949 <https://github.com/ros-planning/moveit/issues/2949>)
* Use newly introduced cmake macro ``moveit_build_options()`` from ``moveit_core``
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* CHOMP: Rename param 'clearence' to 'clearance' (#2702 <https://github.com/ros-planning/moveit/issues/2702>, #2707 <https://github.com/ros-planning/moveit/issues/2707>)
* Contributors: Martin Günther, Michael Görner, Robert Haschke, pvanlaar
```

## moveit_planners_ompl

```
* Use newly introduced cmake macro ``moveit_build_options()`` from ``moveit_core``
* Fix ConstrainedGoalSampler (#2811 <https://github.com/ros-planning/moveit/issues/2811>): actually call ``sample()`` (#2872 <https://github.com/ros-planning/moveit/issues/2872>)
* Provide override for missing isValid method (#2802 <https://github.com/ros-planning/moveit/issues/2802>)
* Add missing dependencies to generated dynamic_reconfigure headers (#2772 <https://github.com/ros-planning/moveit/issues/2772>)
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Contributors: Mathias Lüdtke, Michael Görner, Robert Haschke, pvanlaar, v4hn, werner291
```

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

```
* Use newly introduced cmake macro ``moveit_build_options()`` from ``moveit_core``
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Fix predefined poses benchmark example (#2718 <https://github.com/ros-planning/moveit/issues/2718>)
* Contributors: Captain Yoshi, Robert Haschke
```

## moveit_ros_control_interface

```
* Use newly introduced cmake macro ``moveit_build_options()`` from ``moveit_core``
* Fix reversed check in switchControllers (#2726 <https://github.com/ros-planning/moveit/issues/2726>)
* Contributors: Nathan Brooks, Robert Haschke
```

## moveit_ros_manipulation

```
* Use newly introduced cmake macro ``moveit_build_options()`` from ``moveit_core``
* Introduce a reference frame for collision objects (#2037 <https://github.com/ros-planning/moveit/issues/2037>)
* Add missing dependencies to generated dynamic_reconfigure headers (#2772 <https://github.com/ros-planning/moveit/issues/2772>)
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Contributors: Felix von Drigalski, Mathias Lüdtke, Robert Haschke, pvanlaar
```

## moveit_ros_move_group

```
* Use newly introduced cmake macro ``moveit_build_options()`` from ``moveit_core``
* Introduce a reference frame for collision objects (#2037 <https://github.com/ros-planning/moveit/issues/2037>)
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Contributors: Felix von Drigalski, Robert Haschke, pvanlaar
```

## moveit_ros_occupancy_map_monitor

```
* Use newly introduced cmake macro ``moveit_build_options()`` from ``moveit_core``
* Prefer ``std::make_shared`` over ``new`` operator (#2756 <https://github.com/ros-planning/moveit/issues/2756>)
* Add missing ``OCTOMAP_INCLUDE_DIRS`` (#2671 <https://github.com/ros-planning/moveit/issues/2671>)
* Move ``OccMapTree`` to ``moveit_core/collision_detection`` (#2684 <https://github.com/ros-planning/moveit/issues/2684>)
* Contributors: 0Nel, Michael Görner, Robert Haschke, Simon Schmeisser, Tyler Weaver
```

## moveit_ros_perception

```
* Use newly introduced cmake macro ``moveit_build_options()`` from ``moveit_core``
* Fix clipping of points: only considered points up to ``max_range`` (#2848 <https://github.com/ros-planning/moveit/issues/2848>)
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Move ``OccMapTree`` to ``moveit_core/collision_detection`` (#2684 <https://github.com/ros-planning/moveit/issues/2684>)
* Contributors: Michael Görner, Robert Haschke, Simon Schmeisser, Tyler Weaver, pvanlaar
```

## moveit_ros_planning

```
* Use newly introduced cmake macro ``moveit_build_options()`` from ``moveit_core``
* Split ``CollisionPluginLoader`` (#2834 <https://github.com/ros-planning/moveit/issues/2834>)To avoid circular dependencies, but enable reuse of the ``CollisionPluginLoader``, the non-ROS part was moved into ``moveit_core/moveit_collision_detection.so``
  and the ROS part (reading the plugin name from the parameter server) into ``moveit_ros_planning/moveit_collision_plugin_loader.so`` (as before).
* Introduce a reference frame for collision objects (#2037 <https://github.com/ros-planning/moveit/issues/2037>)
* Fix RDFLoader: uninitialized member (#2806 <https://github.com/ros-planning/moveit/issues/2806>)
* Add missing dependencies to generated dynamic_reconfigure headers (#2772 <https://github.com/ros-planning/moveit/issues/2772>)
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* PSM: Read padding parameters from correct namespace (#2706 <https://github.com/ros-planning/moveit/issues/2706>)
* Load ``max_safe_path_cost`` into namespace ``sense_for_plan`` (#2703 <https://github.com/ros-planning/moveit/issues/2703>)
* Fix order of member initialization (#2687 <https://github.com/ros-planning/moveit/issues/2687>)
* Move ``OccMapTree`` to ``moveit_core/collision_detection`` (#2684 <https://github.com/ros-planning/moveit/issues/2684>)
* Contributors: Felix von Drigalski, Martin Günther, Mathias Lüdtke, Michael Görner, Robert Haschke, Simon Schmeisser, Tyler Weaver, pvanlaar, werner291
```

## moveit_ros_planning_interface

```
* Use test_environment.launch in unittests (#2949 <https://github.com/ros-planning/moveit/issues/2949>)
* Use newly introduced cmake macro ``moveit_build_options()`` from ``moveit_core``
* Add missing replan/look options to interface (#2892 <https://github.com/ros-planning/moveit/issues/2892>)
* PSI: get object.pose from new msg field (#2877 <https://github.com/ros-planning/moveit/issues/2877>)
* Introduce a reference frame for collision objects (#2037 <https://github.com/ros-planning/moveit/issues/2037>)
* Fix trajectory constraints for ``moveit_commander`` (#2429 <https://github.com/ros-planning/moveit/issues/2429>)
* ``MGI::setStartState``: Only fetch current state when new state is diff (#2775 <https://github.com/ros-planning/moveit/issues/2775>)
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Contributors: Felix von Drigalski, Gauthier Hentz, Kevin Chang, Michael Görner, Robert Haschke, pvanlaar
```

## moveit_ros_robot_interaction

```
* Use newly introduced cmake macro ``moveit_build_options()`` from ``moveit_core``
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Contributors: Robert Haschke, pvanlaar
```

## moveit_ros_visualization

```
* Re-initialize params, subscribers, and topics when the ``MoveGroupNS`` has changed (#2922 <https://github.com/ros-planning/moveit/issues/2922>)
* Use newly introduced cmake macro ``moveit_build_options()`` from ``moveit_core``
* Do not save/restore warehouse parameters (#2865 <https://github.com/ros-planning/moveit/issues/2865>) but use the ROS parameters only
* PSD: Correctly update robot's base pose (#2876 <https://github.com/ros-planning/moveit/issues/2876>)
* Fix Python2: convert keys() into list (#2862 <https://github.com/ros-planning/moveit/issues/2862>)
* MP panel: fix order of input widgets for shape size (#2847 <https://github.com/ros-planning/moveit/issues/2847>)
* Use relative topic name in trajectory visualization to allow namespacing (#2835 <https://github.com/ros-planning/moveit/issues/2835>)
* MotionPlanningFrame: Gracefully handle undefined parent widget, e.g. for use via ``librviz.so`` (#2833 <https://github.com/ros-planning/moveit/issues/2833>)
* Introduce a reference frame for collision objects (#2037 <https://github.com/ros-planning/moveit/issues/2037>)
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Support arbitrary real-time factors in trajectory visualization (#2745 <https://github.com/ros-planning/moveit/issues/2745>)Replaced special value ``REALTIME`` to accept arbitrary real-time factors in the format ``<number>x``, e.g. ``3x``.
* Joints tab: Fix handling of mimic + passive joints (#2744 <https://github.com/ros-planning/moveit/issues/2744>)
* Fix ``TrajectoryPanel``: Keep "Pause/Play" button in correct state (#2737 <https://github.com/ros-planning/moveit/issues/2737>)
* Fixed error: ``moveit_joy: RuntimeError: dictionary changed size during iteration`` (#2625 <https://github.com/ros-planning/moveit/issues/2625>, #2628 <https://github.com/ros-planning/moveit/issues/2628>)
* Contributors: Felix von Drigalski, Michael Görner, Rick Staa, Robert Haschke, Yuri Rocha, lorepieri8, pvanlaar
```

## moveit_ros_warehouse

```
* Use newly introduced cmake macro ``moveit_build_options()`` from ``moveit_core``
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Contributors: Robert Haschke, pvanlaar
```

## moveit_runtime

- No changes

## moveit_servo

```
* Backport position limit enforcement from MoveIt2 (#2898 <https://github.com/ros-planning/moveit/issues/2898>)
* Use newly introduced cmake macro ``moveit_build_options()`` from ``moveit_core``
* Minor fixups (#2759 <https://github.com/ros-planning/moveit/issues/2759>)
* Remove gtest include from non-testing source (#2747 <https://github.com/ros-planning/moveit/issues/2747>)
* Fix an off-by-one error in servo_calcs.cpp (#2740 <https://github.com/ros-planning/moveit/issues/2740>)
* Refactor ``moveit_servo::LowPassFilter`` to be assignable (#2722 <https://github.com/ros-planning/moveit/issues/2722>)
* Contributors: Griswald Brooks, Michael Görner, Michael Wiznitzer, Robert Haschke, luisrayas3, toru-kuga
```

## moveit_setup_assistant

```
* Use newly introduced cmake macro ``moveit_build_options()`` from ``moveit_core``
* Correctly state not-found package name
* Finish setup_assistant.launch when MSA finished (#2749 <https://github.com/ros-planning/moveit/issues/2749>)
* **Enabling the following new features requires recreation of your robot's MoveIt config with the new MSA!**
* Various improvements (#2932 <https://github.com/ros-planning/moveit/issues/2932>)
  
    * Define default planner for Pilz pipeline
    * Allow checking/unchecking multiple files for generation
    * ``moveit.rviz``: Use Orbit view controller
    * Rename launch argument ``execution_type`` -> ``fake_execution_type`` to clarify that this parameter is only used for fake controllers
    * ``demo.launch``: Start joint + robot-state publishers in fake mode only
    * Modularize ``demo_gazebo.launch`` reusing ``demo.launch``
    * ``gazebo.launch``
      
        * Delay unpause to ensure that the robot's initial pose is actually held
        * Allow initial_joint_positions
        * Load URDF via xacro if neccessary
      
    * Rework ``moveit_controller_manager`` handlingSo far, ``move_group.launch`` distinguished between fake and real-robot operation only.
      The boolean launch-file argument ``fake_execution`` was translated to ``moveit_controller_manager = [fake|robot]``
      in ``move_group.launch`` and then further translated to the actual plugin name.However, MoveIt provides 3 basic controller manager plugins:
      
        * ``fake`` = ``moveit_fake_controller_manager::MoveItFakeControllerManager`` (default in ``demo.launch``)Doesn't really control the robot. Provides these interpolation types (``fake_execution_type``):
          
            * ``via points``: jumps to the via points
            * ``interpolate``: linearly interpolates between via points (default)
            * ``last point``: jumps to the final trajectory point (used for fast execution testing)
          
        * ``ros_control`` = ``moveit_ros_control_interface::MoveItControllerManager``Interfaces to ``ros_control`` controllers.
        * ``simple`` = ``moveit_simple_controller_manager/MoveItSimpleControllerManager``
          Interfaces to action servers for ``FollowJointTrajectory`` and/or ``GripperCommand``
          that in turn interface to the low-level robot controllers (typically based on ros_control).
      Now, the argument ``moveit_controller_manager`` allows for switching between these 3 variants using the given names.
      Adding more ``*_moveit_controller_manager.launch`` files allows for further extension of this scheme.
  
* Rework Controller Handling (#2945 <https://github.com/ros-planning/moveit/issues/2945>)
  
    * Write separate controller config files for different MoveIt controller managers:
      
        * ``fake_controllers.yaml`` for use with ``MoveItFakeControllerManager``
        * ``simple_moveit_controllers.yaml`` handles everything relevant for ``MoveItSimpleControllerManager``
        * ``ros_controllers.yaml`` defines ``ros_control`` controllers
        * ``gazebo_controllers.yaml`` lists controllers required for Gazebo
      
    * Rework controller config generation
      
        * Provide all types of ``JointTrajectoryController`` (position, velocity, and effort based)
          as well as ``FollowJointTrajectory`` and ``GripperCommand`` (use by simple controller manager)
        * Use ``effort_controllers/JointTrajectoryController`` as default
        * Create ``FollowJointTrajectory`` entries for any ``JointTrajectoryController``
        * Fix controller list generation: always write joint names as a list
      
    * Code refactoring to clarify that controller widget handles all controllers, not only ``ros_control`` controllers
      
        * Update widget texts to speak about generic controllers
        * Rename ``ROSControllersWidget`` -> ``ControllersWidget``
        * Rename files ``ros_controllers_widget.*`` -> ``controllers_widget.*``
        * Rename ``ros_controllers_config_`` -> ``controller_configs_``
        * Rename functions ``*ROSController*`` -> ``*Controller*``
        * Rename ``ROSControlConfig`` -> ``ControllerConfig``
      
  
* Fix sensor config handling (#2708 <https://github.com/ros-planning/moveit/issues/2708>, #2946 <https://github.com/ros-planning/moveit/issues/2946>)
* Load planning pipelines into their own namespace (#2888 <https://github.com/ros-planning/moveit/issues/2888>)
* Add ``jiggle_fraction`` arg to trajopt template (#2858 <https://github.com/ros-planning/moveit/issues/2858>)
* Only define ``default`` values for input argumens in ``*_planning_pipeline.launch`` templates (#2849 <https://github.com/ros-planning/moveit/issues/2849>)
* Mention (optional) Gazebo deps in package.xml templates (#2839 <https://github.com/ros-planning/moveit/issues/2839>)
* Create ``static_transform_publisher`` for each virtual joint type (#2769 <https://github.com/ros-planning/moveit/issues/2769>)
* Use $(dirname) in launch files (#2748 <https://github.com/ros-planning/moveit/issues/2748>)
* CHOMP: Read parameters from proper namespace (#2707 <https://github.com/ros-planning/moveit/issues/2707>)
  
    * Pilz pipeline: remove unused arg ``start_state_max_bounds_error``
    * Set ``jiggle_fraction`` per pipeline
    * Rename param ``clearence`` to ``clearance``
  
* Load ``max_safe_path_cost`` into namespace ``sense_for_plan`` (#2703 <https://github.com/ros-planning/moveit/issues/2703>)
* Contributors: David V. Lu!!, Martin Günther, Max Puig, Michael Görner, Rick Staa, Robert Haschke, pvanlaar, v4hn
```

## moveit_simple_controller_manager

```
* Use newly introduced cmake macro ``moveit_build_options()`` from ``moveit_core``
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Facilitate spotting of empty controller names, using quotes (#2761 <https://github.com/ros-planning/moveit/issues/2761>)
* Contributors: G.A. vd. Hoorn, Robert Haschke
```

## pilz_industrial_motion_planner

```
* Fix calculation of subframe offset (#2890 <https://github.com/ros-planning/moveit/issues/2890>)
* Remove unused moveit_planning_execution.launch
* Use test_environment.launch in unittests (#2949 <https://github.com/ros-planning/moveit/issues/2949>)
* Rename launch argument execution_type -> fake_execution_type
* Improve error messages (#2940 <https://github.com/ros-planning/moveit/issues/2940>)
  * Remove deprecated xacro --inorder
  * Don't complain about missing limits for irrelevant JMGs
  * Avoid duplicate error messages
  * Downgrade ERROR to WARN when checking joint limits, report affected joint name
  * Quote (possibly empty) planner id
* Consider attached bodies for planning (#2773 <https://github.com/ros-planning/moveit/issues/2773>, #2824 <https://github.com/ros-planning/moveit/issues/2824>, #2878 <https://github.com/ros-planning/moveit/issues/2878>)
* Fix collision detection: consider current PlanningScene (#2803 <https://github.com/ros-planning/moveit/issues/2803>)
* Add planning_pipeline_id to MotionSequence action + service (#2755 <https://github.com/ros-planning/moveit/issues/2755>)
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Contributors: Felix von Drigalski, Leroy Rügemer, Michael Görner, Robert Haschke, Tom Noble, aa-tom, cambel, pvanlaar
```

## pilz_industrial_motion_planner_testutils

```
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Contributors: Robert Haschke, pvanlaar
```
