### PR TITLE
Add vosk package for indexing

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9654,7 +9654,7 @@ repositories:
   vosk:
     doc:
       type: git
-      url: https://github.com/alphacep/ros-vosk
+      url: https://github.com/alphacep/ros-vosk.git
       version: master
   vrpn:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9651,6 +9651,11 @@ repositories:
       url: https://github.com/botsync/volta.git
       version: noetic-devel
     status: maintained
+  vosk:
+    doc:
+      type: git
+      url: https://github.com/alphacep/ros-vosk
+      version: master
   vrpn:
     doc:
       type: git


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

vosk

## Package Upstream Source:

https://github.com/alphacep/ros-vosk

## Purpose of using this:

Vosk package provides speech recognition services for ROS nodes 

## Links to distribution packages

   * Debian, Fedora, OSX, Ubuntu:
        https://pypi.org/project/vosk/

# Please Add This Package to be indexed in the rosdistro.

Melodic

# The source is here: 

https://github.com/alphacep/ros-vosk

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
