### PR TITLE
laser_filters: 1.9.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3672,16 +3672,16 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/laser_filters.git
-      version: kinetic-devel
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/laser_filters-release.git
-      version: 1.8.11-1
+      version: 1.9.0-1
     source:
       type: git
       url: https://github.com/ros-perception/laser_filters.git
-      version: kinetic-devel
+      version: noetic-devel
     status: maintained
   laser_geometry:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters` to `1.9.0-1`:

- upstream repository: https://github.com/ros-perception/laser_filters.git
- release repository: https://github.com/ros-gbp/laser_filters-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.8.11-1`

## laser_filters

```
* change_access specifier kinect
* Added nodelet version of scan_to_cloud_filter_chain .
* fix(speckle_filter): Possible segfault when ranges size was smaller than filter window
  formatting
* Lots of fixes to CI
* scan_to_cloud_filter_chain: Make cloud channels configurable
* Fixed naming of laser filter plugins in yaml files
* Add circle sector sharp filter
* Added DynamicReconfigure for RangeFilter
* Added support for laserscanners that spin clockwise
* Added nodelet version of scan_to_cloud_filter_chain .
* Contributors: Arjanboeve, Eric Wiener, Jimmy F. Klarke, Jonathan Binney, Martin Pecka, Rein Appeldoorn, YoshuaNava, renan028, teundeplanque
```
