### PR TITLE
Disable source builds for MoveIt

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4444,6 +4444,8 @@ repositories:
       url: https://github.com/ros-gbp/moveit-release.git
       version: 1.1.6-1
     source:
+      test_pull_requests: false
+      test_commits: false
       type: git
       url: https://github.com/ros-planning/moveit.git
       version: master

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4444,8 +4444,8 @@ repositories:
       url: https://github.com/ros-gbp/moveit-release.git
       version: 1.1.6-1
     source:
-      test_pull_requests: false
       test_commits: false
+      test_pull_requests: false
       type: git
       url: https://github.com/ros-planning/moveit.git
       version: master


### PR DESCRIPTION
The build takes more than 2h and thus always times out.
Interestingly, bloom didn't pick up that I answered "No" when asking for source builds. (I'm pretty sure that I did.)
