### PR TITLE
add libext2fs-dev package

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2921,6 +2921,13 @@ libexpat1-dev:
   gentoo: [dev-libs/expat]
   openembedded: [expat@openembedded-core]
   ubuntu: [libexpat1-dev]
+libext2fs-dev:
+  alpine: [e2fsprogs-dev]
+  debian: [libext2fs-dev]
+  fedora: [e2fsprogs-devel]
+  opensuse: [libext2fs-devel]
+  rhel: [e2fsprogs-devel]
+  ubuntu: [libext2fs-dev]
 libfcl-dev:
   arch: [fcl]
   debian:


### PR DESCRIPTION
Please add the following dependency to the rosdep database. this is somewhat continuation of PR #30769

## Package name:

libext2fs-dev

## Package Upstream Source:
http://e2fsprogs.sourceforge.net/

## Purpose of using this:

This dependency is part of e2fsprogs but debian split some source code into separate packages libext2fs-dev

Distro packaging links:

## Links to Distribution Packages
- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/libext2fs-dev
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/focal/libext2fs-dev

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

Galactic

# The source is here: 

https://sourceforge.net/projects/e2fsprogs/

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
