### PR TITLE
Added libtins-dev as rosdep key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5105,6 +5105,7 @@ libtiff4-dev:
   nixos: [libtiff]
   ubuntu: [libtiff4-dev]
 libtins-dev:
+  alpine: [libtins-dev]
   arch: [libtins]
   debian: [libtins-dev]
   opensuse: [libtins-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5104,6 +5104,11 @@ libtiff4-dev:
   macports: [tiff]
   nixos: [libtiff]
   ubuntu: [libtiff4-dev]
+libtins-dev:
+  arch: [libtins]
+  debian: [libtins-dev]
+  opensuse: [libtins-devel]
+  ubuntu: [libtins-dev]
 libtool:
   arch: [libtool]
   debian:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

libtins-dev

## Package Upstream Source:

[https://github.com/mfontanini/libtins.git](https://github.com/mfontanini/libtins.git)

## Purpose of using this:

Needed for [ros_ouster_drivers](https://github.com/ros-drivers/ros2_ouster_drivers)

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - [https://packages.debian.org/bullseye/libtins-dev](https://packages.debian.org/bullseye/libtins-dev)
- Ubuntu: https://packages.ubuntu.com/
   - [https://packages.ubuntu.com/focal/libtins-dev](https://packages.ubuntu.com/focal/libtins-dev)
- Arch: https://www.archlinux.org/packages/
  - [https://aur.archlinux.org/packages/libtins/](https://aur.archlinux.org/packages/libtins/)