### PR TITLE
webots_ros2: 1.1.2-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4973,8 +4973,8 @@ repositories:
       - webots_ros2_ur_e_description
       tags:
         release: release/galactic/{package}/{version}
-      url: https://github.com/ros2-gbp/webots_ros2-release.git
-      version: 1.0.6-2
+      url: https://github.com/ros2-gbp/webots_ros2-release
+      version: 1.1.2-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `webots_ros2` to `1.1.2-2`:

- upstream repository: https://github.com/cyberbotics/webots_ros2.git
- release repository: https://github.com/ros2-gbp/webots_ros2-release
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.6-2`
