### PR TITLE
webots_ros2: 1.1.2-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4974,7 +4974,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/webots_ros2-release.git
-      version: 1.0.6-2
+      version: 1.1.2-2
     source:
       test_pull_requests: true
       type: git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4958,11 +4958,15 @@ repositories:
     release:
       packages:
       - webots_ros2
+      - webots_ros2_control
       - webots_ros2_core
+      - webots_ros2_driver
       - webots_ros2_epuck
       - webots_ros2_importer
+      - webots_ros2_mavic
       - webots_ros2_msgs
       - webots_ros2_tesla
+      - webots_ros2_tests
       - webots_ros2_tiago
       - webots_ros2_turtlebot
       - webots_ros2_universal_robot

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4958,19 +4958,14 @@ repositories:
     release:
       packages:
       - webots_ros2
-      - webots_ros2_abb
       - webots_ros2_core
-      - webots_ros2_demos
       - webots_ros2_epuck
-      - webots_ros2_examples
       - webots_ros2_importer
       - webots_ros2_msgs
       - webots_ros2_tesla
       - webots_ros2_tiago
       - webots_ros2_turtlebot
-      - webots_ros2_tutorials
       - webots_ros2_universal_robot
-      - webots_ros2_ur_e_description
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/webots_ros2-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `webots_ros2` to `1.1.2-2`:

- upstream repository: https://github.com/cyberbotics/webots_ros2.git
- release repository: https://github.com/ros2-gbp/webots_ros2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.6-2`
