### PR TITLE
transport_drivers: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4192,12 +4192,14 @@ repositories:
       version: main
     release:
       packages:
+      - asio_cmake_module
+      - io_context
       - serial_driver
       - udp_driver
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros-drivers-gbp/transport_drivers-release.git
-      version: 0.0.6-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ros-drivers/transport_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `transport_drivers` to `1.0.1-1`:

- upstream repository: https://github.com/ros-drivers/transport_drivers.git
- release repository: https://github.com/ros-drivers-gbp/transport_drivers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.6-1`

## asio_cmake_module

```
* Export ASIO definitions (#44 <https://github.com/ros-drivers/transport_drivers/issues/44>)
* Deduplicate ASIO CMake module (#43 <https://github.com/ros-drivers/transport_drivers/issues/43>)
  * Added ASIO CMake module
  * Use asio_cmake_module
* Contributors: Esteve Fernandez
```

## io_context

```
* Serial driver debugs (#56 <https://github.com/ros-drivers/transport_drivers/issues/56>)
  * debugged message conversion
  debugged serial bridge segfault (publisher accessed before initialized)
  * refactored message conversion
* update READMEs for each package (#54 <https://github.com/ros-drivers/transport_drivers/issues/54>)
  * update READMEs for each package
  * add more to readme, renamed config to params
* use vectors not mutbuffers (#50 <https://github.com/ros-drivers/transport_drivers/issues/50>)
* Port udp_driver Changes to serial_driver (#47 <https://github.com/ros-drivers/transport_drivers/issues/47>)
  * Adding SerialPort and framework for SerialDriver.
  * Adding SerialDriver
  * Adding SerialBridgeNode
  * Remove serial_driver_node and tests
  * Create new tests for serial_port and serial_driver
  * Changing signature of from_msg for example_interfaces
  * [serial_driver] Adding missing function definition
  * [serial_driver] Adding example params and launch files
  * Trying to apease flake8
  * Fixing allocation snafu
  * [serial_driver] Replacing MutBuffer with std::vector<uint8_t>
  * [serial_driver] Fix typo
  * [serial_driver] Make launch file more reliable
  * [serial_driver] Fix error message
  * [serial_driver] Fix typo
  * [serial_driver] Shorten node name
* Generic udp nodes (#40 <https://github.com/ros-drivers/transport_drivers/issues/40>)
  * use udp_msgs for receiver and sender nodes
  * use vector of uint8_ts instead of mutable buffer
  * all tests passing
* Rename MutSocketBuffer to MutBuffer (#46 <https://github.com/ros-drivers/transport_drivers/issues/46>)
* Export ASIO definitions (#44 <https://github.com/ros-drivers/transport_drivers/issues/44>)
* Enforce C++14. Do not duplicate compiler flags (#45 <https://github.com/ros-drivers/transport_drivers/issues/45>)
* Deduplicate ASIO CMake module (#43 <https://github.com/ros-drivers/transport_drivers/issues/43>)
  * Added ASIO CMake module
  * Use asio_cmake_module
* Use RCLCPP logging macros (#42 <https://github.com/ros-drivers/transport_drivers/issues/42>)
* Fix copyright years (#41 <https://github.com/ros-drivers/transport_drivers/issues/41>)
* Removed Boost (#39 <https://github.com/ros-drivers/transport_drivers/issues/39>)
  * Removed Boost
  * Do not depend on Boost at all
  * Added cmath header
  * Fix linting warning
  * Added ASIO_STANDALONE to more units
  * Call stop on io_service
  * Fix dependency
  * Export asio as a downstream dependency
  * Remove more boost references
  * Force non-Boost version of ASIO
  * Force non-Boost version of ASIO
  * Ignore result to avoid compiler warning
* Create Full UDP Nodes (#38 <https://github.com/ros-drivers/transport_drivers/issues/38>)
  * Reorganize namespaces
  * Apply reviewer feedback
  * Create UdpReceiverNode as LifecycleNode
  * Create UdpSenderNode as Lifecycle Node
  * Adding bridge node
  * Add comment to bridge node about purpose
* Reorg namespaces (#37 <https://github.com/ros-drivers/transport_drivers/issues/37>)
  * Move UDP driver node to correct location
  * Reorganize namespaces
  * Remove unused include_directories
  * Apply reviewer feedback
* move io_context to shared lib (#36 <https://github.com/ros-drivers/transport_drivers/issues/36>)
* Contributors: Esteve Fernandez, Evan Flynn, Haoru Xue, Joshua Whitley
```

## serial_driver

```
* Remove deprecated api from galactic (#57 <https://github.com/ros-drivers/transport_drivers/issues/57>)
* Serial driver debugs (#56 <https://github.com/ros-drivers/transport_drivers/issues/56>)
  * debugged message conversion
  debugged serial bridge segfault (publisher accessed before initialized)
  * refactored message conversion
* update READMEs for each package (#54 <https://github.com/ros-drivers/transport_drivers/issues/54>)
  * update READMEs for each package
  * add more to readme, renamed config to params
* Port udp_driver Changes to serial_driver (#47 <https://github.com/ros-drivers/transport_drivers/issues/47>)
  * Adding SerialPort and framework for SerialDriver.
  * Adding SerialDriver
  * Adding SerialBridgeNode
  * Remove serial_driver_node and tests
  * Create new tests for serial_port and serial_driver
  * Changing signature of from_msg for example_interfaces
  * [serial_driver] Adding missing function definition
  * [serial_driver] Adding example params and launch files
  * Trying to apease flake8
  * Fixing allocation snafu
  * [serial_driver] Replacing MutBuffer with std::vector<uint8_t>
  * [serial_driver] Fix typo
  * [serial_driver] Make launch file more reliable
  * [serial_driver] Fix error message
  * [serial_driver] Fix typo
  * [serial_driver] Shorten node name
* Export ASIO definitions (#44 <https://github.com/ros-drivers/transport_drivers/issues/44>)
* Enforce C++14. Do not duplicate compiler flags (#45 <https://github.com/ros-drivers/transport_drivers/issues/45>)
* Deduplicate ASIO CMake module (#43 <https://github.com/ros-drivers/transport_drivers/issues/43>)
  * Added ASIO CMake module
  * Use asio_cmake_module
* Fix copyright years (#41 <https://github.com/ros-drivers/transport_drivers/issues/41>)
* Removed Boost (#39 <https://github.com/ros-drivers/transport_drivers/issues/39>)
  * Removed Boost
  * Do not depend on Boost at all
  * Added cmath header
  * Fix linting warning
  * Added ASIO_STANDALONE to more units
  * Call stop on io_service
  * Fix dependency
  * Export asio as a downstream dependency
  * Remove more boost references
  * Force non-Boost version of ASIO
  * Force non-Boost version of ASIO
  * Ignore result to avoid compiler warning
* remove autoware namespace (#35 <https://github.com/ros-drivers/transport_drivers/issues/35>)
  * remove autoware namespace
  * move msgs namespace to utils
* Make Nodes Component-Compatible (#22 <https://github.com/ros-drivers/transport_drivers/issues/22>)
  * Making constructors for SerialDriverNode component-compatible.
  * Making constructors for UdpDriverNode component-compatible.
* Contributors: Daisuke Nishimatsu, Esteve Fernandez, Evan Flynn, Haoru Xue, Joshua Whitley
```

## udp_driver

```
* Remove deprecated api from galactic (#57 <https://github.com/ros-drivers/transport_drivers/issues/57>)
* update READMEs for each package (#54 <https://github.com/ros-drivers/transport_drivers/issues/54>)
  * update READMEs for each package
  * add more to readme, renamed config to params
* use vectors not mutbuffers (#50 <https://github.com/ros-drivers/transport_drivers/issues/50>)
* Port udp_driver Changes to serial_driver (#47 <https://github.com/ros-drivers/transport_drivers/issues/47>)
  * Adding SerialPort and framework for SerialDriver.
  * Adding SerialDriver
  * Adding SerialBridgeNode
  * Remove serial_driver_node and tests
  * Create new tests for serial_port and serial_driver
  * Changing signature of from_msg for example_interfaces
  * [serial_driver] Adding missing function definition
  * [serial_driver] Adding example params and launch files
  * Trying to apease flake8
  * Fixing allocation snafu
  * [serial_driver] Replacing MutBuffer with std::vector<uint8_t>
  * [serial_driver] Fix typo
  * [serial_driver] Make launch file more reliable
  * [serial_driver] Fix error message
  * [serial_driver] Fix typo
  * [serial_driver] Shorten node name
* Generic udp nodes (#40 <https://github.com/ros-drivers/transport_drivers/issues/40>)
  * use udp_msgs for receiver and sender nodes
  * use vector of uint8_ts instead of mutable buffer
  * all tests passing
* Rename MutSocketBuffer to MutBuffer (#46 <https://github.com/ros-drivers/transport_drivers/issues/46>)
* Removing duplicate file
* Export ASIO definitions (#44 <https://github.com/ros-drivers/transport_drivers/issues/44>)
* Enforce C++14. Do not duplicate compiler flags (#45 <https://github.com/ros-drivers/transport_drivers/issues/45>)
* Deduplicate ASIO CMake module (#43 <https://github.com/ros-drivers/transport_drivers/issues/43>)
  * Added ASIO CMake module
  * Use asio_cmake_module
* Use RCLCPP logging macros (#42 <https://github.com/ros-drivers/transport_drivers/issues/42>)
* Fix copyright years (#41 <https://github.com/ros-drivers/transport_drivers/issues/41>)
* Fix IoContext thread management
* Pass IoContext through driver instead of storing reference
* Replace ptrs to IoContext with refs
* Removed Boost (#39 <https://github.com/ros-drivers/transport_drivers/issues/39>)
  * Removed Boost
  * Do not depend on Boost at all
  * Added cmath header
  * Fix linting warning
  * Added ASIO_STANDALONE to more units
  * Call stop on io_service
  * Fix dependency
  * Export asio as a downstream dependency
  * Remove more boost references
  * Force non-Boost version of ASIO
  * Force non-Boost version of ASIO
  * Ignore result to avoid compiler warning
* Add warnings for invalid or missing parameters in udp_driver nodes
* Create Full UDP Nodes (#38 <https://github.com/ros-drivers/transport_drivers/issues/38>)
  * Reorganize namespaces
  * Apply reviewer feedback
  * Create UdpReceiverNode as LifecycleNode
  * Create UdpSenderNode as Lifecycle Node
  * Adding bridge node
  * Add comment to bridge node about purpose
* Reorg namespaces (#37 <https://github.com/ros-drivers/transport_drivers/issues/37>)
  * Move UDP driver node to correct location
  * Reorganize namespaces
  * Remove unused include_directories
  * Apply reviewer feedback
* move io_context to shared lib (#36 <https://github.com/ros-drivers/transport_drivers/issues/36>)
* Re-apply ament_cmake_auto to udp_driver
* remove autoware namespace (#35 <https://github.com/ros-drivers/transport_drivers/issues/35>)
  * remove autoware namespace
  * move msgs namespace to utils
* Implement UdpSocket for both Syn. & Async modes (Send & Receive functionality) (#31 <https://github.com/ros-drivers/transport_drivers/issues/31>)
  * Refactor & add UdpReceiver class
  * Add UdpSender class
  * Update node class to refactored driver
  * Update CMake
  * Update tests
  * Resolve a conflict on test/test_udp_driver.cpp
  * Update Readme
  * Rename header file to cpp format
  * Rename header file to cpp format
  * Delete old files
  * Update Udp Driver Node
  * Add message converters
  * Add IoContext class
  * Add UdpDriver class
  * Add UdpSocket class
  * Add IoContext test case
  * Add Udp data transmission test cases
  * Add Udp receive test case
  * Add Udp Sender test case
  * Add UdpDriver test cases
  * Update CMakeLists file
  * Add converters header & source files
  * Add IoContext header & source files
  * Add UdpSocket header & source files
  * Add UdpDriver header & source files
  * Add visibility header file
  * Add UdpDriverNode to examples directory
  * Add main google test program
  * Add IoContext test
  * Add UdpSocket test
  * Add UdpDriver test
  * Add UDP communication tests
  * Add UdpDriverNode test
  * Add changelog file
  * Add CMakeLists file
  * Add package.xml file
  * Delete old udp_driver package
  * Add design document
  * Add std_msgs/Int* variants converters
  * Update converters to ROS2 message in function names
  * Refactor converters to their ROS2 namespaces in converters directory
  * Add common converters header
  * Update licenses
  * Reformat code
  * Remove unnecessary print
  * Update google test header includes to library convention
  * Implement unsigned integer and floating point message variants converters
  * Fix comment in converters
  * Update test and example
  * Update changelog - Bump major version to 0.1.0
  * Update readme
  * Revert back changelog file
  * Update readme
  * Move udp_driver to separate package
  * Revert package name change
  * Apply linter fixes
  Co-authored-by: Joshua Whitley <mailto:josh.whitley@autoware.org>
* Make Nodes Component-Compatible (#22 <https://github.com/ros-drivers/transport_drivers/issues/22>)
  * Making constructors for SerialDriverNode component-compatible.
  * Making constructors for UdpDriverNode component-compatible.
* Contributors: Daisuke Nishimatsu, Esteve Fernandez, Evan Flynn, Joshua Whitley, Reza Ebrahimi
```
