### PR TITLE
rtabmap: 0.20.15-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3841,7 +3841,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.20.13-1
+      version: 0.20.15-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap` to `0.20.15-1`:

- upstream repository: https://github.com/introlab/rtabmap.git
- release repository: https://github.com/introlab/rtabmap-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.20.13-1`
