### PR TITLE
rtabmap_ros: 0.20.15-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4886,6 +4886,21 @@ repositories:
       url: https://github.com/introlab/rtabmap.git
       version: foxy-devel
     status: maintained
+  rtabmap_ros:
+    doc:
+      type: git
+      url: https://github.com/introlab/rtabmap_ros.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/introlab/rtabmap_ros-release.git
+      version: 0.20.15-1
+    source:
+      type: git
+      url: https://github.com/introlab/rtabmap_ros.git
+      version: foxy-devel
+    status: developed
   ruckig:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap_ros` to `0.20.15-1`:

- upstream repository: https://github.com/introlab/rtabmap_ros.git
- release repository: https://github.com/introlab/rtabmap_ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
