### PR TITLE
rtabmap_ros: 0.20.15-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4104,6 +4104,21 @@ repositories:
       url: https://github.com/introlab/rtabmap.git
       version: galactic-devel
     status: maintained
+  rtabmap_ros:
+    doc:
+      type: git
+      url: https://github.com/introlab/rtabmap_ros.git
+      version: galactic-devel
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/introlab/rtabmap_ros-release.git
+      version: 0.20.15-1
+    source:
+      type: git
+      url: https://github.com/introlab/rtabmap_ros.git
+      version: galactic-devel
+    status: developed
   ruckig:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap_ros` to `0.20.15-1`:

- upstream repository: https://github.com/introlab/rtabmap_ros.git
- release repository: https://github.com/introlab/rtabmap_ros-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
