### PR TITLE
rtabmap_ros: 0.20.15-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4895,7 +4895,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.20.15-1
+      version: 0.20.15-2
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap_ros` to `0.20.15-2`:

- upstream repository: https://github.com/introlab/rtabmap_ros.git
- release repository: https://github.com/introlab/rtabmap_ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.20.15-1`
