### PR TITLE
rosmsg_cpp: 1.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7461,7 +7461,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ctu-vras/rosmsg_cpp-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ctu-vras/rosmsg_cpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosmsg_cpp` to `1.0.2-1`:

- upstream repository: https://github.com/ctu-vras/rosmsg_cpp.git
- release repository: https://github.com/ctu-vras/rosmsg_cpp-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.1-1`

## rosmsg_cpp

```
* Fix build on ROS buildfarm.
* Contributors: Martin Pecka
```
