### PR TITLE
toposens: 2.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8955,7 +8955,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 2.3.0-1
+      version: 2.3.1-1
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toposens` to `2.3.1-1`:

- upstream repository: https://gitlab.com/toposens/public/ros-packages.git
- release repository: https://gitlab.com/toposens/public/toposens-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.0-1`

## toposens

```
* Minor clean-up and bug fixes
* Contributors: Baris Yazici, Dennis Maier
```

## toposens_bringup

```
* Minor clean-up and bug fixes
* Contributors: Baris Yazici, Dennis Maier
```

## toposens_description

```
* Minor clean-up and bug fixes
* Contributors: Baris Yazici, Dennis Maier
```

## toposens_driver

```
* Minor clean-up and bug fixes
* Contributors: Baris Yazici, Dennis Maier
```

## toposens_echo_driver

```
* Minor clean-up and bug fixes
* Contributors: Baris Yazici, Dennis Maier
```

## toposens_markers

```
* Minor clean-up and bug fixes
* Contributors: Baris Yazici, Dennis Maier
```

## toposens_msgs

```
* Minor clean-up and bug fixes
* Contributors: Baris Yazici, Dennis Maier
```

## toposens_pointcloud

```
* Minor clean-up and bug fixes
* Contributors: Baris Yazici, Dennis Maier
```

## toposens_sync

```
* Minor clean-up and bug fixes
* Contributors: Baris Yazici, Dennis Maier
```
