### PR TITLE
psen_scan_v2: 0.3.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9321,7 +9321,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/psen_scan_v2-release.git
-      version: 0.3.2-1
+      version: 0.3.3-1
     source:
       type: git
       url: https://github.com/PilzDE/psen_scan_v2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `psen_scan_v2` to `0.3.3-1`:

- upstream repository: https://github.com/PilzDE/psen_scan_v2.git
- release repository: https://github.com/PilzDE/psen_scan_v2-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.2-1`

## psen_scan_v2

```
* Introduce error state and set exception in start-future
* Remove dependency on pilz_testutils
* Always build hardware tests
* Internal refactorings
* Importing the config xml-file and publishing the zoneconfiguration
* Add active zoneset to LaserScan
* Publish active zoneset id to ~/active_zoneset
* Add active zoneset visualization in rviz
* Contributors: Pilz GmbH and Co. KG
```
