### PR TITLE
toposens: 2.3.1-1 in 'melodict/distribution.yaml'

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13329,6 +13329,7 @@ repositories:
       - toposens_bringup
       - toposens_description
       - toposens_driver
+      - toposens_echo_driver
       - toposens_markers
       - toposens_msgs
       - toposens_pointcloud
@@ -13336,7 +13337,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 2.2.1-1
+      version: 2.3.1-1
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toposens` to `2.3.1-1`:

- upstream repository: https://gitlab.com/toposens/public/ros-packages.git
- release repository: https://gitlab.com/toposens/public/toposens-release.git
- distro file: `melodic/distribution.yaml`
- previous version for package: `2.2.1-1`

## toposens

```
* Minor clean-up and bug fixes
* Contributors: Baris Yazici, Dennis Maier
```

## toposens_bringup

```
* Minor clean-up and bug fixes
* Contributors: Baris Yazici, Dennis Maier
```

## toposens_description

```
* Minor clean-up and bug fixes
* Contributors: Baris Yazici, Dennis Maier
```

## toposens_driver

```
* Minor clean-up and bug fixes
* Contributors: Baris Yazici, Dennis Maier
```

## toposens_echo_driver

```
* Minor clean-up and bug fixes
* Contributors: Baris Yazici, Dennis Maier
```

## toposens_markers

```
* Minor clean-up and bug fixes
* Contributors: Baris Yazici, Dennis Maier
```

## toposens_msgs

```
* Minor clean-up and bug fixes
* Contributors: Baris Yazici, Dennis Maier
```

## toposens_pointcloud

```
* Minor clean-up and bug fixes
* Contributors: Baris Yazici, Dennis Maier
```

## toposens_sync

```
* Minor clean-up and bug fixes
* Contributors: Baris Yazici, Dennis Maier
```
