### PR TITLE
tesseract: 0.6.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8886,13 +8886,14 @@ repositories:
       - tesseract_kinematics
       - tesseract_scene_graph
       - tesseract_srdf
+      - tesseract_state_solver
       - tesseract_support
       - tesseract_urdf
       - tesseract_visualization
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-industrial-release/tesseract-release.git
-      version: 0.5.0-1
+      version: 0.6.6-1
     source:
       type: git
       url: https://github.com/ros-industrial-consortium/tesseract.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tesseract` to `0.6.6-1`:

- upstream repository: https://github.com/tesseract-robotics/tesseract.git
- release repository: https://github.com/ros-industrial-release/tesseract-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.5.0-1`

## tesseract_collision

```
* Update ikfast plugin
* Update tesseract_collision benchmarks
* Contributors: Levi-Armstrong
```

## tesseract_common

- No changes

## tesseract_environment

- No changes

## tesseract_geometry

- No changes

## tesseract_kinematics

```
* Update ikfast plugin
* Add determinant check and make kdl solvers thread safe (#664 <https://github.com/ros-industrial-consortium/tesseract/issues/664>)
* Fix Kinematic Group working frames
* Contributors: Levi Armstrong, Levi-Armstrong
```

## tesseract_scene_graph

- No changes

## tesseract_srdf

- No changes

## tesseract_state_solver

- No changes

## tesseract_support

- No changes

## tesseract_urdf

- No changes

## tesseract_visualization

- No changes
