### PR TITLE
Add Azure rosdep pip keys

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -71,6 +71,36 @@ azure-iothub-device-client-pip:
   ubuntu:
     pip:
       packages: [azure-iothub-device-client]
+azure-core-pip:
+  debian:
+    pip:
+      packages: [azure-core]
+  fedora:
+    pip:
+      packages: [azure-core]
+  ubuntu:
+    pip:
+      packages: [azure-core]
+azure-mgmt-storage-pip:
+  debian:
+    pip:
+      packages: [azure-mgmt-storage]
+  fedora:
+    pip:
+      packages: [azure-mgmt-storage]
+  ubuntu:
+    pip:
+      packages: [azure-mgmt-storage]
+azure-storage-file-share-pip:
+  debian:
+    pip:
+      packages: [azure-storage-file-share]
+  fedora:
+    pip:
+      packages: [azure-storage-file-share]
+  ubuntu:
+    pip:
+      packages: [azure-storage-file-share]
 canopen-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -61,16 +61,6 @@ awsiotpythonsdk-pip:
   ubuntu:
     pip:
       packages: [awsiotpythonsdk]
-azure-iothub-device-client-pip:
-  debian:
-    pip:
-      packages: [azure-iothub-device-client]
-  fedora:
-    pip:
-      packages: [azure-iothub-device-client]
-  ubuntu:
-    pip:
-      packages: [azure-iothub-device-client]
 azure-core-pip:
   debian:
     pip:
@@ -81,6 +71,16 @@ azure-core-pip:
   ubuntu:
     pip:
       packages: [azure-core]
+azure-iothub-device-client-pip:
+  debian:
+    pip:
+      packages: [azure-iothub-device-client]
+  fedora:
+    pip:
+      packages: [azure-iothub-device-client]
+  ubuntu:
+    pip:
+      packages: [azure-iothub-device-client]
 azure-mgmt-storage-pip:
   debian:
     pip:


### PR DESCRIPTION
add packages of azure-core, azure-mgmt-storage, azure-storage-file-share

Please add the following dependency to the rosdep database.

## Package name:

azure-core, azure-mgmt-storage, azure-storage-file-share

## Package Upstream Source:

https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/core/azure-core
https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-mgmt-storage
https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-file-share

## Purpose of using this:

This PR provides the azure pip packages to ROS. These packages provides a Python SDK for device clients connecting to the Microsoft Azure storage account and operate files in the cloud. This would be a dependency for any projects making use of Azure storage account within a rospy package.

PyPi Package Description: 
https://pypi.org/project/azure-core/
https://pypi.org/project/azure-mgmt-storage/
https://pypi.org/project/azure-storage-file-share/


