### PR TITLE
Add python3-adafruit-circuitpython-bno055-pip key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5771,6 +5771,16 @@ python3-adafruit-circuitpython-ads1x15-pip:
   ubuntu:
     pip:
       packages: [adafruit-circuitpython-ads1x15]
+python3-adafruit-circuitpython-bno055-pip:
+  debian:
+    pip:
+      packages: [adafruit-circuitpython-bno055]
+  fedora:
+    pip:
+      packages: [adafruit-circuitpython-bno055]
+  ubuntu:
+    pip:
+      packages: [adafruit-circuitpython-bno055]
 python3-adafruit-circuitpython-mcp230xx-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`python3-adafruit-circuitpython-bno055-pip`

## Package Upstream Source:

https://github.com/adafruit/Adafruit_CircuitPython_BNO055

## Purpose of using this:

The current Adafruit Python library for the Bosch BNO055 IMU in the rosdep database had been deprecated (https://github.com/adafruit/Adafruit_Python_BNO055) and replaced by the Adafruit CircuitPython BNO055 library.

Distro packaging links:

## Links to Distribution Packages

- pip: https://pypi.org/
  - https://pypi.org/project/adafruit-circuitpython-bno055/