### PR TITLE
rclc: 2.0.5-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2654,7 +2654,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
-      version: 2.0.4-1
+      version: 2.0.5-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclc` to `2.0.5-2`:

- upstream repository: https://github.com/ros2/rclc.git
- release repository: https://github.com/ros2-gbp/rclc-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.4-1`

## rclc

```
* Fix printf in executor spin
* Fix init options handling
```

## rclc_examples

```
* Bumped version
```

## rclc_lifecycle

```
* Bumped version
```

## rclc_parameter

```
* Fix parameter init
```
