### PR TITLE
mavlink: 2021.11.11-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1939,7 +1939,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/mavlink/mavlink-gbp-release.git
-      version: 2021.10.10-1
+      version: 2021.11.11-1
     source:
       type: git
       url: https://github.com/mavlink/mavlink-gbp-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavlink` to `2021.11.11-1`:

- upstream repository: https://github.com/mavlink/mavlink.git
- release repository: https://github.com/mavlink/mavlink-gbp-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2021.10.10-1`
