### PR TITLE
warthog: 0.1.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9729,6 +9729,25 @@ repositories:
       url: https://github.com/ros-planning/warehouse_ros_mongo.git
       version: noetic-devel
     status: maintained
+  warthog:
+    doc:
+      type: git
+      url: https://github.com/warthog-cpr/warthog.git
+      version: kinetic-devel
+    release:
+      packages:
+      - warthog_control
+      - warthog_description
+      - warthog_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/warthog-release.git
+      version: 0.1.4-1
+    source:
+      type: git
+      url: https://github.com/warthog-cpr/warthog.git
+      version: kinetic-devel
+    status: maintained
   web_video_server:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog` to `0.1.4-1`:

- upstream repository: https://github.com/warthog-cpr/warthog.git
- release repository: https://github.com/clearpath-gbp/warthog-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## warthog_control

- No changes

## warthog_description

```
* CPR extras (#17 <https://github.com/warthog-cpr/warthog/issues/17>)
  * cpr_extras
  * cpr_extras
  * remove cpr_extras.urdf
  Co-authored-by: Ebrahim Shahrivar <mailto:eshahrivar@clearpath.ai>
* Add an envar to set the paint colour of the URDF (#16 <https://github.com/warthog-cpr/warthog/issues/16>)
  * Add the WARTHOG_COLOR envar, with options 'yellow' (default) and 'olive_green'
  * Simplify the paint options, add orange and sand as additional choices based on feedback from sales on the available colours.
* [warthog_description] Added generator accessory.
* Contributors: Chris I-B, Ebrahim Shahrivar, Tony Baltovski
```

## warthog_msgs

- No changes
