### PR TITLE
Add python3-qwt

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7743,13 +7743,14 @@ python3-qtpy:
   ubuntu: [python3-qtpy]
 python3-qwt:
   debian: [python3-qwt]
+  ubuntu: [python3-qwt]
+python3-qwt-pip:
   fedora:
     pip:
       packages: [PythonQwt]
   opensuse:
     pip:
       packages: [PythonQwt]
-  ubuntu: [python3-qwt]
 python3-rafcon-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7745,10 +7745,16 @@ python3-qwt:
   debian: [python3-qwt]
   ubuntu: [python3-qwt]
 python3-qwt-pip:
+  debian:
+    pip:
+      packages: [PythonQwt]
   fedora:
     pip:
       packages: [PythonQwt]
   opensuse:
+    pip:
+      packages: [PythonQwt]
+  ubuntu:
     pip:
       packages: [PythonQwt]
 python3-rafcon-pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7691,6 +7691,15 @@ python3-qtpy:
   gentoo: [dev-python/QtPy]
   nixos: [python3Packages.qtpy]
   ubuntu: [python3-qtpy]
+python3-qwt:
+  debian: [python3-qwt]
+  fedora:
+    pip:
+      packages: [PythonQwt]
+  opensuse:
+    pip:
+      packages: [PythonQwt]
+  ubuntu: [python3-qwt]
 python3-rafcon-pip:
   debian:
     pip:


### PR DESCRIPTION
Eh, I hope I did this right.

Please add the following dependency to the rosdep database.

## Package name:

python3-qwt

## Package Upstream Source:

https://github.com/PierreRaybaut/PythonQwt

## Purpose of using this:

`qwt_dependency` does nothing for Kinetic and above:
https://github.com/ros-visualization/qwt_dependency/blob/73bc532699b6aa219f9c842d6cc88cf65d9f398f/package.xml#L11

Once added to `qwt_dependency` for Noetic, this will enable the use of qwt with Qt5 on Focal, which will make fixes like this work in Noetic https://github.com/ros-visualization/rqt_plot/pull/70
(It doesn't help Melodic, because on Bionic, `python3-qwt` is for Qt4)

## Links to Distribution Packages

Looks like `python3-qwt` only exists on Debian and Ubuntu: https://pkgs.org/download/python3-qwt
So on the other platforms it has to come from pip: https://pypi.org/project/PythonQwt/

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/python3-qwt
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/focal/python3-qwt
