### PR TITLE
visualization_rwt: 0.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -14545,6 +14545,32 @@ repositories:
       url: https://github.com/uji-ros-pkg/visualization_osg.git
       version: melodic-devel
     status: maintained
+  visualization_rwt:
+    doc:
+      type: git
+      url: https://github.com/tork-a/visualization_rwt.git
+      version: kinetic-devel
+    release:
+      packages:
+      - rwt_app_chooser
+      - rwt_image_view
+      - rwt_moveit
+      - rwt_nav
+      - rwt_plot
+      - rwt_robot_monitor
+      - rwt_speech_recognition
+      - rwt_steer
+      - rwt_utils_3rdparty
+      - visualization_rwt
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/visualization_rwt-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/tork-a/visualization_rwt.git
+      version: kinetic-devel
+    status: unmaintained
   visualization_tutorials:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `visualization_rwt` to `0.1.1-1`:

- upstream repository: https://github.com/tork-a/visualization_rwt.git
- release repository: https://github.com/tork-a/visualization_rwt-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## rwt_app_chooser

- No changes

## rwt_image_view

- No changes

## rwt_moveit

- No changes

## rwt_nav

- No changes

## rwt_plot

- No changes

## rwt_robot_monitor

```
* [rwt_robot_monitor] remove roslibjs_experimental from package.xml (#114 <https://github.com/tork-a/visualization_rwt/issues/114>)
* Contributors: Kei Okada
```

## rwt_speech_recognition

- No changes

## rwt_steer

- No changes

## rwt_utils_3rdparty

- No changes

## visualization_rwt

- No changes
