### PR TITLE
[dep] deepdiff-pip for Python3

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6195,6 +6195,16 @@ python3-decorator:
   osx:
     pip: [decorator]
   ubuntu: [python3-decorator]
+python3-deepdiff:
+  arch: [python-deepdiff]
+  debian: [python3-deepdiff]
+  fedora: [python-deepdiff]
+  opensuse: [python3-deepdiff]
+  ubuntu:
+    '*': [python3-deepdiff]
+    bionic:
+      pip:
+        packages: [deepdiff]
 python3-defusedxml:
   debian: [python3-defusedxml]
   fedora: [python3-defusedxml]


### PR DESCRIPTION
## Package name:

deepdiff

## Package Upstream Source:

https://pypi.org/project/deepdiff/

Py2 version is already added in https://github.com/ros/rosdistro/pull/15606

## Purpose of using this:

- Help Python application to deal with dict, iterables

# Distro packaging links:

- Debian: https://packages.debian.org/
  - REQUIRED
  - https://packages.debian.org/search?keywords=%20deepdiff
- Ubuntu: https://packages.ubuntu.com/
   - REQUIRED
   - https://packages.ubuntu.com/search?keywords=deepdiff&searchon=names&suite=all&section=all
- Fedora: https://src.fedoraproject.org/browse/projects/
  - IF AVAILABLE
  - https://src.fedoraproject.org/rpms/python-deepdiff
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
  - https://archlinux.org/packages/community/any/python-deepdiff/
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
  - Not found
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
  - Not found
- OpenSuse https://software.opensuse.org/package/python3-deepdiff