### PR TITLE
microstrain_inertial: 2.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2039,7 +2039,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release.git
-      version: 2.0.6-1
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `2.1.0-1`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.6-1`

## microstrain_inertial_driver

```
* Adds transform broadcaster that will publish transform between filter_frame_id and filter_child_frame_id
* Corrects some ENU conversions that were not being properly made
* Properly disables/enables RTK dongle based on launch config
* Publishes RTK data even when device_setup is set to false if the device was configured to send RTK data
* Contributors: ianmooreparker, robbiefish
```

## microstrain_inertial_examples

- No changes

## microstrain_inertial_msgs

- No changes
