### PR TITLE
launch: 0.10.7-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1703,7 +1703,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.10.6-1
+      version: 0.10.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.10.7-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.10.6-1`

## launch

```
* Allow for raw path specification in IncludeLaunchDescription (#544 <https://github.com/ros2/launch/issues/544>) (#548 <https://github.com/ros2/launch/issues/548>)
* Handle empty strings in type coercion. (#443 <https://github.com/ros2/launch/issues/443>)
* Consolidate type_utils in a way that can be reused in substitution results that need to be coerced to a specific type (#438 <https://github.com/ros2/launch/issues/438>)
* Fix up parser.py (#414 <https://github.com/ros2/launch/issues/414>)
* Contributors: Dan Rose, David V. Lu!!, Ivan Santiago Paunovic, Jacob Perron, Michel Hidalgo
```

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* Consolidate type_utils in a way that can be reused in substitution results that need to be coerced to a specific type (#438 <https://github.com/ros2/launch/issues/438>)
* Contributors: Ivan Santiago Paunovic
```

## launch_yaml

```
* Consolidate type_utils in a way that can be reused in substitution results that need to be coerced to a specific type (#438 <https://github.com/ros2/launch/issues/438>)
* Contributors: Ivan Santiago Paunovic
```
