### PR TITLE
image_pipeline: 1.16.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3037,7 +3037,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/image_pipeline-release.git
-      version: 1.15.3-1
+      version: 1.16.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `1.16.0-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros-gbp/image_pipeline-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.15.3-1`

## camera_calibration

```
* fix premature camera model change in camera_calibration
* Fix shebang lines for noetic python3
* Contributors: Michael Carroll, Victor Dubois
```

## depth_image_proc

```
* Fix includes
  In the following commit in vision_opencv, the include
  opencv2/calib3d/calib3d.hpp was removed from pinhole_camera_model.h :
  https://github.com/ros-perception/vision_opencv/commit/51ca54354a8353fc728fcc8bd8ead7d2b6cf7444
  Since we indirectly depended on this include, we now have to add it
  directly.
* support rgba8 and bgra8 encodings by skipping alpha channel
* functional xyzrgb radial nodelet
* add xyzrgb radial nodelet
* Support MONO16 image encodings.
* Add missing cstdint, vector, cmath includes.
* Contributors: Avinash Thakur, Evan Flynn, Martin Günther, Mike Purvis
```

## image_pipeline

- No changes

## image_proc

- No changes

## image_publisher

- No changes

## image_rotate

- No changes

## image_view

```
* remove GTK3 dep.
* remove harfbuzz.
* Update image_view/CMakeLists.txt
  Co-authored-by: Joshua Whitley <mailto:josh.whitley@autoware.org>
* Update image_view/CMakeLists.txt
  Co-authored-by: Joshua Whitley <mailto:josh.whitley@autoware.org>
* Make GTK3 and harfbuzz optional
* Contributors: Sean Yen, seanyen
```

## stereo_image_proc

```
* Fix includes
  In the following commit in vision_opencv, the include
  opencv2/calib3d/calib3d.hpp was removed from pinhole_camera_model.h :
  https://github.com/ros-perception/vision_opencv/commit/51ca54354a8353fc728fcc8bd8ead7d2b6cf7444
  Since we indirectly depended on this include, we now have to add it
  directly.
* support rgba8 and bgra8 encodings by skipping alpha channel
* downsampling original img / upsampling disparity img
* Contributors: Avinash Thakur, Martin Günther, choi0330
```
