### PR TITLE
power_msgs: 0.4.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5768,7 +5768,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/power_msgs-release.git
-      version: 0.4.1-1
+      version: 0.4.2-1
     source:
       type: git
       url: https://github.com/fetchrobotics/power_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `power_msgs` to `0.4.2-1`:

- upstream repository: https://github.com/fetchrobotics/power_msgs.git
- release repository: https://github.com/fetchrobotics-gbp/power_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.4.1-1`

## power_msgs

```
* Add is_charger_detected to BatteryState
* Contributors: Eric Relson
```
