### PR TITLE
rm_control: 0.1.7-4 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6606,7 +6606,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/rm-controls/rm_control-release.git
-      version: 0.1.7-3
+      version: 0.1.7-4
     source:
       type: git
       url: https://github.com/rm-controls/rm_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rm_control` to `0.1.7-4`:

- upstream repository: https://github.com/rm-controls/rm_control.git
- release repository: https://github.com/rm-controls/rm_control-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.7-3`

## rm_common

```
* 0.1.6
* Update CHANGELOG
* Merge branch 'namespace' into rm_gazebo/imu_sensor_interface
* Merge pull request #8 <https://github.com/rm-controls/rm_control/issues/8> from ye-luo-xi-tui/namespace
  Change name of namespace:from hardware_interface to rm_control.
* Change name of namespace:from hardware_interface to rm_control.
* Contributors: QiayuanLiao, qiayuan, yezi
```

## rm_control

```
* 0.1.6
* Update CHANGELOG
* Contributors: qiayuan
```

## rm_dbus

```
* 0.1.6
* Update CHANGELOG
* Contributors: qiayuan
```

## rm_description

```
* 0.1.6
* Update CHANGELOG
* Update URDF of imu
* Contributors: qiayuan
```

## rm_gazebo

```
* 0.1.6
* Update CHANGELOG
* Update URDF of imu
* Merge branch 'namespace' into rm_gazebo/imu_sensor_interface
* Merge pull request #8 <https://github.com/rm-controls/rm_control/issues/8> from ye-luo-xi-tui/namespace
  Change name of namespace:from hardware_interface to rm_control.
* Change name of namespace:from hardware_interface to rm_control.
* Fix some stupid imu_sensor_interface bug in rm_gazebo
* Tested rm_gazebo imu data using Debug in line.
  TODO: Add gravity and noise to the data
* Add imu_sensor_interface without test.
* Contributors: QiayuanLiao, qiayuan, yezi
```

## rm_hw

```
* 0.1.6
* Update CHANGELOG
* Fix some comment messed up by pre-commit
* Merge branch 'namespace' into rm_gazebo/imu_sensor_interface
* Merge pull request #8 <https://github.com/rm-controls/rm_control/issues/8> from ye-luo-xi-tui/namespace
  Change name of namespace:from hardware_interface to rm_control.
* Change name of namespace:from hardware_interface to rm_control.
* Contributors: QiayuanLiao, qiayuan, yezi
```

## rm_msgs

```
* 0.1.6
* Update CHANGELOG
* Merge branch 'gimbal/opti_or_simplify'
* Modified GimbalCmd.msg, and delete moving_average_filter
* Contributors: qiayuan
```
