### PR TITLE
librealsense2: 2.50.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1772,7 +1772,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/IntelRealSense/librealsense2-release.git
-      version: 2.48.0-1
+      version: 2.50.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense2` to `2.50.0-1`:

- upstream repository: https://github.com/IntelRealSense/librealsense.git
- release repository: https://github.com/IntelRealSense/librealsense2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.48.0-1`
