### PR TITLE
realsense2_camera: 2.3.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10027,7 +10027,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
-      version: 2.3.1-1
+      version: 2.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `2.3.2-1`:

- upstream repository: https://github.com/IntelRealSense/realsense-ros.git
- release repository: https://github.com/IntelRealSense/realsense-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.1-1`

## realsense2_camera

```
* publish metadata
* Add service: device_info
* add wait_for_device_timeout parameter
* Add reconnect_timeout parameter
* show warning when requested profile cannot be selected.
* send only 4 distortion coeffs when using equidistant
* fixed missing std namespace
* Removing spaces when iterating filters
* Contributors: Collin Avidano, Gintaras, Jacco van der Spek, doronhi
```

## realsense2_description

```
* Add D455 description
* Add missing aluminum material to d415 model.
* Contributors: Gilad Bretter, doronhi
```
