### PR TITLE
realsense2_camera: 3.2.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2743,7 +2743,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
-      version: 3.2.2-2
+      version: 3.2.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `3.2.3-1`:

- upstream repository: https://github.com/IntelRealSense/realsense-ros.git
- release repository: https://github.com/IntelRealSense/realsense-ros-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.2.2-2`

## realsense2_camera

```
* add parameter reconnect_timeout
* default frame_id includes namespace.
* Added dummy transformation for multi camera example
* add parameter wait_for_device_timeout
* Fix deprecation warnings when building on Rolling
* Make pointcloud_qos a configurable parameter
* show warning when requested profile cannot be selected.
* send only 4 distortion coeffs when using equidistant
* fixed missing std namespace
* Add ros2 github actions.
* add temperature diagnostics
* Add a parameter, diagnostics_period, to control if and how often will messages be published on the diagnostic topic.
* publish diagnostics topic for Asic and Projector temperature
* Support spaces in the filters Parameter string.
* publish metadata
* Add echo_metadada.py - An example script for subscribing and parsing metadata topics.
* Add service: device_info
* fixed device_name value to snake case
* Add device name.
* Contributors: Guillaume Doisy, Marenix, Nathan Brooks, Jacco van der Spek, doronhi
```

## realsense2_camera_msgs

```
* publish metadata
* Add service: device_info
* Contributors: doronhi
```

## realsense2_description

```
* Add D455 description
* Add missing aluminum material to d415 model.
* Contributors: Gilad Bretter, doronhi
```
