### PR TITLE
turtlebot3: 2.1.2-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4565,6 +4565,30 @@ repositories:
       url: https://github.com/ros-drivers/transport_drivers.git
       version: main
     status: developed
+  turtlebot3:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3.git
+      version: galactic-devel
+    release:
+      packages:
+      - turtlebot3
+      - turtlebot3_bringup
+      - turtlebot3_cartographer
+      - turtlebot3_description
+      - turtlebot3_example
+      - turtlebot3_navigation2
+      - turtlebot3_node
+      - turtlebot3_teleop
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/robotis-ros2-release/turtlebot3-release.git
+      version: 2.1.2-2
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3.git
+      version: galactic-devel
+    status: maintained
   turtlebot3_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3` to `2.1.2-2`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3.git
- release repository: https://github.com/robotis-ros2-release/turtlebot3-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## turtlebot3

```
* use static param types for Galactic
* fix SensorState msg
* rename and update nav2 params
* modify robot_state_publisher
* fix odometry bug
* Contributors: jhbirdchoi, David Park, Ashe Kim, Will Son
```

## turtlebot3_bringup

```
* rename and update nav2 params
* modify robot_state_publisher
* Contributors: David Park, Ashe Kim, Will Son
```

## turtlebot3_cartographer

```
* rename and update nav2 params
* Contributors: Ashe Kim, Will Son
```

## turtlebot3_description

```
* None
```

## turtlebot3_example

```
* None
```

## turtlebot3_navigation2

```
* rename and update nav2 params
* Contributors: Ashe Kim, Will Son
```

## turtlebot3_node

```
* use static param types for Galactic
* fix SensorState msg
* fix odometry bug
* Contributors: jhbirdchoi, Ashe Kim, Will Son
```

## turtlebot3_teleop

```
* None
```
