### PR TITLE
ifopt: 2.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3005,7 +3005,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ethz-adrl/ifopt-release.git
-      version: 2.0.7-1
+      version: 2.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ifopt` to `2.1.1-1`:

- upstream repository: https://github.com/ethz-adrl/ifopt.git
- release repository: https://github.com/ethz-adrl/ifopt-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.7-1`

## ifopt

```
* replace static variable falsely shared between contraints and costs
* Reduce calls to GetJacobian
* Changes to support windows build (#65)
* set default parameter or finite diff for backwards compatibility
* add return-status getter also to SNOPT
* calculate finite difference of cost-term for IPOPT if flag set. (#61)
* add explanation setting jacobian sparsity pattern (#47) (#55)
* Update README.md
* Switch  between catkin and ament based on ROS_VERSION (#52)
* Add GetConstraints and GetCosts to Problem (#51)
* Add GetJacobianOfCosts to Problem (#50)
* Make FillJacobianBlock public in ConstraintSet (#49)
```
