### PR TITLE
rc_genicam_api: 2.5.12-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3108,8 +3108,8 @@ repositories:
     release:
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/roboception-gbp/rc_genicam_api-release.git
-      version: 2.5.6-1
+      url: https://github.com/ros2-gbp/rc_genicam_api-release.git
+      version: 2.5.12-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_api` to `2.5.12-1`:

- upstream repository: https://github.com/roboception/rc_genicam_api.git
- release repository: https://github.com/ros2-gbp/rc_genicam_api-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.5.6-1`

## rc_genicam_api

```
* Imporved Windows build script for compiling with libpng
* Fixed some issues when compiling under Windows
```
