### PR TITLE
launch_ros: 0.11.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1738,7 +1738,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.11.4-1
+      version: 0.11.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.11.5-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.11.4-1`

## launch_ros

```
* Fix problems when parsing a ``Command`` ``Substitution`` as a parameter value (#137 <https://github.com/ros2/launch_ros/issues/137>)
* Contributors: Ivan Santiago Paunovic
```

## launch_testing_ros

- No changes

## ros2launch

- No changes
