### PR TITLE
rclc: 3.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2445,7 +2445,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
-      version: 3.0.3-1
+      version: 3.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclc` to `3.0.4-1`:

- upstream repository: https://github.com/ros2/rclc.git
- release repository: https://github.com/ros2-gbp/rclc-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.0.3-1`

## rclc

```
* Ignoring unsuccessful SERVICE_TAKE (#175)
* Add rclc_parameter Quality Declaration (#144)
* use-ros2-testing (#185)
* Fix: printf in executor spin (#195)
* Fix init options handling (#202) (#205)
* Remove init options from support (#203)
* RCLC Actions Implementation (#170)
* Add rcl_action as build export dependency (#211)
```

## rclc_examples

```
* added pingpong example (#172)
* Provide lifecycle services in the rclc lifecycle nodes (#51)
* RCLC Actions Implementation (#170)
```

## rclc_lifecycle

```
* Provide lifecycle services in the rclc lifecycle nodes (#51)
```

## rclc_parameter

```
* Add rclc_parameter Quality Declaration (#144)
* Check all dynamic allocations in parameter server init (#169)
```
