### PR TITLE
rm_controllers: 0.1.1-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12044,6 +12044,28 @@ repositories:
       url: https://github.com/ridgeback/ridgeback_simulator.git
       version: kinetic-devel
     status: maintained
+  rm_controllers:
+    doc:
+      type: git
+      url: https://github.com/rm-controls/rm_controllers.git
+      version: master
+    release:
+      packages:
+      - rm_calibration_controllers
+      - rm_chassis_controllers
+      - rm_controllers
+      - rm_gimbal_controllers
+      - rm_shooter_controllers
+      - robot_state_controller
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/rm-controls/rm_controllers-release.git
+      version: 0.1.1-2
+    source:
+      type: git
+      url: https://github.com/rm-controls/rm_controllers.git
+      version: master
+    status: developed
   robosense:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rm_controllers` to `0.1.1-2`:

- upstream repository: https://github.com/rm-controls/rm_controllers.git
- release repository: https://github.com/rm-controls/rm_controllers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
