### PR TITLE
mapviz: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1492,6 +1492,26 @@ repositories:
       url: https://github.com/boschglobal/locator_ros_bridge.git
       version: main
     status: maintained
+  mapviz:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/mapviz.git
+      version: ros2-devel
+    release:
+      packages:
+      - mapviz
+      - mapviz_interfaces
+      - mapviz_plugins
+      - multires_image
+      - tile_map
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/mapviz-release.git
+      version: 2.2.0-1
+    source:
+      type: git
+      url: https://github.com/swri-robotics/mapviz.git
+      version: ros2-devel
   marti_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.2.0-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
