### PR TITLE
Updates for the current Fedora releases

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5,8 +5,6 @@
 release_platforms:
   debian:
   - buster
-  fedora:
-  - '32'
   ubuntu:
   - focal
 repositories:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -374,9 +374,7 @@ boost:
     squeeze: [libboost1.42-all-dev]
     stretch: [libboost-all-dev]
     wheezy: [libboost-all-dev]
-  fedora:
-    '*': [boost-devel]
-    '32': [boost-devel, boost-python3-devel]
+  fedora: [boost-devel]
   freebsd: [py27-boost-libs]
   gentoo: ['dev-libs/boost[python]']
   macports: [boost]
@@ -1226,9 +1224,6 @@ gazebo9:
   debian:
     buster: [gazebo9]
     stretch: [gazebo9]
-  fedora:
-    '30': [gazebo]
-    '31': [gazebo]
   gentoo: [sci-electronics/gazebo]
   nixos: [gazebo_9]
   openembedded: []
@@ -2477,9 +2472,7 @@ libboost-python:
 libboost-python-dev:
   alpine: [boost-python2]
   debian: [libboost-python-dev]
-  fedora:
-    '*': [boost-devel]
-    '32': [boost-devel, boost-python3-devel]
+  fedora: [boost-devel]
   gentoo: ['dev-libs/boost[python]']
   nixos: [boost]
   openembedded: [boost@openembedded-core]
@@ -3130,9 +3123,6 @@ libgazebo9-dev:
   debian:
     buster: [libgazebo9-dev]
     stretch: [libgazebo9-dev]
-  fedora:
-    '30': [gazebo-devel]
-    '31': [gazebo-devel]
   gentoo: [sci-electronics/gazebo]
   nixos: [gazebo_9]
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2171,9 +2171,6 @@ python-gst-1.0:
     buster: [python-gst-1.0]
     jessie: [python-gst-1.0]
     stretch: [python-gst-1.0]
-  fedora:
-    '30': [python2-gstreamer1]
-    '31': [python2-gstreamer1]
   gentoo: ['dev-python/gst-python:1.0']
   openembedded: [gstreamer1.0-python@openembedded-core]
   ubuntu: [python-gst-1.0]
@@ -6660,9 +6657,7 @@ python3-importlib-metadata:
     stretch:
       pip:
         packages: [importlib-metadata]
-  fedora:
-    '*': [python3]
-    '31': [python3-importlib-metadata]
+  fedora: [python3]
   gentoo: [dev-python/importlib_metadata]
   nixos: [python3Packages.importlib-metadata]
   openembedded: [python3-importlib-metadata@openembedded-core]
@@ -6816,10 +6811,7 @@ python3-lark-parser:
 python3-lttng:
   alpine: [py3-lttng]
   debian: [python3-lttng]
-  fedora:
-    '*': [python3-lttng]
-    '30': null
-    '31': null
+  fedora: [python3-lttng]
   openembedded: [lttng-tools@openembedded-core]
   ubuntu: [python3-lttng]
 python3-lxml:
@@ -7137,9 +7129,6 @@ python3-pep8:
     buster: [python3-pep8]
     jessie: [python3-pep8]
     stretch: [python3-pep8]
-  fedora:
-    '30': [python3-pep8]
-    '31': [python3-pep8]
   gentoo: [dev-python/pep8]
   nixos: [python3Packages.pep8]
   openembedded: [python3-pep8@meta-ros-common]
@@ -7431,10 +7420,7 @@ python3-pykdl:
   debian:
     '*': [python3-pykdl]
     stretch: null
-  fedora:
-    '*': [python3-pykdl]
-    '30': null
-    '31': null
+  fedora: [python3-pykdl]
   gentoo: [dev-python/python_orocos_kdl]
   nixos: [python3Packages.pykdl]
   openembedded: [python3-pykdl@meta-ros1-noetic]

--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -83,9 +83,9 @@ supported_arches:
 
 name_replacements:
   fedora:
-    '32':
+    '34':
       '%{__isa_name}': 'x86'
-    '33':
+    '35':
       '%{__isa_name}': 'x86'
   rhel:
     '7':

--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -56,8 +56,8 @@ supported_versions:
   debian:
   - buster
   fedora:
-  - '33'
   - '34'
+  - '35'
   opensuse:
   - '15.2'
   rhel:


### PR DESCRIPTION
* Drop support for Fedora 32 and earlier
* Target Fedora 35 for rule verification automation

Fedora 32 reached EOL in May of this year, and Fedora 33 will reach EOL at the end of the month. Fedora 35, the latest stable release, reached GA at the beginning of this month.

Following previous patterns, this change drops explicit rosdep rules for EOL releases and drops them from ROS distribution platform lists.

This change also moves the rosdep automation testing targets to the most current releases.