### PR TITLE
gazebo_ros2_control: 0.0.6-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -931,7 +931,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.0.4-1
+      version: 0.0.6-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros2_control` to `0.0.6-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros2_control/
- release repository: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.4-1`

## gazebo_ros2_control

```
* Fix ros2_control resource manager in galatic (#96 <https://github.com/ros-simulation/gazebo_ros2_control//issues/96>)
* Contributors: Alejandro Hernández Cordero
```

## gazebo_ros2_control_demos

```
* Fix ros2_control resource manager in galatic (#96 <https://github.com/ros-simulation/gazebo_ros2_control//issues/96>)
* Contributors: Alejandro Hernández Cordero
```
