### PR TITLE
gpu-voxels-release: 0.8.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3905,7 +3905,7 @@ repositories:
       url: https://github.com/swri-robotics/gps_umd.git
       version: master
     status: developed
-  gpu-voxels-release:
+  gpu_voxels:
     doc:
       type: git
       url: https://github.com/BV-OpenSource/gpu-voxels.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3905,6 +3905,23 @@ repositories:
       url: https://github.com/swri-robotics/gps_umd.git
       version: master
     status: developed
+  gpu-voxels-release:
+    doc:
+      type: git
+      url: https://github.com/BV-OpenSource/gpu-voxels.git
+      version: melodic-dev
+    release:
+      packages:
+      - gpu_voxels
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/BV-OpenSource/gpu-voxels-release.git
+      version: 0.8.3-1
+    source:
+      type: git
+      url: https://github.com/BV-OpenSource/gpu-voxels.git
+      version: melodic-dev
+    status: developed
   graceful_controller:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gpu-voxels-release` to `0.8.3-1`:

- upstream repository: https://github.com/BV-OpenSource/gpu-voxels.git
- release repository: https://github.com/BV-OpenSource/gpu-voxels-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
