### PR TITLE
qb_chain: 2.2.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9470,11 +9470,13 @@ repositories:
       packages:
       - qb_chain
       - qb_chain_control
+      - qb_chain_controllers
       - qb_chain_description
+      - qb_chain_msgs
       tags:
         release: release/melodic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbchain-ros-release.git
-      version: 2.0.0-0
+      version: 2.2.3-1
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbchain-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_chain` to `2.2.3-1`:

- upstream repository: https://bitbucket.org/qbrobotics/qbchain-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbchain-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-0`

## qb_chain

- No changes

## qb_chain_control

```
* changed ee limits in .yaml file
* Changed delta limits
```

## qb_chain_controllers

- No changes

## qb_chain_description

- No changes

## qb_chain_msgs

```
* Modified package.xml file in order to fix jenkins errors.
```
