### PR TITLE
[rosdep] add python3-sila2lib-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7915,6 +7915,19 @@ python3-shapely:
       packages: [shapely]
   rhel: [python3-shapely]
   ubuntu: [python3-shapely]
+python3-sila2lib-pip:
+  debian:
+    pip:
+      packages: [sila2lib]
+  fedora:
+    pip:
+      packages: [sila2lib]
+  opensuse:
+    pip:
+      packages: [sila2lib]
+  ubuntu:
+    pip:
+      packages: [sila2lib]
 python3-simple-pid-pip:
   debian:
     pip:


### PR DESCRIPTION
this package is only available from PyPi:
https://pypi.org/project/sila2lib/