### PR TITLE
rviz: 9.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3878,7 +3878,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 8.7.0-1
+      version: 9.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `9.0.0-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `8.7.0-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Switch to using Qt::MiddleButton for RViz. (#802 <https://github.com/ros2/rviz/issues/802>)
* Removed traces in renderPanel (#777 <https://github.com/ros2/rviz/issues/777>)
* move yaml_config_writer.hpp to public includes (#764 <https://github.com/ros2/rviz/issues/764>)
* Update displays_panel.cpp (#745 <https://github.com/ros2/rviz/issues/745>)
* Robot: Report mesh loading issues (#744 <https://github.com/ros2/rviz/issues/744>)
* Exposed tool_manager header file. (#767 <https://github.com/ros2/rviz/issues/767>)
* refactor: make const getter methods const (#756 <https://github.com/ros2/rviz/issues/756>)
* Efficiently handle 3-bytes pixel formats (#743 <https://github.com/ros2/rviz/issues/743>)
* Report sample lost events (#686 <https://github.com/ros2/rviz/issues/686>)
* Contributors: ANDOU Tetsuo, Alejandro Hernández Cordero, Chris Lalancette, Gonzo, Joseph Schornak, davidorchansky
```

## rviz_default_plugins

```
* Switch to using Qt::MiddleButton for RViz. (#802 <https://github.com/ros2/rviz/issues/802>)
* Add a tf_buffer_cache_time_ns to tf_wrapper (#792 <https://github.com/ros2/rviz/issues/792>)
* Make libraries to avoid compiling files multiple times (#774 <https://github.com/ros2/rviz/issues/774>)
* Computed inertia with ignition-math (#751 <https://github.com/ros2/rviz/issues/751>)
* Fixed crash when changing rendering parameters for pointcloud2 while 'Selectable' box is unchecked (#768 <https://github.com/ros2/rviz/issues/768>)
* Robot: Report mesh loading issues (#744 <https://github.com/ros2/rviz/issues/744>)
* Handle NaN values for Wrench msgs (#746 <https://github.com/ros2/rviz/issues/746>)
* Triangle lists support textures (#719 <https://github.com/ros2/rviz/issues/719>)
* Report sample lost events (#686 <https://github.com/ros2/rviz/issues/686>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Gonzo, Greg Balke, Ivan Santiago Paunovic, Shane Loretz, bailaC
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Suppress assimp warnings in rviz_rendering build (#775 <https://github.com/ros2/rviz/issues/775>)
* Fix for ogre failing when material already exists (#729 <https://github.com/ros2/rviz/issues/729>)
* Contributors: Scott K Logan, Wolf Vollprecht
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
