### PR TITLE
rmw_implementation: 2.6.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2932,7 +2932,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_implementation-release.git
-      version: 2.6.0-1
+      version: 2.6.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_implementation` to `2.6.1-1`:

- upstream repository: https://github.com/ros2/rmw_implementation.git
- release repository: https://github.com/ros2-gbp/rmw_implementation-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.6.0-1`

## rmw_implementation

```
* Fix renamed rcpputils header (#198 <https://github.com/ros2/rmw_implementation/issues/198>)
* Fix rmw_implementation generated documentation (#197 <https://github.com/ros2/rmw_implementation/issues/197>)
* Contributors: Abrar Rahman Protyasha, Michel Hidalgo
```
