### PR TITLE
turtlesim: 1.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4250,7 +4250,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_tutorials-release.git
-      version: 1.3.2-1
+      version: 1.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlesim` to `1.4.0-1`:

- upstream repository: https://github.com/ros/ros_tutorials.git
- release repository: https://github.com/ros2-gbp/ros_tutorials-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.3.2-1`

## turtlesim

```
* Update maintainers to Audrow Nash and Michael Jeronimo (#137 <https://github.com/ros/ros_tutorials/issues/137>)
* Fixing deprecated subscriber callback warnings (#134 <https://github.com/ros/ros_tutorials/issues/134>)
* Use rosidl_get_typesupport_target() (#132 <https://github.com/ros/ros_tutorials/issues/132>)
* Print out the correct node name on startup. (#122 <https://github.com/ros/ros_tutorials/issues/122>)
* Contributors: Abrar Rahman Protyasha, Audrow Nash, Chris Lalancette, Shane Loretz
```
