### PR TITLE
add libcamera

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2649,6 +2649,15 @@ libcairo2-dev:
   opensuse: [cairo-devel]
   rhel: [cairo-devel]
   ubuntu: [libcairo2-dev]
+libcamera:
+  debian:
+    sid: [libcamera-dev]
+  fedora:
+    "36": [libcamera]
+  gentoo: ['media-libs/libcamera']
+  nixos: [libcamera]
+  ubuntu:
+    impish: [libcamera-dev]
 libcap-dev:
   arch: [libcap]
   debian: [libcap-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2657,7 +2657,9 @@ libcamera:
   gentoo: ['media-libs/libcamera']
   nixos: [libcamera]
   ubuntu:
-    impish: [libcamera-dev]
+    '*': [libcamera-dev]
+    bionic: null
+    focal: null
 libcap-dev:
   arch: [libcap]
   debian: [libcap-dev]


### PR DESCRIPTION
https://libcamera.org

"A complex camera support library for Linux, Android, and ChromeOS"

<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

libcamera

## Package Upstream Source:

https://git.libcamera.org/libcamera/libcamera.git

## Purpose of using this:

The purpose of libcamera is to provide a camera stack that is supported by the industry. See https://libcamera.org for details.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/sid/libcamera-dev
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/impish/libcamera-dev
- Fedora: https://src.fedoraproject.org/browse/projects/
  - https://src.fedoraproject.org/rpms/libcamera
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=unstable&show=libcamera&from=0&size=50&sort=relevance&type=packages&query=libcamera
