### PR TITLE
moveit: 2.2.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2106,7 +2106,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/moveit/moveit2-release.git
-      version: 2.2.1-1
+      version: 2.2.2-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.2.2-1`:

- upstream repository: https://github.com/ros-planning/moveit2.git
- release repository: https://github.com/moveit/moveit2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.2.1-1`

## moveit

- No changes

## moveit_common

- No changes

## moveit_core

```
* collision_detection_bullet: Fix target installation (#658 <https://github.com/ros-planning/moveit2/issues/658>)
* Fix broken test (#701 <https://github.com/ros-planning/moveit2/issues/701>)
* Fixes for Windows (#530 <https://github.com/ros-planning/moveit2/issues/530>)
* Tests for CurrentStateMonitor using dependency injection (#562 <https://github.com/ros-planning/moveit2/issues/562>)
* Contributors: Akash, Robert Haschke, Lior Lustgarten, Tyler Weaver, Vatan Aksoy Tezer, Henning Kayser, Jorge Nicho, Nisala Kalupahana, Jafar Abdi
```

## moveit_kinematics

```
* Fix loading joint_limits.yaml in demo and test launch files (#544 <https://github.com/ros-planning/moveit2/issues/544>)
* Contributors: Jafar Abdi
```

## moveit_planners

- No changes

## moveit_planners_ompl

```
* Fix linking issues for ODE on macOS (#549 <https://github.com/ros-planning/moveit2/issues/549>)
* Contributors: Nisala Kalupahana, Henning Kayser
```

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

```
* Fix loading joint_limits.yaml in demo and test launch files (#544 <https://github.com/ros-planning/moveit2/issues/544>)
* Fixes for Windows (#530 <https://github.com/ros-planning/moveit2/issues/530>)
* Contributors: Akash, Lior Lustgarten, Tyler Weaver, Vatan Aksoy Tezer, Henning Kayser, Jorge Nicho, Nisala Kalupahana, Jafar Abdi
```

## moveit_ros_move_group

- No changes

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

```
* Fixes for Windows (#530 <https://github.com/ros-planning/moveit2/issues/530>)
* Contributors: Akash, Lior Lustgarten, Tyler Weaver, Vatan Aksoy Tezer, Henning Kayser, Jorge Nicho, Nisala Kalupahana, Jafar Abdi
```

## moveit_ros_planning

```
* MoveitCpp - path constraints added from PlanningComponent (#752 <https://github.com/ros-planning/moveit2/issues/752>)
* Fixes for Windows (#530 <https://github.com/ros-planning/moveit2/issues/530>)
* Tests for CurrentStateMonitor using dependency injection (#562 <https://github.com/ros-planning/moveit2/issues/562>)
* Fix joint's position limits loading (#553 <https://github.com/ros-planning/moveit2/issues/553>)
* Contributors: Akash, Marco Lapolla, Lior Lustgarten, Tyler Weaver, Vatan Aksoy Tezer, Henning Kayser, Jorge Nicho, Nisala Kalupahana, Jafar Abdi
```

## moveit_ros_planning_interface

```
* Add getSharedRobotModelLoader to fix race condition when having multiple displays for the same node (#525 <https://github.com/ros-planning/moveit2/issues/525>)
* common_objects: getSharedRobotModelLoader fix deadlock (#734 <https://github.com/ros-planning/moveit2/issues/734>)
* Migrate to joint_state_broadcaster (#656 <https://github.com/ros-planning/moveit2/issues/656>)
* Fix loading joint_limits.yaml in demo and test launch files (#544 <https://github.com/ros-planning/moveit2/issues/544>)
* Fixes for Windows (#530 <https://github.com/ros-planning/moveit2/issues/530>)
* Contributors: Akash, Lior Lustgarten, Tyler Weaver, Vatan Aksoy Tezer, Henning Kayser, Jorge Nicho, Nisala Kalupahana, Jafar Abdi
```

## moveit_ros_robot_interaction

```
* Fixes for Windows (#530 <https://github.com/ros-planning/moveit2/issues/530>)
* Contributors: Akash, Lior Lustgarten, Tyler Weaver, Vatan Aksoy Tezer, Henning Kayser, Jorge Nicho, Nisala Kalupahana, Jafar Abdi
```

## moveit_ros_visualization

```
* Add getSharedRobotModelLoader to fix race condition when having multiple displays for the same node (#525 <https://github.com/ros-planning/moveit2/issues/525>)
* common_objects: getSharedRobotModelLoader fix deadlock (#734 <https://github.com/ros-planning/moveit2/issues/734>)
* Fixes for Windows (#530 <https://github.com/ros-planning/moveit2/issues/530>)
* Contributors: Akash, Lior Lustgarten, Tyler Weaver, Vatan Aksoy Tezer, Henning Kayser, Jorge Nicho, Nisala Kalupahana, Jafar Abdi
```

## moveit_ros_warehouse

```
* Fixes for Windows (#530 <https://github.com/ros-planning/moveit2/issues/530>)
* Contributors: Akash, Lior Lustgarten, Tyler Weaver, Vatan Aksoy Tezer, Henning Kayser, Jorge Nicho, Nisala Kalupahana, Jafar Abdi
```

## moveit_runtime

- No changes

## moveit_servo

```
* Migrate to joint_state_broadcaster (#656 <https://github.com/ros-planning/moveit2/issues/656>)
* Fix missing include in servo example (#609 <https://github.com/ros-planning/moveit2/issues/609>)
* Fix loading joint_limits.yaml in demo and test launch files (#544 <https://github.com/ros-planning/moveit2/issues/544>)
* Fixes for Windows (#530 <https://github.com/ros-planning/moveit2/issues/530>)
* Refactor out velocity limit enforcement with test (#540 <https://github.com/ros-planning/moveit2/issues/540>)
* Refactor moveit_servo::LowPassFilter to be assignable (#572 <https://github.com/ros-planning/moveit2/issues/572>)
* Fix MoveIt Servo compilation on macOS (#555 <https://github.com/ros-planning/moveit2/issues/555>)
* Fix segfault if servo collision checking is disabled (#568 <https://github.com/ros-planning/moveit2/issues/568>)
* Contributors: Akash, Griswald Brooks, Joseph Schornak, Nisala Kalupahana, Lior Lustgarten, Tyler Weaver, Vatan Aksoy Tezer, Henning Kayser, Jorge Nicho, Nisala Kalupahana, Jafar Abdi, Adam Pettinger
```

## moveit_simple_controller_manager

- No changes

## run_move_group

```
* Migrate to joint_state_broadcaster (#656 <https://github.com/ros-planning/moveit2/issues/656>)
* Add missing exec dependencies to demo packages (#582 <https://github.com/ros-planning/moveit2/issues/582>)
* Fix loading joint_limits.yaml in demo and test launch files (#544 <https://github.com/ros-planning/moveit2/issues/544>)
* Contributors: Henning Kayser, Jafar Abdi, Vatan Aksoy Tezer, Tyler Weaver
```

## run_moveit_cpp

```
* Migrate to joint_state_broadcaster (#656 <https://github.com/ros-planning/moveit2/issues/656>)
* Add missing exec dependencies to demo packages (#582 <https://github.com/ros-planning/moveit2/issues/582>)
* Fix loading joint_limits.yaml in demo and test launch files (#544 <https://github.com/ros-planning/moveit2/issues/544>)
* Contributors: Henning Kayser, Jafar Abdi, Vatan Aksoy Tezer, Tyler Weaver
```

## run_ompl_constrained_planning

```
* Migrate to joint_state_broadcaster (#656 <https://github.com/ros-planning/moveit2/issues/656>)
* Add missing exec dependencies to demo packages (#582 <https://github.com/ros-planning/moveit2/issues/582>)
* Fix loading joint_limits.yaml in demo and test launch files (#544 <https://github.com/ros-planning/moveit2/issues/544>)
* Contributors: Henning Kayser, Jafar Abdi, Vatan Aksoy Tezer, Tyler Weaver
```
