### PR TITLE
rmw: 5.1.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2825,7 +2825,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 5.0.0-1
+      version: 5.1.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw` to `5.1.0-2`:

- upstream repository: https://github.com/ros2/rmw.git
- release repository: https://github.com/ros2-gbp/rmw-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `5.0.0-1`

## rmw

```
* Add client/service QoS getters. (#314 <https://github.com/ros2/rmw/issues/314>)
* Contributors: mauropasse
```

## rmw_implementation_cmake

- No changes
