### PR TITLE
rmw_fastrtps: 6.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2898,7 +2898,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 6.0.0-1
+      version: 6.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `6.1.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `6.0.0-1`

## rmw_fastrtps_cpp

```
* Add client/service QoS getters. (#560 <https://github.com/ros2/rmw_fastrtps/issues/560>)
* Contributors: mauropasse
```

## rmw_fastrtps_dynamic_cpp

```
* Add client/service QoS getters. (#560 <https://github.com/ros2/rmw_fastrtps/issues/560>)
* Contributors: mauropasse
```

## rmw_fastrtps_shared_cpp

```
* Add client/service QoS getters. (#560 <https://github.com/ros2/rmw_fastrtps/issues/560>)
* Fix QoS depth settings for clients/service being ignored. (#564 <https://github.com/ros2/rmw_fastrtps/issues/564>)
* Contributors: Chen Lihui, mauropasse
```
