### PR TITLE
rmw_cyclonedds: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2862,7 +2862,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `1.1.0-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.0-1`

## rmw_cyclonedds_cpp

```
* Add client/service QoS getters. (#343 <https://github.com/ros2/rmw_cyclonedds/issues/343>)
* Updated version number and quality level. (#349 <https://github.com/ros2/rmw_cyclonedds/issues/349>)
* Update package maintainers. (#351 <https://github.com/ros2/rmw_cyclonedds/issues/351>)
* Contributors: Joe Speed, Michel Hidalgo, mauropasse
```
