### PR TITLE
rmw_connextdds: 0.8.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2845,7 +2845,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `0.8.1-1`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.8.0-1`

## rmw_connextdds

```
* Add client/service QoS getters. (#67 <https://github.com/rticommunity/rmw_connextdds/issues/67>)
* Contributors: mauropasse
```

## rmw_connextdds_common

```
* Add client/service QoS getters. (#67 <https://github.com/rticommunity/rmw_connextdds/issues/67>)
* Contributors: mauropasse
```

## rti_connext_dds_cmake_module

- No changes
