### PR TITLE
rmw_implementation: 2.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2932,7 +2932,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_implementation-release.git
-      version: 2.6.1-1
+      version: 2.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_implementation` to `2.7.0-1`:

- upstream repository: https://github.com/ros2/rmw_implementation.git
- release repository: https://github.com/ros2-gbp/rmw_implementation-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.6.1-1`

## rmw_implementation

```
* Add client/service QoS getters. (#196 <https://github.com/ros2/rmw_implementation/issues/196>)
* Update maintainers to Audrow Nash and Michael Carroll. (#199 <https://github.com/ros2/rmw_implementation/issues/199>)
* Contributors: Audrow Nash, mauropasse
```
