### PR TITLE
find_object_2d: 0.6.4-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3309,7 +3309,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/introlab/find_object_2d-release.git
-      version: 0.6.2-1
+      version: 0.6.4-2
     source:
       type: git
       url: https://github.com/introlab/find-object.git


### PR DESCRIPTION
Increasing version of package(s) in repository `find_object_2d` to `0.6.4-2`:

- upstream repository: https://github.com/introlab/find-object.git
- release repository: https://github.com/introlab/find_object_2d-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.2-1`
