### PR TITLE
sob_layer: 0.1.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8579,11 +8579,15 @@ repositories:
       version: ros1
     status: maintained
   sob_layer:
+    doc:
+      type: git
+      url: https://github.com/dorezyuk/sob_layer.git
+      version: master
     release:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/dorezyuk/sob_layer-release.git
-      version: 0.1.0-1
+      version: 0.1.0-2
     source:
       type: git
       url: https://github.com/dorezyuk/sob_layer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sob_layer` to `0.1.0-2`:

- upstream repository: https://github.com/dorezyuk/sob_layer.git
- release repository: https://github.com/dorezyuk/sob_layer-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.0-1`

## sob_layer

```
* prepare for debian-packaging
* minor fixes
* adjust documentation
* move the computeCache call into updateBounds
* add documentation about unknown costs
* add warning for unsupported parameters
* fix doc
* misc
* Update README.md
* add travis.yaml
* add doc
* add documentation and licence
* Create LICENSE
* init
* Contributors: Dima Dorezyuk
```
