### PR TITLE
sob_layer: 0.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8579,11 +8579,15 @@ repositories:
       version: ros1
     status: maintained
   sob_layer:
+    doc:
+      type: git
+      url: https://github.com/dorezyuk/sob_layer.git
+      version: 0.1.1
     release:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/dorezyuk/sob_layer-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/dorezyuk/sob_layer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sob_layer` to `0.1.1-1`:

- upstream repository: https://github.com/dorezyuk/sob_layer.git
- release repository: https://github.com/dorezyuk/sob_layer-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.0-1`

## sob_layer

```
* fix segmentation fault (#12 <https://github.com/dorezyuk/sob_layer/issues/12>)
* Dima/unknown cost (#11 <https://github.com/dorezyuk/sob_layer/issues/11>)
* Merge pull request #10 <https://github.com/dorezyuk/sob_layer/issues/10> from dorezyuk/dima/dev2
  Dima/dev2
* update the image generation and images
* adjust doc-string
* move the power computation outside of the parabola loop
* cache-friendlier formulation
* fix compiler warnings when compiling with pedantic
* remove calls to std::sqrt
* fix include order
* more explicit skipping
* fix missing updateBounds call
* Merge pull request #9 <https://github.com/dorezyuk/sob_layer/issues/9> from dorezyuk/dima/dev
  misc fixes
* misc fixes
* Merge pull request #8 <https://github.com/dorezyuk/sob_layer/issues/8> from dorezyuk/dima/dev
  Dima/dev
* update README
* fix cmake
* Contributors: Dima Dorezyuk
```
