### PR TITLE
snowbot_operating_system: 0.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5102,6 +5102,21 @@ repositories:
       url: https://github.com/oKermorgant/slider_publisher.git
       version: ros2
     status: maintained
+  snowbot_operating_system:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/snowbot_operating_system.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/PickNikRobotics/snowbot_release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/snowbot_operating_system.git
+      version: ros2
+    status: maintained
   soccer_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `snowbot_operating_system` to `0.1.0-1`:

- upstream repository: https://github.com/PickNikRobotics/snowbot_operating_system.git
- release repository: https://github.com/PickNikRobotics/snowbot_release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
