### PR TITLE
Add tango-icon-theme rule for RHEL 8+

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7377,8 +7377,7 @@ tango-icon-theme:
   nixos: [tango-icon-theme]
   openembedded: [adwaita-icon-theme@openembedded-core]
   opensuse: [tango-icon-theme]
-  rhel:
-    '7': [tango-icon-theme]
+  rhel: [tango-icon-theme]
   slackware: [tango-icon-theme]
   ubuntu: [tango-icon-theme]
 tap-plugins:


### PR DESCRIPTION
This package is now available via EPEL.

https://src.fedoraproject.org/rpms/tango-icon-theme#bodhi_updates
