### PR TITLE
hash_library_vendor: 0.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1074,6 +1074,21 @@ repositories:
       url: https://github.com/flynneva/grbl_ros.git
       version: devel
     status: maintained
+  hash_library_vendor:
+    doc:
+      type: git
+      url: https://github.com/tier4/hash_library_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/tier4/hash_library_vendor-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/tier4/hash_library_vendor.git
+      version: main
+    status: maintained
   hls_lfcd_lds_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hash_library_vendor` to `0.1.0-1`:

- upstream repository: https://github.com/tier4/hash_library_vendor.git
- release repository: https://github.com/tier4/hash_library_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## hash_library_vendor

```
* Bump streetsidesoftware/cspell-action from 1.3.1 to 1.3.5 (#6 <https://github.com/tier4/hash_library_vendor/issues/6>)
  Bumps [streetsidesoftware/cspell-action](https://github.com/streetsidesoftware/cspell-action) from 1.3.1 to 1.3.5.
  - [Release notes](https://github.com/streetsidesoftware/cspell-action/releases)
  - [Changelog](https://github.com/streetsidesoftware/cspell-action/blob/main/CHANGELOG.md)
  - [Commits](https://github.com/streetsidesoftware/cspell-action/compare/v1.3.1...v1.3.5)
  ---
  updated-dependencies:
  - dependency-name: streetsidesoftware/cspell-action
  dependency-type: direct:production
  update-type: version-update:semver-patch
  ...
  Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
* Add author (#2 <https://github.com/tier4/hash_library_vendor/issues/2>)
* Add files
* Initial commit
* Contributors: Kenji Miyake, dependabot[bot]
```
