### PR TITLE
vision_opencv: 1.16.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9581,7 +9581,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/vision_opencv-release.git
-      version: 1.15.0-1
+      version: 1.16.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `1.16.0-1`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros-gbp/vision_opencv-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.15.0-1`

## cv_bridge

```
* prevent conversion of single channel 16bit integer images to/from colour (#412 <https://github.com/ros-perception/vision_opencv/issues/412>)
* decode images in mode IMREAD_UNCHANGED (#228 <https://github.com/ros-perception/vision_opencv/issues/228>)
* Optimize includes (#354 <https://github.com/ros-perception/vision_opencv/issues/354>)
  As suggested by include-what-you-use
* Fix Python linking on OSX (#331 <https://github.com/ros-perception/vision_opencv/issues/331>)
* Fix typo (#333 <https://github.com/ros-perception/vision_opencv/issues/333>)
* Contributors: Christian Rauch, Markus Vieth, Matthijs van der Burgh, Tobias Fischer
```

## image_geometry

```
* substituted missing sphinx extension (#417 <https://github.com/ros-perception/vision_opencv/issues/417>)
* Fix rectifyRoi when used with binning and/or ROI (#378 <https://github.com/ros-perception/vision_opencv/issues/378>)
* Implement unrectifyImage() (#359 <https://github.com/ros-perception/vision_opencv/issues/359>)
* Add equidistant distortion model (#358 <https://github.com/ros-perception/vision_opencv/issues/358>)
* Optimize includes (#354 <https://github.com/ros-perception/vision_opencv/issues/354>)
* Contributors: Markus Vieth, Martin Günther, Paddy
```

## vision_opencv

- No changes
