### PR TITLE
Clean up RHEL and Fedora rules (Round 1)

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4380,7 +4380,9 @@ libpoco-dev:
   nixos: [poco]
   openembedded: [poco@meta-oe]
   opensuse: [poco-devel]
-  rhel: [poco-devel]
+  rhel:
+    '*': [poco-devel]
+    '8': null
   slackware: [poco]
   ubuntu: [libpoco-dev]
 libpocofoundation9:
@@ -6947,7 +6949,9 @@ sbcl:
   macports: [sbcl]
   nixos: [sbcl]
   opensuse: [sbcl]
-  rhel: [sbcl]
+  rhel:
+    '*': [sbcl]
+    '8': null
   slackware: [sbcl]
   ubuntu: [sbcl]
 scons:
@@ -7401,7 +7405,9 @@ tar:
   nixos: [libtar]
   openembedded: [tar@openembedded-core]
   opensuse: [libtar-devel]
-  rhel: [libtar-devel]
+  rhel:
+    '*': [libtar-devel]
+    '8': null
   ubuntu: [libtar-dev]
 tbb:
   arch: [intel-tbb]
@@ -7801,7 +7807,9 @@ wxwidgets:
   nixos: [wxGTK]
   openembedded: [wxwidgets@meta-ros-common]
   opensuse: [wxGTK-devel]
-  rhel: [wxGTK-devel]
+  rhel:
+    '*': [wxGTK3-devel]
+    '7': [wxGTK-devel]
   ubuntu:
     artful: [libwxgtk3.0-dev]
     bionic: [libwxgtk3.0-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -46,7 +46,6 @@ acpitool:
 alsa-oss:
   arch: [alsa-oss]
   debian: [alsa-oss]
-  fedora: [alsa-oss]
   gentoo: [media-libs/alsa-oss]
   nixos: [alsaOss]
   opensuse: [alsa-oss]
@@ -294,7 +293,6 @@ babeltrace:
 bazaar:
   arch: [bzr]
   debian: [bzr]
-  fedora: [bazaar]
   freebsd: [bazaar]
   gentoo: [dev-vcs/bzr]
   macports: [bazaar]
@@ -644,7 +642,6 @@ collectd-utils:
   ubuntu: [collectd-utils]
 comedi:
   debian: [libcomedi-dev]
-  fedora: [comedilib-devel]
   ubuntu: [libcomedi-dev]
 coreutils:
   arch: [coreutils]
@@ -786,7 +783,6 @@ dfu-util:
   ubuntu: [dfu-util]
 disper:
   debian: [disper]
-  fedora: [disper]
   nixos: [disper]
   ubuntu: [disper]
 dkms:
@@ -907,7 +903,6 @@ eigen2:
   debian:
     jessie: [libeigen2-dev]
     wheezy: [libeigen2-dev]
-  fedora: [eigen2-devel]
   freebsd: [eigen2]
   gentoo: ['dev-cpp/eigen:2']
   nixos: [eigen2]
@@ -1165,7 +1160,6 @@ g++-static:
   ubuntu: [g++]
 gamin:
   debian: [gamin]
-  fedora: [gamin]
   ubuntu: [gamin]
 gawk:
   arch: [gawk]
@@ -1261,7 +1255,6 @@ gcc-static:
 gccxml:
   arch: [gccxml-git]
   debian: [gccxml]
-  fedora: [gccxml]
   gentoo: [dev-cpp/gccxml]
   macports: [gccxml-devel]
   ubuntu: [gccxml]
@@ -1496,7 +1489,6 @@ gradle:
     buster: [gradle]
     jessie: [gradle]
     stretch: [gradle]
-  fedora: [gradle]
   gentoo: [dev-java/gradle-bin]
   nixos: [gradle]
   ubuntu: [gradle]
@@ -2014,7 +2006,6 @@ iputils-ping:
   ubuntu: [iputils-ping]
 iwyu:
   debian: [iwyu]
-  fedora: [iwyu]
   nixos: [include-what-you-use]
   ubuntu: [iwyu]
 jack:
@@ -2090,7 +2081,6 @@ julius-voxforge:
 jython:
   arch: [jython]
   debian: [jython]
-  fedora: [jython]
   gentoo: [dev-java/jython]
   nixos: [jython]
   ubuntu: [jython]
@@ -2161,7 +2151,6 @@ libann-dev:
 libapache2-mod-python:
   arch: [mod_python]
   debian: [libapache2-mod-python]
-  fedora: [mod_python]
   gentoo: [www-apache/mod_python]
   ubuntu: [libapache2-mod-python]
 libargtable2-dev:
@@ -3606,7 +3595,6 @@ libjack-dev:
   ubuntu: [libjack-dev]
 libjackson-json-java:
   debian: [libjackson-json-java]
-  fedora: [jackson]
   gentoo: [dev-java/jackson]
   ubuntu: [libjackson-json-java]
 libjansson-dev:
@@ -3667,7 +3655,6 @@ libjson-glib:
   ubuntu: [libjson-glib-dev]
 libjson-java:
   debian: [libjson-java]
-  fedora: [json-lib]
   gentoo: [dev-java/json]
   ubuntu: [libjson-java]
 libjson0-dev:
@@ -3728,13 +3715,11 @@ liblapacke-dev:
   ubuntu: [liblapacke-dev]
 liblcm:
   debian: [liblcm1]
-  fedora: [liblcm]
   ubuntu:
     '*': [liblcm1]
     xenial: null
 liblcm-dev:
   debian: [liblcm-dev]
-  fedora: [liblcm-devel]
   ubuntu:
     '*': [liblcm-dev]
     xenial: null
@@ -3934,7 +3919,6 @@ libnl-3-dev:
 libnl-dev:
   arch: [libnl1]
   debian: [libnl-dev]
-  fedora: [libnl-devel]
   gentoo: [dev-libs/libnl]
   ubuntu: [libnl-dev]
 libnlopt-cxx-dev:
@@ -4895,7 +4879,6 @@ libreadline-dev:
 libreadline-java:
   arch: [java-readline]
   debian: [libreadline-java]
-  fedora: [libreadline-java]
   gentoo: [dev-java/libreadline-java]
   ubuntu: [libreadline-java]
 libsecp256k1-dev:
@@ -6052,7 +6035,6 @@ mkdocs-bootswatch:
     zesty: [mkdocs-bootswatch]
 mongodb:
   debian: [mongodb]
-  fedora: [mongodb]
   gentoo: [dev-db/mongodb]
   nixos: [mongodb]
   openembedded: [mongodb@meta-oe]
@@ -6060,7 +6042,6 @@ mongodb:
 mongodb-dev:
   arch: [mongodb]
   debian: [libmongo-client-dev, mongodb-dev]
-  fedora: [libmongo-client-devel, mongodb-devel]
   gentoo: [dev-db/mongodb]
   macports: [mongodb]
   nixos: [mongodb]
@@ -6258,14 +6239,12 @@ npm:
 ntp:
   arch: [ntp]
   debian: [ntp]
-  fedora: [ntp]
   gentoo: [net-misc/ntp]
   nixos: [ntp]
   ubuntu: [ntp]
 ntpdate:
   arch: [ntp]
   debian: [ntpdate]
-  fedora: [ntpdate]
   gentoo: [net-misc/ntp]
   nixos: [ntp]
   ubuntu: [ntpdate]
@@ -6290,7 +6269,6 @@ ocl-icd-opencl-dev:
   ubuntu: [ocl-icd-opencl-dev]
 odb:
   debian: [odb]
-  fedora: [odb]
   ubuntu:
     '*': [odb]
     trusty: null
@@ -6891,7 +6869,6 @@ recode:
 recordmydesktop:
   arch: [recordmydesktop]
   debian: [recordmydesktop]
-  fedora: [recordmydesktop]
   gentoo: [media-video/recordmydesktop]
   ubuntu: [recordmydesktop]
 redis-server:
@@ -7539,7 +7516,6 @@ touchegg:
   ubuntu: [touchegg]
 trang:
   debian: [trang]
-  fedora: [trang]
   gentoo: [app-text/trang]
   rhel:
     '7': [trang]
@@ -7591,7 +7567,6 @@ udhcpc:
   ubuntu: [udhcpc]
 unclutter:
   debian: [unclutter]
-  fedora: [unclutter]
   ubuntu: [unclutter]
 uncrustify:
   alpine: [uncrustify]
@@ -7607,14 +7582,12 @@ uncrustify:
 unison:
   arch: [unison]
   debian: [unison]
-  fedora: [unison240]
   gentoo: [net-misc/unison]
   nixos: [unison]
   ubuntu: [unison]
 unison-gui:
   arch: [unison]
   debian: [unison-gtk]
-  fedora: [unison240-gtk]
   gentoo: ['net-misc/unison[gtk]']
   ubuntu: [unison-gtk]
 unoconv:
@@ -7911,7 +7884,6 @@ xterm:
 xulrunner-1.9.2:
   arch: [xulrunner]
   debian: []
-  fedora: [xulrunner]
   ubuntu:
     karmic: [xulrunner-1.9.2]
     lucid: [xulrunner-1.9.2]
@@ -7924,7 +7896,6 @@ xulrunner-1.9.2:
 xulrunner-dev:
   arch: [xulrunner]
   debian: [libv8-dev]
-  fedora: [libv8-devel, xulrunner-devel]
   ubuntu: [libv8-dev]
 xvfb:
   arch: [xorg-server-xvfb]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6980,7 +6980,9 @@ python3-more-itertools:
   debian: [python3-more-itertools]
   fedora: [python3-more-itertools]
   gentoo: [dev-python/more-itertools]
-  rhel: ['python%{python3_pkgversion}-more-itertools']
+  rhel:
+    '*': [python3-more-itertools]
+    '7': null
   ubuntu: [python3-more-itertools]
 python3-msgpack:
   debian:
@@ -7447,7 +7449,9 @@ python3-pygit2:
   osx:
     pip:
       packages: [pygit2]
-  rhel: ['python%{python3_pkgversion}-pygit2']
+  rhel:
+    '*': [python3-pygit2]
+    '7': null
   ubuntu: [python3-pygit2]
 python3-pygments:
   alpine: [py3-pygments]


### PR DESCRIPTION
Using the [rosdep_repo_check](https://github.com/ros/rosdistro/tree/master/test/rosdep_repo_check#readme) automation, I'm surveying the rosdep database for packages that aren't available and investigating them individually.

This PR addresses all of the RHEL problems, and all of the Fedora packages which have been specifically retired.

For RHEL:
* poco has never been available for RHEL 8 - this rule is a holdover from RHEL 7
* sbcl has never been available for RHEL 8 - this rule is a holdover from RHEL 7
* libtar-devel is intentionally omitted from RHEL 8 on claims it has been abandoned upstream
* EPEL 8 has wxGTK3: https://src.fedoraproject.org/rpms/wxGTK3#bodhi_updates
* python3-more-itertools is not available for RHEL 7
* python3-pygit2 is not available for RHEL 7 (though python2-pygit2 is)

Fedora:
* alsa-oss is no longer in Fedora: https://src.fedoraproject.org/rpms/alsa-oss#bodhi_updates
* bazaar is no longer in Fedora: https://src.fedoraproject.org/rpms/bazaar#bodhi_updates
* comedilib is no longer in Fedora: https://src.fedoraproject.org/rpms/comedilib#bodhi_updates
* disper is no longer in Fedora: https://src.fedoraproject.org/rpms/disper#bodhi_updates
* eigen2 is no longer in Fedora: https://src.fedoraproject.org/rpms/eigen2#bodhi_updates
* gamin is no longer in Fedora: https://src.fedoraproject.org/rpms/gamin#bodhi_updates
* gccxml is no longer in Fedora: https://src.fedoraproject.org/rpms/gccxml#bodhi_updates
* gradle is no longer in Fedora: https://src.fedoraproject.org/rpms/gradle#bodhi_updates
* iwyu is no longer in Fedora: https://src.fedoraproject.org/rpms/iwyu#bodhi_updates
* jackson is no longer in Fedora: https://src.fedoraproject.org/rpms/jackson#bodhi_updates
* json-lib is no longer in Fedora: https://src.fedoraproject.org/rpms/json-lib#bodhi_updates
* jython is no longer in Fedora: https://src.fedoraproject.org/rpms/jython#bodhi_updates
* lcm is no longer in Fedora: https://src.fedoraproject.org/rpms/lcm#bodhi_updates
* libnl is no longer in Fedora: https://src.fedoraproject.org/rpms/libnl#bodhi_updates
* libreadline-java is no longer in Fedora: https://src.fedoraproject.org/rpms/libreadline-java#bodhi_updates
* mod_python is no longer in Fedora: https://src.fedoraproject.org/rpms/mod_python#bodhi_updates
* mongodb is no longer in Fedora: https://src.fedoraproject.org/rpms/mongodb#bodhi_updates
* ntp is no longer in Fedora: https://src.fedoraproject.org/rpms/ntp#bodhi_updates
* odb is no longer in Fedora: https://src.fedoraproject.org/rpms/odb#bodhi_updates
* recordmydesktop is no longer in Fedora: https://src.fedoraproject.org/rpms/recordmydesktop#bodhi_updates
* trang is no longer in Fedora: https://src.fedoraproject.org/rpms/jing-trang#bodhi_updates
* unclutter is no longer in Fedora: https://src.fedoraproject.org/rpms/unclutter#bodhi_updates
* unison is no longer in Fedora: https://src.fedoraproject.org/rpms/unison#bodhi_updates
* xulrunner is no longer in Fedora: https://src.fedoraproject.org/rpms/xulrunner#bodhi_updates