### PR TITLE
Clean up missing RHEL packages

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4380,7 +4380,9 @@ libpoco-dev:
   nixos: [poco]
   openembedded: [poco@meta-oe]
   opensuse: [poco-devel]
-  rhel: [poco-devel]
+  rhel:
+    '*': [poco-devel]
+    '8': null
   slackware: [poco]
   ubuntu: [libpoco-dev]
 libpocofoundation9:
@@ -6947,7 +6949,9 @@ sbcl:
   macports: [sbcl]
   nixos: [sbcl]
   opensuse: [sbcl]
-  rhel: [sbcl]
+  rhel:
+    '*': [sbcl]
+    '8': null
   slackware: [sbcl]
   ubuntu: [sbcl]
 scons:
@@ -7401,7 +7405,9 @@ tar:
   nixos: [libtar]
   openembedded: [tar@openembedded-core]
   opensuse: [libtar-devel]
-  rhel: [libtar-devel]
+  rhel:
+    '*': [libtar-devel]
+    '8': null
   ubuntu: [libtar-dev]
 tbb:
   arch: [intel-tbb]
@@ -7801,7 +7807,9 @@ wxwidgets:
   nixos: [wxGTK]
   openembedded: [wxwidgets@meta-ros-common]
   opensuse: [wxGTK-devel]
-  rhel: [wxGTK-devel]
+  rhel:
+    '*': [wxGTK3-devel]
+    '7': [wxGTK-devel]
   ubuntu:
     artful: [libwxgtk3.0-dev]
     bionic: [libwxgtk3.0-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4381,8 +4381,8 @@ libpoco-dev:
   openembedded: [poco@meta-oe]
   opensuse: [poco-devel]
   rhel:
-    '*': [poco-devel]
-    '8': null
+    '*': null
+    '7': [poco-devel]
   slackware: [poco]
   ubuntu: [libpoco-dev]
 libpocofoundation9:
@@ -5490,8 +5490,8 @@ libvulkan-dev:
   nixos: [vulkan-loader]
   openembedded: [vulkan-headers@openembedded-core]
   rhel:
+    '*': [vulkan-loader-devel, vulkan-headers]
     '7': [vulkan-devel]
-    '8': [vulkan-loader-devel, vulkan-headers]
   ubuntu:
     '*': [libvulkan-dev]
     trusty: null
@@ -6950,8 +6950,8 @@ sbcl:
   nixos: [sbcl]
   opensuse: [sbcl]
   rhel:
-    '*': [sbcl]
-    '8': null
+    '*': null
+    '7': [sbcl]
   slackware: [sbcl]
   ubuntu: [sbcl]
 scons:
@@ -7406,8 +7406,8 @@ tar:
   openembedded: [tar@openembedded-core]
   opensuse: [libtar-devel]
   rhel:
-    '*': [libtar-devel]
-    '8': null
+    '*': null
+    '7': [libtar-devel]
   ubuntu: [libtar-dev]
 tbb:
   arch: [intel-tbb]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6980,7 +6980,9 @@ python3-more-itertools:
   debian: [python3-more-itertools]
   fedora: [python3-more-itertools]
   gentoo: [dev-python/more-itertools]
-  rhel: ['python%{python3_pkgversion}-more-itertools']
+  rhel:
+    '*': [python3-more-itertools]
+    '7': null
   ubuntu: [python3-more-itertools]
 python3-msgpack:
   debian:
@@ -7447,7 +7449,9 @@ python3-pygit2:
   osx:
     pip:
       packages: [pygit2]
-  rhel: ['python%{python3_pkgversion}-pygit2']
+  rhel:
+    '*': [python3-pygit2]
+    '7': null
   ubuntu: [python3-pygit2]
 python3-pygments:
   alpine: [py3-pygments]


### PR DESCRIPTION
Using the [rosdep_repo_check](https://github.com/ros/rosdistro/tree/master/test/rosdep_repo_check#readme) automation, I'm surveying the rosdep database for RPM packages that aren't available and investigating them individually.

This PR addresses all of the RHEL problems, and is part 1 of a series of 4 cleanup patches.

* poco has never been available for RHEL 8 - this rule is a holdover from RHEL 7
* sbcl has never been available for RHEL 8 - this rule is a holdover from RHEL 7
* libtar-devel is intentionally omitted from RHEL 8 on claims it has been abandoned upstream
* EPEL 8 has wxGTK3: https://src.fedoraproject.org/rpms/wxGTK3#bodhi_updates
* python3-more-itertools is not available for RHEL 7
* python3-pygit2 is not available for RHEL 7 (though python2-pygit2 is)