### PR TITLE
Drop Fedora rules for retired packages

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -46,7 +46,6 @@ acpitool:
 alsa-oss:
   arch: [alsa-oss]
   debian: [alsa-oss]
-  fedora: [alsa-oss]
   gentoo: [media-libs/alsa-oss]
   nixos: [alsaOss]
   opensuse: [alsa-oss]
@@ -294,7 +293,6 @@ babeltrace:
 bazaar:
   arch: [bzr]
   debian: [bzr]
-  fedora: [bazaar]
   freebsd: [bazaar]
   gentoo: [dev-vcs/bzr]
   macports: [bazaar]
@@ -644,7 +642,6 @@ collectd-utils:
   ubuntu: [collectd-utils]
 comedi:
   debian: [libcomedi-dev]
-  fedora: [comedilib-devel]
   ubuntu: [libcomedi-dev]
 coreutils:
   arch: [coreutils]
@@ -786,7 +783,6 @@ dfu-util:
   ubuntu: [dfu-util]
 disper:
   debian: [disper]
-  fedora: [disper]
   nixos: [disper]
   ubuntu: [disper]
 dkms:
@@ -907,7 +903,6 @@ eigen2:
   debian:
     jessie: [libeigen2-dev]
     wheezy: [libeigen2-dev]
-  fedora: [eigen2-devel]
   freebsd: [eigen2]
   gentoo: ['dev-cpp/eigen:2']
   nixos: [eigen2]
@@ -1165,7 +1160,6 @@ g++-static:
   ubuntu: [g++]
 gamin:
   debian: [gamin]
-  fedora: [gamin]
   ubuntu: [gamin]
 gawk:
   arch: [gawk]
@@ -1261,7 +1255,6 @@ gcc-static:
 gccxml:
   arch: [gccxml-git]
   debian: [gccxml]
-  fedora: [gccxml]
   gentoo: [dev-cpp/gccxml]
   macports: [gccxml-devel]
   ubuntu: [gccxml]
@@ -1496,7 +1489,6 @@ gradle:
     buster: [gradle]
     jessie: [gradle]
     stretch: [gradle]
-  fedora: [gradle]
   gentoo: [dev-java/gradle-bin]
   nixos: [gradle]
   ubuntu: [gradle]
@@ -1550,7 +1542,6 @@ gstreamer0.10-plugins-good:
   debian:
     jessie: [gstreamer0.10-plugins-good]
     wheezy: [gstreamer0.10-plugins-good]
-  fedora: [gstreamer-plugins-good]
   gentoo: ['media-libs/gst-plugins-good:0.10']
   ubuntu: [gstreamer0.10-plugins-good]
 gstreamer0.10-plugins-ugly:
@@ -1558,7 +1549,6 @@ gstreamer0.10-plugins-ugly:
   debian:
     jessie: [gstreamer0.10-plugins-ugly]
     wheezy: [gstreamer0.10-plugins-ugly]
-  fedora: [gstreamer-plugins-ugly]
   gentoo: ['media-libs/gst-plugins-ugly:0.10']
   ubuntu:
     lucid: [gstreamer0.10-plugins-ugly-multiverse]
@@ -2014,7 +2004,6 @@ iputils-ping:
   ubuntu: [iputils-ping]
 iwyu:
   debian: [iwyu]
-  fedora: [iwyu]
   nixos: [include-what-you-use]
   ubuntu: [iwyu]
 jack:
@@ -2090,7 +2079,6 @@ julius-voxforge:
 jython:
   arch: [jython]
   debian: [jython]
-  fedora: [jython]
   gentoo: [dev-java/jython]
   nixos: [jython]
   ubuntu: [jython]
@@ -2161,7 +2149,6 @@ libann-dev:
 libapache2-mod-python:
   arch: [mod_python]
   debian: [libapache2-mod-python]
-  fedora: [mod_python]
   gentoo: [www-apache/mod_python]
   ubuntu: [libapache2-mod-python]
 libargtable2-dev:
@@ -3369,7 +3356,6 @@ libgstreamer-plugins-base0.10-0:
   debian:
     jessie: [libgstreamer-plugins-base0.10-0]
     wheezy: [libgstreamer-plugins-base0.10-0]
-  fedora: [gstreamer-plugins-base]
   gentoo: ['media-libs/gst-plugins-base:0.10']
   ubuntu: [libgstreamer-plugins-base0.10-0]
 libgstreamer-plugins-base0.10-dev:
@@ -3377,7 +3363,6 @@ libgstreamer-plugins-base0.10-dev:
   debian:
     jessie: [libgstreamer-plugins-base0.10-dev]
     wheezy: [libgstreamer-plugins-base0.10-dev]
-  fedora: [gstreamer-plugins-base-devel]
   gentoo: ['media-libs/gst-plugins-base:0.10']
   ubuntu: [libgstreamer-plugins-base0.10-dev]
 libgstreamer-plugins-base1.0-dev:
@@ -3394,7 +3379,6 @@ libgstreamer0.10-0:
   debian:
     jessie: [libgstreamer0.10-0]
     wheezy: [libgstreamer0.10-0]
-  fedora: [gstreamer]
   gentoo: ['media-libs/gstreamer:0.10']
   ubuntu: [libgstreamer0.10-0]
 libgstreamer0.10-dev:
@@ -3402,7 +3386,6 @@ libgstreamer0.10-dev:
   debian:
     jessie: [libgstreamer0.10-dev]
     wheezy: [libgstreamer0.10-dev]
-  fedora: [gstreamer-devel]
   gentoo: ['media-libs/gstreamer:0.10']
   ubuntu: [libgstreamer0.10-dev]
 libgstreamer1.0-dev:
@@ -3606,7 +3589,6 @@ libjack-dev:
   ubuntu: [libjack-dev]
 libjackson-json-java:
   debian: [libjackson-json-java]
-  fedora: [jackson]
   gentoo: [dev-java/jackson]
   ubuntu: [libjackson-json-java]
 libjansson-dev:
@@ -3667,7 +3649,6 @@ libjson-glib:
   ubuntu: [libjson-glib-dev]
 libjson-java:
   debian: [libjson-java]
-  fedora: [json-lib]
   gentoo: [dev-java/json]
   ubuntu: [libjson-java]
 libjson0-dev:
@@ -3728,13 +3709,11 @@ liblapacke-dev:
   ubuntu: [liblapacke-dev]
 liblcm:
   debian: [liblcm1]
-  fedora: [liblcm]
   ubuntu:
     '*': [liblcm1]
     xenial: null
 liblcm-dev:
   debian: [liblcm-dev]
-  fedora: [liblcm-devel]
   ubuntu:
     '*': [liblcm-dev]
     xenial: null
@@ -3884,7 +3863,6 @@ libmysqlcppconn-dev:
   arch:
     aur: [mysql-connector-c++]
   debian: [libmysqlcppconn-dev]
-  fedora: [libmysqlcppconn-devel]
   gentoo: [dev-db/mysql-connector-c++]
   opensuse: [libmysqlcppconn-devel]
   ubuntu: [libmysqlcppconn-dev]
@@ -3934,7 +3912,6 @@ libnl-3-dev:
 libnl-dev:
   arch: [libnl1]
   debian: [libnl-dev]
-  fedora: [libnl-devel]
   gentoo: [dev-libs/libnl]
   ubuntu: [libnl-dev]
 libnlopt-cxx-dev:
@@ -4893,7 +4870,6 @@ libreadline-dev:
 libreadline-java:
   arch: [java-readline]
   debian: [libreadline-java]
-  fedora: [libreadline-java]
   gentoo: [dev-java/libreadline-java]
   ubuntu: [libreadline-java]
 libsecp256k1-dev:
@@ -6050,7 +6026,6 @@ mkdocs-bootswatch:
     zesty: [mkdocs-bootswatch]
 mongodb:
   debian: [mongodb]
-  fedora: [mongodb]
   gentoo: [dev-db/mongodb]
   nixos: [mongodb]
   openembedded: [mongodb@meta-oe]
@@ -6058,7 +6033,6 @@ mongodb:
 mongodb-dev:
   arch: [mongodb]
   debian: [libmongo-client-dev, mongodb-dev]
-  fedora: [libmongo-client-devel, mongodb-devel]
   gentoo: [dev-db/mongodb]
   macports: [mongodb]
   nixos: [mongodb]
@@ -6256,14 +6230,12 @@ npm:
 ntp:
   arch: [ntp]
   debian: [ntp]
-  fedora: [ntp]
   gentoo: [net-misc/ntp]
   nixos: [ntp]
   ubuntu: [ntp]
 ntpdate:
   arch: [ntp]
   debian: [ntpdate]
-  fedora: [ntpdate]
   gentoo: [net-misc/ntp]
   nixos: [ntp]
   ubuntu: [ntpdate]
@@ -6288,7 +6260,6 @@ ocl-icd-opencl-dev:
   ubuntu: [ocl-icd-opencl-dev]
 odb:
   debian: [odb]
-  fedora: [odb]
   ubuntu:
     '*': [odb]
     trusty: null
@@ -6889,7 +6860,6 @@ recode:
 recordmydesktop:
   arch: [recordmydesktop]
   debian: [recordmydesktop]
-  fedora: [recordmydesktop]
   gentoo: [media-video/recordmydesktop]
   ubuntu: [recordmydesktop]
 redis-server:
@@ -7533,7 +7503,6 @@ touchegg:
   ubuntu: [touchegg]
 trang:
   debian: [trang]
-  fedora: [trang]
   gentoo: [app-text/trang]
   rhel:
     '7': [trang]
@@ -7585,7 +7554,6 @@ udhcpc:
   ubuntu: [udhcpc]
 unclutter:
   debian: [unclutter]
-  fedora: [unclutter]
   ubuntu: [unclutter]
 uncrustify:
   alpine: [uncrustify]
@@ -7601,14 +7569,12 @@ uncrustify:
 unison:
   arch: [unison]
   debian: [unison]
-  fedora: [unison240]
   gentoo: [net-misc/unison]
   nixos: [unison]
   ubuntu: [unison]
 unison-gui:
   arch: [unison]
   debian: [unison-gtk]
-  fedora: [unison240-gtk]
   gentoo: ['net-misc/unison[gtk]']
   ubuntu: [unison-gtk]
 unoconv:
@@ -7903,7 +7869,6 @@ xterm:
 xulrunner-1.9.2:
   arch: [xulrunner]
   debian: []
-  fedora: [xulrunner]
   ubuntu:
     karmic: [xulrunner-1.9.2]
     lucid: [xulrunner-1.9.2]
@@ -7916,7 +7881,6 @@ xulrunner-1.9.2:
 xulrunner-dev:
   arch: [xulrunner]
   debian: [libv8-dev]
-  fedora: [libv8-devel, xulrunner-devel]
   ubuntu: [libv8-dev]
 xvfb:
   arch: [xorg-server-xvfb]


### PR DESCRIPTION
Using the [rosdep_repo_check](https://github.com/ros/rosdistro/tree/master/test/rosdep_repo_check#readme) automation, I'm surveying the rosdep database for RPM packages that aren't available and investigating them individually.

This PR addresses Fedora packages which have been retired, and is part 2 of a series of 4 cleanup patches.

* alsa-oss is no longer in Fedora: https://src.fedoraproject.org/rpms/alsa-oss#bodhi_updates
* bazaar is no longer in Fedora: https://src.fedoraproject.org/rpms/bazaar#bodhi_updates
* comedilib is no longer in Fedora: https://src.fedoraproject.org/rpms/comedilib#bodhi_updates
* disper is no longer in Fedora: https://src.fedoraproject.org/rpms/disper#bodhi_updates
* eigen2 is no longer in Fedora: https://src.fedoraproject.org/rpms/eigen2#bodhi_updates
* gamin is no longer in Fedora: https://src.fedoraproject.org/rpms/gamin#bodhi_updates
* gccxml is no longer in Fedora: https://src.fedoraproject.org/rpms/gccxml#bodhi_updates
* gradle is no longer in Fedora: https://src.fedoraproject.org/rpms/gradle#bodhi_updates
* gstreamer 0.x is no longer part of Fedora: https://src.fedoraproject.org/rpms/gstreamer#bodhi_updates
* iwyu is no longer in Fedora: https://src.fedoraproject.org/rpms/iwyu#bodhi_updates
* jackson is no longer in Fedora: https://src.fedoraproject.org/rpms/jackson#bodhi_updates
* json-lib is no longer in Fedora: https://src.fedoraproject.org/rpms/json-lib#bodhi_updates
* jython is no longer in Fedora: https://src.fedoraproject.org/rpms/jython#bodhi_updates
* lcm is no longer in Fedora: https://src.fedoraproject.org/rpms/lcm#bodhi_updates
* libmysqlcppconn-devel is no longer part of Fedora: https://src.fedoraproject.org/rpms/mysql-connector-c++#bodhi_updates
* libnl is no longer in Fedora: https://src.fedoraproject.org/rpms/libnl#bodhi_updates
* libreadline-java is no longer in Fedora: https://src.fedoraproject.org/rpms/libreadline-java#bodhi_updates
* mod_python is no longer in Fedora: https://src.fedoraproject.org/rpms/mod_python#bodhi_updates
* mongodb is no longer in Fedora: https://src.fedoraproject.org/rpms/mongodb#bodhi_updates
* ntp is no longer in Fedora: https://src.fedoraproject.org/rpms/ntp#bodhi_updates
* odb is no longer in Fedora: https://src.fedoraproject.org/rpms/odb#bodhi_updates
* recordmydesktop is no longer in Fedora: https://src.fedoraproject.org/rpms/recordmydesktop#bodhi_updates
* trang is no longer in Fedora: https://src.fedoraproject.org/rpms/jing-trang#bodhi_updates
* unclutter is no longer in Fedora: https://src.fedoraproject.org/rpms/unclutter#bodhi_updates
* unison is no longer in Fedora: https://src.fedoraproject.org/rpms/unison#bodhi_updates
* xulrunner is no longer in Fedora: https://src.fedoraproject.org/rpms/xulrunner#bodhi_updates

The following packages have recently been retired, but are still supported in Fedora 34. We should remove them when Fedora 34 reaches EOL if they have not been un-retired.
* arduino-core: https://src.fedoraproject.org/rpms/arduino#bodhi_updates
* eclipse: https://src.fedoraproject.org/rpms/eclipse#bodhi_updates
* eclipse-emf: https://src.fedoraproject.org/rpms/eclipse-emf#bodhi_updates
* python3-twilio: https://src.fedoraproject.org/rpms/python-twilio#bodhi_updates