### PR TITLE
Mass removal of retired Python 2 packages from Fedora

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -169,7 +169,6 @@ ds4drv-pip:
 epydoc:
   arch: [epydoc]
   debian: [python-epydoc]
-  fedora: [epydoc]
   freebsd: [epydoc]
   gentoo: [dev-python/epydoc]
   macports: [py27-epydoc]
@@ -388,7 +387,6 @@ pyper-pip:
 pyqt4-dev-tools:
   arch: [python2-pyqt4]
   debian: [pyqt4-dev-tools]
-  fedora: [PyQt4-devel]
   gentoo: [dev-python/PyQt4]
   ubuntu: [pyqt4-dev-tools]
 pyqt5-dev-tools:
@@ -422,7 +420,6 @@ pyros-setup-pip:
       packages: [pyros-setup]
 pyside-tools:
   debian: [pyside-tools]
-  fedora: [pyside-tools]
   gentoo: [dev-python/pyside-tools]
   ubuntu: [pyside-tools]
 python:
@@ -504,7 +501,6 @@ python-amqp:
   ubuntu: [python-amqp]
 python-aniso8601:
   debian: [python-aniso8601]
-  fedora: [python2-aniso8601]
   gentoo: [dev-python/aniso8601]
   rhel:
     '7': [python-aniso8601]
@@ -589,7 +585,6 @@ python-astor-pip:
       packages: [astor]
 python-attrs:
   debian: [python-attr]
-  fedora: [python2-attrs]
   gentoo: [dev-python/attrs]
   nixos: [pythonPackages.attrs]
   ubuntu:
@@ -679,7 +674,6 @@ python-backoff-pip:
       packages: [backoff]
 python-backports.ssl-match-hostname:
   debian: [python-backports.ssl-match-hostname]
-  fedora: [python-backports.ssl-match-hostname]
   gentoo: [dev-python/backports-ssl-match-hostname]
   nixos: [pythonPackages.backports_ssl_match_hostname]
   openembedded: ['${PYTHON_PN}-backports-ssl@meta-python']
@@ -706,7 +700,6 @@ python-bcrypt:
 python-beautifulsoup:
   arch: [python2-beautifulsoup3]
   debian: [python-beautifulsoup]
-  fedora: [python-BeautifulSoup]
   gentoo: [dev-python/beautifulsoup]
   ubuntu: [python-beautifulsoup]
 python-bitarray:
@@ -754,7 +747,6 @@ python-bloom:
 python-bluez:
   arch: [python2-pybluez]
   debian: [python-bluez]
-  fedora: [pybluez]
   gentoo: [dev-python/pybluez]
   nixos: [pythonPackages.pybluez]
   openembedded: ['${PYTHON_PN}-pybluez@meta-python']
@@ -801,7 +793,6 @@ python-boltons:
 python-boto3:
   arch: [python-boto3]
   debian: [python-boto3]
-  fedora: [python2-boto3]
   gentoo: [dev-python/boto3]
   nixos: [pythonPackages.boto3]
   openembedded: ['${PYTHON_PN}-boto3@meta-ros-common']
@@ -816,7 +807,6 @@ python-bottle:
   ubuntu: [python-bottle]
 python-box2d:
   debian: [python-box2d]
-  fedora: [pybox2d]
   ubuntu: [python-box2d]
 python-breathe:
   debian: [python-breathe]
@@ -1109,7 +1099,6 @@ python-cherrypy:
   ubuntu: [python-cherrypy3]
 python-clearsilver:
   debian: [python-clearsilver]
-  fedora: [python-clearsilver]
   rhel:
     '7': [python-clearsilver]
   ubuntu: [python-clearsilver]
@@ -1171,13 +1160,11 @@ python-colorama:
   ubuntu: [python-colorama]
 python-concurrent.futures:
   debian: [python-concurrent.futures]
-  fedora: [python-futures]
   gentoo: [virtual/python-futures]
   ubuntu: [python-concurrent.futures]
 python-configparser:
   arch: [python2-configparser]
   debian: [python-configparser]
-  fedora: [python-configparser]
   gentoo: [dev-python/configparser]
   ubuntu: [python-configparser]
 python-construct:
@@ -1230,7 +1217,6 @@ python-cookiecutter-pip:
       packages: [cookiecutter]
 python-couchdb:
   debian: [python-couchdb]
-  fedora: [python-couchdb]
   gentoo: [dev-python/couchdb-python]
   ubuntu: [python-couchdb]
 python-coverage:
@@ -1566,14 +1552,12 @@ python-enum:
   debian:
     jessie: [python-enum]
     wheezy: [python-enum]
-  fedora: [python-enum]
   ubuntu: [python-enum]
 python-enum34:
   debian:
     buster: [python-enum34]
     jessie: [python-enum34]
     stretch: [python-enum34]
-  fedora: [python-enum34]
   gentoo: [virtual/python-enum34]
   nixos: [pythonPackages.enum34]
   openembedded: ['${PYTHON_PN}-enum34@meta-python']
@@ -1585,7 +1569,6 @@ python-enum34-pip:
       packages: [enum34]
 python-espeak:
   debian: [python-espeak]
-  fedora: [python-espeak]
   ubuntu:
     lucid: [python-espeak]
     maverick: [python-espeak]
@@ -1781,7 +1764,6 @@ python-frozendict:
   ubuntu: [python-frozendict]
 python-ftdi1:
   debian: [python-ftdi1]
-  fedora: [python2-libftdi]
   gentoo: [dev-embedded/libftdi]
   ubuntu: [python-ftdi1]
 python-funcsigs:
@@ -1857,7 +1839,6 @@ python-gdal:
   debian:
     buster: [python-gdal]
     stretch: [python-gdal]
-  fedora: [python2-gdal]
   gentoo: ['sci-libs/gdal[python]']
   ubuntu:
     bionic: [python-gdal]
@@ -1904,20 +1885,17 @@ python-gevent:
 python-gi:
   arch: [python2-gobject]
   debian: [python-gi]
-  fedora: [pygobject3]
   gentoo: [dev-python/pygobject]
   nixos: [pythonPackages.pygobject3]
   ubuntu: [python-gi]
 python-gi-cairo:
   debian: [python-gi-cairo]
-  fedora: [pygobject3]
   gentoo: [dev-python/pygobject]
   nixos: [pythonPackages.pygobject3]
   ubuntu: [python-gi-cairo]
 python-git:
   arch: [python2-gitpython]
   debian: [python-git]
-  fedora: [GitPython]
   gentoo: [dev-python/git-python]
   ubuntu: [python-git]
 python-github-pip:
@@ -2015,7 +1993,6 @@ python-google-cloud-vision-pip:
       packages: [google-cloud-vision]
 python-googleapi:
   debian: [python-googleapi]
-  fedora: [google-api-python-client]
   gentoo: [dev-python/google-api-python-client]
   ubuntu:
     trusty: [python-googleapi]
@@ -2182,7 +2159,6 @@ python-gst:
   debian:
     jessie: [python-gst0.10]
     wheezy: [python-gst0.10]
-  fedora: [gstreamer-python]
   gentoo: [dev-python/gst-python]
   ubuntu:
     lucid: [python-gst0.10]
@@ -2223,7 +2199,6 @@ python-gtk2:
   ubuntu: [python-gtk2]
 python-h5py:
   debian: [python-h5py]
-  fedora: [h5py]
   gentoo: [dev-python/h5py]
   nixos: [pythonPackages.h5py]
   opensuse: [python2-h5py]
@@ -2416,7 +2391,6 @@ python-jira-pip:
       packages: [jira]
 python-jmespath:
   debian: [python-jmespath]
-  fedora: [python2-jmespath]
   osx:
     pip:
       packages: [jmespath]
@@ -2465,7 +2439,6 @@ python-kdtree:
     buster: [python-kdtree]
     jessie: [python-kdtree]
     stretch: [python-kdtree]
-  fedora: [libkdtree++-python]
   ubuntu:
     pip:
       packages: [kdtree]
@@ -2525,7 +2498,6 @@ python-levenshtein:
   ubuntu: [python-levenshtein]
 python-libpcap:
   debian: [python-libpcap]
-  fedora: [pylibpcap]
   gentoo: [dev-python/pylibpcap]
   ubuntu: [python-libpcap]
 python-libpgm-pip:
@@ -2622,7 +2594,6 @@ python-mako:
   ubuntu: [python-mako]
 python-mapnik:
   debian: [python-mapnik]
-  fedora: [mapnik-python]
   ubuntu: [python-mapnik]
 python-markdown:
   debian: [python-markdown]
@@ -3065,7 +3036,6 @@ python-opencv:
 python-opengl:
   arch: [python2-opengl]
   debian: [python-opengl]
-  fedora: [python2-pyopengl]
   freebsd: [py27-PyOpenGL]
   gentoo: [dev-python/pyopengl]
   macports: [py27-opengl]
@@ -3228,7 +3198,6 @@ python-pathlib:
 python-pathlib2:
   arch: [python2-pathlib2]
   debian: [python-pathlib2]
-  fedora: [python-pathlib2]
   gentoo: [dev-python/pathlib2]
   nixos: [pythonPackages.pathlib2]
   ubuntu:
@@ -3256,7 +3225,6 @@ python-pbr:
 python-pcapy:
   arch: [python2-pcapy]
   debian: [python-pcapy]
-  fedora: [pcapy]
   gentoo: [dev-python/pcapy]
   ubuntu: [python-pcapy]
 python-pcg-gazebo-pip:
@@ -3271,7 +3239,6 @@ python-pcg-gazebo-pip:
 python-pep8:
   arch: [python2-pep8]
   debian: [pep8]
-  fedora: [python-pep8]
   gentoo: [dev-python/pep8]
   nixos: [pythonPackages.pep8]
   osx:
@@ -3337,7 +3304,6 @@ python-persist-queue-pip:
 python-pexpect:
   arch: [python2-pexpect]
   debian: [python-pexpect]
-  fedora: [pexpect]
   gentoo: [dev-python/pexpect]
   ubuntu: [python-pexpect]
 python-pip:
@@ -3403,7 +3369,6 @@ python-prettytable:
   ubuntu: [python-prettytable]
 python-progressbar:
   debian: [python-progressbar]
-  fedora: [python-progressbar]
   gentoo: [dev-python/progressbar]
   nixos: [pythonPackages.progressbar]
   osx:
@@ -3481,7 +3446,6 @@ python-pulsectl-pip:
 python-pyassimp:
   arch: [python2-pyassimp]
   debian: [python-pyassimp]
-  fedora: [assimp-python]
   gentoo: [media-libs/assimp]
   openembedded: [python-pyassimp@meta-ros-python2]
   osx:
@@ -3506,7 +3470,6 @@ python-pyassimp:
     zesty: [python-pyassimp]
 python-pyaudio:
   debian: [python-pyaudio]
-  fedora: [pyaudio]
   gentoo: [dev-python/pyaudio]
   nixos: [pythonPackages.pyaudio]
   openembedded: ['${PYTHON_PN}-pyalsaaudio@meta-python']
@@ -3549,7 +3512,6 @@ python-pycryptodome:
   ubuntu: [python-pycryptodome]
 python-pycurl:
   debian: [python-pycurl]
-  fedora: [python2-pycurl]
   ubuntu: [python-pycurl]
 python-pydbus:
   ubuntu:
@@ -3582,7 +3544,6 @@ python-pydot:
   ubuntu: [python-pydot]
 python-pyexiv2:
   debian: [python-pyexiv2]
-  fedora: [pyexiv2]
   ubuntu: [python-pyexiv2]
 python-pyftpdlib:
   debian: [python-pyftpdlib]
@@ -3624,7 +3585,6 @@ python-pygraph:
 python-pygraphviz:
   arch: [python2-pygraphviz]
   debian: [python-pygraphviz]
-  fedora: [graphviz-python]
   freebsd: [py27-pygraphviz]
   gentoo: [dev-python/pygraphviz]
   nixos: [pythonPackages.pygraphviz]
@@ -3688,7 +3648,6 @@ python-pymavlink:
       packages: [pymavlink]
 python-pymodbus:
   debian: [python-pymodbus]
-  fedora: [pymodbus]
   ubuntu: [python-pymodbus]
 python-pymongo:
   arch: [python2-pymongo]
@@ -3761,7 +3720,6 @@ python-pypozyx-pip:
 python-pyproj:
   arch: [python2-pyproj]
   debian: [python-pyproj]
-  fedora: [pyproj]
   gentoo: [dev-python/pyproj]
   nixos: [pythonPackages.pyproj]
   openembedded: ['${PYTHON_PN}-pyproj@meta-ros-common']
@@ -3781,7 +3739,6 @@ python-pyqrcode:
     stretch:
       pip:
         packages: [PyQRCode]
-  fedora: [python-pyqrcode]
   gentoo: [dev-python/pyqrcode]
   ubuntu:
     '*': [python-pyqrcode]
@@ -3827,7 +3784,6 @@ python-pyrealsense2-pip:
 python-pyside:
   arch: [python2-pyside]
   debian: [python-pyside]
-  fedora: [python-pyside]
   gentoo: [dev-python/pyside]
   ubuntu:
     lucid: [python-pyside]
@@ -3846,7 +3802,6 @@ python-pyside:
     vivid_python3: [python3-pyside]
 python-pyside.qtuitools:
   debian: [python-pyside.qtuitools]
-  fedora: [python-pyside]
   ubuntu:
     lucid: [python-pyside.qtuitools]
     maverick: [python-pyside.qtuitools]
@@ -3874,7 +3829,6 @@ python-pysimplegui27-pip:
       packages: [pysimplegui27]
 python-pysnmp:
   debian: [python-pysnmp4]
-  fedora: [pysnmp]
   gentoo: [dev-python/pysnmp]
   ubuntu: [python-pysnmp4]
 python-pytesseract-pip:
@@ -4018,7 +3972,6 @@ python-qt-bindings:
     squeeze: [python-qt4, python-qt4-dev, python-sip-dev]
     stretch: [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
     wheezy: [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
-  fedora: [PyQt4, PyQt4-devel, sip-devel]
   gentoo: [dev-python/pyside, dev-python/PyQt4]
   macports: [p27-pyqt4]
   opensuse: [python-qt4-devel]
@@ -4031,25 +3984,21 @@ python-qt-bindings:
 python-qt-bindings-gl:
   arch: [python2-pyqt4]
   debian: [python-qt4-gl]
-  fedora: [PyQt4]
   gentoo: ['dev-python/pyside[opengl]', 'dev-python/PyQt4[opengl]']
   opensuse: [python-qt4-devel]
   ubuntu: [python-qt4-gl]
 python-qt-bindings-qwt5:
   arch: [python2-pyqwt]
   debian: [python-qwt5-qt4]
-  fedora: [PyQwt-devel]
   gentoo: ['dev-python/pyqwt:5']
   macports: [qwt52]
   ubuntu: [python-qwt5-qt4]
 python-qt-bindings-webkit:
   debian: [python-qt4]
-  fedora: [PyQt4]
   gentoo: ['dev-python/pyside[webkit]', 'dev-python/PyQt4[webkit]']
   ubuntu: [python-qt4]
 python-qt4-gl:
   debian: [python-qt4-gl]
-  fedora: [PyQt4]
   gentoo: ['dev-python/pyside[opengl]', 'dev-python/PyQt4[opengl]']
   ubuntu: [python-qt4-gl]
 python-qt5-bindings:
@@ -4094,7 +4043,6 @@ python-qt5-bindings-gl:
     zesty: [python-pyqt5.qtopengl]
 python-qt5-bindings-qsci:
   debian: [python-pyqt5.qsci]
-  fedora: [python2-qscintilla-qt5]
   openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
   ubuntu: [python-pyqt5.qsci]
 python-qt5-bindings-quick:
@@ -4127,7 +4075,6 @@ python-qtpy:
 python-qwt5-qt4:
   arch: [pyqwt]
   debian: [python-qwt5-qt4]
-  fedora: [PyQwt]
   gentoo: ['dev-python/pyqwt:5']
   ubuntu: [python-qwt5-qt4]
 python-rdflib:
@@ -4398,7 +4345,6 @@ python-rpi.gpio-pip:
       packages: [RPi.GPIO]
 python-rrdtool:
   debian: [python-rrdtool]
-  fedora: [rrdtool-python]
   gentoo: [net-analyzer/rrdtool]
   ubuntu:
     lucid: [python-rrdtool]
@@ -4448,7 +4394,6 @@ python-schedule:
 python-scipy:
   arch: [python2-scipy]
   debian: [python-scipy]
-  fedora: [python2-scipy]
   freebsd: [py-scipy]
   gentoo: [sci-libs/scipy]
   macports: [py27-scipy]
@@ -4514,7 +4459,6 @@ python-selenium-pip:
       packages: [selenium]
 python-semantic-version:
   debian: [python-semantic-version]
-  fedora: [python2-semantic_version]
   nixos: [pythonPackages.semantic-version]
   ubuntu:
     bionic: [python-semantic-version]
@@ -4526,7 +4470,6 @@ python-semver:
 python-serial:
   arch: [python2-pyserial]
   debian: [python-serial]
-  fedora: [pyserial]
   gentoo: [dev-python/pyserial]
   nixos: [pythonPackages.pyserial]
   openembedded: ['${PYTHON_PN}-pyserial@meta-python']
@@ -4654,7 +4597,6 @@ python-singledispatch:
 python-sip:
   arch: [sip, python2-sip]
   debian: [python-sip-dev]
-  fedora: [sip-devel]
   freebsd: [py27-sip]
   gentoo: [dev-python/sip]
   macports: [py27-sip]
@@ -4874,7 +4816,6 @@ python-subprocess32:
   debian:
     '*': [python-subprocess32]
     jessie: null
-  fedora: [python-subprocess32]
   gentoo: [dev-python/subprocess32]
   ubuntu:
     '*': [python-subprocess32]
@@ -4900,12 +4841,10 @@ python-svg.path:
         packages: [svg.path]
 python-svn:
   debian: [python-svn]
-  fedora: [pysvn]
   gentoo: [dev-python/pysvn]
   ubuntu: [python-svn]
 python-sympy:
   debian: [python-sympy]
-  fedora: [sympy]
   gentoo: [dev-python/sympy]
   nixos: [pythonPackages.sympy]
   ubuntu:
@@ -4935,7 +4874,6 @@ python-systemd:
     xenial: [python-systemd]
 python-sysv-ipc:
   debian: [python-sysv-ipc]
-  fedora: [python2-sysv-ipc]
   ubuntu: [python-sysv-ipc]
 python-tablib:
   debian: [python-tablib]
@@ -5312,13 +5250,11 @@ python-twilio-pip:
 python-twisted-bin:
   arch: [python2-twisted]
   debian: [python-twisted-bin]
-  fedora: [python-twisted-core]
   gentoo: [dev-python/twisted]
   ubuntu: [python-twisted-bin]
 python-twisted-core:
   arch: [python2-twisted]
   debian: [python-twisted-core]
-  fedora: [python-twisted-core]
   gentoo: [dev-python/twisted]
   nixos: [pythonPackages.twisted]
   openembedded: ['${PYTHON_PN}-twisted-core@meta-python']
@@ -5327,7 +5263,6 @@ python-twisted-core:
 python-twisted-web:
   arch: [python2-twisted]
   debian: [python-twisted-web]
-  fedora: [python-twisted-web]
   gentoo: [dev-python/twisted]
   nixos: [pythonPackages.twisted]
   ubuntu: [python-twisted-web]
@@ -5342,7 +5277,6 @@ python-twitter:
 python-typing:
   arch: [python2-typing]
   debian: [python-typing]
-  fedora: [python2-typing]
   gentoo: [dev-python/typing]
   nixos: [pythonPackages.typing]
   ubuntu:
@@ -5359,7 +5293,6 @@ python-typing-pip:
 python-tz:
   arch: [python2-pytz]
   debian: [python-tz]
-  fedora: [pytz]
   gentoo: [dev-python/pytz]
   nixos: [pythonPackages.pytz]
   ubuntu: [python-tz]
@@ -5401,7 +5334,6 @@ python-ujson:
         packages: [ujson]
 python-unittest2:
   debian: [python-unittest2]
-  fedora: [python-unittest2]
   nixos: [pythonPackages.unittest2]
   osx:
     pip:
@@ -5428,7 +5360,6 @@ python-urllib3:
   ubuntu: [python-urllib3]
 python-usb:
   debian: [python-usb]
-  fedora: [pyusb]
   gentoo: [dev-python/pyusb]
   nixos: [pythonPackages.pyusb]
   openembedded: ['${PYTHON_PN}-pyusb@meta-python']
@@ -5489,7 +5420,6 @@ python-virtualenv:
   ubuntu: [python-virtualenv]
 python-visual:
   debian: [python-visual]
-  fedora: [python-visual]
   gentoo: [dev-python/visual]
   ubuntu: [python-visual]
 python-vlc-pip:
@@ -5514,7 +5444,6 @@ python-voluptuous:
 python-vtk:
   arch: [vtk]
   debian: [python-vtk]
-  fedora: [vtk-python]
   gentoo: [dev-python/pyvtk]
   ubuntu:
     bionic: [python-vtk6]
@@ -5633,7 +5562,6 @@ python-whichcraft:
   ubuntu: [python-whichcraft]
 python-wrapt:
   debian: [python-wrapt]
-  fedora: [python2-wrapt]
   ubuntu: [python-wrapt]
 python-ws4py:
   debian: [python-ws4py]
@@ -5658,7 +5586,6 @@ python-wtforms:
 python-wxtools:
   arch: [wxpython]
   debian: [python-wxtools]
-  fedora: [wxPython]
   freebsd: [py27-wxPython30]
   gentoo: [dev-python/wxpython]
   nixos: [pythonPackages.wxPython]
@@ -5719,7 +5646,6 @@ python-yaml:
   alpine: [py-yaml]
   arch: [python2-yaml]
   debian: [python-yaml]
-  fedora: [PyYAML]
   freebsd: [py27-yaml]
   gentoo: [dev-python/pyyaml]
   macports: [py27-yaml]
@@ -5759,7 +5685,6 @@ python-yaml:
     zesty_python3: [python3-yaml]
 python-zbar:
   debian: [python-zbar]
-  fedora: [zbar-pygtk]
   gentoo: ['media-gfx/zbar[python]']
   ubuntu: [python-zbar]
 python-zmq:
@@ -8632,7 +8557,6 @@ wxpython:
     squeeze: [python-wxgtk2.8]
     stretch: [python-wxgtk3.0]
     wheezy: [python-wxgtk2.8]
-  fedora: [wxPython-devel]
   freebsd: [py27-wxPython]
   gentoo: [dev-python/wxpython]
   macports: [py27-wxpython, py27-gobject, py27-gtk, py27-cairo]


### PR DESCRIPTION
Using the [rosdep_repo_check](https://github.com/ros/rosdistro/tree/master/test/rosdep_repo_check#readme) automation, I'm surveying the rosdep database for RPM packages that aren't available and investigating them individually.

This PR addresses Python 2 Fedora packages, and is part 3 of a series of 4 cleanup patches.

More information on the removal of Python 2 packages from Fedora: https://fedoraproject.org/wiki/Changes/RetirePython2