### PR TITLE
rclc: 3.0.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2462,7 +2462,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
-      version: 3.0.4-1
+      version: 3.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclc` to `3.0.5-1`:

- upstream repository: https://github.com/ros2/rclc.git
- release repository: https://github.com/ros2-gbp/rclc-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.0.4-1`

## rclc

```
* Fix data_available reset for timer (backport #215) (#217)
```

## rclc_examples

```
* no change
```

## rclc_lifecycle

```
* no change
```

## rclc_parameter

```
* no change
```
