### PR TITLE
Adding outsight_alb_driver to the ros index 

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8332,6 +8332,16 @@ repositories:
       url: https://github.com/CPFL/ouster.git
       version: autoware_branch
     status: developed
+  outsight_alb_driver:
+    doc:
+      type: git
+      url: https://gitlab.com/outsight-public/outsight-drivers/outsight_alb_driver.git
+      version: master
+    source:
+      type: git
+      url: https://gitlab.com/outsight-public/outsight-drivers/outsight_alb_driver.git
+      version: master
+    status: maintained
   oxford_gps_eth:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5351,6 +5351,16 @@ repositories:
       url: https://github.com/tier4/osqp_vendor.git
       version: noetic
     status: maintained
+  outsight_alb_driver:
+    doc:
+      type: git
+      url: https://gitlab.com/outsight-public/outsight-drivers/outsight_alb_driver.git
+      version: master
+    source:
+      type: git
+      url: https://gitlab.com/outsight-public/outsight-drivers/outsight_alb_driver.git
+      version: master
+    status: maintained
   oxford_gps_eth:
     doc:
       type: git


### PR DESCRIPTION
Hello rosdistro-Team,

We would like to add to the index a package to interact with our Augmented Lidar Box (https://www.outsight.ai/)

Thanks in advance

# Please Add This Package to be indexed in the rosdistro.

* Melodic
* Noetic

# The source is here: 

https://gitlab.com/outsight-public/outsight-drivers/outsight_alb_driver.git

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro