### PR TITLE
mavros: 1.11.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4139,7 +4139,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 1.10.0-1
+      version: 1.11.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `1.11.1-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.10.0-1`

## libmavconn

- No changes

## mavros

```
* lib: fix build
* Contributors: Vladimir Ermakov
```

## mavros_extras

- No changes

## mavros_msgs

- No changes

## test_mavros

- No changes
