### PR TITLE
Misc fixes for Fedora rules

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -696,7 +696,6 @@ cppunit:
 cpuburn:
   arch: [cpuburn]
   debian: [cpuburn]
-  fedora: [cpuburn]
   ubuntu: [cpuburn]
 crypto++:
   debian: [libcrypto++-dev]
@@ -1011,7 +1010,6 @@ ffmpeg:
 ffmpeg2theora:
   arch: [ffmpeg2theora]
   debian: [ffmpeg2theora]
-  fedora: [ffmpeg2theora]
   gentoo: [media-video/ffmpeg2theora]
   ubuntu: [ffmpeg2theora]
 file:
@@ -1532,7 +1530,6 @@ graphviz-dev:
   ubuntu: [libgraphviz-dev]
 gringo:
   debian: [gringo]
-  fedora: [gringo]
   nixos: [gringo]
   ubuntu: [gringo]
 gstreamer0.10-gconf:
@@ -2167,7 +2164,7 @@ libapache2-mod-python:
 libargtable2-dev:
   arch: [argtable]
   debian: [libargtable2-dev]
-  fedora: [argtable2-devel]
+  fedora: [argtable-devel]
   gentoo: [=dev-libs/argtable-2*]
   ubuntu: [libargtable2-dev]
 libaria:
@@ -2897,7 +2894,7 @@ libestools-dev:
     jessie: [libestools2.1-dev]
     stretch: [libestools-dev]
     wheezy: [libestools2.1-dev]
-  fedora: [festival-speechtools-devel]
+  fedora: [speech-tools-libs-devel]
   gentoo: [app-accessibility/festival]
   ubuntu:
     '*': [libestools-dev]
@@ -3161,7 +3158,7 @@ libgdal-dev:
 libgeographiclib-dev:
   debian:
     wheezy: [libgeographiclib-dev]
-  fedora: [geographiclib]
+  fedora: [GeographicLib-devel]
   gentoo: [sci-geosciences/geographiclib]
   ubuntu: [libgeographiclib-dev]
 libgeos++-dev:
@@ -3198,7 +3195,7 @@ libgfortran3:
   ubuntu: [libgfortran3]
 libgif-dev:
   debian: [libgif-dev]
-  fedora: [libgif-devel]
+  fedora: [giflib-devel]
   gentoo: [media-libs/giflib]
   nixos: [giflib]
   ubuntu: [libgif-dev]
@@ -3245,7 +3242,7 @@ libglui-dev:
 libglw1-mesa:
   arch: [glw]
   debian: [libglw1-mesa]
-  fedora: [mesa-libGlw]
+  fedora: [mesa-libGLw]
   gentoo: [x11-libs/libGLw]
   ubuntu: [libglw1-mesa]
 libgmock-dev:
@@ -3767,7 +3764,7 @@ liblttng-ust-dev:
   ubuntu: [liblttng-ust-dev]
 liblzma-dev:
   debian: [liblzma-dev]
-  fedora: [lzma-devel]
+  fedora: [xz-devel]
   nixos: [xz]
   ubuntu: [liblzma-dev]
 libmagick:
@@ -3780,7 +3777,7 @@ libmagick:
 libmarble-dev:
   arch: [kdeedu-marble]
   debian: [libmarble-dev]
-  fedora: [marble-devel]
+  fedora: [marble-widget-qt5-devel]
   gentoo: [kde-base/marble]
   ubuntu: [libmarble-dev]
 libmicrohttpd:
@@ -3840,7 +3837,7 @@ libmongoclient-dev:
 libmotif-dev:
   arch: [lesstif]
   debian: [libmotif-dev]
-  fedora: [lesstif-devel]
+  fedora: [motif-devel]
   gentoo: [x11-libs/motif]
   ubuntu: [libmotif-dev]
 libmp3lame-dev:
@@ -5004,7 +5001,6 @@ libssl-dev:
 libstdc++5:
   arch: [libstdc++5]
   debian: [libstdc++5]
-  fedora: [libstdc++5]
   freebsd: [builtin]
   gentoo: [virtual/libstdc++]
   opensuse: [libstdc++33]
@@ -5012,7 +5008,7 @@ libstdc++5:
 libstdc++6:
   arch: [gcc-libs]
   debian: [libstdc++6]
-  fedora: [libstdc++6]
+  fedora: [libstdc++]
   nixos: []
   ubuntu: [libstdc++6]
 libsvm-dev:
@@ -5199,7 +5195,7 @@ libudev-dev:
 libunittest++:
   arch: [unittestpp]
   debian: [libunittest++-dev]
-  fedora: [unittest]
+  fedora: [unittest-cpp-devel]
   gentoo: [dev-libs/unittest++]
   macports: [unittest-cpp]
   rhel: [unittest-cpp-devel]
@@ -5371,7 +5367,7 @@ libvlc:
     yakkety: [libvlc5, vlc-nox]
 libvlc-dev:
   debian: [libvlc-dev]
-  fedora: [libvlc-devel]
+  fedora: [vlc-devel]
   gentoo: [media-video/vlc]
   nixos: [vlc]
   openembedded: [vlc@meta-multimedia]
@@ -6539,7 +6535,7 @@ portaudio:
   ubuntu: [libportaudio-dev]
 portaudio19-dev:
   debian: [portaudio19-dev]
-  fedora: [libportaudio-devel]
+  fedora: [portaudio-devel]
   gentoo: [=media-libs/portaudio-19*]
   nixos: [portaudio]
   openembedded: [portaudio-v19@meta-oe]
@@ -6569,7 +6565,7 @@ postgresql-9.x-postgis:
     xenial: [postgresql-9.5-postgis-2.2, postgresql-contrib-9.5, postgresql-server-dev-9.5]
 postgresql-client:
   debian: [postgresql-client]
-  fedora: [postgresql-client]
+  fedora: [postgresql]
   gentoo: [dev-db/postgresql]
   ubuntu: [postgresql-client]
 postgresql-postgis:
@@ -6861,7 +6857,7 @@ range-v3:
   debian:
     '*': [librange-v3-dev]
     stretch: null
-  fedora: [range-v3]
+  fedora: [range-v3-devel]
   gentoo: [dev-cpp/range-v3]
   ubuntu:
     '*': [librange-v3-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6390,7 +6390,6 @@ python3-ezdxf:
     stretch:
       pip:
         packages: [ezdxf]
-  fedora: [python3-ezdxf]
   freebsd: [py37-ezdxf]
   nixos: [python3Packages.ezdxf]
   ubuntu:
@@ -7560,7 +7559,6 @@ python3-pyproj:
 python3-pyqrcode:
   arch: [python-qrcode]
   debian: [python3-pyqrcode]
-  fedora: [python3-pyqrcode]
   gentoo: [dev-python/pyqrcode]
   nixos: [python3Packages.pyqrcode]
   ubuntu: [python3-pyqrcode]
@@ -8021,7 +8019,7 @@ python3-simplejson:
   ubuntu: [python3-simplejson]
 python3-sip:
   debian: [python3-sip-dev]
-  fedora: [python3-sip]
+  fedora: [python3-sip-devel]
   gentoo: [dev-python/sip]
   nixos: [python3Packages.sip_4]
   opensuse: [python3-sip]


### PR DESCRIPTION
Using the [rosdep_repo_check](https://github.com/ros/rosdistro/tree/master/test/rosdep_repo_check#readme) automation, I'm surveying the rosdep database for RPM packages that aren't available and investigating them individually.

This PR addresses miscellaneous Fedora package issues, and is part 4 of a series of 4 cleanup patches.

Justifications for these changes:
* liblzma.so is now provided by xz
* lesstif is now provided by motif-devel, which aligns with the Debuntu rules
* unittest is now provided by unittest-cpp-devel
* mesa-libGlw has incorrect casing
* libgif-devel should be giflib-devel
* geographiclib has incorrect casing
* marble-devel has been renamed to be qt-specific
* range-v3 has been renamed range-v3-devel (header-only package)
* libvlc-devel shouldn't have the 'lib' prefix
* gringo has never been available in Fedora
* postgresql-client doesn't exist in Fedora - postgresql provides those binaries
* libportaudio-devel shouldn't have the 'lib' prefix
* ffmpeg2theora appears to have been dropped from RPMFusion circa Fedora 20
* speech-tools-libs-devel provides the same files as libestools-dev - not sure what happened here
* python3-sip should have -devel to match Debuntu rules
* python3-pyqrcode has never been in Fedora - python3-qrcode is a different package
* libstdc++.so.5 was dropped from Fedora, current is libstdc++.so.6. Fedora doesn't provide a virtual package like 'libstdc++6' like Debuntu does
* python3-ezdxf is part of the third party 'sphere' repository, which is not allowed in rosdep
* cpuburn is part of the third party 'cheese' repository, which is not allowed in rosdep
* argtable2 has been renamed argtable in Fedora