### PR TITLE
ouxt_common: 0.0.8-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2012,6 +2012,24 @@ repositories:
       url: https://github.com/osrf/osrf_testing_tools_cpp.git
       version: master
     status: maintained
+  ouxt_common:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/ouxt_common.git
+      version: master
+    release:
+      packages:
+      - ouxt_common
+      - ouxt_lint_common
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/OUXT-Polaris/ouxt_common-release.git
+      version: 0.0.8-3
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/ouxt_common.git
+      version: master
+    status: developed
   pcl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ouxt_common` to `0.0.8-3`:

- upstream repository: https://github.com/OUXT-Polaris/ouxt_common.git
- release repository: https://github.com/OUXT-Polaris/ouxt_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
