### PR TITLE
navigation_2d: 0.4.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4742,6 +4742,23 @@ repositories:
       url: https://github.com/ros-planning/navigation.git
       version: noetic-devel
     status: maintained
+  navigation_2d:
+    release:
+      packages:
+      - nav2d
+      - nav2d_exploration
+      - nav2d_karto
+      - nav2d_localizer
+      - nav2d_msgs
+      - nav2d_navigator
+      - nav2d_operator
+      - nav2d_remote
+      - nav2d_tutorials
+      tags:
+        release: release/noetic/{package}/{version}
+      url: git@github.com:skasperski/navigation_2d-release.git
+      version: 0.4.3-1
+    status: maintained
   navigation_experimental:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4743,6 +4743,10 @@ repositories:
       version: noetic-devel
     status: maintained
   navigation_2d:
+    doc:
+      type: git
+      url: https://github.com/skasperski/navigation_2d.git
+      version: noetic
     release:
       packages:
       - nav2d
@@ -4756,8 +4760,12 @@ repositories:
       - nav2d_tutorials
       tags:
         release: release/noetic/{package}/{version}
-      url: git@github.com:skasperski/navigation_2d-release.git
+      url: https://github.com/skasperski/navigation_2d-release.git
       version: 0.4.3-1
+    source:
+      type: git
+      url: https://github.com/skasperski/navigation_2d.git
+      version: noetic
     status: maintained
   navigation_experimental:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_2d` to `0.4.3-1`:

- upstream repository: https://github.com/skasperski/navigation_2d.git
- release repository: git@github.com:skasperski/navigation_2d-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
