### PR TITLE
twist_mux: 4.1.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4681,6 +4681,21 @@ repositories:
       url: https://github.com/autowarefoundation/tvm_vendor.git
       version: main
     status: maintained
+  twist_mux:
+    doc:
+      type: git
+      url: https://github.com/ros-teleop/twist_mux.git
+      version: galactic
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros-gbp/twist_mux-release.git
+      version: 4.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros-teleop/twist_mux.git
+      version: galactic
+    status: maintained
   twist_stamper:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `twist_mux` to `4.1.0-1`:

- upstream repository: https://github.com/ros-teleop/twist_mux.git
- release repository: https://github.com/ros-gbp/twist_mux-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## twist_mux

```
* Cleanup parameter warnings & cpplint (#32 <https://github.com/ros-teleop/twist_mux/issues/32>)
* Update maintainer and license tag
* Contributors: Stephen Street, Bence Magyar
```
