### PR TITLE
xsens_mti_driver: 0.2021.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9976,6 +9976,21 @@ repositories:
       url: https://github.com/leggedrobotics/xpp.git
       version: master
     status: maintained
+  xsens_mti_driver:
+    doc:
+      type: git
+      url: https://github.com/nobleo/xsens_mti_driver.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/nobleo/xsens_mti_driver-release.git
+      version: 0.2021.4-1
+    source:
+      type: git
+      url: https://github.com/nobleo/xsens_mti_driver.git
+      version: master
+    status: maintained
   xv_11_laser_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xsens_mti_driver` to `0.2021.4-1`:

- upstream repository: https://github.com/nobleo/xsens_mti_driver.git
- release repository: https://github.com/nobleo/xsens_mti_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
