### PR TITLE
mavros: 1.12.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6284,7 +6284,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 1.10.0-1
+      version: 1.12.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `1.12.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.10.0-1`

## libmavconn

```
* Merge pull request #1658 <https://github.com/mavlink/mavros/issues/1658> from asherikov/as_bugfixes
  Fix multiple bugs
* Fix multiple bugs
  - fix bad_weak_ptr on connect and disconnect
  - introduce new API to avoid thread race when assigning callbacks
  - fix uninitialized variable in TCP client constructor which would
  randomly block TCP server
  This is an API breaking change: if client code creates connections using
  make_shared<>() instead of open_url(), it is now necessary to call new
  connect() method explicitly.
* Contributors: Alexander Sherikov, Vladimir Ermakov
```

## mavros

```
* Merge pull request #1658 <https://github.com/mavlink/mavros/issues/1658> from asherikov/as_bugfixes
  Fix multiple bugs
* Fix multiple bugs
  - fix bad_weak_ptr on connect and disconnect
  - introduce new API to avoid thread race when assigning callbacks
  - fix uninitialized variable in TCP client constructor which would
  randomly block TCP server
  This is an API breaking change: if client code creates connections using
  make_shared<>() instead of open_url(), it is now necessary to call new
  connect() method explicitly.
* lib: fix mission frame debug print
* Contributors: Alexander Sherikov, Vladimir Ermakov
```

## mavros_extras

```
* extras: distance_sensor: revert back to zero quaternion
  Fix #1653 <https://github.com/mavlink/mavros/issues/1653>
* Contributors: Vladimir Ermakov
```

## mavros_msgs

- No changes

## test_mavros

- No changes
