### PR TITLE
grbl_ros: 0.0.16-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1068,7 +1068,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/flynneva/grbl_ros-release.git
-      version: 0.0.15-1
+      version: 0.0.16-1
     source:
       type: git
       url: https://github.com/flynneva/grbl_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grbl_ros` to `0.0.16-1`:

- upstream repository: https://github.com/flynneva/grbl_ros.git
- release repository: https://github.com/flynneva/grbl_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.15-1`

## grbl_ros

```
* fix changelog tags that were missing dates
* bump version in prep for release
* Merge pull request #111 <https://github.com/flynneva/grbl_ros/issues/111> from flynneva/fix/default-params-and-grbl-obj-err
  Fix/default params and grbl obj err
* fix flake8 errors
* [110] add warning about missing fields in status
* set defaults for parameters, fix grbl_obj error
* add more info to quickstart README
* fixed typo
* bump ros action
* still trying to fix docs
* docs source ros
* ls ros in docs build
* remove HOME env var
* add a bunch of prints
* docs still not sourcing ros
* ugly source filepath
* source ros from opt
* full path source
* fix fpath for docs
* one more try for the docs
* dont include connext
* cd to source code before building docs
* test including connext
* forgot quotes
* test for optional connext ci
* forgot one cd
* change gh action directories
* debugging sourcing ros
* ls opt ros path to debug
* sh not bash
* try another way to source ros
* update README
* source ros with make docs cmd
* source ros before building docs
* update os for docs action
* add ros setup action to docs action
* fixed flake8 errors
* more doc updates
* more updates to docs
* update doc structure, add gitignore
* removed pytest from requirements.txt
* remove ros pkgs from requirements
* one more time
* filepath to requirements
* trying to fix filepath
* add filepath for requirements
* move dependencies install after ros env setup
* fixed yml typo
* add requirements.txt file
* switched back to ammaraskar sphinx action
* trying to update docs action
* hopefully final pep257 fix
* more pep257 fixes
* fixed pep257 errors
* Merge pull request #75 <https://github.com/flynneva/grbl_ros/issues/75> from flynneva/improve_docs
  fix flake8 errors
* fix flake8 errors
* Merge pull request #73 <https://github.com/flynneva/grbl_ros/issues/73> from flynneva/improve_docs
  Improve docs
* slowly improve docs
* remove blank line in package.xml
* bumped docs version
* forgot to bump setup.py
* Contributors: Evan Flynn, flynneva
```
