### PR TITLE
mavros: 2.0.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1591,7 +1591,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 2.0.4-1
+      version: 2.0.5-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `2.0.5-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.4-1`

## libmavconn

```
* extras: fix some linter errors.
  Do you know how to make me mad? Just let ament_uncrustify and
  ament_cpplint require opposite requirements!
* lib: fix linter errors
* fix some build warnings; drop old copter vis
* lib: fix merge artifact
* Merge branch 'master' into ros2
  * master:
  1.12.0
  update changelog
  Fix multiple bugs
  lib: fix mission frame debug print
  extras: distance_sensor: revert back to zero quaternion
* 1.12.0
* update changelog
* Merge pull request #1658 <https://github.com/mavlink/mavros/issues/1658> from asherikov/as_bugfixes
  Fix multiple bugs
* Fix multiple bugs
  - fix bad_weak_ptr on connect and disconnect
  - introduce new API to avoid thread race when assigning callbacks
  - fix uninitialized variable in TCP client constructor which would
  randomly block TCP server
  This is an API breaking change: if client code creates connections using
  make_shared<>() instead of open_url(), it is now necessary to call new
  connect() method explicitly.
* cmake: require C++20 to build all modules
* lib: ignore MAVPACKED-related warnings from mavlink
* Merge branch 'master' into ros2
  * master:
  1.11.1
  update changelog
  lib: fix build
* 1.11.1
* update changelog
* Merge branch 'master' into ros2
  * master:
  1.11.0
  update changelog
  lib: fix ftf warnings
  msgs: use pragmas to ignore unaligned pointer warnings
  extras: landing_target: fix misprint
  msgs: fix convert const
  plugin: setpoint_raw: fix misprint
  msgs: try to hide 'unaligned pointer' warning
  plugin: sys: fix compillation error
  plugin: initialize quaternions with identity
  plugin: sys: Use wall timers for connection management
  Use meters for relative altitude
  distance_sensor: Initialize sensor orientation quaternion to zero
  Address review comments
  Add camera plugin for interfacing with mavlink camera protocol
* 1.11.0
* update changelog
* Contributors: Alexander Sherikov, Vladimir Ermakov
```

## mavros

```
* fix some build warnings; drop old copter vis
* router: fix #1655 <https://github.com/mavlink/mavros/issues/1655>: use MAVConnInterface::connect() from #1658 <https://github.com/mavlink/mavros/issues/1658>
* Merge branch 'master' into ros2
  * master:
  1.12.0
  update changelog
  Fix multiple bugs
  lib: fix mission frame debug print
  extras: distance_sensor: revert back to zero quaternion
* 1.12.0
* update changelog
* Merge pull request #1658 <https://github.com/mavlink/mavros/issues/1658> from asherikov/as_bugfixes
  Fix multiple bugs
* Fix multiple bugs
  - fix bad_weak_ptr on connect and disconnect
  - introduce new API to avoid thread race when assigning callbacks
  - fix uninitialized variable in TCP client constructor which would
  randomly block TCP server
  This is an API breaking change: if client code creates connections using
  make_shared<>() instead of open_url(), it is now necessary to call new
  connect() method explicitly.
* extras: fix some more lint warns
* plugin: fix some compile warnings
* cmake: require C++20 to build all modules
* extras: port distance_sensor plugin
* lib: ignore MAVPACKED-related warnings from mavlink
* lib: fix mission frame debug print
* msgs: update conversion header
* Merge branch 'master' into ros2
  * master:
  1.11.1
  update changelog
  lib: fix build
* 1.11.1
* update changelog
* lib: fix build
* Merge branch 'master' into ros2
  * master:
  1.11.0
  update changelog
  lib: fix ftf warnings
  msgs: use pragmas to ignore unaligned pointer warnings
  extras: landing_target: fix misprint
  msgs: fix convert const
  plugin: setpoint_raw: fix misprint
  msgs: try to hide 'unaligned pointer' warning
  plugin: sys: fix compillation error
  plugin: initialize quaternions with identity
  plugin: sys: Use wall timers for connection management
  Use meters for relative altitude
  distance_sensor: Initialize sensor orientation quaternion to zero
  Address review comments
  Add camera plugin for interfacing with mavlink camera protocol
* 1.11.0
* update changelog
* lib: fix ftf warnings
* plugin: setpoint_raw: fix misprint
* plugin: sys: fix compillation error
* plugin: initialize quaternions with identity
  Eigen::Quaternion[d|f] () does not initialize with zeroes or identity.
  So we must initialize with identity vector objects that can be left
  unassigned.
  Related to #1652 <https://github.com/mavlink/mavros/issues/1652>
* plugin: sys: Use wall timers for connection management
  Fixes #1629 <https://github.com/mavlink/mavros/issues/1629>
* Merge pull request #1651 <https://github.com/mavlink/mavros/issues/1651> from Jaeyoung-Lim/pr-image-capture-plugin
  Add camera plugin for interfacing with mavlink camera protocol
* Add camera plugin for interfacing with mavlink camera protocol
  Add camera image captured message for handling camera trigger information
* extras: port log_transfer
* Contributors: Alexander Sherikov, Jaeyoung-Lim, Vladimir Ermakov
```

## mavros_extras

```
* extras: make cpplint happy
* extras: fix most of build errors of SSP
* extras: servo_state_publisher ported. almost...
* extras: start porting servo_state_publisher
* extras: make cpplint happy
* extras: fix some linter errors.
  Do you know how to make me mad? Just let ament_uncrustify and
  ament_cpplint require opposite requirements!
* fix some build warnings; drop old copter vis
* Merge branch 'master' into ros2
  * master:
  1.12.0
  update changelog
  Fix multiple bugs
  lib: fix mission frame debug print
  extras: distance_sensor: revert back to zero quaternion
* 1.12.0
* update changelog
* extras: fix some more lint warns
* plugin: fix some compile warnings
* cmake: require C++20 to build all modules
* extras: port distance_sensor plugin
* extras: fix camera plugin
* extras: port camera plugin
* lib: ignore MAVPACKED-related warnings from mavlink
* extras: distance_sensor: revert back to zero quaternion
  Fix #1653 <https://github.com/mavlink/mavros/issues/1653>
* msgs: update conversion header
* Merge branch 'master' into ros2
  * master:
  1.11.1
  update changelog
  lib: fix build
* 1.11.1
* update changelog
* Merge branch 'master' into ros2
  * master:
  1.11.0
  update changelog
  lib: fix ftf warnings
  msgs: use pragmas to ignore unaligned pointer warnings
  extras: landing_target: fix misprint
  msgs: fix convert const
  plugin: setpoint_raw: fix misprint
  msgs: try to hide 'unaligned pointer' warning
  plugin: sys: fix compillation error
  plugin: initialize quaternions with identity
  plugin: sys: Use wall timers for connection management
  Use meters for relative altitude
  distance_sensor: Initialize sensor orientation quaternion to zero
  Address review comments
  Add camera plugin for interfacing with mavlink camera protocol
* 1.11.0
* update changelog
* extras: landing_target: fix misprint
* plugin: initialize quaternions with identity
  Eigen::Quaternion[d|f] () does not initialize with zeroes or identity.
  So we must initialize with identity vector objects that can be left
  unassigned.
  Related to #1652 <https://github.com/mavlink/mavros/issues/1652>
* Merge pull request #1651 <https://github.com/mavlink/mavros/issues/1651> from Jaeyoung-Lim/pr-image-capture-plugin
  Add camera plugin for interfacing with mavlink camera protocol
* Merge pull request #1652 <https://github.com/mavlink/mavros/issues/1652> from scoutdi/avoid-uninit-orientation
  distance_sensor: Initialize sensor orientation quaternion to zero
* Use meters for relative altitude
* distance_sensor: Initialize sensor orientation quaternion to zero
  Without this, you'll get random garbage data for the quaternion field
  of the DISTANCE_SENSOR MAVLink messages sent to the autopilot.
  The quaternion field should be set to zero when unused, according to the
  MAVLink message's field description.
* Address review comments
* Add camera plugin for interfacing with mavlink camera protocol
  Add camera image captured message for handling camera trigger information
* extras: port fake_gps
* extras: port tunnel
* extras: update metadata
* extras: port hil
* extras: fix odom
* extras: port odom
* extras: port px4flow
* extras: fix some linter warnings
* extras: fix some linter warnings
* extras: fix some linter warnings
* extras: fix some linter warnings
* extras: port wheel_odometry (partially)
* extras: port vision_speed
* extras: port vibration
* extras: port vfr_hud
* extras: port trajectory
* extras: port rangefinder
* extras: port onboard computer status, play_tune
* extras: fix linter warnings
* extras: port obstacle_distance
* extras: update metadata xml
* extras: port mount_control
* extras: fix build for Foxy
* extras: port mocap
* extras: port mag cal status
* extras: port log_transfer
* extras: fix rtcm seq
* extras: port gps_rtk
* extras: port gps_input
* extras: fixing some linter warnings
* extras: fixing some linter warnings
* Contributors: Jaeyoung-Lim, Morten Fyhn Amundsen, Vladimir Ermakov
```

## mavros_msgs

```
* Merge branch 'master' into ros2
  * master:
  1.12.0
  update changelog
  Fix multiple bugs
  lib: fix mission frame debug print
  extras: distance_sensor: revert back to zero quaternion
* 1.12.0
* update changelog
* extras: fix some more lint warns
* msgs: update conversion header
* Merge branch 'master' into ros2
  * master:
  1.11.1
  update changelog
  lib: fix build
* 1.11.1
* update changelog
* Merge branch 'master' into ros2
  * master:
  1.11.0
  update changelog
  lib: fix ftf warnings
  msgs: use pragmas to ignore unaligned pointer warnings
  extras: landing_target: fix misprint
  msgs: fix convert const
  plugin: setpoint_raw: fix misprint
  msgs: try to hide 'unaligned pointer' warning
  plugin: sys: fix compillation error
  plugin: initialize quaternions with identity
  plugin: sys: Use wall timers for connection management
  Use meters for relative altitude
  distance_sensor: Initialize sensor orientation quaternion to zero
  Address review comments
  Add camera plugin for interfacing with mavlink camera protocol
* 1.11.0
* update changelog
* msgs: use pragmas to ignore unaligned pointer warnings
* msgs: fix convert const
* msgs: try to hide 'unaligned pointer' warning
* Merge pull request #1651 <https://github.com/mavlink/mavros/issues/1651> from Jaeyoung-Lim/pr-image-capture-plugin
  Add camera plugin for interfacing with mavlink camera protocol
* Address review comments
* Add camera plugin for interfacing with mavlink camera protocol
  Add camera image captured message for handling camera trigger information
* Merge branch 'master' into ros2
  * master:
  msgs: add yaw field to GPS_INPUT
* msgs: add yaw field to GPS_INPUT
* Contributors: Jaeyoung-Lim, Vladimir Ermakov
```
