### PR TITLE
foonathan_memory_vendor: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -858,7 +858,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/foonathan_memory_vendor-release.git
-      version: 1.0.0-2
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/eProsima/foonathan_memory_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foonathan_memory_vendor` to `1.2.0-1`:

- upstream repository: https://github.com/eProsima/foonathan_memory_vendor.git
- release repository: https://github.com/ros2-gbp/foonathan_memory_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.0-2`

## foonathan_memory_vendor

```
* Update upstream to release 0.7-1 (#49)
```
