### PR TITLE
libfranka: 0.8.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1756,6 +1756,21 @@ repositories:
       url: https://github.com/lgsvl/lgsvl_msgs.git
       version: foxy-devel
     status: developed
+  libfranka:
+    doc:
+      type: git
+      url: https://github.com/frankaemika/libfranka-release.git
+      version: release/foxy/libfranka
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/frankaemika/libfranka-release.git
+      version: 0.8.0-1
+    source:
+      type: git
+      url: https://github.com/frankaemika/libfranka.git
+      version: master
+    status: developed
   libg2o:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `libfranka` to `0.8.0-1`:

- upstream repository: https://github.com/frankaemika/libfranka.git
- release repository: https://github.com/frankaemika/libfranka-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
