### PR TITLE
launch_ros: 0.16.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1439,7 +1439,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.15.0-1
+      version: 0.16.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.16.0-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.15.0-1`

## launch_ros

```
* fix bug in warning when an entry point fails to load (#243 <https://github.com/ros2/launch_ros/issues/243>)
* More Helpful Error Messages (#275 <https://github.com/ros2/launch_ros/issues/275>)
* Update maintainers in setup.py (#287 <https://github.com/ros2/launch_ros/issues/287>)
* Set parameters from file for composable nodes (#281 <https://github.com/ros2/launch_ros/issues/281>)
* Update package maintainers (#284 <https://github.com/ros2/launch_ros/issues/284>)
* Update node name matcher (#282 <https://github.com/ros2/launch_ros/issues/282>)
* Support both parameter file configurations for composable nodes (#259 <https://github.com/ros2/launch_ros/issues/259>)
* Contributors: Aditya Pande, Audrow Nash, David V. Lu!!, Jacob Perron, Michel Hidalgo, Rebecca Butler, William Woodall
```

## launch_testing_ros

```
* Update maintainers in setup.py (#287 <https://github.com/ros2/launch_ros/issues/287>)
* Move pytest entrypoints to own module (#278 <https://github.com/ros2/launch_ros/issues/278>)
* Update package maintainers (#284 <https://github.com/ros2/launch_ros/issues/284>)
* Check that future is done, and always call rclpy.shutdown (#273 <https://github.com/ros2/launch_ros/issues/273>)
* Revert "launch testing : Wait for topics to publish (#274 <https://github.com/ros2/launch_ros/issues/274>)" (#276 <https://github.com/ros2/launch_ros/issues/276>)
* Contributors: Audrow Nash, Jorge Perez, Michel Hidalgo, Shane Loretz
```

## ros2launch

```
* Update maintainers in setup.py (#287 <https://github.com/ros2/launch_ros/issues/287>)
* Use frontend group dependency & explicit dependencies in ros2launch (#256 <https://github.com/ros2/launch_ros/issues/256>)
* Update package maintainers (#284 <https://github.com/ros2/launch_ros/issues/284>)
* Contributors: Audrow Nash, Christophe Bedard, Michel Hidalgo
```
