### PR TITLE
mavros: 1.12.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4137,7 +4137,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 1.11.1-1
+      version: 1.12.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `1.12.1-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.11.1-1`

## libmavconn

```
* mavconn: fix connection issue introduced by #1658 <https://github.com/mavlink/mavros/issues/1658>
* Contributors: Vladimir Ermakov
```

## mavros

```
* mavconn: fix connection issue introduced by #1658 <https://github.com/mavlink/mavros/issues/1658>
* Merge pull request #1660 <https://github.com/mavlink/mavros/issues/1660> from scoutdi/fix-warnings
  Fix warnings
* mavros: Fix some warnings
* Contributors: Morten Fyhn Amundsen, Vladimir Ermakov
```

## mavros_extras

```
* Merge pull request #1660 <https://github.com/mavlink/mavros/issues/1660> from scoutdi/fix-warnings
  Fix warnings
* mavros_extras: Fix some warnings
* Contributors: Morten Fyhn Amundsen, Vladimir Ermakov
```

## mavros_msgs

- No changes

## test_mavros

- No changes
