### PR TITLE
ifopt: 2.1.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1434,7 +1434,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ethz-adrl/ifopt-release.git
-      version: 2.1.0-1
+      version: 2.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ifopt` to `2.1.2-1`:

- upstream repository: https://github.com/ethz-adrl/ifopt.git
- release repository: https://github.com/ethz-adrl/ifopt-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.0-1`

## ifopt

```
* Expose epsilon for cost gradient finite difference approximation
* Contributors: Levi Armstrong
```
