### PR TITLE
nonpersistent_voxel_layer: 2.2.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2015,6 +2015,17 @@ repositories:
       url: https://github.com/osrf/nodl_to_policy.git
       version: master
     status: maintained
+  nonpersistent_voxel_layer:
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/SteveMacenski/nonpersistent_voxel_layer-release.git
+      version: 2.2.2-1
+    source:
+      type: git
+      url: https://github.com/SteveMacenski/nonpersistent_voxel_layer.git
+      version: galactic
+    status: maintained
   ntpd_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nonpersistent_voxel_layer` to `2.2.2-1`:

- upstream repository: https://github.com/SteveMacenski/nonpersistent_voxel_layer.git
- release repository: https://github.com/SteveMacenski/nonpersistent_voxel_layer-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
