### PR TITLE
sr_hand_detector: 0.0.8-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8691,7 +8691,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/shadow-robot/sr_hand_detector-release.git
-      version: 0.0.7-1
+      version: 0.0.8-1
     source:
       type: git
       url: https://github.com/shadow-robot/sr_hand_detector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sr_hand_detector` to `0.0.8-1`:

- upstream repository: https://github.com/shadow-robot/sr_hand_detector.git
- release repository: https://github.com/shadow-robot/sr_hand_detector-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.7-1`

## sr_hand_detector

```
* Adjusting to new xacros (#29 <https://github.com/shadow-robot/sr_hand_detector/issues/29>)
  Co-authored-by: georgiablanco <mailto:georgia@shadowrobot.com>
* Adding executables to package lib (#26 <https://github.com/shadow-robot/sr_hand_detector/issues/26>)
* Contributors: mikramarc
```
