### PR TITLE
raptor_dbw_ros2: 1.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3044,7 +3044,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/NewEagleRaptor/raptor-dbw-ros2-release.git
-      version: 1.1.1-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/NewEagleRaptor/raptor-dbw-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `raptor_dbw_ros2` to `1.2.0-1`:

- upstream repository: https://github.com/NewEagleRaptor/raptor-dbw-ros2.git
- release repository: https://github.com/NewEagleRaptor/raptor-dbw-ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.1-1`

## can_dbc_parser

- No changes

## raptor_dbw_can

```
* Update DBC to version 3.4
* Fix accel and steer ignore to not disable the system on overrides (#11 <https://github.com/NewEagleRaptor/raptor-dbw-ros2/issues/11>)
* Contributors: Benjamin Gervan, neweagleraptor
```

## raptor_dbw_joystick

```
* Update DBC to version 3.4
* Contributors: neweagleraptor
```

## raptor_dbw_msgs

```
* Update DBC to version 3.4
* Contributors: neweagleraptor
```

## raptor_pdu

- No changes

## raptor_pdu_msgs

- No changes
