### PR TITLE
avt_vimba_camera: 1.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -341,7 +341,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/astuff/avt_vimba_camera-release.git
-      version: 0.0.12-2
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `avt_vimba_camera` to `1.0.0-1`:

- upstream repository: https://github.com/astuff/avt_vimba_camera.git
- release repository: https://github.com/astuff/avt_vimba_camera-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.12-2`

## avt_vimba_camera

```
* Code Cleanup and Autoformat (#52 <https://github.com/astuff/avt_vimba_camera/issues/52>)
* Improve rosout logging (#50 <https://github.com/astuff/avt_vimba_camera/issues/50>)
* Improve README (#48 <https://github.com/astuff/avt_vimba_camera/issues/48>)
* Parameter Refactor (#46 <https://github.com/astuff/avt_vimba_camera/issues/46>)
* Use timestamp from image capture in ROS header (#41 <https://github.com/astuff/avt_vimba_camera/issues/41>)
* Trigger over Ethernet (#39 <https://github.com/astuff/avt_vimba_camera/issues/39>)
* Remove stereo camera code (#43 <https://github.com/astuff/avt_vimba_camera/issues/43>)
* Update CI (#44 <https://github.com/astuff/avt_vimba_camera/issues/44>)
* Update to VimbaCPP Version 1.8.4 (SDK version 5.0) (#36 <https://github.com/astuff/avt_vimba_camera/issues/36>)
* Fixed 'escalating to SIGTERM' when closing (#22 <https://github.com/astuff/avt_vimba_camera/issues/22>)
* Contributors: icolwell-as, vbrebion
```
