### PR TITLE
mia_hand_ros_pkgs: 1.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4294,6 +4294,22 @@ repositories:
       url: https://github.com/ros/metapackages.git
       version: noetic-devel
     status: maintained
+  mia_hand_ros_pkgs:
+    release:
+      packages:
+      - mia_hand_bringup
+      - mia_hand_description
+      - mia_hand_driver
+      - mia_hand_gazebo
+      - mia_hand_moveit_config
+      - mia_hand_msgs
+      - mia_hand_ros_control
+      - mia_hand_ros_pkgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release.git
+      version: 1.0.0-1
+    status: maintained
   microstrain_3dmgx2_imu:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mia_hand_ros_pkgs` to `1.0.0-1`:

- upstream repository: https://bitbucket.org/prensiliasrl/mia_hand_ros_pkgs.git
- release repository: https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## mia_hand_bringup

```
* Initial commit.
* Fix package xml files.
* Initial commit.
* Contributors: frcini
```

## mia_hand_description

```
* Initial commit.
* Fix package xml files.
* Initial commit.
* Contributors: frcini
```

## mia_hand_driver

```
* Initial commit.
* Fix package xml files.
* Initial commit.
* Contributors: frcini
```

## mia_hand_gazebo

```
* Initial commit.
* Fix package xml files.
* Initial commit.
* Contributors: frcini
```

## mia_hand_moveit_config

```
* Initial commit.
* Fix package xml files.
* Initial commit.
* Contributors: frcini
```

## mia_hand_msgs

```
* Initial commit.
* Fix package xml files.
* Initial commit.
* Contributors: frcini
```

## mia_hand_ros_control

```
* Initial commit.
* Fix package xml files.
* Initial commit.
* Contributors: frcini
```

## mia_hand_ros_pkgs

```
* Initial commit.
* Fix package xml files.
* Initial commit.
* Contributors: frcini
```
