### PR TITLE
psen_scan_v2: 0.20.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2818,6 +2818,21 @@ repositories:
       url: https://github.com/fmrico/popf.git
       version: foxy-devel
     status: developed
+  psen_scan_v2:
+    doc:
+      type: git
+      url: https://github.com/PilzDE/psen_scan_v2.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/PilzDE/psen_scan_v2-ros2-release.git
+      version: 0.20.0-1
+    source:
+      type: git
+      url: https://github.com/PilzDE/psen_scan_v2.git
+      version: ros2
+    status: developed
   py_trees:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `psen_scan_v2` to `0.20.0-1`:

- upstream repository: https://github.com/PilzDE/psen_scan_v2.git
- release repository: https://github.com/PilzDE/psen_scan_v2-ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## psen_scan_v2

```
* Port to ros2 foxy (#270)
  
  Rename launch files to *.launch.xml
  
  <string>:8: (WARNING/2) Inline emphasis start-string without end-string.
  
  Update README.md
  
  Add migration notes
  
  Remove delay in signal handler
  
  Introduce _ROS_BUILD_ define in order to choose between ros2 and (pure) cpp logging
  
  Rename ParamMissingOnServer to ParameterNotSet
  
  Allow more flexibel usage of util::Barrier
  
  Add linter clang-format and xmllint
* Update REAMDE.md
* Minor improvement of TenthOfDegree
* Fix scanner destruction problems. Fixes #241
* Remove dependency on pilz_testutils
* Always build hardware tests
* Internal refactorings
* Contributors: Pilz GmbH and Co. KG
```
