### PR TITLE
added python3-pytrinamic-pip to /rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7596,6 +7596,16 @@ python3-pytest-timeout:
   gentoo: [dev-python/pytest-timeout]
   opensuse: [python3-pytest-timeout]
   ubuntu: [python3-pytest-timeout]
+python3-pytrinamic-pip:
+  debian:
+    pip:
+      packages: [pytrinamic]
+  fedora:
+    pip:
+      packages: [pytrinamic]
+  ubuntu:
+    pip:
+      packages: [pytrinamic]
 python3-pyvista-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7603,6 +7603,9 @@ python3-pytrinamic-pip:
   fedora:
     pip:
       packages: [pytrinamic]
+  opensuse:
+    pip:
+      packages: [pytrinamic]
   ubuntu:
     pip:
       packages: [pytrinamic]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-pytrinamic-pip

## Package Upstream Source:

[https://github.com/trinamic/PyTrinamic](https://github.com/trinamic/PyTrinamic)

## Purpose of using this:

This dependency is used to communicate with TRINAMIC Modules and Evaluation boards (such as motors and encoders).

Distro packaging links:

## Links to Distribution Packages

[https://pypi.org/project/PyTrinamic/](https://pypi.org/project/PyTrinamic/)