### PR TITLE
qwt_dependency: 1.1.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6302,7 +6302,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/qwt_dependency-release.git
-      version: 1.1.1-1
+      version: 1.1.1-2
     source:
       type: git
       url: https://github.com/ros-visualization/qwt_dependency.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qwt_dependency` to `1.1.1-2`:

- upstream repository: https://github.com/ros-visualization/qwt_dependency.git
- release repository: https://github.com/ros-gbp/qwt_dependency-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.1-1`
