### PR TITLE
snowbot_operating_system: 0.1.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4305,7 +4305,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/PickNikRobotics/snowbot_release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/snowbot_operating_system.git


### PR DESCRIPTION
Increasing version of package(s) in repository `snowbot_operating_system` to `0.1.1-1`:

- upstream repository: https://github.com/PickNikRobotics/snowbot_operating_system.git
- release repository: https://github.com/PickNikRobotics/snowbot_release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.0-1`
