### PR TITLE
snowbot_operating_system: 0.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12869,7 +12869,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PickNikRobotics/snowbot_release.git
-      version: 0.0.1-1
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/snowbot_operating_system.git


### PR DESCRIPTION
Increasing version of package(s) in repository `snowbot_operating_system` to `0.0.2-1`:

- upstream repository: https://github.com/PickNikRobotics/snowbot_operating_system.git
- release repository: https://github.com/PickNikRobotics/snowbot_release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.1-1`
