### PR TITLE
Add sqlite3 rule for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7182,6 +7182,7 @@ sqlite3:
   fedora: [sqlite]
   gentoo: [=dev-db/sqlite-3*]
   nixos: [sqlite]
+  rhel: [sqlite]
   ubuntu: [sqlite3]
 ssh-askpass:
   debian: [ssh-askpass]


### PR DESCRIPTION
RHEL 7: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/sqlite-3.7.17-8.el7_7.1.i686.rpm
RHEL 8: http://mirror.centos.org/centos-8/8/BaseOS/x86_64/os/Packages/sqlite-3.26.0-15.el8.i686.rpm