### PR TITLE
Add jq rule for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2066,6 +2066,7 @@ jq:
   fedora: [jq]
   gentoo: [app-misc/jq]
   nixos: [jq]
+  rhel: [jq]
   ubuntu: [jq]
 julius-voxforge:
   arch: [voxforge-am-julius]


### PR DESCRIPTION
EPEL 7: https://src.fedoraproject.org/rpms/jq#bodhi_updates
RHEL 8: http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/Packages/jq-1.5-12.el8.i686.rpm