### PR TITLE
neonavigation: 0.11.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7489,7 +7489,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.11.2-1
+      version: 0.11.3-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.11.3-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.11.2-1`

## costmap_cspace

- No changes

## joystick_interrupt

- No changes

## map_organizer

- No changes

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

- No changes

## obj_to_pointcloud

- No changes

## planner_cspace

```
* planner_cspace: fix DistanceMap::init() (#625 <https://github.com/at-wat/neonavigation/issues/625>)
* Fix flaky tests and add debug outputs (#628 <https://github.com/at-wat/neonavigation/issues/628>)
* Contributors: Atsushi Watanabe, Naotaka Hatao
```

## safety_limiter

```
* Fix flaky tests and add debug outputs (#628 <https://github.com/at-wat/neonavigation/issues/628>)
* Contributors: Atsushi Watanabe
```

## track_odometry

- No changes

## trajectory_tracker

- No changes
