### PR TITLE
ros_inorbit_samples: 0.2.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13119,6 +13119,14 @@ repositories:
       url: https://github.com/jstnhuang/ros_explorer.git
       version: kinetic-devel
     status: developed
+  ros_inorbit_samples:
+    release:
+      packages:
+      - inorbit_republisher
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/inorbit-ai/ros_inorbit_samples-release.git
+      version: 0.2.1-1
   ros_monitoring_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_inorbit_samples` to `0.2.1-1`:

- upstream repository: https://github.com/inorbit-ai/ros_inorbit_samples.git
- release repository: https://github.com/inorbit-ai/ros_inorbit_samples-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## inorbit_republisher

```
* Initial Implementation
* Contributors: Leandro Pineda
```
