### PR TITLE
ros_industrial_cmake_boilerplate: 0.2.13-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10849,6 +10849,20 @@ repositories:
       type: git
       url: https://github.com/shadow-robot/ros_ethercat_eml.git
       version: melodic-devel
+  ros_industrial_cmake_boilerplate:
+    release:
+      packages:
+      - gtest
+      - ros_industrial_cmake_boilerplate
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release.git
+      version: 0.2.13-1
+    source:
+      type: git
+      url: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git
+      version: master
+    status: developed
   ros_inorbit_samples:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_industrial_cmake_boilerplate` to `0.2.13-1`:

- upstream repository: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git
- release repository: https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ros_industrial_cmake_boilerplate

```
* Add --output-on-failure to add_run_test_target
* Remove deprecated variables
* Add CXX_STANDARD_REQUIRED ON
* Contributors: Levi Armstrong, Levi-Armstrong
```
