### PR TITLE
snowbot_operating_system: 0.0.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8576,6 +8576,21 @@ repositories:
       url: https://github.com/oKermorgant/slider_publisher.git
       version: ros1
     status: maintained
+  snowbot_operating_system:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/snowbot_operating_system.git
+      version: main
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/PickNikRobotics/snowbot_release.git
+      version: 0.0.4-1
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/snowbot_operating_system.git
+      version: main
+    status: maintained
   sob_layer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `snowbot_operating_system` to `0.0.4-1`:

- upstream repository: https://github.com/PickNikRobotics/snowbot_operating_system.git
- release repository: https://github.com/PickNikRobotics/snowbot_release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
