### PR TITLE
rm_controllers: 0.1.1-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6629,7 +6629,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/rm-controls/rm_controllers-release.git
-      version: 0.1.1-1
+      version: 0.1.1-3
     source:
       type: git
       url: https://github.com/rm-controls/rm_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rm_controllers` to `0.1.1-3`:

- upstream repository: https://github.com/rm-controls/rm_controllers.git
- release repository: https://github.com/rm-controls/rm_controllers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.1-1`

## rm_calibration_controllers

```
* Set all version to the same
* Add license to rm_calibration_controllers source files
* Merge remote-tracking branch 'alias_memory/metapackage'
* Move all files to rm_calibration_controllers/rm_calibration_controllers, prepare for merge
* Contributors: qiayuan
```

## rm_chassis_controllers

```
* Set all version to the same
* Add license to rm_chassis_controllers and rm_gimbal_controllers source files
* Remove test_depend of rm_chassis_controllers
* Merge remote-tracking branch 'alias_memory/metapackage'
* Move all files to rm_chassis_controllers/rm_chassis_controllers, prepare for merge
* Contributors: qiayuan
```

## rm_controllers

```
* Set all version to the same
* Add license to robot_state_controller source files
* Add rm_controllers
* Contributors: qiayuan
```

## rm_gimbal_controllers

```
* Set all version to the same
* Add license to rm_chassis_controllers and rm_gimbal_controllers source files
* Add add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
* Merge remote-tracking branch 'alias_memory/metapackage'
* Move all files to rm_gimbal_controllers/rm_gimbal_controllers, prepare for merge
* Contributors: qiayuan
```

## rm_shooter_controllers

```
* Set all version to the same
* Add license to rm_chassis_controllers and rm_gimbal_controllers source files
* Merge remote-tracking branch 'alias_memory/metapackage'
* Move all files to rm_shooter_controllers/rm_shooter_controllers, prepare for merge
* Contributors: qiayuan
```

## robot_state_controller

```
* Set all version to the same
* Add license to robot_state_controller source files
* Merge remote-tracking branch 'alias_memory/metapackage'
* Move all files to robot_state_controller/robot_state_controller, prepare for merge
* Contributors: qiayuan
```