### PR TITLE
leo_common: 2.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3762,11 +3762,12 @@ repositories:
       packages:
       - leo
       - leo_description
+      - leo_msgs
       - leo_teleop
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_common-release.git
-      version: 1.2.2-1
+      version: 2.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_common` to `2.0.0-1`:

- upstream repository: https://github.com/LeoRover/leo_common.git
- release repository: https://github.com/fictionlab-gbp/leo_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.2-1`

## leo

```
* Add leo_msgs to leo metapackage dependencies
```

## leo_description

- No changes

## leo_msgs

```
* Add comments to the Imu and WheelOdom message definitions
* Add pwm_duty_cycle field to WheelStates
* Add WheelOdom and WheelStates messages
* Add temperature to Imu message
* Initial leo_msgs package
```

## leo_teleop

- No changes
