### PR TITLE
opw_kinematics: 0.4.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8284,6 +8284,17 @@ repositories:
       url: https://github.com/evocortex/optris_drivers.git
       version: master
     status: maintained
+  opw_kinematics:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-industrial-release/opw_kinematics-release.git
+      version: 0.4.4-1
+    source:
+      type: git
+      url: https://github.com/Jmeyer1292/opw_kinematics.git
+      version: master
+    status: developed
   orb_slam2_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `opw_kinematics` to `0.4.4-1`:

- upstream repository: https://github.com/Jmeyer1292/opw_kinematics.git
- release repository: https://github.com/ros-industrial-release/opw_kinematics-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## opw_kinematics

```
* Fix numerical issue in inverse function
* Contributors: Levi-Armstrong
```
