### PR TITLE
Adding outsight_alb_driver to documentation index for melodic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8332,6 +8332,16 @@ repositories:
       url: https://github.com/CPFL/ouster.git
       version: autoware_branch
     status: developed
+  outsight_alb_driver:
+    doc:
+      type: git
+      url: https://gitlab.com/outsight-public/outsight-drivers/outsight_alb_driver.git
+      version: master
+    source:
+      type: git
+      url: https://gitlab.com/outsight-public/outsight-drivers/outsight_alb_driver.git
+      version: master
+    status: maintained
   oxford_gps_eth:
     doc:
       type: git


### PR DESCRIPTION
Hello rosdistro-team,
Here is the new PR to add the Outsight driver for the Augmented Lidar Box (https://www.outsight.ai/)


<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

Melodic

# The source is here: 

https://gitlab.com/outsight-public/outsight-drivers/outsight_alb_driver

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
