### PR TITLE
Adding outsight_alb_driver to documentation index for noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5349,6 +5349,16 @@ repositories:
       url: https://github.com/tier4/osqp_vendor.git
       version: noetic
     status: maintained
+  outsight_alb_driver:
+    doc:
+      type: git
+      url: https://gitlab.com/outsight-public/outsight-drivers/outsight_alb_driver.git
+      version: master
+    source:
+      type: git
+      url: https://gitlab.com/outsight-public/outsight-drivers/outsight_alb_driver.git
+      version: master
+    status: maintained
   oxford_gps_eth:
     doc:
       type: git


### PR DESCRIPTION
Hello rosdistro-team,
Here is the new PR to add the Outsight driver for the Augmented Lidar Box (https://www.outsight.ai/)


<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

Noetic

# The source is here: 

https://gitlab.com/outsight-public/outsight-drivers/outsight_alb_driver

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
