### PR TITLE
microstrain_inertial: 2.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6502,7 +6502,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/LORD-MicroStrain/microstrain_inertial-release.git
-      version: 2.1.0-1
+      version: 2.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `2.2.0-1`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/LORD-MicroStrain/microstrain_inertial-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.0-1`

## microstrain_inertial_driver

```
* Adds set filter speed lever arm service to allow users to configure Measurement Speed Lever Arm at runtime with a service call
* Subscribes to external speed measurements
* Adds ability to configure hardware odometer at config time by sending the Odometer Settings command based on launch config
* Adds RTCM subscriber that will subscribe to RTCM corrections as mavros_msgs/RTCM messages and send them to the GQ7 through the aux port
* Adds NMEA publisher that will read NMEA sentences from the GQ7 aux port and publish them as nmea_msgs/Sentence messages to a topic
* Updates to use FACTORY_STREAMING_MERGE instead of manually casting the hex value when factory streaming is enabled
* Updates udev rules to differentiate between main and aux ports
* Contributors: ianmooreparker, robbiefish
```

## microstrain_inertial_examples

- No changes

## microstrain_inertial_msgs

```
* Adds set filter speed lever arm service definition to allow users to configure Measurement Speed Lever Arm at runtime with a service call
* Adds Input Speed Measurement message
* Contributors: robbiefish
```
