### PR TITLE
ouxt_common: 0.0.8-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2534,6 +2534,24 @@ repositories:
       url: https://github.com/osrf/osrf_testing_tools_cpp.git
       version: foxy
     status: maintained
+  ouxt_common:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/ouxt_common.git
+      version: master
+    release:
+      packages:
+      - ouxt_common
+      - ouxt_lint_common
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/OUXT-Polaris/ouxt_common-release.git
+      version: 0.0.8-2
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/ouxt_common.git
+      version: master
+    status: developed
   paho-mqtt-c:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ouxt_common` to `0.0.8-2`:

- upstream repository: https://github.com/OUXT-Polaris/ouxt_common.git
- release repository: https://github.com/OUXT-Polaris/ouxt_common-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ouxt_common

- No changes

## ouxt_lint_common

- No changes
