### PR TITLE
add serial package to noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8431,7 +8431,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/wjwwood/serial.git
-      version: master
+      version: main
     status: maintained
   septentrio_gnss_driver:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8421,6 +8421,18 @@ repositories:
       url: https://github.com/ctu-vras/sensor_filters.git
       version: master
     status: developed
+  serial:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/wjwwood/serial-release.git
+      version: 1.2.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/wjwwood/serial.git
+      version: master
+    status: maintained
   septentrio_gnss_driver:
     doc:
       type: git


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

serial

## Package Upstream Source:

https://github.com/wjwwood/serial

## Purpose of using this:

It was in rosdistro up until Melodic, adding to Noetic too.

# Checks
 - [x] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro

### Note
waiting for the package's maintainer @wjwwood to approve this pr.
Up until then, this is just a draft.