### PR TITLE
Noetic/add serial

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8421,18 +8421,6 @@ repositories:
       url: https://github.com/ctu-vras/sensor_filters.git
       version: master
     status: developed
-  serial:
-    release:
-      tags:
-        release: release/melodic/{package}/{version}
-      url: https://github.com/wjwwood/serial-release.git
-      version: 1.2.1-0
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/wjwwood/serial.git
-      version: main
-    status: maintained
   septentrio_gnss_driver:
     doc:
       type: git
@@ -8448,6 +8436,18 @@ repositories:
       type: git
       url: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
       version: master
+    status: maintained
+  serial:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/wjwwood/serial-release.git
+      version: 1.2.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/wjwwood/serial.git
+      version: main
     status: maintained
   sick_ldmrs_laser:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8421,6 +8421,18 @@ repositories:
       url: https://github.com/ctu-vras/sensor_filters.git
       version: master
     status: developed
+  serial:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/wjwwood/serial-release.git
+      version: 1.2.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/wjwwood/serial.git
+      version: main
+    status: maintained
   septentrio_gnss_driver:
     doc:
       type: git


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

serial

## Package Upstream Source:

https://github.com/wjwwood/serial

## Purpose of using this:

It was in rosdistro up until Melodic, adding to Noetic too.

# Checks
 - [x] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
   - there is a [pr to add it](https://github.com/wjwwood/serial/pull/261/files), waiting approval
 - [x] This package is expected to build on the submitted rosdistro

### Note
Waiting for the package's maintainer @wjwwood to approve this pr.
Up until then, this is just a draft.