### PR TITLE
Revert ros_industrial_cmake_boilerplate release and dependent packages (melodic)

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8284,17 +8284,6 @@ repositories:
       url: https://github.com/evocortex/optris_drivers.git
       version: master
     status: maintained
-  opw_kinematics:
-    release:
-      tags:
-        release: release/melodic/{package}/{version}
-      url: https://github.com/ros-industrial-release/opw_kinematics-release.git
-      version: 0.4.4-1
-    source:
-      type: git
-      url: https://github.com/Jmeyer1292/opw_kinematics.git
-      version: master
-    status: developed
   orb_slam2_ros:
     doc:
       type: git
@@ -10860,20 +10849,6 @@ repositories:
       type: git
       url: https://github.com/shadow-robot/ros_ethercat_eml.git
       version: melodic-devel
-  ros_industrial_cmake_boilerplate:
-    release:
-      packages:
-      - gtest
-      - ros_industrial_cmake_boilerplate
-      tags:
-        release: release/melodic/{package}/{version}
-      url: https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release.git
-      version: 0.2.14-1
-    source:
-      type: git
-      url: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git
-      version: master
-    status: developed
   ros_inorbit_samples:
     release:
       packages:


### PR DESCRIPTION
Reverted commits:

commit e84a79ab34ba871f0bef538a4f8df9a6deedfa0f
    ros_industrial_cmake_boilerplate: 0.2.13-1 in 'melodic/distribution.yaml' [bloom] (#31362)

commit 2c43065abb5d8180878e128e4fdc37dc11781379
    ros_industrial_cmake_boilerplate: 0.2.14-1 in 'melodic/distribution.yaml' [bloom] (#31379)

commit 84592d3af098c6eb85cd65d9a3ec9b6e52125d22
    opw_kinematics: 0.4.4-1 in 'melodic/distribution.yaml' [bloom] (#31368)

Reason: overrides default `gtest` package and introduces version conflict that breaks linking


Example:
```
CMakeFiles/rosconsole-assertion_test.dir/test/assertion_test.cpp.o: In function `RosAssert_assert_Test::TestBody()':
assertion_test.cpp:(.text+0x84b): undefined reference to `testing::internal::DeathTest::Create(char const*, testing::Matcher<std::__cxx11::basic_string<char, std::char_traits<char>, std::allo
CMakeFiles/rosconsole-assertion_test.dir/test/assertion_test.cpp.o: In function `RosAssert_breakpoint_Test::TestBody()':
assertion_test.cpp:(.text+0xbc3): undefined reference to `testing::internal::DeathTest::Create(char const*, testing::Matcher<std::__cxx11::basic_string<char, std::char_traits<char>, std::allo
CMakeFiles/rosconsole-assertion_test.dir/test/assertion_test.cpp.o: In function `RosAssert_assertWithMessage_Test::TestBody()':
assertion_test.cpp:(.text+0xf3b): undefined reference to `testing::internal::DeathTest::Create(char const*, testing::Matcher<std::__cxx11::basic_string<char, std::char_traits<char>, std::allo
collect2: error: ld returned 1 exit status
CMakeFiles/rosconsole-assertion_test.dir/build.make:109: recipe for target '/home/asherikov/ros_catkin_ws/devel_isolated/rosconsole/lib/rosconsole/rosconsole-assertion_test' failed
make[3]: *** [/home/asherikov/ros_catkin_ws/devel_isolated/rosconsole/lib/rosconsole/rosconsole-assertion_test] Error 1
CMakeFiles/Makefile2:171: recipe for target 'CMakeFiles/rosconsole-assertion_test.dir/all' failed
```

Reproduce with (Ubuntu 18)
```
mkdir ~/ros_catkin_ws
cd ~/ros_catkin_ws
rosinstall_generator rosconsole --rosdistro melodic --deps --tar > test.rosinstall                       
mkdir src
vcs import src < test.rosinstall                
./src/catkin/bin/catkin_make_isolated --install --catkin-make-args run_tests        
```

Validate the source of the problem with
```
rm -Rf build_isolated/ devel_isolated/ install_isolated/ 
rm -Rf src/ros_industrial_cmake_boilerplate/
./src/catkin/bin/catkin_make_isolated --install --catkin-make-args run_tests
```

Reported to maintainer -> https://github.com/ros-industrial/ros_industrial_cmake_boilerplate/issues/57, but no reaction so far.