### PR TITLE
urdf_tutorial: 1.0.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4865,6 +4865,22 @@ repositories:
       url: https://github.com/ros/urdf_parser_py.git
       version: ros2
     status: maintained
+  urdf_tutorial:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf_tutorial.git
+      version: ros2
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/urdf_tutorial-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/urdf_tutorial.git
+      version: ros2
+    status: maintained
   urdfdom:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_tutorial` to `1.0.0-1`:

- upstream repository: https://github.com/ros/urdf_tutorial
- release repository: https://github.com/ros2-gbp/urdf_tutorial-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## urdf_tutorial

```
* Fixing a problem that failed the startup of launch file of this package on my ROS2 Galactic installation (#53 <https://github.com/ros/urdf_tutorial/issues/53>)
* Rebasing Commits from ROS 1 Branch (#51 <https://github.com/ros/urdf_tutorial/issues/51>)
* Updated launch file (#50 <https://github.com/ros/urdf_tutorial/issues/50>)
* Updated rviz to rviz2 in package.xml (#49 <https://github.com/ros/urdf_tutorial/issues/49>)
* Port over to ROS2 foxy (#45 <https://github.com/ros/urdf_tutorial/issues/45>)
* Contributors: Arturs Elksnis, David V. Lu!!, Kuni Natsuki, Leo Stanislas
```
