### PR TITLE
add ply for python

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3330,6 +3330,10 @@ python-planar-pip:
   ubuntu:
     pip:
       packages: [planar]
+python-ply:
+  '*':
+    pip:
+      packages: [ply]
 python-plyfile-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python-ply

## Purpose of using this:

"PLY provides most of the standard lex/yacc features including support for empty productions, precedence rules, error recovery, and support for ambiguous grammars."

## Links to Distribution Packages

This is a pip package found at https://pypi.org/project/ply/.