### PR TITLE
add gnutls

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3263,6 +3263,13 @@ libgmp:
   gentoo: [dev-libs/gmp]
   nixos: [gmp]
   ubuntu: [libgmp-dev]
+libgnutls28-dev:
+  alpine: [gnutls-dev]
+  debian: [libgnutls28-dev]
+  fedora: [gnutls-devel]
+  opensuse: [libgnutls-devel]
+  rhel: [gnutls-devel]
+  ubuntu: [libgnutls28-dev]
 libgomp1:
   debian: [libgomp1]
   gentoo: [sys-libs/gcc]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

gnutls

## Purpose of using this:

"GnuTLS is a secure communications library implementing the SSL, TLS and DTLS protocols and technologies around them."

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/libgnutls28-dev
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/focal/libgnutls28-dev
- Fedora: https://src.fedoraproject.org/browse/projects/
  - https://src.fedoraproject.org/rpms/gnutls
