### PR TITLE
python_qt_binding: 1.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2255,7 +2255,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/python_qt_binding-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `1.1.1-1`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros2-gbp/python_qt_binding-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.0-1`

## python_qt_binding

```
* Replace PythonInterp to Python3 COMPONENTS (#108 <https://github.com/ros-visualization/python_qt_binding/issues/108>)
* Use PyQt5 module path to find SIP bindings (#106 <https://github.com/ros-visualization/python_qt_binding/issues/106>)
* Contributors: Ben Wolsieffer, Homalozoa X
```
