### PR TITLE
python_qt_binding: 1.0.8-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2456,7 +2456,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/python_qt_binding-release.git
-      version: 1.0.7-2
+      version: 1.0.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `1.0.8-1`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros2-gbp/python_qt_binding-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.7-2`

## python_qt_binding

```
* Replace PythonInterp to Python3 COMPONENTS (#110 <https://github.com/ros-visualization/python_qt_binding/issues/110>)
* fuerte-devel is too new for ROS Electric (#101 <https://github.com/ros-visualization/python_qt_binding/issues/101>)
* Contributors: Homalozoa X, Shane Loretz
```
