### PR TITLE
osqp_vendor: 0.0.4-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2149,7 +2149,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/tier4/osqp_vendor-release.git
-      version: 0.0.3-1
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/tier4/osqp_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `osqp_vendor` to `0.0.4-1`:

- upstream repository: https://github.com/tier4/osqp_vendor.git
- release repository: https://github.com/tier4/osqp_vendor-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.3-1`

## osqp_vendor

```
* Suppress update of pinned git repository (#8 <https://github.com/tier4/osqp_vendor/issues/8>)
  The source at that ref will never change, so there is no need to try to
  update it. This will avoid unnecessary invalidation of the build and
  install targets for the external project.
* Always preserve source permissions in vendor packages (#7 <https://github.com/tier4/osqp_vendor/issues/7>)
  In vendor packages where we're installing an executable, we use
  USE_SOURCE_PERMISSIONS to make sure that the executable permissions on
  the binaries are maintained when the external project's staging
  directory is recursively installed to the final installation directory.
  In most of our vendor packages, we aren't using that flag where we don't
  expect an executable binary to be installed. However, for reasons I
  won't go into here, some systems use executable permissions on shared
  object libraries as well. The linker seems to handle this on our behalf,
  but we're losing the permissions during the recursive copy operation if
  we don't use this flag.
* Add buildtool_depend on git (#6 <https://github.com/tier4/osqp_vendor/issues/6>)
* Update workflows (#9 <https://github.com/tier4/osqp_vendor/issues/9>)
  * Update workflows
  * Remove artifact
  * Skip tests
* Contributors: Daisuke Nishimatsu, Scott K Logan
```
