### PR TITLE
rm_control: 0.1.8-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6666,7 +6666,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/rm-controls/rm_control-release.git
-      version: 0.1.7-4
+      version: 0.1.8-2
     source:
       type: git
       url: https://github.com/rm-controls/rm_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rm_control` to `0.1.8-2`:

- upstream repository: https://github.com/rm-controls/rm_control.git
- release repository: https://github.com/rm-controls/rm_control-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.7-4`

## rm_common

```
* Merge branch 'master' into master
* Merge remote-tracking branch 'origin/master'
* Merge pull request #14 <https://github.com/rm-controls/rm_control/issues/14> from CQUMechaX/master
  Fix rm_msgs generation problem on clean make
* Fix rm_msgs generation problem on clean make
  When you use catkin_make with make -jxx, rm_msgs may be compiled later than
  targets which need it. It will throw an error on a clean workspace and works
  perfectly later on.
  - See https://answers.ros.org/question/73048
* Make rm_manual can be used with gimbal controller in gimbal/opti_simplify branch.
* Merge branch 'master' into gimbal/opti_or_simplify
* Update CHANGELOG
* Merge remote-tracking branch 'origin/gimbal/opti_or_simplify' into gimbal/opti_or_simplify
* Put filtered quaternion into imu_extra_handle.
* Add setOrientation to ImuExtraHandle
* Add orientation to ImuExtraHandle
* Add ImuExtraInterface
* Contributors: BruceLannn, QiayuanLiao, Tiger3018, YuuinIH, qiayuan
```

## rm_control

```
* Merge branch 'master' into gimbal/opti_or_simplify
* Update CHANGELOG
* Contributors: qiayuan
```

## rm_dbus

```
* Merge branch 'master' into master
* Remove priority from dbus_node
* Merge branch 'master' into gimbal/opti_or_simplify
* Update CHANGELOG
* Contributors: YuuinIH, qiayuan
```

## rm_description

```
* Merge pull request #19 <https://github.com/rm-controls/rm_control/issues/19> from ye-luo-xi-tui/fix_rmua_bug
  Fix rmua bug
* Change limit of rmua.
  (cherry picked from commit a1e4d841dd4cda83d50189a8f5d3bd84d604d244)
* Fix a bug in rmua urdf
  (cherry picked from commit cd6f7fac5c375cd74408620438039ca2c83437cd)
* Merge branch 'master' into master
* Update standard4.urdf.xacro and rm_hw/config/standard4.yaml.
* Merge remote-tracking branch 'origin/master'
* Merge pull request #16 <https://github.com/rm-controls/rm_control/issues/16> from Edwinlinks/master
  Modify the date of standard in rm_description
* Modify the date of standard in rm_description
* Fix imu inertia and add imu to balance
* Merge branch 'master' into gimbal/opti_or_simplify
* Update CHANGELOG
* Update standard5's imu orientation
* Update IMU orientation of standard5.urdf.xacro
* Merge branch 'master' into gimbal/opti_or_simplify
* Merge branch 'master' into gimbal/opti_or_simplify
* Update URDF of imu
* Contributors: BruceLannn, Edwinlinks, QiayuanLiao, YuuinIH, qiayuan, yezi
```

## rm_gazebo

```
* Fix imu inertia and add imu to balance
* Merge branch 'master' into gimbal/opti_or_simplify
* Update CHANGELOG
* Merge branch 'master' into gimbal/opti_or_simplify
* Update URDF of imu
* Contributors: qiayuan
```

## rm_hw

```
* Fix End of files.
* Merge branch 'master' into master
* Update standard4.urdf.xacro and rm_hw/config/standard4.yaml.
* Fix "sorry, unimplemented: non-trivial designated initializers not supported" under melodic
* Merge branch 'master' into gimbal/opti_or_simplify
* Update CHANGELOG
* Set accel_coeff of imu to 6G's
* Receive camera_trigger CAN frame
* Add orientation to ImuExtraHandle
* Update coefficient and standard5.yaml
* Merge branch 'master' into gimbal/opti_or_simplify
* Test can receive of imu2can successfully
* Update CanBus::read() for new imu
* Add ImuExtraInterface
* Contributors: BruceLannn, YuuinIH, qiayuan
```

## rm_msgs

```
* Merge branch 'master' into gimbal/opti_or_simplify
* Update CHANGELOG
* Remove cover of ShooterCmd
* Contributors: qiayuan
```
