### PR TITLE
ros_industrial_cmake_boilerplate: 0.2.14-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10862,13 +10862,10 @@ repositories:
       version: melodic-devel
   ros_industrial_cmake_boilerplate:
     release:
-      packages:
-      - gtest
-      - ros_industrial_cmake_boilerplate
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release.git
-      version: 0.2.14-1
+      version: 0.2.14-2
     source:
       type: git
       url: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_industrial_cmake_boilerplate` to `0.2.14-2`:

- upstream repository: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git
- release repository: https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.14-1`

## ros_industrial_cmake_boilerplate

```
* Add newer version of clang-tidy to the list
* Contributors: Levi Armstrong
```
