### PR TITLE
yaml_cpp_vendor: 7.1.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5161,7 +5161,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
-      version: 7.1.0-2
+      version: 7.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `yaml_cpp_vendor` to `7.1.1-1`:

- upstream repository: https://github.com/ros2/yaml_cpp_vendor.git
- release repository: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `7.1.0-2`

## yaml_cpp_vendor

```
* Update maintainers to Audrow Nash (#26 <https://github.com/ros2/yaml_cpp_vendor/issues/26>)
* Fix handling of CMAKE_C[XX]_FLAGS lists (#24 <https://github.com/ros2/yaml_cpp_vendor/issues/24>)
* Contributors: Christophe Bedard, Scott K Logan
```
