### PR TITLE
snowbot_operating_system: 0.0.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8642,7 +8642,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/PickNikRobotics/snowbot_release.git
-      version: 0.0.4-1
+      version: 0.0.5-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/snowbot_operating_system.git


### PR DESCRIPTION
Increasing version of package(s) in repository `snowbot_operating_system` to `0.0.5-1`:

- upstream repository: https://github.com/PickNikRobotics/snowbot_operating_system.git
- release repository: https://github.com/PickNikRobotics/snowbot_release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.4-1`
