### PR TITLE
bno055: 0.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -414,7 +414,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/flynneva/bno055-release.git
-      version: 0.1.1-3
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/flynneva/bno055.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bno055` to `0.2.0-1`:

- upstream repository: https://github.com/flynneva/bno055.git
- release repository: https://github.com/flynneva/bno055-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.1-3`

## bno055

```
* Merge pull request #36 <https://github.com/flynneva/bno055/issues/36> from flynneva/feature/add-covariance
  [33] add default covariance values, make them configurable
* fix printout for parameters
* [33] add defaults for magnetic field covariance values
* [37] add logic to set offsets
* [33] add default covariance values, make them configurable
* Merge pull request #24 <https://github.com/flynneva/bno055/issues/24> from flynneva/fix/scaling_factors
* [35] add back in comm constants, modify variable names as needed to fix bug introduced by #16 <https://github.com/flynneva/bno055/issues/16>
* [34] use underscores in setup.cfg instead of dashes
* [23] fix acc and mag scaling factors and make them configurable
* only run docs ci on main updates
* use sh instead of bash script for docs ci
* use . instead of source for docs ci
* remove -r from pip install
* use relative paths for docs ci
* use absolute paths for docs ci
* ls in docs ci
* switch doc generation ci to pre-built docker image
* source galactic not rolling
* Merge branch 'develop' of github.com:flynneva/bno055 into develop
* dont use forked repo for setup-ros
* Merge branch 'main' into develop
* fix setup-ros version to 0.2
* Merge pull request #28 <https://github.com/flynneva/bno055/issues/28> from flynneva/develop
  fix setup ros version to v0.2
* fix setup ros version to v0.2
* Merge pull request #27 <https://github.com/flynneva/bno055/issues/27> from flynneva/develop
  use galactic for doc generation
* Merge pull request #26 <https://github.com/flynneva/bno055/issues/26> from flynneva/feature/sphinx_docs
  use galactic for doc generation, not rolling
* use galactic for doc generation, not rolling
* Merge pull request #25 <https://github.com/flynneva/bno055/issues/25> from flynneva/develop
  bring over updates to main, generate docs for first time
* Merge pull request #16 <https://github.com/flynneva/bno055/issues/16> from flynneva/feature/sphinx_docs
  Feature/sphinx docs
* fix docs ci path when uploading docs to gh-pages
* Merge branch 'develop' into feature/sphinx_docs
* add modules to docs and update registers
* Merge pull request #21 <https://github.com/flynneva/bno055/issues/21> from flynneva/develop
  normalize quaternion
* Merge pull request #20 <https://github.com/flynneva/bno055/issues/20> from flynneva/fix/normalize_quaternion
  normalize quaterion
* normalize quat
* Merge pull request #19 <https://github.com/flynneva/bno055/issues/19> from flynneva/feature/prebuilt_docker_ci
  move to pre-built ros docker images
* move to pre-built ros docker images
* minor docs updates
* doc page templates
* starting on docs
* Merge pull request #13 <https://github.com/flynneva/bno055/issues/13> from flynneva/develop
  bump for release
* Merge pull request #10 <https://github.com/flynneva/bno055/issues/10> from flynneva/develop
  bring over updates to main
* Contributors: Evan Flynn, flynneva
```
