### PR TITLE
Adding quori_launch to documentation index for distro

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6350,6 +6350,12 @@ repositories:
       url: https://github.com/QuanergySystems/quanergy_client_ros.git
       version: master
     status: developed
+  quori_launch:
+    doc:
+      type: git
+      url: https://github.com/Quori-ROS/quori_ros.git
+      version: master
+    status: maintained
   qwt_dependency:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

noetic

# The source is here: 

https://github.com/Quori-ROS/quori_ros/tree/master/src/quori_launch


# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
