### PR TITLE
serial: 1.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8498,7 +8498,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/wjwwood/serial.git
-      version: master
+      version: main
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -8507,7 +8507,7 @@ repositories:
     source:
       type: git
       url: https://github.com/wjwwood/serial.git
-      version: master
+      version: main
     status: maintained
   sick_ldmrs_laser:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8494,6 +8494,21 @@ repositories:
       url: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
       version: master
     status: maintained
+  serial:
+    doc:
+      type: git
+      url: https://github.com/wjwwood/serial.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/wjwwood/serial-release.git
+      version: 1.2.1-1
+    source:
+      type: git
+      url: https://github.com/wjwwood/serial.git
+      version: master
+    status: maintained
   sick_ldmrs_laser:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `serial` to `1.2.1-1`:

- upstream repository: https://github.com/wjwwood/serial.git
- release repository: https://github.com/wjwwood/serial-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## serial

```
* Removed the use of a C++11 feature for compatibility with older browsers.
* Fixed an issue with cross compiling with mingw on Windows.
* Restructured Visual Studio project layout.
* Added include of ``#include <AvailabilityMacros.h>`` on OS X (listing of ports).
* Fixed MXE for the listing of ports on Windows.
* Now closes file device if ``reconfigureDevice`` fails (Windows).
* Added the MARK/SPACE parity bit option, also made it optional.
  Adding the enumeration values for MARK and SPACE was the only code change to an API header.
  It should not affect ABI or API.
* Added support for 576000 baud on Linux.
* Now releases iterator properly in listing of ports code for OS X.
* Fixed the ability to open COM ports over COM10 on Windows.
* Fixed up some documentation about exceptions in ``serial.h``.
```
