### PR TITLE
domain_bridge: 0.4.0-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -703,7 +703,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/domain_bridge-release.git
-      version: 0.4.0-1
+      version: 0.4.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `domain_bridge` to `0.4.0-2`:

- upstream repository: https://github.com/ros2/domain_bridge.git
- release repository: https://github.com/ros2-gbp/domain_bridge-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.0-1`

## domain_bridge

```
* Make some end to end tests more reliable (#51 <https://github.com/ros2/domain_bridge/issues/51>)
* Install CLI parsing header (#45 <https://github.com/ros2/domain_bridge/issues/45>)
* Run communication-related tests with all available RMWs (#43 <https://github.com/ros2/domain_bridge/issues/43>)
* Fix bug when waiting for service to be available (#42 <https://github.com/ros2/domain_bridge/issues/42>) (#55 <https://github.com/ros2/domain_bridge/issues/55>)
* Update CI to target Galactic (#37 <https://github.com/ros2/domain_bridge/issues/37>)
* Add --mode argument to domain_bridge (#35 <https://github.com/ros2/domain_bridge/issues/35>)
* Add template method to help bridging services (#26 <https://github.com/ros2/domain_bridge/issues/26>)
* Fix library target install (#36 <https://github.com/ros2/domain_bridge/issues/36>)
* Update CI workflow (#34 <https://github.com/ros2/domain_bridge/issues/34>)
* Prevent bridging from/to same domain ID (#33 <https://github.com/ros2/domain_bridge/issues/33>)
* RTI QoS profiles patch (#25 <https://github.com/ros2/domain_bridge/issues/25>)
  * Add option to run callback before creating new Domain
  * Add a domain_bridge executable that allows to load an RTI qos profile before creating a new domain  participant
* Add compressing and decompressing modes (#24 <https://github.com/ros2/domain_bridge/issues/24>)
* Refactor to use generic pub/sub from rclcpp (#30 <https://github.com/ros2/domain_bridge/issues/30>)
* Fix bug in generic subscription (#27 <https://github.com/ros2/domain_bridge/issues/27>)
* Contributors: Ivan Santiago Paunovic, Jacob Perron, Rebecca Butler
```
