### PR TITLE
microstrain_inertial: 2.2.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6502,7 +6502,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/LORD-MicroStrain/microstrain_inertial-release.git
-      version: 2.2.0-1
+      version: 2.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `2.2.1-1`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/LORD-MicroStrain/microstrain_inertial-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.2.0-1`

## microstrain_inertial_driver

```
* Defaults RTCM subscription and NMEA publisher to false
* Contributors: robbiefish
```

## microstrain_inertial_examples

- No changes

## microstrain_inertial_msgs

- No changes
