### PR TITLE
add python-dt-apriltags-pip dependency for ubuntu

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1345,6 +1345,9 @@ python-docx:
   fedora: [python-docx]
   ubuntu:
     pip: [python-docx]
+python-dt-apriltags:
+  ubuntu:
+    pip: [dt-apriltags]
 python-dxfgrabber-pip:
   ubuntu:
     pip: [dxfgrabber]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1345,7 +1345,7 @@ python-docx:
   fedora: [python-docx]
   ubuntu:
     pip: [python-docx]
-python-dt-apriltags:
+python-dt-apriltags-pip:
   ubuntu:
     pip: [dt-apriltags]
 python-dxfgrabber-pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1346,6 +1346,14 @@ python-docx:
   ubuntu:
     pip: [python-docx]
 python-dt-apriltags-pip:
+  debian:
+    pip: [dt-apriltags]
+  fedora:
+    pip: [dt-apriltags]
+  opensuse:
+    pip: [dt-apriltags]
+  osx:
+    pip: [dt-apriltags]
   ubuntu:
     pip: [dt-apriltags]
 python-dxfgrabber-pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

dt-apriltags

## Package Upstream Source:

[github source](https://github.com/duckietown/lib-dt-apriltags)

## Purpose of using this:

Useful for easy apriltag detection in python

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - i do not have a debian machine and cannot test to make sure a similar rule would work for it.
- Ubuntu: https://packages.ubuntu.com/
   - [pip](https://pypi.org/project/dt-apriltags/)
- Fedora: https://src.fedoraproject.org/browse/projects/
  - IF AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL
