### PR TITLE
mir_robot: 1.1.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4366,7 +4366,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/uos-gbp/mir_robot-release.git
-      version: 1.1.3-1
+      version: 1.1.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mir_robot` to `1.1.4-1`:

- upstream repository: https://github.com/dfki-ric/mir_robot.git
- release repository: https://github.com/uos-gbp/mir_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.3-1`

## mir_actions

- No changes

## mir_description

```
* Replace gazebo_plugins IMU with hector_gazebo_plugins
* Use cylinders instead of STLs for wheel collision geometries
  Fixes #99 <https://github.com/dfki-ric/mir_robot/issues/99>.
* mir_debug_urdf.launch: Fix GUI display
* Contributors: Martin Günther
```

## mir_driver

- No changes

## mir_dwb_critics

- No changes

## mir_gazebo

```
* Remove outdated comment
* Contributors: Martin Günther
```

## mir_msgs

```
* mir_msgs: Build all messages (#98 <https://github.com/dfki-ric/mir_robot/issues/98>)
* Contributors: Martin Günther
```

## mir_navigation

- No changes

## mir_robot

- No changes

## sdc21x0

- No changes
