### PR TITLE
add python-rdflib on ubuntu focal

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4083,7 +4083,9 @@ python-rdflib:
   debian: [python-rdflib]
   fedora: [python-rdflib]
   gentoo: [dev-python/rdflib]
-  ubuntu: [python-rdflib]
+  ubuntu:
+    '*' : [python-rdflib]
+    focal: [python-rdflib-tools]
 python-readchar-pip:
   ubuntu:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python-rdflib

## Package Upstream Source:

https://github.com/RDFLib/rdflib

## Purpose of using this:

python-rdflib is already in the file, however ubuntu changed the package name in focal to python-rdflib-tools

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Ubuntu: https://packages.ubuntu.com/focal/python/python-rdflib-tools

I didn't include the other links because the package is already in the current rosdep rules.