### PR TITLE
mavros: 1.12.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4159,7 +4159,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 1.12.1-1
+      version: 1.12.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `1.12.2-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.12.1-1`

## libmavconn

- No changes

## mavros

```
* Merge pull request #1672 <https://github.com/mavlink/mavros/issues/1672> from okalachev/patch-1
  Set time/publish_sim_time to false by default
* Set time/publish_sim_time to false by default
* Merge pull request #1669 <https://github.com/mavlink/mavros/issues/1669> from Hs293Go/master
  plugin: setpoint_raw: move getParam to initializer
* plugin: setpoint_raw: move getParam to initializer
  Repeatedly getting the thrust_scaling parameter in a callback that can
  be invoked from a fast control loop may fail spuriously and trigger a
  fatal error
* Contributors: Oleg Kalachev, Vladimir Ermakov, hs293go
```

## mavros_extras

```
* extras: trajectory: backport #1667 <https://github.com/mavlink/mavros/issues/1667>
* Contributors: Vladimir Ermakov
```

## mavros_msgs

- No changes

## test_mavros

- No changes
