### PR TITLE
Add nuscenes-devkit

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7015,6 +7015,22 @@ python3-numpy-stl:
   ubuntu:
     '*': [python3-numpy-stl]
     xenial: null
+python3-nuscenes-devkit-pip:
+  arch:
+    pip:
+      packages: [nuscenes-devkit]
+  debian:
+    pip:
+      packages: [nuscenes-devkit]
+  fedora:
+    pip:
+      packages: [nuscenes-devkit]
+  osx:
+    pip:
+      packages: [nuscenes-devkit]
+  ubuntu:
+    pip:
+      packages: [nuscenes-devkit]
 python3-open3d-pip:
   debian:
     pip:


### PR DESCRIPTION
Signed-off-by: wep21 <border_goldenmarket@yahoo.co.jp>

<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

nuscenes-devkit

## Package Upstream Source:

https://github.com/nutonomy/nuscenes-devkit

## Purpose of using this:

The nuScenes and nuImages datasets are one of the most popular dataset for autonomous driving.
The devkit is useful to process the dataset.

Distro packaging links:

## Links to Distribution Packages

We can install `nuscenes devkit` via `pip`.
https://pypi.org/project/nuscenes-devkit/

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/
   - REQUIRED
- Fedora: https://src.fedoraproject.org/browse/projects/
  - IF AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL
