### PR TITLE
rviz_visual_tools: 4.0.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5027,7 +5027,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/PickNikRobotics/rviz_visual_tools-release.git
-      version: 4.0.2-2
+      version: 4.0.3-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/rviz_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `4.0.3-1`:

- upstream repository: https://github.com/PickNikRobotics/rviz_visual_tools.git
- release repository: https://github.com/PickNikRobotics/rviz_visual_tools-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `4.0.2-2`

## rviz_visual_tools

```
* Make sure to add all dependencies to the package.xml (#209 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/209>) (#214 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/214>)
* Backport Fix faulty templated constructor (#213 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/213>)
* Contributors: Vatan Aksoy Tezer, Chris Lalancette
```
