### PR TITLE
rviz_visual_tools: 4.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3948,7 +3948,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/PickNikRobotics/rviz_visual_tools-release.git
-      version: 4.1.1-1
+      version: 4.1.2-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/rviz_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `4.1.2-1`:

- upstream repository: https://github.com/PickNikRobotics/rviz_visual_tools.git
- release repository: https://github.com/PickNikRobotics/rviz_visual_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `4.1.1-1`

## rviz_visual_tools

```
* Fix faulty templated constructor (#211 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/211>)
* Make sure to add all dependencies to the package.xml (#209 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/209>)
  Otherwise it will fail to build on the buildfarm.
* Contributors: Chris Lalancette, Vatan Aksoy Tezer
```
