### PR TITLE
jsk_roseus: 1.7.5-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3530,6 +3530,26 @@ repositories:
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git
       version: master
     status: developed
+  jsk_roseus:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_roseus.git
+      version: master
+    release:
+      packages:
+      - jsk_roseus
+      - roseus
+      - roseus_smach
+      - roseus_tutorials
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/tork-a/jsk_roseus-release.git
+      version: 1.7.5-2
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_roseus.git
+      version: master
+    status: developed
   jsk_visualization:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.7.5-2`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## jsk_roseus

- No changes

## roseus

```
* add noetic test on travis (#700 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/700>)
  
    * allow service-call to fail 3 times, see https://github.com/ros/ros_comm/issues/1976 for reason
    * from noetic roslaunch set params https://github.com/ros/ros_comm/blob/07fb5469c71e10e4a05fa3a631897d9adece61c5/tools/roslaunch/src/roslaunch/launch.py#L448-L449
  
* [eustf.l] fix bug in ros::create-quaternion-from-rpy (#663 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/663>)
  
    * ros::create-quaternion-from-rpy returns [x y z w] whcih is bug in euslisp. It should return [w x y z]
    * [roseus/eustf.l] add comment in doc string.
    * [roseus/test-tf.l] add test-rpy->quaternion-msg
  
* [roseus/eustf.cpp] convert [mm]->[m] in :set-transform (#649 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/649>)
* Fix check-func variable scope in ros::simple-action-server (#670 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/670>)
* Check for preemption request on test/fibonacci-server.l (#672 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/672>)
* Update advertise-service function documentation (#694 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/694>)
* Fixing a couple comment typos in roseus.l (#677 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/677>)
* fix typo: recieve -> receive (#687 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/687>)
* [roseus] add :groupname in create-timer (#688 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/688>)
* Fix unadvertise service (#680 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/680>)
* Add :groupname option to ros::advertise-service (#679 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/679>)
* [roseus] fix typo in subscribe documentation (#690 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/690>)
* [roseus] Remove duplicated dependency in package.xml (#642 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/642>)
* Fix typo: geoometry -> geometry (#645 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/645>)
* add more info on timeout parameter of wait-for-service (#646 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/646>)
* fix comment typo in actionlib.l (#643 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/643>)
* [eustf.l] add comment to :wait-for-transform (#648 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/648>)
* [eustf.l] fix comment :lookup-transform (#650 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/650>)
* add functions to convert shape_msgs/SolidPrimitive <-> euslisp object (#640 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/640>)
* fix warning message for load-ros-manifest (#638 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/638>)
* add SoundRequest.volume for kinetic (#620 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/620>)
* Return t after calling service in (call-empty-service service) (#621 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/621>)
  
    * Return t after service call in call-empty-service function
  Remove unmatched parenthesis
  
  Return nil in call-empty-service if service is not ready
  
  Add timeout in call-empty-service.
* add python like AnyMsg support (#631 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/631>)
* add list-param and search-param with test code (#629 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/629>)
* Add command line option to start roseus with gdb (#630 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/630>)
  
    * Don't use suffixes on gdb config to avoid creating multiple files
    * Print backtrace on every error break in gdb
    * Enable command line option --gdb
    * call ros::roseus on the top of the file
  
* Allow to load pathnames (#612 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/612>)
* Ignore _connection-header in 'print-ros-msg' (#606 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/606>)
* Remove unmatched parenthesis (#607 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/607>)
* Contributors: Guilherme Affonso, Kei Okada, Naoki Hiraoka, Naoya Yamaguchi, Shingo Kitagawa, Yuto Uchimi
```

## roseus_smach

```
* [roseus_smach] add :append-goal-state (#696 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/696>)
* add nested example with make-state-machine function (#661 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/661>)
  
    * add readme on smach-simple-nested
    * use defmacro instead of defun for make-simple-state
  without this, we need to write
  ```
  (setq sm-top
  (make-state-machine
  '((:bas :outcome3 :sub) ;; transitions
  (:sub :outcome4 :outcome5))
  `((:bas 'func-bas)  ;; functon maps
  (:sub ,sm-sub))   ;; set "nestaed state machine"
  '(:bas)      ;; initial
  '(:outcome5) ;; goal
  ))
  ```
  to avoid
  ```
  /opt/ros/melodic/share/euslisp/jskeus/eus/Linux64/bin/irteusgl unittest-error: unbound variable sm-sub in (eval (get-alist node func-map)), exitting...
  ```
  errors,
  this change enable us to write intuitive way
  ```
  '((:bas 'func-bas)  ;; functon maps
  (:sub sm-sub))   ;; set "nestaed state machine"
  ```
  you can test this behavior with
  ```
  (defmacro test (l)
  `(dolist (e ,l)
  (print e)
  (print (eval (cadr e)))))
  (defmacro test (l)
  (dolist (e l)
  (print e)
  (print (eval (cadr e)))))
  (let (a)
  (setq a 10)
  (test '((:foo 1)  (:bar a))))
  ```
* [roseus_smach] make roseus_smach execution faster (#684 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/684>)
  
    * sleep 0.5 s for publisher
    * use ros::sleep for smach execution
  
* [roseus_smach] add more ros-info in convert-smach (#683 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/683>)
* [roseus_smach] fix typo in state-machine-utils.l (#693 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/693>)
* [roseus_smach] add :start-state and :goal-state in convert-smach (#682 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/682>)
* [roseus_smach] add groupname in state-machine-inspector (#691 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/691>)
  
    * use send sm :spin-once in state-machine-utils.l
    * add groupname and spin-once with groupname
  
* Updates to README sample code and explanations (#659 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/659>)
  
    * extend test time limit to 120 sec for test-samples.l
    * add example/test for smach-simple with make-state-machine function
    * write more info similar to rospy implementation
    * add more info(URL/python code) on sample
    * fix typo of nestate state machine example path
    * add make-sample-parallel-state-machine tests
    * add more test, check :active-tates, duration time
  
* [roseus_smach] use roseus for parallel-state-machine-sample (#651 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/651>)
* [roseus_smach] add smach_viewer installation to README (#641 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/641>)
* [roseus_smach] add code explanation of simple-state-machine in README.md. (#627 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/627>)
* Contributors: Guilherme Affonso, Kei Okada, Naoki Hiraoka, Naoya Yamaguchi, Shingo Kitagawa, Yoichiro Kawamura
```

## roseus_tutorials

```
* [roseus_tutorials/src/aques-talk.l, roseus_tutorials/src/vision-action-example] add SoundRequest.volume for kinetic (#620 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/620>)
* [roseus_tutorials/launch/hsi_color_filter.launch] Add euslisp example using hsi_color_filter (#615 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/615>)
* Contributors: Kei Okada, Yuto Uchimi
```
