### PR TITLE
leo_robot: 2.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3827,7 +3827,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_robot-release.git
-      version: 1.2.1-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_robot` to `2.0.0-1`:

- upstream repository: https://github.com/LeoRover/leo_robot.git
- release repository: https://github.com/fictionlab-gbp/leo_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.1-1`

## leo_bringup

```
* Add parameters for firmware_message_converter
* Add firmware_message_parser node to launch file
* Add parameters for leo_hat firmware
```

## leo_fw

```
* Add Leo Hat firmware binary
* Update package description
* Get rid of python2 dependencies
* Rename core2 firmware binary
* Allow explicitly specifying board type in flash script
* Add functions for determining board type and firmware version
* Use format strings when applicable
* Add initial Leo Hat support
* Add firmware_message_parser node
```

## leo_robot

- No changes
