### PR TITLE
ntrip_client: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1914,6 +1914,18 @@ repositories:
       url: https://github.com/vooon/ntpd_driver.git
       version: ros2
     status: maintained
+  ntrip_client:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/LORD-MicroStrain/ntrip_client-ros2-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/LORD-MicroStrain/ntrip_client.git
+      version: ros2
+    status: developed
   object_recognition_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ntrip_client` to `1.0.0-1`:

- upstream repository: https://github.com/LORD-MicroStrain/ntrip_client.git
- release repository: https://github.com/LORD-MicroStrain/ntrip_client-ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## ntrip_client

```
* Initial implementation of ROS2 NTRIP client
* Adds ability to cache packets if they do contain some of a mesage but not the whole thing
* Contributors: drobb257, nathanmillerparker, robbiefish
```
