### PR TITLE
avt_vimba_camera: 2001.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -328,6 +328,21 @@ repositories:
       url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
       version: master
     status: developed
+  avt_vimba_camera:
+    doc:
+      type: git
+      url: https://github.com/astuff/avt_vimba_camera.git
+      version: ros2_master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/astuff/avt_vimba_camera-release.git
+      version: 2001.1.0-1
+    source:
+      type: git
+      url: https://github.com/astuff/avt_vimba_camera.git
+      version: ros2_master
+    status: maintained
   aws-robomaker-small-warehouse-world:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `avt_vimba_camera` to `2001.1.0-1`:

- upstream repository: https://github.com/astuff/avt_vimba_camera.git
- release repository: https://github.com/astuff/avt_vimba_camera-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## avt_vimba_camera

```
* Port to ROS2 (#56 <https://github.com/astuff/avt_vimba_camera/issues/56>)
* Update README for ROS2 (#58 <https://github.com/astuff/avt_vimba_camera/issues/58>)
* Contributors: icolwell-as
```
