### PR TITLE
moveit_msgs: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1744,7 +1744,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/moveit/moveit_msgs-release.git
-      version: 2.1.1-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_msgs` to `2.2.0-1`:

- upstream repository: https://github.com/ros-planning/moveit_msgs.git
- release repository: https://github.com/moveit/moveit_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.1-1`

## moveit_msgs

```
* Add hybrid planning action definitons (#135 <https://github.com/ros-planning/moveit_msgs/issues/135>)
* Contributors: AndyZe, Sebastian Jahr, Tyler Weaver
```
