### PR TITLE
tlsf: 0.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4231,7 +4231,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tlsf-release.git
-      version: 0.5.2-1
+      version: 0.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tlsf` to `0.6.0-1`:

- upstream repository: https://github.com/ros2/tlsf.git
- release repository: https://github.com/ros2-gbp/tlsf-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.5.2-1`

## tlsf

```
* Export a modern CMake target instead of old-style variables (#10 <https://github.com/ros2/tlsf/issues/10>)
* Contributors: Shane Loretz
```
