### PR TITLE
Update two keys which are no longer present in Focal or Bullseye.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1339,7 +1339,9 @@ python-cryptography:
   ubuntu: [python-cryptography]
 python-cvxopt:
   arch: [python-cvxopt]
-  debian: [python-cvxopt]
+  debian:
+    '*': null
+    buster: [python-cvxopt]
   fedora: [python-cvxopt]
   macports: [py27-cvxopt]
   nixos: [pythonPackages.cvxopt]
@@ -2185,7 +2187,9 @@ python-gst-1.0:
   ubuntu: [python-gst-1.0]
 python-gtk2:
   arch: [pygtk]
-  debian: [python-gtk2]
+  debian:
+    '*': null
+    buster: [python-gtk2]
   fedora: [pygtk2]
   freebsd: [py-gtk2]
   gentoo: [=dev-python/pygtk-2*]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1343,7 +1343,9 @@ python-cvxopt:
   fedora: [python-cvxopt]
   macports: [py27-cvxopt]
   nixos: [pythonPackages.cvxopt]
-  ubuntu: [python-cvxopt]
+  ubuntu:
+    '*': null
+    bionic: [python-cvxopt]
 python-cwiid:
   arch: [cwiid]
   debian: [python-cwiid]
@@ -2194,7 +2196,9 @@ python-gtk2:
     pip:
       packages: []
   rhel: [pygtk2]
-  ubuntu: [python-gtk2]
+  ubuntu:
+    '*': null
+    bionic: [python-gtk2]
 python-h5py:
   debian: [python-h5py]
   gentoo: [dev-python/h5py]


### PR DESCRIPTION
These packages are causing repo check failures due to adjacent package
additions.

I expect to do a full sweep of dependencies for focal and jammy later
but this will unblock checks for an existing PR.

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please remove the following dependency to the rosdep database.

## Package names:

python-cvxopt, python-gtk2

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/buster/python-cvxopt
  - https://packages.debian.org/buster/python-gtk2
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/bionic/python-cvxopt
   - https://packages.ubuntu.com/bionic/python-gtk2
- Fedora: https://src.fedoraproject.org/browse/projects/
  - https://src.fedoraproject.org/rpms/python-cvxopt
  - https://src.fedoraproject.org/rpms/pygtk2
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/community/x86_64/python-cvxopt/
