### PR TITLE
hash_library_vendor: 0.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1083,7 +1083,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/tier4/hash_library_vendor-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/tier4/hash_library_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hash_library_vendor` to `0.1.1-1`:

- upstream repository: https://github.com/tier4/hash_library_vendor.git
- release repository: https://github.com/tier4/hash_library_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.0-1`

## hash_library_vendor

```
* Declare missing dependency on git (#8 <https://github.com/tier4/hash_library_vendor/issues/8>)
* Contributors: Scott K Logan
```
