### PR TITLE
grpc: 0.0.10-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2800,6 +2800,21 @@ repositories:
       url: https://github.com/anybotics/grid_map-release.git
       version: 1.6.4-1
     status: maintained
+  grpc:
+    doc:
+      type: git
+      url: https://github.com/CogRob/catkin_grpc.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/CogRobRelease/catkin_grpc-release.git
+      version: 0.0.10-2
+    source:
+      type: git
+      url: https://github.com/CogRob/catkin_grpc.git
+      version: master
+    status: maintained
   haf_grasping:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grpc` to `0.0.10-2`:

- upstream repository: https://github.com/CogRob/catkin_grpc.git
- release repository: https://github.com/CogRobRelease/catkin_grpc-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## grpc

```
* Follow upstream grpc 1.15.1 (#33 <https://github.com/CogRob/catkin_grpc/issues/33>)
  * Sync grpc to upstream 1.15.1
  * Typo fix
* Contributors: Shengye Wang
```
