### PR TITLE
add debian:bullseye to boost

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -367,6 +367,7 @@ boost:
   arch: [boost]
   cygwin: [libboost-devel, libboost1.40]
   debian:
+    bullseye: [libboost-all-dev]
     buster: [libboost-all-dev]
     jessie: [libboost-all-dev]
     squeeze: [libboost1.42-all-dev]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

boost

## Package Upstream Source:

https://www.boost.org/

## Purpose of using this:

This is an already existing package. This addition is to fix rosdep being unable to find boost when targeting debian:bullseye.

## Links to Distribution Packages

- Debian: https://packages.debian.org/bullseye/libboost-all-dev
