### PR TITLE
add debian:bullseye to python3-opencv

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7054,6 +7054,7 @@ python3-open3d-pip:
       packages: [open3d-python]
 python3-opencv:
   debian:
+    bullseye: [python3-opencv]
     buster: [python3-opencv]
   fedora: [python3-opencv]
   gentoo: ['media-libs/opencv[python]']


### PR DESCRIPTION
Please add the following dependency to the rosdep database.
## Package name:

python3-opencv

## Package Upstream Source:

https://opencv.org/

## Purpose of using this:

This is an already existing package. This addition is to fix rosdep being unable to find python3-opencv when targeting debian:bullseye.

## Links to Distribution Packages

* Debian: https://packages.debian.org/bullseye/python3-opencv
