### PR TITLE
spatio_temporal_voxel_layer: 1.4.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8786,6 +8786,22 @@ repositories:
       url: https://github.com/ros-perception/sparse_bundle_adjustment.git
       version: melodic-devel
     status: maintained
+  spatio_temporal_voxel_layer:
+    doc:
+      type: git
+      url: https://github.com/SteveMacenski/spatio_temporal_voxel_layer.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/SteveMacenski/spatio_temporal_voxel_layer-release.git
+      version: 1.4.5-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/SteveMacenski/spatio_temporal_voxel_layer.git
+      version: noetic-devel
+    status: maintained
   sr_hand_detector:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `spatio_temporal_voxel_layer` to `1.4.5-1`:

- upstream repository: https://github.com/SteveMacenski/spatio_temporal_voxel_layer.git
- release repository: https://github.com/SteveMacenski/spatio_temporal_voxel_layer-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
