### PR TITLE
spatio_temporal_voxel_layer: 2.2.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4373,6 +4373,22 @@ repositories:
       url: https://github.com/ijnek/soccer_visualization.git
       version: main
     status: developed
+  spatio_temporal_voxel_layer:
+    doc:
+      type: git
+      url: https://github.com/SteveMacenski/spatio_temporal_voxel_layer.git
+      version: galactic
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/SteveMacenski/spatio_temporal_voxel_layer-release.git
+      version: 2.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/SteveMacenski/spatio_temporal_voxel_layer.git
+      version: galactic
+    status: maintained
   spdlog_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `spatio_temporal_voxel_layer` to `2.2.0-1`:

- upstream repository: https://github.com/SteveMacenski/spatio_temporal_voxel_layer.git
- release repository: https://github.com/SteveMacenski/spatio_temporal_voxel_layer-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
