### PR TITLE
rviz: 1.13.23-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12432,7 +12432,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.13.22-1
+      version: 1.13.23-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.13.23-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.13.22-1`

## rviz

```
* Destroy panels before destroying the RenderPanels and its SceneManager (Fixes #1683 <https://github.com/ros-visualization/rviz/issues/1683>)
* Fix regression in assimp mesh loading (Fixes #1688 <https://github.com/ros-visualization/rviz/pull/1689>)
* Contributors: Robert Haschke
```
