### PR TITLE
rviz: 1.14.13-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8300,7 +8300,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.14.12-1
+      version: 1.14.13-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.14.13-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.14.12-1`

## rviz

```
* Destroy panels before destroying the RenderPanels and its SceneManager (Fixes #1683 <https://github.com/ros-visualization/rviz/issues/1683>)
* Fix regression in assimp mesh loading (Fixes #1688 <https://github.com/ros-visualization/rviz/pull/1689>)
* Contributors: Robert Haschke
```
