### PR TITLE
uncrustify_vendor: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4403,7 +4403,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/uncrustify_vendor-release.git
-      version: 1.5.3-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/ament/uncrustify_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `uncrustify_vendor` to `2.0.0-1`:

- upstream repository: https://github.com/ament/uncrustify_vendor.git
- release repository: https://github.com/ros2-gbp/uncrustify_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.5.3-1`
