### PR TITLE
geometry2: 0.20.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -956,7 +956,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.19.0-1
+      version: 0.20.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.20.0-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.19.0-1`

## examples_tf2_py

```
* Update maintainers to Alejandro Hernandez Cordero and Chris Lalancette (#481 <https://github.com/ros2/geometry2/issues/481>)
* Contributors: Audrow Nash
```

## geometry2

- No changes

## tf2

```
* Move time functions into time.cpp.
* Change a for loop to a while loop.
* Switch to C++-style casts.
* Remove totally unused (and unreachable) code.
* Replace NULL with nullptr.
* Fix up some comments.
* Use std::make_shared where we can.
* Replace two comparisons with empty string to empty().
* Make sure to include-what-you-use.
* Remove unnecessary internal method.
* Remove long-deprecated walkToTopParent overload.
* Contributors: Chris Lalancette
```

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Fixes for uncrustify 0.72 (#486 <https://github.com/ros2/geometry2/issues/486>)
* Contributors: Chris Lalancette
```

## tf2_ros_py

```
* Update maintainers to Alejandro Hernandez Cordero and Chris Lalancette (#481 <https://github.com/ros2/geometry2/issues/481>)
* Contributors: Audrow Nash
```

## tf2_sensor_msgs

- No changes

## tf2_tools

```
* Update maintainers to Alejandro Hernandez Cordero and Chris Lalancette (#481 <https://github.com/ros2/geometry2/issues/481>)
* Contributors: Audrow Nash
```
