### PR TITLE
rcpputils: 2.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2550,7 +2550,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 2.3.0-1
+      version: 2.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `2.3.1-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.0-1`

## rcpputils

```
* Fixes for uncrustify 0.72 (#154 <https://github.com/ros2/rcpputils/issues/154>)
* Fix the BSD license headers to use the standard one. (#153 <https://github.com/ros2/rcpputils/issues/153>)
* Update maintainers to Chris Lalancette (#152 <https://github.com/ros2/rcpputils/issues/152>)
* Contributors: Audrow Nash, Chris Lalancette
```
