### PR TITLE
rviz: 9.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3932,7 +3932,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 9.0.0-1
+      version: 9.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `9.0.1-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `9.0.0-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Fixes for uncrustify 0.72 (#807 <https://github.com/ros2/rviz/issues/807>)
* Do not block visualization manager updates when opening the display panel dialog (#795 <https://github.com/ros2/rviz/issues/795>)
* Contributors: Chris Lalancette, Ivan Santiago Paunovic
```

## rviz_default_plugins

```
* Fixes for uncrustify 0.72 (#807 <https://github.com/ros2/rviz/issues/807>)
* Contributors: Chris Lalancette
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Fixes for uncrustify 0.72 (#807 <https://github.com/ros2/rviz/issues/807>)
* Contributors: Chris Lalancette
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

```
* Fixes for uncrustify 0.72 (#807 <https://github.com/ros2/rviz/issues/807>)
* Contributors: Chris Lalancette
```
