### PR TITLE
Revert "toposens: 2.3.1-1 in 'melodict/distribution.yaml' (#31186)"

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13521,7 +13521,6 @@ repositories:
       - toposens_bringup
       - toposens_description
       - toposens_driver
-      - toposens_echo_driver
       - toposens_markers
       - toposens_msgs
       - toposens_pointcloud
@@ -13529,7 +13528,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 2.3.1-1
+      version: 2.2.1-1
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git


### PR DESCRIPTION
This reverts commit 5c554fc8c8bc7cbfc2e57f387f92d8d5b581569f.

The toposense_echo_driver hasn't build on armhf since #31186 was merged: https://build.ros.org/view/Mbin_ubhf_uBhf/job/Mbin_ubhf_uBhf__toposens_echo_driver__ubuntu_bionic_armhf__binary/ .

@BarisYazici FYI