### PR TITLE
ply for python3 (distribution packages)

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7255,6 +7255,16 @@ python3-pkg-resources:
   opensuse: [python3-setuptools]
   rhel: ['python%{python3_pkgversion}-setuptools']
   ubuntu: [python3-pkg-resources]
+python3-ply:
+  arch: [python-ply]
+  debian: [python3-ply]
+  fedora: [python3-ply]
+  gentoo: [dev-python/ply]
+  opensuse: [python3-ply]
+  rhel:
+    '*': [python3-ply]
+    '7': null
+  ubuntu: [python3-ply]
 python3-pqdict-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3376,7 +3376,7 @@ python-planar-pip:
   ubuntu:
     pip:
       packages: [planar]
-python-ply:
+python-ply-pip:
   '*':
     pip:
       packages: [ply]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-ply

This is a follow up of https://github.com/ros/rosdistro/pull/31393 which added the pip version of this. This very PR adds the distributed python3 packages. I am renaming the old key to follow the pip convention, and reuse the "version 3" key for the distribution packages.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/python3-ply
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/focal/python3-ply
- Fedora: https://src.fedoraproject.org/browse/projects/
  - https://src.fedoraproject.org/rpms/python3-ply
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/any/python-ply/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/ply
- openSUSE:
  - https://software.opensuse.org/package/python3-ply
