### PR TITLE
use pkg-config names where available

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,6 +208,31 @@ Work has been proposed to add a separate installer for AUR packages [ros-infrast
 
 For pip installers they are expected to be in the main PyPI index https://pypi.org/.
 
+### pkg-config rules
+
+For packages that contain a [pkg-config file](https://linux.die.net/man/1/pkg-config) (\*.pc) the pkg-config name must be used as rosdep key.
+This pkg-config name is set by the developers of a library or component and will be the same across distributions.
+Commonly, the very same key will be used in CMake's [`FindPkgConfig`](https://cmake.org/cmake/help/latest/module/FindPkgConfig.html) to query this dependency.
+
+Example:
+
+The Eigen3 [upstream repo](https://gitlab.com/libeigen/eigen) contains the pkg-config file [`eigen3.pc`](https://gitlab.com/libeigen/eigen/-/blob/master/eigen3.pc.in). Hence, on all systems that have Eigen3 installed, one can query information about Eigen3 using the `eigen3` key:
+```
+pkg-config --modversion eigen3
+```
+
+Querying a package that contains this pkg-config file can then be easily done by searching for the `eigen3.pc` file and should only provide a single package per distribution.
+
+Example:
+
+Searching for exact file name matches for `eigen3.pc` at https://packages.ubuntu.com (`Search the contents of packages` -> `packages that contain files named like this`) will return `libeigen3-dev` https://packages.ubuntu.com/search?suite=focal&arch=any&mode=exactfilename&searchon=contents&keywords=eigen3.pc.
+
+While this process might be automated in the future, for now the index should match this mapping of "pkg-config name" key to the "package name of the package that contains this pkg-config file":
+```yaml
+eigen3:
+  ubuntu: [libeigen3-dev]
+```
+
 ### Python rules
 
 #### Python 3


### PR DESCRIPTION
As suggested in https://github.com/ros/rosdistro/pull/31394#issuecomment-991091407, this is a proposal to use the pkg-config names as rosdep keys for packages that support them (i.e. where a *.pc file exists).

Using pkg-config names as keys has a couple of benefits:
1. they are determined by the developers of a library or component
2. are the same across distributions and operation systems
3. the rosdep key will match the dependency name when used via cmake's FindPkgConfig or meson
4. have a unique solution for mapping the rosdep key to a package name
5. the mapping can be automated (searching for the package with file `${ROSDEP_KEY}.pc`)

Since the pkg-config names are encoded in the *.pc file names and are also commonly used in cmake and other build systems, the process of extracting the keys from a build script and finding the corresponding distribution package name could be largely automated.

I did not find any conflicting convention in the documentation about how to select rosdep keys for non-python packages. To avoid conflicts with the old keys, where it was common to use the Debian/Ubuntu packages name, this rule should only apply to new rosdep key entries, where applicable (i.e. where a *.pc file exists).

Over time, keys could be used in parallel and map to the same package, and new ROS packages that are submitted to the build server could be asked to use the new pkg-config convention until eventually all official ROS packages follow this convention.