### PR TITLE
azure-iot-sdk-c: 1.8.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -364,7 +364,7 @@ repositories:
       test_commits: false
       type: git
       url: https://github.com/Azure/azure-iot-sdk-c.git
-      version: master
+      version: main
     status: maintained
   backward_ros:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -359,7 +359,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/nobleo/azure-iot-sdk-c-release.git
-      version: 1.7.0-4
+      version: 1.8.0-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `azure-iot-sdk-c` to `1.8.0-1`:

- upstream repository: https://github.com/Azure/azure-iot-sdk-c.git
- release repository: https://github.com/nobleo/azure-iot-sdk-c-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.7.0-4`
