### PR TITLE
ros2_control: 0.9.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3993,7 +3993,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 0.8.1-1
+      version: 0.9.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `0.9.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.8.1-1`

## controller_interface

- No changes

## controller_manager

```
* Make output of not available controllers nicer and make it informative. (#577 <https://github.com/ros-controls/ros2_control/issues/577>) (#578 <https://github.com/ros-controls/ros2_control/issues/578>)
  (cherry picked from commit a47a0347acd28a47b5095e4b206257e1520918ee)
  Co-authored-by: Denis Štogl <mailto:destogl@users.noreply.github.com>
* feat: add colored output into spawner.py (#560 <https://github.com/ros-controls/ros2_control/issues/560>) (#563 <https://github.com/ros-controls/ros2_control/issues/563>)
  in order to highlight if controllers are loaded and configured and started.
  (cherry picked from commit afa0e01989e5b923e5c330f71d9270b30f03276d)
  Co-authored-by: Michael <mailto:50864015+fmros@users.noreply.github.com>
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## transmission_interface

```
* simple transmission configure multiple definition fix (#571 <https://github.com/ros-controls/ros2_control/issues/571>) (#576 <https://github.com/ros-controls/ros2_control/issues/576>)
  (cherry picked from commit 1dc970b3a56913a7ac978b89ae000eeb33550a29)
  Co-authored-by: niiquaye <mailto:68795163+niiquaye@users.noreply.github.com>
* Contributors: mergify[bot]
```
