### PR TITLE
rosbag2: 0.12.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3312,7 +3312,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.11.0-1
+      version: 0.12.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.12.0-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.11.0-1`

## ros2bag

```
* TopicFilter use regex_search instead of regex_match (#932 <https://github.com/ros2/rosbag2/issues/932>)
* Add start-offset play option (#931 <https://github.com/ros2/rosbag2/issues/931>)
* Expose bag_rewrite as ros2 bag convert (#921 <https://github.com/ros2/rosbag2/issues/921>)
* Add "ignore leaf topics" option to recorder (#925 <https://github.com/ros2/rosbag2/issues/925>)
* Auto-detect storage_id for Reader (if possible) (#918 <https://github.com/ros2/rosbag2/issues/918>)
* Add pause/resume options to the bag recorder (#905 <https://github.com/ros2/rosbag2/issues/905>)
* Contributors: Abrar Rahman Protyasha, Emerson Knapp, Ivan Santiago Paunovic
```

## rosbag2

- No changes

## rosbag2_compression

```
* Changes for uncrustify 0.72 (#937 <https://github.com/ros2/rosbag2/issues/937>)
* Bugfix for broken bag split when using cache (#936 <https://github.com/ros2/rosbag2/issues/936>)
* Contributors: Chris Lalancette, Michael Orlov
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Changes for uncrustify 0.72 (#937 <https://github.com/ros2/rosbag2/issues/937>)
* Redesign in cache consumer and circular message cache to get rid from busy loop (#941 <https://github.com/ros2/rosbag2/issues/941>)
* Bugfix for broken bag split when using cache (#936 <https://github.com/ros2/rosbag2/issues/936>)
* Remove JumpHandler copy-implementation from PlayerClock/TimeControllerClock (#935 <https://github.com/ros2/rosbag2/issues/935>)
* Auto-detect storage_id for Reader (if possible) (#918 <https://github.com/ros2/rosbag2/issues/918>)
* Contributors: Chris Lalancette, Emerson Knapp, Michael Orlov
```

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

```
* Enable YAML encoding/decoding for RecordOptions and StorageOptions (#916 <https://github.com/ros2/rosbag2/issues/916>)
  * Enable YAML encoding/decoding for RecordOptions and StorageOptions
* Contributors: Emerson Knapp
```

## rosbag2_py

```
* Add start-offset play option (#931 <https://github.com/ros2/rosbag2/issues/931>)
* Expose bag_rewrite as ros2 bag convert (#921 <https://github.com/ros2/rosbag2/issues/921>)
* Add "ignore leaf topics" option to recorder (#925 <https://github.com/ros2/rosbag2/issues/925>)
* Add a ReaderWriterFactory utility to share logic for reuse (#923 <https://github.com/ros2/rosbag2/issues/923>)
* Add pause/resume options to the bag recorder (#905 <https://github.com/ros2/rosbag2/issues/905>)
* Contributors: Abrar Rahman Protyasha, Emerson Knapp, Ivan Santiago Paunovic
```

## rosbag2_storage

```
* Enable YAML encoding/decoding for RecordOptions and StorageOptions (#916 <https://github.com/ros2/rosbag2/issues/916>)
* Contributors: Emerson Knapp
```

## rosbag2_storage_default_plugins

```
* Enable YAML encoding/decoding for RecordOptions and StorageOptions (#916 <https://github.com/ros2/rosbag2/issues/916>)
* Contributors: Emerson Knapp
```

## rosbag2_test_common

- No changes

## rosbag2_tests

```
* Add pause/resume options to the bag recorder (#905 <https://github.com/ros2/rosbag2/issues/905>)
* Contributors: Ivan Santiago Paunovic
```

## rosbag2_transport

```
* Changes for uncrustify 0.72 (#937 <https://github.com/ros2/rosbag2/issues/937>)
* TopicFilter use regex_search instead of regex_match (#932 <https://github.com/ros2/rosbag2/issues/932>)
* Add start-offset play option (#931 <https://github.com/ros2/rosbag2/issues/931>)
* Add parentheses suggested by Clang on OSX to fix build warning (#930 <https://github.com/ros2/rosbag2/issues/930>)
* Bag rewriter (C++) (#920 <https://github.com/ros2/rosbag2/issues/920>)
* Add "ignore leaf topics" option to recorder (#925 <https://github.com/ros2/rosbag2/issues/925>)
* Rewrite TopicFilter for single-call reusability (#924 <https://github.com/ros2/rosbag2/issues/924>)
* Add a ReaderWriterFactory utility to share logic for reuse (#923 <https://github.com/ros2/rosbag2/issues/923>)
* Add pause/resume options to the bag recorder (#905 <https://github.com/ros2/rosbag2/issues/905>)
* Add logging macros for rosbag2_transport (#917 <https://github.com/ros2/rosbag2/issues/917>)
* Enable YAML encoding/decoding for RecordOptions and StorageOptions (#916 <https://github.com/ros2/rosbag2/issues/916>)
* Expose the QoS object wrapper (#910 <https://github.com/ros2/rosbag2/issues/910>)
* Contributors: Abrar Rahman Protyasha, Chris Lalancette, Emerson Knapp, Geoffrey Biggs, Ivan Santiago Paunovic
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
