### PR TITLE
sol_vendor: 0.0.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5209,6 +5209,21 @@ repositories:
       url: https://github.com/ijnek/soccer_interfaces.git
       version: rolling
     status: developed
+  sol_vendor:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/sol_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/OUXT-Polaris/sol_vendor-release.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/sol_vendor.git
+      version: main
+    status: developed
   sophus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sol_vendor` to `0.0.3-1`:

- upstream repository: https://github.com/OUXT-Polaris/sol_vendor.git
- release repository: https://github.com/OUXT-Polaris/sol_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## sol_vendor

```
* Merge pull request #23 <https://github.com/OUXT-Polaris/sol_vendor/issues/23> from OUXT-Polaris/fix/license
  fix license
* empty commit
* modify description
* fix license
* Setup workflow (#22 <https://github.com/OUXT-Polaris/sol_vendor/issues/22>)
* Setup workflow (#21 <https://github.com/OUXT-Polaris/sol_vendor/issues/21>)
* Setup workflow (#20 <https://github.com/OUXT-Polaris/sol_vendor/issues/20>)
* Setup workflow (#19 <https://github.com/OUXT-Polaris/sol_vendor/issues/19>)
* Setup workflow (#18 <https://github.com/OUXT-Polaris/sol_vendor/issues/18>)
* Setup workflow (#17 <https://github.com/OUXT-Polaris/sol_vendor/issues/17>)
* Setup workflow (#16 <https://github.com/OUXT-Polaris/sol_vendor/issues/16>)
* Setup workflow (#15 <https://github.com/OUXT-Polaris/sol_vendor/issues/15>)
* Setup workflow (#14 <https://github.com/OUXT-Polaris/sol_vendor/issues/14>)
* Setup build test workflow (#13 <https://github.com/OUXT-Polaris/sol_vendor/issues/13>)
* Setup build test workflow (#12 <https://github.com/OUXT-Polaris/sol_vendor/issues/12>)
* Merge pull request #11 <https://github.com/OUXT-Polaris/sol_vendor/issues/11> from OUXT-Polaris/workflow/build_test
  [Bot] Update workflow
* remvoe old CI
* update repos
* Setup build test workflow
* Setup scenario test workflow (#10 <https://github.com/OUXT-Polaris/sol_vendor/issues/10>)
* Setup scenario test workflow (#9 <https://github.com/OUXT-Polaris/sol_vendor/issues/9>)
* Setup scenario test workflow (#8 <https://github.com/OUXT-Polaris/sol_vendor/issues/8>)
* Setup scenario test workflow (#7 <https://github.com/OUXT-Polaris/sol_vendor/issues/7>)
* Contributors: Masaya Kataoka, MasayaKataoka, wam-v-tan
```
