### PR TITLE
psen_scan_v2: 0.3.4-1 in 'melodic/distribution.yaml'

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9359,7 +9359,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/psen_scan_v2-release.git
-      version: 0.3.3-1
+      version: 0.3.4-1
     source:
       type: git
       url: https://github.com/PilzDE/psen_scan_v2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `psen_scan_v2` to `0.3.4-1`:

- upstream repository: https://github.com/PilzDE/psen_scan_v2.git
- release repository: https://github.com/PilzDE/psen_scan_v2-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.3-1`

## psen_scan_v2

```
* Prevent error when diagnostics are disabled. Fix #294
* Set exception in stop-future
* Apply clang-tidy fixes to header-files. Fix #277
* Remove latched flag from active zoneset topic
* API change: convenience usage of ScannerConfiguration
* Remove unrelated parameter DEFAULT_X_AXIS_ROTATION from standalone
* Contributors: Pilz GmbH and Co. KG
```
