### PR TITLE
Rosdep rule for pytz package in Python 3: python3-tz.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8398,6 +8398,9 @@ python3-tz:
   fedora: [python3-pytz]
   gentoo: [dev-python/pytz]
   nixos: [python39Packages.pytz]
+  rhel:
+    '*': [python3-pytz]
+    '7': null
   ubuntu: [python3-tz]
 python3-ubjson:
   debian: [python3-ubjson]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8391,6 +8391,12 @@ python3-twisted:
     '*': ['python%{python3_pkgversion}-twisted']
     '7': null
   ubuntu: [python3-twisted]
+python3-tz:
+  arch: [python-pytz]
+  debian: [python3-tz]
+  gentoo: [dev-python/pytz]
+  nixos: [pythonPackages.pytz]
+  ubuntu: [python3-tz]
 python3-ubjson:
   debian: [python3-ubjson]
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8392,10 +8392,12 @@ python3-twisted:
     '7': null
   ubuntu: [python3-twisted]
 python3-tz:
+  alpine: [py3-tz]
   arch: [python-pytz]
   debian: [python3-tz]
+  fedora: [python3-pytz]
   gentoo: [dev-python/pytz]
-  nixos: [pythonPackages.pytz]
+  nixos: [python39Packages.pytz]
   ubuntu: [python3-tz]
 python3-ubjson:
   debian: [python3-ubjson]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:
pytz for python3

## Package Upstream Source:
https://git.launchpad.net/pytz

## Purpose of using this:
I think this is a standard Python package for which the equivalent python2 package is already part of the rosdep database. I want to add the python3 key to rosdep because I need it in one of my projects. I use it for setting the timezone of Python datetime objects. I believe other users might also need it at some point.

## Links to Distribution Packages

- Debian: https://packages.debian.org/bullseye/python3-tz
- Ubuntu: https://ubuntu.pkgs.org/20.04/ubuntu-main-amd64/python3-tz_2019.3-1_all.deb.html
- Fedora: https://fedora.pkgs.org/35/fedora-aarch64/python3-pytz-2021.1-4.fc35.noarch.rpm.html
- Arch: https://archlinux.org/packages/community/any/python-pytz/
- Gentoo: https://packages.gentoo.org/packages/dev-python/pytz
- macOS: NOT AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/package/edge/main/x86_64/py3-tz
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=21.11&show=python39Packages.pytz&from=0&size=50&sort=relevance&type=packages&query=python3+tz