### PR TITLE
Add python-staticmap-pip and python3-staticmap-pip to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4859,13 +4859,6 @@ python-sqlalchemy:
 python-sqlite:
   debian: [python-sqlite]
   ubuntu: [python-sqlite]
-python-staticmap-pip:
-  debian:
-    pip:
-      packages: [staticmap]
-  ubuntu:
-    pip:
-      packages: [staticmap]
 python-statsd:
   debian: [python-statsd]
   fedora: [python-statsd]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4859,6 +4859,13 @@ python-sqlalchemy:
 python-sqlite:
   debian: [python-sqlite]
   ubuntu: [python-sqlite]
+python-staticmap-pip:
+  debian:
+    pip:
+      packages: [staticmap]
+  ubuntu:
+    pip:
+      packages: [staticmap]
 python-statsd:
   debian: [python-statsd]
   fedora: [python-statsd]
@@ -8238,6 +8245,13 @@ python3-stable-baselines3-pip:
   ubuntu:
     pip:
       packages: [stable-baselines3]
+python3-staticmap-pip:
+  debian:
+    pip:
+      packages: [staticmap]
+  ubuntu:
+    pip:
+      packages: [staticmap]
 python3-suas-interop-clients-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

- python-staticmap-pip
- python3-staticmap-pip

## Package Upstream Source:

- https://github.com/komoot/staticmap

## Purpose of using this:

This package will render a map image from map tiles (e.g. openstreetmap).
I create a map publisher with this package in order to visualize robot location.

- https://github.com/k-okada/jsk_demos/pull/108

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - pip: https://pypi.org/project/staticmap/#description
- Ubuntu: https://packages.ubuntu.com/
   - pip: https://pypi.org/project/staticmap/#description
