### PR TITLE
mapviz: 2.2.0-3 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1540,6 +1540,23 @@ repositories:
       url: https://github.com/OUXT-Polaris/lua_vendor.git
       version: main
     status: developed
+  mapviz:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/mapviz.git
+      version: ros2-devel
+    release:
+      packages:
+      - mapviz
+      - mapviz_interfaces
+      - mapviz_plugins
+      - multires_image
+      - tile_map
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/mapviz-release.git
+      version: 2.2.0-3
+    status: developed
   marti_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.2.0-3`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
