### PR TITLE
octomap_rviz_plugins: 0.2.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5213,7 +5213,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/octomap_rviz_plugins-release.git
-      version: 0.2.3-1
+      version: 0.2.4-1
     source:
       type: git
       url: https://github.com/OctoMap/octomap_rviz_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_rviz_plugins` to `0.2.4-1`:

- upstream repository: https://github.com/OctoMap/octomap_rviz_plugins.git
- release repository: https://github.com/ros-gbp/octomap_rviz_plugins-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.3-1`

## octomap_rviz_plugins

```
* Use automoc feature of CMake (#34 <https://github.com/OctoMap/octomap_rviz_plugins/issues/34>)
* Contributors: Simon Schmeisser (isys vision), Wolfgang Merkt
```
