### PR TITLE
ros2_control: 1.3.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3315,7 +3315,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 1.2.0-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `1.3.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.0-1`

## controller_interface

```
* fix get_update_rate visibility in windows (#586 <https://github.com/ros-controls/ros2_control/issues/586>) (#588 <https://github.com/ros-controls/ros2_control/issues/588>)
  (cherry picked from commit 3f4a55bd898d5ae16fbefb6b19822dce0dbeba2a)
  Co-authored-by: Melvin Wang <mailto:melvin.mc.wang@gmail.com>
* Use lifecycle name constants from hardware interface in controller interface (#575 <https://github.com/ros-controls/ros2_control/issues/575>)
  * Use lifecycle name constants from hardware interface in controller interface
  * Remove controller_state_names.hpp since it is not needed.
* Contributors: Xi-Huang, mergify[bot]
```

## controller_manager

```
* fix get_update_rate visibility in windows (#586 <https://github.com/ros-controls/ros2_control/issues/586>) (#588 <https://github.com/ros-controls/ros2_control/issues/588>)
  (cherry picked from commit 3f4a55bd898d5ae16fbefb6b19822dce0dbeba2a)
  Co-authored-by: Melvin Wang <mailto:melvin.mc.wang@gmail.com>
* Make output of not available controller nicer and make it informational. (#577 <https://github.com/ros-controls/ros2_control/issues/577>)
* Contributors: Denis Štogl, mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## ros2_control

```
* Point control_msgs to galactic branch.
* Contributors: Denis Štogl
```

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## transmission_interface

```
* simple transmission configure multiple definition fix (#571 <https://github.com/ros-controls/ros2_control/issues/571>)
* Contributors: niiquaye
```
