### PR TITLE
octomap_rviz_plugins: 2.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2461,6 +2461,21 @@ repositories:
       url: https://github.com/OctoMap/octomap_ros.git
       version: ros2
     status: maintained
+  octomap_rviz_plugins:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap_rviz_plugins.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/octomap_rviz_plugins-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap_rviz_plugins.git
+      version: ros2
+    status: maintained
   ompl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_rviz_plugins` to `2.0.0-1`:

- upstream repository: https://github.com/OctoMap/octomap_rviz_plugins.git
- release repository: https://github.com/ros2-gbp/octomap_rviz_plugins-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## octomap_rviz_plugins

```
* ROS2 Migration (#41 <https://github.com/OctoMap/octomap_rviz_plugins/issues/41>)
* Contributors: Daisuke Nishimatsu, Wolfgang Merkt
```
