### PR TITLE
keyboard_handler: 0.0.3-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1328,7 +1328,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/keyboard_handler-release.git
-      version: 0.0.2-1
+      version: 0.0.3-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `keyboard_handler` to `0.0.3-2`:

- upstream repository: https://github.com/ros-tooling/keyboard_handler.git
- release repository: https://github.com/ros2-gbp/keyboard_handler-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.2-1`

## keyboard_handler

```
* Fixes for uncrustify 0.72
* Install SIGINT handler optionally and call old handler
* Contributors: Chris Lalancette, Christophe Bedard, Emerson Knapp, Michael Orlov
```
