### PR TITLE
Drop rules for EOL Fedora 33

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2965,9 +2965,7 @@ libfftw3:
   ubuntu: [libfftw3-3, libfftw3-dev]
 libfl-dev:
   debian: [libfl-dev]
-  fedora:
-    '*': [libfl-devel]
-    '33': [flex-devel]
+  fedora: [libfl-devel]
   opensuse: [libfl-devel]
   ubuntu: [libfl-dev]
 libflann:


### PR DESCRIPTION
Fedora 33 was declared EOL on 2021-11-30.