### PR TITLE
Use AlmaLinux repositories for checking RHEL 8 rules

### DIFF
--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -27,10 +27,10 @@ package_sources:
     - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/sclo/$basearch/rh/
     '8':
     - !rpm_base_url https://dl.fedoraproject.org/pub/epel/$releasever/Everything/$basearch/
-    - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/BaseOS/$basearch/os/
-    - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/AppStream/$basearch/os/
-    - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/PowerTools/$basearch/os/
-    - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/extras/$basearch/os/
+    - !rpm_base_url https://repo.almalinux.org/almalinux/$releasever/BaseOS/$basearch/os/
+    - !rpm_base_url https://repo.almalinux.org/almalinux/$releasever/AppStream/$basearch/os/
+    - !rpm_base_url https://repo.almalinux.org/almalinux/$releasever/PowerTools/$basearch/os/
+    - !rpm_base_url https://repo.almalinux.org/almalinux/$releasever/extras/$basearch/os/
   - !rpm_base_url https://download1.rpmfusion.org/free/el/updates/$releasever/$basearch/
   ubuntu:
   - !deb_base_url http://archive.ubuntu.com/ubuntu main


### PR DESCRIPTION
Elsewhere in our infrastructure, we've already switched from CentOS to AlmaLinux. This is the last spot I'm aware of.

This switch results in no changes to the repository checks for RHEL rules, where there are currently no invalid rules.

More info: https://www.centos.org/centos-linux-eol/