### PR TITLE
sick_safetyscanners_base: 1.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5114,7 +5114,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/SICKAG/sick_safetyscanners_base-release.git
-      version: 1.0.0-2
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_safetyscanners_base.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safetyscanners_base` to `1.0.1-1`:

- upstream repository: https://github.com/SICKAG/sick_safetyscanners_base.git
- release repository: https://github.com/SICKAG/sick_safetyscanners_base-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.0-2`

## sick_safetyscanners_base

```
* Merge fix for memory leak in command execution
* Fix memory leak in createAndExecuteCommand
* Adding multicast functionality
* Merge constant setting of field angles
* Contributors: Andrew Kooiman, Lennart Puck
```
