### PR TITLE
sick_safetyscanners2: 1.0.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5084,7 +5084,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/SICKAG/sick_safetyscanners2-release.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_safetyscanners2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safetyscanners2` to `1.0.3-1`:

- upstream repository: https://github.com/SICKAG/sick_safetyscanners2.git
- release repository: https://github.com/SICKAG/sick_safetyscanners2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.2-1`

## sick_safetyscanners2

```
* Fixes unsafe pointer access in UDP callback
* Implement lifecycle node
* Added functionality to allow multicast
* set not using the default sick angles as default
* moved changeSensor settings to be always be invoked
* fixed typo in launch file
* Contributors: Brice, Erwin Lejeune, Soma Gallai, Lennart Puck, Tanmay
```
