### PR TITLE
sick_safetyscanners2: 1.0.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4309,6 +4309,21 @@ repositories:
       url: https://github.com/ros/sdformat_urdf.git
       version: ros2
     status: maintained
+  sick_safetyscanners2:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/sick_safetyscanners2.git
+      version: master
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/SICKAG/sick_safetyscanners2-release.git
+      version: 1.0.3-1
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_safetyscanners2.git
+      version: master
+    status: developed
   simple_launch:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safetyscanners2` to `1.0.3-1`:

- upstream repository: https://github.com/SICKAG/sick_safetyscanners2.git
- release repository: https://github.com/SICKAG/sick_safetyscanners2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## sick_safetyscanners2

```
* Fixes unsafe pointer access in UDP callback
* Implement lifecycle node
* Added functionality to allow multicast
* set not using the default sick angles as default
* moved changeSensor settings to be always be invoked
* fixed typo in launch file
* Contributors: Brice, Erwin Lejeune, Soma Gallai, Lennart Puck, Tanmay
```
