### PR TITLE
ros_babel_fish: 0.9.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10658,7 +10658,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/StefanFabian/ros_babel_fish-release.git
-      version: 0.9.0-1
+      version: 0.9.2-1
     source:
       type: git
       url: https://github.com/StefanFabian/ros_babel_fish.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10662,7 +10662,7 @@ repositories:
     source:
       type: git
       url: https://github.com/StefanFabian/ros_babel_fish.git
-      version: master
+      version: kinetic
     status: developed
   ros_canopen:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_babel_fish` to `0.9.2-1`:

- upstream repository: https://github.com/StefanFabian/ros_babel_fish.git
- release repository: https://github.com/StefanFabian/ros_babel_fish-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.9.0-1`

## ros_babel_fish

```
* Better rosbag support + example (#7 <https://github.com/StefanFabian/ros_babel_fish/issues/7>)
  * Accept a more general IBabelFishMessage interface in read-only functions.
  * Add a rosbag example, add some useful method overloads.
* Add noetic to CI, improvements to type safety checking (#6 <https://github.com/StefanFabian/ros_babel_fish/issues/6>)
  * Add noetic to CI.
  * Simplify isCompatible() and inBounds() checks, add tests.
  * Moved compatibility checks to header and internal namespace.
  Co-authored-by: Stefan Fabian <mailto:fabian@sim.tu-darmstadt.de>
* Accept True and False as boolean constants (#4 <https://github.com/StefanFabian/ros_babel_fish/issues/4>)
  Co-authored-by: Stefan Fabian <mailto:fabian@sim.tu-darmstadt.de>
* Added more explicit warning if message type is not a valid message name.
* Made BabelFishMessageException subclass of BabelFishException.
* Contributors: Martin Valgur, Stefan Fabian
```

## ros_babel_fish_test_msgs

```
* Accept True and False as boolean constants (#4 <https://github.com/StefanFabian/ros_babel_fish/issues/4>)
* Contributors: Martin Valgur
```
