### PR TITLE
microstrain_inertial: 2.3.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6494,15 +6494,20 @@ repositories:
       version: indigo-devel
     status: maintained
   microstrain_inertial:
+    doc:
+      type: git
+      url: https://github.com/LORD-MicroStrain/microstrain_inertial.git
+      version: ros
     release:
       packages:
       - microstrain_inertial_driver
       - microstrain_inertial_examples
       - microstrain_inertial_msgs
+      - microstrain_inertial_rqt
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/LORD-MicroStrain/microstrain_inertial-release.git
-      version: 2.2.1-1
+      version: 2.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `2.3.0-1`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/LORD-MicroStrain/microstrain_inertial-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.2.1-1`

## microstrain_inertial_driver

```
* BREAKING: Updates device_report_service to return the device information instead of just printing it
* Publishes Aiding Measurement Summary messages to topic nav/aiding_summary
* Publishes Fix Info messages to topic gnss1/fix_info and gnss2/fix_info
* Contributors: robbiefish
```

## microstrain_inertial_examples

- No changes

## microstrain_inertial_msgs

```
* BREAKING: Updates DeviceReport.srv to return the device report instead of just printing it
* Adds Fix Info message
* Adds Aiding Measurement Summary message
* Updates license files to be accurate for each package
* Contributors: robbiefish
```

## microstrain_inertial_rqt

```
* Initial Release of microstrain_inertial_rqt package
```
