### PR TITLE
microstrain_inertial: 2.3.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1695,15 +1695,20 @@ repositories:
       version: galactic
     status: maintained
   microstrain_inertial:
+    doc:
+      type: git
+      url: https://github.com/LORD-MicroStrain/microstrain_inertial.git
+      version: ros2
     release:
       packages:
       - microstrain_inertial_driver
       - microstrain_inertial_examples
       - microstrain_inertial_msgs
+      - microstrain_inertial_rqt
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release.git
-      version: 2.2.0-1
+      version: 2.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `2.3.0-1`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.2.0-1`

## microstrain_inertial_driver

```
* BREAKING: Updates device_report_service to return the device information instead of just printing it
* Publishes Aiding Measurement Summary messages to topic nav/aiding_summary
* Publishes Fix Info messages to topic gnss1/fix_info and gnss2/fix_info
* Contributors: robbiefish
```

## microstrain_inertial_examples

- No changes

## microstrain_inertial_msgs

```
* BREAKING: Updates DeviceReport.srv to return the device report instead of just printing it
* Adds Fix Info message
* Adds Aiding Measurement Summary message
* Updates license files to be accurate for each package
* Contributors: robbiefish
```

## microstrain_inertial_rqt

```
* Initial Release of microstrain_inertial_rqt package
```
