### PR TITLE
Update python-numpy key.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2966,9 +2966,9 @@ python-ntplib:
   gentoo: [dev-python/ntplib]
   ubuntu: [python-ntplib]
 python-numpy:
-  alpine: [py-numpy]
   arch: [python2-numpy]
-  debian: [python-numpy]
+  debian:
+    buster: [python-numpy]
   fedora: [numpy]
   freebsd: [py27-numpy]
   gentoo: [dev-python/numpy]
@@ -2982,25 +2982,8 @@ python-numpy:
   rhel: [python2-numpy]
   slackware: [numpy]
   ubuntu:
-    artful: [python-numpy]
     bionic: [python-numpy]
     focal: [python-numpy]
-    lucid: [python-numpy]
-    maverick: [python-numpy]
-    natty: [python-numpy]
-    oneiric: [python-numpy]
-    precise: [python-numpy]
-    quantal: [python-numpy]
-    raring: [python-numpy]
-    saucy: [python-numpy]
-    trusty: [python-numpy]
-    trusty_python3: [python3-numpy]
-    utopic: [python-numpy]
-    vivid: [python-numpy]
-    wily: [python-numpy]
-    xenial: [python-numpy]
-    yakkety: [python-numpy]
-    zesty: [python-numpy]
 python-numpy-quaternion-pip:
   debian:
     pip:


### PR DESCRIPTION
* Remove out-of-support Ubuntu distributions.
* This package is no longer available in Alpine Edge.
* This package is no longer available in Debian as of Bullseye.
* This package is no longer available in Ubuntu as of Jammy.