### PR TITLE
Update python3-flask-cors key.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6500,7 +6500,9 @@ python3-flask-cors:
   rhel:
     '*': [python3-flask-cors]
     '7': null
-  ubuntu: [python3-flask-cors]
+  ubuntu:
+    '*': [python3-flask-cors]
+    bionic: null
 python3-flask-restplus-pip:
   ubuntu:
     pip:


### PR DESCRIPTION
This package is not available in Ubuntu Bionic.
https://packages.ubuntu.com/focal/python3-flask-cors