### PR TITLE
Update python-lxml key.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2609,7 +2609,8 @@ python-luis-pip:
       packages: [luis]
 python-lxml:
   arch: [python2-lxml]
-  debian: [python-lxml]
+  debian:
+    buster: [python-lxml]
   fedora: [python-lxml]
   freebsd: [py27-lxml]
   gentoo: [dev-python/lxml]
@@ -2622,7 +2623,9 @@ python-lxml:
   rhel:
     '*': [python2-lxml]
     '7': [python-lxml]
-  ubuntu: [python-lxml]
+  ubuntu:
+    bionic: [python-lxml]
+    focal: [python-lxml]
 python-lzf-pip:
   debian:
     pip:


### PR DESCRIPTION
* `python-lxml` is no longer available in Debian as of Bullseye.
* `python-lxml` is no longer available in Ubuntu as of Jammy.
