### PR TITLE
rmw_cyclonedds: 0.22.4-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3178,7 +3178,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 0.22.3-1
+      version: 0.22.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `0.22.4-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.22.3-1`

## rmw_cyclonedds_cpp

```
* Fix use of deprecated is_loan_available (#359 <https://github.com/ros2/rmw_cyclonedds/issues/359>)
* rmw_cyclonedds_cpp/CMakeLists.txt: add -latomic for RISC-V (#334 <https://github.com/ros2/rmw_cyclonedds/issues/334>)
* Contributors: eboasson, guillaume-pais-siemens
```
