### PR TITLE
common_interfaces: 2.0.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -581,7 +581,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 2.0.4-1
+      version: 2.0.5-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `common_interfaces` to `2.0.5-1`:

- upstream repository: https://github.com/ros2/common_interfaces.git
- release repository: https://github.com/ros2-gbp/common_interfaces-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.4-1`

## actionlib_msgs

- No changes

## common_interfaces

- No changes

## diagnostic_msgs

- No changes

## geometry_msgs

- No changes

## nav_msgs

- No changes

## sensor_msgs

```
* Add equidistant distortion model (#160 <https://github.com/ros2/common_interfaces/issues/160>) (#164 <https://github.com/ros2/common_interfaces/issues/164>)
* Contributors: mergify[bot]
```

## sensor_msgs_py

- No changes

## shape_msgs

- No changes

## std_msgs

- No changes

## std_srvs

- No changes

## stereo_msgs

- No changes

## trajectory_msgs

- No changes

## visualization_msgs

- No changes
