### PR TITLE
Revert "sick_safetyscanners2: 1.0.3-1 in 'galactic/distribution.yaml' [bloom] (#31542)"

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4314,21 +4314,6 @@ repositories:
       url: https://github.com/ros/sdformat_urdf.git
       version: ros2
     status: maintained
-  sick_safetyscanners2:
-    doc:
-      type: git
-      url: https://github.com/SICKAG/sick_safetyscanners2.git
-      version: master
-    release:
-      tags:
-        release: release/galactic/{package}/{version}
-      url: https://github.com/SICKAG/sick_safetyscanners2-release.git
-      version: 1.0.3-1
-    source:
-      type: git
-      url: https://github.com/SICKAG/sick_safetyscanners2.git
-      version: master
-    status: developed
   sick_safetyscanners2_interfaces:
     doc:
       type: git


### PR DESCRIPTION
This package was not released properly and needs to be re-released.

This reverts #31542