### PR TITLE
Update boost keys for Debian and Ubuntu.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2422,8 +2422,8 @@ libboost-iostreams-dev:
   ubuntu: [libboost-iostreams-dev]
 libboost-math:
   debian:
+    bullseye: [libboost-math1.74.0]
     buster: [libboost-math1.67.0]
-    stretch: [libboost-math1.62.0]
   fedora: [boost-math]
   gentoo: [dev-libs/boost]
   nixos: [boost]
@@ -2433,7 +2433,7 @@ libboost-math:
     bionic: [libboost-math1.65.1]
     eoan: [libboost-math1.67.0]
     focal: [libboost-math1.71.0]
-    xenial: [libboost-math1.58.0]
+    jammy: [libboost-math1.74.0]
 libboost-math-dev:
   debian: [libboost-math-dev]
   fedora: [boost-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2341,8 +2341,8 @@ libboost-chrono-dev:
   ubuntu: [libboost-chrono-dev]
 libboost-date-time:
   debian:
+    bullseye: [libboost-date-time1.74.0]
     buster: [libboost-date-time1.67.0]
-    stretch: [libboost-date-time1.62.0]
   fedora: [boost-date-time]
   gentoo: [dev-libs/boost]
   nixos: [boost]
@@ -2353,7 +2353,7 @@ libboost-date-time:
     bionic: [libboost-date-time1.65.1]
     eoan: [libboost-date-time1.67.0]
     focal: [libboost-date-time1.71.0]
-    xenial: [libboost-date-time1.58.0]
+    jammy: [libboost-date-time1.74.0]
 libboost-date-time-dev:
   debian: [libboost-date-time-dev]
   fedora: [boost-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2317,8 +2317,8 @@ libboost-atomic-dev:
   ubuntu: [libboost-atomic-dev]
 libboost-chrono:
   debian:
+    bullseye: [libboost-chrono1.74.0]
     buster: [libboost-chrono1.67.0]
-    stretch: [libboost-chrono1.62.0]
   fedora: [boost-chrono]
   gentoo: [dev-libs/boost]
   nixos: [boost]
@@ -2329,7 +2329,7 @@ libboost-chrono:
     bionic: [libboost-chrono1.65.1]
     eoan: [libboost-chrono1.67.0]
     focal: [libboost-chrono1.71.0]
-    xenial: [libboost-chrono1.58.0]
+    jammy: [libboost-chrono1.74.0]
 libboost-chrono-dev:
   debian: [libboost-chrono-dev]
   fedora: [boost-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2631,8 +2631,8 @@ libboost-thread-dev:
   ubuntu: [libboost-thread-dev]
 libboost-timer:
   debian:
+    bullseye: [libboost-timer1.74.0]
     buster: [libboost-timer1.67.0]
-    stretch: [libboost-timer1.62.0]
   fedora: [boost-timer]
   gentoo: [dev-libs/boost]
   nixos: [boost]
@@ -2642,7 +2642,7 @@ libboost-timer:
     bionic: [libboost-timer1.65.1]
     eoan: [libboost-timer1.67.0]
     focal: [libboost-timer1.71.0]
-    xenial: [libboost-timer1.58.0]
+    jammy: [libboost-timer1.74.0]
 libboost-timer-dev:
   debian: [libboost-timer-dev]
   fedora: [boost-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2478,9 +2478,8 @@ libboost-program-options-dev:
 libboost-python:
   alpine: [boost-python2]
   debian:
+    bullseye: [libboost-python1.74.0]
     buster: [libboost-python1.67.0]
-    jessie: [libboost-python1.55.0]
-    stretch: [libboost-python1.62.0]
   fedora: [boost-python3]
   gentoo: ['dev-libs/boost[python]']
   nixos: [boost]
@@ -2494,8 +2493,7 @@ libboost-python:
     disco: [libboost-python1.67.0]
     eoan: [libboost-python1.67.0]
     focal: [libboost-python1.71.0]
-    trusty: [libboost-python1.54.0]
-    xenial: [libboost-python1.58.0]
+    jammy: [libboost-python1.74.0]
 libboost-python-dev:
   alpine: [boost-python2]
   debian: [libboost-python-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2306,6 +2306,7 @@ libboost-atomic:
     eoan: [libboost-atomic1.67.0]
     focal: [libboost-atomic1.71.0]
     jammy: [libboost-atomic1.74.0]
+    xenial: [libboost-atomic1.58.0]
 libboost-atomic-dev:
   debian: [libboost-atomic-dev]
   fedora: [boost-devel]
@@ -2330,6 +2331,7 @@ libboost-chrono:
     eoan: [libboost-chrono1.67.0]
     focal: [libboost-chrono1.71.0]
     jammy: [libboost-chrono1.74.0]
+    xenial: [libboost-chrono1.58.0]
 libboost-chrono-dev:
   debian: [libboost-chrono-dev]
   fedora: [boost-devel]
@@ -2354,6 +2356,7 @@ libboost-date-time:
     eoan: [libboost-date-time1.67.0]
     focal: [libboost-date-time1.71.0]
     jammy: [libboost-date-time1.74.0]
+    xenial: [libboost-date-time1.58.0]
 libboost-date-time-dev:
   debian: [libboost-date-time-dev]
   fedora: [boost-devel]
@@ -2387,6 +2390,7 @@ libboost-filesystem:
     eoan: [libboost-filesystem1.67.0]
     focal: [libboost-filesystem1.71.0]
     jammy: [libboost-filesystem1.74.0]
+    xenial: [libboost-filesystem1.58.0]
 libboost-filesystem-dev:
   debian: [libboost-filesystem-dev]
   fedora: [boost-devel]
@@ -2411,6 +2415,7 @@ libboost-iostreams:
     eoan: [libboost-iostreams1.67.0]
     focal: [libboost-iostreams1.71.0]
     jammy: [libboost-iostreams1.74.0]
+    xenial: [libboost-iostreams1.58.0]
 libboost-iostreams-dev:
   debian: [libboost-iostreams-dev]
   fedora: [boost-devel]
@@ -2434,6 +2439,7 @@ libboost-math:
     eoan: [libboost-math1.67.0]
     focal: [libboost-math1.71.0]
     jammy: [libboost-math1.74.0]
+    xenial: [libboost-math1.58.0]
 libboost-math-dev:
   debian: [libboost-math-dev]
   fedora: [boost-devel]
@@ -2466,6 +2472,7 @@ libboost-program-options:
     eoan: [libboost-program-options1.67.0]
     focal: [libboost-program-options1.71.0]
     jammy: [libboost-program-options1.74.0]
+    xenial: [libboost-program-options1.58.0]
 libboost-program-options-dev:
   debian: [libboost-program-options-dev]
   fedora: [boost-devel]
@@ -2494,6 +2501,7 @@ libboost-python:
     eoan: [libboost-python1.67.0]
     focal: [libboost-python1.71.0]
     jammy: [libboost-python1.74.0]
+    xenial: [libboost-python1.58.0]
 libboost-python-dev:
   alpine: [boost-python2]
   debian: [libboost-python-dev]
@@ -2522,6 +2530,7 @@ libboost-random:
     eoan: [libboost-random1.67.0]
     focal: [libboost-random1.71.0]
     jammy: [libboost-random1.74.0]
+    xenial: [libboost-random1.58.0]
 libboost-random-dev:
   debian: [libboost-random-dev]
   fedora: [boost-devel]
@@ -2546,6 +2555,7 @@ libboost-regex:
     eoan: [libboost-regex1.67.0]
     focal: [libboost-regex1.71.0]
     jammy: [libboost-regex1.74.0]
+    xenial: [libboost-regex1.58.0]
 libboost-regex-dev:
   debian: [libboost-regex-dev]
   fedora: [boost-devel]
@@ -2570,6 +2580,7 @@ libboost-serialization:
     eoan: [libboost-serialization1.67.0]
     focal: [libboost-serialization1.71.0]
     jammy: [libboost-serialization1.74.0]
+    xenial: [libboost-serialization1.58.0]
 libboost-serialization-dev:
   debian: [libboost-serialization-dev]
   fedora: [boost-devel]
@@ -2595,6 +2606,7 @@ libboost-system:
     eoan: [libboost-system1.67.0]
     focal: [libboost-system1.71.0]
     jammy: [libboost-system1.74.0]
+    xenial: [libboost-system1.58.0]
 libboost-system-dev:
   debian: [libboost-system-dev]
   fedora: [boost-devel]
@@ -2620,6 +2632,7 @@ libboost-thread:
     eoan: [libboost-thread1.67.0]
     focal: [libboost-thread1.71.0]
     jammy: [libboost-thread1.74.0]
+    xenial: [libboost-thread1.58.0]
 libboost-thread-dev:
   debian: [libboost-thread-dev]
   fedora: [boost-devel]
@@ -2643,6 +2656,7 @@ libboost-timer:
     eoan: [libboost-timer1.67.0]
     focal: [libboost-timer1.71.0]
     jammy: [libboost-timer1.74.0]
+    xenial: [libboost-timer1.58.0]
 libboost-timer-dev:
   debian: [libboost-timer-dev]
   fedora: [boost-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2606,8 +2606,8 @@ libboost-system-dev:
   ubuntu: [libboost-system-dev]
 libboost-thread:
   debian:
+    bullseye: [libboost-thread1.74.0]
     buster: [libboost-thread1.67.0]
-    stretch: [libboost-thread1.62.0]
   fedora: [boost-thread]
   gentoo: ['dev-libs/boost[threads]']
   nixos: [boost]
@@ -2619,8 +2619,7 @@ libboost-thread:
     disco: [libboost-thread1.67.0]
     eoan: [libboost-thread1.67.0]
     focal: [libboost-thread1.71.0]
-    trusty: [libboost-thread1.55.0]
-    xenial: [libboost-thread1.58.0]
+    jammy: [libboost-thread1.74.0]
 libboost-thread-dev:
   debian: [libboost-thread-dev]
   fedora: [boost-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2508,10 +2508,8 @@ libboost-python-dev:
   ubuntu: [libboost-python-dev]
 libboost-random:
   debian:
+    bullseye: [libboost-random1.74.0]
     buster: [libboost-random1.67.0]
-    jessie: [libboost-random1.55.0]
-    stretch: [libboost-random1.62.0]
-    wheezy: [libboost-random1.49.0]
   fedora: [boost-random]
   gentoo: [dev-libs/boost]
   nixos: [boost]
@@ -2523,9 +2521,7 @@ libboost-random:
     disco: [libboost-random1.67.0]
     eoan: [libboost-random1.67.0]
     focal: [libboost-random1.71.0]
-    precise: [libboost-random1.46.1]
-    trusty: [libboost-random1.54.0]
-    xenial: [libboost-random1.58.0]
+    jammy: [libboost-random1.74.0]
 libboost-random-dev:
   debian: [libboost-random-dev]
   fedora: [boost-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2533,8 +2533,8 @@ libboost-random-dev:
   ubuntu: [libboost-random-dev]
 libboost-regex:
   debian:
+    bullseye: [libboost-regex1.74.0]
     buster: [libboost-regex1.67.0]
-    stretch: [libboost-regex1.62.0]
   fedora: [boost-regex]
   gentoo: [dev-libs/boost]
   nixos: [boost]
@@ -2545,7 +2545,7 @@ libboost-regex:
     bionic: [libboost-regex1.65.1]
     eoan: [libboost-regex1.67.0]
     focal: [libboost-regex1.71.0]
-    xenial: [libboost-regex1.58.0]
+    jammy: [libboost-regex1.74.0]
 libboost-regex-dev:
   debian: [libboost-regex-dev]
   fedora: [boost-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -366,13 +366,7 @@ boost:
   alpine: [boost-dev]
   arch: [boost]
   cygwin: [libboost-devel, libboost1.40]
-  debian:
-    bullseye: [libboost-all-dev]
-    buster: [libboost-all-dev]
-    jessie: [libboost-all-dev]
-    squeeze: [libboost1.42-all-dev]
-    stretch: [libboost-all-dev]
-    wheezy: [libboost-all-dev]
+  debian: [libboost-all-dev]
   fedora: [boost-devel]
   freebsd: [py27-boost-libs]
   gentoo: ['dev-libs/boost[python]']
@@ -384,13 +378,7 @@ boost:
   slackware:
     slackpkg:
       packages: [boost]
-  ubuntu:
-    '*': [libboost-all-dev]
-    lucid: [libboost1.40-all-dev]
-    maverick: [libboost1.42-all-dev]
-    natty: [libboost1.42-all-dev]
-    oneiric: [libboost1.46-all-dev]
-    trusty_python3: [libboost-all-dev]
+  ubuntu: [libboost-all-dev]
 box2d-dev:
   arch: [box2d]
   debian: [libbox2d-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2452,9 +2452,8 @@ libboost-numpy-dev:
   ubuntu: [libboost-numpy-dev]
 libboost-program-options:
   debian:
+    bullseye: [libboost-program-options1.74.0]
     buster: [libboost-program-options1.67.0]
-    jessie: [libboost-program-options1.55.0]
-    stretch: [libboost-program-options1.62.0]
   fedora: [boost-program-options]
   gentoo: [dev-libs/boost]
   nixos: [boost]
@@ -2466,8 +2465,7 @@ libboost-program-options:
     disco: [libboost-program-options1.67.0]
     eoan: [libboost-program-options1.67.0]
     focal: [libboost-program-options1.71.0]
-    trusty: [libboost-program-options1.55.0]
-    xenial: [libboost-program-options1.58.0]
+    jammy: [libboost-program-options1.74.0]
 libboost-program-options-dev:
   debian: [libboost-program-options-dev]
   fedora: [boost-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2557,8 +2557,8 @@ libboost-regex-dev:
   ubuntu: [libboost-regex-dev]
 libboost-serialization:
   debian:
+    bullseye: [libboost-serialization1.74.0]
     buster: [libboost-serialization1.67.0]
-    stretch: [libboost-serialization1.62.0]
   fedora: [boost-serialization]
   gentoo: [dev-libs/boost]
   nixos: [boost]
@@ -2569,7 +2569,7 @@ libboost-serialization:
     bionic: [libboost-serialization1.65.1]
     eoan: [libboost-serialization1.67.0]
     focal: [libboost-serialization1.71.0]
-    xenial: [libboost-serialization1.58.0]
+    jammy: [libboost-serialization1.74.0]
 libboost-serialization-dev:
   debian: [libboost-serialization-dev]
   fedora: [boost-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2293,8 +2293,8 @@ libbluetooth-dev:
   ubuntu: [libbluetooth-dev]
 libboost-atomic:
   debian:
+    bullseye: [libboost-atomic1.74.0]
     buster: [libboost-atomic1.67.0]
-    stretch: [libboost-atomic1.62.0]
   fedora: [boost-atomic]
   gentoo: [dev-libs/boost]
   nixos: [boost]
@@ -2305,7 +2305,7 @@ libboost-atomic:
     bionic: [libboost-atomic1.65.1]
     eoan: [libboost-atomic1.67.0]
     focal: [libboost-atomic1.71.0]
-    xenial: [libboost-atomic1.58.0]
+    jammy: [libboost-atomic1.74.0]
 libboost-atomic-dev:
   debian: [libboost-atomic-dev]
   fedora: [boost-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2398,8 +2398,8 @@ libboost-filesystem-dev:
   ubuntu: [libboost-filesystem-dev]
 libboost-iostreams:
   debian:
+    bullseye: [libboost-iostreams1.74.0]
     buster: [libboost-iostreams1.67.0]
-    stretch: [libboost-iostreams1.62.0]
   fedora: [boost-iostreams]
   gentoo: [dev-libs/boost]
   nixos: [boost]
@@ -2410,7 +2410,7 @@ libboost-iostreams:
     bionic: [libboost-iostreams1.65.1]
     eoan: [libboost-iostreams1.67.0]
     focal: [libboost-iostreams1.71.0]
-    xenial: [libboost-iostreams1.58.0]
+    jammy: [libboost-iostreams1.74.0]
 libboost-iostreams-dev:
   debian: [libboost-iostreams-dev]
   fedora: [boost-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2581,8 +2581,8 @@ libboost-serialization-dev:
   ubuntu: [libboost-serialization-dev]
 libboost-system:
   debian:
+    bullseye: [libboost-system1.74.0]
     buster: [libboost-system1.67.0]
-    stretch: [libboost-system1.62.0]
   fedora: [boost-system]
   gentoo: [dev-libs/boost]
   nixos: [boost]
@@ -2594,8 +2594,7 @@ libboost-system:
     disco: [libboost-system1.67.0]
     eoan: [libboost-system1.67.0]
     focal: [libboost-system1.71.0]
-    trusty: [libboost-system1.55.0]
-    xenial: [libboost-system1.58.0]
+    jammy: [libboost-system1.74.0]
 libboost-system-dev:
   debian: [libboost-system-dev]
   fedora: [boost-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2374,8 +2374,8 @@ libboost-dev:
   ubuntu: [libboost-dev]
 libboost-filesystem:
   debian:
+    bullseye: [libboost-filesystem1.74.0]
     buster: [libboost-filesystem1.67.0]
-    stretch: [libboost-filesystem1.62.0]
   fedora: [boost-filesystem]
   gentoo: [dev-libs/boost]
   nixos: [boost]
@@ -2386,7 +2386,7 @@ libboost-filesystem:
     bionic: [libboost-filesystem1.65.1]
     eoan: [libboost-filesystem1.67.0]
     focal: [libboost-filesystem1.71.0]
-    xenial: [libboost-filesystem1.58.0]
+    jammy: [libboost-filesystem1.74.0]
 libboost-filesystem-dev:
   debian: [libboost-filesystem-dev]
   fedora: [boost-devel]


### PR DESCRIPTION
* `boost`
  * Use `libboost-dev-all` package for all Debian distributions.
  * Use `libboost-dev-all` package for all Ubuntu distributions.
* `libboost-atomic`
  * Add Debian Bullseye definition.
  * Drop Debian Stretch definition.
  * Add Ubuntu Jammy definition.
  * Drop Ubuntu Xenial definition.
* `libboost-chrono`
  * Add Debian Bullseye definition.
  * Drop Debian Stretch definition.
  * Add Ubuntu Jammy definition.
  * Drop Ubuntu Xenial definition.
* `libboost-date-time`
  * Add Debian Bullseye definition.
  * Drop Debian Stretch definition.
  * Add Ubuntu Jammy definition.
  * Drop Ubuntu Xenial definition.
* `libboost-filesystem`
  * Add Debian Bullseye definition.
  * Drop Debian Stretch definition.
  * Add Ubuntu Jammy definition.
  * Drop Ubuntu Xenial definition.
* `libboost-iostreams`
  * Add Debian Bullseye definition.
  * Drop Debian Stretch definition.
  * Add Ubuntu Jammy definition.
  * Drop Ubuntu Xenial definition.
* `libboost-math`
  * Add Debian Bullseye definition.
  * Drop Debian Stretch definition.
  * Add Ubuntu Jammy definition.
  * Drop Ubuntu Xenial definition.
* `libboost-program-options`
  * Add Debian Bullseye definition.
  * Drop Debian Stretch definition.
  * Drop Debian Jessie definition.
  * Add Ubuntu Jammy definition.
  * Drop Ubuntu Xenial definition.
  * Drop Ubuntu Trusty definition.
* `libboost-python`
  * Add Debian Bullseye definition.
  * Drop Debian Stretch definition.
  * Drop Debian Jessie definition.
  * Add Ubuntu Jammy definition.
  * Drop Ubuntu Xenial definition.
  * Drop Ubuntu Trusty definition.
* `libboost-random`
  * Add Debian Bullseye definition.
  * Drop Debian Stretch definition.
  * Drop Debian Jessie definition.
  * Drop Debian Wheezy definition.
  * Add Ubuntu Jammy definition.
  * Drop Ubuntu Xenial definition.
  * Drop Ubuntu Trusty definition.
  * Drop Ubuntu Precise definition.
* `libboost-regex`
  * Add Debian Bullseye definition.
  * Drop Debian Stretch definition.
  * Add Ubuntu Jammy definition.
  * Drop Ubuntu Xenial definition.
* `libboost-serialization`
  * Add Debian Bullseye definition.
  * Drop Debian Stretch definition.
  * Add Ubuntu Jammy definition.
  * Drop Ubuntu Xenial definition.
* `libboost-system`
  * Add Debian Bullseye definition.
  * Drop Debian Stretch definition.
  * Add Ubuntu Jammy definition.
  * Drop Ubuntu Xenial definition.
  * Drop Ubuntu Trusty definition.
* `libboost-thread`
  * Add Debian Bullseye definition.
  * Drop Debian Stretch definition.
  * Add Ubuntu Jammy definition.
  * Drop Ubuntu Xenial definition.
  * Drop Ubuntu Trusty definition.
* `libboost-timer`
  * Add Debian Bullseye definition.
  * Drop Debian Stretch definition.
  * Add Ubuntu Jammy definition.
  * Drop Ubuntu Xenial definition.
