### PR TITLE
Update gazebo keys.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1166,52 +1166,29 @@ gawk:
   openembedded: [gawk@openembedded-core]
   ubuntu: [gawk]
 gazebo:
-  arch: [gazebo]
   debian:
+    bullseye: [gazebo]
     buster: [gazebo11]
-    jessie: [gazebo7]
-    stretch: [gazebo9]
   fedora: [gazebo]
   gentoo: [sci-electronics/gazebo]
   nixos: [gazebo]
   slackware: [gazebo]
   ubuntu:
-    artful: [gazebo9]
     bionic: [gazebo9]
     cosmic: [gazebo9]
     disco: [gazebo9]
     eoan: [gazebo9]
     focal: [gazebo11]
-    precise: [gazebo]
-    quantal: [gazebo]
-    raring: [gazebo]
-    saucy: [gazebo2]
-    trusty: [gazebo2]
-    wily: [gazebo7]
-    xenial: [gazebo7]
-    yakkety: [gazebo7]
-    zesty: [gazebo7]
+    jammy: [gazebo]
 gazebo11:
   debian:
+    bullseye: [gazebo]
     buster: [gazebo11]
-  gentoo: [=sci-electronics/gazebo-11*]
+  gentoo: [=sci-electronics/gazebo]
   nixos: [gazebo_11]
   ubuntu:
     focal: [gazebo11]
-gazebo5:
-  arch: [gazebo]
-  gentoo: [=sci-electronics/gazebo-5*]
-  ubuntu: [gazebo5]
-gazebo7:
-  arch: [gazebo]
-  debian:
-    buster: [gazebo7]
-    jessie: [gazebo7]
-    stretch: [gazebo7]
-  gentoo: [=sci-electronics/gazebo-7*]
-  nixos: [gazebo_7]
-  slackware: [gazebo]
-  ubuntu: [gazebo7]
+    jammy: [gazebo]
 gazebo9:
   debian:
     buster: [gazebo9]
@@ -1220,11 +1197,11 @@ gazebo9:
   nixos: [gazebo_9]
   openembedded: []
   ubuntu:
-    artful: [gazebo9]
     bionic: [gazebo9]
     cosmic: [gazebo9]
     disco: [gazebo9]
     eoan: [gazebo9]
+    focal: [gazebo9]
 gcc-arm-none-eabi:
   arch: [gcc-arm-none-eabi]
   debian: [gcc-arm-none-eabi]


### PR DESCRIPTION
* Remove key for gazebo5.
* Remove key for gazebo7.
* Update key for gazebo9.
  * Remove definition for out-of-support Ubuntu Artful.
  * Add definition for Ubuntu Focal.
* Update key for gazebo11.
  * Change Gentoo key to unversioned [gazebo](https://packages.gentoo.org/packages/sci-electronics/gazebo).
  * Add definition for Debian Bullseye.
  * Add definition for Ubuntu Jammy.
* Update key for gazebo.
  * Drop definition for Debian Jessie.
  * Drop definition for Debian Stretch.
  * Remove archlinux definition as it is no longer packaged.
  * Add definition for Debian Bullseye.
  * Add definition for Ubuntu Jammy.
