### PR TITLE
Update yaml-cpp-dev key.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7934,15 +7934,7 @@ yaml:
 yaml-cpp:
   alpine: [yaml-cpp-dev]
   arch: [yaml-cpp]
-  debian:
-    buster: [libyaml-cpp-dev]
-    jessie: [libyaml-cpp-dev]
-    squeeze:
-      source:
-        md5sum: f7fb81fd4a2fbd5022daa7686e816359
-        uri: https://kforge.ros.org/rosrelease/viewvc/sourcedeps/yaml-cpp/yaml-cpp-0.2.5.rdmanifest
-    stretch: [libyaml-cpp-dev]
-    wheezy: [libyaml-cpp-dev]
+  debian: [libyaml-cpp-dev]
   fedora: [yaml-cpp-devel]
   freebsd: [yaml-cpp]
   gentoo: [dev-cpp/yaml-cpp]
@@ -7952,29 +7944,7 @@ yaml-cpp:
   opensuse: [yaml-cpp-devel]
   rhel: [yaml-cpp-devel]
   slackware: [yaml-cpp]
-  ubuntu:
-    artful: [libyaml-cpp-dev]
-    bionic: [libyaml-cpp-dev]
-    cosmic: [libyaml-cpp-dev]
-    disco: [libyaml-cpp-dev]
-    eoan: [libyaml-cpp-dev]
-    focal: [libyaml-cpp-dev]
-    lucid: [yaml-cpp0.2.6-dev]
-    maverick: [yaml-cpp0.2.6-dev]
-    natty: [yaml-cpp0.2.6-dev]
-    oneiric: [yaml-cpp0.2.6-dev]
-    precise: [yaml-cpp]
-    quantal: [libyaml-cpp-dev]
-    raring: [libyaml-cpp-dev]
-    saucy: [libyaml-cpp-dev]
-    trusty: [libyaml-cpp-dev]
-    trusty_python3: [libyaml-cpp-dev]
-    utopic: [libyaml-cpp-dev]
-    vivid: [libyaml-cpp-dev]
-    wily: [libyaml-cpp-dev]
-    xenial: [libyaml-cpp-dev]
-    yakkety: [libyaml-cpp-dev]
-    zesty: [libyaml-cpp-dev]
+  ubuntu: [libyaml-cpp-dev]
 yamllint:
   arch: [yamllint]
   debian:


### PR DESCRIPTION
Elide distribution codename for Debian and Ubuntu. All currently supported platforms use the same package name.