### PR TITLE
Add tesseract-ocr-jpn language package

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7425,6 +7425,11 @@ tesseract-ocr:
   fedora: [tesseract-devel]
   gentoo: [app-text/tesseract]
   ubuntu: [tesseract-ocr]
+tesseract-ocr-jpn:
+  arch: [tesseract-data-jpn]
+  debian: [tesseract-ocr-jpn]
+  fedora: [tesseract-langpack-jpn]
+  ubuntu: [tesseract-ocr-jpn]
 texlive-fonts-extra:
   arch: [texlive-fontsextra]
   debian: [texlive-fonts-extra]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7429,6 +7429,7 @@ tesseract-ocr-jpn:
   arch: [tesseract-data-jpn]
   debian: [tesseract-ocr-jpn]
   fedora: [tesseract-langpack-jpn]
+  rhel: [tesseract-langpack-jpn]
   ubuntu: [tesseract-ocr-jpn]
 texlive-fonts-extra:
   arch: [texlive-fontsextra]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

tesseract-ocr-jpn

## Package Upstream Source:

https://github.com/tesseract-ocr/tessdata

## Purpose of using this:

I would like to use this package because it provides Japanese OCR function.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/tesseract-ocr-jpn
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/impish/tesseract-ocr-jpn
- Fedora: https://src.fedoraproject.org/browse/projects/
  - https://fedora.pkgs.org/35/fedora-aarch64/tesseract-langpack-jpn-4.1.0-2.fc35.noarch.rpm.html
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/community/any/tesseract-data-jpn/
- Gentoo: https://packages.gentoo.org/
  - 'not available'
- macOS: https://formulae.brew.sh/
  - 'not available'
- Alpine: https://pkgs.alpinelinux.org/packages
  - 'not available'
- NixOS/nixpkgs: https://search.nixos.org/packages
  - 'not available'

