### PR TITLE
Parse Alpine package alias names in rosdep_repo_check

### DIFF
--- a/test/rosdep_repo_check/apk.py
+++ b/test/rosdep_repo_check/apk.py
@@ -63,9 +63,28 @@ def parse_apkindex(f):
 
 
 class Dependency:
+    """
+    Dependency class represents apk (Alpine Package) dependency information.
+    """
+
     type = None
+    """
+    :ivar: the type of the Dependency.
+           e.g.
+           - None: package
+           - 'cmd': command
+           - 'so': shared object
+    """
+
     name = None
+    """
+    :ivar: the name of the Dependency.
+    """
+
     version = None
+    """
+    :ivar: the version of the Dependency.
+    """
 
     def __init__(self, item):
         try:

--- a/test/rosdep_repo_check/apk.py
+++ b/test/rosdep_repo_check/apk.py
@@ -48,6 +48,7 @@ def parse_apkindex(f):
     # t:1602354892
     # c:183e99f73bb1223768aa7231a836a3e98e94c03e
     # i:docs rtpproxy=2.1.1-r0
+    # p:alias-of-rtpproxy=2.1.1-r0
 
     while True:
         entry = {}
@@ -59,6 +60,26 @@ def parse_apkindex(f):
             yield entry
         else:
             break
+
+
+class Dependency:
+    type = None
+    name = None
+    version = None
+
+    def __init__(self, item):
+        try:
+            self.type, self.name = item.split(':', 1)
+        except (ValueError):
+            self.name = item
+        try:
+            self.name, self.version = self.name.split('=', 1)
+        except (ValueError):
+            pass
+
+
+def parse_deps(text):
+    return [Dependency(item) for item in text.split(' ')]
 
 
 def enumerate_apk_packages(base_url, os_name, os_code_name, os_arch):
@@ -92,6 +113,11 @@ def enumerate_apk_packages(base_url, os_name, os_code_name, os_arch):
                 pkg_filename = '%s-%s.apk' % (pkg_name, pkg_version)
                 pkg_url = os.path.join(base_url, pkg_filename)
                 yield PackageEntry(pkg_name, pkg_version, pkg_url, source_name=source_name)
+
+                if 'p' in index_entry:
+                    for d in parse_deps(index_entry['p']):
+                        if d.type is None:
+                            yield PackageEntry(d.name, pkg_version, pkg_url, source_name=source_name)
 
 
 def apk_base_url(base_url):

--- a/test/rosdep_repo_check/apk.py
+++ b/test/rosdep_repo_check/apk.py
@@ -117,7 +117,7 @@ def enumerate_apk_packages(base_url, os_name, os_code_name, os_arch):
                 if 'p' in index_entry:
                     for d in parse_deps(index_entry['p']):
                         if d.type is None:
-                            yield PackageEntry(d.name, pkg_version, pkg_url, source_name=source_name)
+                            yield PackageEntry(d.name, pkg_version, pkg_url, source_name=source_name, binary_name=pkg_name)
 
 
 def apk_base_url(base_url):


### PR DESCRIPTION
This PR fixes `rosdep_repo_check` test to handle alias package names on Alpine Linux.

For example on the recent version of Alpine including `edge`, [package `boost` does not exist](https://pkgs.alpinelinux.org/packages?name=boost&branch=v3.15&arch=x86_64) but [`boost1.77` package provides boost with alias name of `boost`](https://git.alpinelinux.org/aports/tree/main/boost1.77/APKBUILD#n71).
In such case, entry in APKINDEX is like:
```
C:Q1eEjzBgEI0tEBwEsKN8xHqWg8lPI=
P:boost1.77
V:1.77.0-r3
A:x86_64
S:503233
I:1212416
T:Free peer-reviewed portable C++ source libraries
U:https://www.boost.org/
L:BSL-1.0
o:boost1.77
m:Natanael Copa <ncopa@alpinelinux.org>
t:1639595897
c:f28bbb115a3af88eb17647009520f3ed1de0d061
D:boost1.77-libs so:libc.musl-x86_64.so.1 so:libgcc_s.so.1 so:libstdc++.so.6
p:boost=1.77.0-r3 cmd:b2=1.77.0-r3 cmd:bcp=1.77.0-r3 cmd:bjam=1.77.0-r3
```

### References
- problem was found in: https://github.com/alpine-ros/rosdistro/pull/89
- apk repository support has been added by: https://github.com/ros/rosdistro/pull/30100