### PR TITLE
cob_manipulation: 0.7.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -981,12 +981,13 @@ repositories:
       - cob_collision_monitor
       - cob_grasp_generation
       - cob_lookat_action
+      - cob_manipulation_msgs
       - cob_moveit_bringup
       - cob_moveit_interface
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_manipulation-release.git
-      version: 0.7.5-1
+      version: 0.7.6-1
     source:
       type: git
       url: https://github.com/ipa320/cob_manipulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_manipulation` to `0.7.6-1`:

- upstream repository: https://github.com/ipa320/cob_manipulation.git
- release repository: https://github.com/ipa320/cob_manipulation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.5-1`

## cob_collision_monitor

- No changes

## cob_grasp_generation

```
* Merge pull request #150 <https://github.com/ipa320/cob_manipulation/issues/150> from fmessmer/fix_pylint
  fix ci
* move messages to dedicated package
* Contributors: Felix Messmer, fmessmer
```

## cob_lookat_action

- No changes

## cob_manipulation_msgs

```
* update changelogs
* Merge pull request #150 <https://github.com/ipa320/cob_manipulation/issues/150> from fmessmer/fix_pylint
  fix ci
* move messages to dedicated package
* Contributors: Felix Messmer, fmessmer
* Merge pull request #150 <https://github.com/ipa320/cob_manipulation/issues/150> from fmessmer/fix_pylint
  fix ci
* move messages to dedicated package
* Contributors: Felix Messmer, fmessmer
```

## cob_moveit_bringup

- No changes

## cob_moveit_interface

- No changes
