### PR TITLE
cob_navigation: 0.6.12-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1010,7 +1010,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_navigation-release.git
-      version: 0.6.11-1
+      version: 0.6.12-1
     source:
       type: git
       url: https://github.com/ipa320/cob_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_navigation` to `0.6.12-1`:

- upstream repository: https://github.com/ipa320/cob_navigation.git
- release repository: https://github.com/ipa320/cob_navigation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.11-1`

## cob_linear_nav

```
* Merge pull request #121 <https://github.com/ipa320/cob_navigation/issues/121> from fmessmer/fix_catkin_lint
  fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## cob_map_accessibility_analysis

- No changes

## cob_mapping_slam

- No changes

## cob_navigation

- No changes

## cob_navigation_config

- No changes

## cob_navigation_global

- No changes

## cob_navigation_local

- No changes

## cob_navigation_slam

- No changes
