### PR TITLE
Revert "Update python-lxml key."

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2609,8 +2609,7 @@ python-luis-pip:
       packages: [luis]
 python-lxml:
   arch: [python2-lxml]
-  debian:
-    buster: [python-lxml]
+  debian: [python-lxml]
   fedora: [python-lxml]
   freebsd: [py27-lxml]
   gentoo: [dev-python/lxml]
@@ -2623,9 +2622,7 @@ python-lxml:
   rhel:
     '*': [python2-lxml]
     '7': [python-lxml]
-  ubuntu:
-    bionic: [python-lxml]
-    focal: [python-lxml]
+  ubuntu: [python-lxml]
 python-lzf-pip:
   debian:
     pip:


### PR DESCRIPTION
Reverts ros/rosdistro#31554

Canonical still supports xenial/kinetic https://ubuntu.com/engage/ros-kinetic-eol , I think we should revert this PR.
In addition to that, if we write like
```
  ubuntu:
    bionic: [python-lxml]
    focal: [python-lxml]
```
we need to update distribution key every 2 year, so I think 
```
  ubuntu: [python-lxml]
```
is better