### PR TITLE
cob_calibration_data: 0.6.16-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -771,7 +771,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_calibration_data-release.git
-      version: 0.6.15-1
+      version: 0.6.16-1
     source:
       type: git
       url: https://github.com/ipa320/cob_calibration_data.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_calibration_data` to `0.6.16-1`:

- upstream repository: https://github.com/ipa320/cob_calibration_data.git
- release repository: https://github.com/ipa320/cob_calibration_data-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.15-1`

## cob_calibration_data

```
* Merge pull request #166 <https://github.com/ipa320/cob_calibration_data/issues/166> from ipa-foj/fixup_cob4-25
  fixup cob4-25 for noetic
* fixup cob4-25 for noetic
* update travis config
* Contributors: Felix Messmer, mailto:robot@cob4-25
```
