### PR TITLE
cob_command_tools: 0.6.26-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -798,7 +798,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_command_tools-release.git
-      version: 0.6.21-1
+      version: 0.6.26-1
     source:
       type: git
       url: https://github.com/ipa320/cob_command_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.26-1`:

- upstream repository: https://github.com/ipa320/cob_command_tools.git
- release repository: https://github.com/ipa320/cob_command_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.21-1`

## cob_command_gui

- No changes

## cob_command_tools

- No changes

## cob_dashboard

- No changes

## cob_helper_tools

- No changes

## cob_interactive_teleop

- No changes

## cob_monitoring

```
* Merge pull request #307 <https://github.com/ipa320/cob_command_tools/issues/307> from floweisshardt/feature/emergency_monitor
  add topics for em released info
* add topics for em released info
* Merge pull request #306 <https://github.com/ipa320/cob_command_tools/issues/306> from fmessmer/fix_cob_monitoring
  fix cob_monitoring
* add traceback to all cob_monitoring exceptions
* fix string format
* add exception traceback
* Contributors: Felix Messmer, fmessmer, mailto:robot@mrk-4
```

## cob_script_server

- No changes

## cob_teleop

- No changes

## generic_throttle

- No changes

## scenario_test_tools

- No changes

## service_tools

- No changes
