### PR TITLE
cob_substitute: 0.6.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1091,10 +1091,11 @@ repositories:
       - cob_reflector_referencing
       - cob_safety_controller
       - cob_substitute
+      - ipa_differential_docking
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_substitute-release.git
-      version: 0.6.10-1
+      version: 0.6.11-1
     source:
       type: git
       url: https://github.com/ipa320/cob_substitute.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_substitute` to `0.6.11-1`:

- upstream repository: https://github.com/ipa320/cob_substitute.git
- release repository: https://github.com/ipa320/cob_substitute-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.10-1`

## cob_docker_control

- No changes

## cob_reflector_referencing

- No changes

## cob_safety_controller

- No changes

## cob_substitute

- No changes

## ipa_differential_docking

```
* Merge pull request #57 <https://github.com/ipa320/cob_substitute/issues/57> from fmessmer/substitute/ipa_differential_docking
  substitute for ipa_differential_docking
* substitute for ipa_differential_docking
* Contributors: Felix Messmer, fmessmer
```
