### PR TITLE
cob_control: 0.8.17-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -853,7 +853,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_control-release.git
-      version: 0.8.13-1
+      version: 0.8.17-1
     source:
       type: git
       url: https://github.com/ipa320/cob_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.8.17-1`:

- upstream repository: https://github.com/ipa320/cob_control.git
- release repository: https://github.com/ipa320/cob_control-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.8.13-1`

## cob_base_controller_utils

- No changes

## cob_base_velocity_smoother

- No changes

## cob_cartesian_controller

- No changes

## cob_collision_velocity_filter

- No changes

## cob_control

- No changes

## cob_control_mode_adapter

- No changes

## cob_control_msgs

- No changes

## cob_footprint_observer

- No changes

## cob_frame_tracker

- No changes

## cob_hardware_emulation

```
* Merge pull request #265 <https://github.com/ipa320/cob_control/issues/265> from fmessmer/fix/emulation_argparse
  fixup emulation argparse
* fixup emulation argparse
* Merge pull request #264 <https://github.com/ipa320/cob_control/issues/264> from HannesBachter/feature/laser_odometry
  [no odom] make odom frame configurable
* make odom frame configurable
* Merge pull request #263 <https://github.com/ipa320/cob_control/issues/263> from fmessmer/emulation_nav
  separate emulation_nav from emulation_base
* separate emulation_nav from emulation_base
* Contributors: Felix Messmer, HannesBachter, fmessmer
```

## cob_mecanum_controller

- No changes

## cob_model_identifier

- No changes

## cob_obstacle_distance

- No changes

## cob_omni_drive_controller

- No changes

## cob_trajectory_controller

- No changes

## cob_tricycle_controller

- No changes

## cob_twist_controller

```
* Merge pull request #262 <https://github.com/ipa320/cob_control/issues/262> from fmessmer/debug_cart_vel_recursive
  publish cart vel magnitudes for frames of chain
* fix catkin_lint
* calculate fk_vel_recursive based on joint_trajectory_controller state for both desired and actual joint states
* rename debug node
* fix getNrOfJoints vs getNrOfSegments and fixed joint handling
* debug chain
* provide launch file for debug_evaluate_jointstates
* fill header.stamp in twist_magnitude msg
* extend debug_evaluate_jointstates_node to recursively publish cart vel magnitudes for frames of chain
* Contributors: Felix Messmer, fmessmer
```
