### PR TITLE
cob_gazebo_plugins: 0.7.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -947,7 +947,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_gazebo_plugins-release.git
-      version: 0.7.5-1
+      version: 0.7.6-1
     source:
       type: git
       url: https://github.com/ipa320/cob_gazebo_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_gazebo_plugins` to `0.7.6-1`:

- upstream repository: https://github.com/ipa320/cob_gazebo_plugins.git
- release repository: https://github.com/ipa320/cob_gazebo_plugins-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.5-1`

## cob_gazebo_plugins

```
* Merge pull request #49 <https://github.com/ipa320/cob_gazebo_plugins/issues/49> from fmessmer/feature/mimic_plugin
  add MimicJoint gazebo plugin
* set max force for mimic joints
* fix catkin_lint
* fix plugin
* export plugin
* debug plugin
* add MimicJoint gazebo plugin
* Contributors: Felix Messmer, fmessmer
```

## cob_gazebo_ros_control

- No changes
