### PR TITLE
cob_common: 0.7.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -820,7 +820,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_common-release.git
-      version: 0.7.4-1
+      version: 0.7.7-1
     source:
       type: git
       url: https://github.com/ipa320/cob_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `0.7.7-1`:

- upstream repository: https://github.com/ipa320/cob_common.git
- release repository: https://github.com/ipa320/cob_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.4-1`

## cob_actions

- No changes

## cob_common

- No changes

## cob_description

```
* Merge pull request #295 <https://github.com/ipa320/cob_common/issues/295> from ipa-fog/fix/kinect_frame_id
  adjusted frames of kinect topics to tf-tree
* adjusted frames of kinect topics to tf-tree
* Merge pull request #294 <https://github.com/ipa320/cob_common/issues/294> from fmessmer/unique_control_plugin
  guarantee unique plugin name for hwi_switch_gazebo_ros_control
* add plugins for mimic joints
* guarantee unique plugin name for hwi_switch_gazebo_ros_control
* Contributors: Felix Messmer, fmessmer, fog
```

## cob_msgs

- No changes

## cob_srvs

- No changes

## raw_description

```
* Merge pull request #294 <https://github.com/ipa320/cob_common/issues/294> from fmessmer/unique_control_plugin
  guarantee unique plugin name for hwi_switch_gazebo_ros_control
* guarantee unique plugin name for hwi_switch_gazebo_ros_control
* Contributors: Felix Messmer, fmessmer
```
