### PR TITLE
Revert "Update python-numpy key. (#31552)"

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2969,9 +2969,9 @@ python-ntplib:
   gentoo: [dev-python/ntplib]
   ubuntu: [python-ntplib]
 python-numpy:
+  alpine: [py-numpy]
   arch: [python2-numpy]
-  debian:
-    buster: [python-numpy]
+  debian: [python-numpy]
   fedora: [numpy]
   freebsd: [py27-numpy]
   gentoo: [dev-python/numpy]
@@ -2985,8 +2985,25 @@ python-numpy:
   rhel: [python2-numpy]
   slackware: [numpy]
   ubuntu:
+    artful: [python-numpy]
     bionic: [python-numpy]
     focal: [python-numpy]
+    lucid: [python-numpy]
+    maverick: [python-numpy]
+    natty: [python-numpy]
+    oneiric: [python-numpy]
+    precise: [python-numpy]
+    quantal: [python-numpy]
+    raring: [python-numpy]
+    saucy: [python-numpy]
+    trusty: [python-numpy]
+    trusty_python3: [python3-numpy]
+    utopic: [python-numpy]
+    vivid: [python-numpy]
+    wily: [python-numpy]
+    xenial: [python-numpy]
+    yakkety: [python-numpy]
+    zesty: [python-numpy]
 python-numpy-quaternion-pip:
   debian:
     pip:


### PR DESCRIPTION
Revert #31552 

Same reason as #31570.
Canonical still supports xenial/kinetic.

