### PR TITLE
webots_ros2: 1.2.0-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5229,7 +5229,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/webots_ros2-release.git
-      version: 1.1.2-2
+      version: 1.2.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `webots_ros2` to `1.2.0-2`:

- upstream repository: https://github.com/cyberbotics/webots_ros2.git
- release repository: https://github.com/ros2-gbp/webots_ros2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.2-2`

## webots_ros2_control

```
* Fix the controller_manager update rate.
```

## webots_ros2_driver

```
* Adapt the worlds to the new R2022a FLU convention.
* Remove a double webots_ros2_driver header installation.
* Add the publication of the 'gps/speed_vector' topic to the GPS ROS 2 device.
```

## webots_ros2_epuck

```
* Adapt the worlds to the new R2022a FLU convention.
```

## webots_ros2_mavic

```
* Adapt the worlds to the new R2022a FLU convention.
```

## webots_ros2_tesla

```
* Adapt the worlds to the new R2022a FLU convention.
```

## webots_ros2_tests

```
* Adapt the worlds to the new R2022a FLU convention.
* Add a system test for the TurtleBot3 Navigation scenario.
```

## webots_ros2_tiago

```
* Adapt the worlds to the new R2022a FLU convention.
```

## webots_ros2_turtlebot

```
* Adapt the worlds to the new R2022a FLU convention.
```

## webots_ros2_universal_robot

```
* Adapt the worlds to the new R2022a FLU convention.
* Fix synchornosiation issue when the trajectory controller was receiving goals but was not ready to execute them.
```
