### PR TITLE
rclpy: 3.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2549,7 +2549,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 3.1.0-1
+      version: 3.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `3.2.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.1.0-1`

## rclpy

```
* Implement managed nodes. (#865 <https://github.com/ros2/rclpy/issues/865>)
* Make rclpy.try_shutdown() behavior to follow rclpy.shutdown() more closely. (#868 <https://github.com/ros2/rclpy/issues/868>)
* Update TopicEndpointTypeEnum.__str__() method to include history kind and history depth. (#849 <https://github.com/ros2/rclpy/issues/849>)
* Add Clock.sleep_for() using Clock.sleep_until(). (#864 <https://github.com/ros2/rclpy/issues/864>)
* Add Clock.sleep_until() (#858 <https://github.com/ros2/rclpy/issues/858>)
* Add __enter__ and __exit__ to JumpHandle. (#862 <https://github.com/ros2/rclpy/issues/862>)
* Don't override rclpy._rclpy_pybind11 docs. (#863 <https://github.com/ros2/rclpy/issues/863>)
* Improve JumpThreshold documentation and forbid zero durations. (#861 <https://github.com/ros2/rclpy/issues/861>)
* Fix time.py and clock.py circular import. (#860 <https://github.com/ros2/rclpy/issues/860>)
* Make context.on_shutdown() allow free functions. (#859 <https://github.com/ros2/rclpy/issues/859>)
* Fix automatically declared parameters descriptor type. (#853 <https://github.com/ros2/rclpy/issues/853>)
* Shutdown asynchronously when sigint is received. (#844 <https://github.com/ros2/rclpy/issues/844>)
* Update maintainers. (#845 <https://github.com/ros2/rclpy/issues/845>)
* Add entities to callback group before making them available to the executor to avoid a race condition. (#839 <https://github.com/ros2/rclpy/issues/839>)
* Avoid race condition in client.call(). (#838 <https://github.com/ros2/rclpy/issues/838>)
* Contributors: Ivan Santiago Paunovic, Jacob Perron, Shane Loretz, Tomoya Fujita
```
