### PR TITLE
geometric_shapes: 2.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -926,7 +926,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/moveit/geometric_shapes-release.git
-      version: 2.1.1-1
+      version: 2.1.2-1
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `2.1.2-1`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/moveit/geometric_shapes-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.1-1`

## geometric_shapes

```
* Fix cmake such that Boost::filesystem is exported properly (#206 <https://github.com/ros-planning/geometric_shapes/issues/206>)
  Co-authored-by: Jordan Lack <mailto:jlack@houstonmechatronics.com>
* Contributors: Jafar Abdi
```
