### PR TITLE
Ignition Fortress rosdep keys

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1810,6 +1810,11 @@ ignition-edifice:
     buster: [ignition-edifice]
   ubuntu:
     focal: [ignition-edifice]
+ignition-fortress:
+  debian:
+    buster: [ignition-fortress]
+  ubuntu:
+    focal: [ignition-fortress]
 ignition-fuel-tools4:
   debian:
     buster: [libignition-fuel-tools4-dev]
@@ -1821,6 +1826,11 @@ ignition-fuel-tools6:
     buster: [libignition-fuel-tools6-dev]
   ubuntu:
     focal: [libignition-fuel-tools6-dev]
+ignition-fuel-tools7:
+  debian:
+    buster: [libignition-fuel-tools7-dev]
+  ubuntu:
+    focal: [libignition-fuel-tools7-dev]
 ignition-gazebo3:
   debian:
     buster: [libignition-gazebo3-dev]
@@ -1836,6 +1846,16 @@ ignition-gazebo5-plugins:
     buster: [libignition-gazebo5-plugins]
   ubuntu:
     focal: [libignition-gazebo5-plugins]
+ignition-gazebo6:
+  debian:
+    buster: [libignition-gazebo6-dev]
+  ubuntu:
+    focal: [libignition-gazebo6-dev]
+ignition-gazebo6-plugins:
+  debian:
+    buster: [libignition-gazebo6-plugins]
+  ubuntu:
+    focal: [libignition-gazebo6-plugins]
 ignition-gui3:
   debian:
     buster: [libignition-gui3-dev]
@@ -1846,6 +1866,11 @@ ignition-gui5:
     buster: [libignition-gui5-dev]
   ubuntu:
     focal: [libignition-gui5-dev]
+ignition-gui6:
+  debian:
+    buster: [libignition-gui6-dev]
+  ubuntu:
+    focal: [libignition-gui6-dev]
 ignition-launch2:
   debian:
     buster: [libignition-launch2-dev]
@@ -1856,6 +1881,11 @@ ignition-launch4:
     buster: [libignition-launch4-dev]
   ubuntu:
     focal: [libignition-launch4-dev]
+ignition-launch5:
+  debian:
+    buster: [libignition-launch5-dev]
+  ubuntu:
+    focal: [libignition-launch5-dev]
 ignition-math6:
   debian:
     buster: [libignition-math6-dev]
@@ -1879,6 +1909,11 @@ ignition-msgs7:
     buster: [libignition-msgs7-dev]
   ubuntu:
     focal: [libignition-msgs7-dev]
+ignition-msgs8:
+  debian:
+    buster: [libignition-msgs8-dev]
+  ubuntu:
+    focal: [libignition-msgs8-dev]
 ignition-physics2:
   debian:
     buster: [libignition-physics2-dev]
@@ -1889,6 +1924,11 @@ ignition-physics4:
     buster: [libignition-physics4-dev]
   ubuntu:
     focal: [libignition-physics4-dev]
+ignition-physics5:
+  debian:
+    buster: [libignition-physics5-dev]
+  ubuntu:
+    focal: [libignition-physics5-dev]
 ignition-plugin:
   debian:
     buster: [libignition-plugin-dev]
@@ -1904,6 +1944,11 @@ ignition-rendering5:
     buster: [libignition-rendering5-dev]
   ubuntu:
     focal: [libignition-rendering5-dev]
+ignition-rendering6:
+  debian:
+    buster: [libignition-rendering6-dev]
+  ubuntu:
+    focal: [libignition-rendering6-dev]
 ignition-sensors3:
   debian:
     buster: [libignition-sensors3-dev]
@@ -1914,6 +1959,11 @@ ignition-sensors5:
     buster: [libignition-sensors5-dev]
   ubuntu:
     focal: [libignition-sensors5-dev]
+ignition-sensors6:
+  debian:
+    buster: [libignition-sensors6-dev]
+  ubuntu:
+    focal: [libignition-sensors6-dev]
 ignition-tools:
   debian:
     buster: [libignition-tools-dev]
@@ -1925,6 +1975,11 @@ ignition-transport10:
     buster: [libignition-transport10-dev]
   ubuntu:
     focal: [libignition-transport10-dev]
+ignition-transport11:
+  debian:
+    buster: [libignition-transport11-dev]
+  ubuntu:
+    focal: [libignition-transport11-dev]
 ignition-transport8:
   debian:
     buster: [libignition-transport8-dev]
@@ -6983,6 +7038,11 @@ sdformat11:
     buster: [libsdformat11-dev]
   ubuntu:
     focal: [libsdformat11-dev]
+sdformat12:
+  debian:
+    buster: [libsdformat12-dev]
+  ubuntu:
+    focal: [libsdformat12-dev]
 sdl:
   arch: [sdl]
   debian: [libsdl1.2-dev]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

* Part of https://github.com/ignition-tooling/release-tools/issues/459
* Depends on https://github.com/ros-infrastructure/reprepro-updater/pull/128 and https://github.com/ros-infrastructure/reprepro-updater/pull/138

## Package name:

[Ignition Fortress libraries](https://ignitionrobotics.org/docs/fortress)

## Package Upstream Source:

All libraries are on this org: https://github.com/ignitionrobotics/

## Purpose of using this:

As defined on [REP-2000](https://www.ros.org/reps/rep-2000.html#humble-hawksbill-may-2022-may-2027), Ignition Fortress will be the official Ignition version to be used with ROS Humble. Note that the keys will need to be updated once Rolling moves to Ubuntu Jammy / Debian Bullseye.

Once the rosdep keys are available, we'll make a release of [ros_ign](https://github.com/ignitionrobotics/ros_ign/) into Rolling using Fortress. ROS packages can interface with Ignition Gazebo through `ros_ign`, and they can also use Ignition libraries directly.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/
  - http://packages.osrfoundation.org/gazebo/debian-stable/
- Ubuntu: https://packages.ubuntu.com/
   - http://packages.osrfoundation.org/gazebo/ubuntu-stable/
- macOS: https://formulae.brew.sh/
  - https://github.com/osrf/homebrew-simulation/
