### PR TITLE
Automatically label PRs based on files they change

### DIFF
--- a/.github/labeler-config.yaml
+++ b/.github/labeler-config.yaml
@@ -1,0 +1,23 @@
+# Add 'melodic' label if any files in melodic/ folder are changed by a PR
+melodic:
+  - melodic/*
+
+# Add 'noetic' label if any files in noetic/ folder are changed by a PR
+noetic:
+  - noetic/*
+
+# Add 'foxy' label if any files in foxy/ folder are changed by a PR
+foxy:
+  - foxy/*
+
+# Add 'galactic' label if any files in galactic/ folder are changed by a PR
+galactic:
+  - galactic/*
+
+# Add 'rolling' label if any files in rolling/ folder are changed by a PR
+rolling:
+  - rolling/*
+
+# Add 'rosdep' label if any files in rosdep/ folder are changed by a PR
+rosdep:
+  - rosdep/*

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: ".github/labeler-config.yaml"


### PR DESCRIPTION
Signed-off-by: Shane Loretz <sloretz@osrfoundation.org>

This uses https://github.com/actions/labeler to automatically label PRs based on which files they change. See proof that this PR works by looking at the PRs on my fork: https://github.com/sloretz/rosdistro/pulls

* sloretz/rosdistro#2
* sloretz/rosdistro#3
* sloretz/rosdistro#4
* sloretz/rosdistro#5
* sloretz/rosdistro#6
* sloretz/rosdistro#7
* sloretz/rosdistro#8