### PR TITLE
octomap_mapping: 0.6.7-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7835,7 +7835,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/octomap_mapping-release.git
-      version: 0.6.5-1
+      version: 0.6.7-2
     source:
       type: git
       url: https://github.com/OctoMap/octomap_mapping.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_mapping` to `0.6.7-2`:

- upstream repository: https://github.com/OctoMap/octomap_mapping
- release repository: https://github.com/ros-gbp/octomap_mapping-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.5-1`

## octomap_mapping

```
* Address warnings on Noetic (#81 <https://github.com/octomap/octomap_mapping/issues/81>)
* Contributors: Wolfgang Merkt
```

## octomap_server

```
* Address warnings on Noetic (#81 <https://github.com/octomap/octomap_mapping/issues/81>)
* Contributors: Wolfgang Merkt
```
