### PR TITLE
octomap_mapping: 0.6.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5158,7 +5158,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/octomap_mapping-release.git
-      version: 0.6.6-1
+      version: 0.6.7-1
     source:
       type: git
       url: https://github.com/OctoMap/octomap_mapping.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_mapping` to `0.6.7-1`:

- upstream repository: https://github.com/OctoMap/octomap_mapping
- release repository: https://github.com/ros-gbp/octomap_mapping-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.6-1`

## octomap_mapping

```
* Address warnings on Noetic (#81 <https://github.com/octomap/octomap_mapping/issues/81>)
* Contributors: Wolfgang Merkt
```

## octomap_server

```
* Address warnings on Noetic (#81 <https://github.com/octomap/octomap_mapping/issues/81>)
* Contributors: Wolfgang Merkt
```
