### PR TITLE
octomap_rviz_plugins: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1974,6 +1974,21 @@ repositories:
       url: https://github.com/OctoMap/octomap_ros.git
       version: ros2
     status: maintained
+  octomap_rviz_plugins:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap_rviz_plugins.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/octomap_rviz_plugins-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap_rviz_plugins.git
+      version: ros2
+    status: maintained
   ompl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_rviz_plugins` to `2.0.0-1`:

- upstream repository: https://github.com/OctoMap/octomap_rviz_plugins.git
- release repository: https://github.com/ros2-gbp/octomap_rviz_plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## octomap_rviz_plugins

```
* ROS2 Migration (#41 <https://github.com/OctoMap/octomap_rviz_plugins/issues/41>)
* Contributors: Daisuke Nishimatsu, Wolfgang Merkt
```
