### PR TITLE
moveit: 2.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1700,13 +1700,21 @@ repositories:
       version: main
     release:
       packages:
+      - chomp_motion_planner
       - moveit
+      - moveit_chomp_optimizer_adapter
       - moveit_common
       - moveit_core
+      - moveit_hybrid_planning
       - moveit_kinematics
       - moveit_planners
+      - moveit_planners_chomp
       - moveit_planners_ompl
       - moveit_plugins
+      - moveit_resources_prbt_ikfast_manipulator_plugin
+      - moveit_resources_prbt_moveit_config
+      - moveit_resources_prbt_pg70_support
+      - moveit_resources_prbt_support
       - moveit_ros
       - moveit_ros_benchmarks
       - moveit_ros_control_interface
@@ -1720,14 +1728,14 @@ repositories:
       - moveit_ros_warehouse
       - moveit_runtime
       - moveit_servo
+      - moveit_setup_assistant
       - moveit_simple_controller_manager
-      - run_move_group
-      - run_moveit_cpp
-      - run_ompl_constrained_planning
+      - pilz_industrial_motion_planner
+      - pilz_industrial_motion_planner_testutils
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/moveit/moveit2-release.git
-      version: 2.3.0-1
+      version: 2.3.1-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.3.1-1`:

- upstream repository: https://github.com/ros-planning/moveit2.git
- release repository: https://github.com/moveit/moveit2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.0-1`

## chomp_motion_planner

```
* Replaced C-Style Cast with C++ Style Cast. (#935 <https://github.com/ros-planning/moveit2/issues/935>)
* Add codespell to precommit, fix A LOT of spelling mistakes (#934 <https://github.com/ros-planning/moveit2/issues/934>)
* Get rid of "std::endl" (#918 <https://github.com/ros-planning/moveit2/issues/918>)
* changed post-increments in loops to preincrements (#888 <https://github.com/ros-planning/moveit2/issues/888>)
* Port CHOMP Motion Planner to ROS 2 (#809 <https://github.com/ros-planning/moveit2/issues/809>)
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Contributors: David V. Lu!!, Henning Kayser, Kaustubh, Parthasarathy Bana, Robert Haschke, Sencer Yazıcı, andreas-botbuilt, pvanlaar
```

## moveit

```
* Enforce package.xml format 3 Schema (#779 <https://github.com/ros-planning/moveit2/issues/779>)
* Update Maintainers of MoveIt package (#697 <https://github.com/ros-planning/moveit2/issues/697>)
* Contributors: Dave Coleman, Henning Kayser, Robert Haschke
```

## moveit_chomp_optimizer_adapter

```
* Port CHOMP Motion Planner to ROS 2 (#809 <https://github.com/ros-planning/moveit2/issues/809>)
* Contributors: Henning Kayser, andreas-botbuilt
```

## moveit_common

```
* Enforce package.xml format 3 Schema (#779 <https://github.com/ros-planning/moveit2/issues/779>)
* Update Maintainers of MoveIt package (#697 <https://github.com/ros-planning/moveit2/issues/697>)
* Add backward_ros to moveit_common (#794 <https://github.com/ros-planning/moveit2/issues/794>)
* Contributors: Dave Coleman, Henning Kayser, Tyler Weaver
```

## moveit_core

```
* Convert to modern include guard #882 <https://github.com/ros-planning/moveit2/issues/882> (#891 <https://github.com/ros-planning/moveit2/issues/891>)
* Replaced C-Style Cast with C++ Style Cast. (#935 <https://github.com/ros-planning/moveit2/issues/935>)
* Fix CHOMP motion planner build on Windows (#890 <https://github.com/ros-planning/moveit2/issues/890>)
* Add codespell to precommit, fix A LOT of spelling mistakes (#934 <https://github.com/ros-planning/moveit2/issues/934>)
* Get rid of "std::endl" (#918 <https://github.com/ros-planning/moveit2/issues/918>)
* changed post-increments in loops to preincrements (#888 <https://github.com/ros-planning/moveit2/issues/888>)
* Fix boost linking errors (#900 <https://github.com/ros-planning/moveit2/issues/900>)
* Remove unused dependency from cmake (#839 <https://github.com/ros-planning/moveit2/issues/839>)
* Revert debug warning (#884 <https://github.com/ros-planning/moveit2/issues/884>)
* tf2_eigen header fix for galactic
* Clang-tidy fixes (#596 <https://github.com/ros-planning/moveit2/issues/596>)
* Enforce package.xml format 3 Schema (#779 <https://github.com/ros-planning/moveit2/issues/779>)
* Update Maintainers of MoveIt package (#697 <https://github.com/ros-planning/moveit2/issues/697>)
* RobotTrajectory as standard container (#720 <https://github.com/ros-planning/moveit2/issues/720>)
  * Based on initial size/iterator implementations from https://github.com/ros-planning/moveit/pull/1162
* Ruckig trajectory smoothing improvements (#712 <https://github.com/ros-planning/moveit2/issues/712>)
* Fixed Bullet collision checker not taking defaults into account. (#2871 <https://github.com/ros-planning/moveit/issues/2871>)
* PlanningScene::getPlanningSceneDiffMsg(): Do not list an object as destroyed when it got attached (#2864 <https://github.com/ros-planning/moveit/issues/2864>)
* Fix bullet-collision constructor not updating world objects (#2830 <https://github.com/ros-planning/moveit/issues/2830>)
  Ensure getting notified about any objects in the world.
* Split CollisionPluginLoader (#2834 <https://github.com/ros-planning/moveit/issues/2834>)
* Use default copy constructor to clone attached objects (#2855 <https://github.com/ros-planning/moveit/issues/2855>)
* Remove unnecessary copy of global sub-frames map (#2850 <https://github.com/ros-planning/moveit/issues/2850>)
* update comments to current parameter name (#2853 <https://github.com/ros-planning/moveit/issues/2853>)
* Fix pose-not-set-bug (#2852 <https://github.com/ros-planning/moveit/issues/2852>)
* add API for passing RNG to setToRandomPositionsNearBy (#2799 <https://github.com/ros-planning/moveit/issues/2799>)
* PS: backwards compatibility for specifying poses for a single collision shape (#2816 <https://github.com/ros-planning/moveit/issues/2816>)
* Fix Bullet collision returning wrong contact type (#2829 <https://github.com/ros-planning/moveit/issues/2829>)
* Add RobotState::setToDefaultValues from group string (#2828 <https://github.com/ros-planning/moveit/issues/2828>)
* Fix issue #2809 <https://github.com/ros-planning/moveit/issues/2809> (broken test with clang) (#2820 <https://github.com/ros-planning/moveit/issues/2820>)
  Because std::make_pair uses the decayed type (std::string), the strings were actually copied into a temporary, which was subsequently referenced by the elements of std::pair, leading to a stack-use-after-scope error.
  Explicitly passing const references into std::make_pair via std::cref() resolves the issue mentioned in #2809 <https://github.com/ros-planning/moveit/issues/2809>.
* [moveit_core] Fix export of FCL dependency (#2819 <https://github.com/ros-planning/moveit/issues/2819>)
  Regression of 93c3f63
  Closes: #2804 <https://github.com/ros-planning/moveit/issues/2804>
* code fix on wrong substitution (#2815 <https://github.com/ros-planning/moveit/issues/2815>)
* Preserve metadata when detaching objects (#2814 <https://github.com/ros-planning/moveit/issues/2814>)
* [fix] RobotState constructor segfault (#2790 <https://github.com/ros-planning/moveit/issues/2790>)
* Fix compiler selecting the wrong function overload
* more fixes for the clang-tidy job (#2813 <https://github.com/ros-planning/moveit/issues/2813>)
* fix clang-tidy CI job (#2792 <https://github.com/ros-planning/moveit/issues/2792>)
* Fix bullet plugin library path name (#2783 <https://github.com/ros-planning/moveit/issues/2783>)
* Trajectory: Improve docstrings (#2781 <https://github.com/ros-planning/moveit/issues/2781>)
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Fix Windows CI (#2776 <https://github.com/ros-planning/moveit/issues/2776>)
* Fixup devel-space build after #2604 <https://github.com/ros-planning/moveit/issues/2604>
* Cleanup CollisionDetectorAllocatorTemplate::getName()
* RobotTrajectory: add convenience constructor
* Fix windows compilation failures
* CMakeLists.txt and package.xml fixes for cross-platform CI
* Contributors: Abishalini, Akash, AndyZe, Captain Yoshi, Dave Coleman, David V. Lu!!, Felix von Drigalski, Henning Kayser, Jafar Abdi, Jochen Sprickerhof, Kaustubh, Michael Görner, Michael Wiznitzer, Parthasarathy Bana, Peter Mitrano, Robert Haschke, Sencer Yazıcı, Silvio Traversaro, Simon Schmeisser, Tobias Fischer, Tyler Weaver, Vatan Aksoy Tezer, Wolf Vollprecht, Yuri Rocha, predystopic-dev, pvanlaar, toru-kuga, v4hn, werner291
```

## moveit_hybrid_planning

```
* Bump new packages to 2.3.0
* Add codespell to precommit, fix A LOT of spelling mistakes (#934 <https://github.com/ros-planning/moveit2/issues/934>)
* CMake fix and cleanup abstract class (#6 <https://github.com/ros-planning/moveit2/issues/6>)
  * Install hybrid_planning_demo_node separately to avoid exporting it
  * Fix exported include directory
  * Remove getTargetWayPointIndex() from abstract trajectory operator class
  * Delete unused getTargetWayPointIndex()
* Standardize with moveit_cpp parameters. Fix some parameter loading errors
* Enable reaction to planner failure in the planner logic (#3 <https://github.com/ros-planning/moveit2/issues/3>)
  * Add unsuccessful action Hybrid Planning events and handle them in logic
  * Replace std::once with simple bool variable
  * Remove unneeded variable and update comments
  Don't const& for built-in types
  Co-authored-by: Tyler Weaver <tylerjw@gmail.com>
* Update robot state properly
  Update robot state properly; remove debug prints; clang format
  Check if the local planner is stuck within the forward_traj plugin, not local_planner_component
* Pass GlobalPlanner failing to HybridPlanningManager
* Move common launch elements to a Python file, for easy re-use
  Refactor Global and Local Planner Components into NodeClasses
  Add a simple launch test (#1 <https://github.com/ros-planning/moveit2/issues/1>)
  Try to fix plugin export; add helpful debug when stuck
  Error if global planning fails
  READY and AWAIT_TRAJ states are redundant
  Lock the planning scene as briefly as possible
  Specify joint group when checking waypoint distance
  Implement a reset() function in the local planner
  Detect when the local planner gets stuck
* Add generic global planner plugin, support MotionSequenceRequest (#585 <https://github.com/ros-planning/moveit2/issues/585>)
  Fix hybrid planning include folders (#675 <https://github.com/ros-planning/moveit2/issues/675>)
  Order stuff in the CMakeLists.txt and remove control_box package
  Update README
  Move member initialization to initializer lists
  Remove control_box include dependency
  Replace "loop-run" with "iteration"
  Remove cpp interface class constructors and destructors
  Use joint_state_broadcaster, clean up test node, add execution dependencies
  Use only plugin interface header files and add missing dependencies
  Clean up constructor and destructor definitions
  Declare missing parameter in moveit_planning_pipeline_plugin
  Move rclcpp::Loggers into anonymous namespaces
  Switch CI branches to feature/hybrid_planning
  Update message name
  Remove moveit_msgs from .repos file
  Update github workflows
  Remove note from readme about building from source
  Minor renamings, make reset() noexcept
  Check for vector length of zero
  Load moveit_cpp options with the Options helper. Reduces LOC.
  Set the planning parameters within plan()
  Function renaming
  Authors and descriptions in header files only. New header file for error code interface.
  Update namespacing
  Use default QoS for subscribers
  Better progress comparison
  Add publish_joint_positions and publish_joint_velocities param
  Grammar and other minor nitpicks
  Restore moveit_msgs to .repos, for now
* Refactor local planner plugins (#447 <https://github.com/ros-planning/moveit2/issues/447>)
  * Add reset method for trajectory operator and local constraint sampler
  * Refactor next_waypoint_sampler into simple_sampler
  * Include collision checking to forward_trajectory and remove unneeded plugin
  * Fix formatting and plugin description
  * Update README and add missing planner logic plugin description
  Add TODO to use lifecycle components nodes to trigger initialization
  Return a reaction result instead of bool on react()
  Set invalidation flag to false on reset() in ForwardTrajectory local solver
  Return local planner feedback from trajectory operator function calls
  Fix segfault caused by passing through the global trajectory
  Update comment, unify logging and add missing config parameters
  Update to rolling
* Restructure hybrid_planning package (#426 <https://github.com/ros-planning/moveit2/issues/426>)
  * Add forward_trajectory local solver plugin (#359 <https://github.com/ros-planning/moveit2/issues/359>)
  * Use ros2_control based joint simulation and remove unnecessary comment
  * Update copyrights
  * Restructure hybrid planning package
  * Fix formatting and add missing time stamp in local solver plugin
  * Remove unnecessary logging and param loading
  * Enable different interfaces between local planner and controller
  * Use JointGroupPositionController as demo hardware controller
* Code cleanup & MoveIt best practices (#351 <https://github.com/ros-planning/moveit2/issues/351>)
  * Export missing plugins
  * Use std::chrono_literals
  * Construct smart pointers with std::make_* instead of 'new'
  * Fixup const-ref in function signatures, reduce copies
  * Improve planning scene locking, robot state processing, controller logic
* Refine local planner component (#326 <https://github.com/ros-planning/moveit2/issues/326>)
  * Make local planner component generic
  * Add next_waypoint_sampler trajectory operator
  * Update hybrid planning test to include collision object
  * Clean up code and fix minor bugs.
  * Update local planner component parameter
  * Add local collision constraint solver
  * Update planning scene topic name and test node
  * Fix bugs and runtime errors in local planner component and it's plugins
  * Add collision object that invalidates global trajectory
  * Add simple "stop in front of collision object" demo
  * Add hybrid planning manager reaction to local planner feedback
  * Fix ament_lint_cmake
  * Ensure that local planner start command and collision event are send once
  * Add simple replanning logic plugin
  * Use current state as start state for global planner
  * Use RobotTrajectory instead of constraint vector describe local problem
  * Add PlanningSceneMonitorPtr to local solver plugin
  * Add local planner frequency parameter
  * Use PID controller to create control outputs for robot controller
  * Add hybrid_planning_manager config file
  * Add more complex test node
  * Update README
  * Reset index in next_waypoint_sampler
  * Use correct isPathValid() interface
  * Rename path_invalidation flag
  * Read planning scene instead of cloning it in local planner
  * Add TODO creator
  * Rename local constraint solver plugin
  * Use read-locked access to the planning scene for collision checking
  * Rename constraint_solver into local_constraint_solver
  * Add missing pointer initialization
* Hybrid planning architecture (#311 <https://github.com/ros-planning/moveit2/issues/311>)
  * Add hybrid_planning architecture skeleton code
  * Add simple state machines to hybrid planning manager and local planner
  * Initial global planner prototype implementation
  * Forward joint_trajectory with local planner
  * Forward hybrid planning motion request to global planner
  * Abstract planner logic from hybrid planning manager by using a plugin
  * Implement single plan execution logic
  * Add test launch files, RViz and demo config
  * Add test for motion_planning_request
* Contributors: AndyZe, David V. Lu!!, Henning Kayser, Jens Vanhooydonck, Sebastian Jahr
```

## moveit_kinematics

```
* Convert to modern include guard #882 <https://github.com/ros-planning/moveit2/issues/882> (#891 <https://github.com/ros-planning/moveit2/issues/891>)
* Replaced C-Style Cast with C++ Style Cast. (#935 <https://github.com/ros-planning/moveit2/issues/935>)
* Add codespell to precommit, fix A LOT of spelling mistakes (#934 <https://github.com/ros-planning/moveit2/issues/934>)
* Get rid of "std::endl" (#918 <https://github.com/ros-planning/moveit2/issues/918>)
* changed post-increments in loops to preincrements (#888 <https://github.com/ros-planning/moveit2/issues/888>)
* Update README (#812 <https://github.com/ros-planning/moveit2/issues/812>)
* Enforce package.xml format 3 Schema (#779 <https://github.com/ros-planning/moveit2/issues/779>)
* Update Maintainers of MoveIt package (#697 <https://github.com/ros-planning/moveit2/issues/697>)
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Contributors: Dave Coleman, David V. Lu!!, Henning Kayser, Kaustubh, Parthasarathy Bana, Robert Haschke, Sencer Yazıcı, Stephanie Eng, predystopic-dev, pvanlaar
```

## moveit_planners

```
* PILZ: Migrate and Restructure test directory
* Enforce package.xml format 3 Schema (#779 <https://github.com/ros-planning/moveit2/issues/779>)
* Update Maintainers of MoveIt package (#697 <https://github.com/ros-planning/moveit2/issues/697>)
* Contributors: Dave Coleman, Henning Kayser, Robert Haschke, Sebastian Jahr
```

## moveit_planners_chomp

```
* Port CHOMP Motion Planner to ROS 2 (#809 <https://github.com/ros-planning/moveit2/issues/809>)
* Update Maintainers of MoveIt package (#697 <https://github.com/ros-planning/moveit2/issues/697>)
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Contributors: Dave Coleman, Henning Kayser, Robert Haschke, andreas-botbuilt, pvanlaar
```

## moveit_planners_ompl

```
* Add codespell to precommit, fix A LOT of spelling mistakes (#934 <https://github.com/ros-planning/moveit2/issues/934>)
* Get rid of "std::endl" (#918 <https://github.com/ros-planning/moveit2/issues/918>)
* changed post-increments in loops to preincrements (#888 <https://github.com/ros-planning/moveit2/issues/888>)
* Enforce package.xml format 3 Schema (#779 <https://github.com/ros-planning/moveit2/issues/779>)
* Update Maintainers of MoveIt package (#697 <https://github.com/ros-planning/moveit2/issues/697>)
* Reduce log verbosity, improved info message (#714 <https://github.com/ros-planning/moveit2/issues/714>)
* Fix #2811 <https://github.com/ros-planning/moveit/issues/2811> (#2872 <https://github.com/ros-planning/moveit/issues/2872>)
  This is a PR for #2811 <https://github.com/ros-planning/moveit/issues/2811>
* Add missing dependencies to generated dynamic_reconfigure headers
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Contributors: Dave Coleman, David V. Lu!!, Henning Kayser, Mathias Lüdtke, Parthasarathy Bana, Robert Haschke, Sencer Yazıcı, pvanlaar, v4hn, werner291
```

## moveit_plugins

```
* Enforce package.xml format 3 Schema (#779 <https://github.com/ros-planning/moveit2/issues/779>)
* Update Maintainers of MoveIt package (#697 <https://github.com/ros-planning/moveit2/issues/697>)
* Contributors: Dave Coleman, Henning Kayser
```

## moveit_resources_prbt_ikfast_manipulator_plugin

```
* Bump new packages to 2.3.0
* Add PRBT test dependencies for PILZ planner (#909 <https://github.com/ros-planning/moveit2/issues/909>)
  * Adding PRBT config
  * Port prbt packages to ROS 2
  * Move PRBT into test_configs directory
  * Fix pre-commit for pilz test_config
  * Revert "Docker - Temporarily move moveit_resources under target workspace due to #885 <https://github.com/ros-planning/moveit2/issues/885> (#915 <https://github.com/ros-planning/moveit2/issues/915>)"
  * Reset repos file entry for moveit_resources
  * prbt_support: drop all test code
  Co-authored-by: Christian Henkel <mailto:post@henkelchristian.de>
  Co-authored-by: Michael Görner <mailto:me@v4hn.de>
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Contributors: Henning Kayser, Tyler Weaver
* initial commit from upstream PilzDE/pilz_robots version 0.5.19 (2020-09-07)
```

## moveit_resources_prbt_moveit_config

```
* Bump new packages to 2.3.0
* Add PRBT test dependencies for PILZ planner (#909 <https://github.com/ros-planning/moveit2/issues/909>)
  * Adding PRBT config
  * Port prbt packages to ROS 2
  * Move PRBT into test_configs directory
  * Fix pre-commit for pilz test_config
  * Revert "Docker - Temporarily move moveit_resources under target workspace due to #885 <https://github.com/ros-planning/moveit2/issues/885> (#915 <https://github.com/ros-planning/moveit2/issues/915>)"
  * Reset repos file entry for moveit_resources
  * prbt_support: drop all test code
  Co-authored-by: Christian Henkel <mailto:post@henkelchristian.de>
  Co-authored-by: Michael Görner <mailto:me@v4hn.de>
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Contributors: Henning Kayser, Tyler Weaver
* initial commit from upstream PilzDE/prbt_movit_config version 0.5.18
```

## moveit_resources_prbt_pg70_support

```
* Bump new packages to 2.3.0
* Add PRBT test dependencies for PILZ planner (#909 <https://github.com/ros-planning/moveit2/issues/909>)
  * Adding PRBT config
  * Port prbt packages to ROS 2
  * Move PRBT into test_configs directory
  * Fix pre-commit for pilz test_config
  * Revert "Docker - Temporarily move moveit_resources under target workspace due to #885 <https://github.com/ros-planning/moveit2/issues/885> (#915 <https://github.com/ros-planning/moveit2/issues/915>)"
  * Reset repos file entry for moveit_resources
  * prbt_support: drop all test code
  Co-authored-by: Christian Henkel <mailto:post@henkelchristian.de>
  Co-authored-by: Michael Görner <mailto:me@v4hn.de>
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Contributors: Henning Kayser, Tyler Weaver
* initial commit from upstream PilzDE/prbt_grippers version 0.0.4
```

## moveit_resources_prbt_support

```
* Bump new packages to 2.3.0
* Add PRBT test dependencies for PILZ planner (#909 <https://github.com/ros-planning/moveit2/issues/909>)
  * Adding PRBT config
  * Port prbt packages to ROS 2
  * Move PRBT into test_configs directory
  * Fix pre-commit for pilz test_config
  * Revert "Docker - Temporarily move moveit_resources under target workspace due to #885 <https://github.com/ros-planning/moveit2/issues/885> (#915 <https://github.com/ros-planning/moveit2/issues/915>)"
  * Reset repos file entry for moveit_resources
  * prbt_support: drop all test code
  Co-authored-by: Christian Henkel <mailto:post@henkelchristian.de>
  Co-authored-by: Michael Görner <mailto:me@v4hn.de>
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Contributors: Henning Kayser, Tyler Weaver
* initial commit from upstream PilzDE/pilz_robots version 0.5.19 (2020-09-07)
```

## moveit_ros

```
* Enforce package.xml format 3 Schema (#779 <https://github.com/ros-planning/moveit2/issues/779>)
* Update Maintainers of MoveIt package (#697 <https://github.com/ros-planning/moveit2/issues/697>)
* Contributors: Dave Coleman, Henning Kayser
```

## moveit_ros_benchmarks

```
* Replaced C-Style Cast with C++ Style Cast. (#935 <https://github.com/ros-planning/moveit2/issues/935>)
* Add codespell to precommit, fix A LOT of spelling mistakes (#934 <https://github.com/ros-planning/moveit2/issues/934>)
* Get rid of "std::endl" (#918 <https://github.com/ros-planning/moveit2/issues/918>)
* Enforce package.xml format 3 Schema (#779 <https://github.com/ros-planning/moveit2/issues/779>)
* Update Maintainers of MoveIt package (#697 <https://github.com/ros-planning/moveit2/issues/697>)
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Contributors: Dave Coleman, David V. Lu!!, Henning Kayser, Kaustubh, Parthasarathy Bana, Robert Haschke, pvanlaar
```

## moveit_ros_control_interface

```
* Fix installation of moveit_ros_control_interface header files (#789 <https://github.com/ros-planning/moveit2/issues/789>)
* Enforce package.xml format 3 Schema (#779 <https://github.com/ros-planning/moveit2/issues/779>)
* Update Maintainers of MoveIt package (#697 <https://github.com/ros-planning/moveit2/issues/697>)
* Update controller_manager_plugin to fix MoveIt-managed controller switching (#785 <https://github.com/ros-planning/moveit2/issues/785>)
* moveit_ros_control_interface: Small comment cleanup (#754 <https://github.com/ros-planning/moveit2/issues/754>)
* Contributors: AndyZe, Dave Coleman, Henning Kayser, Joseph Schornak, Robert Haschke
```

## moveit_ros_move_group

```
* Add codespell to precommit, fix A LOT of spelling mistakes (#934 <https://github.com/ros-planning/moveit2/issues/934>)
* Get rid of "std::endl" (#918 <https://github.com/ros-planning/moveit2/issues/918>)
* Consider simulated time (#883 <https://github.com/ros-planning/moveit2/issues/883>)
* Enforce package.xml format 3 Schema (#779 <https://github.com/ros-planning/moveit2/issues/779>)
* Update Maintainers of MoveIt package (#697 <https://github.com/ros-planning/moveit2/issues/697>)
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Contributors: Dave Coleman, David V. Lu!!, Felix von Drigalski, Gaël Écorchard, Henning Kayser, Parthasarathy Bana, Robert Haschke, pvanlaar
```

## moveit_ros_occupancy_map_monitor

```
* Replaced C-Style Cast with C++ Style Cast. (#935 <https://github.com/ros-planning/moveit2/issues/935>)
* Add codespell to precommit, fix A LOT of spelling mistakes (#934 <https://github.com/ros-planning/moveit2/issues/934>)
* Get rid of "std::endl" (#918 <https://github.com/ros-planning/moveit2/issues/918>)
* Fix boost linking errors (#900 <https://github.com/ros-planning/moveit2/issues/900>)
* Enforce package.xml format 3 Schema (#779 <https://github.com/ros-planning/moveit2/issues/779>)
* Update Maintainers of MoveIt package (#697 <https://github.com/ros-planning/moveit2/issues/697>)
* Prefer std::make_shared over new operator (#2756 <https://github.com/ros-planning/moveit/issues/2756>)
* Contributors: Dave Coleman, David V. Lu!!, Henning Kayser, Kaustubh, Michael Görner, Parthasarathy Bana, Robert Haschke, Vatan Aksoy Tezer
```

## moveit_ros_perception

```
* Replaced C-Style Cast with C++ Style Cast. (#935 <https://github.com/ros-planning/moveit2/issues/935>)
* Add codespell to precommit, fix A LOT of spelling mistakes (#934 <https://github.com/ros-planning/moveit2/issues/934>)
* Enforce package.xml format 3 Schema (#779 <https://github.com/ros-planning/moveit2/issues/779>)
* Update Maintainers of MoveIt package (#697 <https://github.com/ros-planning/moveit2/issues/697>)
* clipped points should only be considered up to the max_range (#2848 <https://github.com/ros-planning/moveit/issues/2848>)
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Contributors: Dave Coleman, David V. Lu!!, Henning Kayser, Kaustubh, Michael Görner, Robert Haschke, pvanlaar
```

## moveit_ros_planning

```
* Replaced C-Style Cast with C++ Style Cast. (#935 <https://github.com/ros-planning/moveit2/issues/935>)
* Add codespell to precommit, fix A LOT of spelling mistakes (#934 <https://github.com/ros-planning/moveit2/issues/934>)
* Get rid of "std::endl" (#918 <https://github.com/ros-planning/moveit2/issues/918>)
* changed post-increments in loops to preincrements (#888 <https://github.com/ros-planning/moveit2/issues/888>)
* Latched Strings for URDF and SRDF (#765 <https://github.com/ros-planning/moveit2/issues/765>)
* Consider simulated time (#883 <https://github.com/ros-planning/moveit2/issues/883>)
* Make controller management logic more tolerant of missing or late ros2_control nodes (#792 <https://github.com/ros-planning/moveit2/issues/792>)
* Enforce package.xml format 3 Schema (#779 <https://github.com/ros-planning/moveit2/issues/779>)
* Update Maintainers of MoveIt package (#697 <https://github.com/ros-planning/moveit2/issues/697>)
* Tests for TrajectoryMonitor using dependency injection (#570 <https://github.com/ros-planning/moveit2/issues/570>)
* Update controller_manager_plugin to fix MoveIt-managed controller switching (#785 <https://github.com/ros-planning/moveit2/issues/785>)
* MoveitCpp - path constraints added from PlanningComponent (backport #752 <https://github.com/ros-planning/moveit2/issues/752>) (#781 <https://github.com/ros-planning/moveit2/issues/781>)
* Split CollisionPluginLoader (#2834 <https://github.com/ros-planning/moveit/issues/2834>)
* Bugfix in RDFLoader (#2806 <https://github.com/ros-planning/moveit/issues/2806>)
* Fix obvious typo (#2787 <https://github.com/ros-planning/moveit/issues/2787>)
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Contributors: Abishalini Sivaraman, Dave Coleman, David V. Lu!!, Felix von Drigalski, Gaël Écorchard, Henning Kayser, Joseph Schornak, Kaustubh, Mathias Lüdtke, Michael Görner, Parthasarathy Bana, Robert Haschke, Sencer Yazıcı, pvanlaar, werner291
```

## moveit_ros_planning_interface

```
* Add codespell to precommit, fix A LOT of spelling mistakes (#934 <https://github.com/ros-planning/moveit2/issues/934>)
* Consider simulated time (#883 <https://github.com/ros-planning/moveit2/issues/883>)
* Enforce package.xml format 3 Schema (#779 <https://github.com/ros-planning/moveit2/issues/779>)
* Update Maintainers of MoveIt package (#697 <https://github.com/ros-planning/moveit2/issues/697>)
* Find/replace deprecated spawner.py (#737 <https://github.com/ros-planning/moveit2/issues/737>)
* common_objects: getSharedRobotModelLoader fix deadlock (#734 <https://github.com/ros-planning/moveit2/issues/734>)
* fix trajectory constraints for moveit commander (#2429 <https://github.com/ros-planning/moveit/issues/2429>)
* MGI::setStartState: Only fetch current state when new state is diff (#2775 <https://github.com/ros-planning/moveit/issues/2775>)
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Contributors: AndyZe, Dave Coleman, David V. Lu!!, Felix von Drigalski, Gaël Écorchard, Henning Kayser, Jafar Abdi, Kevin Chang, Robert Haschke, pvanlaar
```

## moveit_ros_robot_interaction

```
* Add codespell to precommit, fix A LOT of spelling mistakes (#934 <https://github.com/ros-planning/moveit2/issues/934>)
* changed post-increments in loops to preincrements (#888 <https://github.com/ros-planning/moveit2/issues/888>)
* Enforce package.xml format 3 Schema (#779 <https://github.com/ros-planning/moveit2/issues/779>)
* Update Maintainers of MoveIt package (#697 <https://github.com/ros-planning/moveit2/issues/697>)
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Contributors: Dave Coleman, David V. Lu!!, Henning Kayser, Robert Haschke, Sencer Yazıcı, pvanlaar
```

## moveit_ros_visualization

```
* Convert to modern include guard #882 <https://github.com/ros-planning/moveit2/issues/882> (#891 <https://github.com/ros-planning/moveit2/issues/891>)
* Replaced C-Style Cast with C++ Style Cast. (#935 <https://github.com/ros-planning/moveit2/issues/935>)
* Add codespell to precommit, fix A LOT of spelling mistakes (#934 <https://github.com/ros-planning/moveit2/issues/934>)
* Get rid of "std::endl" (#918 <https://github.com/ros-planning/moveit2/issues/918>)
* changed post-increments in loops to preincrements (#888 <https://github.com/ros-planning/moveit2/issues/888>)
* Latched Strings for URDF and SRDF (#765 <https://github.com/ros-planning/moveit2/issues/765>)
* Consider simulated time (#883 <https://github.com/ros-planning/moveit2/issues/883>)
* Enforce package.xml format 3 Schema (#779 <https://github.com/ros-planning/moveit2/issues/779>)
* Update Maintainers of MoveIt package (#697 <https://github.com/ros-planning/moveit2/issues/697>)
* Reduce log verbosity, improved info message (#714 <https://github.com/ros-planning/moveit2/issues/714>)
* Fix Python2: convert keys() into list (#2862 <https://github.com/ros-planning/moveit/issues/2862>)
* MP panel: fix order of input widgets for shape size (#2847 <https://github.com/ros-planning/moveit/issues/2847>)
* Makes rviz trajectory visualization topic relative (#2835 <https://github.com/ros-planning/moveit/issues/2835>)
* MotionPlanningFrame: Gracefully handle undefined parent widget (#2833 <https://github.com/ros-planning/moveit/issues/2833>)
* more fixes for the clang-tidy job (#2813 <https://github.com/ros-planning/moveit/issues/2813>)
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Contributors: Dave Coleman, David V. Lu!!, Felix von Drigalski, Gaël Écorchard, Henning Kayser, Kaustubh, Michael Görner, Parthasarathy Bana, Rick Staa, Robert Haschke, Sencer Yazıcı, Yuri Rocha, lorepieri8, predystopic-dev, pvanlaar
```

## moveit_ros_warehouse

```
* Replaced C-Style Cast with C++ Style Cast. (#935 <https://github.com/ros-planning/moveit2/issues/935>)
* Get rid of "std::endl" (#918 <https://github.com/ros-planning/moveit2/issues/918>)
* Enforce package.xml format 3 Schema (#779 <https://github.com/ros-planning/moveit2/issues/779>)
* Update Maintainers of MoveIt package (#697 <https://github.com/ros-planning/moveit2/issues/697>)
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Contributors: Dave Coleman, Henning Kayser, Kaustubh, Parthasarathy Bana, Robert Haschke, pvanlaar
```

## moveit_runtime

```
* Enforce package.xml format 3 Schema (#779 <https://github.com/ros-planning/moveit2/issues/779>)
* Update Maintainers of MoveIt package (#697 <https://github.com/ros-planning/moveit2/issues/697>)
* Contributors: Dave Coleman, Henning Kayser
```

## moveit_servo

```
* Servo: fix -Wunused-private-field (#937 <https://github.com/ros-planning/moveit2/issues/937>)
* Add codespell to precommit, fix A LOT of spelling mistakes (#934 <https://github.com/ros-planning/moveit2/issues/934>)
* Add descriptions and default values to servo parameters (#799 <https://github.com/ros-planning/moveit2/issues/799>)
* Update README (#812 <https://github.com/ros-planning/moveit2/issues/812>)
* Enforce package.xml format 3 Schema (#779 <https://github.com/ros-planning/moveit2/issues/779>)
* Update Maintainers of MoveIt package (#697 <https://github.com/ros-planning/moveit2/issues/697>)
* moveit_servo: Fix ACM for collision checking & PSM's scene monitor topic (#673 <https://github.com/ros-planning/moveit2/issues/673>)
* Fix initialization of PSM publisher in servo (#771 <https://github.com/ros-planning/moveit2/issues/771>)
* Move initialization of ServoNode into constructor (#761 <https://github.com/ros-planning/moveit2/issues/761>)
* Fix missing test depend in servo (#759 <https://github.com/ros-planning/moveit2/issues/759>)
* Find/replace deprecated spawner.py (#737 <https://github.com/ros-planning/moveit2/issues/737>)
* Fix the servo executable name (#746 <https://github.com/ros-planning/moveit2/issues/746>)
* Use rclcpp::SystemDefaultsQoS in Servo (#721 <https://github.com/ros-planning/moveit2/issues/721>)
* Use multi-threaded component container, do not use intraprocess comms in Servo (#723 <https://github.com/ros-planning/moveit2/issues/723>)
* Disable use_intra_process_comms in servo launch files (#722 <https://github.com/ros-planning/moveit2/issues/722>)
* Servo: minor fixups (#2759 <https://github.com/ros-planning/moveit/issues/2759>)
* Contributors: AndyZe, Dave Coleman, David V. Lu!!, Henning Kayser, Jafar Abdi, Robert Haschke, Stephanie Eng, Tyler Weaver, toru-kuga
```

## moveit_setup_assistant

```
* Replaced C-Style Cast with C++ Style Cast. (#935 <https://github.com/ros-planning/moveit2/issues/935>)
* Add codespell to precommit, fix A LOT of spelling mistakes (#934 <https://github.com/ros-planning/moveit2/issues/934>)
* Get rid of "std::endl" (#918 <https://github.com/ros-planning/moveit2/issues/918>)
* changed post-increments in loops to preincrements (#888 <https://github.com/ros-planning/moveit2/issues/888>)
* Update README (#812 <https://github.com/ros-planning/moveit2/issues/812>)
* Enforce package.xml format 3 Schema (#779 <https://github.com/ros-planning/moveit2/issues/779>)
* Update Maintainers of MoveIt package (#697 <https://github.com/ros-planning/moveit2/issues/697>)
* Ported the collision updater from ros1 to ros2 in the moveit_setup_assistant (#732 <https://github.com/ros-planning/moveit2/issues/732>)
* Adds jiggle fraction arg to trajopt template (#2858 <https://github.com/ros-planning/moveit/issues/2858>)
* Fixes _planning_pipeline.launch template input args defaults (#2849 <https://github.com/ros-planning/moveit/issues/2849>)
* Fixes setup_assistant custom planner ns problem (#2842 <https://github.com/ros-planning/moveit/issues/2842>)
* MSA: Mention optional Gazebo deps in package.xml templates (#2839 <https://github.com/ros-planning/moveit/issues/2839>)
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
  Co-authored-by: Robert Haschke <mailto:rhaschke@techfak.uni-bielefeld.de>
* Revert $(dirname) use for rviz config file
  ... due to this bug: https://github.com/ros/ros_comm/issues/1487
  This partially reverts 442c3202a4124877afbb6e2bdee682c537f25553
* Fix MSA templates (#2769 <https://github.com/ros-planning/moveit/issues/2769>)
  * create static_transform_publisher for each virtual joint type
  * another $(dirname)
  augmenting #2748 <https://github.com/ros-planning/moveit/issues/2748>
  * formatting
* Contributors: Brennand Pierce, Dave Coleman, David V. Lu!!, Henning Kayser, Kaustubh, Parthasarathy Bana, Rick Staa, Robert Haschke, Sencer Yazıcı, Stephanie Eng, pvanlaar
```

## moveit_simple_controller_manager

```
* Add codespell to precommit, fix A LOT of spelling mistakes (#934 <https://github.com/ros-planning/moveit2/issues/934>)
* Make controller management logic more tolerant of missing or late ros2_control nodes (#792 <https://github.com/ros-planning/moveit2/issues/792>)
* Clang-tidy fixes (#596 <https://github.com/ros-planning/moveit2/issues/596>)
* Enforce package.xml format 3 Schema (#779 <https://github.com/ros-planning/moveit2/issues/779>)
* Update Maintainers of MoveIt package (#697 <https://github.com/ros-planning/moveit2/issues/697>)
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* controller manager: enclose name in quotes (#2761 <https://github.com/ros-planning/moveit/issues/2761>)
* Contributors: Dave Coleman, David V. Lu!!, G.A. vd. Hoorn, Henning Kayser, Joseph Schornak, Robert Haschke, pvanlaar
```

## pilz_industrial_motion_planner

```
* Convert to modern include guard #882 <https://github.com/ros-planning/moveit2/issues/882> (#891 <https://github.com/ros-planning/moveit2/issues/891>)
* Add codespell to precommit, fix A LOT of spelling mistakes (#934 <https://github.com/ros-planning/moveit2/issues/934>)
* Get rid of "std::endl" (#918 <https://github.com/ros-planning/moveit2/issues/918>)
* changed post-increments in loops to preincrements (#888 <https://github.com/ros-planning/moveit2/issues/888>)
* Consider simulated time (#883 <https://github.com/ros-planning/moveit2/issues/883>)
* Use CallbackGroup for MoveGroupSequenceAction
* PILZ: Build fixups, silence warnings, fix unit tests
* PILZ: Migrate and Restructure test directory
* PILZ: Migrate planner and testutils packages to ROS 2
* Enforce package.xml format 3 Schema (#779 <https://github.com/ros-planning/moveit2/issues/779>)
* Consider attached bodies in Pilz planner #2773 <https://github.com/ros-planning/moveit/issues/2773> (#2824 <https://github.com/ros-planning/moveit/issues/2824>)
  - Remove convertToRobotTrajectory() and integrate its line of code into setSuccessResponse()
  - Pass the final start_state into setSuccessResponse()
* Fix Pilz planner's collision detection (#2803 <https://github.com/ros-planning/moveit/issues/2803>)
  We need to pass the current PlanningScene down to the actual collision checking methods
* Add planning_pipeline_id to MotionSequence service (#2755 <https://github.com/ros-planning/moveit/issues/2755>)
  * Add planning_pipeline_id to MotionSequence action and service
  * check for empty request
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Improve readability of comment
* Contributors: David V. Lu!!, Felix von Drigalski, Gaël Écorchard, Henning Kayser, Parthasarathy Bana, Robert Haschke, Sebastian Jahr, Sencer Yazıcı, aa-tom, cambel, predystopic-dev, pvanlaar
* [feature] Add Pilz industrial motion planner (#1893 <https://github.com/tylerjw/moveit/issues/1893>)
* Contributors: Pilz GmbH and Co. KG, Christian Henkel, Immanuel Martini, Joachim Schleicher, rfeistenauer
```

## pilz_industrial_motion_planner_testutils

```
* Convert to modern include guard #882 <https://github.com/ros-planning/moveit2/issues/882> (#891 <https://github.com/ros-planning/moveit2/issues/891>)
* Add codespell to precommit, fix A LOT of spelling mistakes (#934 <https://github.com/ros-planning/moveit2/issues/934>)
* PILZ: Build fixups, silence warnings, fix unit tests
* PILZ: Migrate and Restructure test directory
* PILZ: Migrate planner and testutils packages to ROS 2
* Enforce package.xml format 3 Schema (#779 <https://github.com/ros-planning/moveit2/issues/779>)
* clang-tidy: modernize-make-shared, modernize-make-unique (#2762 <https://github.com/ros-planning/moveit/issues/2762>)
* Contributors: David V. Lu!!, Henning Kayser, Robert Haschke, Sebastian Jahr, predystopic-dev, pvanlaar, Pilz GmbH and Co. KG, Christian Henkel, Immanuel Martini, Joachim Schleicher, rfeistenauer
```
