### PR TITLE
openvslam: 0.2.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2476,7 +2476,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/OpenVSLAM-Community/openvslam-release.git
-      version: 0.2.2-1
+      version: 0.2.4-1
     source:
       type: git
       url: https://github.com/OpenVSLAM-Community/openvslam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openvslam` to `0.2.4-1`:

- upstream repository: https://github.com/OpenVSLAM-Community/openvslam.git
- release repository: https://github.com/OpenVSLAM-Community/openvslam-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.2.2-1`
