### PR TITLE
openvslam: 0.2.4-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2150,7 +2150,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/OpenVSLAM-Community/openvslam-release.git
-      version: 0.2.3-3
+      version: 0.2.4-1
     source:
       type: git
       url: https://github.com/OpenVSLAM-Community/openvslam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openvslam` to `0.2.4-1`:

- upstream repository: https://github.com/OpenVSLAM-Community/openvslam.git
- release repository: https://github.com/OpenVSLAM-Community/openvslam-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.3-3`
