### PR TITLE
visp: 3.4.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4672,6 +4672,21 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: ros2
     status: maintained
+  visp:
+    doc:
+      type: git
+      url: https://github.com/lagadic/visp.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/lagadic/visp-release.git
+      version: 3.4.0-2
+    source:
+      type: git
+      url: https://github.com/lagadic/visp.git
+      version: master
+    status: maintained
   warehouse_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `visp` to `3.4.0-2`:

- upstream repository: https://github.com/lagadic/visp.git
- release repository: https://github.com/lagadic/visp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
