### PR TITLE
rtabmap_ros: 0.20.16-1 in 'melodic/distribution.yaml'

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12269,7 +12269,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.20.14-1
+      version: 0.20.16-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -12284,7 +12284,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.20.14-1
+      version: 0.20.16-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap_ros` to `0.20.16-1`:

- upstream repository: https://github.com/introlab/rtabmap_ros.git
- release repository: https://github.com/introlab/rtabmap_ros-release.git
- distro file: `melodic/distribution.yaml`
- previous version for package: `0.20.14-1`