### PR TITLE
rtabmap_ros: 0.20.16-2 in 'galactic/distribution.yaml'

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4208,7 +4208,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.20.15-1
+      version: 0.20.16-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -4223,7 +4223,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.20.15-2
+      version: 0.20.16-2
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap_ros` to `0.20.16-2`:

- upstream repository: https://github.com/introlab/rtabmap_ros.git
- release repository: https://github.com/introlab/rtabmap_ros-release.git
- distro file: `galactic/distribution.yaml`
- previous version for package: `0.20.15-2`
