### PR TITLE
velodyne_simulator: 2.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5973,7 +5973,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne_simulator` to `2.0.2-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
- release repository: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.1-1`

## velodyne_description

```
* Adds tf_prefix SDF parameter
* Contributors: Micho Radovnikovich
```

## velodyne_gazebo_plugins

```
* Adds tf_prefix SDF parameter
* Contributors: Micho Radovnikovich
```

## velodyne_simulator

- No changes
