### PR TITLE
velodyne_simulator: 2.0.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5125,6 +5125,25 @@ repositories:
       url: https://github.com/ros-drivers/velodyne.git
       version: ros2
     status: developed
+  velodyne_simulator:
+    doc:
+      type: git
+      url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
+      version: foxy-devel
+    release:
+      packages:
+      - velodyne_description
+      - velodyne_gazebo_plugins
+      - velodyne_simulator
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
+      version: 2.0.2-1
+    source:
+      type: git
+      url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
+      version: foxy-devel
+    status: maintained
   vision_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne_simulator` to `2.0.2-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
- release repository: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## velodyne_description

```
* Adds tf_prefix SDF parameter
* Contributors: Micho Radovnikovich
```

## velodyne_gazebo_plugins

```
* Adds tf_prefix SDF parameter
* Contributors: Micho Radovnikovich
```

## velodyne_simulator

- No changes
