### PR TITLE
Temporarily redefine some keys for Xenial.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6055,6 +6055,7 @@ mongodb:
   ubuntu:
     bionic: [mongodb]
     focal: [mongodb]
+    xenial: [mongodb]
 mongodb-dev:
   debian: [libmongoclient-dev]
   gentoo: [dev-db/mongodb]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1348,6 +1348,7 @@ python-cvxopt:
   ubuntu:
     '*': null
     bionic: [python-cvxopt]
+    xenial: [python-cvxopt]
 python-cvxpy-pip: &migrate_eol_2025_04_30_python3_cvxpy_pip
   debian:
     pip:
@@ -2626,6 +2627,7 @@ python-lxml:
   ubuntu:
     bionic: [python-lxml]
     focal: [python-lxml]
+    xenial: [python-lxml]
 python-lzf-pip:
   debian:
     pip:
@@ -2987,6 +2989,7 @@ python-numpy:
   ubuntu:
     bionic: [python-numpy]
     focal: [python-numpy]
+    xenial: [python-numpy]
 python-numpy-quaternion-pip:
   debian:
     pip:


### PR DESCRIPTION
Ubuntu Xenial is no longer a supported platform for rosdep.
While we work with the community to define a recommended path for
continuing to use it outside of official support definitions for these
keys are being re-introduced.

It should be noted that these changes do not meet our usual review guidelines as they are targeted at unsupported platforms. In offline discussion with @cottsay we concluded that moving forward will be easier if the community members who reported the impact of these changes on their work were not still trying to juggle various options while we worked.