### PR TITLE
Add RHEL 8 rule for lcov

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2115,8 +2115,7 @@ lcov:
   nixos: [lcov]
   openembedded: [lcov@meta-oe]
   opensuse: [lcov]
-  rhel:
-    '7': [lcov]
+  rhel: [lcov]
   ubuntu: [lcov]
 leveldb:
   debian: [libleveldb-dev]


### PR DESCRIPTION
This package recently became available for RHEL 8 via EPEL: https://src.fedoraproject.org/rpms/lcov#bodhi_updates
https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2021-ff8fed6ebc