### PR TITLE
Add Fedora and RHEL rules for nlohmann-json-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6209,9 +6209,11 @@ nlohmann-json-dev:
     jessie: null
     sid: [nlohmann-json3-dev]
     stretch: [nlohmann-json-dev]
+  fedora: [json-devel]
   gentoo: [dev-cpp/nlohmann_json]
   nixos: [nlohmann_json]
   openembedded: [nlohmann-json@meta-oe]
+  rhel: [json-devel]
   ubuntu:
     bionic: [nlohmann-json-dev]
     focal: [nlohmann-json3-dev]


### PR DESCRIPTION
This package is available for RHEL 7 and 8 via EPEL, and provides the same CMake, pkgconfig, headers, and libraries as `nlohmann-json-dev`.
https://src.fedoraproject.org/rpms/json#bodhi_updates