### PR TITLE
grepros: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2778,6 +2778,21 @@ repositories:
       url: https://github.com/mikeferguson/grasping_msgs.git
       version: ros1
     status: maintained
+  grepros:
+    doc:
+      type: git
+      url: https://github.com/suurjaak/grepros.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/suurjaak/grepros-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/suurjaak/grepros.git
+      version: master
+    status: developed
   grid_map:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `grepros` to `0.4.0-1`:

- upstream repository: https://github.com/suurjaak/grepros.git
- release repository: https://github.com/suurjaak/grepros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## grepros

```
* add --plugin grepros.plugins.parquet (Parquet output)
* add --plugin grepros.plugins.sql (SQL schema output)
* add --plugin grepros.plugins.embag (faster ROS1 bag reader)
* add --reindex-if-unindexed option
* add --every-nth-match option
* add --every-nth-message option
* add --every-nth-interval option
* allow multiple write sinks, combine --write-format and --write-option to --write
* refactor plugins interface
* populate topics.offered_qos_profiles in ROS2 bag output where possible
* fix progress bar afterword not updating when grepping multiple bags
* fix error on empty bag with no messages
* fix error in Postgres output for NaNs in nested JSON values
* fix skipping some messages in ROS1 bag for types with identical hashes
* fix not being able to specify list arguments several times
* ensure no conflicts from changed message types or identical type hashes
* add tests
```
