### PR TITLE
leo_robot: 2.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3847,7 +3847,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_robot-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_robot` to `2.0.1-1`:

- upstream repository: https://github.com/LeoRover/leo_robot.git
- release repository: https://github.com/fictionlab-gbp/leo_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-1`

## leo_bringup

```
* Change imu frame_id to imu_frame
```

## leo_fw

```
* Update leocore firmware to version 1.0.1
* Change the new board name to LeoCore (codename leocore)
* Make the flashing scripts work when run under ROS namespace
```

## leo_robot

- No changes
