### PR TITLE
Add Pip Installation Option for Networkx

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6948,13 +6948,13 @@ python3-networkx:
 python3-networkx-pip:
   debian:
     pip:
-      packages: [python3-networkx]
+      packages: [networkx]
   fedora:
     pip:
-      packages: [python3-networkx]
+      packages: [networkx]
   ubuntu:
     pip:
-      packages: [python3-networkx]
+      packages: [networkx]
 python3-nose:
   debian: [python3-nose]
   fedora: [python3-nose]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6945,6 +6945,17 @@ python3-networkx:
   fedora: [python3-networkx]
   nixos: [python3Packages.networkx]
   ubuntu: [python3-networkx]
+python3-networkx-pip:
+  debian: 
+    pip:
+      packages: [python3-networkx]
+  fedora:
+    pip:
+      packages: [python3-networkx]
+  ubuntu:     
+    pip:
+      packages: [python3-networkx]
+
 python3-nose:
   debian: [python3-nose]
   fedora: [python3-nose]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6955,7 +6955,6 @@ python3-networkx-pip:
   ubuntu:     
     pip:
       packages: [python3-networkx]
-
 python3-nose:
   debian: [python3-nose]
   fedora: [python3-nose]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6946,13 +6946,13 @@ python3-networkx:
   nixos: [python3Packages.networkx]
   ubuntu: [python3-networkx]
 python3-networkx-pip:
-  debian: 
+  debian:
     pip:
       packages: [python3-networkx]
   fedora:
     pip:
       packages: [python3-networkx]
-  ubuntu:     
+  ubuntu:
     pip:
       packages: [python3-networkx]
 python3-nose:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

networkx

## Package Upstream Source:

https://pypi.org/project/networkx/

## Purpose of using this:

Debians are older than what is available via pip, so some users may want access to later versions.