### PR TITLE
Update python-googleapi Version

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -157,6 +157,16 @@ exhale-pip:
   ubuntu:
     pip:
       packages: [exhale]
+google-api-python-client-pip:
+  debian:
+    pip:
+      packages: [google-api-python-client]
+  fedora:
+    pip:
+      packages: [google-api-python-client]
+  ubuntu:
+    pip:
+      packages: [google-api-python-client]
 gunicorn:
   debian: [gunicorn]
   fedora: [python-gunicorn]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -157,16 +157,6 @@ exhale-pip:
   ubuntu:
     pip:
       packages: [exhale]
-google-api-python-client-pip:
-  debian:
-    pip:
-      packages: [google-api-python-client]
-  fedora:
-    pip:
-      packages: [google-api-python-client]
-  ubuntu:
-    pip:
-      packages: [google-api-python-client]
 gunicorn:
   debian: [gunicorn]
   fedora: [python-gunicorn]
@@ -1997,14 +1987,7 @@ python-googleapi:
   debian: [python-googleapi]
   fedora: [google-api-python-client]
   gentoo: [dev-python/google-api-python-client]
-  ubuntu:
-    trusty: [python-googleapi]
-    utopic: [python-googleapi]
-    vivid: [python-googleapi]
-    wily: [python-googleapi]
-    wily_python3: [python3-googleapi]
-    xenial: [python-googleapi]
-    xenial_python3: [python3-googleapi]
+  ubuntu: [python3-googleapi]
 python-gpiozero:
   debian:
     buster: [python-gpiozero]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1987,7 +1987,16 @@ python-googleapi:
   debian: [python-googleapi]
   fedora: [google-api-python-client]
   gentoo: [dev-python/google-api-python-client]
-  ubuntu: [python3-googleapi]
+  ubuntu:
+    bionic: [python3-googleapi]
+    focal: [python3-googleapi]
+    trusty: [python-googleapi]
+    utopic: [python-googleapi]
+    vivid: [python-googleapi]
+    wily: [python-googleapi]
+    wily_python3: [python3-googleapi]
+    xenial: [python-googleapi]
+    xenial_python3: [python3-googleapi]
 python-gpiozero:
   debian:
     buster: [python-gpiozero]


### PR DESCRIPTION
Adding support for python3-googleapi for bionic and focal ubuntu releases 