### PR TITLE
Add python3-googleapi Rule

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6617,6 +6617,7 @@ python3-google-cloud-storage-pip: *migrate_eol_2025_04_30_python3_google_cloud_s
 python3-google-cloud-texttospeech-pip: *migrate_eol_2025_04_30_python3_google_cloud_texttospeech_pip
 python3-googleapi:
   debian: [python3-googleapi]
+  fedora: [python3-google-api-client]
   gentoo: [dev-python/google-api-python-client]
   ubuntu: [python3-googleapi]
 python3-gpiozero:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2044,11 +2044,6 @@ python-googleapi:
     vivid: [python-googleapi]
     wily: [python-googleapi]
     xenial: [python-googleapi]
-python3-googleapi:
-  debian: [python3-googleapi]
-  fedora: [google-api-python-client]
-  gentoo: [dev-python/google-api-python-client]
-  ubuntu: [python3-googleapi]
 python-gpiozero:
   debian:
     buster: [python-gpiozero]
@@ -6622,6 +6617,8 @@ python3-google-cloud-storage-pip: *migrate_eol_2025_04_30_python3_google_cloud_s
 python3-google-cloud-texttospeech-pip: *migrate_eol_2025_04_30_python3_google_cloud_texttospeech_pip
 python3-googleapi:
   debian: [python3-googleapi]
+  fedora: [google-api-python-client]
+  gentoo: [dev-python/google-api-python-client]
   ubuntu: [python3-googleapi]
 python3-gpiozero:
   debian: [python3-gpiozero]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1992,9 +1992,7 @@ python-googleapi:
     utopic: [python-googleapi]
     vivid: [python-googleapi]
     wily: [python-googleapi]
-    wily_python3: [python3-googleapi]
     xenial: [python-googleapi]
-    xenial_python3: [python3-googleapi]
 python3-googleapi:
   debian: [python3-googleapi]
   fedora: [google-api-python-client]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1995,6 +1995,11 @@ python-googleapi:
     wily_python3: [python3-googleapi]
     xenial: [python-googleapi]
     xenial_python3: [python3-googleapi]
+python3-googleapi:
+  debian: [python3-googleapi]
+  fedora: [google-api-python-client]
+  gentoo: [dev-python/google-api-python-client]
+  ubuntu: [python3-googleapi]
 python-gpiozero:
   debian:
     buster: [python-gpiozero]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6617,7 +6617,6 @@ python3-google-cloud-storage-pip: *migrate_eol_2025_04_30_python3_google_cloud_s
 python3-google-cloud-texttospeech-pip: *migrate_eol_2025_04_30_python3_google_cloud_texttospeech_pip
 python3-googleapi:
   debian: [python3-googleapi]
-  fedora: [google-api-python-client]
   gentoo: [dev-python/google-api-python-client]
   ubuntu: [python3-googleapi]
 python3-gpiozero:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-googleapi

## Package Upstream Source:

https://src.fedoraproject.org/rpms/google-api-python-client
https://packages.debian.org/bullseye/python3-googleapi
https://packages.ubuntu.com/focal/python3-googleapi
https://packages.gentoo.org/packages/dev-python/google-api-python-client

## Purpose of using this:

Python3 version is the standard library now for this package