### PR TITLE
Add pip Installation for fastapi and uvicorn

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8747,6 +8747,20 @@ yapf:
     yakkety:
       pip:
         packages: [yapf]
+univorn-pip:
+  debian:
+    pip:
+      packages: [uvicorn]
+  ubuntu:
+    pip:
+      packages: [uvicorn]
+fastapi-pip:
+  debian:
+    pip:
+      packages: [fastapi]
+  ubuntu:
+    pip:
+      packages: [fastapi]
 yapf3:
   debian: [yapf3]
   fedora: [python3-yapf]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6390,9 +6390,20 @@ python3-falcon:
   ubuntu: [python3-falcon]
 python3-fastapi:
   arch: [python-fastapi]
-  debian: [python3-fastapi]
+  debian:
+    '*': [python3-fastapi]
+    buster:
+      pip:
+        packages: [fastapi]
   fedora: [python-fastapi]
-  ubuntu: [python3-fastapi]
+  ubuntu:
+    '*': [python3-fastapi]
+    bionic:
+      pip:
+        packages: [fastapi]
+    focal:
+      pip:
+        packages: [fastapi]
 python3-fastnumbers-pip:
   arch:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8443,7 +8443,11 @@ python3-uvicorn:
   alpine: [uvicorn]
   debian: [python3-uvicorn]
   fedora: [python-uvicorn]
-  ubuntu: [python3-uvicorn]
+  ubuntu:
+    '*': [python3-uvicorn]
+    bionic:
+      pip:
+        packages: [uvicorn]
 python3-vcstool:
   alpine: [vcstool]
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -186,6 +186,16 @@ exhale-pip:
   ubuntu:
     pip:
       packages: [exhale]
+fastapi-pip:
+  debian:
+    pip:
+      packages: [fastapi]
+  fedora:
+    pip:
+      packages: [fastapi]
+  ubuntu:
+    pip:
+      packages: [fastapi]
 gunicorn:
   debian: [gunicorn]
   fedora: [python-gunicorn]
@@ -8670,6 +8680,16 @@ uavcan-pip:
   ubuntu:
     pip:
       packages: [uavcan]
+univorn-pip:
+  debian:
+    pip:
+      packages: [uvicorn]
+  fedora:
+    pip:
+      packages: [univorn]
+  ubuntu:
+    pip:
+      packages: [uvicorn]
 urdf2webots-pip:
   debian:
     pip:
@@ -8747,20 +8767,6 @@ yapf:
     yakkety:
       pip:
         packages: [yapf]
-univorn-pip:
-  debian:
-    pip:
-      packages: [uvicorn]
-  ubuntu:
-    pip:
-      packages: [uvicorn]
-fastapi-pip:
-  debian:
-    pip:
-      packages: [fastapi]
-  ubuntu:
-    pip:
-      packages: [fastapi]
 yapf3:
   debian: [yapf3]
   fedora: [python3-yapf]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -186,16 +186,6 @@ exhale-pip:
   ubuntu:
     pip:
       packages: [exhale]
-fastapi-pip:
-  debian:
-    pip:
-      packages: [fastapi]
-  fedora:
-    pip:
-      packages: [fastapi]
-  ubuntu:
-    pip:
-      packages: [fastapi]
 gunicorn:
   debian: [gunicorn]
   fedora: [python-gunicorn]
@@ -6398,6 +6388,16 @@ python3-falcon:
   fedora: [python3-falcon]
   opensuse: [python3-falcon]
   ubuntu: [python3-falcon]
+python3-fastapi-pip:
+  debian:
+    pip:
+      packages: [fastapi]
+  fedora:
+    pip:
+      packages: [fastapi]
+  ubuntu:
+    pip:
+      packages: [fastapi]
 python3-fastnumbers-pip:
   arch:
     pip:
@@ -8433,6 +8433,16 @@ python3-usb:
   nixos: [python3Packages.pyusb]
   openembedded: [python3-pyusb@meta-python]
   ubuntu: [python3-usb]
+python3-uvicorn-pip:
+  debian:
+    pip:
+      packages: [uvicorn]
+  fedora:
+    pip:
+      packages: [uvicorn]
+  ubuntu:
+    pip:
+      packages: [uvicorn]
 python3-vcstool:
   alpine: [vcstool]
   debian:
@@ -8680,16 +8690,6 @@ uavcan-pip:
   ubuntu:
     pip:
       packages: [uavcan]
-univorn-pip:
-  debian:
-    pip:
-      packages: [uvicorn]
-  fedora:
-    pip:
-      packages: [univorn]
-  ubuntu:
-    pip:
-      packages: [uvicorn]
 urdf2webots-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6388,16 +6388,11 @@ python3-falcon:
   fedora: [python3-falcon]
   opensuse: [python3-falcon]
   ubuntu: [python3-falcon]
-python3-fastapi-pip:
-  debian:
-    pip:
-      packages: [fastapi]
-  fedora:
-    pip:
-      packages: [fastapi]
-  ubuntu:
-    pip:
-      packages: [fastapi]
+python3-fastapi:
+  arch: [python-fastapi]
+  debian: [python3-fastapi]
+  fedora: [python-fastapi]
+  ubuntu: [python3-fastapi]
 python3-fastnumbers-pip:
   arch:
     pip:
@@ -8433,16 +8428,11 @@ python3-usb:
   nixos: [python3Packages.pyusb]
   openembedded: [python3-pyusb@meta-python]
   ubuntu: [python3-usb]
-python3-uvicorn-pip:
-  debian:
-    pip:
-      packages: [uvicorn]
-  fedora:
-    pip:
-      packages: [uvicorn]
-  ubuntu:
-    pip:
-      packages: [uvicorn]
+python3-uvicorn:
+  alpine: [uvicorn]
+  debian: [python3-uvicorn]
+  fedora: [python-uvicorn]
+  ubuntu: [python3-uvicorn]
 python3-vcstool:
   alpine: [vcstool]
   debian:


### PR DESCRIPTION
## Package name:

- ~~fastapi-pip~~ python3-fastapi
- ~~uvicorn-pip~~ python3-uvicorn

## Package Upstream Source:

https://pypi.org/project/fastapi/
https://pypi.org/project/uvicorn/


## Purpose of using this:

To run a restful api server in python, with uvicorn fast ASGI server implementation. Although `uvicorn` is avail via debian, will prefer api server is running as near "latest", hence using pip. If we should follow the convention, I can make the change to `python3-uvicorn`.

Also, not sure for `fastapi`, should we can mix the installation from various sources (e.g. debian `pip`, ubuntu : `python-*` ....)

## Links to Distribution Packages



### Fastapi
- Debian: ~~NOT AVAILABLE~~ https://packages.debian.org/bullseye/python3-fastapi
- Ubuntu: https://packages.ubuntu.com/impish/python3-fastapi   (Not avail in focal)
- Fedora: https://src.fedoraproject.org/rpms/python-fastapi
- Arch: https://archlinux.org/packages/community/any/python-fastapi/

### Uvicorn
- Debian: https://packages.debian.org/bullseye/python3-uvicorn
- Ubuntu: https://packages.ubuntu.com/focal/python3-uvicorn
- Fedora: https://src.fedoraproject.org/rpms/python-uvicorn
- Arch: https://archlinux.org/packages/community/any/uvicorn/

