### PR TITLE
fix package.xml add url

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -149,6 +149,35 @@ repositories:
       url: https://github.com/ubi-agni/agni_tf_tools.git
       version: master
     status: maintained
+  agxrobots_test:
+    doc:
+      type: git
+      url: https://github.com/885288421/agxrobots_test.git
+      version: 0.0.2
+    release:
+      packages:
+      - hunter_base
+      - hunter_bringup
+      - hunter_msgs
+      - scout_base
+      - scout_bringup
+      - scout_msgs
+      - tracer_base
+      - tracer_bringup
+      - tracer_description
+      - tracer_gazebo_sim
+      - tracer_msgs
+      - ugv_sdk
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/885288421/agxrobots_test_release.git
+      version: 0.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/885288421/agxrobots_test.git
+      version: 0.0.2
+    status: maintained   
   ainstein_radar:
     release:
       packages:


### PR DESCRIPTION
I have resolved your feedback.
I have to add url and  maintainer information,I want to use python-bloom to creat a ros package ,but it's failed ,the terminal show

agx@agx-tx:~/agilex_ws/agxrobots_test$ bloom-release --rosdistro melodic --track melodic agxrobots_test --edit
Specified repository 'agxrobots_test' is not in the distribution file located at 'https://raw.githubusercontent.com/ros/rosdistro/master/melodic/distribution.yaml'
Did you mean one of these: 'ros_pytest', 'pyros_test', 'robot_one'?
Could not determine release repository url for repository 'agxrobots_test' of distro 'melodic'
You can continue the release process by manually specifying the location of the RELEASE repository.
To be clear this is the url of the RELEASE repository not the upstream repository.
For release repositories on GitHub, you should provide the `https://` url which should end in `.git`.
Here is the url for a typical release repository on GitHub: https://github.com/ros-gbp/rviz-release.git
==> Looking for a release of this repository in a different distribution...
No reasonable default release repository url could be determined from previous releases.
Release repository url [press enter to abort]: https://github.com/885288421/agxrobots_test_release.git
==> Fetching 'agxrobots_test' repository from 'https://github.com/885288421/agxrobots_test_release.git'
Cloning into '/tmp/tmpTa2jDZ'...
remote: Enumerating objects: 3, done.
remote: Counting objects: 100% (3/3), done.
remote: Total 3 (delta 0), reused 0 (delta 0), pack-reused 0
Receiving objects: 100% (3/3), done.
Creating track 'melodic'...
Repository Name:
  upstream
    Default value, leave this as upstream if you are unsure
  <name>
    Name of the repository (used in the archive name)
  ['upstream']: agxrobots_test
Upstream Repository URI:
  <uri>
    Any valid URI. This variable can be templated, for example an svn url
    can be templated as such: "https://svn.foo.com/foo/tags/foo-:{version}"
    where the :{version} token will be replaced with the version for this release.
  [None]: https://github.com/885288421/agxrobots_test.git
Upstream VCS Type:
  svn
    Upstream URI is a svn repository
  git
    Upstream URI is a git repository
  hg
    Upstream URI is a hg repository
  tar
    Upstream URI is a tarball
  ['git']: 
Version:
  :{ask}
    This means that the user will be prompted for the version each release.
    This also means that the upstream devel will be ignored.
  :{auto}
    This means the version will be guessed from the devel branch.
    This means that the devel branch must be set, the devel branch must exist,
    and there must be a valid package.xml in the upstream devel branch.
  <version>
    This will be the version used.
    It must be updated for each new upstream version.
  [':{auto}']: 
Release Tag:
  :{none}
    For svn and tar only you can set the release tag to :{none}, so that
    it is ignored.  For svn this means no revision number is used.
  :{ask}
    This means the user will be prompted for the release tag on each release.
  :{version}
    This means that the release tag will match the :{version} tag.
    This can be further templated, for example: "foo-:{version}" or "v:{version}"
    
    This can describe any vcs reference. For git that means {tag, branch, hash},
    for hg that means {tag, branch, hash}, for svn that means a revision number.
    For tar this value doubles as the sub directory (if the repository is
    in foo/ of the tar ball, putting foo here will cause the contents of
    foo/ to be imported to upstream instead of foo itself).
  [':{version}']: 
Upstream Devel Branch:
  <vcs reference>
    Branch in upstream repository on which to search for the version.
    This is used only when version is set to ':{auto}'.
  [None]: 
ROS Distro:
  <ROS distro>
    This can be any valid ROS distro, e.g. indigo, kinetic, lunar, melodic
  ['melodic']: 
Patches Directory:
  :{none}
    Use this if you want to disable overlaying of files.
  <path in bloom branch>
    This can be any valid relative path in the bloom branch. The contents
    of this folder will be overlaid onto the upstream branch after each
    import-upstream.  Additionally, any package.xml files found in the
    overlay will have the :{version} string replaced with the current
    version being released.
  [None]: 
Release Repository Push URL:
  :{none}
    This indicates that the default release url should be used.
  <url>
    (optional) Used when pushing to remote release repositories. This is only
    needed when the release uri which is in the rosdistro file is not writable.
    This is useful, for example, when a releaser would like to use a ssh url
    to push rather than a https:// url.
  [None]: 
Created 'melodic' track.
==> Testing for push permission on release repository
==> git remote -v
origin	git@github.com:885288421/agxrobots_test_release.git (fetch)
origin	git@github.com:885288421/agxrobots_test_release.git (push)
==> git push --dry-run
To github.com:885288421/agxrobots_test_release.git
   1c82ea3..fca005c  master -> master
==> Releasing 'agxrobots_test' using release track 'melodic'
==> git-bloom-release melodic
Processing release track settings for 'melodic'
Checking upstream devel branch '<default>' for package.xml(s)
Cloning into '/tmp/tmpHjPABq/upstream'...
remote: Enumerating objects: 499, done.
remote: Counting objects: 100% (499/499), done.
remote: Compressing objects: 100% (312/312), done.
remote: Total 499 (delta 178), reused 482 (delta 164), pack-reused 0
Receiving objects: 100% (499/499), 124.80 MiB | 6.17 MiB/s, done.
Resolving deltas: 100% (178/178), done.
Looking for packages in 'master' branch... found 13 packages.
Detected version '0.0.1' from package(s): ['scout_base', 'hunter_base', 'tracer_bringup', 'hunter_bringup', 'scout_bringup', 'tracer_gazebo_sim', 'scout_description', 'scout_msgs', 'hunter_msgs', 'tracer_description', 'tracer_base', 'ugv_sdk', 'tracer_msgs']

Executing release track 'melodic'
==> bloom-export-upstream /tmp/tmpHjPABq/upstream git --tag 0.0.1 --display-uri https://github.com/885288421/agxrobots_test.git --name agxrobots_test --output-dir /tmp/tmpWpuj2X
Checking out repository at 'https://github.com/885288421/agxrobots_test.git' to reference '0.0.1'.
Exporting to archive: '/tmp/tmpWpuj2X/agxrobots_test-0.0.1.tar.gz'
md5: 99408626cd8c58994b174e920b191edd

==> git-bloom-import-upstream /tmp/tmpWpuj2X/agxrobots_test-0.0.1.tar.gz  --release-version 0.0.1 --replace
Creating upstream branch.
Importing archive into upstream branch...
Creating tag: 'upstream/0.0.1'
I'm happy.  You should be too.

==> git-bloom-generate -y rosrelease melodic --source upstream -i 1
Releasing packages: ['scout_base', 'hunter_base', 'tracer_bringup', 'hunter_bringup', 'scout_bringup', 'tracer_gazebo_sim', 'scout_description', 'scout_msgs', 'hunter_msgs', 'tracer_description', 'tracer_base', 'ugv_sdk', 'tracer_msgs']
Releasing package 'scout_base' for 'melodic' to: 'release/melodic/scout_base'
Releasing package 'hunter_base' for 'melodic' to: 'release/melodic/hunter_base'
Releasing package 'tracer_bringup' for 'melodic' to: 'release/melodic/tracer_bringup'
Releasing package 'hunter_bringup' for 'melodic' to: 'release/melodic/hunter_bringup'
Releasing package 'scout_bringup' for 'melodic' to: 'release/melodic/scout_bringup'
Releasing package 'tracer_gazebo_sim' for 'melodic' to: 'release/melodic/tracer_gazebo_sim'
Releasing package 'scout_description' for 'melodic' to: 'release/melodic/scout_description'
Releasing package 'scout_msgs' for 'melodic' to: 'release/melodic/scout_msgs'
Releasing package 'hunter_msgs' for 'melodic' to: 'release/melodic/hunter_msgs'
Releasing package 'tracer_description' for 'melodic' to: 'release/melodic/tracer_description'
Releasing package 'tracer_base' for 'melodic' to: 'release/melodic/tracer_base'
Releasing package 'ugv_sdk' for 'melodic' to: 'release/melodic/ugv_sdk'
Releasing package 'tracer_msgs' for 'melodic' to: 'release/melodic/tracer_msgs'

==> git-bloom-generate -y rosdebian --prefix release/melodic melodic -i 1 --os-name ubuntu
Generating source debs for the packages: ['hunter_base', 'scout_base', 'tracer_description', 'ugv_sdk', 'hunter_msgs', 'hunter_bringup', 'scout_bringup', 'tracer_gazebo_sim', 'tracer_base', 'tracer_msgs', 'scout_description', 'scout_msgs', 'tracer_bringup']
Debian Incremental Version: 1
Debian Distributions: ['bionic']
Releasing for rosdistro: melodic

Pre-verifying Debian dependency keys...
Running 'rosdep update'...
Could not resolve rosdep key 'async_port'
Failed to resolve async_port on ubuntu:bionic with: Error running generator: Failed to resolve rosdep key 'async_port', aborting.
async_port is depended on by these packages: ['ugv_sdk']
<== Failed
Some of the dependencies for packages in this repository could not be resolved by rosdep.
<== The following generator action reported that it is missing one or more
    rosdep keys, but that the key exists in other platforms:
'['/usr/bin/git-bloom-generate', '-y', 'rosdebian', '--prefix', 'release/melodic', 'melodic', '-i', '1', '--os-name', 'ubuntu']'

If you are absolutely sure that this key is unavailable for the platform in
question, the generator can be skipped and you can proceed with the release.
Skip generator action and continue with release [y/N]? y

Action skipped, continuing with release.

==> git-bloom-generate -y rosdebian --prefix release/melodic melodic -i 1 --os-name debian --os-not-required
No platforms defined for os 'debian' in release file for the 'melodic' distro. This os was not required; continuing without error.

==> git-bloom-generate -y rosrpm --prefix release/melodic melodic -i 1 --os-name fedora
No platforms defined for os 'fedora' in release file for the 'melodic' distro.
Not performing RPM generation.

==> git-bloom-generate -y rosrpm --prefix release/melodic melodic -i 1 --os-name rhel
No platforms defined for os 'rhel' in release file for the 'melodic' distro.
Not performing RPM generation.




Tip: Check to ensure that the debian tags created have the same version as the upstream version you are releasing.
Everything went as expected, you should check that the new tags match your expectations, and then push to the release repo with:
  git push --all && git push --tags  # You might have to add --force to the second command if you are over-writing existing tags
<== Released 'agxrobots_test' using release track 'melodic' successfully
==> git remote -v
origin	git@github.com:885288421/agxrobots_test_release.git (fetch)
origin	git@github.com:885288421/agxrobots_test_release.git (push)
Releasing complete, push to release repository?
Continue [Y/n]? Y
==> Pushing changes to release repository for 'agxrobots_test'
==> git push --all
Counting objects: 532, done.
Delta compression using up to 8 threads.
Compressing objects: 100% (480/480), done.
Writing objects: 100% (532/532), 13.69 MiB | 1.58 MiB/s, done.
Total 532 (delta 152), reused 0 (delta 0)
remote: Resolving deltas: 100% (152/152), done.
To github.com:885288421/agxrobots_test_release.git
   1c82ea3..0751bb4  master -> master
 * [new branch]      patches/release/melodic/hunter_base -> patches/release/melodic/hunter_base
 * [new branch]      patches/release/melodic/hunter_bringup -> patches/release/melodic/hunter_bringup
 * [new branch]      patches/release/melodic/hunter_msgs -> patches/release/melodic/hunter_msgs
 * [new branch]      patches/release/melodic/scout_base -> patches/release/melodic/scout_base
 * [new branch]      patches/release/melodic/scout_bringup -> patches/release/melodic/scout_bringup
 * [new branch]      patches/release/melodic/scout_description -> patches/release/melodic/scout_description
 * [new branch]      patches/release/melodic/scout_msgs -> patches/release/melodic/scout_msgs
 * [new branch]      patches/release/melodic/tracer_base -> patches/release/melodic/tracer_base
 * [new branch]      patches/release/melodic/tracer_bringup -> patches/release/melodic/tracer_bringup
 * [new branch]      patches/release/melodic/tracer_description -> patches/release/melodic/tracer_description
 * [new branch]      patches/release/melodic/tracer_gazebo_sim -> patches/release/melodic/tracer_gazebo_sim
 * [new branch]      patches/release/melodic/tracer_msgs -> patches/release/melodic/tracer_msgs
 * [new branch]      patches/release/melodic/ugv_sdk -> patches/release/melodic/ugv_sdk
 * [new branch]      release/melodic/hunter_base -> release/melodic/hunter_base
 * [new branch]      release/melodic/hunter_bringup -> release/melodic/hunter_bringup
 * [new branch]      release/melodic/hunter_msgs -> release/melodic/hunter_msgs
 * [new branch]      release/melodic/scout_base -> release/melodic/scout_base
 * [new branch]      release/melodic/scout_bringup -> release/melodic/scout_bringup
 * [new branch]      release/melodic/scout_description -> release/melodic/scout_description
 * [new branch]      release/melodic/scout_msgs -> release/melodic/scout_msgs
 * [new branch]      release/melodic/tracer_base -> release/melodic/tracer_base
 * [new branch]      release/melodic/tracer_bringup -> release/melodic/tracer_bringup
 * [new branch]      release/melodic/tracer_description -> release/melodic/tracer_description
 * [new branch]      release/melodic/tracer_gazebo_sim -> release/melodic/tracer_gazebo_sim
 * [new branch]      release/melodic/tracer_msgs -> release/melodic/tracer_msgs
 * [new branch]      release/melodic/ugv_sdk -> release/melodic/ugv_sdk
 * [new branch]      upstream -> upstream
<== Pushed changes successfully
==> Pushing tags to release repository for 'agxrobots_test'
==> git push --tags
Total 0 (delta 0), reused 0 (delta 0)
To github.com:885288421/agxrobots_test_release.git
 * [new tag]         release/melodic/hunter_base/0.0.1-1 -> release/melodic/hunter_base/0.0.1-1
 * [new tag]         release/melodic/hunter_bringup/0.0.1-1 -> release/melodic/hunter_bringup/0.0.1-1
 * [new tag]         release/melodic/hunter_msgs/0.0.1-1 -> release/melodic/hunter_msgs/0.0.1-1
 * [new tag]         release/melodic/scout_base/0.0.1-1 -> release/melodic/scout_base/0.0.1-1
 * [new tag]         release/melodic/scout_bringup/0.0.1-1 -> release/melodic/scout_bringup/0.0.1-1
 * [new tag]         release/melodic/scout_description/0.0.1-1 -> release/melodic/scout_description/0.0.1-1
 * [new tag]         release/melodic/scout_msgs/0.0.1-1 -> release/melodic/scout_msgs/0.0.1-1
 * [new tag]         release/melodic/tracer_base/0.0.1-1 -> release/melodic/tracer_base/0.0.1-1
 * [new tag]         release/melodic/tracer_bringup/0.0.1-1 -> release/melodic/tracer_bringup/0.0.1-1
 * [new tag]         release/melodic/tracer_description/0.0.1-1 -> release/melodic/tracer_description/0.0.1-1
 * [new tag]         release/melodic/tracer_gazebo_sim/0.0.1-1 -> release/melodic/tracer_gazebo_sim/0.0.1-1
 * [new tag]         release/melodic/tracer_msgs/0.0.1-1 -> release/melodic/tracer_msgs/0.0.1-1
 * [new tag]         release/melodic/ugv_sdk/0.0.1-1 -> release/melodic/ugv_sdk/0.0.1-1
 * [new tag]         upstream/0.0.1 -> upstream/0.0.1
<== Pushed tags successfully
==> Generating pull request to distro file located at 'https://raw.githubusercontent.com/ros/rosdistro/master/melodic/distribution.yaml'
Would you like to add documentation information for this repository? [Y/n]? Y
==> Looking for a doc entry for this repository in a different distribution...
No existing doc entries found for use as defaults.
Please enter your repository information for the doc generation job.
This information should point to the repository from which documentation should be generated.
VCS Type must be one of git, svn, hg, or bzr.
VCS type: git
VCS url: https://github.com/885288421/agxrobots_test.git
VCS version must be a branch, tag, or commit, e.g. master or 0.1.0
VCS version: 0.0.1
Would you like to add source information for this repository? [Y/n]? Y
==> Looking for a source entry for this repository in a different distribution...
No existing source entries found for use as defaults.
Please enter information which points to the active development branch for this repository.
This information is used to run continuous integration jobs and for developers to checkout from.
VCS Type must be one of git, svn, hg, or bzr.
VCS type: git
VCS url: https://github.com/885288421/agxrobots_test.git
VCS version must be a branch, tag, or commit, e.g. master or 0.1.0
VCS version: 0.0.1
Since you are on github we can add a job to run your tests on each pull request.If you would like to turn this on please see http://wiki.ros.org/buildfarm/Pull%20request%20testing for more information. There is more setup required to setup the hooks correctly. 
Would you like to turn on pull request testing? [y/N]? y
Would you like to add a maintenance status for this repository? [Y/n]? Y
Please enter a maintenance status.
Valid maintenance statuses:
- developed: active development is in progress
- maintained: no new development, but bug fixes and pull requests are addressed
- unmaintained: looking for new maintainer, bug fixes and pull requests will not be addressed
- end-of-life: should not be used, will disappear at some point
Status: maintained
You can also enter a status description.
This is usually reserved for giving a reason when a status is 'end-of-life'.
Status Description [press Enter for no change]: 
Unified diff for the ROS distro file located at '/tmp/tmpwG1PEt/agxrobots_test-0.0.1-1.patch':
--- melodic/distribution.yaml
+++ melodic/distribution.yaml
@@ -148,6 +148,36 @@
       type: git
       url: https://github.com/ubi-agni/agni_tf_tools.git
       version: master
+    status: maintained
+  agxrobots_test:
+    doc:
+      type: git
+      url: https://github.com/885288421/agxrobots_test.git
+      version: 0.0.1
+    release:
+      packages:
+      - hunter_base
+      - hunter_bringup
+      - hunter_msgs
+      - scout_base
+      - scout_bringup
+      - scout_description
+      - scout_msgs
+      - tracer_base
+      - tracer_bringup
+      - tracer_description
+      - tracer_gazebo_sim
+      - tracer_msgs
+      - ugv_sdk
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/885288421/agxrobots_test_release.git
+      version: 0.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/885288421/agxrobots_test.git
+      version: 0.0.1
     status: maintained
   ainstein_radar:
     release:
==> Checking on GitHub for a fork to make the pull request from...
Could not find a fork of ros/rosdistro on the <tang___xi@163.com> GitHub account.
Would you like to create one now?
Continue [Y/n]? y
Aborting pull request: HTTP Error 401: Unauthorized (https://api.github.com/repos/ros/rosdistro/forks)
The release of your packages was successful, but the pull request failed.
Please manually open a pull request by editing the file here: 'https://raw.githubusercontent.com/ros/rosdistro/master/melodic/distribution.yaml'
<== No pull request opened.
so .I only to git clone the sodistro source ,add our package message to /melodic/distribution.yaml.I hope you can help me finilsh it.
thanks for you very mush 