### PR TITLE
ros2_controllers: 1.2.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3387,7 +3387,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `1.2.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.0-1`

## diff_drive_controller

```
* Add velocity feedback option for diff_drive_controller (#260 <https://github.com/ros-controls/ros2_controllers/issues/260>)
* Contributors: Patrick Roncagliolo
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

```
* Forward command controller test update (#273 <https://github.com/ros-controls/ros2_controllers/issues/273>)
  * removed unnecessary lines and updated comments
  * fixed pre-commit issues
  * removed extra part of test
* Contributors: Jack Center
```

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

```
* [Joint State Broadcaster] Add mapping of custom states to standard values in "/joint_state" message (#217 <https://github.com/ros-controls/ros2_controllers/issues/217>)
* [Joint State Broadcaster] Add option to support only specific interfaces on specific joints (#216 <https://github.com/ros-controls/ros2_controllers/issues/216>)
* Contributors: Denis Štogl, Bence Magyar
```

## joint_trajectory_controller

- No changes

## position_controllers

- No changes

## ros2_controllers

- No changes

## velocity_controllers

- No changes
