### PR TITLE
grepros: 0.4.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1403,6 +1403,21 @@ repositories:
       url: https://github.com/flynneva/grbl_ros.git
       version: main
     status: developed
+  grepros:
+    doc:
+      type: git
+      url: https://github.com/suurjaak/grepros.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/suurjaak/grepros-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/suurjaak/grepros.git
+      version: master
+    status: developed
   hls_lfcd_lds_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grepros` to `0.4.0-1`:

- upstream repository: https://github.com/suurjaak/grepros.git
- release repository: https://github.com/suurjaak/grepros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## grepros

```
* add --plugin grepros.plugins.parquet (Parquet output)
* add --plugin grepros.plugins.sql (SQL schema output)
* add --plugin grepros.plugins.embag (faster ROS1 bag reader)
* add --reindex-if-unindexed option
* add --every-nth-match option
* add --every-nth-message option
* add --every-nth-interval option
* allow multiple write sinks, combine --write-format and --write-option to --write
* refactor plugins interface
* populate topics.offered_qos_profiles in ROS2 bag output where possible
* fix progress bar afterword not updating when grepping multiple bags
* fix error on empty bag with no messages
* fix error in Postgres output for NaNs in nested JSON values
* fix skipping some messages in ROS1 bag for types with identical hashes
* fix not being able to specify list arguments several times
* ensure no conflicts from changed message types or identical type hashes
* add tests
```
