### PR TITLE
plotjuggler: 3.3.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8863,7 +8863,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.3.3-1
+      version: 3.3.4-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.3.4-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.3.3-1`

## plotjuggler

```
* Video plugin (#574 <https://github.com/facontidavide/PlotJuggler/issues/574>)
* gitignore *.swp files (#569 <https://github.com/facontidavide/PlotJuggler/issues/569>)
* Added libprotoc-dev to the apt install targets (#573 <https://github.com/facontidavide/PlotJuggler/issues/573>)
* turn on Sol3 safety flag
* trying to solve reported issue with Lua
* add fields that were not set in Protobuf
* Protobuf update (#568 <https://github.com/facontidavide/PlotJuggler/issues/568>)
* add zoomOut after loadDataFile
* Protobuf options refactored
* changed the protobuf implementation to deal with dependencies
* Protobuf parser and MQTT plugins
* Merge pull request #531 <https://github.com/facontidavide/PlotJuggler/issues/531> from erickisos/fix/517
  Homebrew path added into CMakeLists #517 <https://github.com/facontidavide/PlotJuggler/issues/517>
* LUA version updated
* fix dependency between transformed series
* fix issue #557 <https://github.com/facontidavide/PlotJuggler/issues/557>
* Homebrew path added into CMakeLists
* Contributors: Adeeb Shihadeh, Davide Faconti, Erick G. Islas-Osuna, Miklós Márton
```
