### PR TITLE
ros_msg_parser: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10944,6 +10944,21 @@ repositories:
       url: https://github.com/aws-robotics/monitoringmessages-ros1.git
       version: master
     status: maintained
+  ros_msg_parser:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/ros_msg_parser.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/facontidavide/ros_msg_parser-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/facontidavide/ros_msg_parser.git
+      version: master
+    status: developed
   ros_numpy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_msg_parser` to `1.0.0-1`:

- upstream repository: https://github.com/facontidavide/ros_msg_parser.git
- release repository: https://github.com/facontidavide/ros_msg_parser-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
