### PR TITLE
ros_msg_parser: 1.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7297,6 +7297,21 @@ repositories:
       url: https://github.com/CopterExpress/ros_led.git
       version: master
     status: maintained
+  ros_msg_parser:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/ros_msg_parser.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/facontidavide/ros_msg_parser-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/facontidavide/ros_msg_parser.git
+      version: master
+    status: developed
   ros_numpy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_msg_parser` to `1.0.0-1`:

- upstream repository: https://github.com/facontidavide/ros_msg_parser.git
- release repository: https://github.com/facontidavide/ros_msg_parser-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
