### PR TITLE
ros_ign: 0.111.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7259,7 +7259,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_ign-release.git
-      version: 0.111.1-2
+      version: 0.111.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_ign` to `0.111.2-1`:

- upstream repository: https://github.com/ignitionrobotics/ros_ign
- release repository: https://github.com/ros-gbp/ros_ign-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.111.1-2`

## ros_ign

- No changes

## ros_ign_bridge

```
* [noetic] 🏁 Dome EOL (#197 <https://github.com/osrf/ros_ign/issues/197>)
* Don't double-build convert.cpp (#184 <https://github.com/osrf/ros_ign/issues/184>)
* 🥳 [Noetic] Tweaks to bridge tutorial (#180 <https://github.com/osrf/ros_ign/issues/180>)
* Contributors: Louise Poubel, Michael Carroll
```

## ros_ign_gazebo

```
* [noetic] 🏁 Dome EOL (#197 <https://github.com/osrf/ros_ign/issues/197>)
* Contributors: Louise Poubel
```

## ros_ign_gazebo_demos

```
* [noetic] 🏁 Dome EOL (#197 <https://github.com/osrf/ros_ign/issues/197>)
* Contributors: Louise Poubel
```

## ros_ign_image

```
* [noetic] 🏁 Dome EOL (#197 <https://github.com/osrf/ros_ign/issues/197>)
* Contributors: Louise Poubel
```
