### PR TITLE
ros_ign: 0.244.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3322,7 +3322,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 0.233.2-1
+      version: 0.244.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
* Part of https://github.com/ignition-tooling/release-tools/issues/459
* This marks the move from Edifice to Fortress on Rolling

Increasing version of package(s) in repository `ros_ign` to `0.244.0-1`:

- upstream repository: https://github.com/ignitionrobotics/ros_ign
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.233.2-1`

## ros_ign

- No changes

## ros_ign_bridge

```
* Default to Fortress for Rolling (future Humble) (#195 <https://github.com/osrf/ros_ign/issues/195>)
* [ros2] 🏁 Dome EOL (#199 <https://github.com/osrf/ros_ign/issues/199>)
* New Light Message, also bridge Color (#187 <https://github.com/osrf/ros_ign/issues/187>)
* Statically link each translation unit (#193 <https://github.com/osrf/ros_ign/issues/193>)
* Break apart convert and factories translation unit (#192 <https://github.com/osrf/ros_ign/issues/192>)
* Fixed ROS subscriber test in ros_ign_bridge (#189 <https://github.com/osrf/ros_ign/issues/189>)
* Enable QoS overrides (#181 <https://github.com/osrf/ros_ign/issues/181>)
* Fixed ros ign bridge documentation (#178 <https://github.com/osrf/ros_ign/issues/178>)
* Expose Contacts through ROS bridge (#175 <https://github.com/osrf/ros_ign/issues/175>)
* Contributors: Alejandro Hernández Cordero, Guillaume Doisy, Louise Poubel, Michael Carroll, Vatan Aksoy Tezer, William Lew
```

## ros_ign_gazebo

```
* Default to Fortress for Rolling (future Humble) (#195 <https://github.com/osrf/ros_ign/issues/195>)
* [ros2] 🏁 Dome EOL (#199 <https://github.com/osrf/ros_ign/issues/199>)
* Contributors: Guillaume Doisy, Louise Poubel
```

## ros_ign_gazebo_demos

```
* Default to Fortress for Rolling (future Humble) (#195 <https://github.com/osrf/ros_ign/issues/195>)
* [ros2] 🏁 Dome EOL (#199 <https://github.com/osrf/ros_ign/issues/199>)
* Enable QoS overrides (#181 <https://github.com/osrf/ros_ign/issues/181>)
* Contributors: Guillaume Doisy, Louise Poubel
```

## ros_ign_image

```
* Default to Fortress for Rolling (future Humble) (#195 <https://github.com/osrf/ros_ign/issues/195>)
* [ros2] 🏁 Dome EOL (#199 <https://github.com/osrf/ros_ign/issues/199>)
* Statically link each translation unit (#193 <https://github.com/osrf/ros_ign/issues/193>)
* Contributors: Guillaume Doisy, Louise Poubel, Michael Carroll
```

## ros_ign_interfaces

```
* New Light Message, also bridge Color (#187 <https://github.com/osrf/ros_ign/issues/187>)
* Expose Contacts through ROS bridge (#175 <https://github.com/osrf/ros_ign/issues/175>)
* Contributors: Guillaume Doisy, Vatan Aksoy Tezer, William Lew
```
