### PR TITLE
moveit: 1.1.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4561,7 +4561,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 1.1.6-1
+      version: 1.1.7-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `1.1.7-1`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.6-1`

## chomp_motion_planner

- No changes

## moveit

- No changes

## moveit_chomp_optimizer_adapter

- No changes

## moveit_commander

- No changes

## moveit_core

```
* Move ``MoveItErrorCode`` class to ``moveit_core`` (#3009 <https://github.com/ros-planning/moveit/issues/3009>)
* Disable (flaky) timing tests in ``DEBUG`` mode (#3012 <https://github.com/ros-planning/moveit/issues/3012>)
* ``RobotState::attachBody``: Migrate to unique_ptr argument (#3011 <https://github.com/ros-planning/moveit/issues/3011>)
* Add API stress tests for ``TOTG``, fix undefined behavior (#2957 <https://github.com/ros-planning/moveit/issues/2957>)
* Do not assert on printTransform with non-isometry (#3005 <https://github.com/ros-planning/moveit/issues/3005>)
* Provide ``MOVEIT_VERSION_CHECK`` macro (#2997 <https://github.com/ros-planning/moveit/issues/2997>)
* Quietly use backward_cpp/ros if available (#2988 <https://github.com/ros-planning/moveit/issues/2988>)
* Allow restricting collision pairs to a group (#2987 <https://github.com/ros-planning/moveit/issues/2987>)
* Add backwards compatibility for old scene serialization format (#2986 <https://github.com/ros-planning/moveit/issues/2986>)
* Switch to ``std::bind`` (#2967 <https://github.com/ros-planning/moveit/issues/2967>)
* Add waypoint duration to the trajectory deep copy unit test (#2961 <https://github.com/ros-planning/moveit/issues/2961>)
* Contributors: AndyZe, Henning Kayser, Jafar Abdi, Jochen Sprickerhof, Michael Görner, Robert Haschke, Simon Schmeisser, Wolfgang Merkt, pvanlaar
```

## moveit_fake_controller_manager

```
* Switch to ``std::bind`` (#2967 <https://github.com/ros-planning/moveit/issues/2967>)
* Contributors: Jochen Sprickerhof
```

## moveit_kinematics

```
* ``round_collada_numbers.py``: python 2/3 compatibility (#2983 <https://github.com/ros-planning/moveit/issues/2983>)
* Switch to ``std::bind`` (#2967 <https://github.com/ros-planning/moveit/issues/2967>)
* Contributors: Jochen Sprickerhof, Tomislav Bazina
```

## moveit_planners

```
* Add pilz planner to ``moveit_planners`` dependency
* Contributors: v4hn
```

## moveit_planners_chomp

```
* Move ``MoveItErrorCode`` class to ``moveit_core`` (#3009 <https://github.com/ros-planning/moveit/issues/3009>)
* Contributors: Jafar Abdi
```

## moveit_planners_ompl

```
* Use termination condition for simplification step (#2981 <https://github.com/ros-planning/moveit/issues/2981>)
* Switch to ``std::bind`` (#2967 <https://github.com/ros-planning/moveit/issues/2967>)
* Contributors: Jochen Sprickerhof, Simon Schmeisser
```

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

```
* Provide ``MOVEIT_VERSION_CHECK`` macro (#2997 <https://github.com/ros-planning/moveit/issues/2997>)
* Switch to ``std::bind`` (#2967 <https://github.com/ros-planning/moveit/issues/2967>)
* Contributors: Jochen Sprickerhof, Robert Haschke
```

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

```
* Switch to ``std::bind`` (#2967 <https://github.com/ros-planning/moveit/issues/2967>)
* Contributors: Jochen Sprickerhof
```

## moveit_ros_move_group

```
* Switch to ``std::bind`` (#2967 <https://github.com/ros-planning/moveit/issues/2967>)
* Contributors: Jochen Sprickerhof
```

## moveit_ros_occupancy_map_monitor

```
* Switch to ``std::bind`` (#2967 <https://github.com/ros-planning/moveit/issues/2967>)
* Contributors: Jochen Sprickerhof
```

## moveit_ros_perception

```
* Switch to ``std::bind`` (#2967 <https://github.com/ros-planning/moveit/issues/2967>)
* Add ns for depth image & pointcloud octomap updaters (#2916 <https://github.com/ros-planning/moveit/issues/2916>)
* Contributors: Jochen Sprickerhof, Tim Redick
```

## moveit_ros_planning

```
* Move ``MoveItErrorCode`` class to ``moveit_core`` (#3009 <https://github.com/ros-planning/moveit/issues/3009>)
* Switch to ``std::bind`` (#2967 <https://github.com/ros-planning/moveit/issues/2967>)
* ``MoveitCpp``: Added ability to set path constraints for ``PlanningComponent`` (#2959 <https://github.com/ros-planning/moveit/issues/2959>)
* ``RDFLoader``: clear buffer before reading content (#2963 <https://github.com/ros-planning/moveit/issues/2963>)
* Reset markers on ``display_contacts`` topic for a new planning attempt (#2944 <https://github.com/ros-planning/moveit/issues/2944>)
* Contributors: Colin Kohler, Jafar Abdi, Jochen Sprickerhof, Rick Staa, Robert Haschke
```

## moveit_ros_planning_interface

```
* Move ``MoveItErrorCode`` class to ``moveit_core`` (#3009 <https://github.com/ros-planning/moveit/issues/3009>)
* Fix uninitialized ``RobotState`` in ``MoveGroupInterface`` (#3008 <https://github.com/ros-planning/moveit/issues/3008>)
* Switch to ``std::bind`` (#2967 <https://github.com/ros-planning/moveit/issues/2967>)
* Contributors: Captain Yoshi, Jafar Abdi, Jochen Sprickerhof
```

## moveit_ros_robot_interaction

```
* Add marker for subgroups even if no endeffector is defined for them (#2977 <https://github.com/ros-planning/moveit/issues/2977>)
* Switch to ``std::bind`` (#2967 <https://github.com/ros-planning/moveit/issues/2967>)
* Contributors: Jochen Sprickerhof, Michael Görner
```

## moveit_ros_visualization

```
* Move ``MoveItErrorCode`` class to ``moveit_core`` (#3009 <https://github.com/ros-planning/moveit/issues/3009>)
* ``RobotState::attachBody``: Migrate to ``unique_ptr`` argument (#3011 <https://github.com/ros-planning/moveit/issues/3011>)
* Fix "ClassLoader: SEVERE WARNING" on reset of MPD (#2925 <https://github.com/ros-planning/moveit/issues/2925>)
* Switch to ``std::bind`` (#2967 <https://github.com/ros-planning/moveit/issues/2967>)
* Various fixes to MotionPlanning display (#2944 <https://github.com/ros-planning/moveit/issues/2944>)
  
    * Avoid flickering of the progress bar
    * Joints widget: avoid flickering of the nullspace slider
  
* Modernize: std::make_shared
* Contributors: Jafar Abdi, JafarAbdi, Jochen Sprickerhof, Robert Haschke, pvanlaar
```

## moveit_ros_warehouse

```
* Switch to ``std::bind`` (#2967 <https://github.com/ros-planning/moveit/issues/2967>)
* Contributors: Jochen Sprickerhof
```

## moveit_runtime

- No changes

## moveit_servo

- No changes

## moveit_setup_assistant

```
* Pass xacro_args to both, urdf and srdf loading (#3013 <https://github.com/ros-planning/moveit/issues/3013>)
* Switch to ``std::bind`` (#2967 <https://github.com/ros-planning/moveit/issues/2967>)
* Update timestamp of .setup_assistant file when writing files (#2964 <https://github.com/ros-planning/moveit/issues/2964>)
* Upload controller_list for simple controller manager (#2954 <https://github.com/ros-planning/moveit/issues/2954>)
* Contributors: Jochen Sprickerhof, Rick Staa, Robert Haschke
```

## moveit_simple_controller_manager

```
* ``simple_controller_manager``: add ``max_effort`` parameter to ``GripperCommand`` action (#2984 <https://github.com/ros-planning/moveit/issues/2984>)
* Switch to ``std::bind`` (#2967 <https://github.com/ros-planning/moveit/issues/2967>)
* Contributors: Jochen Sprickerhof, Rick Staa
```

## pilz_industrial_motion_planner

```
* Pilz planner: improve reporting of invalid start joints (#3000 <https://github.com/ros-planning/moveit/issues/3000>)
* Switch to ``std::bind`` (#2967 <https://github.com/ros-planning/moveit/issues/2967>)
* Contributors: Jochen Sprickerhof, Robert Haschke, v4hn
```

## pilz_industrial_motion_planner_testutils

```
* Switch to ``std::bind`` (#2967 <https://github.com/ros-planning/moveit/issues/2967>)
* Contributors: Jochen Sprickerhof
```
