### PR TITLE
diagnostics: 1.11.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1573,7 +1573,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/diagnostics-release.git
-      version: 1.10.4-1
+      version: 1.11.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `1.11.0-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros-gbp/diagnostics-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.10.4-1`

## diagnostic_aggregator

```
* Use DiagnosticLevel enum instead of hardcoded integers (#208 <https://github.com/ros/diagnostics/issues/208>)
  Spellcheck fixes
* Add install command for demo in CMakeLists
* Contributors: Amilcar Lucas, gemignani
```

## diagnostic_analysis

```
* Fix type comparison for python3 (#194 <https://github.com/ros/diagnostics/issues/194>)
* Contributors: Mikael Arguedas
```

## diagnostic_common_diagnostics

```
* Added ram monitor (#222 <https://github.com/ros/diagnostics/issues/222>)
* Improve sensor output processing in sensors_monitor.py (#223 <https://github.com/ros/diagnostics/issues/223>)
* Decode bytes into string in ntp_monitor (#220 <https://github.com/ros/diagnostics/issues/220>)
  Co-authored-by: Maxime Noizet <mailto:maxime.noizet@etu.utc.fr>
* Add missing lm-sensors dependency for sensors_monitor.py (#198 <https://github.com/ros/diagnostics/issues/198>)
  Co-authored-by: Vincent Rousseau <mailto:vincent.rousseau@sabi-agri.com>
* Contributors: Noizet Maxime, Rousseau Vincent, chrisflesher
```

## diagnostic_updater

```
* Use DiagnosticLevel enum instead of hardcoded integers (#208 <https://github.com/ros/diagnostics/issues/208>)
  Spellcheck fixes
* Contributors: Amilcar Lucas
```

## diagnostics

- No changes

## rosdiagnostic

- No changes

## self_test

- No changes

## test_diagnostic_aggregator

- No changes
