### PR TITLE
nmea_hardware_interface: 0.0.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2013,6 +2013,21 @@ repositories:
       url: https://github.com/neobotix/neo_simulation2.git
       version: galactic
     status: maintained
+  nmea_hardware_interface:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/nmea_hardware_interface.git
+      version: master
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/OUXT-Polaris/nmea_hardware_interface-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/nmea_hardware_interface.git
+      version: master
+    status: developed
   nmea_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_hardware_interface` to `0.0.1-1`:

- upstream repository: https://github.com/OUXT-Polaris/nmea_hardware_interface.git
- release repository: https://github.com/OUXT-Polaris/nmea_hardware_interface-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## nmea_hardware_interface

```
* Merge pull request #3 <https://github.com/OUXT-Polaris/nmea_hardware_interface/issues/3> from OUXT-Polaris/feature/future
  clang-format
* clang-format
* Merge pull request #2 <https://github.com/OUXT-Polaris/nmea_hardware_interface/issues/2> from OUXT-Polaris/feature/future
  change_include_order
* change_include_order
* Merge pull request #1 <https://github.com/OUXT-Polaris/nmea_hardware_interface/issues/1> from OUXT-Polaris/feature/future
  Feature/future
* add stamped
* topic echo geopose
* fix error
* 11/03
* change urdf
* change $GxRMC
* connect serialport
* add xml file
* fix build error
* 10/06
* change cmakeLists
* aiueo
* add
* add
* add
* create
* Initial commit
* Contributors: KentaOkamoto, kentaokamoto
```
