### PR TITLE
rosbridge_suite: 1.1.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3690,7 +3690,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `1.1.2-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.1-1`

## rosapi

- No changes

## rosapi_msgs

- No changes

## rosbridge_library

```
* [694] update DurabilityPolicy api that are being deprecated (#695 <https://github.com/RobotWebTools/rosbridge_suite/issues/695>)
* Fix byte behavior (#693 <https://github.com/RobotWebTools/rosbridge_suite/issues/693>)
* Fix test_message_conversion.py (#645 <https://github.com/RobotWebTools/rosbridge_suite/issues/645>)
* Fix test_ros_loader.py (#644 <https://github.com/RobotWebTools/rosbridge_suite/issues/644>)
* Fix CI test configuration and temporarily disable rosbridge_library test (#686 <https://github.com/RobotWebTools/rosbridge_suite/issues/686>)
* Contributors: Evan Flynn, Jacob Bandes-Storch, Kenji Miyake
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* [694] update DurabilityPolicy api that are being deprecated (#695 <https://github.com/RobotWebTools/rosbridge_suite/issues/695>)
* Contributors: Evan Flynn
```

## rosbridge_suite

- No changes

## rosbridge_test_msgs

- No changes
