### PR TITLE
libnabo: 1.0.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1479,6 +1479,21 @@ repositories:
       url: https://github.com/ros2-gbp/libg2o-release.git
       version: 2020.5.29-2
     status: maintained
+  libnabo:
+    doc:
+      type: git
+      url: https://github.com/ethz-asl/libnabo.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/nobleo/libnabo-release.git
+      version: 1.0.7-1
+    source:
+      type: git
+      url: https://github.com/ethz-asl/libnabo.git
+      version: master
+    status: maintained
   libstatistics_collector:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libnabo` to `1.0.7-1`:

- upstream repository: https://github.com/ethz-asl/libnabo.git
- release repository: https://github.com/nobleo/libnabo-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## libnabo

```
* Disabled cmake compile tests by default and on compilers that do not support them (#95)
* Fix Python 2 bindings support in CMake scripts (#90)
* Port libnabo to c++11 (#89)
* Remove register keyword in index_heap.h (#88)
* Fix compilation warning for MSVC (#85)
* Assert template type for invalid setters (#80)
* Return numerically maximal index (unsigned) or -1 (signed) for no match case (#79)
* Add generate step for ${PROJECT_BINARY_DIR}/libnaboConfig.cmake (#76)
* Removed compiler-specific flags for compilers that do not support them (#74)
* Added cmake_policy(SET CMP0054 NEW) (#73)
* Output compiler message with compile test fatal error in cmake (#72)
* Removed erroneous commas from test/CMakeLists.txt (#71)
* Removed fatal "," suffix from FATAL_ERROR in CMakeLists.txt (#70)
* Fixed regression concerning installed libnaboConfig.cmake (#65)
* Fix/relax compiler requirements (#63)
* Removed hard dependency on the doc target (#62)
* Install any.hpp (#61)
* Remove boost::any and boost:format dependencies (#59)
* Port the python bindings to python3 (#57)
* Added cmake switch to disable usage of OpenMP (#53)
* Zero copy for Eigen::Matrix3XT and Eigen::Map<const Eigen::Matrix3XT> (#43)
* Fix warnings and switch on Wextra (#42)
* Disallow instantiation with non dynamic matrices (#41)
* Update README.md
* Removed all code dealing with libnaboTargets.cmake (#32)
* Got rid of unused locally defined typedefs (#27)
* Contributors: David Landry, Hannes Sommer, Simon Lynen, Simon-Pierre Deschênes, Stéphane Magnenat, cezheng, ffurrer, magehrig, renning22, sandsmark, taketwo, tcies
```
