### PR TITLE
Switch the branch for velodyne in foxy to 'foxy-devel'.

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5993,7 +5993,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/velodyne.git
-      version: ros2
+      version: foxy-devel
     release:
       packages:
       - velodyne
@@ -6008,7 +6008,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/velodyne.git
-      version: ros2
+      version: foxy-devel
     status: developed
   velodyne_simulator:
     doc:


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>