### PR TITLE
plotjuggler: 3.3.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8863,7 +8863,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.3.4-1
+      version: 3.3.5-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.3.5-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.3.4-1`

## plotjuggler

```
* fix zoom issue when toggling T_offset
* cosmetic changes
* show missing curves in error dialog (#579 <https://github.com/facontidavide/PlotJuggler/issues/579>)
* fix #550 <https://github.com/facontidavide/PlotJuggler/issues/550>
* Contributors: Adeeb Shihadeh, Davide Faconti
```
