### PR TITLE
plotjuggler: 3.3.5-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5831,7 +5831,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.3.4-1
+      version: 3.3.5-2
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.3.5-2`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.3.4-1`

## plotjuggler

```
* fix zoom issue when toggling T_offset
* cosmetic changes
* show missing curves in error dialog (#579 <https://github.com/facontidavide/PlotJuggler/issues/579>)
* fix #550 <https://github.com/facontidavide/PlotJuggler/issues/550>
* Contributors: Adeeb Shihadeh, Davide Faconti
```
