### PR TITLE
ros_ign: 0.244.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3322,7 +3322,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 0.244.0-1
+      version: 0.244.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_ign` to `0.244.1-1`:

- upstream repository: https://github.com/ignitionrobotics/ros_ign
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.244.0-1`

## ros_ign

- No changes

## ros_ign_bridge

```
* Improve modularity of ign/ros publisher tests (#194 <https://github.com/osrf/ros_ign/issues/194>)
* Contributors: Michael Carroll
```

## ros_ign_gazebo

- No changes

## ros_ign_gazebo_demos

- No changes

## ros_ign_image

- No changes

## ros_ign_interfaces

- No changes
