### PR TITLE
moveit_opw_kinematics_plugin: 0.4.0-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4607,7 +4607,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/JeroenDM/moveit_opw_kinematics_plugin-release.git
-      version: 0.3.1-2
+      version: 0.4.0-3
     source:
       type: git
       url: https://github.com/JeroenDM/moveit_opw_kinematics_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_opw_kinematics_plugin` to `0.4.0-3`:

- upstream repository: https://github.com/JeroenDM/moveit_opw_kinematics_plugin.git
- release repository: https://github.com/JeroenDM/moveit_opw_kinematics_plugin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.1-2`

## moveit_opw_kinematics_plugin

```
* Update status badge noetic-devel (default) branch
* Run melodic ci job on ubuntu 18.04
* Sync melodic changes to noetic
  - fix bug introduced when cherry-picking commits
  - minor formatting improvement
  - replace logstring with variable LOGNAME
  - print out odd posture used in self-test on error
  - Print all deviations and check zero pose as well
* Update Jeroen's email address
* Add github actions
  - Add roscpp as CATKIN_DEPENDS
  - Use the .ci.rosinstall to install dependencies
  - Move rosinstall for testing to typical place for industrial-ci
  - Update ci badges to GHA
  - Remove travis
* Contributors: JeroenDM, Simon Schmeisser
```
