### PR TITLE
octomap_mapping: 2.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2481,6 +2481,24 @@ repositories:
       url: https://github.com/octomap/octomap.git
       version: devel
     status: maintained
+  octomap_mapping:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap_mapping.git
+      version: ros2
+    release:
+      packages:
+      - octomap_mapping
+      - octomap_server
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/octomap_mapping-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap_mapping.git
+      version: ros2
+    status: maintained
   octomap_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_mapping` to `2.0.0-1`:

- upstream repository: https://github.com/OctoMap/octomap_mapping.git
- release repository: https://github.com/ros2-gbp/octomap_mapping-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## octomap_mapping

```
* ROS2 Migration (#95 <https://github.com/octomap/octomap_mapping/issues/95>)
* Contributors: Daisuke Nishimatsu
```

## octomap_server

```
* ROS2 Migration (#95 <https://github.com/octomap/octomap_mapping/issues/95>)
* Contributors: Daisuke Nishimatsu, Wolfgang Merkt
```
