### PR TITLE
Switch the depthimage_to_laserscan Rolling branch to 'ros2'.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -624,7 +624,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/depthimage_to_laserscan.git
-      version: foxy-devel
+      version: ros2
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -634,7 +634,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/depthimage_to_laserscan.git
-      version: foxy-devel
+      version: ros2
     status: maintained
   diagnostics:
     doc:


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>