### PR TITLE
ros_image_to_qimage: 0.0.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3624,6 +3624,21 @@ repositories:
       url: https://github.com/ignitionrobotics/ros_ign.git
       version: galactic
     status: developed
+  ros_image_to_qimage:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/ros_image_to_qimage.git
+      version: rolling
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros-sports/ros_image_to_qimage-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-sports/ros_image_to_qimage.git
+      version: rolling
+    status: developed
   ros_testing:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_image_to_qimage` to `0.0.1-1`:

- upstream repository: https://github.com/ros-sports/ros_image_to_qimage.git
- release repository: https://github.com/ros-sports/ros_image_to_qimage-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ros_image_to_qimage

```
* implemented ros_image_to_qimage package
* Contributors: Kenji Brameld, ijnek
```
