### PR TITLE
Update release repositories for ROS 2 releases from tier4.

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2651,7 +2651,7 @@ repositories:
     release:
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/tier4/osqp_vendor-release.git
+      url: https://github.com/ros2-gbp/osqp_vendor-release.git
       version: 0.0.4-1
     source:
       type: git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1145,7 +1145,7 @@ repositories:
     release:
       tags:
         release: release/galactic/{package}/{version}
-      url: https://github.com/tier4/hash_library_vendor-release.git
+      url: https://github.com/ros2-gbp/hash_library_vendor-release.git
       version: 0.1.1-1
     source:
       type: git
@@ -2255,7 +2255,7 @@ repositories:
     release:
       tags:
         release: release/galactic/{package}/{version}
-      url: https://github.com/tier4/osqp_vendor-release.git
+      url: https://github.com/ros2-gbp/osqp_vendor-release.git
       version: 0.0.4-1
     source:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1097,7 +1097,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/tier4/hash_library_vendor-release.git
+      url: https://github.com/ros2-gbp/hash_library_vendor-release.git
       version: 0.1.1-1
     source:
       type: git
@@ -2098,7 +2098,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/tier4/osqp_vendor-release.git
+      url: https://github.com/ros2-gbp/osqp_vendor-release.git
       version: 0.0.4-1
     source:
       type: git


### PR DESCRIPTION
Responding to the request in https://github.com/ros/rosdistro/pull/31289#issuecomment-1006495518
This updates the release repository url for ROS 2 distros to all use the
ros2-gbp copy of the repository.

Since the same osqp_vendor-release repository is used for ROS Noetic as
well we could either update that url and use the ros2-gbp repository for
all distributions or maintain the existing release repository just for
ROS Noetic.

