### PR TITLE
Update release repositories for ROS 2 from microstrain.

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2119,7 +2119,7 @@ repositories:
       - microstrain_inertial_rqt
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release.git
+      url: https://github.com/ros2-gbp/microstrain_inertial-release.git
       version: 2.4.0-1
     source:
       test_pull_requests: true
@@ -2473,7 +2473,7 @@ repositories:
     release:
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/LORD-MicroStrain/ntrip_client-ros2-release.git
+      url: https://github.com/ros2-gbp/ntrip_client-release.git
       version: 1.0.0-1
     source:
       test_pull_requests: true

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1724,7 +1724,7 @@ repositories:
       - microstrain_inertial_rqt
       tags:
         release: release/galactic/{package}/{version}
-      url: https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release.git
+      url: https://github.com/ros2-gbp/microstrain_inertial-release.git
       version: 2.4.0-1
     source:
       test_pull_requests: true
@@ -2107,7 +2107,7 @@ repositories:
     release:
       tags:
         release: release/galactic/{package}/{version}
-      url: https://github.com/LORD-MicroStrain/ntrip_client-ros2-release.git
+      url: https://github.com/ros2-gbp/ntrip_client-release.git
       version: 1.0.0-1
     source:
       test_pull_requests: true

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1690,7 +1690,7 @@ repositories:
       - microstrain_inertial_rqt
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release.git
+      url: https://github.com/ros2-gbp/microstrain_inertial-release.git
       version: 2.4.0-1
     source:
       test_pull_requests: true
@@ -1965,7 +1965,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/LORD-MicroStrain/ntrip_client-ros2-release.git
+      url: https://github.com/ros2-gbp/ntrip_client-release.git
       version: 1.0.0-2
     source:
       test_pull_requests: true


### PR DESCRIPTION
Responding to the request in https://github.com/ros/rosdistro/pull/31550#issuecomment-1005934429
This updates the release repository url for ROS 2 distros to all use the
ros2-gbp copy of the repository.
