### PR TITLE
Update gurumdds rosdep keys.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1687,9 +1687,20 @@ gtk3:
       packages: [gtk+3]
   ubuntu: [libgtk-3-dev]
 gurumdds-2.6:
-  ubuntu: [gurumdds-2.6]
+  ubuntu:
+    bionic: [gurumdds-2.6]
+    focal: [gurumdds-2.6]
+    xenial: [gurumdds-2.6]
 gurumdds-2.7:
-  ubuntu: [gurumdds-2.7]
+  ubuntu:
+    bionic: [gurumdds-2.7]
+    focal: [gurumdds-2.7]
+    xenial: [gurumdds-2.7]
+gurumdds-2.8:
+  ubuntu:
+    bionic: [gurumdds-2.8]
+    focal: [gurumdds-2.8]
+    xenial: [gurumdds-2.8]
 gv:
   arch: [gv]
   debian: [gv]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

The GurumDDS keys need to be un-elided.

* gurumdds-2.6 is available for Xenial, Bionic, and Focal, but not Jammy.
  http://repos.ros.org/repos/ros_bootstrap/pool/main/g/gurumdds-2.6/
* gurumdds-2.7 is available for Xenial, Bionic, and Focal, but not Jammy.
  http://repos.ros.org/repos/ros_bootstrap/pool/main/g/gurumdds-2.7/
* gurumdds-2.8 is available for Bionic, and Focal, but Jammy is still
  forthcoming.
  http://repos.ros.org/repos/ros_bootstrap/pool/main/g/gurumdds-2.8/

## Package Upstream Source:

[GurumDDS](https://gurum.cc/gurumdds) is an rmw provider distributed in the ROS bootstrap repository.

## Purpose of using this:

This package is used by [rmw_gurumdds](https://github.com/ros2/rmw_gurumdds).

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - not available
- Ubuntu: via ROS bootstrap repository
   -  http://repos.ros.org/repos/ros_bootstrap/pool/main/g/gurumdds-2.6/
   -  http://repos.ros.org/repos/ros_bootstrap/pool/main/g/gurumdds-2.7/
   -  http://repos.ros.org/repos/ros_bootstrap/pool/main/g/gurumdds-2.8/
- Fedora: https://src.fedoraproject.org/browse/projects/
  - NOT AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - NOT AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - NOT AVAILABLE
- macOS: https://formulae.brew.sh/
  - NOT AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - NOT AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - NOT AVAILABLE
