### PR TITLE
Update python3-opencv key.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7110,20 +7110,13 @@ python3-open3d-pip:
     pip:
       packages: [open3d-python]
 python3-opencv:
-  debian:
-    bullseye: [python3-opencv]
-    buster: [python3-opencv]
+  debian: [python3-opencv]
   fedora: [python3-opencv]
   gentoo: ['media-libs/opencv[python]']
   nixos: [python3Packages.opencv3]
   openembedded: [opencv@meta-oe]
   opensuse: [python3-opencv]
-  ubuntu:
-    bionic: [python3-opencv]
-    cosmic: [python3-opencv]
-    disco: [python3-opencv]
-    eoan: [python3-opencv]
-    focal: [python3-opencv]
+  ubuntu: [python3-opencv]
 python3-opengl:
   debian: [python3-opengl]
   fedora: [python3-pyopengl]


### PR DESCRIPTION
Since all supported Debian and Ubuntu distributions now provide this key
the distribution version/codename can be elided.

