### PR TITLE
libpointmatcher: 1.3.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1497,6 +1497,21 @@ repositories:
       url: https://github.com/ethz-asl/libnabo.git
       version: master
     status: maintained
+  libpointmatcher:
+    doc:
+      type: git
+      url: https://github.com/ethz-asl/libpointmatcher.git
+      version: master
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/nobleo/libpointmatcher-release.git
+      version: 1.3.1-1
+    source:
+      type: git
+      url: https://github.com/ethz-asl/libpointmatcher.git
+      version: master
+    status: maintained
   librealsense2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libpointmatcher` to `1.3.1-1`:

- upstream repository: https://github.com/ethz-asl/libpointmatcher.git
- release repository: https://github.com/nobleo/libpointmatcher-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## libpointmatcher

```
* Added documentation for people using ROS.
* Increased libnabo minimal version to 1.0.7.
* Added interface to inform if maximum number of iterations was reached.
* Fixed portability issue of the FileLogger.
* Fixed unit tests on Windows.
* Fixed parameter-less modules having 'unknown' as class name.
* Updated Windows compilation tutorial.
* Fixed compilation problems on Windows.
* Fixed PointToPlan error residual.
* Changed DOI resolver link in documentation.
* Added validation for the input transformation matrix in ICP.cpp.
* Removed duplication of PointToPoint compute in PointToPointWithCov.
* Added the RemoveSensorBias filter.
* Splitted ErrorMinimizersImpl.cpp into multiple files.
```
