### PR TITLE
ign_ros2_control: 0.1.1-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1488,7 +1488,7 @@ repositories:
       type: git
       url: https://github.com/ignitionrobotics/ign_ros2_control.git
       version: foxy
-    status: developed    
+    status: developed
   image_common:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1471,6 +1471,24 @@ repositories:
       url: https://github.com/ethz-adrl/ifopt.git
       version: master
     status: maintained
+  ign_ros2_control:
+    doc:
+      type: git
+      url: https://github.com/ignitionrobotics/ign_ros2_control.git
+      version: foxy
+    release:
+      packages:
+      - ign_ros2_control
+      - ign_ros2_control_demos
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/ign_ros2_control-release.git
+      version: 0.1.1-2
+    source:
+      type: git
+      url: https://github.com/ignitionrobotics/ign_ros2_control.git
+      version: foxy
+    status: developed    
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ign_ros2_control` to `0.1.1-2`:

- upstream repository: https://github.com/ignitionrobotics/ign_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

```
* Change package names from ignition_ to ign_ (#19 <https://github.com/ignitionrobotics/ign_ros2_control/pull/22>)
  * Change package names from ignition_ to ign_
* Contributors: Alejandro Hernández Cordero
```

```
* Change package names from ignition_ to ign_ (#19 <https://github.com/ignitionrobotics/ign_ros2_control/issues/19>)
  * Change package names from ignition_ to ign_
* Added missing dependencies to package.xml (#18 <https://github.com/ignitionrobotics/ign_ros2_control/pull/21>)
* Contributors: Alejandro Hernández Cordero
```

Signed-off-by: ahcorde <ahcorde@gmail.com>

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
