### PR TITLE
add libiio-dev to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3622,6 +3622,11 @@ libignition-utils1:
     buster: [libignition-utils1]
   ubuntu:
     focal: [libignition-utils1]
+libiio-dev:
+  debian: [libiio-dev]
+  fedora: [libiio-devel]
+  gentoo: [net-libs/libiio]
+  ubuntu: [libiio-dev]
 libimage-exiftool-perl:
   arch: [perl-image-exiftool]
   debian: [libimage-exiftool-perl]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

libiio-dev

## Package Upstream Source:

[https://github.com/analogdevicesinc/libiio](https://github.com/analogdevicesinc/libiio)

## Purpose of using this:

This library is useful for communicating with Linux IIO devices. We plan to use the library in our ros2_control and hardware interface layers.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - [https://packages.debian.org/bullseye/libiio-dev](https://packages.debian.org/bullseye/libiio-dev)
- Ubuntu: https://packages.ubuntu.com/
   - [https://packages.ubuntu.com/impish/libiio-dev](https://packages.ubuntu.com/impish/libiio-dev)
- Fedora: https://src.fedoraproject.org/browse/projects/
  - [https://src.fedoraproject.org/rpms/libiio#bodhi_updates](https://src.fedoraproject.org/rpms/libiio#bodhi_updates)
- Gentoo: https://packages.gentoo.org/
  - [https://packages.gentoo.org/packages/net-libs/libiio](https://packages.gentoo.org/packages/net-libs/libiio)
