### PR TITLE
soccer_object_msgs: 1.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5323,23 +5323,6 @@ repositories:
       url: https://github.com/PickNikRobotics/snowbot_operating_system.git
       version: ros2
     status: maintained
-  soccer_interfaces:
-    doc:
-      type: git
-      url: https://github.com/ijnek/soccer_interfaces.git
-      version: rolling
-    release:
-      packages:
-      - soccer_vision_msgs
-      tags:
-        release: release/foxy/{package}/{version}
-      url: https://github.com/ijnek/soccer_interfaces-release.git
-      version: 1.0.0-1
-    source:
-      type: git
-      url: https://github.com/ijnek/soccer_interfaces.git
-      version: rolling
-    status: developed
   soccer_object_msgs:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5340,6 +5340,21 @@ repositories:
       url: https://github.com/ijnek/soccer_interfaces.git
       version: rolling
     status: developed
+  soccer_object_msgs:
+    doc:
+      type: git
+      url: https://github.com/ijnek/soccer_object_msgs.git
+      version: rolling
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ijnek/soccer_object_msgs-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ijnek/soccer_object_msgs.git
+      version: rolling
+    status: developed
   sol_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `soccer_object_msgs` to `1.0.1-1`:

- upstream repository: https://github.com/ijnek/soccer_interfaces.git
- release repository: https://github.com/ijnek/soccer_object_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## soccer_object_msgs

```
* rename soccer_vision_msgs to soccer_object_msgs
* move everything up a repo
* Contributors: Kenji Brameld
```
