### PR TITLE
soccer_visualization: 0.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4174,7 +4174,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ijnek/soccer_visualization.git
-      version: main
+      version: rolling
     release:
       packages:
       - soccer_marker_generation
@@ -4185,7 +4185,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ijnek/soccer_visualization.git
-      version: main
+      version: rolling
     status: developed
   sol_vendor:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4170,6 +4170,23 @@ repositories:
       url: https://github.com/ijnek/soccer_object_msgs.git
       version: rolling
     status: developed
+  soccer_visualization:
+    doc:
+      type: git
+      url: https://github.com/ijnek/soccer_visualization.git
+      version: main
+    release:
+      packages:
+      - soccer_marker_generation
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ijnek/soccer_visualization-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/ijnek/soccer_visualization.git
+      version: main
+    status: developed
   sol_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `soccer_visualization` to `0.0.2-1`:

- upstream repository: https://github.com/ijnek/soccer_visualization.git
- release repository: https://github.com/ijnek/soccer_visualization-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## soccer_marker_generation

```
* rename soccer_interfaces/soccer_vision_msgs to soccer_object_msgs
* Use new Ball msg, rather than Point msg
* add ament_cmake_gtest to package.xml
* Contributors: Kenji Brameld, ijnek
```
