### PR TITLE
rqt_image_overlay: 0.0.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4067,6 +4067,24 @@ repositories:
       url: https://github.com/ros-visualization/rqt_graph.git
       version: galactic-devel
     status: maintained
+  rqt_image_overlay:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/rqt_image_overlay.git
+      version: rolling
+    release:
+      packages:
+      - rqt_image_overlay
+      - rqt_image_overlay_layer
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros-sports/rqt_image_overlay-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-sports/rqt_image_overlay.git
+      version: rolling
+    status: developed
   rqt_image_view:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_image_overlay` to `0.0.1-1`:

- upstream repository: https://github.com/ros-sports/rqt_image_overlay.git
- release repository: https://github.com/ros-sports/rqt_image_overlay-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## rqt_image_overlay

```
* Initial release
* Contributors: ijnek
```

## rqt_image_overlay_layer

```
* Initial release
* Contributors: ijnek
```
