### PR TITLE
rm_controllers: 0.1.2-1 in 'noetic/distribution.yaml'

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6790,7 +6790,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/rm-controls/rm_controllers-release.git
-      version: 0.1.1-3
+      version: 0.1.1-4
     source:
       type: git
       url: https://github.com/rm-controls/rm_controllers.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6790,7 +6790,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/rm-controls/rm_controllers-release.git
-      version: 0.1.1-4
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/rm-controls/rm_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rm_controllers` to `0.1.2-1`:

* upstream repository: https://github.com/rm-controls/rm_controllers.git
* release repository: https://github.com/rm-controls/rm_controllers-release.git
* distro file: `noetic/distribution.yaml`
* bloom version: `0.10.7`
* previous version for package: `0.1.1-3`

