### PR TITLE
moveit_resources: 0.8.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6905,7 +6905,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/moveit_resources-release.git
-      version: 0.7.3-1
+      version: 0.8.2-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_resources.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `0.8.2-1`:

- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros-gbp/moveit_resources-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.3-1`

## moveit_resources

- No changes

## moveit_resources_fanuc_description

- No changes

## moveit_resources_fanuc_moveit_config

```
* test_environment.launch: use fake_execution_type="last point" by default
* Contributors: Robert Haschke
```

## moveit_resources_panda_description

```
* Fix transparency of meshes for Gazebo 8 (https://github.com/frankaemika/franka_ros/pull/79)
* Contributors: Robert Haschke
```

## moveit_resources_panda_moveit_config

```
* test_environment.launch: use fake_execution_type="last point" by default
* Contributors: Robert Haschke
```

## moveit_resources_pr2_description

- No changes

## moveit_resources_prbt_ikfast_manipulator_plugin

- No changes

## moveit_resources_prbt_moveit_config

- No changes

## moveit_resources_prbt_pg70_support

- No changes

## moveit_resources_prbt_support

- No changes
