### PR TITLE
moveit: 1.0.9-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6815,7 +6815,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 1.0.8-1
+      version: 1.0.9-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `1.0.9-1`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.8-1`

## chomp_motion_planner

- No changes

## moveit

- No changes

## moveit_chomp_optimizer_adapter

```
* Use mailto:moveit-resources@master (#2951 <https://github.com/ros-planning/moveit/issues/2951>)
  
    * Simplify launch files to use the test_environment.launch files from mailto:moveit_resources@master
    * Provide compatibility to the Noetic-style configuration of (multiple) planning pipelines
      Only a single pipeline can be used at a time, specified via the ~default_planning_pipeline parameter.
  
* Contributors: Robert Haschke
```

## moveit_commander

- No changes

## moveit_controller_manager_example

- No changes

## moveit_core

```
* Use mailto:moveit-resources@master (#2951 <https://github.com/ros-planning/moveit/issues/2951>)
  
    * Simplify launch files to use the test_environment.launch files from mailto:moveit_resources@master
    * Provide compatibility to the Noetic-style configuration of (multiple) planning pipelines
      Only a single pipeline can be used at a time, specified via the ~default_planning_pipeline parameter.
  
* Make TimeParameterization classes polymorphic (#3023 <https://github.com/ros-planning/moveit/issues/3023>)
* Move ``MoveItErrorCode`` class to ``moveit_core`` (#3009 <https://github.com/ros-planning/moveit/issues/3009>)
* Provide ``MOVEIT_VERSION_CHECK`` macro (#2997 <https://github.com/ros-planning/moveit/issues/2997>)
* Fix padding collision attached objects (#2721 <https://github.com/ros-planning/moveit/issues/2721>)
* Contributors: Michael Görner, Robert Haschke, Toru Kuga, Andrea Pupa
```

## moveit_fake_controller_manager

- No changes

## moveit_kinematics

- No changes

## moveit_planners

- No changes

## moveit_planners_chomp

```
* Use mailto:moveit-resources@master (#2951 <https://github.com/ros-planning/moveit/issues/2951>)
  
    * Simplify launch files to use the test_environment.launch files from mailto:moveit_resources@master
    * Provide compatibility to the Noetic-style configuration of (multiple) planning pipelines
      Only a single pipeline can be used at a time, specified via the ~default_planning_pipeline parameter.
  
* Move ``MoveItErrorCode`` class to ``moveit_core`` (#3009 <https://github.com/ros-planning/moveit/issues/3009>)
* Contributors: Robert Haschke
```

## moveit_planners_ompl

- No changes

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

```
* Provide ``MOVEIT_VERSION_CHECK`` macro (#2997 <https://github.com/ros-planning/moveit/issues/2997>)
* Contributors: Robert Haschke
```

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

- No changes

## moveit_ros_move_group

```
* Use mailto:moveit-resources@master (#2951 <https://github.com/ros-planning/moveit/issues/2951>)
  
    * Simplify launch files to use the test_environment.launch files from mailto:moveit_resources@master
    * Provide compatibility to the Noetic-style configuration of (multiple) planning pipelines
      Only a single pipeline can be used at a time, specified via the ~default_planning_pipeline parameter.
  
* Contributors: Robert Haschke
```

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

- No changes

## moveit_ros_planning

```
* Use mailto:moveit-resources@master (#2951 <https://github.com/ros-planning/moveit/issues/2951>)
  
    * Simplify launch files to use the test_environment.launch files from mailto:moveit_resources@master
    * Provide compatibility to the Noetic-style configuration of (multiple) planning pipelines
      Only a single pipeline can be used at a time, specified via the ~default_planning_pipeline parameter.
  
* Contributors: Robert Haschke
```

## moveit_ros_planning_interface

```
* Use mailto:moveit-resources@master (#2951 <https://github.com/ros-planning/moveit/issues/2951>)
  
    * Simplify launch files to use the test_environment.launch files from mailto:moveit_resources@master
    * Provide compatibility to the Noetic-style configuration of (multiple) planning pipelines
      Only a single pipeline can be used at a time, specified via the ~default_planning_pipeline parameter.
  
* Add missing noexcept declarations (#3016 <https://github.com/ros-planning/moveit/issues/3016>)
* Move ``MoveItErrorCode`` class to ``moveit_core`` (#3009 <https://github.com/ros-planning/moveit/issues/3009>)
* Revert "Fix scaling factor parameter names" (#2907 <https://github.com/ros-planning/moveit/issues/2907>)
* Contributors: Michael Görner, Robert Haschke
```

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

```
* Move ``MoveItErrorCode`` class to ``moveit_core`` (#3009 <https://github.com/ros-planning/moveit/issues/3009>)
* Contributors: Michael Görner, Robert Haschke
```

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_servo

```
* Fix an off-by-one error in servo_calcs.cpp (#2908 <https://github.com/ros-planning/moveit/issues/2908>)
* Contributors: Michael Görner
```

## moveit_setup_assistant

```
* Use mailto:moveit-resources@master (#2951 <https://github.com/ros-planning/moveit/issues/2951>)
  
    * Simplify launch files to use the test_environment.launch files from mailto:moveit_resources@master
    * Provide compatibility to the Noetic-style configuration of (multiple) planning pipelines
      Only a single pipeline can be used at a time, specified via the ~default_planning_pipeline parameter.
    * Rename launch argument execution_type -> fake_execution_type
  
* Templates: Fix passing capabilities arguments (#2729 <https://github.com/ros-planning/moveit/issues/2729>)
* Fix writing an empty sensor config (#2708 <https://github.com/ros-planning/moveit/issues/2708>)
* Contributors: David V. Lu!!, G.A. vd. Hoorn, Michael Görner, Robert Haschke
```

## moveit_simple_controller_manager

- No changes

## pilz_industrial_motion_planner

```
* Use mailto:moveit-resources@master (#2951 <https://github.com/ros-planning/moveit/issues/2951>)
  
    * Simplify launch files to use the test_environment.launch files from mailto:moveit_resources@master
    * Provide compatibility to the Noetic-style configuration of (multiple) planning pipelines
      Only a single pipeline can be used at a time, specified via the ~default_planning_pipeline parameter.
    * Rename launch argument execution_type -> fake_execution_type
  
* Contributors: Michael Görner, Robert Haschke
```

## pilz_industrial_motion_planner_testutils

- No changes
