### PR TITLE
webots_ros: 5.0.1-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -14962,7 +14962,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/cyberbotics/webots_ros-release.git
-      version: 4.1.0-1
+      version: 5.0.1-2
     source:
       type: git
       url: https://github.com/cyberbotics/webots_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `webots_ros` to `5.0.1-2`:

- upstream repository: https://github.com/cyberbotics/webots_ros.git
- release repository: https://github.com/cyberbotics/webots_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `4.1.0-1`
