### PR TITLE
webots_ros2: 1.2.1-3 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5405,7 +5405,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/webots_ros2-release.git
-      version: 1.2.0-2
+      version: 1.2.1-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `webots_ros2` to `1.2.1-3`:

- upstream repository: https://github.com/cyberbotics/webots_ros2.git
- release repository: https://github.com/ros2-gbp/webots_ros2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.0-2`

## webots_ros2_driver

```
* Fix link error for 'webots_ros2_control' on macOS.
* Fix lidar device according to FLU convention.
```

## webots_ros2_tests

```
* Add a system test for the FLU lidar device.
```

## webots_ros2_turtlebot

```
* Add ros2control parameters for the lidar device.
```
