### PR TITLE
moveit: 2.2.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2178,11 +2178,14 @@ repositories:
       version: main
     release:
       packages:
+      - chomp_motion_planner
       - moveit
+      - moveit_chomp_optimizer_adapter
       - moveit_common
       - moveit_core
       - moveit_kinematics
       - moveit_planners
+      - moveit_planners_chomp
       - moveit_planners_ompl
       - moveit_plugins
       - moveit_ros
@@ -2204,7 +2207,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/moveit/moveit2-release.git
-      version: 2.2.2-1
+      version: 2.2.3-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.2.3-1`:

- upstream repository: https://github.com/ros-planning/moveit2.git
- release repository: https://github.com/moveit/moveit2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.2.2-1`

## chomp_motion_planner

```
* Port CHOMP Motion Planner to ROS 2 (backport #809 <https://github.com/ros-planning/moveit2/issues/809>) (#836 <https://github.com/ros-planning/moveit2/issues/836>)
* Contributors: Henning Kayser, Jafar Abdi, andreas-botbuilt
```

## moveit

- No changes

## moveit_chomp_optimizer_adapter

```
* Port CHOMP Motion Planner to ROS 2 (backport #809 <https://github.com/ros-planning/moveit2/issues/809>) (#836 <https://github.com/ros-planning/moveit2/issues/836>)
* Contributors: Henning Kayser, Jafar Abdi, andreas-botbuilt
```

## moveit_common

- No changes

## moveit_core

```
* Fix CHOMP motion planner build on Windows (#890 <https://github.com/ros-planning/moveit2/issues/890>) (#936 <https://github.com/ros-planning/moveit2/issues/936>)
* Fix boost linking errors (#900 <https://github.com/ros-planning/moveit2/issues/900>) (#920 <https://github.com/ros-planning/moveit2/issues/920>)
* Contributors: Vatan Aksoy Tezer, Akash
```

## moveit_kinematics

- No changes

## moveit_planners

- No changes

## moveit_planners_chomp

```
* Port CHOMP Motion Planner to ROS 2 (backport #809 <https://github.com/ros-planning/moveit2/issues/809>) (#836 <https://github.com/ros-planning/moveit2/issues/836>)
* Contributors: Henning Kayser, Jafar Abdi, andreas-botbuilt
```

## moveit_planners_ompl

```
* Link boost serializaiton (#925 <https://github.com/ros-planning/moveit2/issues/925>)
* Contributors: Vatan Aksoy Tezer
```

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_move_group

- No changes

## moveit_ros_occupancy_map_monitor

```
* Fix boost linking errors (#900 <https://github.com/ros-planning/moveit2/issues/900>) (#920 <https://github.com/ros-planning/moveit2/issues/920>)
* Contributors: Vatan Aksoy Tezer
```

## moveit_ros_perception

- No changes

## moveit_ros_planning

- No changes

## moveit_ros_planning_interface

- No changes

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

- No changes

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_servo

- No changes

## moveit_simple_controller_manager

- No changes

## run_move_group

- No changes

## run_moveit_cpp

- No changes

## run_ompl_constrained_planning

- No changes
