### PR TITLE
jsk_visualization: 2.1.8-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5327,7 +5327,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 2.1.7-2
+      version: 2.1.8-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `2.1.8-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_visualization
- release repository: https://github.com/tork-a/jsk_visualization-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.7-2`

## jsk_interactive

- No changes

## jsk_interactive_marker

```
* Resolve fixed frame of rviz (#842 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/842>)
  
    * frame_id_ is std::string, so we need to use c_str() or ROS_ERROR_STREAM
    * Resolve fixed frame of rviz
      * The pose in callback function of interactive marker is represented
      respect to fixed frame of rviz.
      * In order to publish consistent tf transformation, the pose should be
      transformed respect to the frame_id which is specified as ros
      parameter.
  
* Fix sample display robot state demo (#838 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/838>)
  
    * [jsk_interactive_marker] fix bugs
    * [jsk_interactive_marker] change the robot of
      sample_display_robot_state from JAXON to PR2
  
* [jsk_interactive_markers][jsk_rqt_plugins] fix yaml load (#818 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/818>)
* Enable to publish camera info from yaml file (#793 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/793>)
* Contributors: Adi Vardi, Kei Okada, Koki Shinjo, Naoya Yamaguchi, Ryohei Ueda
```

## jsk_interactive_test

- No changes

## jsk_rqt_plugins

```
* [jsk_interactive_markers][jsk_rqt_plugins] fix yaml load (#818 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/818>)
* fix with '2to3 -w -f zip .' (#817 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/817>)
  
    * In python3, sys.maxint changed to sys.maxsize
    * fix "TypeError: 'dict_keys' object is not subscriptable" error
      we can fix this by '2to3 -w -f dict', but it will change too many lines, so we do not use this for now....
    * fix with '2to3 -w -f import .'
    * fix cStringIO.StringIO -> io.BytesIO, see https://stackoverflow.com/questions/11914472/stringio-in-python3 / https://stackoverflow.com/questions/50797043/string-argument-expected-got-bytes-in-buffer-write
    * [jsk_rqt_plugins][jsk_rviz_plugins] Fix has_key
  
* add tabbed_buttuns to rqt_plugin (#813 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/813>)
* update .travis to 0.5.21 (#814 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/814>)
* Updating the URLs of the jsk_rviz_plugins and jsk_rqt_plugins so the generated README points to working links (closes #805 ). (#806 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/806>)
* Support single button setup in ServiceButtons plugin (#798 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/798>)
  
    * *column_indices expects to be an array of integers and the length
  should be equal or longer than 2.
  * If column_indices is just an array of a single integer (length is
  1), do not apply sum with expanding a list argument.
* fix for using button_general.py without perspective file (#796 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/796>)
* [jsk_rqt_plugins/button_general.py] reset button if SetBool fail (#794 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/794>)
* sample_service_button.py support SetBool (#792 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/792>)
* add sample_service_radio_buttons script (#789 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/789>)
* add sample_service_buttons scriptf (#790 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/790>)
* add sample_service_buttons.launch (#791 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/791>)
* Contributors: Adi Vardi, Kei Okada, Naoki Hiraoka, Ryohei Ueda, Sam Pfeiffer, Shingo Kitagawa, Yohei Kakiuchi
```

## jsk_rviz_plugins

```
* Fix font name for pictgram (#835 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/835>)
  
    * add launch/pictogram_sample.launch config/pictogram_sample.rviz
    * Add FontAwesome5: #759 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/759> need to update Font Name too
      PR #579 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/579> reported fa-mendeley is not displayed correctly. This because of the plugin uses system font, which is installed by fonts-font-awesome deb package, not font defined in fontawesome.dat. So if you remove fonts-font-awesome, you can not display most of font correctly. This PR update getFont function to return the correct font family
  
* Change pie chart color at your custom threshold (#840 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/840>)
* [jsk_rviz_plugins] added new Linear Gauge rviz plugin (#831 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/831>)
* add dependency.yml to check resolve circular dependency in jsk_rviz_plugins/package.xml (#830 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/830>)
* add test code for jsk_rviz_plugins (#825 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/825>)
  
    * fix #799 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/799>
    * move normal.test and face_detecotr.test to xml because of missing bag files
    * skip if it failed to download bag file, due to 'could not download file. maximum download trial exceeded.'
    * add more info on rviz_config_check.py
      - fix bugs when waiting rviz service takes more than 5 sec
      - rviz_config_check.py: check subscribing topic of rviz while rosnode ping rviz
    * increase time-limit to 30
    * skip install test on indigo
    * jsk_rviz_plugins : enable add_rostest for all DISTRO
    * normal.test requires jsk_pcl/NormalConcatenater whcih needs jsk_pcl_ros on kinetic
    * on <meloidc, rviz/SendFilePath is not found, use std_srvs/Empty for rviz/reload_shaders
    * install gdown / jsk_pcl_ros_utils for install_sample_data
    * install_sample_data requries jsk_data
    * enable normal.test, face_detector.test
    * fix normal_sample.launch to suport launch_openni arg and use async
    * fix face_detector_sample.launch to work with 2017-06-20-12-00-00_people_images_in_lab.bag
    * fix typo t_start -> self.t_start
    * add install_sample_data.py to download 2017-06-20-12-00-00_people_images_in_lab.bag for test
    * add joint_state_publisher and robot_state_publisher to test_depend
    * add robot_command_interface_sample.rviz and service_call_panel.rviz
    * [test/segmen_array.test, config/segment_array_sample.rviz] fix wrong Topic /polygon_array_sample/output -> /segment_array_sample/output
    * jsk_rviz_plugins: add test codes
    * link_marker_publisher_sample.launch, contact_state_marker_sample.launch requires pr2_description
    * add rostest to package.xml, run test code from catkin
    * rviz_config_check.py : node to check if rviz arives
  
* [jsk_rviz_plugins] move rviz config from cfg/ to config/ and fix typo (#823 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/823>)
* [jsk_rviz_plugins] add piechart sample (#824 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/824>)
* Resize and repositioning of PieChart wasn't working, corrected. (#822 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/822>)
* fix with '2to3 -w -f zip .' (#817 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/817>)
* Use multiple billboard lines when exceeding max elements per line (#808 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/808>)
* Updating the URLs of the jsk_rviz_plugins and jsk_rqt_plugins so the generated README points to working links (closes #805 ). (#806 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/806>)
* added a regex for "color: XXX;" pattern to have a properly colored shadow (#802 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/802>)
  
    * fix
      [jsk_rviz_plugins:make] /home/user/ws_jsk_visualization/src/jsk_visualization/jsk_rviz_plugins/src/overlay_text_display.cpp:274:81: error: no matching function for call to ‘regex_replace(std::string&, std::regex&, const char [1])’
      [jsk_rviz_plugins:make]          std::string formatted_text_ = std::regex_replace(text_, color_tag_re, );
      [jsk_rviz_plugins:make]                                                                                  ^
      [jsk_rviz_plugins:make] /home/user/ws_jsk_visualization/src/jsk_visualization/jsk_rviz_plugins/src/overlay_text_display.cpp:274:81: note: candidates are:
      [jsk_rviz_plugins:make] In file included from /usr/include/c++/4.8/regex:62:0,
      [jsk_rviz_plugins:make]                  from /home/user/ws_jsk_visualization/src/jsk_visualization/jsk_rviz_plugins/src/overlay_text_display.cpp:48:
      [jsk_rviz_plugins:make] /usr/include/c++/4.8/bits/regex.h:2162:5: note: template<class _Out_iter, class _Bi_iter, class _Rx_traits, class _Ch_type> _Out_iter std::regex_replace(_Out_iter, _Bi_iter, _Bi_iter, const std::basic_regex<_Ch_type, _Rx_traits>&, const std::basic_string<
      _Ch_type>&, std::regex_constants::match_flag_type)
      error, for compile on ubuntu 12.04
  
* [jsk_rviz_plugins] add warn for deprecated jsk_rviz_plugins/PoseArrayDisplay (#786 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/786>)
* Contributors: Adi Vardi, Andres Kushnir, Francois Teyssere, Francois Teyssere, Jan Krieglstein, Kei Okada, Sam Pfeiffer, Shingo Kitagawa, Shumpei Wakabayashi
```

## jsk_visualization

- No changes
