### PR TITLE
tork_moveit_tutorial: 0.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13578,6 +13578,21 @@ repositories:
       url: https://gitlab.com/toposens/public/ros-packages.git
       version: master
     status: developed
+  tork_moveit_tutorial:
+    doc:
+      type: git
+      url: https://github.com/tork-a/tork_moveit_tutorial.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/tork_moveit_tutorial-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/tork-a/tork_moveit_tutorial.git
+      version: indigo-devel
+    status: maintained
   towr:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tork_moveit_tutorial` to `0.1.1-1`:

- upstream repository: https://github.com/tork-a/tork_moveit_tutorial.git
- release repository: https://github.com/tork-a/tork_moveit_tutorial-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## tork_moveit_tutorial

```
* more fix for melodic .circleci (#57 <https://github.com/tork-a/tork_moveit_tutorial/issues/57>)
* Contributors: Tokyo Opensource Robotics Developer 534
```
