### PR TITLE
rslidar_msg: 0.0.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4329,6 +4329,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_topic.git
       version: foxy-devel
     status: maintained
+  rslidar_msg:
+    doc:
+      type: git
+      url: https://github.com/RoboSense-LiDAR/rslidar_msg.git
+      version: master
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/nobleo/rslidar_msg-release.git
+      version: 0.0.0-1
+    source:
+      type: git
+      url: https://github.com/RoboSense-LiDAR/rslidar_msg.git
+      version: master
+    status: maintained
   rtabmap:
     doc:
       type: git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4338,7 +4338,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/nobleo/rslidar_msg-release.git
-      version: 0.0.0-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/RoboSense-LiDAR/rslidar_msg.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rslidar_msg` to `0.0.0-1`:

- upstream repository: https://github.com/RoboSense-LiDAR/rslidar_msg.git
- release repository: https://github.com/nobleo/rslidar_msg-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
