### PR TITLE
Add webargs and Flask-JWT-Extended

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8536,13 +8536,13 @@ python3-weasyprint-pip:
 python3-webargs:
   arch: [python-webargs]
   debian:
+    '*': [python3-webargs]
     bullseye:
       pip:
         packages: [webargs]
     buster:
       pip:
         packages: [webargs]
-    '*': [python3-webargs]
   nixos: [python39Packages.webargs]
   ubuntu:
     '*': [python3-webargs]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8545,6 +8545,7 @@ python3-webargs:
   opensuse: [python-webargs]
   ubuntu:
     impish: [python3-webargs]
+    jammy: [python3-webargs]
     pip:
       packages: [webargs]
 python3-websocket:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8539,7 +8539,7 @@ python3-webargs:
   debian:
     pip:
       packages: [webargs]
-    sid: [python3-webargs]
+    '*': [python3-webargs]
   nixos: [python39Packages.webargs]
   ubuntu:
     impish: [python3-webargs]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6517,7 +6517,7 @@ python3-flask-cors:
     bionic: null
 python3-flask-jwt-extended:
   debian:
-    bullseye: [python3-python-flask-jwt-extended]
+    '*': [python3-python-flask-jwt-extended]
     pip:
       packages: [flask-jwt-extended]
   freebsd: [py-flask-jwt-extended]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8542,7 +8542,6 @@ python3-webargs:
       packages: [webargs]
     sid: [python3-webargs]
   nixos: [python39Packages.webargs]
-  opensuse: [python-webargs]
   ubuntu:
     impish: [python3-webargs]
     jammy: [python3-webargs]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1750,13 +1750,6 @@ python-flask-cors-pip:
   ubuntu:
     pip:
       packages: [flask-cors]
-python-flask-jwt-extended-pip: &migrate_eol_2025_04_30_python3_flask_jwt_extended_pip
-  debian:
-    pip:
-      packages: [flask-jwt-extended]
-  ubuntu:
-    pip:
-      packages: [flask-jwt-extended]
 python-flask-restful:
   debian: [python-flask-restful]
   fedora: [python-flask-restful]
@@ -5532,13 +5525,6 @@ python-watchdog:
     xenial: [python-watchdog]
     yakkety: [python-watchdog]
     zesty: [python-watchdog]
-python-webargs-pip: &migrate_eol_2025_04_30_python3_webargs_pip
-  debian:
-    pip:
-      packages: [webargs]
-  ubuntu:
-    pip:
-      packages: [webargs]
 python-webob:
   debian: [python-webob]
   fedora: [python-webob]
@@ -6529,7 +6515,21 @@ python3-flask-cors:
   ubuntu:
     '*': [python3-flask-cors]
     bionic: null
-python3-flask-jwt-extended-pip: *migrate_eol_2025_04_30_python3_flask_jwt_extended_pip
+python3-flask-jwt-extended:
+  debian:
+    bullseye: [python3-python-flask-jwt-extended]
+    pip:
+      packages: [flask-jwt-extended]
+    sid: [python3-python-flask-jwt-extended]
+  freebsd: [py-flask-jwt-extended]
+  nixos: [python39Packages.flask-jwt-extended]
+  opensuse: [python-flask-jwt-extended]
+  ubuntu:
+    focal: [python3-python-flask-jwt-extended]
+    hirsuite: [python3-python-flask-jwt-extended] 
+    impish: [python3-python-flask-jwt-extended]
+    pip:
+      packages: [flask-jwt-extended]
 python3-flask-restplus-pip:
   ubuntu:
     pip:
@@ -8534,7 +8534,18 @@ python3-weasyprint-pip:
   ubuntu:
     pip:
       packages: [weasyprint]
-python3-webargs-pip: *migrate_eol_2025_04_30_python3_webargs_pip
+python3-webargs:
+  arch: [python-webargs]
+  debian: 
+    pip:
+      packages: [webargs]
+    sid: [python3-webargs]
+  nixos: [python39Packages.webargs]
+  opensuse: [python-webargs]
+  ubuntu:
+    impish: [python3-webargs]
+    pip:
+      packages: [webargs]
 python3-websocket:
   debian: [python3-websocket]
   fedora: [python3-websocket-client]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6524,7 +6524,6 @@ python3-flask-jwt-extended:
   nixos: [python39Packages.flask-jwt-extended]
   opensuse: [python-flask-jwt-extended]
   ubuntu:
-    focal: [python3-python-flask-jwt-extended]
     hirsuite: [python3-python-flask-jwt-extended]
     impish: [python3-python-flask-jwt-extended]
     '*': [python3-python-flask-jwt-extended]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8539,7 +8539,7 @@ python3-webargs:
     '*': [python3-webargs]
   nixos: [python39Packages.webargs]
   ubuntu:
-    jammy: [python3-webargs]
+    '*': [python3-webargs]
     pip:
       packages: [webargs]
 python3-websocket:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5532,7 +5532,7 @@ python-watchdog:
     xenial: [python-watchdog]
     yakkety: [python-watchdog]
     zesty: [python-watchdog]
-python3-webargs-pip: &migrate_eol_2025_04_30_python3_webargs_pip
+python-webargs-pip: &migrate_eol_2025_04_30_python3_webargs_pip
   debian:
     pip:
       packages: [webargs]
@@ -8534,7 +8534,7 @@ python3-weasyprint-pip:
   ubuntu:
     pip:
       packages: [weasyprint]
-python-webargs-pip: *migrate_eol_2025_04_30_python3_webargs_pip
+python3-webargs-pip: *migrate_eol_2025_04_30_python3_webargs_pip
 python3-websocket:
   debian: [python3-websocket]
   fedora: [python3-websocket-client]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6528,7 +6528,7 @@ python3-flask-jwt-extended:
     focal: [python3-python-flask-jwt-extended]
     hirsuite: [python3-python-flask-jwt-extended]
     impish: [python3-python-flask-jwt-extended]
-    jammy: [python3-python-flask-jwt-extended]
+    '*': [python3-python-flask-jwt-extended]
     pip:
       packages: [flask-jwt-extended]
 python3-flask-restplus-pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6526,8 +6526,9 @@ python3-flask-jwt-extended:
   opensuse: [python-flask-jwt-extended]
   ubuntu:
     focal: [python3-python-flask-jwt-extended]
-    hirsuite: [python3-python-flask-jwt-extended] 
+    hirsuite: [python3-python-flask-jwt-extended]
     impish: [python3-python-flask-jwt-extended]
+    jammy: [python3-python-flask-jwt-extended]
     pip:
       packages: [flask-jwt-extended]
 python3-flask-restplus-pip:
@@ -8536,7 +8537,7 @@ python3-weasyprint-pip:
       packages: [weasyprint]
 python3-webargs:
   arch: [python-webargs]
-  debian: 
+  debian:
     pip:
       packages: [webargs]
     sid: [python3-webargs]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6518,15 +6518,17 @@ python3-flask-cors:
 python3-flask-jwt-extended:
   debian:
     '*': [python3-python-flask-jwt-extended]
-    pip:
-      packages: [flask-jwt-extended]
+    buster:
+      pip:
+        packages: [flask-jwt-extended]
   freebsd: [py-flask-jwt-extended]
   nixos: [python39Packages.flask-jwt-extended]
   opensuse: [python-flask-jwt-extended]
   ubuntu:
     '*': [python3-python-flask-jwt-extended]
-    pip:
-      packages: [flask-jwt-extended]
+    bionic:
+      pip:
+        packages: [flask-jwt-extended]
 python3-flask-restplus-pip:
   ubuntu:
     pip:
@@ -8534,14 +8536,22 @@ python3-weasyprint-pip:
 python3-webargs:
   arch: [python-webargs]
   debian:
-    pip:
-      packages: [webargs]
+    bullseye:
+      pip:
+        packages: [webargs]
+    buster:
+      pip:
+        packages: [webargs]
     '*': [python3-webargs]
   nixos: [python39Packages.webargs]
   ubuntu:
     '*': [python3-webargs]
-    pip:
-      packages: [webargs]
+    bionic:
+      pip:
+        packages: [webargs]
+    focal:
+      pip:
+        packages: [webargs]
 python3-websocket:
   debian: [python3-websocket]
   fedora: [python3-websocket-client]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6520,7 +6520,6 @@ python3-flask-jwt-extended:
     bullseye: [python3-python-flask-jwt-extended]
     pip:
       packages: [flask-jwt-extended]
-    sid: [python3-python-flask-jwt-extended]
   freebsd: [py-flask-jwt-extended]
   nixos: [python39Packages.flask-jwt-extended]
   opensuse: [python-flask-jwt-extended]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6524,7 +6524,6 @@ python3-flask-jwt-extended:
   nixos: [python39Packages.flask-jwt-extended]
   opensuse: [python-flask-jwt-extended]
   ubuntu:
-    impish: [python3-python-flask-jwt-extended]
     '*': [python3-python-flask-jwt-extended]
     pip:
       packages: [flask-jwt-extended]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8534,7 +8534,7 @@ python3-weasyprint-pip:
   ubuntu:
     pip:
       packages: [weasyprint]
-python3-webargs-pip: *migrate_eol_2025_04_30_python3_webargs_pip
+python-webargs-pip: *migrate_eol_2025_04_30_python3_webargs_pip
 python3-websocket:
   debian: [python3-websocket]
   fedora: [python3-websocket-client]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6524,7 +6524,6 @@ python3-flask-jwt-extended:
   nixos: [python39Packages.flask-jwt-extended]
   opensuse: [python-flask-jwt-extended]
   ubuntu:
-    hirsuite: [python3-python-flask-jwt-extended]
     impish: [python3-python-flask-jwt-extended]
     '*': [python3-python-flask-jwt-extended]
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1750,6 +1750,13 @@ python-flask-cors-pip:
   ubuntu:
     pip:
       packages: [flask-cors]
+python-flask-jwt-extended-pip: &migrate_eol_2025_04_30_python3_flask_jwt_extended_pip
+  debian:
+    pip:
+      packages: [flask-jwt-extended]
+  ubuntu:
+    pip:
+      packages: [flask-jwt-extended]
 python-flask-restful:
   debian: [python-flask-restful]
   fedora: [python-flask-restful]
@@ -5525,6 +5532,13 @@ python-watchdog:
     xenial: [python-watchdog]
     yakkety: [python-watchdog]
     zesty: [python-watchdog]
+python3-webargs-pip: &migrate_eol_2025_04_30_python3_webargs_pip
+  debian:
+    pip:
+      packages: [webargs]
+  ubuntu:
+    pip:
+      packages: [webargs]
 python-webob:
   debian: [python-webob]
   fedora: [python-webob]
@@ -6515,6 +6529,7 @@ python3-flask-cors:
   ubuntu:
     '*': [python3-flask-cors]
     bionic: null
+python3-flask-jwt-extended-pip: *migrate_eol_2025_04_30_python3_flask_jwt_extended_pip
 python3-flask-restplus-pip:
   ubuntu:
     pip:
@@ -8519,6 +8534,7 @@ python3-weasyprint-pip:
   ubuntu:
     pip:
       packages: [weasyprint]
+python3-webargs-pip: *migrate_eol_2025_04_30_python3_webargs_pip
 python3-websocket:
   debian: [python3-websocket]
   fedora: [python3-websocket-client]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8542,7 +8542,6 @@ python3-webargs:
     '*': [python3-webargs]
   nixos: [python39Packages.webargs]
   ubuntu:
-    impish: [python3-webargs]
     jammy: [python3-webargs]
     pip:
       packages: [webargs]


### PR DESCRIPTION
Please add the following dependencies to the rosdep database.

## Package names

- python3-webargs
- python3-flask-jwt-extended

## Package Upstream Sources

- webargs: https://github.com/marshmallow-code/webargs
- Flask-JWT-Extended: https://github.com/vimalloc/flask-jwt-extended

## Purpose of using these

- Webargs is a great package for simplifying HTTP parse objects and is compatiable with many backends (Flask, Django, etc.)
- Flask-JWT-Extended enables the use of JSON Web Tokens with Flask

## Links to Distribution Packages

#### webargs

- Arch: https://archlinux.org/packages/community/any/python-webargs/
- Debian: https://packages.debian.org/en/sid/python3-webargs
  - REQUIRED
- NixOS: https://hydra.nixos.org/job/nixos/release-21.11/nixpkgs.python39Packages.webargs.x86_64-linux
- PyPi: https://pypi.org/project/webargs/
- Ubuntu: https://packages.ubuntu.com/impish/python3-webargs
   - REQUIRED

#### Flask-JWT-Extended

- Debian: https://packages.debian.org/en/sid/python3-python-flask-jwt-extended
  - REQUIRED
- FreeBSD: https://cgit.freebsd.org/ports/tree/www/py-flask-jwt-extended
- NixOS: https://hydra.nixos.org/job/nixos/release-21.11/nixpkgs.python39Packages.flask-jwt-extended.x86_64-linux
- OpenSuse: https://software.opensuse.org/package/python-flask-jwt-extended
- PyPi: https://pypi.org/project/Flask-JWT-Extended/
- Ubuntu: https://packages.ubuntu.com/impish/python3-python-flask-jwt-extended
   - REQUIRED
