### PR TITLE
aws-robomaker-small-warehouse-world: 1.0.5-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -338,7 +338,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/aws-gbp/aws_robomaker_small_warehouse_world-release.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/aws-robotics/aws-robomaker-small-warehouse-world.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aws-robomaker-small-warehouse-world` to `1.0.5-1`:

- upstream repository: https://github.com/aws-robotics/aws-robomaker-small-warehouse-world.git
- release repository: https://github.com/aws-gbp/aws_robomaker_small_warehouse_world-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.4-1`
