### PR TITLE
soccer_visualization: 0.0.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4561,7 +4561,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ijnek/soccer_visualization-release.git
-      version: 0.0.1-1
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/ijnek/soccer_visualization.git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4554,7 +4554,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ijnek/soccer_visualization.git
-      version: main
+      version: rolling
     release:
       packages:
       - soccer_marker_generation
@@ -4565,7 +4565,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ijnek/soccer_visualization.git
-      version: main
+      version: rolling
     status: developed
   sol_vendor:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `soccer_visualization` to `0.0.2-1`:

- upstream repository: https://github.com/ijnek/soccer_visualization.git
- release repository: https://github.com/ijnek/soccer_visualization-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.1-1`

## soccer_marker_generation

```
* rename soccer_interfaces/soccer_vision_msgs to soccer_object_msgs
* Use new Ball msg, rather than Point msg
* add ament_cmake_gtest to package.xml
* Contributors: Kenji Brameld, ijnek
```
