### PR TITLE
cob_command_tools: 0.6.27-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -798,7 +798,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_command_tools-release.git
-      version: 0.6.26-1
+      version: 0.6.27-1
     source:
       type: git
       url: https://github.com/ipa320/cob_command_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.27-1`:

- upstream repository: https://github.com/ipa320/cob_command_tools.git
- release repository: https://github.com/ipa320/cob_command_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.26-1`

## cob_command_gui

- No changes

## cob_command_tools

- No changes

## cob_dashboard

- No changes

## cob_helper_tools

```
* Merge pull request #309 <https://github.com/ipa320/cob_command_tools/issues/309> from pgehring/feature/auto_tools
  combine auto_init and auto_recover
* check enable state for subscribing and unsubscribing
* fix imports
* fix package name conflict
* Revert "move dynamic reconfigure to python module"
  This reverts commit ce13c73a7638b44a8dcf23f75c82d86a83431ad4.
* move dynamic reconfigure to python module
* preserve auto_init and auto_recover nodes
* use params from server to enable init or recover
* setup auto_tools node
* add auto_tools node
* move auto_init and auto_recover to python module
* Contributors: Felix Messmer, pgehring
```

## cob_interactive_teleop

- No changes

## cob_monitoring

- No changes

## cob_script_server

- No changes

## cob_teleop

- No changes

## generic_throttle

- No changes

## scenario_test_tools

- No changes

## service_tools

- No changes
