### PR TITLE
cob_control: 0.8.18-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -853,7 +853,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_control-release.git
-      version: 0.8.17-1
+      version: 0.8.18-1
     source:
       type: git
       url: https://github.com/ipa320/cob_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.8.18-1`:

- upstream repository: https://github.com/ipa320/cob_control.git
- release repository: https://github.com/ipa320/cob_control-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.8.17-1`

## cob_base_controller_utils

- No changes

## cob_base_velocity_smoother

- No changes

## cob_cartesian_controller

- No changes

## cob_collision_velocity_filter

- No changes

## cob_control

- No changes

## cob_control_mode_adapter

- No changes

## cob_control_msgs

- No changes

## cob_footprint_observer

- No changes

## cob_frame_tracker

- No changes

## cob_hardware_emulation

```
* Merge pull request #266 <https://github.com/ipa320/cob_control/issues/266> from HannesBachter/fix/emulation
  fix initialpose and add laser odom in emulation
* fix some typos
* add emulation_odom_laser to CMakeLists
* generate odom laser from odom (not from twist)
* publish odom->base in emulation_odom_laser
* add emulation for laser odom
* harmonize variables (add leading underscore)
* fix initialpose handling in emulation
* Contributors: Felix Messmer, HannesBachter
```

## cob_mecanum_controller

- No changes

## cob_model_identifier

- No changes

## cob_obstacle_distance

- No changes

## cob_omni_drive_controller

- No changes

## cob_trajectory_controller

- No changes

## cob_tricycle_controller

- No changes

## cob_twist_controller

- No changes
