### PR TITLE
pointgrey_camera_driver: 0.14.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8985,7 +8985,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
-      version: 0.14.1-1
+      version: 0.14.2-1
     source:
       type: git
       url: https://github.com/ros-drivers/pointgrey_camera_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pointgrey_camera_driver` to `0.14.2-1`:

- upstream repository: https://github.com/ros-drivers/pointgrey_camera_driver.git
- release repository: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.14.1-1`

## image_exposure_msgs

- No changes

## pointgrey_camera_description

```
* Added xacro: to tag calling bumblebee2 xacro, required in noetic
* Contributors: Luis Camero
```

## pointgrey_camera_driver

- No changes

## statistics_msgs

- No changes

## wfov_camera_msgs

- No changes
