### PR TITLE
launch: 0.10.8-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1751,7 +1751,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.10.7-1
+      version: 0.10.8-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.10.8-2`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.10.7-1`

## launch

```
* Validate unparsed attributes and subentities in launch_xml and launch_yaml. (#468 <https://github.com/ros2/launch/issues/468>) (#567 <https://github.com/ros2/launch/issues/567>)
* Evaluate math symbols and functions in python expression. (#557 <https://github.com/ros2/launch/issues/557>) (#562 <https://github.com/ros2/launch/issues/562>)
* Contributors: Aditya, Immanuel Martini, mergify[bot]
```

## launch_testing

```
* Fix launch_testing README.md: Changed 'proc' keyword to 'process'. (#554 <https://github.com/ros2/launch/issues/554>)
* Contributors: Aditya, Michael McConnell
```

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* Validate unparsed attributes and subentities in launch_xml and launch_yaml. (#468 <https://github.com/ros2/launch/issues/468>) (#567 <https://github.com/ros2/launch/issues/567>)
* Contributors: Aditya, mergify[bot]
```

## launch_yaml

```
* Validate unparsed attributes and subentities in launch_xml and launch_yaml. (#468 <https://github.com/ros2/launch/issues/468>) (#567 <https://github.com/ros2/launch/issues/567>)
* Contributors: Aditya, mergify[bot]
```
