### PR TITLE
pointgrey_camera_driver: 0.15.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5953,7 +5953,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
-      version: 0.15.0-1
+      version: 0.15.1-1
     source:
       type: git
       url: https://github.com/ros-drivers/pointgrey_camera_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pointgrey_camera_driver` to `0.15.1-1`:

- upstream repository: https://github.com/ros-drivers/pointgrey_camera_driver.git
- release repository: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.15.0-1`

## image_exposure_msgs

- No changes

## pointgrey_camera_description

```
* Added xacro: to tag calling bumblebee2 xacro, required in noetic
* Contributors: Luis Camero
```

## pointgrey_camera_driver

- No changes

## statistics_msgs

- No changes

## wfov_camera_msgs

- No changes
