### PR TITLE
mavros: 1.13.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4241,7 +4241,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 1.12.2-2
+      version: 1.13.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `1.13.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.12.2-2`

## libmavconn

- No changes

## mavros

```
* Merge pull request #1690 <https://github.com/mavlink/mavros/issues/1690> from mavlink/fix-enum_sensor_orientation
  Fix enum sensor_orientation
* py-lib: fix compatibility with py3 for Noetic
* test: add checks for ROTATION_CUSTOM
* lib: Fix rotation search for CUSTOM
  Fix #1688 <https://github.com/mavlink/mavros/issues/1688>.
* Contributors: Vladimir Ermakov
```

## mavros_extras

```
* Merge pull request #1677 <https://github.com/mavlink/mavros/issues/1677> from AndersonRayner/add_terrain
  Add plugin for reporting terrain height estimate from the FCU
* Removed CamelCase for class members.  Publish to "report"
* More explicitly state "TerrainReport" to allow for future extension of the plugin to support other terrain messages
* Fixed callback name to match handle_{MESSAGE_NAME.lower()} convention
* Fixed topic names to match more closely what other plugins use.  Fixed a typo.
* Add plugin for reporting terrain height estimate from FCU
* Contributors: Vladimir Ermakov, matt
```

## mavros_msgs

```
* Merge pull request #1690 <https://github.com/mavlink/mavros/issues/1690> from mavlink/fix-enum_sensor_orientation
  Fix enum sensor_orientation
* re-generate all coglets
* Merge pull request #1680 <https://github.com/mavlink/mavros/issues/1680> from AndersonRayner/new_mav_frames
  Add extra MAV_FRAMES to waypoint message
* Merge pull request #1677 <https://github.com/mavlink/mavros/issues/1677> from AndersonRayner/add_terrain
  Add plugin for reporting terrain height estimate from the FCU
* More explicitly state "TerrainReport" to allow for future extension of the plugin to support other terrain messages
* Add extra MAV_FRAMES to waypoint message as defined in https://mavlink.io/en/messages/common.html
* Add plugin for reporting terrain height estimate from FCU
* Contributors: Vladimir Ermakov, matt
```

## test_mavros

- No changes
