### PR TITLE
rslidar_sdk: 1.3.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12297,7 +12297,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/nobleo/rslidar_sdk-release.git
-      version: 1.3.0-2
+      version: 1.3.0-3
     source:
       type: git
       url: https://github.com/RoboSense-LiDAR/rslidar_sdk.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12288,6 +12288,21 @@ repositories:
       url: https://github.com/RoverRobotics/rr_openrover_stack.git
       version: melodic-devel
     status: developed
+  rslidar_sdk:
+    doc:
+      type: git
+      url: https://github.com/RoboSense-LiDAR/rslidar_sdk.git
+      version: dev
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/nobleo/rslidar_sdk-release.git
+      version: 1.3.0-2
+    source:
+      type: git
+      url: https://github.com/RoboSense-LiDAR/rslidar_sdk.git
+      version: dev
+    status: maintained
   rt_usb_9axisimu_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rslidar_sdk` to `1.3.0-2`:

- upstream repository: https://github.com/RoboSense-LiDAR/rslidar_sdk.git
- release repository: https://github.com/nobleo/rslidar_sdk-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
