### PR TITLE
clober_msgs: 0.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -557,6 +557,22 @@ repositories:
       url: https://github.com/ros/class_loader.git
       version: foxy
     status: maintained
+  clober_msgs:
+    doc:
+      type: git
+      url: https://github.com/CLOBOT-Co-Ltd/clober_msgs.git
+      version: 0.1.0
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/CLOBOT-Co-Ltd-release/clober_msgs_ros2-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/CLOBOT-Co-Ltd/clober_msgs.git
+      version: foxy-devel
+    status: developed
   color_names:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clober_msgs` to `0.1.0-1`:

- upstream repository: https://github.com/CLOBOT-Co-Ltd/clober_msgs.git
- release repository: https://github.com/CLOBOT-Co-Ltd-release/clober_msgs_ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## clober_msgs

```
* add initial clober_msgs pacakage
```
