### PR TITLE
urdf: 2.5.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4652,7 +4652,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdf-release.git
-      version: 2.5.2-1
+      version: 2.5.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf` to `2.5.3-1`:

- upstream repository: https://github.com/ros2/urdf.git
- release repository: https://github.com/ros2-gbp/urdf-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.5.2-1`

## urdf

```
* Add linter tests and fix errors (#30 <https://github.com/ros2/urdf/issues/30>)
* Add in a Doxyfile to predefine macros. (#28 <https://github.com/ros2/urdf/issues/28>)
* Contributors: Chris Lalancette, Jacob Perron
```

## urdf_parser_plugin

```
* Add linter tests and fix errors (#30 <https://github.com/ros2/urdf/issues/30>)
* Contributors: Jacob Perron
```
