### PR TITLE
ridgeback: 0.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6789,6 +6789,26 @@ repositories:
       url: https://github.com/ros-drivers/rgbd_launch.git
       version: noetic-devel
     status: maintained
+  ridgeback:
+    doc:
+      type: git
+      url: https://github.com/ridgeback/ridgeback.git
+      version: melodic-devel
+    release:
+      packages:
+      - ridgeback_control
+      - ridgeback_description
+      - ridgeback_msgs
+      - ridgeback_navigation
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/ridgeback-release.git
+      version: 0.3.1-1
+    source:
+      type: git
+      url: https://github.com/ridgeback/ridgeback.git
+      version: melodic-devel
+    status: maintained
   riptide_controllers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback` to `0.3.1-1`:

- upstream repository: https://github.com/ridgeback/ridgeback.git
- release repository: https://github.com/clearpath-gbp/ridgeback-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ridgeback_control

```
* add predict_to_current_time param
* Add envar to set joy device (#44 <https://github.com/ridgeback/ridgeback/issues/44>)
  * Add the RIDGEBACK_JOY_DEVICE envar, move the control_extras to the end of control.launch so it can be used to override anything
  * Don't use the envar for the joy device when the PS3 flag is enabled
  * Add the default device for the ps3 configuration
  * Remove the joy device from the ps4 config; we explicitly set it with the envar
* Contributors: Chris I-B, Ebrahim
```

## ridgeback_description

- No changes

## ridgeback_msgs

- No changes

## ridgeback_navigation

```
* Expose the scan_topic argument in the amcl and gmapping demos (#43 <https://github.com/ridgeback/ridgeback/issues/43>)
* [Nav][AMCL] adds args to pass initial pose to AMCL
  This adds the ros launch arguments initial_pose_x, initial_pose_y and
  initial_pose_a which are passed through to the AMCL params of the same
  name.
  These args are defaulted to 0.0, 0.0, 0.0 as they were before so they
  should have no changing effects if not set.
  These args can be used to pre-seed the initial localization estimate.
  Which is useful when you know where in the map you've spawned the robot.
* Contributors: Alex Moriarty, Chris I-B
```
