### PR TITLE
sros2: 0.10.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4637,7 +4637,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.10.2-2
+      version: 0.10.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.10.3-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.10.2-2`

## sros2

```
* Wait for node discovery in test_generate_policy. (#262 <https://github.com/ros2/sros2/issues/262>)
* Contributors: Michel Hidalgo
```

## sros2_cmake

```
* Fix variables in sros2_cmake (#274 <https://github.com/ros2/sros2/issues/274>)
* Contributors: Keisuke Shima
```
