### PR TITLE
rviz: 9.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4117,7 +4117,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 9.0.1-1
+      version: 9.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `9.1.0-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `9.0.1-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Fix cpplint errors (#818 <https://github.com/ros2/rviz/issues/818>)
* Set message type for ros topic display (#800 <https://github.com/ros2/rviz/issues/800>)
* Contributors: Daisuke Nishimatsu, Jacob Perron
```

## rviz_default_plugins

```
* Remove TF filter from ImageTransportDisplay (#788 <https://github.com/ros2/rviz/issues/788>)
* Add underscores to material names (#811 <https://github.com/ros2/rviz/issues/811>)
* Export image_transport dependency (#813 <https://github.com/ros2/rviz/issues/813>)
* Contributors: Chen Lihui, Cory Crean, Jacob Perron
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Fix cpplint errors (#818 <https://github.com/ros2/rviz/issues/818>)
* Contributors: Jacob Perron
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
