### PR TITLE
ros_testing: 0.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3435,7 +3435,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_testing-release.git
-      version: 0.3.0-1
+      version: 0.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_testing` to `0.4.0-1`:

- upstream repository: https://github.com/ros2/ros_testing.git
- release repository: https://github.com/ros2-gbp/ros_testing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.0-1`

## ros2test

```
* Use new domain_coordinator API (#10 <https://github.com/ros2/ros_testing/issues/10>)
* Contributors: Timo Röhling
```

## ros_testing

- No changes
