### PR TITLE
ament_cmake_ros: 0.10.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -114,7 +114,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake_ros-release.git
-      version: 0.9.2-1
+      version: 0.10.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake_ros` to `0.10.0-1`:

- upstream repository: https://github.com/ros2/ament_cmake_ros.git
- release repository: https://github.com/ros2-gbp/ament_cmake_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.9.2-1`

## ament_cmake_ros

```
* Refactor domain_coordinator API to use a context manager (#12 <https://github.com/ros2/ament_cmake_ros/issues/12>)
* Contributors: Timo Röhling
```

## domain_coordinator

```
* Update maintainers to Michel Hidalgo (#13 <https://github.com/ros2/ament_cmake_ros/issues/13>)
* Refactor domain_coordinator API to use a context manager (#12 <https://github.com/ros2/ament_cmake_ros/issues/12>)
* Contributors: Audrow Nash, Timo Röhling
```
