### PR TITLE
rmw_gurumdds: 3.1.2-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3119,7 +3119,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
-      version: 3.1.2-1
+      version: 3.1.2-2
     source:
       type: git
       url: https://github.com/ros2/rmw_gurumdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_gurumdds` to `3.1.2-2`:

- upstream repository: https://github.com/ros2/rmw_gurumdds.git
- release repository: https://github.com/ros2-gbp/rmw_gurumdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.1.2-1`

## rmw_gurumdds_cpp

```
* Update packages to use gurumdds-2.8 & Update README
* Contributors: Youngjin Yun
```

## rmw_gurumdds_shared_cpp

```
* Update packages to use gurumdds-2.8 & Update README
* Contributors: Youngjin Yun
```
