### PR TITLE
rmw_gurumdds: 2.2.0-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3335,7 +3335,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
-      version: 2.2.0-1
+      version: 2.2.0-2
     source:
       type: git
       url: https://github.com/ros2/rmw_gurumdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_gurumdds` to `2.2.0-2`:

- upstream repository: https://github.com/ros2/rmw_gurumdds.git
- release repository: https://github.com/ros2-gbp/rmw_gurumdds-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.2.0-1`

## rmw_gurumdds_cpp

```
* Update packages to use gurumdds-2.8 & Update README
* Remove dds_typesupport from Publisher/Subscriber Info
* Change the return time when destroying entities
* Add ommited memory manage code
* Modify unnecessary code
* Fix typo
* Update return value
* Contributors: Youngjin Yun
```

## rmw_gurumdds_shared_cpp

```
* Update packages to use gurumdds-2.8 & Update README
* Update return value
* Contributors: Youngjin Yun
```
