### PR TITLE
ipcamera_driver: 0.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3280,6 +3280,21 @@ repositories:
       url: https://github.com/EduArt-Robotik/iotbot.git
       version: main
     status: maintained
+  ipcamera_driver:
+    doc:
+      type: git
+      url: https://github.com/alireza-hosseini/ipcamera_driver.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/alireza-hosseini/ipcamera_driver-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/alireza-hosseini/ipcamera_driver.git
+      version: master
+    status: maintained
   ira_laser_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ipcamera_driver` to `0.1.1-1`:

- upstream repository: https://github.com/alireza-hosseini/ipcamera_driver.git
- release repository: https://github.com/alireza-hosseini/ipcamera_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ipcamera_driver

- No changes
