### PR TITLE
ament_cmake: 1.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -80,7 +80,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 1.2.0-1
+      version: 1.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake` to `1.2.1-1`:

- upstream repository: https://github.com/ament/ament_cmake.git
- release repository: https://github.com/ros2-gbp/ament_cmake-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.0-1`

## ament_cmake

```
* Update maintainers to Michael Jeronimo and Michel Hidalgo (#362 <https://github.com/ament/ament_cmake/issues/362>)
* Contributors: Audrow Nash
```

## ament_cmake_auto

```
* Fix typo in ament_auto_find_test_dependencies (#363 <https://github.com/ament/ament_cmake/issues/363>)
* Update maintainers to Michael Jeronimo and Michel Hidalgo (#362 <https://github.com/ament/ament_cmake/issues/362>)
* Contributors: Audrow Nash, Daisuke Nishimatsu
```

## ament_cmake_core

```
* Resolve various ament_lint linter violations (#360 <https://github.com/ament/ament_cmake/issues/360>)
  We can't add ament_lint linters in ament_cmake in the traditional way
  without creating a circular dependency between the repositories. Even
  though we can't automatically enforce linting, it's still a good idea to
  try to keep conformance where possible.
* Update maintainers to Michael Jeronimo and Michel Hidalgo (#362 <https://github.com/ament/ament_cmake/issues/362>)
* Contributors: Audrow Nash, Scott K Logan
```

## ament_cmake_export_definitions

```
* Update maintainers to Michael Jeronimo and Michel Hidalgo (#362 <https://github.com/ament/ament_cmake/issues/362>)
* Contributors: Audrow Nash
```

## ament_cmake_export_dependencies

```
* Resolve various ament_lint linter violations (#360 <https://github.com/ament/ament_cmake/issues/360>)
  We can't add ament_lint linters in ament_cmake in the traditional way
  without creating a circular dependency between the repositories. Even
  though we can't automatically enforce linting, it's still a good idea to
  try to keep conformance where possible.
* Update maintainers to Michael Jeronimo and Michel Hidalgo (#362 <https://github.com/ament/ament_cmake/issues/362>)
* Contributors: Audrow Nash, Scott K Logan
```

## ament_cmake_export_include_directories

```
* Update maintainers to Michael Jeronimo and Michel Hidalgo (#362 <https://github.com/ament/ament_cmake/issues/362>)
* Contributors: Audrow Nash
```

## ament_cmake_export_interfaces

```
* Update maintainers to Michael Jeronimo and Michel Hidalgo (#362 <https://github.com/ament/ament_cmake/issues/362>)
* Contributors: Audrow Nash
```

## ament_cmake_export_libraries

```
* Resolve various ament_lint linter violations (#360 <https://github.com/ament/ament_cmake/issues/360>)
  We can't add ament_lint linters in ament_cmake in the traditional way
  without creating a circular dependency between the repositories. Even
  though we can't automatically enforce linting, it's still a good idea to
  try to keep conformance where possible.
* Update maintainers to Michael Jeronimo and Michel Hidalgo (#362 <https://github.com/ament/ament_cmake/issues/362>)
* Contributors: Audrow Nash, Scott K Logan
```

## ament_cmake_export_link_flags

```
* Update maintainers to Michael Jeronimo and Michel Hidalgo (#362 <https://github.com/ament/ament_cmake/issues/362>)
* Contributors: Audrow Nash
```

## ament_cmake_export_targets

```
* Update maintainers to Michael Jeronimo and Michel Hidalgo (#362 <https://github.com/ament/ament_cmake/issues/362>)
* Contributors: Audrow Nash
```

## ament_cmake_gen_version_h

```
* Update maintainers to Michael Jeronimo and Michel Hidalgo (#362 <https://github.com/ament/ament_cmake/issues/362>)
* Contributors: Audrow Nash
```

## ament_cmake_gmock

```
* Update maintainers to Michael Jeronimo and Michel Hidalgo (#362 <https://github.com/ament/ament_cmake/issues/362>)
* Contributors: Audrow Nash
```

## ament_cmake_google_benchmark

```
* Resolve various ament_lint linter violations (#360 <https://github.com/ament/ament_cmake/issues/360>)
  We can't add ament_lint linters in ament_cmake in the traditional way
  without creating a circular dependency between the repositories. Even
  though we can't automatically enforce linting, it's still a good idea to
  try to keep conformance where possible.
* Update maintainers to Michael Jeronimo and Michel Hidalgo (#362 <https://github.com/ament/ament_cmake/issues/362>)
* Contributors: Audrow Nash, Scott K Logan
```

## ament_cmake_gtest

```
* Update maintainers to Michael Jeronimo and Michel Hidalgo (#362 <https://github.com/ament/ament_cmake/issues/362>)
* Contributors: Audrow Nash
```

## ament_cmake_include_directories

```
* Make ament_include_directories_order a function to allow paths with backslashes on windows. (#371 <https://github.com/ament/ament_cmake/issues/371>)
  * Repalce backslashes with forward slashes on Windows
  * Typo
  * Replace slashes in ARGN
  * Don't quote
  * Check ARGN has values before trying to string(REPLACE them
  * Make ament_include_directories_order a function
* Update maintainers to Michael Jeronimo and Michel Hidalgo (#362 <https://github.com/ament/ament_cmake/issues/362>)
* Contributors: Audrow Nash, Shane Loretz
```

## ament_cmake_libraries

```
* Resolve various ament_lint linter violations (#360 <https://github.com/ament/ament_cmake/issues/360>)
  We can't add ament_lint linters in ament_cmake in the traditional way
  without creating a circular dependency between the repositories. Even
  though we can't automatically enforce linting, it's still a good idea to
  try to keep conformance where possible.
* Update maintainers to Michael Jeronimo and Michel Hidalgo (#362 <https://github.com/ament/ament_cmake/issues/362>)
* Contributors: Audrow Nash, Scott K Logan
```

## ament_cmake_nose

```
* Update maintainers to Michael Jeronimo and Michel Hidalgo (#362 <https://github.com/ament/ament_cmake/issues/362>)
* Contributors: Audrow Nash
```

## ament_cmake_pytest

```
* Update maintainers to Michael Jeronimo and Michel Hidalgo (#362 <https://github.com/ament/ament_cmake/issues/362>)
* Fix misleading comment (#361 <https://github.com/ament/ament_cmake/issues/361>)
* Contributors: Audrow Nash, Tim Clephas
```

## ament_cmake_python

```
* Resolve various ament_lint linter violations (#360 <https://github.com/ament/ament_cmake/issues/360>)
  We can't add ament_lint linters in ament_cmake in the traditional way
  without creating a circular dependency between the repositories. Even
  though we can't automatically enforce linting, it's still a good idea to
  try to keep conformance where possible.
* Update maintainers to Michael Jeronimo and Michel Hidalgo (#362 <https://github.com/ament/ament_cmake/issues/362>)
* Contributors: Audrow Nash, Scott K Logan
```

## ament_cmake_target_dependencies

```
* Update maintainers to Michael Jeronimo and Michel Hidalgo (#362 <https://github.com/ament/ament_cmake/issues/362>)
* Contributors: Audrow Nash
```

## ament_cmake_test

```
* Resolve various ament_lint linter violations (#360 <https://github.com/ament/ament_cmake/issues/360>)
  We can't add ament_lint linters in ament_cmake in the traditional way
  without creating a circular dependency between the repositories. Even
  though we can't automatically enforce linting, it's still a good idea to
  try to keep conformance where possible.
* Update maintainers to Michael Jeronimo and Michel Hidalgo (#362 <https://github.com/ament/ament_cmake/issues/362>)
* Contributors: Audrow Nash, Scott K Logan
```

## ament_cmake_version

```
* Update maintainers to Michael Jeronimo and Michel Hidalgo (#362 <https://github.com/ament/ament_cmake/issues/362>)
* Contributors: Audrow Nash
```
