### PR TITLE
ament_package: 0.12.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -208,7 +208,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_package-release.git
-      version: 0.12.0-1
+      version: 0.12.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_package` to `0.12.1-1`:

- upstream repository: https://github.com/ament/ament_package.git
- release repository: https://github.com/ros2-gbp/ament_package-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.12.0-1`

## ament_package

```
* Set forthcoming for previous version
* Add support for appending to environment variables (#130 <https://github.com/ament/ament_package/issues/130>)
  This works largely the same as 'prepend-non-duplicate', but instead puts
  the candidate value at the end of the target variable.
* Update maintainers to Audrow Nash (#135 <https://github.com/ament/ament_package/issues/135>)
* Make python executable variable ament_package specific (#134 <https://github.com/ament/ament_package/issues/134>)
* Contributors: Audrow Nash, Scott K Logan, Shane Loretz
```
