### PR TITLE
google_benchmark_vendor: 0.0.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -998,11 +998,15 @@ repositories:
       version: ros2
     status: developed
   google_benchmark_vendor:
+    doc:
+      type: git
+      url: https://github.com/ament/google_benchmark_vendor.git
+      version: 0.0.7
     release:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/google_benchmark_vendor-release.git
-      version: 0.0.6-1
+      version: 0.0.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `google_benchmark_vendor` to `0.0.7-1`:

- upstream repository: https://github.com/ament/google_benchmark_vendor.git
- release repository: https://github.com/ros2-gbp/google_benchmark_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.6-1`

## google_benchmark_vendor

```
* Update maintainers to Audrow Nash (#18 <https://github.com/ament/google_benchmark_vendor/issues/18>)
* Update google_benchmark to v1.5.3 (#16 <https://github.com/ament/google_benchmark_vendor/issues/16>)
  1. Change google_benchmark version from v1.5.2 to v1.5.3. Because v1.5.2
  can not build with GCC 11
  2. Removed shrink-tz-offset-size.patch because of this patch was merged in
  google-benchmark repo.
* Add changelog (#15 <https://github.com/ament/google_benchmark_vendor/issues/15>)
* Contributors: Audrow Nash, Homalozoa X, Ivan Santiago Paunovic
```
