### PR TITLE
googletest: 1.10.9004-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1017,7 +1017,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/googletest-release.git
-      version: 1.10.9003-1
+      version: 1.10.9004-2
     source:
       type: git
       url: https://github.com/ament/googletest.git


### PR DESCRIPTION
Increasing version of package(s) in repository `googletest` to `1.10.9004-2`:

- upstream repository: https://github.com/ament/googletest.git
- release repository: https://github.com/ros2-gbp/googletest-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.10.9003-1`
