### PR TITLE
image_common: 3.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1207,7 +1207,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 3.1.1-1
+      version: 3.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `3.1.2-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.1.1-1`

## camera_calibration_parsers

```
* Export a modern CMake target instead of variables and install includes to include/${PROJECT_NAME} (#218 <https://github.com/ros-perception/image_common/issues/218>)
* Contributors: Shane Loretz
```

## camera_info_manager

```
* Export a modern CMake target instead of variables and install includes to include/${PROJECT_NAME} (#218 <https://github.com/ros-perception/image_common/issues/218>)
* Contributors: Shane Loretz
```

## image_common

- No changes

## image_transport

```
* Fix include order for cpplint (#221 <https://github.com/ros-perception/image_common/issues/221>)
  Relates to https://github.com/ament/ament_lint/pull/324
* Export a modern CMake target instead of variables and install includes to include/${PROJECT_NAME} (#218 <https://github.com/ros-perception/image_common/issues/218>)
* Contributors: Jacob Perron, Shane Loretz
```
