### PR TITLE
osrf_testing_tools_cpp: 1.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2159,7 +2159,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/osrf_testing_tools_cpp-release.git
-      version: 1.4.0-1
+      version: 1.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `osrf_testing_tools_cpp` to `1.5.0-1`:

- upstream repository: https://github.com/osrf/osrf_testing_tools_cpp.git
- release repository: https://github.com/ros2-gbp/osrf_testing_tools_cpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.4.0-1`

## osrf_testing_tools_cpp

```
* Update backward-cpp to latest master commit (#64 <https://github.com/osrf/osrf_testing_tools_cpp/issues/64>)
* Patch googletest to 1.10.0.2 (#65 <https://github.com/osrf/osrf_testing_tools_cpp/issues/65>)
* Contributors: Christophe Bedard, Homalozoa X
```
