### PR TITLE
demos: 0.19.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -603,6 +603,7 @@ repositories:
       - image_tools
       - intra_process_demo
       - lifecycle
+      - lifecycle_py
       - logging_demo
       - pendulum_control
       - pendulum_msgs
@@ -613,7 +614,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.18.0-1
+      version: 0.19.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.19.0-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.18.0-1`

## action_tutorials_cpp

- No changes

## action_tutorials_interfaces

- No changes

## action_tutorials_py

- No changes

## composition

- No changes

## demo_nodes_cpp

- No changes

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

- No changes

## dummy_map_server

- No changes

## dummy_robot_bringup

- No changes

## dummy_sensors

- No changes

## image_tools

```
* Fix include order and relative paths for cpplint (#551 <https://github.com/ros2/demos/issues/551>)
* Reduce the number of OpenCV libraries image_tools links against. (#549 <https://github.com/ros2/demos/issues/549>)
* Adds copy constructor and assignment operator to ROSCvMatContainer (#546 <https://github.com/ros2/demos/issues/546>)
* Contributors: Chris Lalancette, Gonzo, Jacob Perron
```

## intra_process_demo

```
* Fix include order and relative paths for cpplint (#551 <https://github.com/ros2/demos/issues/551>)
* Contributors: Jacob Perron
```

## lifecycle

- No changes

## logging_demo

- No changes

## pendulum_control

```
* Fix include order and relative paths for cpplint (#551 <https://github.com/ros2/demos/issues/551>)
* Contributors: Jacob Perron
```

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

```
* Fix include order and relative paths for cpplint (#551 <https://github.com/ros2/demos/issues/551>)
* Contributors: Jacob Perron
```

## quality_of_service_demo_py

- No changes

## topic_monitor

- No changes

## topic_statistics_demo

- No changes
