### PR TITLE
interactive_markers: 2.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1269,7 +1269,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/interactive_markers-release.git
-      version: 2.3.0-1
+      version: 2.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_markers` to `2.3.1-1`:

- upstream repository: https://github.com/ros-visualization/interactive_markers.git
- release repository: https://github.com/ros2-gbp/interactive_markers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.0-1`

## interactive_markers

```
* Install includes to include/ and misc CMake fixes (#85 <https://github.com/ros-visualization/interactive_markers/issues/85>)
* Contributors: Shane Loretz
```
