### PR TITLE
rqt_action: 2.0.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3982,7 +3982,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_action-release.git
-      version: 2.0.0-2
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_action.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_action` to `2.0.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_action.git
- release repository: https://github.com/ros2-gbp/rqt_action-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-2`

## rqt_action

```
* Update maintainers (#12 <https://github.com/ros-visualization/rqt_action/issues/12>)
* Fix modern setuptools warning about dashes instead of underscores (#11 <https://github.com/ros-visualization/rqt_action/issues/11>)
* Contributors: Audrow Nash, Chris Lalancette
```
