### PR TITLE
class_loader: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -473,7 +473,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/class_loader-release.git
-      version: 2.1.2-1
+      version: 2.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `2.2.0-1`:

- upstream repository: https://github.com/ros/class_loader.git
- release repository: https://github.com/ros2-gbp/class_loader-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.2-1`

## class_loader

```
* Install includes to include/ (#191 <https://github.com/ros/class_loader/issues/191>)
* Fix include order for cpplint (#192 <https://github.com/ros/class_loader/issues/192>)
* Update maintainers to Geoffrey Biggs and Michael Carroll (#190 <https://github.com/ros/class_loader/issues/190>)
* Fix spelling mistake (#184 <https://github.com/ros/class_loader/issues/184>)
* Contributors: Audrow Nash, David V. Lu!!, Jacob Perron, Shane Loretz
```
