### PR TITLE
pluginlib: 5.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2315,7 +2315,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 5.0.0-1
+      version: 5.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `5.1.0-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `5.0.0-1`

## pluginlib

```
* Install includes to include/${PROJECT_NAME} and remove ament_target_dependencies calls (#226 <https://github.com/ros/pluginlib/issues/226>)
* Require <memory> (#225 <https://github.com/ros/pluginlib/issues/225>)
* Move LibraryLoadExceptions down a level for more accurate error messages (#221 <https://github.com/ros/pluginlib/issues/221>)
* Update maintainers to Chris Lalancette (#223 <https://github.com/ros/pluginlib/issues/223>)
* extend termination condition to avoid infinite loop if package.xml is not found (#220 <https://github.com/ros/pluginlib/issues/220>)
* Remove deprecated headers. (#217 <https://github.com/ros/pluginlib/issues/217>)
* Contributors: Alberto Soragna, Audrow Nash, Chris Lalancette, David V. Lu!!, Shane Loretz
```
