### PR TITLE
resource_retriever: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2771,7 +2771,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 2.5.0-1
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `3.0.0-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros2-gbp/resource_retriever-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.5.0-1`

## libcurl_vendor

```
* Update maintainers (#66 <https://github.com/ros/resource_retriever/issues/66>)
* Contributors: Audrow Nash
```

## resource_retriever

```
* Fix include order for cpplint (#69 <https://github.com/ros/resource_retriever/issues/69>)
* Update maintainers (#66 <https://github.com/ros/resource_retriever/issues/66>)
* Remove the deprecated retriever.h header (#63 <https://github.com/ros/resource_retriever/issues/63>)
* Contributors: Audrow Nash, Chris Lalancette, Jacob Perron
```
