### PR TITLE
robot_state_publisher: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3160,7 +3160,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/robot_state_publisher-release.git
-      version: 2.7.0-1
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `3.0.0-1`:

- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros2-gbp/robot_state_publisher-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.7.0-1`

## robot_state_publisher

```
* Fix include order for cpplint (#186 <https://github.com/ros/robot_state_publisher/issues/186>)
* Change how parameter updates are handled (#180 <https://github.com/ros/robot_state_publisher/issues/180>)
* Install includes to instal/${PROJECT_NAME} (#184 <https://github.com/ros/robot_state_publisher/issues/184>)
* Make the change_fixed_joint test more robust (#183 <https://github.com/ros/robot_state_publisher/issues/183>)
* Add in a test to make sure fixed transforms change on update
* Small C++ nice-isms in the tests
* Switch to using target_include_directories for tests
* Publish new fixed transforms when URDF is updated
* Make joint_states subscription QoS configurable; default to SensorDataQoS (#179 <https://github.com/ros/robot_state_publisher/issues/179>)
* Remove dependency on urdfdom_headers (#168 <https://github.com/ros/robot_state_publisher/issues/168>)
* Contributors: Anthony Deschamps, Chris Lalancette, Jacob Perron, Russell Joyce, Shane Loretz
```
