### PR TITLE
launch: 0.21.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1435,7 +1435,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.20.0-1
+      version: 0.21.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.21.0-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.20.0-1`

## launch

```
* Use asyncio.wait with timeout rather than sleep (#576 <https://github.com/ros2/launch/issues/576>)
* Make test_parser compatible with Python older than 3.8 (#575 <https://github.com/ros2/launch/issues/575>)
* Propagate exceptions of completed actions to launch service main loop (#566 <https://github.com/ros2/launch/issues/566>)
* Warn when loading launch extensions fails (#572 <https://github.com/ros2/launch/issues/572>)
* Add in two fixes for Jammy (#571 <https://github.com/ros2/launch/issues/571>)
* Contributors: Chris Lalancette, Scott K Logan, Shane Loretz, tumtom
```

## launch_pytest

- No changes

## launch_testing

```
* Renamed three files from example_processes (#573 <https://github.com/ros2/launch/issues/573>)
* Fix launch_testing README.md proc keyword to process. (#554 <https://github.com/ros2/launch/issues/554>) (#560 <https://github.com/ros2/launch/issues/560>)
* Contributors: Jacob Perron, Khush Jain
```

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
