### PR TITLE
rcpputils: 2.3.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2702,7 +2702,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 2.3.1-1
+      version: 2.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `2.3.2-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.1-1`

## rcpputils

```
* Fix include order for cpplint (#158 <https://github.com/ros2/rcpputils/issues/158>)
* [path] Declare the default assignment operator (#156 <https://github.com/ros2/rcpputils/issues/156>)
* Contributors: Abrar Rahman Protyasha, Jacob Perron
```
