### PR TITLE
rclcpp: 15.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2670,7 +2670,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 14.1.0-1
+      version: 15.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `15.0.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `14.1.0-1`

## rclcpp

```
* Cleanup the TypeAdapt tests (#1858 <https://github.com/ros2/rclcpp/issues/1858>)
* Cleanup includes (#1857 <https://github.com/ros2/rclcpp/issues/1857>)
* Fix include order and relative paths for cpplint (#1859 <https://github.com/ros2/rclcpp/issues/1859>)
* Rename stringstream in macros to a more unique name (#1862 <https://github.com/ros2/rclcpp/issues/1862>)
* Add non transform capabilities for intra-process (#1849 <https://github.com/ros2/rclcpp/issues/1849>)
* Fix rclcpp documentation build (#1779 <https://github.com/ros2/rclcpp/issues/1779>)
* Contributors: Chris Lalancette, Doug Smith, Gonzo, Jacob Perron, Michel Hidalgo
```

## rclcpp_action

```
* Fix include order and relative paths for cpplint (#1859 <https://github.com/ros2/rclcpp/issues/1859>)
* Contributors: Jacob Perron
```

## rclcpp_components

```
* Add rclcpp_components::component (#1855 <https://github.com/ros2/rclcpp/issues/1855>)
* Contributors: Shane Loretz
```

## rclcpp_lifecycle

```
* Automatically transition lifecycle entities when node transitions (#1863 <https://github.com/ros2/rclcpp/issues/1863>)
* Contributors: Ivan Santiago Paunovic
```
