### PR TITLE
Add pybind11-dev rule for RHEL 8

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6720,6 +6720,9 @@ pybind11-dev:
   debian: [pybind11-dev]
   fedora: [pybind11-devel]
   nixos: [pybind11]
+  rhel:
+    '*': [pybind11-devel]
+    '7': null
   ubuntu: [pybind11-dev]
 python-dev:
   debian: [python-dev]


### PR DESCRIPTION
This package is available for RHEL 8 via EPEL, but I could not find it for RHEL 7.

https://src.fedoraproject.org/rpms/pybind11#bodhi_updates