### PR TITLE
dingo_desktop: 0.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2414,7 +2414,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/dingo_desktop-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/dingo-cpr/dingo_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_desktop` to `0.1.1-1`:

- upstream repository: https://github.com/dingo-cpr/dingo_desktop.git
- release repository: https://github.com/clearpath-gbp/dingo_desktop-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.0-1`

## dingo_desktop

- No changes

## dingo_viz

```
* Add rqt directory and launch file check
* Add rqt_gui as exec_depend
* Alphabetized and separated test_depend
* Changed run_depend to exec_depend
* Added view_diagnostics
* Contributors: Luis Camero, luis-camero
```
