### PR TITLE
clober_msgs: 0.1.0-4 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -566,7 +566,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/CLOBOT-Co-Ltd-release/clober_msgs_ros2-release.git
-      version: 0.1.0-1
+      version: 0.1.0-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clober_msgs` to `0.1.0-4`:

- upstream repository: https://github.com/CLOBOT-Co-Ltd/clober_msgs.git
- release repository: https://github.com/CLOBOT-Co-Ltd-release/clober_msgs_ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.0-1`

## clober_msgs

```
* add initial clober_msgs pacakage
```
