### PR TITLE
husky: 0.4.12-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4433,7 +4433,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 0.4.11-1
+      version: 0.4.12-1
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `0.4.12-1`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.11-1`

## husky_base

- No changes

## husky_bringup

- No changes

## husky_control

- No changes

## husky_description

- No changes

## husky_desktop

- No changes

## husky_gazebo

- No changes

## husky_msgs

- No changes

## husky_navigation

- No changes

## husky_robot

- No changes

## husky_simulator

- No changes

## husky_viz

```
* Added view_diagnostics
* Add rqt directory
* Added rqt_gui dependencies
* Contributors: Luis Camero, luis-camero
```
