### PR TITLE
Adding mitch_v2_driver and muse_v2_driver to documentation index for …

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4476,6 +4476,11 @@ repositories:
       url: https://github.com/dfki-ric/mir_robot.git
       version: noetic
     status: developed
+  mitch_v2_driver:
+    doc:
+      type: git
+      url: https://github.com/221eROS/mitch_v2_driver.git
+      version: main
   mobile_robot_simulator:
     doc:
       type: git
@@ -4832,6 +4837,11 @@ repositories:
       url: https://github.com/carnegierobotics/multisense_ros.git
       version: master
     status: maintained
+  muse_v2_driver:
+    doc:
+      type: git
+      url: https://github.com/221eROS/muse_v2_driver.git
+      version: main
   navigation:
     doc:
       type: git


### PR DESCRIPTION
# Please Add These Packages to be indexed in the rosdistro.

mitch_v2_driver
muse_v2_driver

# The sources are here: 

https://github.com/221eROS/mitch_v2_driver.git
https://github.com/221eROS/muse_v2_driver.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
