### PR TITLE
paho-mqtt-cpp: 1.2.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2346,6 +2346,21 @@ repositories:
       url: https://github.com/eclipse/paho.mqtt.c.git
       version: master
     status: maintained
+  paho-mqtt-cpp:
+    doc:
+      type: git
+      url: https://github.com/eclipse/paho.mqtt.cpp.git
+      version: master
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/nobleo/paho.mqtt.cpp-release.git
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://github.com/eclipse/paho.mqtt.cpp.git
+      version: master
+    status: maintained
   pal_statistics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `paho-mqtt-cpp` to `1.2.0-1`:

- upstream repository: https://github.com/eclipse/paho.mqtt.cpp.git
- release repository: https://github.com/nobleo/paho.mqtt.cpp-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
