### PR TITLE
mocap_optitrack: 0.1.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4535,7 +4535,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/mocap_optitrack-release.git
-      version: 0.1.3-1
+      version: 0.1.4-1
     source:
       type: git
       url: https://github.com/ros-drivers/mocap_optitrack.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mocap_optitrack` to `0.1.4-1`:

- upstream repository: https://github.com/ros-drivers/mocap_optitrack.git
- release repository: https://github.com/ros-drivers-gbp/mocap_optitrack-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.3-1`

## mocap_optitrack

```
* initialize the  dynamic server in the initializer list
* white space
* unnecessary changes
* fix: params namespace
* Contributors: Jad
```
