### PR TITLE
laser_geometry: 2.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1416,7 +1416,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/laser_geometry-release.git
-      version: 2.2.2-4
+      version: 2.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_geometry` to `2.3.0-1`:

- upstream repository: https://github.com/ros-perception/laser_geometry.git
- release repository: https://github.com/ros2-gbp/laser_geometry-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.2.2-4`

## laser_geometry

```
* Fix building on running on Windows Debug (#82 <https://github.com/ros-perception/laser_geometry/issues/82>)
* Update python code and tests for ros2 (#80 <https://github.com/ros-perception/laser_geometry/issues/80>)
* Contributors: Chris Lalancette, Jonathan Binney
```
