### PR TITLE
ament_package: 0.13.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -207,7 +207,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/ament_package-release.git
-      version: 0.12.0-2
+      version: 0.13.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_package` to `0.13.0-1`:

- upstream repository: https://github.com/ament/ament_package.git
- release repository: https://github.com/ros2-gbp/ament_package-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.12.0-2`

## ament_package

```
* Add support for appending to environment variables (#130 <https://github.com/ament/ament_package/issues/130>) (#137 <https://github.com/ament/ament_package/issues/137>)
* Update maintainers to Audrow Nash (#135 <https://github.com/ament/ament_package/issues/135>) (#136 <https://github.com/ament/ament_package/issues/136>)
* Contributors: Scott K Logan, Audrow Nash
* Revert "Generate Setuptools Dict Helper Method (#126 <https://github.com/ament/ament_package/issues/126>)" (#131 <https://github.com/ament/ament_package/issues/131>)
* Contributors: Audrow Nash
```
