### PR TITLE
rosbag2: 0.13.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3499,7 +3499,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.12.0-1
+      version: 0.13.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.13.0-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.12.0-1`

## ros2bag

- No changes

## rosbag2

- No changes

## rosbag2_compression

- No changes

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Fix relative path syntax for cpplint (#947 <https://github.com/ros2/rosbag2/issues/947>)
* Mark up the message_cache with TSA annotations (#946 <https://github.com/ros2/rosbag2/issues/946>)
* Contributors: Chris Lalancette, Jacob Perron
```

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_py

```
* Fix relative path syntax for cpplint (#947 <https://github.com/ros2/rosbag2/issues/947>)
* Update to pybind11 2.7.1 (#945 <https://github.com/ros2/rosbag2/issues/945>)
* Contributors: Chris Lalancette, Jacob Perron
```

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

```
* Emit a warning rather than crash when a message is too big for sqlite (#919 <https://github.com/ros2/rosbag2/issues/919>)
* Contributors: William Woodall
```

## rosbag2_test_common

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

- No changes

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
