### PR TITLE
rqt_image_view uses rolling-devel branch

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3854,7 +3854,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_image_view.git
-      version: foxy-devel
+      version: rolling-devel
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -3864,7 +3864,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_image_view.git
-      version: foxy-devel
+      version: rolling-devel
     status: maintained
   rqt_moveit:
     doc:


### PR DESCRIPTION
For https://github.com/ros-visualization/rqt_image_view/pull/62