### PR TITLE
husky: 0.6.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3038,7 +3038,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 0.6.0-2
+      version: 0.6.1-1
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `0.6.1-1`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.0-2`

## husky_control

```
* Overwrite 'wheel_radius_multiplier' with env. var. HUSKY_WHEEL_MULTIPLIER
* Check launch file only if testing
  When building husky_control, husky_description, husky_navigation or
  husky_viz without tests, CMake fails as it does not find
  catkin_run_tests_target command. This patch adds conditions to fix
  this problem.
* predict odom->base_link tf to current time
* Contributors: Alexandre Iooss, Ebrahim Shahrivar, Luis Camero
```

## husky_description

```
* Fixed error in URDF
* Added Hokuyo
* Check launch file only if testing
  When building husky_control, husky_description, husky_navigation or
  husky_viz without tests, CMake fails as it does not find
  catkin_run_tests_target command. This patch adds conditions to fix
  this problem.
* Revert changes to mount_base_link to preserve use of origin argument; instead, simply created an additional plate link that sits between the supports and VLP16
* Create visual geometry of vlp16_mount_base_link
* Update mount support dimensions and spacing to better represent real-world measurements
* [husky_description] Fixed malformed STL warning for top_plate.stl.
* Contributors: Alexandre Iooss, Luis Camero, Tony Baltovski, jyang-cpr
```

## husky_desktop

- No changes

## husky_gazebo

```
* [husky_gazebo] Fixed roslaunch tests.
* Contributors: Tony Baltovski
```

## husky_msgs

- No changes

## husky_navigation

```
* Check launch file only if testing
  When building husky_control, husky_description, husky_navigation or
  husky_viz without tests, CMake fails as it does not find
  catkin_run_tests_target command. This patch adds conditions to fix
  this problem.
* Contributors: Alexandre Iooss
```

## husky_simulator

- No changes

## husky_viz

```
* Add rqt directory to CMakeLists
* Add rqt_gui as run_depend
* Check launch file only if testing
  When building husky_control, husky_description, husky_navigation or
  husky_viz without tests, CMake fails as it does not find
  catkin_run_tests_target command. This patch adds conditions to fix
  this problem.
* Added view_diagnostics.launch
* Contributors: Alexandre Iooss, Luis Camero, luis-camero
```
