### PR TITLE
angles: 1.13.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -224,7 +224,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/angles-release.git
-      version: 1.12.4-1
+      version: 1.13.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `angles` to `1.13.0-1`:

- upstream repository: https://github.com/ros/angles.git
- release repository: https://github.com/ros2-gbp/angles-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.12.4-1`

## angles

```
* Export ament_cmake buildtool dependency (#32 <https://github.com/ros/angles/issues/32>)
* Install includes to include/angles and add modern CMake target (#28 <https://github.com/ros/angles/issues/28>)
* Contributors: Shane Loretz
```
