### PR TITLE
jackal: 0.8.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3410,7 +3410,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.8.0-2
+      version: 0.8.1-1
     source:
       type: git
       url: https://github.com/jackal/jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.8.1-1`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.8.0-2`

## jackal_control

```
* predict odom->base_link tf to current time
* Contributors: Ebrahim Shahrivar
```

## jackal_description

```
* Updated to match melodic-devel
* Contributors: Luis Camero
```

## jackal_msgs

- No changes

## jackal_navigation

- No changes

## jackal_tutorials

- No changes
