### PR TITLE
ridgeback_desktop: 0.1.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6854,6 +6854,24 @@ repositories:
       url: https://github.com/ridgeback/ridgeback.git
       version: melodic-devel
     status: maintained
+  ridgeback_desktop:
+    doc:
+      type: git
+      url: https://github.com/ridgeback/ridgeback_desktop.git
+      version: kinetic-devel
+    release:
+      packages:
+      - ridgeback_desktop
+      - ridgeback_viz
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/ridgeback_desktop-release.git
+      version: 0.1.3-1
+    source:
+      type: git
+      url: https://github.com/ridgeback/ridgeback_desktop.git
+      version: kinetic-devel
+    status: maintained
   riptide_controllers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_desktop` to `0.1.3-1`:

- upstream repository: https://github.com/ridgeback/ridgeback_desktop
- release repository: https://github.com/clearpath-gbp/ridgeback_desktop-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ridgeback_desktop

- No changes

## ridgeback_viz

```
* Add rqt directory and launch check
* Alphabetized and added rqt_gui as run_depend
* Add view_diagnostics.launch
* Use the RIDGEBACK_CONFIG envar as the default value for the config arg when viewing the model
* Contributors: Chris Iverach-Brereton, Luis Camero, luis-camero
```
