### PR TITLE
warthog_desktop: 0.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -14929,7 +14929,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/warthog_desktop-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/warthog-cpr/warthog_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog_desktop` to `0.1.1-1`:

- upstream repository: https://github.com/warthog-cpr/warthog_desktop.git
- release repository: https://github.com/clearpath-gbp/warthog_desktop-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.0-1`

## warthog_desktop

- No changes

## warthog_viz

```
* [warthog_viz] Added rqt folder to be installed and add launch test for view_diagnostics.
* Alphabetized and added rqt_gui as run_depend
* Add view_diagnostics.launch
* Contributors: Luis Camero, Tony Baltovski, luis-camero
```
