### PR TITLE
warthog_simulator: 0.2.2-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -14947,7 +14947,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/warthog_simulator-release.git
-      version: 0.2.1-1
+      version: 0.2.2-2
     source:
       type: git
       url: https://github.com/warthog-cpr/warthog_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog_simulator` to `0.2.2-2`:

- upstream repository: https://github.com/warthog-cpr/warthog_simulator.git
- release repository: https://github.com/clearpath-gbp/warthog_simulator-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.1-1`

## warthog_gazebo

```
* Use the new arg added in warthog_control to always enable the game controller input when using Gazebo.
* Contributors: Chris Iverach-Brereton
```

## warthog_simulator

- No changes
