### PR TITLE
warthog: 0.1.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10109,7 +10109,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/warthog-release.git
-      version: 0.1.4-1
+      version: 0.1.5-1
     source:
       type: git
       url: https://github.com/warthog-cpr/warthog.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog` to `0.1.5-1`:

- upstream repository: https://github.com/warthog-cpr/warthog.git
- release repository: https://github.com/clearpath-gbp/warthog-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.4-1`

## warthog_control

```
* Add support for WARTHOG_COLOR in gazebo (#18 <https://github.com/warthog-cpr/warthog/issues/18>)
  * Move the headlights & taillights into their own links so we can apply the correct Gazebo materials to them (otherwise the robot looks symmetrical, which is confusing). Start applying different materials to the wheel diff links, depending on the paint colour. Sand & Olive are not yet supported
  * Start trying to implement custom colours for the sand & olive materials. No joy so far.
  * Remove the material scripts; they weren't working anyway. Add the visual tag around the gazebo material, explicitly define the ambient, diffuse, specular, and emissive properties. Add emissive attributes to the headlights & taillights so they actually show up in the dark
  * Add an argument to enable game-controller input via an arg; this makes using the controller inside gazebo easier as we don't need to explicitly define an envar (though that option still exists)
* Contributors: Chris I-B
```

## warthog_description

```
* Add support for WARTHOG_COLOR in gazebo (#18 <https://github.com/warthog-cpr/warthog/issues/18>)
  * Move the headlights & taillights into their own links so we can apply the correct Gazebo materials to them (otherwise the robot looks symmetrical, which is confusing). Start applying different materials to the wheel diff links, depending on the paint colour. Sand & Olive are not yet supported
  * Start trying to implement custom colours for the sand & olive materials. No joy so far.
  * Remove the material scripts; they weren't working anyway. Add the visual tag around the gazebo material, explicitly define the ambient, diffuse, specular, and emissive properties. Add emissive attributes to the headlights & taillights so they actually show up in the dark
  * Add an argument to enable game-controller input via an arg; this makes using the controller inside gazebo easier as we don't need to explicitly define an envar (though that option still exists)
* Contributors: Chris I-B
```

## warthog_msgs

- No changes
