### PR TITLE
dingo_desktop: 0.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1600,6 +1600,24 @@ repositories:
       url: https://github.com/dingo-cpr/dingo.git
       version: melodic-devel
     status: maintained
+  dingo_desktop:
+    doc:
+      type: git
+      url: https://github.com/dingo-cpr/dingo_desktop.git
+      version: master
+    release:
+      packages:
+      - dingo_desktop
+      - dingo_viz
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/dingo_desktop-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/dingo-cpr/dingo_desktop.git
+      version: master
+    status: maintained
   dnn_detect:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_desktop` to `0.1.1-1`:

- upstream repository: https://github.com/dingo-cpr/dingo_desktop.git
- release repository: https://github.com/clearpath-gbp/dingo_desktop-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## dingo_desktop

- No changes

## dingo_viz

```
* Add rqt directory and launch file check
* Add rqt_gui as exec_depend
* Alphabetized and separated test_depend
* Changed run_depend to exec_depend
* Added view_diagnostics
* Contributors: Luis Camero, luis-camero
```
