### PR TITLE
clober: 0.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -557,6 +557,29 @@ repositories:
       url: https://github.com/ros/class_loader.git
       version: foxy
     status: maintained
+  clober:
+    doc:
+      type: git
+      url: https://github.com/CLOBOT-Co-Ltd/clober.git
+      version: 0.1.0
+    release:
+      packages:
+      - clober_bringup
+      - clober_description
+      - clober_navigation
+      - clober_serial
+      - clober_simulation
+      - clober_slam
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/CLOBOT-Co-Ltd-release/clober_ros2-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/CLOBOT-Co-Ltd/clober.git
+      version: foxy-devel
+    status: developed
   clober_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clober` to `0.1.0-1`:

- upstream repository: https://github.com/CLOBOT-Co-Ltd/clober.git
- release repository: https://github.com/CLOBOT-Co-Ltd-release/clober_ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## clober_bringup

```
* add initial clober_bringup pacakage
```

## clober_description

```
* add initial clober_description pacakage
```

## clober_navigation

```
* add initial clober_navigation pacakage
```

## clober_simulation

```
* add initial clober_simulation pacakage
```

## clober_slam

```
* add initial clober_slam pacakage
```
