### PR TITLE
vision_opencv: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4889,7 +4889,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 2.2.1-1
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `3.0.0-1`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros2-gbp/vision_opencv-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.2.1-1`

## cv_bridge

```
* Export Modern CMake targets and install includes to another folder(#419 <https://github.com/ros-perception/vision_opencv/issues/419>)
* Handle padded img msg in Python (#400 <https://github.com/ros-perception/vision_opencv/issues/400>)
* Remove boost endian (#399 <https://github.com/ros-perception/vision_opencv/issues/399>)
* Add conversions from YUV422 YUY2 (#396 <https://github.com/ros-perception/vision_opencv/issues/396>)
* fix endianness comparison (#397 <https://github.com/ros-perception/vision_opencv/issues/397>)
* Export sensor_msgs dependency (#392 <https://github.com/ros-perception/vision_opencv/issues/392>)
* Fix multiple undefined references (#370 <https://github.com/ros-perception/vision_opencv/issues/370>)
* Updated cv_bridge.dll install location. (#356 <https://github.com/ros-perception/vision_opencv/issues/356>)
* Contributors: Homalozoa X, Jacob Perron, Patrick Musau, Sean Yen, Shane Loretz
```

## image_geometry

```
* Export Modern CMake targets and install includes to another folder(#419 <https://github.com/ros-perception/vision_opencv/issues/419>)
* fix windows build for image_geometry (#388 <https://github.com/ros-perception/vision_opencv/issues/388>)
* Contributors: Evan Flynn, Shane Loretz
```

## vision_opencv

- No changes
