### PR TITLE
xacro: 1.13.15-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -15108,7 +15108,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.13.14-1
+      version: 1.13.15-1
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.13.15-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.13.14-1`

## xacro

```
* Fix resolving of macros and properties declared and used in/from a namespace (#297 <https://github.com/ros/xacro/issues/297>, #306 <https://github.com/ros/xacro/issues/306>)Macros and properties that are declared within a namespaced include shouldn't require the namespace prefix when used within the namespace.
* Perform expression evaluation in comments (#300 <https://github.com/ros/xacro/issues/300>)
* Expose xacro.arg() to facilitate access to substitution args
* Contributors: Robert Haschke
```
