### PR TITLE
xacro: 1.14.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10256,7 +10256,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.14.10-1
+      version: 1.14.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.14.11-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.14.10-1`

## xacro

```
* Fix resolving of macros and properties declared and used in/from a namespace (#297 <https://github.com/ros/xacro/issues/297>, #306 <https://github.com/ros/xacro/issues/306>)Macros and properties that are declared within a namespaced include shouldn't require the namespace prefix when used within the namespace.
* Perform expression evaluation in comments (#300 <https://github.com/ros/xacro/issues/300>)
* Expose ``xacro.arg()`` to facilitate access to substitution args
* Fix scoped macro evaluation
  
    * Replace ``[Macro|Property]NameSpace`` with common ``NameSpace`` class derived from ``Table``
    * Use the scoped macro Table
  
* Contributors: Robert Haschke
```
