### PR TITLE
psen_scan_v2: 0.10.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6307,7 +6307,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/PilzDE/psen_scan_v2-release.git
-      version: 0.3.4-1
+      version: 0.10.0-1
     source:
       type: git
       url: https://github.com/PilzDE/psen_scan_v2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `psen_scan_v2` to `0.10.0-1`:

- upstream repository: https://github.com/PilzDE/psen_scan_v2.git
- release repository: https://github.com/PilzDE/psen_scan_v2-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.4-1`

## psen_scan_v2

```
* Change to new versioning method for ROS1 (0.10.0+) and ROS2 (0.20.0+).
* Deprecate get/set methods with 'get/set' prefix in favour of methods without the prefix(#298)
* ADD IO states to LaserScan and publish them at ~/io_state (#281)
* Renaming Slave to Subscriber (#303)
* Contributors: Pilz GmbH and Co. KG
```
