### PR TITLE
ntrip_client: 1.0.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2134,11 +2134,15 @@ repositories:
       version: ros2
     status: maintained
   ntrip_client:
+    doc:
+      type: git
+      url: https://github.com/LORD-MicroStrain/ntrip_client.git
+      version: ros2
     release:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/ntrip_client-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ntrip_client` to `1.0.1-1`:

- upstream repository: https://github.com/LORD-MicroStrain/ntrip_client.git
- release repository: https://github.com/ros2-gbp/ntrip_client-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.0-1`

## ntrip_client

```
* Replaces ROS timer destroy methods with ROS2 methods and removes extra destroy
* Contributors: robbiefish
```
