### PR TITLE
mimick_vendor: 0.2.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1757,7 +1757,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mimick_vendor-release.git
-      version: 0.2.6-1
+      version: 0.2.7-1
     source:
       type: git
       url: https://github.com/ros2/mimick_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mimick_vendor` to `0.2.7-1`:

- upstream repository: https://github.com/ros2/mimick_vendor.git
- release repository: https://github.com/ros2-gbp/mimick_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.6-1`

## mimick_vendor

```
* Update maintainers to Geoffrey Biggs (#23 <https://github.com/ros2/mimick_vendor/issues/23>)
* Update to latest commit for Apple M1 support (#20 <https://github.com/ros2/mimick_vendor/issues/20>)
* Contributors: Audrow Nash, Christophe Bedard
```
