### PR TITLE
moveit: 2.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1805,7 +1805,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/moveit/moveit2-release.git
-      version: 2.3.2-1
+      version: 2.4.0-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.4.0-1`:

- upstream repository: https://github.com/ros-planning/moveit2.git
- release repository: https://github.com/moveit/moveit2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.2-1`

## chomp_motion_planner

```
* Replace NULL with nullptr (#961 <https://github.com/ros-planning/moveit2/issues/961>)
  * Fixes #841 <https://github.com/ros-planning/moveit2/issues/841>
* moveit_build_options()
  Declare common build options like CMAKE_CXX_STANDARD, CMAKE_BUILD_TYPE,
  and compiler options (namely warning flags) once.
  Each package depending on moveit_core can use these via moveit_build_options().
* Contributors: Robert Haschke, Stephanie Eng
```

## moveit

- No changes

## moveit_chomp_optimizer_adapter

```
* moveit_build_options()
  Declare common build options like CMAKE_CXX_STANDARD, CMAKE_BUILD_TYPE,
  and compiler options (namely warning flags) once.
  Each package depending on moveit_core can use these via moveit_build_options().
* Contributors: Robert Haschke
```

## moveit_common

```
* Merge https://github.com/ros-planning/moveit/commit/f3ac6070497da90da33551fc1dc3a68938340413
* Contributors: Abishalini
```

## moveit_core

```
* Move background_processing (#997 <https://github.com/ros-planning/moveit2/issues/997>)
* Fix boost linking errors for Windows (#957 <https://github.com/ros-planning/moveit2/issues/957>)
* Delete backtrace hack (#995 <https://github.com/ros-planning/moveit2/issues/995>)
* Use size_t for index variables (#946 <https://github.com/ros-planning/moveit2/issues/946>)
* Remove moveit_build_options
* Merge https://github.com/ros-planning/moveit/commit/f3ac6070497da90da33551fc1dc3a68938340413
* Replace NULL with nullptr (#961 <https://github.com/ros-planning/moveit2/issues/961>)
  * Fixes #841 <https://github.com/ros-planning/moveit2/issues/841>
* Merge https://github.com/ros-planning/moveit/commit/a0ee2020c4a40d03a48044d71753ed23853a665d
* Add jerk to the robot model (#683 <https://github.com/ros-planning/moveit2/issues/683>)
  * Add jerk to the robot model
  * Add joint limit parsing to a unit test
  * Add jerk to computeVariableBoundsMsg and <<, too
* collision_distance_field: Fix undefined behavior vector insertion (#942 <https://github.com/ros-planning/moveit2/issues/942>)
* Normalize incoming transforms (#2920 <https://github.com/ros-planning/moveit2/issues/2920>)
  * Normalize incoming transforms
  * fixup: adapt comment according to review suggestion
  Co-authored-by: Michael Görner <mailto:me@v4hn.de>
* Completely silent -Wmaybe-uninitialized
* Don't fail on -Wmaybe-uninitialized. Needs more analysis!
* Fix unused-variable warning
* Silent unused-function warnings
* Remove unused arguments from global_adjustment_factor()
  Looks like, dt and x were passed originally to call fit_cubic_spline()
  inside that function. However, later it was assumed that fit_cubic_spline()
  was already called, rendering these parameters superfluous.
* Simplify API: Remove obviously unused arguments
* clang-tidy: fix unused parameter (critical cases)
  This warnings should be considered in more detail (TODO).
  Not using these arguments might be an actual bug.
* clang-tidy: fix unused parameter (uncritical cases)
  These parameters aren't used for an obvious reason.
* moveit_build_options()
  Declare common build options like CMAKE_CXX_STANDARD, CMAKE_BUILD_TYPE,
  and compiler options (namely warning flags) once.
  Each package depending on moveit_core can use these via moveit_build_options().
* RobotState: write to correct array (#2909 <https://github.com/ros-planning/moveit2/issues/2909>)
  Not an actual bug because both arrays share the same memory.
  As mentioned in https://github.com/ros-planning/moveit2/pull/683#pullrequestreview-780447848
* fix uninitialized orientation in default shape pose (#2896 <https://github.com/ros-planning/moveit2/issues/2896>)
* Readability and consistency improvements in TOTG (#2882 <https://github.com/ros-planning/moveit2/issues/2882>)
  * Use std::fabs() everywhere
  * Better comments
* Contributors: Abishalini, Akash, AndyZe, Michael Görner, Robert Haschke, Stephanie Eng, Tyler Weaver, andreas-botbuilt
```

## moveit_hybrid_planning

```
* hybrid_planning: Fix global_planner action name (#960 <https://github.com/ros-planning/moveit2/issues/960>)
* Put hybrid planning actions under a common namespace (#932 <https://github.com/ros-planning/moveit2/issues/932>)
  * Put hybrid planning actions under a common namespace
  * Use ~
  * New pkg for common resources. Does not work.
  * Use inline rather than anonymous namespace
  Co-authored-by: Jafar Abdi <mailto:cafer.abdi@gmail.com>
  * Revert "Use inline rather than anonymous namespace"
  This reverts commit 29a7d279776be21f4666c7e0fadeaa6b7ef8debf.
  * Revert "New pkg for common resources. Does not work."
  This reverts commit 68a173baee4b7f8b2c1f74285f96c8e3892c5909.
  * Some progress toward loading common parameters
  Co-authored-by: Jafar Abdi <mailto:cafer.abdi@gmail.com>
* Contributors: AndyZe
```

## moveit_kinematics

```
* Fix IKFast test dependency (#993 <https://github.com/ros-planning/moveit2/issues/993>)
* Replace NULL with nullptr (#961 <https://github.com/ros-planning/moveit2/issues/961>)
  * Fixes #841 <https://github.com/ros-planning/moveit2/issues/841>
* moveit_build_options()
  Declare common build options like CMAKE_CXX_STANDARD, CMAKE_BUILD_TYPE,
  and compiler options (namely warning flags) once.
  Each package depending on moveit_core can use these via moveit_build_options().
* Contributors: Henning Kayser, Robert Haschke, Stephanie Eng
```

## moveit_planners

- No changes

## moveit_planners_chomp

```
* moveit_build_options()
  Declare common build options like CMAKE_CXX_STANDARD, CMAKE_BUILD_TYPE,
  and compiler options (namely warning flags) once.
  Each package depending on moveit_core can use these via moveit_build_options().
* Contributors: Robert Haschke
```

## moveit_planners_ompl

```
* moveit_build_options()
  Declare common build options like CMAKE_CXX_STANDARD, CMAKE_BUILD_TYPE,
  and compiler options (namely warning flags) once.
  Each package depending on moveit_core can use these via moveit_build_options().
* Contributors: Robert Haschke
```

## moveit_plugins

- No changes

## moveit_resources_prbt_ikfast_manipulator_plugin

```
* Replace NULL with nullptr (#961 <https://github.com/ros-planning/moveit2/issues/961>)
  * Fixes #841 <https://github.com/ros-planning/moveit2/issues/841>
* Contributors: Stephanie Eng
```

## moveit_resources_prbt_moveit_config

- No changes

## moveit_resources_prbt_pg70_support

- No changes

## moveit_resources_prbt_support

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

```
* Merge https://github.com/ros-planning/moveit/commit/f3ac6070497da90da33551fc1dc3a68938340413
* moveit_build_options()
  Declare common build options like CMAKE_CXX_STANDARD, CMAKE_BUILD_TYPE,
  and compiler options (namely warning flags) once.
  Each package depending on moveit_core can use these via moveit_build_options().
* Contributors: Abishalini, Robert Haschke
```

## moveit_ros_control_interface

```
* moveit_build_options()
  Declare common build options like CMAKE_CXX_STANDARD, CMAKE_BUILD_TYPE,
  and compiler options (namely warning flags) once.
  Each package depending on moveit_core can use these via moveit_build_options().
* Contributors: Robert Haschke
```

## moveit_ros_move_group

```
* moveit_build_options()
  Declare common build options like CMAKE_CXX_STANDARD, CMAKE_BUILD_TYPE,
  and compiler options (namely warning flags) once.
  Each package depending on moveit_core can use these via moveit_build_options().
* Contributors: Robert Haschke
```

## moveit_ros_occupancy_map_monitor

```
* Fix boost linking errors for Windows (#957 <https://github.com/ros-planning/moveit2/issues/957>)
* Replace NULL with nullptr (#961 <https://github.com/ros-planning/moveit2/issues/961>)
  * Fixes #841 <https://github.com/ros-planning/moveit2/issues/841>
* moveit_build_options()
  Declare common build options like CMAKE_CXX_STANDARD, CMAKE_BUILD_TYPE,
  and compiler options (namely warning flags) once.
  Each package depending on moveit_core can use these via moveit_build_options().
* Contributors: Akash, Robert Haschke, Stephanie Eng
```

## moveit_ros_perception

```
* Fix boost linking errors for Windows (#957 <https://github.com/ros-planning/moveit2/issues/957>)
* moveit_build_options()
  Declare common build options like CMAKE_CXX_STANDARD, CMAKE_BUILD_TYPE,
  and compiler options (namely warning flags) once.
  Each package depending on moveit_core can use these via moveit_build_options().
* Contributors: Akash, Robert Haschke
```

## moveit_ros_planning

```
* Merge https://github.com/ros-planning/moveit/commit/f3ac6070497da90da33551fc1dc3a68938340413
* Replace NULL with nullptr (#961 <https://github.com/ros-planning/moveit2/issues/961>)
  * Fixes #841 <https://github.com/ros-planning/moveit2/issues/841>
* Add jerk to the robot model (#683 <https://github.com/ros-planning/moveit2/issues/683>)
  * Add jerk to the robot model
  * Add joint limit parsing to a unit test
  * Add jerk to computeVariableBoundsMsg and <<, too
* Silent clang-tidy's -Wpotentially-evaluated-expression
  https://stackoverflow.com/questions/46494928/clang-warning-on-expression-side-effects
* moveit_build_options()
  Declare common build options like CMAKE_CXX_STANDARD, CMAKE_BUILD_TYPE,
  and compiler options (namely warning flags) once.
  Each package depending on moveit_core can use these via moveit_build_options().
* Contributors: Abishalini, AndyZe, Robert Haschke, Stephanie Eng
```

## moveit_ros_planning_interface

```
* Fix boost linking errors for Windows (#957 <https://github.com/ros-planning/moveit2/issues/957>)
* Replace NULL with nullptr (#961 <https://github.com/ros-planning/moveit2/issues/961>)
  * Fixes #841 <https://github.com/ros-planning/moveit2/issues/841>
* Merge https://github.com/ros-planning/moveit/commit/a0ee2020c4a40d03a48044d71753ed23853a665d
* moveit_build_options()
  Declare common build options like CMAKE_CXX_STANDARD, CMAKE_BUILD_TYPE,
  and compiler options (namely warning flags) once.
  Each package depending on moveit_core can use these via moveit_build_options().
* MGI: add missing replan/look options to interface (#2892 <https://github.com/ros-planning/moveit2/issues/2892>)
  - reordered methods because looking requires replanning
  - there's no sense in wrapping methods in methods.
  just use pimpl-friend paradigm instead. Someone could
  rework all the other methods in the future.
* PSI: get object.pose from new msg field (#2877 <https://github.com/ros-planning/moveit2/issues/2877>)
* Contributors: Abishalini, Akash, Gauthier Hentz, Michael Görner, Robert Haschke, Stephanie Eng
```

## moveit_ros_robot_interaction

```
* Replace NULL with nullptr (#961 <https://github.com/ros-planning/moveit2/issues/961>)
  * Fixes #841 <https://github.com/ros-planning/moveit2/issues/841>
* moveit_build_options()
  Declare common build options like CMAKE_CXX_STANDARD, CMAKE_BUILD_TYPE,
  and compiler options (namely warning flags) once.
  Each package depending on moveit_core can use these via moveit_build_options().
* Contributors: Robert Haschke, Stephanie Eng
```

## moveit_ros_visualization

```
* Move background_processing (#997 <https://github.com/ros-planning/moveit2/issues/997>)
* Merge https://github.com/ros-planning/moveit/commit/f3ac6070497da90da33551fc1dc3a68938340413
* Merge https://github.com/ros-planning/moveit/commit/a0ee2020c4a40d03a48044d71753ed23853a665d
* moveit_build_options()
  Declare common build options like CMAKE_CXX_STANDARD, CMAKE_BUILD_TYPE,
  and compiler options (namely warning flags) once.
  Each package depending on moveit_core can use these via moveit_build_options().
* MPD: do not save/restore warehouse parameters (#2865 <https://github.com/ros-planning/moveit2/issues/2865>)
  If we reload these values from the config, setting the ROS parameters is much less useful.
  At least the *type* of warehouse_ros plugin (mongo or sqlite) cannot be selected
  in the display, so you will probably need to meddle with the parameters anyway if you want
  to connect to a different db.
  search for parameters warehouse_host/port because they are usually set at the top level, but
  you might want to set them differently for different move_groups.
* PlanningSceneDisplay: always update the main scene node's pose (#2876 <https://github.com/ros-planning/moveit2/issues/2876>)
* Contributors: Abishalini, Michael Görner, Robert Haschke, Tyler Weaver
```

## moveit_ros_warehouse

```
* Merge https://github.com/ros-planning/moveit/commit/f3ac6070497da90da33551fc1dc3a68938340413
* moveit_build_options()
  Declare common build options like CMAKE_CXX_STANDARD, CMAKE_BUILD_TYPE,
  and compiler options (namely warning flags) once.
  Each package depending on moveit_core can use these via moveit_build_options().
* Contributors: Abishalini, Robert Haschke
```

## moveit_runtime

- No changes

## moveit_servo

```
* Remove 'using namespace' from header files. (#994 <https://github.com/ros-planning/moveit2/issues/994>)
* Servo: re-order velocity limit check & minor cleanup (#956 <https://github.com/ros-planning/moveit2/issues/956>)
* moveit_build_options()
  Declare common build options like CMAKE_CXX_STANDARD, CMAKE_BUILD_TYPE,
  and compiler options (namely warning flags) once.
  Each package depending on moveit_core can use these via moveit_build_options().
* Contributors: AndyZe, Cory Crean, Robert Haschke
```

## moveit_setup_assistant

```
* Replace NULL with nullptr (#961 <https://github.com/ros-planning/moveit2/issues/961>)
  * Fixes #841 <https://github.com/ros-planning/moveit2/issues/841>
* Merge https://github.com/ros-planning/moveit/commit/a0ee2020c4a40d03a48044d71753ed23853a665d
* moveit_build_options()
  Declare common build options like CMAKE_CXX_STANDARD, CMAKE_BUILD_TYPE,
  and compiler options (namely warning flags) once.
  Each package depending on moveit_core can use these via moveit_build_options().
* Load all planning pipelines into their own namespace (#2888 <https://github.com/ros-planning/moveit2/issues/2888>)
  Reduce code redundancy, specifying the namespace once in planning_pipeline.launch.
* MSA: Correctly state not-found package name
  The warning message was accessing the config_data_ variable, which
  was assigned just a few lines later.
* Contributors: Abishalini, Robert Haschke, Stephanie Eng
```

## moveit_simple_controller_manager

```
* moveit_build_options()
  Declare common build options like CMAKE_CXX_STANDARD, CMAKE_BUILD_TYPE,
  and compiler options (namely warning flags) once.
  Each package depending on moveit_core can use these via moveit_build_options().
* Contributors: Robert Haschke
```

## pilz_industrial_motion_planner

```
* Remove 'using namespace' from header files. (#994 <https://github.com/ros-planning/moveit2/issues/994>)
* Fix missing ament_cmake_gtest dependency (#981 <https://github.com/ros-planning/moveit2/issues/981>)
* Remove some Maintainers from Pilz Planner (#971 <https://github.com/ros-planning/moveit2/issues/971>)
* Fix usage of boost placeholder (#958 <https://github.com/ros-planning/moveit2/issues/958>)
* Merge https://github.com/ros-planning/moveit/commit/a0ee2020c4a40d03a48044d71753ed23853a665d
* Remove '-W*' options from cmake files (#2903 <https://github.com/ros-planning/moveit2/issues/2903>)
* Add test for pilz planner with attached objects (#2878 <https://github.com/ros-planning/moveit2/issues/2878>)
  * Add test case for #2824 <https://github.com/ros-planning/moveit2/issues/2824>
  Co-authored-by: Cristian Beltran <mailto:cristianbehe@gmail.com>
  Co-authored-by: Joachim Schleicher <mailto:joachimsl@gmx.de>
  Co-authored-by: jschleicher <mailto:j.schleicher@pilz.de>
* Contributors: Abishalini, Cory Crean, Leroy Rügemer, Tyler Weaver, Wolf Vollprecht, cambel, jschleicher
```

## pilz_industrial_motion_planner_testutils

```
* Remove some Maintainers from Pilz Planner (#971 <https://github.com/ros-planning/moveit2/issues/971>)
* Remove '-W*' options from cmake files (#2903 <https://github.com/ros-planning/moveit2/issues/2903>)
* Contributors: Leroy Rügemer, jschleicher
```
