### PR TITLE
ros2_tracing: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3304,7 +3304,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 3.1.0-1
+      version: 4.0.0-1
     source:
       type: git
       url: https://gitlab.com/ros-tracing/ros2_tracing.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `4.0.0-1`:

- upstream repository: https://gitlab.com/ros-tracing/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.1.0-1`

## ros2trace

```
* Don't require kernel tracer and detect when it's not installed
* Deprecate 'context_names' param and replace with 'context_fields'
* Contributors: Christophe Bedard
```

## tracetools

```
* Merge branch 'update-mentions-of-tracetools-test' into 'master'
  Update applicable mentions of tracetools_test to test_tracetools
  See merge request ros-tracing/ros2_tracing!259 <https://gitlab.com/ros-tracing/ros2_tracing/-/merge_requests/259>
* Update applicable mentions of tracetools_test to test_tracetools
* Merge branch 'version-3-1-0' into 'master'
  Version 3.1.0
  See merge request ros-tracing/ros2_tracing!256 <https://gitlab.com/ros-tracing/ros2_tracing/-/merge_requests/256>
* Contributors: Christophe Bedard
```

## tracetools_launch

```
* Disable kernel tracing by default
* Don't require kernel tracer and detect when it's not installed
* Add support for preloading pthread and dl instrumentation shared libs
* Remove profile_fast option and consider LD_PRELOADing both libs
* Improve event matching for shared lib preloading
* Improve LdPreload action's lib-finding function and add proper tests
* Fix multiple LdPreload actions not working and add test
* Deprecate 'context_names' param and replace with 'context_fields'
* Support per-domain context fields for the Trace action
* Improve LdPreload.get_shared_lib_path() for when a static lib may exist
* Move some tests from tracetools_launch to test_tracetools_launch
* Expose Trace action as frontend action and support substitutions
* Contributors: Christophe Bedard, Ingo Lütkebohle
```

## tracetools_test

```
* Remove default value for 'package' kwarg for TraceTestCase
* Move actual tests out of tracetools_test to new test_tracetools package
* Contributors: Christophe Bedard
```

## tracetools_trace

```
* Disable kernel tracing by default
* Don't require kernel tracer and detect when it's not installed
* Introduce constants for tracepoint names
* Optimize default tracing session channel config values
* Deprecate 'context_names' param and replace with 'context_fields'
* Support per-domain context fields for the Trace action
* Contributors: Christophe Bedard
```
