### PR TITLE
hri_msgs: 0.2.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3038,6 +3038,21 @@ repositories:
       url: https://github.com/at-wat/hokuyo3d.git
       version: master
     status: developed
+  hri_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/hri_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros4hri/hri_msgs-release.git
+      version: 0.2.1-2
+    source:
+      type: git
+      url: https://github.com/ros4hri/hri_msgs.git
+      version: master
+    status: developed
   human_description:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hri_msgs` to `0.2.1-2`:

- upstream repository: https://github.com/ros4hri/hri_msgs.git
- release repository: https://github.com/ros4hri/hri_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## hri_msgs

```
* new package, part of the ROS4HRI project
* Contributors: Séverin Lemaignan
```
