### PR TITLE
human_description: 1.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3020,6 +3020,21 @@ repositories:
       url: https://github.com/at-wat/hokuyo3d.git
       version: master
     status: developed
+  human_description:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/human_description.git
+      version: main
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros4hri/human_description-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros4hri/human_description.git
+      version: main
+    status: developed
   husky:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `human_description` to `1.0.0-1`:

- upstream repository: https://github.com/ros4hri/human_description.git
- release repository: https://github.com/ros4hri/human_description-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
