### PR TITLE
tracetools_analysis: 3.0.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4477,7 +4477,7 @@ repositories:
     doc:
       type: git
       url: https://gitlab.com/ros-tracing/tracetools_analysis.git
-      version: foxy
+      version: master
     release:
       packages:
       - ros2trace_analysis
@@ -4489,7 +4489,7 @@ repositories:
     source:
       type: git
       url: https://gitlab.com/ros-tracing/tracetools_analysis.git
-      version: foxy
+      version: master
     status: developed
   transport_drivers:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4485,7 +4485,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://gitlab.com/ros-tracing/tracetools_analysis-release.git
-      version: 2.0.3-3
+      version: 3.0.0-2
     source:
       type: git
       url: https://gitlab.com/ros-tracing/tracetools_analysis.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4484,7 +4484,7 @@ repositories:
       - tracetools_analysis
       tags:
         release: release/rolling/{package}/{version}
-      url: https://gitlab.com/ros-tracing/tracetools_analysis-release.git
+      url: https://github.com/ros2-gbp/tracetools_analysis-release.git
       version: 3.0.0-2
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tracetools_analysis` to `3.0.0-2`:

- upstream repository: https://gitlab.com/ros-tracing/tracetools_analysis.git
- release repository: https://gitlab.com/ros-tracing/tracetools_analysis-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.3-3`

## ros2trace_analysis

```
* Add 'process --convert-only' option
* Deprecate 'convert' verb since it is just an implementation detail
* Contributors: Christophe Bedard
```

## tracetools_analysis

```
* Update context_fields option name in profile example launch file
* Fix both rcl and rmw subscriptions being added to the rcl dataframe
* Support rmw pub/sub init and take instrumentation
* Support publishing instrumentation
* Change 'input_path' arg help message wording
* Add 'process --convert-only' option
* Deprecate 'convert' verb since it is just an implementation detail
* Simplify jupyter notebooks and add way to use Debian packages
* Contributors: Christophe Bedard
```
