### PR TITLE
launch_param_builder: 0.1.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1451,6 +1451,21 @@ repositories:
       url: https://github.com/ros2/launch.git
       version: galactic
     status: developed
+  launch_param_builder:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/launch_param_builder.git
+      version: main
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/PickNikRobotics/launch_param_builder-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/launch_param_builder.git
+      version: main
+    status: maintained
   launch_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_param_builder` to `0.1.0-1`:

- upstream repository: https://github.com/PickNikRobotics/launch_param_builder.git
- release repository: https://github.com/PickNikRobotics/launch_param_builder-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## launch_param_builder

```
* First commit
* Contributors: Jafar Abdi
```
