### PR TITLE
depthimage_to_laserscan: 2.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -645,7 +645,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/depthimage_to_laserscan-release.git
-      version: 2.3.1-1
+      version: 2.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthimage_to_laserscan` to `2.5.0-1`:

- upstream repository: https://github.com/ros-perception/depthimage_to_laserscan.git
- release repository: https://github.com/ros2-gbp/depthimage_to_laserscan-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.1-1`

## depthimage_to_laserscan

```
* Install includes to ${PROJECT_NAME} folder and use modern CMake (#58 <https://github.com/ros-perception/depthimage_to_laserscan/issues/58>)
* Fix the launch files to work with Rolling. (#59 <https://github.com/ros-perception/depthimage_to_laserscan/issues/59>)
* Contributors: Chris Lalancette, Shane Loretz
```
