### PR TITLE
cudnn_cmake_module: 0.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -587,8 +587,7 @@ repositories:
       url: https://github.com/ros-controls/control_toolbox.git
       version: ros2-master
     status: maintained
-  
-  _cmake_module:
+  cudnn_cmake_module:
     doc:
       type: git
       url: https://github.com/tier4/cudnn_cmake_module.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -587,7 +587,8 @@ repositories:
       url: https://github.com/ros-controls/control_toolbox.git
       version: ros2-master
     status: maintained
-  cudnn_cmake_module:
+  
+  _cmake_module:
     doc:
       type: git
       url: https://github.com/tier4/cudnn_cmake_module.git
@@ -595,7 +596,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/tier4/cudnn_cmake_module-release.git
+      url: https://github.com/ros2-gbp/cudnn_cmake_module-release.git
       version: 0.0.1-1
     source:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -587,6 +587,21 @@ repositories:
       url: https://github.com/ros-controls/control_toolbox.git
       version: ros2-master
     status: maintained
+  cudnn_cmake_module:
+    doc:
+      type: git
+      url: https://github.com/tier4/cudnn_cmake_module.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/tier4/cudnn_cmake_module-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/tier4/cudnn_cmake_module.git
+      version: main
+    status: maintained
   cyclonedds:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `cudnn_cmake_module` to `0.0.1-1`:

- upstream repository: https://github.com/tier4/cudnn_cmake_module.git
- release repository: https://github.com/ros2-gbp/cudnn_cmake_module-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## cudnn_cmake_module

```
* ci: add build and test action
* initial commit
* Contributors: wep21
```
