### PR TITLE
tensorrt_cmake_module: 0.0.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4805,6 +4805,21 @@ repositories:
       url: https://github.com/ros2/teleop_twist_keyboard.git
       version: dashing
     status: maintained
+  tensorrt_cmake_module:
+    doc:
+      type: git
+      url: https://github.com/tier4/tensorrt_cmake_module.git
+      version: main
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/tier4/tensorrt_cmake_module-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/tier4/tensorrt_cmake_module.git
+      version: main
+    status: maintained
   test_interface_files:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tensorrt_cmake_module` to `0.0.1-1`:

- upstream repository: https://github.com/tier4/tensorrt_cmake_module.git
- release repository: https://github.com/tier4/tensorrt_cmake_module-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## tensorrt_cmake_module

```
* ci: add build and test action
* initial commit
* Contributors: wep21
```
