### PR TITLE
nao_interfaces: 0.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1910,6 +1910,24 @@ repositories:
       url: https://github.com/KIT-MRT/mrt_cmake_modules.git
       version: master
     status: maintained
+  nao_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ijnek/nao_interfaces.git
+      version: rolling
+    release:
+      packages:
+      - nao_command_msgs
+      - nao_sensor_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ijnek/nao_interfaces-release.git
+      version: 0.0.4-1
+    source:
+      type: git
+      url: https://github.com/ijnek/nao_interfaces.git
+      version: rolling
+    status: developed
   navigation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_interfaces` to `0.0.4-1`:

- upstream repository: https://github.com/ijnek/nao_interfaces.git
- release repository: https://github.com/ijnek/nao_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## nao_command_msgs

```
* update comments in JointPositions and JointStiffnesses
* update package descriptions, and remove unused dependency
* Contributors: Kenji Brameld
```

## nao_sensor_msgs

```
* update package descriptions, and remove unused dependency
* Contributors: Kenji Brameld
```
