### PR TITLE
nao_interfaces: 0.0.4-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1934,7 +1934,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ijnek/nao_interfaces.git
-      version: main
+      version: rolling
     release:
       packages:
       - nao_command_msgs
@@ -1946,7 +1946,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ijnek/nao_interfaces.git
-      version: main
+      version: rolling
     status: developed
   nao_lola:
     doc:

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1942,7 +1942,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ijnek/nao_interfaces-release.git
-      version: 0.0.3-1
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/ijnek/nao_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_interfaces` to `0.0.4-1`:

- upstream repository: https://github.com/ijnek/nao_interfaces.git
- release repository: https://github.com/ijnek/nao_interfaces-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.3-1`

## nao_command_msgs

```
* update comments in JointPositions and JointStiffnesses
* update package descriptions, and remove unused dependency
* Contributors: Kenji Brameld
```

## nao_sensor_msgs

```
* update package descriptions, and remove unused dependency
* Contributors: Kenji Brameld
```
