### PR TITLE
rplidar_ros: 2.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7891,6 +7891,21 @@ repositories:
       url: https://github.com/tork-a/roswww.git
       version: develop
     status: unmaintained
+  rplidar_ros:
+    doc:
+      type: git
+      url: https://github.com/Slamtec/rplidar_ros.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/nobleo/rplidar_ros-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/Slamtec/rplidar_ros.git
+      version: master
+    status: maintained
   rqt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rplidar_ros` to `2.0.0-1`:

- upstream repository: https://github.com/Slamtec/rplidar_ros.git
- release repository: https://github.com/nobleo/rplidar_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## rplidar_ros

```
* Update RPLIDAR SDK to 2.0.0
* [new feature] 1.redesign the skelton of the sdk. 2.support Rplidar S2
* Contributors: tony,WubinXia
```
