### PR TITLE
simple_launch: 1.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4193,6 +4193,21 @@ repositories:
       url: https://github.com/ros/sdformat_urdf.git
       version: ros2
     status: maintained
+  simple_launch:
+    doc:
+      type: git
+      url: https://github.com/oKermorgant/simple_launch.git
+      version: 1.0.2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/oKermorgant/simple_launch-release.git
+      version: 1.2.1-1
+    source:
+      type: git
+      url: https://github.com/oKermorgant/simple_launch.git
+      version: devel
+    status: maintained
   snowbot_operating_system:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_launch` to `1.2.1-1`:

- upstream repository: https://github.com/oKermorgant/simple_launch.git
- release repository: https://github.com/oKermorgant/simple_launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## simple_launch

```
* add Ignition support
* Contributors: Olivier Kermorgant
```
