### PR TITLE
Add more platform rules for 'yamllint'

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7988,12 +7988,16 @@ yaml-cpp:
   slackware: [yaml-cpp]
   ubuntu: [libyaml-cpp-dev]
 yamllint:
+  alpine: [yamllint]
   arch: [yamllint]
-  debian:
-    buster: [yamllint]
-    stretch: [yamllint]
+  debian: [yamllint]
   fedora: [yamllint]
   gentoo: [dev-util/yamllint]
+  nixos: [yamllint]
+  osx:
+    homebrew:
+      packages: [yamllint]
+  rhel: [yamllint]
   ubuntu: [yamllint]
 yasm:
   arch: [yasm]


### PR DESCRIPTION
Alpine: https://pkgs.alpinelinux.org/package/edge/community/x86_64/yamllint
Debian: https://packages.debian.org/search?suite=all&searchon=names&keywords=yamllint
OSX/Homebrew: https://formulae.brew.sh/formula/yamllint#default
NixOS: https://search.nixos.org/packages?channel=21.05&show=yamllint&type=packages&query=yamllint
RHEL: https://src.fedoraproject.org/rpms/yamllint#bodhi_updates