### PR TITLE
clober: 0.1.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -573,7 +573,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/CLOBOT-Co-Ltd-release/clober_ros2-release.git
-      version: 0.1.0-1
+      version: 0.1.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clober` to `0.1.0-2`:

- upstream repository: https://github.com/CLOBOT-Co-Ltd/clober.git
- release repository: https://github.com/CLOBOT-Co-Ltd-release/clober_ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.0-1`

## clober_bringup

```
* add initial clober_bringup pacakage
```

## clober_description

```
* add initial clober_description pacakage
```

## clober_navigation

```
* add initial clober_navigation pacakage
```

## clober_simulation

```
* add initial clober_simulation pacakage
```

## clober_slam

```
* add initial clober_slam pacakage
```
