### PR TITLE
rslidar_sdk: 1.3.0-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4399,6 +4399,21 @@ repositories:
       url: https://github.com/RoboSense-LiDAR/rslidar_msg.git
       version: master
     status: maintained
+  rslidar_sdk:
+    doc:
+      type: git
+      url: https://github.com/RoboSense-LiDAR/rslidar_sdk.git
+      version: dev
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/nobleo/rslidar_sdk-release.git
+      version: 1.3.0-2
+    source:
+      type: git
+      url: https://github.com/RoboSense-LiDAR/rslidar_sdk.git
+      version: dev
+    status: maintained
   rtabmap:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rslidar_sdk` to `1.3.0-2`:

- upstream repository: https://github.com/RoboSense-LiDAR/rslidar_sdk.git
- release repository: https://github.com/nobleo/rslidar_sdk-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
