### PR TITLE
rclc: 2.0.6-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2900,7 +2900,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
-      version: 2.0.5-2
+      version: 2.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclc` to `2.0.6-1`:

- upstream repository: https://github.com/ros2/rclc.git
- release repository: https://github.com/ros2-gbp/rclc-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.5-2`

## rclc

```
* [backport galactic, foxy] data_available optimization (#212)
* Fix data_available reset for timer (#215) (#216)
* Executor ignore canceled timers (#220) (#221)
* Resolved error in unit test see issue #230 (#231) (#232)
* Updated documentation README.md (#229)
```

## rclc_examples

```
* [backport galactic, foxy] data_available optimization (#212)
```

## rclc_lifecycle

```
* Note regression in lifecycle services (#227)
```

## rclc_parameter

```
* no change
```
