### PR TITLE
rclc: 1.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3532,7 +3532,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
-      version: 1.0.2-1
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclc` to `1.1.0-1`:

- upstream repository: https://github.com/ros2/rclc.git
- release repository: https://github.com/ros2-gbp/rclc-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.2-1`

## rclc

```
* Update codecov to ignore rclc_examples and all test folders (backport #145) (#150)
* Updated table of bloom releases (removed dashing, inserted galactic) (backport #147) (#152)
* Refactor #116 remove callback_type (#154)
* Fix codecov to ignore unit tests and rclc_examples package (backport #155) (#162)
* Feature request: check for valid ros context in spin_some (#165) (#167)
* Ignoring unsuccessful SERVICE_TAKE (#175) (#177)
* Backport windows port of PR #144 (#182)
* Fix: printf in executor spin (#195) (#197)
* Fix init options handling (#202) (#204)
* [backport galactic, foxy] data_available optimization (backport #212) (#213)
* Fix data_available reset for timer (#215)
* Executor ignore canceled timers (#220) (#222)
* Resolved error in unit test see issue #230 (#231) (#233)
* Updated documentation README.md (#234)
```

## rclc_examples

```
* Feature request: check for valid ros context in spin_some (#165) (#167)
* Ignoring unsuccessful SERVICE_TAKE (#175) (#177)
* added pingpong example (backport #172) (#187)
* [backport galactic, foxy] data_available optimization (backport #212) (#213)
```

## rclc_lifecycle

```
* Note wrt services implemented for rolling (#226)
```
