### PR TITLE
rclc: 3.0.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2684,7 +2684,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
-      version: 3.0.5-1
+      version: 3.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclc` to `3.0.6-1`:

- upstream repository: https://github.com/ros2/rclc.git
- release repository: https://github.com/ros2-gbp/rclc-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.0.5-1`

## rclc

```
* executor ignore canceled timers (#220)
* uddated documentation README.md (#229)
* resolved error in unit test see issue #230 (#231)
* Add thread dependency to examples (Rolling) (#237) (resolves in this package only cpplint errors)
```

## rclc_examples

```
* Create service context in main (#224)
* Add thread dependency to examples (Rolling) (#237)
```

## rclc_lifecycle

```
* Create service context in main (#224)
```

## rclc_parameter

```
* Add thread dependency to examples (Rolling) (#237) (resolves in this package only cpplint errors)
```
