### PR TITLE
rviz: 9.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4152,7 +4152,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 9.1.0-1
+      version: 9.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `9.1.1-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `9.1.0-1`

## rviz2

- No changes

## rviz_assimp_vendor

```
* Fix support for assimp 5.1.0 (#817 <https://github.com/ros2/rviz/issues/817>)
* Contributors: Silvio Traversaro
```

## rviz_common

```
* Fix support for assimp 5.1.0 (#817 <https://github.com/ros2/rviz/issues/817>)
* Contributors: Silvio Traversaro
```

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Fix support for assimp 5.1.0 (#817 <https://github.com/ros2/rviz/issues/817>)
* Contributors: Silvio Traversaro
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
