### PR TITLE
human_description: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4412,6 +4412,21 @@ repositories:
       url: https://github.com/fkanehiro/hrpsys-base.git
       version: master
     status: maintained
+  human_description:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/human_description.git
+      version: main
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros4hri/human_description-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros4hri/human_description.git
+      version: main
+    status: developed
   husky:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `human_description` to `1.0.0-1`:

- upstream repository: https://github.com/ros4hri/human_description.git
- release repository: https://github.com/ros4hri/human_description-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
