### PR TITLE
hri_msgs: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3047,7 +3047,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros4hri/hri_msgs-release.git
-      version: 0.2.1-2
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/ros4hri/hri_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hri_msgs` to `0.4.0-1`:

- upstream repository: https://github.com/ros4hri/hri_msgs.git
- release repository: https://github.com/ros4hri/hri_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.1-2`

## hri_msgs

```
0.4.0 (2022-01-25)

-   split BodyAttitude into BodyPosture and Gesture
-   Contributors: Séverin Lemaignan

0.3.0 (2022-01-21)

-   remove GroupsStamped and GazesStamped
    GroupsStamped and GazesStamped are essentially arrays of Groups and Gazes, they are not needed as nodes would simply publish several message on the corresponding topics
-   {GazeSenderReceiver->Gaze}.msg and rename fields in Group.msg and GazeSenderReceiver.msg
-   add LiveSpeech.msg for encoding of incremental results of speech-to-text
-   Contributors: Séverin Lemaignan
```
