### PR TITLE
ros_comm: 1.14.13-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10762,7 +10762,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.14.12-1
+      version: 1.14.13-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.14.13-1`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.14.12-1`

## message_filters

- No changes

## ros_comm

- No changes

## rosbag

- No changes

## rosbag_storage

- No changes

## roscpp

```
* Use recursive mutex to fix dead lock (#2209 <https://github.com/ros/ros_comm/issues/2209>)
* Contributors: Chen Lihui, Jacob Perron
```

## rosgraph

```
* Fix memory leak in rosgraph for kernel < 4.16 and Python 3 (#2165 <https://github.com/ros/ros_comm/issues/2165>)
* Contributors: Alexis Schad, Jacob Perron
```

## roslaunch

```
* Allow passing _TIMEOUT_SIGINT and _TIMEOUT_SIGTERM as parameters (#1937 <https://github.com/ros/ros_comm/issues/1937>)
* Contributors: Jacob Perron, Martin Pecka
```

## roslz4

- No changes

## rosmaster

- No changes

## rosmsg

- No changes

## rosnode

- No changes

## rosout

- No changes

## rosparam

- No changes

## rospy

```
* Add current_real docstring in timer.py (#2178 <https://github.com/ros/ros_comm/issues/2178>)
* Do not set self.transport unless persistent in ServiceProxy (#2171 <https://github.com/ros/ros_comm/issues/2171>)
* Fix #2123 <https://github.com/ros/ros_comm/issues/2123>:  Do not raise exception if socket is busy in TCPROSTransport (#2131 <https://github.com/ros/ros_comm/issues/2131>)
* Contributors: Jacob Perron, Kevin Chang, Shingo Kitagawa, 金梦磊
```

## rosservice

- No changes

## rostest

- No changes

## rostopic

- No changes

## roswtf

- No changes

## topic_tools

- No changes

## xmlrpcpp

```
* Keep the persistent connection only if rosmaster supports http1.1 (#2208 <https://github.com/ros/ros_comm/issues/2208>)
* Fix build when gtest is not available (#2177 <https://github.com/ros/ros_comm/issues/2177>)
* Contributors: Chen Lihui, Jacob Perron, Wolfgang Merkt
```
