### PR TITLE
hri_msgs: 0.4.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3047,7 +3047,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros4hri/hri_msgs-release.git
-      version: 0.2.1-2
+      version: 0.4.1-2
     source:
       type: git
       url: https://github.com/ros4hri/hri_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hri_msgs` to `0.4.1-2`:

- upstream repository: https://github.com/ros4hri/hri_msgs.git
- release repository: https://github.com/ros4hri/hri_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.1-2`

## hri_msgs

```
* CMakeLists: update references to BodyPosture and Gesture messages
* add BSD LICENSE file
* Contributors: Séverin Lemaignan
```
