### PR TITLE
hri_msgs: 0.4.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4397,6 +4397,21 @@ repositories:
       url: https://github.com/humanoid-path-planner/hpp-fcl.git
       version: devel
     status: developed
+  hri_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/hri_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros4hri/hri_msgs-release.git
+      version: 0.4.1-1
+    source:
+      type: git
+      url: https://github.com/ros4hri/hri_msgs.git
+      version: master
+    status: developed
   hrpsys:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hri_msgs` to `0.4.1-1`:

- upstream repository: https://github.com/ros4hri/hri_msgs.git
- release repository: https://github.com/ros4hri/hri_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## hri_msgs

```
* CMakeLists: update references to BodyPosture and Gesture messages
* add BSD LICENSE file
* Contributors: Séverin Lemaignan
```
