### PR TITLE
Add python3-geographiclib to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6557,6 +6557,12 @@ python3-gdal:
     '7': null
   ubuntu: [python3-gdal]
 python3-gdown-pip: *migrate_eol_2025_04_30_python3_gdown_pip
+python3-geographiclib:
+  arch: [python-geographiclib]
+  debian: [python3-geographiclib]
+  fedora: [python3-GeographicLib]
+  nixos: [python3Packages.geographiclib]
+  ubuntu: [python3-geographiclib]
 python3-geomag-pip:
   debian:
     pip:
@@ -6570,12 +6576,6 @@ python3-geomag-pip:
   ubuntu:
     pip:
       packages: [geomag]
-python3-geographiclib:
-  arch: [python-geographiclib]
-  debian: [python3-geographiclib]
-  fedora: [python3-GeographicLib]
-  nixos: [python3Packages.geographiclib]
-  ubuntu: [python3-geographiclib]
 python3-geopy:
   debian: [python3-geopy]
   fedora: [python3-geopy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6562,6 +6562,7 @@ python3-geographiclib:
   debian: [python3-geographiclib]
   fedora: [python3-GeographicLib]
   nixos: [python3Packages.geographiclib]
+  opensuse: [python3-geographiclib]
   ubuntu: [python3-geographiclib]
 python3-geomag-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6561,6 +6561,7 @@ python3-geographiclib:
   arch: [python-geographiclib]
   debian: [python3-geographiclib]
   fedora: [python3-GeographicLib]
+  gentoo: [sci-geosciences/GeographicLib]
   nixos: [python3Packages.geographiclib]
   opensuse: [python3-geographiclib]
   ubuntu: [python3-geographiclib]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6570,6 +6570,12 @@ python3-geomag-pip:
   ubuntu:
     pip:
       packages: [geomag]
+python3-geographiclib:
+  arch: [python-geographiclib]
+  debian: [python3-geographiclib]
+  fedora: [python3-GeographicLib]
+  nixos: [python3Packages.geographiclib]
+  ubuntu: [python3-geographiclib]
 python3-geopy:
   debian: [python3-geopy]
   fedora: [python3-geopy]


### PR DESCRIPTION
Signed-off-by: Alexander Xydes <alexander.xydes@navy.mil>

Please add the following dependency to the rosdep database.

## Package name:

python3-geographiclib

## Package Upstream Source:

https://sourceforge.net/p/geographiclib/code/ci/release/tree/

## Purpose of using this:

Python3 version of the python-geographiclib package which implements the geographiclib package in python. This package is used to solve some geodesic problems.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=geographiclib
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=python3-geographiclib&searchon=names
- Fedora: https://src.fedoraproject.org/browse/projects/
  - https://packages.fedoraproject.org/pkgs/GeographicLib/python3-GeographicLib/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/community/any/python-geographiclib/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/sci-geosciences/GeographicLib
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- OpenSUSE: https://software.opensuse.org/
  - https://software.opensuse.org/package/python3-geographiclib?search_term=python3-geographiclib
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=geographiclib

## Tested locally
```
axydes@lord-snow: ~ $ rosdep resolve python3-geographiclib --os=debian:stretch
#apt
python3-geographiclib
axydes@lord-snow: ~ $ rosdep resolve python3-geographiclib --os=ubuntu:focal
#apt
python3-geographiclib
axydes@lord-snow: ~ $ rosdep resolve python3-geographiclib --os=fedora:36
#yum
python3-GeographicLib
axydes@lord-snow: ~ $ rosdep resolve python3-geographiclib --os=arch:2022.01.01
#pacman
python-geographiclib
axydes@lord-snow: ~ $ rosdep resolve python3-geographiclib --os=opensuse:15.4
#zypper
python3-geographiclib
axydes@lord-snow: ~ $ rosdep resolve python3-geographiclib --os=nixos:unstable
#nix
python3Packages.geographiclib
```
