### PR TITLE
vision_opencv: 3.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4919,7 +4919,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `3.0.1-1`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros2-gbp/vision_opencv-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.0.0-1`

## cv_bridge

```
* Use Boost::python3 if Boost < 1.67 (#422 <https://github.com/ros-perception/vision_opencv/issues/422>)
* Use Boost::pythonXY target (#421 <https://github.com/ros-perception/vision_opencv/issues/421>)
* Contributors: Shane Loretz
```

## image_geometry

- No changes

## vision_opencv

- No changes
