### PR TITLE
toposens: 2.3.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13580,6 +13580,7 @@ repositories:
       - toposens_bringup
       - toposens_description
       - toposens_driver
+      - toposens_echo_driver
       - toposens_markers
       - toposens_msgs
       - toposens_pointcloud
@@ -13587,7 +13588,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 2.2.1-1
+      version: 2.3.2-1
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toposens` to `2.3.2-1`:

- upstream repository: https://gitlab.com/toposens/public/ros-packages.git
- release repository: https://gitlab.com/toposens/public/toposens-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.2.1-1`

## toposens

- No changes

## toposens_bringup

- No changes

## toposens_description

- No changes

## toposens_driver

```
* Download test data to /tmp/tests
* Contributors: Thomas Böhm
```

## toposens_echo_driver

```
* fix formatting error in toposens-library
* Contributors: Baris Yazici
```

## toposens_markers

```
* Download test data to /tmp/tests
* Contributors: Thomas Böhm
```

## toposens_msgs

- No changes

## toposens_pointcloud

```
* Download test data to /tmp/tests
* Contributors: Thomas Böhm
```

## toposens_sync

- No changes
