### PR TITLE
toposens: 2.3.2-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9400,7 +9400,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 2.3.1-1
+      version: 2.3.2-2
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toposens` to `2.3.2-2`:

- upstream repository: https://gitlab.com/toposens/public/ros-packages.git
- release repository: https://gitlab.com/toposens/public/toposens-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.1-1`

## toposens

- No changes

## toposens_bringup

- No changes

## toposens_description

- No changes

## toposens_driver

```
* Download test data to /tmp/tests
* Contributors: Thomas Böhm
```

## toposens_echo_driver

```
* fix formatting error in toposens-library
* Contributors: Baris Yazici
```

## toposens_markers

```
* Download test data to /tmp/tests
* Contributors: Thomas Böhm
```

## toposens_msgs

- No changes

## toposens_pointcloud

```
* Download test data to /tmp/tests
* Contributors: Thomas Böhm
```

## toposens_sync

- No changes
