### PR TITLE
urg_node: 0.1.16-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9801,7 +9801,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/urg_node-release.git
-      version: 0.1.15-1
+      version: 0.1.16-1
     source:
       type: git
       url: https://github.com/ros-drivers/urg_node.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_node` to `0.1.16-1`:

- upstream repository: https://github.com/ros-drivers/urg_node.git
- release repository: https://github.com/ros-gbp/urg_node-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.15-1`

## urg_node

```
* roslint fixes.
* Diagnostic Analyzers (#93 <https://github.com/ros-drivers/urg_node/issues/93>)
  * Added diagnostic analyzers to organize robot_monitor
  * Update Change Log
  * Moved addDiagnostics call to the diagnostics thread
  * Changed parameter prefix from "/" to ""
  * Removed edits to the CHANGELOG
* Contributors: Tony Baltovski, luis-camero
```
