### PR TITLE
microstrain_inertial: 2.5.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4544,7 +4544,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/LORD-MicroStrain/microstrain_inertial-release.git
-      version: 2.4.1-1
+      version: 2.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `2.5.0-1`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/LORD-MicroStrain/microstrain_inertial-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.4.1-1`

## microstrain_inertial_driver

```
* Only attempts to publish GNSS aiding status if the pointer has been initialized
* Added RTK v2 support
  * Upgraded to MSCL 63.1.0
* Adds ability to use ROS time when populating messages
* Fixes "does not support" logs
* Fixed submodule initialization
* Contributors: dacuster, robbiefish
```

## microstrain_inertial_examples

- No changes

## microstrain_inertial_msgs

```
* Added RTK v2 support
* Fixed submodule initialization
* Contributors: dacuster, robbiefish
```

## microstrain_inertial_rqt

```
* Added RTK v2 support
  * Changed quickview default namespace from gx5 to 'empty'
* Fixed submodule initialization
* Contributors: dacuster, robbiefish
```
