### PR TITLE
vision_opencv: 3.0.2-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4952,7 +4952,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 3.0.1-1
+      version: 3.0.2-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `3.0.2-2`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros2-gbp/vision_opencv-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.0.1-1`

## cv_bridge

```
* Minor cleanups to the ROS 2 branch (#418 <https://github.com/ros-perception/vision_opencv/issues/418>)
* Find Python3 if not on Android (#423 <https://github.com/ros-perception/vision_opencv/issues/423>)
* Forward ports from noetic (#420 <https://github.com/ros-perception/vision_opencv/issues/420>)
  * Add header arg to cv2_to_imgmsg (#326 <https://github.com/ros-perception/vision_opencv/issues/326>)
  * prevent conversion of single channel 16bit integer images to/from colour (#412 <https://github.com/ros-perception/vision_opencv/issues/412>)
* Contributors: Chris Lalancette, Christian Rauch, Michael Carroll, Naoya Yamaguchi, Shane Loretz
```

## image_geometry

```
* Minor cleanups to the ROS 2 branch (#418 <https://github.com/ros-perception/vision_opencv/issues/418>)
* Forward ports from Noetic (#420 <https://github.com/ros-perception/vision_opencv/issues/420>)
  * substituted missing sphinx extension (#417 <https://github.com/ros-perception/vision_opencv/issues/417>)
  * Fix rectifyRoi when used with binning and/or ROI (#378 <https://github.com/ros-perception/vision_opencv/issues/378>)
  * Implement unrectifyImage() (#359 <https://github.com/ros-perception/vision_opencv/issues/359>)
  * Add equidistant distortion model (#358 <https://github.com/ros-perception/vision_opencv/issues/358>)
* Contributors: Chris Lalancette, Martin Günther, Michael Carroll, Paddy
```

## vision_opencv

```
* Minor cleanups to the ROS 2 branch (#418 <https://github.com/ros-perception/vision_opencv/issues/418>)
* Contributors: Chris Lalancette
```
