### PR TITLE
gazebo_ros2_control uses galactic branch

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -939,7 +939,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git
-      version: master
+      version: galactic
     release:
       packages:
       - gazebo_ros2_control
@@ -951,7 +951,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git
-      version: master
+      version: galactic
     status: maintained
   gazebo_ros_pkgs:
     doc:


### PR DESCRIPTION
There are some new changes in rolling that are [imcomplatible](https://build.ros2.org/job/Gdev__gazebo_ros2_control__ubuntu_focal_amd64/changes) with galactic, I created a branch to keep the galactic release. 

I will release `gazebo_ros2_control` for rolling soon 