### PR TITLE
gazebo_ros2_control: 0.0.8-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -906,6 +906,24 @@ repositories:
       url: https://github.com/ros-drivers/four_wheel_steering_msgs.git
       version: ros2
     status: maintained
+  gazebo_ros2_control:
+    doc:
+      type: git
+      url: https://github.com/ros-simulation/gazebo_ros2_control.git
+      version: master
+    release:
+      packages:
+      - gazebo_ros2_control
+      - gazebo_ros2_control_demos
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
+      version: 0.0.8-1
+    source:
+      type: git
+      url: https://github.com/ros-simulation/gazebo_ros2_control.git
+      version: master
+    status: developed
   gazebo_ros_pkgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros2_control` to `0.0.8-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros2_control/
- release repository: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## gazebo_ros2_control

```
* Enable setting default position of the simulated robot using ros2_control URDF tag. (#100 <https://github.com/ros-simulation/gazebo_ros2_control//issues/100>)
* Contributors: Denis Štogl
```

## gazebo_ros2_control_demos

```
* Enable setting default position of the simulated robot using ros2_control URDF tag. (#100 <https://github.com/ros-simulation/gazebo_ros2_control//issues/100>)
* Contributors: Denis Štogl
```
