### PR TITLE
ros2_controllers: 1.3.0-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3482,7 +3482,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git
-      version: master
+      version: galactic
     release:
       packages:
       - diff_drive_controller
@@ -3503,7 +3503,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git
-      version: master
+      version: galactic
     status: developed
   ros2_ouster_drivers:
     doc:

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3499,7 +3499,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 1.3.0-1
+      version: 1.3.0-2
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `1.3.0-2`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.3.0-1`

## diff_drive_controller

```
* Add publish_rate option for the diff_drive_controller (#278 <https://github.com/ros-controls/ros2_controllers/issues/278>)
* Fix angular velocity direction of diff_drive_controller odometry (#281 <https://github.com/ros-controls/ros2_controllers/issues/281>)
* Contributors: Benjamin Hug, Paul Verhoeckx
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

```
* Adding reset() for forward_command_controller (#283 <https://github.com/ros-controls/ros2_controllers/issues/283>)
* Contributors: bailaC
```

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

- No changes

## position_controllers

- No changes

## ros2_controllers

- No changes

## velocity_controllers

- No changes
