### PR TITLE
joystick_drivers: 3.0.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1348,7 +1348,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/joystick_drivers-release.git
-      version: 3.0.0-5
+      version: 3.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joystick_drivers` to `3.0.1-1`:

- upstream repository: https://github.com/ros-drivers/joystick_drivers.git
- release repository: https://github.com/ros2-gbp/joystick_drivers-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.0.0-5`

## joy

```
* Override device_id when device_name is provided. (#199 <https://github.com/ros-drivers/joystick_drivers/issues/199>) (#211 <https://github.com/ros-drivers/joystick_drivers/issues/211>)
* Contributors: Tiger Sachse
```

## joy_linux

- No changes

## sdl2_vendor

```
* Update SDL2 vendored library to 2.0.14. (#202 <https://github.com/ros-drivers/joystick_drivers/issues/202>)
* Contributors: Chris Lalancette
```

## spacenav

```
* Make sure to ament_target_dependencies on rclcpp_components (#209 <https://github.com/ros-drivers/joystick_drivers/issues/209>)
* Contributors: Chris Lalancette
```

## wiimote

- No changes

## wiimote_msgs

- No changes
