### PR TITLE
Switch Galactic and Foxy joystick_drivers branch.

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1640,7 +1640,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/joystick_drivers.git
-      version: ros2
+      version: foxy-devel
     release:
       packages:
       - joy
@@ -1657,7 +1657,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-drivers/joystick_drivers.git
-      version: ros2
+      version: foxy-devel
     status: maintained
   kdl_parser:
     doc:

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1336,7 +1336,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/joystick_drivers.git
-      version: ros2
+      version: foxy-devel
     release:
       packages:
       - joy
@@ -1353,7 +1353,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-drivers/joystick_drivers.git
-      version: ros2
+      version: foxy-devel
     status: maintained
   kdl_parser:
     doc:


### PR DESCRIPTION
It should be foxy-devel now.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>