### PR TITLE
joystick_drivers: 3.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1331,7 +1331,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/joystick_drivers-release.git
-      version: 3.0.0-4
+      version: 3.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joystick_drivers` to `3.1.0-1`:

- upstream repository: https://github.com/ros-drivers/joystick_drivers.git
- release repository: https://github.com/ros2-gbp/joystick_drivers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.0.0-4`

## joy

```
* Install includes to include/ and misc CMake fixes (#225 <https://github.com/ros-drivers/joystick_drivers/issues/225>)
* Style fixes for newer cpplint.
* Contributors: Chris Lalancette, Shane Loretz
```

## joy_linux

```
* Style fixes for newer cpplint.
* Contributors: Chris Lalancette
```

## sdl2_vendor

- No changes

## spacenav

```
* Install includes to include/ and misc CMake fixes (#225 <https://github.com/ros-drivers/joystick_drivers/issues/225>)
* Style fixes for newer cpplint.
* Contributors: Chris Lalancette, Shane Loretz
```

## wiimote

```
* Install includes to include/ and misc CMake fixes (#225 <https://github.com/ros-drivers/joystick_drivers/issues/225>)
* Style fixes for newer cpplint.
* Contributors: Chris Lalancette, Shane Loretz
```

## wiimote_msgs

- No changes
