### PR TITLE
rcss3d_agent: Temporary Removal from galactic track

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1986,7 +1986,6 @@ repositories:
     release:
       packages:
       - nao_button_sim
-      - rcss3d_agent
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ijnek/naosoccer_sim-release.git


### PR DESCRIPTION
Temporary removal of `rcss3d_agent` from the galactic track, before moving it to a separate repo. Once this is merged, a galactic version of https://github.com/ros/rosdistro/pull/31945 will be raised to re-add rcss3d_agent back.

Bloom release fails due to a name conflict with the rcss3d_agent that already exists.

Signed-off-by: ijnek <kenjibrameld@gmail.com>