### PR TITLE
rcss3d_agent: 0.0.3-4 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2959,6 +2959,25 @@ repositories:
       url: https://github.com/ros2/rcpputils.git
       version: galactic
     status: developed
+  rcss3d_agent:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/rcss3d_agent.git
+      version: rolling
+    release:
+      packages:
+      - rcss3d_agent
+      - rcss3d_agent_basic
+      - rcss3d_agent_msgs
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros-sports/rcss3d_agent-release.git
+      version: 0.0.3-4
+    source:
+      type: git
+      url: https://github.com/ros-sports/rcss3d_agent.git
+      version: rolling
+    status: developed
   rcutils:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcss3d_agent` to `0.0.3-4`:

- upstream repository: https://github.com/ros-sports/rcss3d_agent.git
- release repository: https://github.com/ros-sports/rcss3d_agent-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## rcss3d_agent

```
* follow guidelines for ament library creation
* move all non public hpp files into src directory
* separate rcss3d_agent_node into separate package
* separate JointPos and JointVel for perceptor and effector
* add subscriptions for joints, beam and say
* large refactor to purify rcss3d_agent to be a layer between rcssserver3d and ros2
* update package description
* copied files across from https://gitlab.com/ijnek/ros2_rcss3d/-/tree/kenji-rolling
* add sexpresso submodule
* Contributors: ijnek
```

## rcss3d_agent_basic

```
* refactor rcss3d_agent_node to rcss3d_agent_basic, and make it a component that can be run as a standalone executable
* Contributors: ijnek
```

## rcss3d_agent_msgs

```
* Implemented all rcss3d_agent_msgs interfaces
* Contributors: ijnek
```
