### PR TITLE
Revert "rtabmap/rtabmap_ros: 0.20.18-1 in 'melodic/distribution.yaml'"

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12358,7 +12358,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.20.18-1
+      version: 0.20.16-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -12373,7 +12373,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.20.18-1
+      version: 0.20.16-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
I merged too quickly.
Reverts ros/rosdistro#31952 per https://github.com/ros/rosdistro/pull/31952#issuecomment-1024855926