### PR TITLE
rcss3d_agent: 0.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2762,6 +2762,25 @@ repositories:
       url: https://github.com/ros2/rcpputils.git
       version: master
     status: developed
+  rcss3d_agent:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/rcss3d_agent.git
+      version: rolling
+    release:
+      packages:
+      - rcss3d_agent
+      - rcss3d_agent_basic
+      - rcss3d_agent_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros-sports/rcss3d_agent-release.git
+      version: 0.0.4-1
+    source:
+      type: git
+      url: https://github.com/ros-sports/rcss3d_agent.git
+      version: rolling
+    status: developed
   rcutils:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcss3d_agent` to `0.0.4-1`:

- upstream repository: https://github.com/ijnek/rcss3d_agent.git
- release repository: https://github.com/ros-sports/rcss3d_agent-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## rcss3d_agent

```
* adapt to new changes in cpplint about using a leading "./" in include statements
* Contributors: ijnek
```

## rcss3d_agent_basic

- No changes

## rcss3d_agent_msgs

- No changes
