### PR TITLE
plotjuggler: 3.4.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8932,7 +8932,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.3.5-1
+      version: 3.4.0-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.4.0-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.3.5-1`

## plotjuggler

```
* fix #585 <https://github.com/facontidavide/PlotJuggler/issues/585>
* fix #560 <https://github.com/facontidavide/PlotJuggler/issues/560>
* fix #575 <https://github.com/facontidavide/PlotJuggler/issues/575>
* Reactive scripts (#589 <https://github.com/facontidavide/PlotJuggler/issues/589>)
* Fix Quaternion toolbox, issue #587 <https://github.com/facontidavide/PlotJuggler/issues/587>
* fix double delete
* fix memory leaks #582 <https://github.com/facontidavide/PlotJuggler/issues/582>
* Contributors: Davide Faconti
```
