### PR TITLE
plotjuggler: 3.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5981,7 +5981,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.3.5-2
+      version: 3.4.0-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.4.0-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.3.5-2`

## plotjuggler

```
* fix #585 <https://github.com/facontidavide/PlotJuggler/issues/585>
* fix #560 <https://github.com/facontidavide/PlotJuggler/issues/560>
* fix #575 <https://github.com/facontidavide/PlotJuggler/issues/575>
* Reactive scripts (#589 <https://github.com/facontidavide/PlotJuggler/issues/589>)
* Fix Quaternion toolbox, issue #587 <https://github.com/facontidavide/PlotJuggler/issues/587>
* fix double delete
* fix memory leaks #582 <https://github.com/facontidavide/PlotJuggler/issues/582>
* Contributors: Davide Faconti
```
