### PR TITLE
ros_industrial_cmake_boilerplate: 0.2.15-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10961,7 +10961,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release.git
-      version: 0.2.14-2
+      version: 0.2.15-1
     source:
       type: git
       url: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_industrial_cmake_boilerplate` to `0.2.15-1`:

- upstream repository: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git
- release repository: https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.14-2`

## ros_industrial_cmake_boilerplate

```
* Add missing one value arg NAMESPACE to configure_package
* Auto generation of *-config.cmake files for simple cases (#59 <https://github.com/ros-industrial/ros_industrial_cmake_boilerplate/issues/59>)
* Contributors: Josh Langsfeld, Levi Armstrong
```
