### PR TITLE
ros_industrial_cmake_boilerplate: 0.2.15-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7480,7 +7480,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release.git
-      version: 0.2.14-1
+      version: 0.2.15-1
     source:
       type: git
       url: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_industrial_cmake_boilerplate` to `0.2.15-1`:

- upstream repository: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git
- release repository: https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.14-1`

## ros_industrial_cmake_boilerplate

```
* Add missing one value arg NAMESPACE to configure_package
* Auto generation of *-config.cmake files for simple cases (#59 <https://github.com/ros-industrial/ros_industrial_cmake_boilerplate/issues/59>)
* Contributors: Josh Langsfeld, Levi Armstrong
```
