### PR TITLE
xacro: 1.13.16-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -15139,7 +15139,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.13.15-1
+      version: 1.13.16-1
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.13.16-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.13.15-1`

## xacro

```
* Issue a warning only for evaluation errors in comments
* Add LICENSE file
* Contributors: Robert Haschke
```
