### PR TITLE
ridgeback_simulator: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6938,6 +6938,26 @@ repositories:
       url: https://github.com/ridgeback/ridgeback_desktop.git
       version: kinetic-devel
     status: maintained
+  ridgeback_simulator:
+    doc:
+      type: git
+      url: https://github.com/ridgeback/ridgeback_simulator.git
+      version: noetic-devel
+    release:
+      packages:
+      - mecanum_gazebo_plugin
+      - ridgeback_gazebo
+      - ridgeback_gazebo_plugins
+      - ridgeback_simulator
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/ridgeback_simulator-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/ridgeback/ridgeback_simulator.git
+      version: noetic-devel
+    status: maintained
   riptide_controllers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_simulator` to `0.2.0-1`:

- upstream repository: https://github.com/ridgeback/ridgeback_simulator.git
- release repository: https://github.com/clearpath-gbp/ridgeback_simulator-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## mecanum_gazebo_plugin

- No changes

## ridgeback_gazebo

- No changes

## ridgeback_gazebo_plugins

```
* Update the libgazebo dependency to use gazebo11 instead of gazebo9
* Contributors: Chris Iverach-Brereton
```

## ridgeback_simulator

- No changes
