### PR TITLE
leo_common: 2.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3941,7 +3941,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_common-release.git
-      version: 2.0.1-1
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_common` to `2.1.0-1`:

- upstream repository: https://github.com/LeoRover/leo_common.git
- release repository: https://github.com/fictionlab-gbp/leo_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.1-1`

## leo

- No changes

## leo_description

```
* Add simulated imu sensor
* Increase wheel friction
* Update ODE properties for links
```

## leo_msgs

```
* Fix catkin_lint errors
```

## leo_teleop

```
* Fix catkin_lint errors
```
