### PR TITLE
leo_simulator: 1.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3994,11 +3994,13 @@ repositories:
     release:
       packages:
       - leo_gazebo
+      - leo_gazebo_plugins
+      - leo_gazebo_worlds
       - leo_simulator
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_simulator-release.git
-      version: 0.2.0-1
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_simulator` to `1.0.0-1`:

- upstream repository: https://github.com/LeoRover/leo_simulator.git
- release repository: https://github.com/fictionlab-gbp/leo_simulator-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.0-1`

## leo_gazebo

```
* Fix catkin_lint warnings/errors
* Set starting position for marsyard2021 world
* Reformat launch files
* relay odometry to wheel_odom_with_covariance topic
* Remove odom_relay script
* Update diff_drive_controller parameters
* Split the leo_gazebo package into multiple packages
* Update author and maintainer info
```

## leo_gazebo_plugins

```
* Split the leo_gazebo package into multiple packages
```

## leo_gazebo_worlds

```
* Add marsyard2021 world
* Split the leo_gazebo package into multiple packages
```

## leo_simulator

```
* Add new packages to metapackage dependencies
* Update author and maintainer info
```
