### PR TITLE
rcl: 1.1.12-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3434,7 +3434,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 1.1.11-1
+      version: 1.1.12-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `1.1.12-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.11-1`

## rcl

```
* Add setter and getter for domain_id in rcl_init_options_t (#678 <https://github.com/ros2/rcl/issues/678>) (#946 <https://github.com/ros2/rcl/issues/946>)
* Fix test_info_by_topic flaky (#859 <https://github.com/ros2/rcl/issues/859>) (#944 <https://github.com/ros2/rcl/issues/944>)
* Contributors: Jacob Perron, Tomoya.Fujita
```

## rcl_action

- No changes

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

- No changes
