### PR TITLE
pluginlib: 2.5.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2950,7 +2950,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 2.5.3-1
+      version: 2.5.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `2.5.4-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.5.3-1`

## pluginlib

```
* Enable plugin testing (#202 <https://github.com/ros/pluginlib/issues/202>)
* Make the default filesystem lib c++fs unless otherwise specified (#214 <https://github.com/ros/pluginlib/issues/214>)
* Contributors: Ahmed Sobhy, Karsten Knese, Shane Loretz
```
