### PR TITLE
geometry2: 0.13.13-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1324,7 +1324,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.13.12-1
+      version: 0.13.13-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.13.13-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.13.12-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

```
* Fix covariance transformation in ``doTransform<PoseWithCovarianceStamped, TransformStamped>`` (#430 <https://github.com/ros2/geometry2/issues/430>) (#489 <https://github.com/ros2/geometry2/issues/489>)
* Contributors: Abrar Rahman Protyasha
```

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

- No changes

## tf2_sensor_msgs

- No changes

## tf2_tools

```
* Address security bug in yaml loading (#313 <https://github.com/ros2/geometry2/issues/313>) (#484 <https://github.com/ros2/geometry2/issues/484>)
* Add ``graphviz`` as a runtime dependency (#483 <https://github.com/ros2/geometry2/issues/483>)
* Contributors: Abrar Rahman Protyasha, Víctor Mayoral Vilches
```
