### PR TITLE
launch_ros: 0.11.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1840,7 +1840,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.11.5-1
+      version: 0.11.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.11.6-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.11.5-1`

## launch_ros

```
* Validate complex attributes of 'node' action (backport #198 <https://github.com/ros2/launch_ros/issues/198>) (#293 <https://github.com/ros2/launch_ros/issues/293>)
* More Helpful Error Messages (#275 <https://github.com/ros2/launch_ros/issues/275>) (#289 <https://github.com/ros2/launch_ros/issues/289>)
* Contributors: Aditya Pande, David V. Lu!!, Ivan Santiago Paunovic
```

## launch_testing_ros

- No changes

## ros2launch

- No changes
