### PR TITLE
rclcpp: 2.4.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3553,7 +3553,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 2.4.0-1
+      version: 2.4.1-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `2.4.1-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.4.0-1`

## rclcpp

```
* Fix subscription instrumentation for ConstSharedPtr[WithInfo]Callback (#1872 <https://github.com/ros2/rclcpp/issues/1872>)
* Add node_waitables_ to copy constructor (backport #1799 <https://github.com/ros2/rclcpp/issues/1799>) (#1834 <https://github.com/ros2/rclcpp/issues/1834>)
* Fix returning invalid namespace if sub_namespace is empty (#1658 <https://github.com/ros2/rclcpp/issues/1658>) (#1811 <https://github.com/ros2/rclcpp/issues/1811>)
* [service] Don't use a weak_ptr to avoid leaking (#1668 <https://github.com/ros2/rclcpp/issues/1668>) (#1669 <https://github.com/ros2/rclcpp/issues/1669>)
* Use dynamic_pointer_cast to detect allocator mismatch in intra process manager (backport #1643 <https://github.com/ros2/rclcpp/issues/1643>) (#1645 <https://github.com/ros2/rclcpp/issues/1645>)
* Contributors: Abrar Rahman Protyasha, Christophe Bedard, Ivan Santiago Paunovic, M. Hofstätter, Michel Hidalgo, Tomoya Fujita, William Woodall
```

## rclcpp_action

```
* Add node_waitables_ to copy constructor (backport #1799 <https://github.com/ros2/rclcpp/issues/1799>) (#1834 <https://github.com/ros2/rclcpp/issues/1834>)
* Contributors: Abrar Rahman Protyasha, Tomoya Fujita
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
