### PR TITLE
extend rosdep rule for open3d pip package in python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7116,13 +7116,13 @@ python3-nuscenes-devkit-pip:
 python3-open3d-pip:
   debian:
     pip:
-      packages: [open3d-python]
+      packages: [open3d-python, open3d]
   fedora:
     pip:
-      packages: [open3d-python]
+      packages: [open3d-python, open3d]
   ubuntu:
     pip:
-      packages: [open3d-python]
+      packages: [open3d-python, open3d]
 python3-opencv:
   debian: [python3-opencv]
   fedora: [python3-opencv]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3055,13 +3055,13 @@ python-omniorb:
 python-open3d-pip:
   debian:
     pip:
-      packages: [open3d-python]
+      packages: [open3d-python, open3d]
   fedora:
     pip:
-      packages: [open3d-python]
+      packages: [open3d-python, open3d]
   ubuntu:
     pip:
-      packages: [open3d-python]
+      packages: [open3d-python, open3d]
 python-opencv:
   arch: [opencv, python2-numpy]
   debian: [python-opencv]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3055,13 +3055,13 @@ python-omniorb:
 python-open3d-pip:
   debian:
     pip:
-      packages: [open3d-python, open3d]
+      packages: [open3d-python]
   fedora:
     pip:
-      packages: [open3d-python, open3d]
+      packages: [open3d-python]
   ubuntu:
     pip:
-      packages: [open3d-python, open3d]
+      packages: [open3d-python]
 python-opencv:
   arch: [opencv, python2-numpy]
   debian: [python-opencv]
@@ -7116,13 +7116,13 @@ python3-nuscenes-devkit-pip:
 python3-open3d-pip:
   debian:
     pip:
-      packages: [open3d-python, open3d]
+      packages: [open3d]
   fedora:
     pip:
-      packages: [open3d-python, open3d]
+      packages: [open3d]
   ubuntu:
     pip:
-      packages: [open3d-python, open3d]
+      packages: [open3d]
 python3-opencv:
   debian: [python3-opencv]
   fedora: [python3-opencv]


### PR DESCRIPTION
This PR extends the rosdep definitions for open3d. As per [documentation](http://www.open3d.org/docs/release/getting_started.html#pip-pypi) of open3d ``pip install open3d`` is the preferred way for installing the package. MR does not remove the old open3d-python definition such that  unintended consequences can be avoided. 
