### PR TITLE
sros2: 0.9.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5470,7 +5470,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.9.4-1
+      version: 0.9.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.9.5-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.9.4-1`

## sros2

```
* Make use of ros_testing to test policy generation. (#214 <https://github.com/ros2/sros2/issues/214>) (#254 <https://github.com/ros2/sros2/issues/254>)
* Contributors: Mikael Arguedas
```

## sros2_cmake

- No changes
