### PR TITLE
micro_ros_diagnostics: 0.3.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1771,7 +1771,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/micro_ros_diagnostics-release.git
-      version: 0.2.0-4
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/micro-ROS/micro_ros_diagnostics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `micro_ros_diagnostics` to `0.3.0-1`:

- upstream repository: https://github.com/micro-ROS/micro_ros_diagnostics.git
- release repository: https://github.com/ros2-gbp/micro_ros_diagnostics-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.0-4`
