### PR TITLE
Add python3-gi-cairo

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6586,8 +6586,10 @@ python3-gi:
 python3-gi-cairo:
   arch: [python-gobject]
   debian: [python3-gi-cairo]
+  fedora: [python3-gobject]
   gentoo: [dev-python/pygobject]
   nixos: [python3Packages.pygobject3]
+  opensuse: [python3-gobject]
   ubuntu: [python3-gi-cairo]
 python3-git:
   arch: [python-gitpython]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6583,6 +6583,12 @@ python3-gi:
   nixos: [python3Packages.pygobject3]
   openembedded: [python3-pygobject@openembedded-core]
   ubuntu: [python3-gi]
+python3-gi-cairo:
+  arch: [python-gobject]
+  debian: [python3-gi-cairo]
+  gentoo: [dev-python/pygobject]
+  nixos: [python3Packages.pygobject3]
+  ubuntu: [python3-gi-cairo]
 python3-git:
   arch: [python-gitpython]
   debian: [python3-git]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-gi-cairo

## Package Upstream Source:

-

## Purpose of using this:

https://github.com/ros-visualization/executive_smach_visualization/pull/39

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/sid/python3-gi-cairo
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/focal/python3-gi-cairo
- Fedora: https://src.fedoraproject.org/browse/projects/
  - https://rpmfind.net/linux/rpm2html/search.php?query=python3-gobject
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/python-gobject/  Same as python2 entry, cairo is dependency
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/pygobject  Same as python2 entry, cairo is flag
- macOS: https://formulae.brew.sh/
  - NOT AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - NOT AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://hydra.nixos.org/job/nixos/release-21.11/nixpkgs.python38Packages.pygobject3.x86_64-linux

Feel free to improve this PR if more target platforms are available :+1: 