### PR TITLE
micro_ros_diagnostics: 0.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1754,7 +1754,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/micro_ros_diagnostics-release.git
-      version: 0.2.0-2
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/micro-ROS/micro_ros_diagnostics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `micro_ros_diagnostics` to `0.3.0-1`:

- upstream repository: https://github.com/micro-ROS/micro_ros_diagnostics.git
- release repository: https://github.com/ros2-gbp/micro_ros_diagnostics-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.0-2`
