### PR TITLE
Add python3-xdot

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8602,6 +8602,7 @@ python3-wxgtk4.0:
   nixos: [python3Packages.wxPython_4_0]
   ubuntu: [python3-wxgtk4.0]
 python3-xdot:
+  arch: [xdot]
   debian: [xdot]
   fedora: [python-xdot]
   gentoo: [media-gfx/xdot]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8601,6 +8601,11 @@ python3-wxgtk4.0:
   gentoo: [dev-python/wxpython]
   nixos: [python3Packages.wxPython_4_0]
   ubuntu: [python3-wxgtk4.0]
+python3-xdot:
+  debian: [xdot]
+  fedora: [python-xdot]
+  gentoo: [media-gfx/xdot]
+  ubuntu: [xdot]
 python3-xmlschema:
   debian:
     '*': [python3-xmlschema]


### PR DESCRIPTION
## Package name:

python3-xdot

## Package Upstream Source:

-

## Purpose of using this:

https://github.com/ros-visualization/executive_smach_visualization/pull/39

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/sid/xdot
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/focal/xdot
- Fedora: https://src.fedoraproject.org/browse/projects/
  - https://src.fedoraproject.org/rpms/python-xdot
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/community/any/xdot/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/media-gfx/xdot
- macOS: https://formulae.brew.sh/
  - NOT AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - NOT AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - NOT AVAILABLE
