### PR TITLE
Add python-modbus-pip to python.yaml 

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3701,13 +3701,6 @@ python-pymodbus-pip:
   ubuntu:
     pip:
       packages: [pymodbus]
-python3-pymodbus-pip:
-  debian:
-    pip:
-      packages: [pymodbus]
-  ubuntu:
-    pip:
-      packages: [pymodbus]
 python-pymongo:
   arch: [python2-pymongo]
   debian: [python-pymongo]
@@ -7576,6 +7569,13 @@ python3-pymodbus:
   ubuntu:
     '*': [python3-pymodbus]
     xenial: null
+python3-pymodbus-pip:
+  debian:
+    pip:
+      packages: [pymodbus]
+  ubuntu:
+    pip:
+      packages: [pymodbus]
 python3-pymongo:
   arch: [python-pymongo]
   debian: [python3-pymongo]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3701,6 +3701,13 @@ python-pymodbus-pip:
   ubuntu:
     pip:
       packages: [pymodbus]
+python3-pymodbus-pip:
+  debian:
+    pip:
+      packages: [pymodbus]
+  ubuntu:
+    pip:
+      packages: [pymodbus]
 python-pymongo:
   arch: [python2-pymongo]
   debian: [python-pymongo]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3692,6 +3692,9 @@ python-pymavlink:
     pip:
       packages: [pymavlink]
 python-pymodbus:
+  debian: [python-pymodbus]
+  ubuntu: [python-pymodbus]
+python-pymodbus-pip:
   debian:
     pip:
       packages: [pymodbus]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3694,7 +3694,7 @@ python-pymavlink:
 python-pymodbus:
   debian: [python-pymodbus]
   ubuntu: [python-pymodbus]
-python-pymodbus-pip:
+python-pymodbus-pip: &migrate_eol_2027_04_30_python3_pymodbus_pip
   debian:
     pip:
       packages: [pymodbus]
@@ -7569,13 +7569,7 @@ python3-pymodbus:
   ubuntu:
     '*': [python3-pymodbus]
     xenial: null
-python3-pymodbus-pip:
-  debian:
-    pip:
-      packages: [pymodbus]
-  ubuntu:
-    pip:
-      packages: [pymodbus]
+python3-pymodbus-pip: *migrate_eol_2027_04_30_python3_pymodbus_pip
 python3-pymongo:
   arch: [python-pymongo]
   debian: [python3-pymongo]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3693,7 +3693,10 @@ python-pymavlink:
       packages: [pymavlink]
 python-pymodbus:
   debian: [python-pymodbus]
-  ubuntu: [python-pymodbus]
+  ubuntu:
+    '*': [python-pymodbus]
+    focal: null
+    jammy: null
 python-pymodbus-pip: &migrate_eol_2027_04_30_python3_pymodbus_pip
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3694,9 +3694,7 @@ python-pymavlink:
 python-pymodbus:
   debian: [python-pymodbus]
   ubuntu:
-    '*': [python-pymodbus]
-    focal: null
-    jammy: null
+    bionic: [python-pymodbus]
 python-pymodbus-pip: &migrate_eol_2027_04_30_python3_pymodbus_pip
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3692,8 +3692,12 @@ python-pymavlink:
     pip:
       packages: [pymavlink]
 python-pymodbus:
-  debian: [python-pymodbus]
-  ubuntu: [python-pymodbus]
+  debian:
+    pip:
+      packages: [pymodbus]
+  ubuntu:
+    pip:
+      packages: [pymodbus]
 python-pymongo:
   arch: [python2-pymongo]
   debian: [python-pymongo]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the `python-modbus-pip` dependency to the rosdep database.

## Package name:

python-modbus-pip

## Package Upstream Source:

Link to source repository: https://github.com/riptideio/pymodbus

## Purpose of using this:

There already is an entry for `python-modbus` in the YAML. However, the Ubuntu and Debian repositories have outdated versions, [1.3.2](https://packages.ubuntu.com/search?suite=bionic&searchon=names&keywords=pymodbus) and [1.2.0](https://packages.debian.org/stretch/python-pymodbus) respectively.

When installing from PyPI we get a more recent version - [2.5.3](https://pypi.org/project/pymodbus/). 

I suggest to keep the outdated `python-modbus` inside the YAML to not break compatibility.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://pypi.org/project/pymodbus/
- Ubuntu: https://packages.ubuntu.com/
  - https://pypi.org/project/pymodbus/