### PR TITLE
Add json-rpc-cxx library

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3757,6 +3757,24 @@ libjsoncpp-dev:
   opensuse: [jsoncpp-devel]
   rhel: [jsoncpp-devel]
   ubuntu: [libjsoncpp-dev]
+libjsonrpccpp-client0:
+  debian: [libjsonrpccpp-client0]
+  ubuntu: [libjsonrpccpp-client0]
+libjsonrpccpp-common0:
+  debian: [libjsonrpccpp-common0]
+  ubuntu: [libjsonrpccpp-common0]
+libjsonrpccpp-dev:
+  debian: [libjsonrpccpp-dev]
+  ubuntu: [libjsonrpccpp-dev]
+libjsonrpccpp-server0:
+  debian: [libjsonrpccpp-server0]
+  ubuntu: [libjsonrpccpp-server0]
+libjsonrpccpp-stub0:
+  debian: [libjsonrpccpp-stub0]
+  ubuntu: [libjsonrpccpp-stub0]
+libjsonrpccpp-tools:
+  debian: [libjsonrpccpp-tools]
+  ubuntu: [libjsonrpccpp-tools]
 libkdtree++-dev:
   debian: [libkdtree++-dev]
   fedora: [libkdtree++-devel]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`libjsonrpccpp`

## Package Upstream Source:

Link to source repository: https://github.com/cinemast/libjson-rpc-cpp

## Purpose of using this:

libjson-rpc-cpp is a C++ library for building applications that use the JSONRPC 2.0 spec, it includes APIs for both client and servers.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/stretch/libjsonrpccpp-dev
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/bionic/libjsonrpccpp-dev
