### PR TITLE
mavros: 2.1.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1722,7 +1722,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 2.0.5-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `2.1.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.5-1`

## libmavconn

```
* lib: fix reorder
* Merge branch 'master' into ros2
  * master:
  1.13.0
  update changelog
  py-lib: fix compatibility with py3 for Noetic
  re-generate all coglets
  test: add checks for ROTATION_CUSTOM
  lib: Fix rotation search for CUSTOM
  Removed CamelCase for class members.  Publish to "report"
  More explicitly state "TerrainReport" to allow for future extension of the plugin to support other terrain messages
  Fixed callback name to match handle_{MESSAGE_NAME.lower()} convention
  Add extra MAV_FRAMES to waypoint message as defined in https://mavlink.io/en/messages/common.html
  Fixed topic names to match more closely what other plugins use.  Fixed a typo.
  Add plugin for reporting terrain height estimate from FCU
  1.12.2
  update changelog
  Set time/publish_sim_time to false by default
  plugin: setpoint_raw: move getParam to initializer
  extras: trajectory: backport #1667 <https://github.com/mavlink/mavros/issues/1667>
* 1.13.0
* update changelog
* Merge pull request #1682 <https://github.com/mavlink/mavros/issues/1682> from SylvainPastor/fix/libmavconn/tcp/resource_deadlock
  fix std::system_error when tcp interface loses connection
* fix code style divergences
* fix std::system_error when tcp interface loses connection
  When the tcp connection is lost (remote TCP server stopped), an 'End of file' error is caught
  by the io_thread in the do_recv() that calls the close() function.
  In the close() function, we stop the io_service and wait for the end of the io_thread which
  causes an std::system_error exception (cause: Resource deadlock avoided).
  Error:   mavconn: tcp0: receive: End of file at line 250 in libmavconn/src/tcp.cpp
  terminate called after throwing an instance of 'std::system_error'
  what():  Resource deadlock avoided
  Aborted (core dumped)
  fix:
  - close() function: stop io_service if current thread id != io_thread id
  - ~MAVConnTCPClient(): stop io_service and io_thread if thread is running
* Merge pull request #1679 <https://github.com/mavlink/mavros/issues/1679> from SylvainPastor/libmavconn/fix-tcp-deadlock-when-close
  libmavconn: fix deadlock when call close()
* fix deadlock when call close()
  When calling the close() function (by a different thread), a lock (mutex) is taken at
  the start of this function which closes the socket and waits the end of io_service thread.
  Closing the socket causes the 'Operation aborted' error in do_recv() function called by
  io_service thread which in turn calls the close() function: sthis->close().
  This causes a 'deadlock'.
  fix: Reduce the scope of the lock in the close() function so that it is released before
  waiting for the thread to end.
* 1.12.2
* update changelog
* lib: fix linter errors
* Merge branch 'master' into ros2
  * master:
  1.12.1
  update changelog
  mavconn: fix connection issue introduced by #1658 <https://github.com/mavlink/mavros/issues/1658>
  mavros_extras: Fix some warnings
  mavros: Fix some warnings
* 1.12.1
* update changelog
* mavconn: fix connection issue introduced by #1658 <https://github.com/mavlink/mavros/issues/1658>
* Contributors: Sylvain Pastor, Vladimir Ermakov
```

## mavros

```
* plugin: sys_status: Add temporary hack from @Michel1968
  https://github.com/mavlink/mavros/issues/1588#issuecomment-1027699924
* py-lib: make linters happy again
* py-lib: fix WPL loading
* py-lib: reformat with black, fix WPL
* py-lib: gracefull exiting - need to join to spinner thread
* py-lib: debug shutdown call
* py-lib: fix checkid
* sys: place service servers to separate callback group
* plugins: fix topic names to use  prefix for namespaced ones
* py-lib: fix import
* uas: fix linter warnings
* uas: set executor timeout to 1s
* uas: use custom executor derived from MultiThreadedExecutor one
* uas: fix lambda
* ci: fix several lint warnings
* uas: log amount of executor threads
* command: add request header for possible future use
* Merge branch 'master' into ros2
  * master:
  1.13.0
  update changelog
  py-lib: fix compatibility with py3 for Noetic
  re-generate all coglets
  test: add checks for ROTATION_CUSTOM
  lib: Fix rotation search for CUSTOM
  Removed CamelCase for class members.  Publish to "report"
  More explicitly state "TerrainReport" to allow for future extension of the plugin to support other terrain messages
  Fixed callback name to match handle_{MESSAGE_NAME.lower()} convention
  Add extra MAV_FRAMES to waypoint message as defined in https://mavlink.io/en/messages/common.html
  Fixed topic names to match more closely what other plugins use.  Fixed a typo.
  Add plugin for reporting terrain height estimate from FCU
  1.12.2
  update changelog
  Set time/publish_sim_time to false by default
  plugin: setpoint_raw: move getParam to initializer
  extras: trajectory: backport #1667 <https://github.com/mavlink/mavros/issues/1667>
* 1.13.0
* update changelog
* Merge pull request #1690 <https://github.com/mavlink/mavros/issues/1690> from mavlink/fix-enum_sensor_orientation
  Fix enum sensor_orientation
* py-lib: fix compatibility with py3 for Noetic
* test: add checks for ROTATION_CUSTOM
* lib: Fix rotation search for CUSTOM
  Fix #1688 <https://github.com/mavlink/mavros/issues/1688>.
* 1.12.2
* update changelog
* Merge pull request #1672 <https://github.com/mavlink/mavros/issues/1672> from okalachev/patch-1
  Set time/publish_sim_time to false by default
* Set time/publish_sim_time to false by default
* Merge pull request #1669 <https://github.com/mavlink/mavros/issues/1669> from Hs293Go/master
  plugin: setpoint_raw: move getParam to initializer
* plugin: setpoint_raw: move getParam to initializer
  Repeatedly getting the thrust_scaling parameter in a callback that can
  be invoked from a fast control loop may fail spuriously and trigger a
  fatal error
* Merge pull request #1670 <https://github.com/mavlink/mavros/issues/1670> from windelbouwman/fix-uninitialized-struct-member
  Fix spurious bug because class field was uninitialized.
* Fix spurious bug because class field was uninitialized.
* Merge branch 'master' into ros2
  * master:
  1.12.1
  update changelog
  mavconn: fix connection issue introduced by #1658 <https://github.com/mavlink/mavros/issues/1658>
  mavros_extras: Fix some warnings
  mavros: Fix some warnings
* 1.12.1
* update changelog
* mavconn: fix connection issue introduced by #1658 <https://github.com/mavlink/mavros/issues/1658>
* Merge pull request #1660 <https://github.com/mavlink/mavros/issues/1660> from scoutdi/fix-warnings
  Fix warnings
* mavros: Fix some warnings
* Contributors: Morten Fyhn Amundsen, Oleg Kalachev, Vladimir Ermakov, Windel Bouwman, hs293go
```

## mavros_extras

```
* plugins: fix topic names to use  prefix for namespaced ones
* plugins: fix topic names to use  prefix for namespaced ones
* ci: fix several lint warnings
* extras: terrain: fix copy-paste artifact
* extras: port terrain plugin
* Merge branch 'master' into ros2
  * master:
  1.13.0
  update changelog
  py-lib: fix compatibility with py3 for Noetic
  re-generate all coglets
  test: add checks for ROTATION_CUSTOM
  lib: Fix rotation search for CUSTOM
  Removed CamelCase for class members.  Publish to "report"
  More explicitly state "TerrainReport" to allow for future extension of the plugin to support other terrain messages
  Fixed callback name to match handle_{MESSAGE_NAME.lower()} convention
  Add extra MAV_FRAMES to waypoint message as defined in https://mavlink.io/en/messages/common.html
  Fixed topic names to match more closely what other plugins use.  Fixed a typo.
  Add plugin for reporting terrain height estimate from FCU
  1.12.2
  update changelog
  Set time/publish_sim_time to false by default
  plugin: setpoint_raw: move getParam to initializer
  extras: trajectory: backport #1667 <https://github.com/mavlink/mavros/issues/1667>
* 1.13.0
* update changelog
* Merge pull request #1677 <https://github.com/mavlink/mavros/issues/1677> from AndersonRayner/add_terrain
  Add plugin for reporting terrain height estimate from the FCU
* Removed CamelCase for class members.  Publish to "report"
* More explicitly state "TerrainReport" to allow for future extension of the plugin to support other terrain messages
* Fixed callback name to match handle_{MESSAGE_NAME.lower()} convention
* Fixed topic names to match more closely what other plugins use.  Fixed a typo.
* Add plugin for reporting terrain height estimate from FCU
* 1.12.2
* update changelog
* Merge pull request #1675 <https://github.com/mavlink/mavros/issues/1675> from BOB4Drone/ros2
  fix bof
* Update mag_calibration_status.cpp
* fix code style
  fix code style
* Update mag_calibration_status.cpp
* fix misprint and use size()
  fix misprint and use size()
* fix bof
  fix #1668 <https://github.com/mavlink/mavros/issues/1668>
* extras: trajectory: backport #1667 <https://github.com/mavlink/mavros/issues/1667>
* extras: trajectory: make linter happy after #1667 <https://github.com/mavlink/mavros/issues/1667>
* Merge pull request #1667 <https://github.com/mavlink/mavros/issues/1667> from BOB4Drone/ros2
  fix bof
* fix bof
* Merge branch 'master' into ros2
  * master:
  1.12.1
  update changelog
  mavconn: fix connection issue introduced by #1658 <https://github.com/mavlink/mavros/issues/1658>
  mavros_extras: Fix some warnings
  mavros: Fix some warnings
* 1.12.1
* update changelog
* Merge pull request #1660 <https://github.com/mavlink/mavros/issues/1660> from scoutdi/fix-warnings
  Fix warnings
* mavros_extras: Fix some warnings
* extras: fix parameter name
* extras: fix topic names
* Contributors: BOB4Drone, Morten Fyhn Amundsen, Vladimir Ermakov, matt
```

## mavros_msgs

```
* Merge branch 'master' into ros2
  * master:
  1.13.0
  update changelog
  py-lib: fix compatibility with py3 for Noetic
  re-generate all coglets
  test: add checks for ROTATION_CUSTOM
  lib: Fix rotation search for CUSTOM
  Removed CamelCase for class members.  Publish to "report"
  More explicitly state "TerrainReport" to allow for future extension of the plugin to support other terrain messages
  Fixed callback name to match handle_{MESSAGE_NAME.lower()} convention
  Add extra MAV_FRAMES to waypoint message as defined in https://mavlink.io/en/messages/common.html
  Fixed topic names to match more closely what other plugins use.  Fixed a typo.
  Add plugin for reporting terrain height estimate from FCU
  1.12.2
  update changelog
  Set time/publish_sim_time to false by default
  plugin: setpoint_raw: move getParam to initializer
  extras: trajectory: backport #1667 <https://github.com/mavlink/mavros/issues/1667>
* 1.13.0
* update changelog
* Merge pull request #1690 <https://github.com/mavlink/mavros/issues/1690> from mavlink/fix-enum_sensor_orientation
  Fix enum sensor_orientation
* re-generate all coglets
* Merge pull request #1680 <https://github.com/mavlink/mavros/issues/1680> from AndersonRayner/new_mav_frames
  Add extra MAV_FRAMES to waypoint message
* Merge pull request #1677 <https://github.com/mavlink/mavros/issues/1677> from AndersonRayner/add_terrain
  Add plugin for reporting terrain height estimate from the FCU
* More explicitly state "TerrainReport" to allow for future extension of the plugin to support other terrain messages
* Add extra MAV_FRAMES to waypoint message as defined in https://mavlink.io/en/messages/common.html
* Add plugin for reporting terrain height estimate from FCU
* 1.12.2
* update changelog
* Merge branch 'master' into ros2
  * master:
  1.12.1
  update changelog
  mavconn: fix connection issue introduced by #1658 <https://github.com/mavlink/mavros/issues/1658>
  mavros_extras: Fix some warnings
  mavros: Fix some warnings
* 1.12.1
* update changelog
* Contributors: Vladimir Ermakov, matt
```
