### PR TITLE
rcss3d_agent: 0.0.5-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2987,7 +2987,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros-sports/rcss3d_agent-release.git
-      version: 0.0.3-4
+      version: 0.0.5-1
     source:
       type: git
       url: https://github.com/ros-sports/rcss3d_agent.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcss3d_agent` to `0.0.5-1`:

- upstream repository: https://github.com/ros-sports/rcss3d_agent.git
- release repository: https://github.com/ros-sports/rcss3d_agent-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.3-4`

## rcss3d_agent

```
* add score left and score right to message received from simulator
* don't rely on the order of items in sexp. Use their path. This prevents buggy code when the sexp is updated on the simulator end in the future.
* comunicate that the node has to be restarted
* make error msg easier to understand
* make sure program can exit when connection to simulator is broken
* add a model parameter so differnet types of robots can be loaded
* don't allow sending empty say messages
* add team name to hear msg
* fix bug in gamestate parsing
* Contributors: ijnek
```

## rcss3d_agent_basic

```
* comunicate that the node has to be restarted
* define perceptPub so rcss3dAgent is destroyed before perceptPub
* add a model parameter so differnet types of robots can be loaded
* Contributors: ijnek
```

## rcss3d_agent_msgs

```
* add score left and score right to message received from simulator
* add team name to hear msg
* Contributors: ijnek
```
