### PR TITLE
ur_client_library: 1.0.0-3 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5199,6 +5199,21 @@ repositories:
       url: https://github.com/ros2/unique_identifier_msgs.git
       version: galactic
     status: maintained
+  ur_client_library:
+    doc:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git
+      version: master
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
+      version: 1.0.0-3
+    source:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git
+      version: master
+    status: developed
   urdf:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `1.0.0-3`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ur_client_library

```
* Added Cartesian streaming interface #75 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/75>
* Added trajectory forwarding interface #72 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/72>
* Refactored Reverse interface #70 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/70> from fmauch/refactor_reverse_interface
* Added option for robot_ip as runtime argument for rtde_test (#71 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/71>)
* Added reverse_ip parameter (#52 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/52>)
* Move calibration check out of constructor. #65 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/65> from fmauch/calibration_check_optional
* Install the resources folder instead of the script file directly (#62 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/62>)
* Use a non-blocking tcp server for the ReverseInterface and ScriptSender. #46 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/46> from fmauch/tcp_server
* Added LogHandler #40 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/40> from urmahp/logging_feature
* Fixed links in README (#35 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/35>)
* Contributors: Felix Exner, G.A. vd. Hoorn, JS00000, Lennart Puck, Mads Holm Peters, Tristan Schnell
```
