### PR TITLE
rmw_fastrtps: 1.3.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4025,7 +4025,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 1.2.6-1
+      version: 1.3.0-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `1.3.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.6-1`

## rmw_fastrtps_cpp

- No changes

## rmw_fastrtps_dynamic_cpp

```
* Avoid memory leaks and undefined behavior in rmw_fastrtps_dynamic_cpp typesupport code (#429 <https://github.com/ros2/rmw_fastrtps/issues/429>) (#577 <https://github.com/ros2/rmw_fastrtps/issues/577>)
* Contributors: Jacob Perron, Miguel Company
```

## rmw_fastrtps_shared_cpp

- No changes
