### PR TITLE
rcss3d_agent: 0.0.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2808,7 +2808,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros-sports/rcss3d_agent-release.git
-      version: 0.0.4-1
+      version: 0.0.6-1
     source:
       type: git
       url: https://github.com/ros-sports/rcss3d_agent.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcss3d_agent` to `0.0.6-1`:

- upstream repository: https://github.com/ijnek/rcss3d_agent.git
- release repository: https://github.com/ros-sports/rcss3d_agent-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.4-1`

## rcss3d_agent

```
* add missing include for std::optional
* add effector msg to allow synchronize effector to be used
* Contributors: ijnek, Scott K Logan
```

## rcss3d_agent_basic

```
* add synchronize subscription
* remove leading slash from topic name
* Contributors: ijnek
```

## rcss3d_agent_msgs

```
* add Synchronize message
* add effector msg to allow synchronize effector to be used
* Contributors: ijnek
```
