### PR TITLE
velodyne: 2.1.1-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5395,7 +5395,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/velodyne-release.git
-      version: 2.1.1-1
+      version: 2.1.1-2
     source:
       type: git
       url: https://github.com/ros-drivers/velodyne.git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5384,7 +5384,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/velodyne.git
-      version: ros2
+      version: galactic-devel
     release:
       packages:
       - velodyne
@@ -5399,7 +5399,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/velodyne.git
-      version: ros2
+      version: galactic-devel
     status: developed
   velodyne_simulator:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne` to `2.1.1-2`:

- upstream repository: https://github.com/ros-drivers/velodyne.git
- release repository: https://github.com/ros-drivers-gbp/velodyne-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.1-1`

## velodyne

- No changes

## velodyne_driver

```
* Minor fixes to string formatting. (#396 <https://github.com/ros-drivers/velodyne/issues/396>)
  These changes will allow velodyne to compile without warnings
  on Rolling (soon to be Galactic).  The changes are also backwards
  compatible to Foxy if we want to backport them.
* Contributors: Chris Lalancette
```

## velodyne_laserscan

- No changes

## velodyne_msgs

- No changes

## velodyne_pointcloud

- No changes
