### PR TITLE
nao_lola: 0.0.4-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1982,7 +1982,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ijnek/nao_lola.git
-      version: main
+      version: rolling
     release:
       tags:
         release: release/galactic/{package}/{version}
@@ -1991,7 +1991,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ijnek/nao_lola.git
-      version: main
+      version: rolling
     status: developed
   naosoccer_sim:
     doc:

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1987,7 +1987,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ijnek/nao_lola-release.git
-      version: 0.0.3-1
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/ijnek/nao_lola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_lola` to `0.0.4-1`:

- upstream repository: https://github.com/ijnek/nao_lola.git
- release repository: https://github.com/ijnek/nao_lola-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.3-1`

## nao_lola

```
* fix cpplint warning
* add changes to ci to test all distros
* Contributors: Kenji Brameld, ijnek
```
