### PR TITLE
yaml_cpp_vendor: 8.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5121,7 +5121,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
-      version: 7.1.1-1
+      version: 8.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `yaml_cpp_vendor` to `8.0.0-1`:

- upstream repository: https://github.com/ros2/yaml_cpp_vendor.git
- release repository: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `7.1.1-1`

## yaml_cpp_vendor

```
* Upgrade to yaml-cpp 0.7.0 (#25 <https://github.com/ros2/yaml_cpp_vendor/issues/25>)
* Contributors: Chris Lalancette
```
