### PR TITLE
rosbag2: 0.3.9-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4477,6 +4477,7 @@ repositories:
       version: foxy
     release:
       packages:
+      - bag_recorder_nodes
       - ros2bag
       - rosbag2
       - rosbag2_compression
@@ -4493,7 +4494,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.3.8-1
+      version: 0.3.9-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.3.9-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.8-1`

## ros2bag

- No changes

## rosbag2

- No changes

## rosbag2_compression

- No changes

## rosbag2_converter_default_plugins

- No changes

## rosbag2_cpp

```
* Enable sanitizers only if code actually can run (#572 <https://github.com/ros2/rosbag2/issues/572>) (#953 <https://github.com/ros2/rosbag2/issues/953>)
* Contributors: Jacob Perron, Shane Loretz
```

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

```
* Fixed inability to record hidden topics (#835 <https://github.com/ros2/rosbag2/issues/835>)
* Contributors: Cameron Miller
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
