### PR TITLE
rmw_cyclonedds: 0.7.8-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3987,7 +3987,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 0.7.7-1
+      version: 0.7.8-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `0.7.8-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.7-1`

## rmw_cyclonedds_cpp

```
* Free with the same allocator in rmw_destroy_node (#355 <https://github.com/ros2/rmw_cyclonedds/issues/355>) (#369 <https://github.com/ros2/rmw_cyclonedds/issues/369>)
* Contributors: Jacob Perron
```
