### PR TITLE
rviz: 8.2.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5215,7 +5215,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 8.2.5-1
+      version: 8.2.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `8.2.6-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `8.2.5-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Add rviz_rendering dependency to rviz_common (#727 <https://github.com/ros2/rviz/issues/727>) (#785 <https://github.com/ros2/rviz/issues/785>)
* Contributors: Jacob Perron, Rebecca Butler
```

## rviz_default_plugins

```
* Add underscores to material names (#811 <https://github.com/ros2/rviz/issues/811>) (#824 <https://github.com/ros2/rviz/issues/824>)
* Export Qt5 dependencies properly (#687 <https://github.com/ros2/rviz/issues/687>) (#822 <https://github.com/ros2/rviz/issues/822>)
* Change image display to not rely on TF (#781 <https://github.com/ros2/rviz/issues/781>)
* Contributors: Cory Crean, Helen Oleynikova, Jacob Perron, Michel Hidalgo
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Export Qt5 dependencies properly (#687 <https://github.com/ros2/rviz/issues/687>) (#822 <https://github.com/ros2/rviz/issues/822>)
* Contributors: Jacob Perron, Michel Hidalgo
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
