### PR TITLE
Add rti-connext-dds-6.0.1 which is now in the ROS bootstrap repositories

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6980,6 +6980,11 @@ rti-connext-dds-5.3.1:
     bionic: [rti-connext-dds-5.3.1]
     focal: [rti-connext-dds-5.3.1]
     xenial: [rti-connext-dds-5.3.1]
+rti-connext-dds-6.0.1:
+  nixos: []
+  ubuntu:
+    focal: [rti-connext-dds-6.0.1]
+    jammy: [rti-connext-dds-6.0.1]
 rtmidi:
   debian: [librtmidi-dev]
   fedora: [rtmidi-devel]


### PR DESCRIPTION
## Package name: rti-connext-dds-6.0.1

Distro packaging links:

## Links to Distribution Packages

This package is hosted on the ROS bootstrap repository for Ubuntu. Since the package is not available on ARM platforms an empty package is provided to satisfy the build dependency and the packages which require rti-connext-dds to be installed are configured to become empty packages themselves if this dependency is not present at build time.

- Debian: https://packages.debian.org/
  - NOT AVAILABLE
- Ubuntu:
   - http://repos.ros.org/repos/ros_bootstrap/pool/main/r/rti-connext-dds-6.0.1/
- Fedora: https://src.fedoraproject.org/browse/projects/
  - NOT AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - NOT AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - NOT AVAILABLE
- macOS: https://formulae.brew.sh/
  - NOT AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - NOT AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - NOT AVAILABLE
