### PR TITLE
Update libceres-dev key.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2744,9 +2744,7 @@ libcereal-dev:
   gentoo: [dev-libs/cereal]
   ubuntu: [libcereal-dev]
 libceres-dev:
-  debian:
-    buster: [libceres-dev]
-    stretch: [libceres-dev]
+  debian: [libceres-dev]
   fedora: [ceres-solver-devel]
   gentoo: ['sci-libs/ceres-solver[sparse,lapack]']
   nixos: [ceres-solver]


### PR DESCRIPTION
Elide the key for Debian now that all supported platforms provide the
package.

* https://packages.debian.org/bullseye/libceres-dev
* https://packages.debian.org/buster/libceres-dev
