### PR TITLE
Update libpng-dev key.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4380,11 +4380,7 @@ libpng++-dev:
   ubuntu: [libpng++-dev]
 libpng-dev:
   arch: [libpng]
-  debian:
-    buster: [libpng-dev]
-    jessie: [libpng12-dev]
-    stretch: [libpng-dev]
-    wheezy: [libpng12-dev]
+  debian: [libpng-dev]
   fedora: [libpng-devel]
   freebsd: [png]
   gentoo: [media-libs/libpng]


### PR DESCRIPTION
Elide codename in Debian definition now that all supported distributions
use the package name libpng-dev.

* https://packages.debian.org/buster/libpng-dev
* https://packages.debian.org/bullseye/libpng-dev