### PR TITLE
Update libgpgme-dev key.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3339,11 +3339,7 @@ libgoogle-glog-dev:
 libgpgme-dev:
   alpine: [gpgme-dev]
   arch: [gpgme]
-  debian:
-    buster: [libgpgme-dev]
-    jessie: [libgpgme11-dev]
-    stretch: [libgpgme-dev]
-    wheezy: [libgpgme11-dev]
+  debian: [libgpgme-dev]
   fedora: [gpgme-devel]
   freebsd: [gpgme]
   gentoo: [app-crypt/gpgme]


### PR DESCRIPTION
Elide codename in Debian definition now that all supported distributions
use the same package name.

* https://packages.debian.org/bullseye/libgpgme-dev
* https://packages.debian.org/buster/libgpgme-dev