### PR TITLE
Update development branch for control_msgs in Galactic

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -579,7 +579,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/control_msgs.git
-      version: foxy-devel
+      version: galactic-devel
     release:
       tags:
         release: release/galactic/{package}/{version}
@@ -588,7 +588,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git
-      version: foxy-devel
+      version: galactic-devel
     status: maintained
   control_toolbox:
     doc:


### PR DESCRIPTION
It appears that this package was released out of a new branch but rosdistro wasn't updated.

https://github.com/ros-controls/control_msgs/tree/galactic-devel

FYI @bmagyar.