### PR TITLE
plotjuggler: 3.4.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5983,7 +5983,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.4.0-1
+      version: 3.4.1-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.4.1-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.4.0-1`

## plotjuggler

```
* add flip axis
* fix zoom in icon
* Fix typo in toolbox Lua (#598 <https://github.com/facontidavide/PlotJuggler/issues/598>)
* Fix MutableTimeseries shadowed by MutableScatterXY (#597 <https://github.com/facontidavide/PlotJuggler/issues/597>)
  * Fix MutableTimeseries shadowed by MutableScatterXY
  * add math library
  Co-authored-by: Simon CHANU <mailto:simon.chanu@cmdl.pro>
* MQTT upgraded
* Update README.md
* Installer and readme updates
* Contributors: Davide Faconti, SebasAlmagro, Simon CHANU
```
