### PR TITLE
nao_button_sim: Temporary Removal from galactic track

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1993,23 +1993,6 @@ repositories:
       url: https://github.com/ijnek/nao_lola.git
       version: main
     status: developed
-  naosoccer_sim:
-    doc:
-      type: git
-      url: https://github.com/ijnek/naosoccer_sim.git
-      version: main
-    release:
-      packages:
-      - nao_button_sim
-      tags:
-        release: release/galactic/{package}/{version}
-      url: https://github.com/ijnek/naosoccer_sim-release.git
-      version: 0.0.2-1
-    source:
-      type: git
-      url: https://github.com/ijnek/naosoccer_sim.git
-      version: main
-    status: developed
   navigation2:
     doc:
       type: git


### PR DESCRIPTION
Temporary removal of nao_button_sim from the galactic track, before moving it to a separate repo. Once this is merged, a galactic version of https://github.com/ros/rosdistro/pull/32058 will be raised to re-add nao_button_sim back.

Bloom release fails due to a name conflict with the nao_button_sim that already exists.

Signed-off-by: ijnek [kenjibrameld@gmail.com](mailto:kenjibrameld@gmail.com)