### PR TITLE
mia_hand_ros_pkgs: 1.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4515,7 +4515,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release.git
-      version: 1.0.0-14
+      version: 1.0.1-1
     status: maintained
   microstrain_3dmgx2_imu:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `mia_hand_ros_pkgs` to `1.0.1-1`:

- upstream repository: https://bitbucket.org/prensiliasrl/mia_hand_ros_pkgs.git
- release repository: https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.0-14`

## mia_hand_bringup

```
* Merge branch 'master' of bitbucket.org:prensiliasrl/mia_hand_ros_pkgs
* Update trajectory velocity controllers (also for moveit).
* Contributors: Andrea Burani, frcini
```

## mia_hand_description

- No changes

## mia_hand_driver

```
* Forced CMake to find at least version 1.0.0 of libserial.
* Contributors: Andrea Burani
```

## mia_hand_gazebo

- No changes

## mia_hand_moveit_config

- No changes

## mia_hand_msgs

- No changes

## mia_hand_ros_control

```
* Merge branch 'master' of bitbucket.org:prensiliasrl/mia_hand_ros_pkgs
* Update trajectory velocity controllers (also for moveit).
* Contributors: Andrea Burani, frcini
```

## mia_hand_ros_pkgs

- No changes
