### PR TITLE
libhri: 0.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4059,6 +4059,22 @@ repositories:
       url: https://github.com/ros-gbp/libg2o-release.git
       version: 2020.5.3-1
     status: maintained
+  libhri:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/libhri.git
+      version: main
+    release:
+      packages:
+      - hri
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros4hri/libhri-release.git
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/ros4hri/libhri.git
+      version: main
   libnabo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libhri` to `0.3.0-1`:

- upstream repository: https://github.com/ros4hri/libhri.git
- release repository: https://github.com/ros4hri/libhri-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## hri

```
0.3.0 (2022-02-07)
------------------
* expose enum with the 4 feature types person,face,body,voice
* add voices and persons + improve const semantics
* Contributors: Séverin Lemaignan

0.2.3 (2022-01-21)
------------------
* Body::{getRoI->roi} + RoI not optional + add Body::cropped
* Contributors: Séverin Lemaignan

0.2.2 (2022-01-21)
------------------
* Face::{getRoI->roi} + RoI not optional + add Face::cropped
  In the latest revision of the ROS4HRI spec, the region of interest is
  always expected to be available (as well as the cropped face). As such,
  no point in using a boost::optional there.
* Contributors: Séverin Lemaignan

0.2.1 (2022-01-14)
------------------
* replace hri_msgs::RegionOfInterestStamped by sensor_msgs::RegionOfInterest
  Follows changes in hri_msgs 0.2.0
* add skeleton of hri::Person class
* add empty Voice class
* expose the features' topic namespace + doc
* Contributors: Séverin Lemaignan

0.2.0 (2022-01-05)
------------------
* add basic support for bodies; only the RoIs for now
* Contributors: Séverin Lemaignan

0.1.0 (2022-01-05)
------------------
* use boost::optional for faces' features like RoI
* doc: setup rosdoc. Run `rosdoc_lite .` to generate
* test: expand the test suite
* cmake: explicit SYSTEM headers to avoid ROS shadowing issues
* Contributors: Séverin Lemaignan

0.0.3 (2022-01-05)
------------------
* do not try to compile hri_demo (internal test)
* Contributors: Séverin Lemaignan

```
