### PR TITLE
lusb: 2.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1986,6 +1986,21 @@ repositories:
       url: https://github.com/OUXT-Polaris/lua_vendor.git
       version: main
     status: developed
+  lusb:
+    doc:
+      type: git
+      url: https://bitbucket.org/dataspeedinc/lusb.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/DataspeedInc-release/lusb-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://bitbucket.org/dataspeedinc/lusb.git
+      version: ros2
+    status: developed
   map_transformer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lusb` to `2.0.0-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/lusb
- release repository: https://github.com/DataspeedInc-release/lusb-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## lusb

```
* Initial ROS2 release
* Use std instead of boost
* Contributors: Kevin Hallenbeck
```
