### PR TITLE
mia_hand_ros_pkgs: 1.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4533,7 +4533,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     status: maintained
   microstrain_3dmgx2_imu:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `mia_hand_ros_pkgs` to `1.0.2-1`:

- upstream repository: https://bitbucket.org/prensiliasrl/mia_hand_ros_pkgs.git
- release repository: https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.1-1`

## mia_hand_bringup

- No changes

## mia_hand_description

- No changes

## mia_hand_driver

```
* Added Threads package finding in CMake.
* Contributors: Andrea Burani
```

## mia_hand_gazebo

- No changes

## mia_hand_moveit_config

- No changes

## mia_hand_msgs

- No changes

## mia_hand_ros_control

- No changes

## mia_hand_ros_pkgs

- No changes
