### PR TITLE
ros_ign: 0.233.4-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3729,7 +3729,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 0.233.3-1
+      version: 0.233.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_ign` to `0.233.4-1`:

- upstream repository: https://github.com/ignitionrobotics/ros_ign
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.233.3-1`

## ros_ign

- No changes

## ros_ign_bridge

```
* [galactic] backport test memory usage improvements (#215 <https://github.com/ignitionrobotics/ros_ign/issues/215>)
  - Improve modularity of ign/ros publisher tests (#194 <https://github.com/ignitionrobotics/ros_ign/issues/194>)
  - Break apart ros_subscriber test translation unit (#212 <https://github.com/ignitionrobotics/ros_ign/issues/212>)
  - Fix deprecated parameter declaration
  Co-authored-by: Louise Poubel <mailto:louise@openrobotics.org>
* Contributors: Michael Carroll
```

## ros_ign_gazebo

```
* [galactic] backport test memory usage improvements (#215 <https://github.com/ignitionrobotics/ros_ign/issues/215>)
  - Improve modularity of ign/ros publisher tests (#194 <https://github.com/ignitionrobotics/ros_ign/issues/194>)
  - Break apart ros_subscriber test translation unit (#212 <https://github.com/ignitionrobotics/ros_ign/issues/212>)
  - Fix deprecated parameter declaration
  Co-authored-by: Louise Poubel <mailto:louise@openrobotics.org>
* Contributors: Michael Carroll
```

## ros_ign_gazebo_demos

- No changes

## ros_ign_image

- No changes

## ros_ign_interfaces

- No changes
