### PR TITLE
python_qt_binding: 1.0.6-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3201,7 +3201,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/python_qt_binding-release.git
-      version: 1.0.5-1
+      version: 1.0.6-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `1.0.6-2`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros2-gbp/python_qt_binding-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.5-1`

## python_qt_binding

```
* Update maintainers (#96 <https://github.com/ros-visualization/python_qt_binding/issues/96>) (#98 <https://github.com/ros-visualization/python_qt_binding/issues/98>)
* Add pytest.ini so local tests don't display warning (#93 <https://github.com/ros-visualization/python_qt_binding/issues/93>)
* Contributors: Chris Lalancette, Shane Loretz
```
