### PR TITLE
Update autoware_auto_msgs release repository.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -321,7 +321,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs-release.git
+      url: https://github.com/ros2-gbp/autoware_auto_msgs-release.git
       version: 1.0.0-2
     source:
       type: git


### PR DESCRIPTION
The release repository was forked into ros2-gbp for the Galactic migration in April 2021.  Since then there have been releases into the upstream release repository.

These releases were merged into the ros2-gbp branch on 2022-02-07.
Since the upcoming Rolling platform migration will again branch the release repositories into ros2-gbp and the ros2-gbp repository is now up-to-date with the external repository I recommend that we update the release repository pre-emptively to reduce churn in the bloom configuration branches.