### PR TITLE
fp: 0.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -921,6 +921,17 @@ repositories:
       url: https://github.com/ros-drivers/four_wheel_steering_msgs.git
       version: ros2
     status: maintained
+  fp:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/tylerjw/fp-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/tylerjw/fp.git
+      version: main
+    status: developed
   gazebo_ros2_control:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fp` to `0.0.1-1`:

- upstream repository: https://github.com/tylerjw/fp
- release repository: https://github.com/tylerjw/fp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## fp

```
* memo
  
  Tutorials (#13)
* memo
  
  Readme badges (#12)
* bricks
  
  codecov config
* Unreachable default
* tsan test (#11 <https://github.com/tylerjw/fp/issues/11>)
* ament_lint_copyright
* Results with names and don't leak memory
* tada
  
  try_to_result (#10)
* bricks
  
  issue template
* bricks
  
  link codecov to testspace (#5)
* package
  
  Rename library to fp (#4)
* fire
  
  remove all using namespace statements (#3)
* lock
  
  namespace monad (#2)
* goal_net
  
  maybe_error (#1)Co-authored-by: Griswald Brooks <mailto:griswald.brooks@gmail.com>
* tada
  
  FP extensions for C++
* Contributors: Tyler Weaver
```
