### PR TITLE
Update mrpt2 release repository.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1921,7 +1921,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/mrpt-ros2-pkg-release/mrpt2-release.git
+      url: https://github.com/ros2-gbp/mrpt2-release.git
       version: 2.1.3-2
     source:
       type: git


### PR DESCRIPTION
This release repository was forked into ros2-gbp for the Galactic migration in April 2021 and has not been released into the upstream repository since.

Since the [upcoming Rolling platform migration](https://github.com/ros/rosdistro/pull/32036) will again branch the release repository into ros2-gbp I recommend that we update it pre-emptively to reduce churn in the bloom configuration branches.