### PR TITLE
Update octomap_msgs release repository.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2145,7 +2145,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/ros-gbp/octomap_msgs-release.git
+      url: https://github.com/ros2-gbp/octomap_msgs-release.git
       version: 2.0.0-1
     source:
       type: git


### PR DESCRIPTION
This release repository was forked into ros2-gbp for the Galactic migration in April 2021 and has not been released into the upstream repository since.

Since the [upcoming Rolling platform migration](https://github.com/ros/rosdistro/pull/32036) will again branch the release repository into ros2-gbp I recommend that we update it pre-emptively to reduce churn in the bloom configuration branches.