### PR TITLE
Update ros2_socketcan release repository.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3366,7 +3366,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/autowarefoundation/ros2_socketcan-release.git
+      url: https://github.com/ros2-gbp/ros2_socketcan-release.git
       version: 1.0.0-1
     source:
       type: git


### PR DESCRIPTION
This release repository was forked into ros2-gbp for the Galactic migration in April 2021 and has not been released into the upstream repository since.

Since the [upcoming Rolling platform migration](https://github.com/ros/rosdistro/pull/32036) will again branch the release repository into ros2-gbp I recommend that we update it pre-emptively to reduce churn in the bloom configuration branches.