### PR TITLE
Update ros_canopen release repository.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3467,7 +3467,7 @@ repositories:
       - can_msgs
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/ros-industrial-release/ros_canopen-release.git
+      url: https://github.com/ros2-gbp/ros_canopen-release.git
       version: 2.0.0-2
     source:
       type: git


### PR DESCRIPTION
This release repository was forked into ros2-gbp for the Galactic migration in April 2021 and has not been released into the upstream repository since.

Since the [upcoming Rolling platform migration](https://github.com/ros/rosdistro/pull/32036) will again branch the release repository into ros2-gbp I recommend that we update it pre-emptively to reduce churn in the bloom configuration branches.
