### PR TITLE
Update ublox release repository.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4725,7 +4725,7 @@ repositories:
       - ublox_serialization
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/KumarRobotics/ublox-release.git
+      url: https://github.com/ros2-gbp/ublox-release.git
       version: 2.0.0-2
     source:
       test_pull_requests: true


### PR DESCRIPTION
The release repository was forked into ros2-gbp for the Galactic migration in April 2021.  Since then there have been releases into the upstream release repository.

These releases were merged into the ros2-gbp branch on 2022-02-07.

Since the [upcoming Rolling platform migration](https://github.com/ros/rosdistro/pull/32036) will again branch the release repositories into ros2-gbp and the ros2-gbp repository is now up-to-date with the external repository I recommend that we update the release repository pre-emptively to reduce churn in the bloom configuration branches.