### PR TITLE
ros2_socketcan: 1.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4279,8 +4279,8 @@ repositories:
     release:
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/autowarefoundation/ros2_socketcan-release.git
-      version: 1.0.0-1
+      url: https://github.com/ros2-gbp/ros2_socketcan-release.git
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/ros2_socketcan.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_socketcan` to `1.1.0-1`:

- upstream repository: https://github.com/autowarefoundation/ros2_socketcan.git
- release repository: https://github.com/ros2-gbp/ros2_socketcan-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.0-1`

## ros2_socketcan

```
* Added bus time (#12 <https://github.com/autowarefoundation/ros2_socketcan/issues/12>)
  * added the ability to get the bus time for the can packet, versus using ros time when received; packs bus time as part of the can id struct
  * cleanup; cast fix
  * chore: apply uncrustify
  * chore: fix include order for cpplint
  Co-authored-by: wep21 <mailto:border_goldenmarket@yahoo.co.jp>
* Merge pull request #10 <https://github.com/autowarefoundation/ros2_socketcan/issues/10> from wep21/ci-galactic
  Add galactic into action
* Add galactic into action
* Contributors: Andrew Saba, Daisuke Nishimatsu, Joshua Whitley
```
