### PR TITLE
velodyne: 2.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6130,7 +6130,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros-drivers-gbp/velodyne-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/ros-drivers/velodyne.git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne` to `2.1.1-1`:

- upstream repository: https://github.com/ros-drivers/velodyne.git
- release repository: https://github.com/ros-drivers-gbp/velodyne-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.0-1`

## velodyne

```
* Replace deprecated argument names in launch (#435 <https://github.com/ros-drivers/velodyne/issues/435>)
  Co-authored-by: Keane Quigley <mailto:keaneq@protonmail.com>
* Contributors: Chris Lalancette
```

## velodyne_driver

```
* Replace deprecated argument names in launch (#435 <https://github.com/ros-drivers/velodyne/issues/435>)
  Co-authored-by: Keane Quigley <mailto:keaneq@protonmail.com>
* Contributors: Chris Lalancette
```

## velodyne_laserscan

```
* Replace deprecated argument names in launch (#435 <https://github.com/ros-drivers/velodyne/issues/435>)
  Co-authored-by: Keane Quigley <mailto:keaneq@protonmail.com>
* Contributors: Chris Lalancette
```

## velodyne_msgs

- No changes

## velodyne_pointcloud

```
* Replace deprecated argument names in launch (#435 <https://github.com/ros-drivers/velodyne/issues/435>)
  Co-authored-by: Keane Quigley <mailto:keaneq@protonmail.com>
* Contributors: Chris Lalancette
```
