### PR TITLE
velodyne: 2.2.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5411,7 +5411,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/velodyne-release.git
-      version: 2.1.1-2
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/ros-drivers/velodyne.git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne` to `2.2.0-1`:

- upstream repository: https://github.com/ros-drivers/velodyne.git
- release repository: https://github.com/ros-drivers-gbp/velodyne-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.1-2`

## velodyne

```
* Updating for first Galactic release
* Contributors: Joshua Whitley
```

## velodyne_driver

```
* Updating for first Galactic release
* Minor fixes to string formatting. (#396 <https://github.com/ros-drivers/velodyne/issues/396>)
  These changes will allow velodyne to compile without warnings
  on Rolling (soon to be Galactic).  The changes are also backwards
  compatible to Foxy if we want to backport them.
* Contributors: Chris Lalancette, Joshua Whitley
```

## velodyne_laserscan

```
* Updating for first Galactic release
* Contributors: Joshua Whitley
```

## velodyne_msgs

```
* Updating for first Galactic release
* Contributors: Joshua Whitley
```

## velodyne_pointcloud

```
* Updating for first Galactic release
* Contributors: Joshua Whitley
```
