### PR TITLE
Add python3-wrapt to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5607,7 +5607,11 @@ python-whichcraft:
   ubuntu: [python-whichcraft]
 python-wrapt:
   debian: [python-wrapt]
-  ubuntu: [python-wrapt]
+  ubuntu:
+    '*': [python-wrapt]
+    focal: [python3-wrapt]
+    trusty_python3: [python3-wrapt]
+    xenial_python3: [python3-wrapt]
 python-ws4py:
   debian: [python-ws4py]
   ubuntu: [python-ws4py]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8594,6 +8594,9 @@ python3-wrapt:
   fedora: [python3-wrapt]
   gentoo: [dev-python/wrapt]
   nixos: [python3Packages.wrapt]
+  opensuse: [python3-wrapt]
+  rhel:
+    '8': [python3-wrapt]
   ubuntu: [python3-wrapt]
 python3-wxgtk4.0:
   debian: [python3-wxgtk4.0]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5607,11 +5607,7 @@ python-whichcraft:
   ubuntu: [python-whichcraft]
 python-wrapt:
   debian: [python-wrapt]
-  ubuntu:
-    '*': [python-wrapt]
-    focal: [python3-wrapt]
-    trusty_python3: [python3-wrapt]
-    xenial_python3: [python3-wrapt]
+  ubuntu: [python-wrapt]
 python-ws4py:
   debian: [python-ws4py]
   ubuntu: [python-ws4py]
@@ -8592,6 +8588,13 @@ python3-whichcraft:
   gentoo: [dev-python/whichcraft]
   nixos: [python3Packages.whichcraft]
   ubuntu: [python3-whichcraft]
+python3-wrapt:
+  arch: [python-wrapt]
+  debian: [python3-wrapt]
+  fedora: [python3-wrapt]
+  gentoo: [dev-python/wrapt]
+  nixos: [python3Packages.wrapt]
+  ubuntu: [python3-wrapt]
 python3-wxgtk4.0:
   debian: [python3-wxgtk4.0]
   fedora: [python3-wxpython4]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-wrapt

## Package Upstream Source:

[Link](https://github.com/GrahamDumpleton/wrapt)

## Purpose of using this:

This package is already available as `python-wrapt`, but I would like to have access to it in python3.
It eases the use and design of decorators in python.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - [Link](https://packages.debian.org/buster/python3-wrapt)
- Ubuntu: https://packages.ubuntu.com/
   - [Link](https://packages.ubuntu.com/focal/python3-wrapt)
- Fedora: https://src.fedoraproject.org/browse/projects/
  - [Link](https://koji.fedoraproject.org/koji/rpminfo?rpmID=28640047)
- Arch: https://www.archlinux.org/packages/
  - [Link](https://archlinux.org/packages/extra/x86_64/python-wrapt/)
- Gentoo: https://packages.gentoo.org/
  - [Link](https://packages.gentoo.org/packages/dev-python/wrapt)
- macOS: https://formulae.brew.sh/
  - None
- Alpine: https://pkgs.alpinelinux.org/packages
  - None
- NixOS/nixpkgs: https://search.nixos.org/packages
  - [Link](https://hydra.nixos.org/job/nixos/release-21.11/nixpkgs.python38Packages.whichcraft.x86_64-linux#tabs-status)
