### PR TITLE
rc_reason_clients: 0.3.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2811,7 +2811,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_reason_clients-release.git
-      version: 0.2.1-1
+      version: 0.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_reason_clients` to `0.3.0-1`:

- upstream repository: https://github.com/roboception/rc_reason_clients_ros2.git
- release repository: https://github.com/roboception-gbp/rc_reason_clients-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.1-1`

## rc_reason_clients

```
* add rc_cadmatch_client and rc_load_carrier_client
* use refactored and updated rc_reason_msgs
* replace deprecated set_parameters_callback with add_on_set_parameters_callback
```

## rc_reason_msgs

```
* refactor and update for v22.01
```
