### PR TITLE
rc_reason_clients: 0.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6792,7 +6792,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_reason_clients_ros-release.git
-      version: 0.2.1-1
+      version: 0.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_reason_clients` to `0.3.0-1`:

- upstream repository: https://github.com/roboception/rc_reason_clients_ros.git
- release repository: https://github.com/roboception-gbp/rc_reason_clients_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.1-1`

## rc_reason_clients

```
* use updated rc_reason_msgs
```

## rc_reason_msgs

```
* refactor and update for v22.01
```
