### PR TITLE
rc_visard: 3.3.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10047,7 +10047,6 @@ repositories:
       packages:
       - rc_hand_eye_calibration_client
       - rc_pick_client
-      - rc_roi_manager_gui
       - rc_silhouettematch_client
       - rc_tagdetect_client
       - rc_visard
@@ -10056,7 +10055,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_visard-release.git
-      version: 3.2.4-1
+      version: 3.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_visard` to `3.3.0-1`:

- upstream repository: https://github.com/roboception/rc_visard_ros.git
- release repository: https://github.com/roboception-gbp/rc_visard-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.2.4-1`

## rc_hand_eye_calibration_client

- No changes

## rc_pick_client

```
* remove load_carrier and ROI services
* remove load_carrier parameters
```

## rc_silhouettematch_client

```
* remove ROI services
```

## rc_tagdetect_client

- No changes

## rc_visard

- No changes

## rc_visard_description

- No changes

## rc_visard_driver

- No changes
