### PR TITLE
Update velodyne_simulator release repository.

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6148,7 +6148,7 @@ repositories:
       - velodyne_simulator
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
+      url: https://github.com/ros2-gbp/velodyne_simulator-release.git
       version: 2.0.2-1
     source:
       type: git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5429,7 +5429,7 @@ repositories:
       - velodyne_simulator
       tags:
         release: release/galactic/{package}/{version}
-      url: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
+      url: https://github.com/ros2-gbp/velodyne_simulator-release.git
       version: 2.0.2-1
     source:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4968,7 +4968,7 @@ repositories:
       - velodyne_simulator
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
+      url: https://github.com/ros2-gbp/velodyne_simulator-release.git
       version: 2.0.2-1
     source:
       type: git


### PR DESCRIPTION
Based on the request in https://github.com/ros/rosdistro/pull/31612#issuecomment-1028403672
A complete mirror of the external release repository has been pushed to
the ros2-gbp organization so that repository can be used for all ROS 2
releases going forward.