### PR TITLE
[migration-tools] Always release source version with updated release increment instead of last_version.

### DIFF
--- a/migration-tools/migrate-rosdistro.py
+++ b/migration-tools/migrate-rosdistro.py
@@ -183,10 +183,12 @@ for repo_name in sorted(new_repositories + repositories_to_retry):
         # interactivity and :{auto} may result in a previously unreleased tag
         # on the development branch being released for the first time.
         if dest_track['version'] in [':{ask}', ':{auto}']:
-            # Override the version for this release to guarantee the same version is released.
+            # Override the version for this release to guarantee the same version from our
+            # source distribution is released.
             dest_track['version_saved'] = dest_track['version']
-            dest_track['version'] = dest_track['last_version']
-            write_tracks_file(tracks, f'Update {args.dest} track to release exactly last-released version.')
+            source_version, source_inc = source_distribution.repositories[repo_name].release_repository.version.split('-')
+            dest_track['version'] = source_version
+            write_tracks_file(tracks, f'Update {args.dest} track to release the same version as the source distribution.')
 
         if dest_track['release_tag'] == ':{ask}' and 'last_release' in dest_track:
             # Override the version for this release to guarantee the same version is released.
@@ -194,9 +196,11 @@ for repo_name in sorted(new_repositories + repositories_to_retry):
             dest_track['release_tag'] = dest_track['last_release']
             write_tracks_file(tracks, f'Update {args.dest} track to release exactly last-released tag.')
 
+        # Update release increment for the upcoming release.
+        release_inc = str(int(source_inc) + 1)
         # Bloom will not run with multiple remotes.
         subprocess.check_call(['git', 'remote', 'remove', 'oldorigin'])
-        subprocess.check_call(['git', 'bloom-release', '--non-interactive', '--unsafe', args.dest], env=os.environ)
+        subprocess.check_call(['git', 'bloom-release', '--non-interactive', '--release-increment', release_inc, '--unsafe', args.dest], env=os.environ)
         subprocess.check_call(['git', 'push', 'origin', '--all', '--force'])
         subprocess.check_call(['git', 'push', 'origin', '--tags', '--force'])
         subprocess.check_call(['git', 'checkout', 'master'])


### PR DESCRIPTION
When performing the Rolling platform migration several repositories had bloom releases which were not committed to the distribution file at the time of the source ref.
As a result the `last_version` entries for those repositories did not match the release version in the source distribution during migration.
Since the migration tool was using the last_release in order to handle any releases that were not hard coded to a specifc version and/or release tag this created a split between what was performed by git-bloom-release during migration and what was configured in the resulting distribution file.

One example is the ros2_control repository which had a 2.2.0-1 release made in https://github.com/ros2-gbp/ros2_control-release/commit/7504ac3640529603ee80dae424b516caf1a53409 but which never received a rosdistro PR.
Thus the migration tool released 2.2.0-2 based on the last_release information in the tracks file but the source distribution was anticipating 2.1.0-2.

Of the changes in this commit I am most hesitant about the release_increment handling since this script will eventually generate and force push updated release artifacts and if in a similar situation a 2.1.0-2 was released but not published in the source distribution file its artifacts would be clobbered where they overlapped with the migration-tool's own 2.1.0-2.
However I don't have a method of resolving that situation without searching each release repository's artifacts for a full list of release increments associated with a version.