### PR TITLE
lusb: 2.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1995,7 +1995,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/DataspeedInc-release/lusb-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://bitbucket.org/dataspeedinc/lusb.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lusb` to `2.0.1-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/lusb
- release repository: https://github.com/DataspeedInc-release/lusb-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-1`

## lusb

```
* Add README and example
* Fix cmake problems and update for best practices
* Add pkg-config build dependency
* Contributors: Kevin Hallenbeck
```
