### PR TITLE
dataspeed_can: 2.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -732,6 +732,25 @@ repositories:
       url: https://github.com/eclipse-cyclonedds/cyclonedds.git
       version: releases/0.7.x
     status: maintained
+  dataspeed_can:
+    doc:
+      type: git
+      url: https://bitbucket.org/dataspeedinc/dataspeed_can.git
+      version: ros2
+    release:
+      packages:
+      - dataspeed_can
+      - dataspeed_can_msg_filters
+      - dataspeed_can_usb
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/DataspeedInc-release/dataspeed_can-release.git
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://bitbucket.org/dataspeedinc/dataspeed_can.git
+      version: ros2
+    status: developed
   demos:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dataspeed_can` to `2.0.1-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/dataspeed_can.git
- release repository: https://github.com/DataspeedInc-release/dataspeed_can-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## dataspeed_can

- No changes

## dataspeed_can_msg_filters

```
* Fix cmake problems and update for best practices
* Avoid deprecation warnings in Galactic
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```

## dataspeed_can_usb

```
* Fix cmake problems and update for best practices
* Change parameters to work in Foxy and Galactic
* Avoid deprecation warnings in Galactic
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```
