### PR TITLE
fix URL of relaese repository for quaternion_operation

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2516,7 +2516,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/quaternion_operation-release.git
+      url: https://github.com/OUXT-Polaris/quaternion_operation-release.git
       version: 0.0.7-2
     source:
       type: git


### PR DESCRIPTION
Signed-off-by: MasayaKataoka <ms.kataoka@gmail.com>

## Package name:

quaternion_operation

## Purpose of using this:

release repository URL of my package was wrong, so I want to correct this.

# The source is here: 

https://github.com/OUXT-Polaris/quaternion_operation.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
