### PR TITLE
message_synchronizer: 0.0.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1759,6 +1759,21 @@ repositories:
       url: https://github.com/ros2/message_filters.git
       version: galactic
     status: maintained
+  message_synchronizer:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/message_synchronizer.git
+      version: master
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/OUXT-Polaris/message_synchronizer-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/message_synchronizer.git
+      version: master
+    status: developed
   micro_ros_diagnostics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_synchronizer` to `0.0.2-1`:

- upstream repository: https://github.com/OUXT-Polaris/message_synchronizer.git
- release repository: https://github.com/OUXT-Polaris/message_synchronizer-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## message_synchronizer

```
* Setup workflow (#30 <https://github.com/OUXT-Polaris/message_synchronizer/issues/30>)
  Co-authored-by: MasayaKataoka <mailto:ms.kataoka@gmail.com>
* add boost to the depends
* Setup workflow (#29 <https://github.com/OUXT-Polaris/message_synchronizer/issues/29>)
* Contributors: MasayaKataoka, wam-v-tan
```
