### PR TITLE
plotjuggler_ros: 1.7.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2550,7 +2550,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
-      version: 1.5.1-1
+      version: 1.7.1-1
     source:
       type: git
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler_ros` to `1.7.1-1`:

- upstream repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
- release repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.5.1-1`
