### PR TITLE
mir_robot: 1.1.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4590,7 +4590,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/uos-gbp/mir_robot-release.git
-      version: 1.1.4-1
+      version: 1.1.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mir_robot` to `1.1.5-1`:

- upstream repository: https://github.com/dfki-ric/mir_robot.git
- release repository: https://github.com/uos-gbp/mir_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.4-1`

## mir_actions

- No changes

## mir_description

```
* Remove xacro comment to work around xacro bug
  Since xacro 1.14.11, xacro now also evaluates expressions in comments
  and throws an error if the substition argument is undefined. In xacro
  1.14.12, this error was changed to a warning.
  This commit removes that warning.
  Workaround for https://github.com/ros/xacro/issues/309 .
* xacro: drop --inorder option
  In-order processing became default in ROS Melodic.
* Add gazebo_plugins to dependency list (#103 <https://github.com/dfki-ric/mir_robot/issues/103>)
  This is needed for the ground truth pose via p3d plugin.
* Contributors: Martin Günther, moooeeeep
```

## mir_driver

- No changes

## mir_dwb_critics

- No changes

## mir_gazebo

- No changes

## mir_msgs

- No changes

## mir_navigation

- No changes

## mir_robot

- No changes

## sdc21x0

- No changes
