### PR TITLE
nmea_hardware_interface: 0.0.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2103,7 +2103,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/OUXT-Polaris/nmea_hardware_interface-release.git
-      version: 0.0.1-1
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/OUXT-Polaris/nmea_hardware_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_hardware_interface` to `0.0.2-1`:

- upstream repository: https://github.com/OUXT-Polaris/nmea_hardware_interface.git
- release repository: https://github.com/OUXT-Polaris/nmea_hardware_interface-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.1-1`

## nmea_hardware_interface

```
* Merge pull request #8 <https://github.com/OUXT-Polaris/nmea_hardware_interface/issues/8> from OUXT-Polaris/fix/depends_diagnostic_msgs
  add diagnostic_msgs to the depends
* remove old repos file
* add diagnostic_msgs to the depends
* Merge pull request #7 <https://github.com/OUXT-Polaris/nmea_hardware_interface/issues/7> from OUXT-Polaris/workflow/sync
  [Bot] Update workflow
* Setup workflow
* Contributors: Masaya Kataoka, MasayaKataoka, wam-v-tan
```
