### PR TITLE
realsense_hardware_interface: 0.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3674,7 +3674,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/OUXT-Polaris/realsense_hardware_interface-release.git
-      version: 0.0.1-1
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/OUXT-Polaris/realsense_hardware_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense_hardware_interface` to `0.0.2-1`:

- upstream repository: https://github.com/OUXT-Polaris/realsense_hardware_interface.git
- release repository: https://github.com/OUXT-Polaris/realsense_hardware_interface-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.1-1`

## realsense_hardware_interface

```
* Merge pull request #21 <https://github.com/OUXT-Polaris/realsense_hardware_interface/issues/21> from OUXT-Polaris/fix/depends_diagnostic_msgs
  add diagnostic_msgs to the depends
* add diagnostic_msgs to the depends
* [Bot] Update workflow (#20 <https://github.com/OUXT-Polaris/realsense_hardware_interface/issues/20>)
  * Setup workflow
  * remove old repos
  * remove quaternion_operation package
  Co-authored-by: MasayaKataoka <mailto:ms.kataoka@gmail.com>
* Setup workflow (#19 <https://github.com/OUXT-Polaris/realsense_hardware_interface/issues/19>)
* Setup workflow (#18 <https://github.com/OUXT-Polaris/realsense_hardware_interface/issues/18>)
* Setup workflow (#17 <https://github.com/OUXT-Polaris/realsense_hardware_interface/issues/17>)
* Setup workflow (#16 <https://github.com/OUXT-Polaris/realsense_hardware_interface/issues/16>)
* Setup workflow (#15 <https://github.com/OUXT-Polaris/realsense_hardware_interface/issues/15>)
* Merge pull request #14 <https://github.com/OUXT-Polaris/realsense_hardware_interface/issues/14> from OUXT-Polaris/fix/galactic_build
  enable pass compile in galactic environment
* enable pass compile in galactic environment
* Merge pull request #13 <https://github.com/OUXT-Polaris/realsense_hardware_interface/issues/13> from OUXT-Polaris/fix/update_mathod
  enable pass compile in galactic
* enable pass compile in galactic
* Setup workflow (#12 <https://github.com/OUXT-Polaris/realsense_hardware_interface/issues/12>)
* Merge pull request #11 <https://github.com/OUXT-Polaris/realsense_hardware_interface/issues/11> from OUXT-Polaris/fix/ros2_control_branch
  update target branch
* fix errors in galactic
* Merge branch 'master' into fix/ros2_control_branch
* update target branch
* Setup workflow (#10 <https://github.com/OUXT-Polaris/realsense_hardware_interface/issues/10>)
* Setup workflow (#9 <https://github.com/OUXT-Polaris/realsense_hardware_interface/issues/9>)
* Setup workflow (#8 <https://github.com/OUXT-Polaris/realsense_hardware_interface/issues/8>)
* Setup workflow (#7 <https://github.com/OUXT-Polaris/realsense_hardware_interface/issues/7>)
* [Bot] Update workflow (#6 <https://github.com/OUXT-Polaris/realsense_hardware_interface/issues/6>)
  * Setup build test workflow
  * specify ros2_control version
  * update workflow
  Co-authored-by: Masaya Kataoka <mailto:ms.kataoka@gmail.com>
* Merge pull request #5 <https://github.com/OUXT-Polaris/realsense_hardware_interface/issues/5> from OUXT-Polaris/feature/remove_old_workflow
  remove old workflow
* remove old workflow
* Merge pull request #4 <https://github.com/OUXT-Polaris/realsense_hardware_interface/issues/4> from OUXT-Polaris/workflow/build_test
  [Bot] Update workflow
* add ros2_control to the repos file
* add ouxt_common to the repos
* add ouxt_lint_common
* Setup build test workflow
* Merge pull request #3 <https://github.com/OUXT-Polaris/realsense_hardware_interface/issues/3> from OUXT-Polaris/feature/imu_driver
* enable publish imu data
* modify launch files
* add imu publisher class
* enable get value in hardware interface
* add isready function
* add toMsg function
* add imu handle
* Merge pull request #2 <https://github.com/OUXT-Polaris/realsense_hardware_interface/issues/2> from OUXT-Polaris/feature/add_depends
  update depends
* update depends
* Contributors: Masaya Kataoka, MasayaKataoka, wam-v-tan
```
