### PR TITLE
lockmount_description: 0.0.2-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4164,6 +4164,21 @@ repositories:
       url: https://github.com/boschglobal/locator_ros_bridge.git
       version: noetic
     status: maintained
+  lockmount_description:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/lockmount_description.git
+      version: main
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/lockmount_description-release.git
+      version: 0.0.2-2
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/lockmount_description.git
+      version: main
+    status: maintained
   log_view:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lockmount_description` to `0.0.2-2`:

- upstream repository: https://github.com/clearpathrobotics/lockmount_description.git
- release repository: https://github.com/clearpath-gbp/lockmount_description-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## lockmount_description

```
* Remove a copy & paste error in the cmake file that's breaking the install
* Contributors: Chris Iverach-Brereton
```
