### PR TITLE
Revert "xacro: 1.14.11-1 in 'noetic/distribution.yaml' [bloom]"

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10446,7 +10446,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.14.11-1
+      version: 1.14.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#31860

@rhaschke While options are being discussed in ros/xacro#300, what do you think about reverting to the previous release? I can do a sync over the weekend.