### PR TITLE
rviz: 1.13.24-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12502,7 +12502,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.13.23-1
+      version: 1.13.24-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.13.24-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.13.23-1`

## rviz

```
* Fix regression in mesh loader: correctly transform normals (#1703 <https://github.com/ros-visualization/rviz/issues/1703>)
* MovableText: gracefully handle string of whitespaces (#1700 <https://github.com/ros-visualization/rviz/issues/1700>)
* Contributors: Robert Haschke
```
