### PR TITLE
rviz: 1.14.14-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8632,7 +8632,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.14.13-1
+      version: 1.14.14-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.14.14-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.14.13-1`

## rviz

```
* Fixup #1497 <https://github.com/ros-visualization/rviz/issues/1497>: Initialize ``fixed_frame_id``
* Add service ``load_config_discarding_changes`` (#1710 <https://github.com/ros-visualization/rviz/issues/1710>)
* Fix regression in mesh loader: correctly transform normals (#1703 <https://github.com/ros-visualization/rviz/issues/1703>)
* MovableText: gracefully handle string of whitespaces (#1700 <https://github.com/ros-visualization/rviz/issues/1700>)
* Contributors: Filip Sund, Robert Haschke
```
