### PR TITLE
xacro: 1.13.17-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -15120,7 +15120,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.13.15-1
+      version: 1.13.17-1
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.13.17-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.13.15-1`

## xacro

```
* Only optionally activate comment evaluation (#310 <https://github.com/ros/xacro/issues/310>)Comment evaluation can be enabled with a special comment:
  
    * ``<!-- xacro:eval-comments -->`` or
    * ``<!-- xacro:eval-comments:on -->``
  It remains active for the following comments until:
  
    * the current XML tag's scope is left (or a new tag entered)
    * another tag or non-whitespace text is processed
    * it becomes explicitly disabled via: ``<!-- xacro:eval-comments:off -->``
  
* Fix property resolution with namespace usage (#308 <https://github.com/ros/xacro/issues/308>)
  
    * Allow access to properties in parent scopes again (fixes #305 <https://github.com/ros/xacro/issues/305#issuecomment-1016811150>)
    * Pick correct scope when defining a property into the parent (fixes #307 <https://github.com/ros/xacro/issues/307>)Setting a property within the parent scope may occur in two contexts:From within a macro. In that case, one wants to set the property in the caller's scope.
      
      From within the included file. In that case, one wants to set the property in the includer's scope.
  
* Contributors: Robert Haschke
```
