### PR TITLE
plotjuggler: 3.4.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6005,7 +6005,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.4.1-1
+      version: 3.4.2-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.4.2-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.4.1-1`

## plotjuggler

```
* delete orhphaned transforms
* bug fix that cause crash
* fix error #603 <https://github.com/facontidavide/PlotJuggler/issues/603>
* Fix #594 <https://github.com/facontidavide/PlotJuggler/issues/594>
* Contributors: Davide Faconti
```
