### PR TITLE
plotjuggler: 3.4.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2520,7 +2520,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.3.4-1
+      version: 3.4.2-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.4.2-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.3.4-1`

## plotjuggler

```
* delete orhphaned transforms
* bug fix that cause crash
* fix error #603 <https://github.com/facontidavide/PlotJuggler/issues/603>
* Fix #594 <https://github.com/facontidavide/PlotJuggler/issues/594>
* Contributors: Davide Faconti
```
