### PR TITLE
rmw_connextdds: 0.8.3-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3141,7 +3141,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 0.8.3-1
+      version: 0.8.3-2
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `0.8.3-2`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.8.3-1`

## rmw_connextdds

- No changes

## rmw_connextdds_common

- No changes

## rti_connext_dds_cmake_module

```
* Update rti-connext-dds dependency to 6.0.1. (#71 <https://github.com/ros2/rmw_connextdds/issues/71>)
* Contributors: Steven! Ragnarök
```
