### PR TITLE
Revert "fastrtps: 2.3.4-3 in 'rolling/distribution.yaml' [bloom]"

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -846,7 +846,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fastrtps-release.git
-      version: 2.3.4-3
+      version: 2.3.4-2
     source:
       test_commits: true
       test_pull_requests: false


### PR DESCRIPTION
Reverts ros/rosdistro#32148 this release is not currently building due to failures compiling against openssl.

https://build.ros2.org/job/Rbin_uJ64__fastrtps__ubuntu_jammy_amd64__binary/3