### PR TITLE
plotjuggler: 3.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2345,7 +2345,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.4.0-2
+      version: 3.4.2-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.4.2-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/ros2-gbp/plotjuggler-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.4.0-2`

## plotjuggler

```
* delete orhphaned transforms
* bug fix that cause crash
* fix error #603 <https://github.com/facontidavide/PlotJuggler/issues/603>
* Fix #594 <https://github.com/facontidavide/PlotJuggler/issues/594>
* Contributors: Davide Faconti
```
