### PR TITLE
gscam: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1138,6 +1138,21 @@ repositories:
       url: https://github.com/flynneva/grbl_ros.git
       version: devel
     status: maintained
+  gscam:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/gscam.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gscam-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/gscam.git
+      version: ros2
+    status: developed
   hash_library_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gscam` to `2.0.0-1`:

- upstream repository: https://github.com/ros-drivers/gscam.git
- release repository: https://github.com/ros2-gbp/gscam-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## gscam

```
* fix: fix test dependency in package.xml
* Add note on testing and examples
* Update README
* chore: fix for uncrustify
* fix: fix smoke test
* chore: fix copyright
* chore: fix flake8
* chore: fix pep257
* chore: fix lint_cmake
* chore: fix cpplint
* chore: change license
* chore: apply uncrustify
* chore: add linter dependencies
* chore: simplify parameter declaration
* adding explicit parameter types to string parameters
* Add smoke test
* Break deadlock for a clean exit
* fix: fix legacy group namespace
* chore: install examples directory
* fix: fix launch extension
* fix: fix launch executable name
* feat: create node exe from rclcpp components
* Update README
* Remove extra files, rename .h to .hpp
* Configure once, avoids re-declaring parameters
* Port launch files to ros2
* Remove support for gstreamer-0.10
* Use Github Actions and ros-tooling for CI
* Remove deprecation warnings, clean up includes
* Fixed crash in GStreamer 1.16.2, works on Foxy
* Minimal ROS2 port, works in Eloquent
* Contributors: Clyde McQueen, Jonathan Bohren, wep21
```
