### PR TITLE
ign_ros2_control: 0.1.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1541,7 +1541,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 0.1.1-2
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/ignitionrobotics/ign_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ign_ros2_control` to `0.1.2-1`:

- upstream repository: https://github.com/ignitionrobotics/ign_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.1-2`

## ign_ros2_control

```
* Fixed position control (#29 <https://github.com/ignitionrobotics/ign_ros2_control/issues/29>) (#34 <https://github.com/ignitionrobotics/ign_ros2_control/issues/34>)
* typo fix. (#25 <https://github.com/ignitionrobotics/ign_ros2_control/issues/25>) (#26 <https://github.com/ignitionrobotics/ign_ros2_control/issues/26>)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* Contributors: Alejandro Hernández Cordero
```

## ign_ros2_control_demos

```
* Updated docs and renamed diff drive launch file (#32 <https://github.com/ignitionrobotics/ign_ros2_control/issues/32>)
  Co-authored-by: Denis Štogl <mailto:denis@stogl.de>
* Added Diff drive example (#28 <https://github.com/ignitionrobotics/ign_ros2_control/issues/28>)
* Contributors: Alejandro Hernández Cordero
```
