### PR TITLE
pinocchio: 2.6.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5990,7 +5990,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/stack-of-tasks/pinocchio-ros-release.git
-      version: 2.6.4-1
+      version: 2.6.5-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/pinocchio.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pinocchio` to `2.6.5-1`:

- upstream repository: https://github.com/stack-of-tasks/pinocchio.git
- release repository: https://github.com/stack-of-tasks/pinocchio-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.6.4-1`
