### PR TITLE
osrf_testing_tools_cpp: 1.5.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2234,7 +2234,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/osrf_testing_tools_cpp-release.git
-      version: 1.5.0-2
+      version: 1.5.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `osrf_testing_tools_cpp` to `1.5.1-1`:

- upstream repository: https://github.com/osrf/osrf_testing_tools_cpp.git
- release repository: https://github.com/ros2-gbp/osrf_testing_tools_cpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.5.0-2`

## osrf_testing_tools_cpp

```
* Changed to use ``CMAKE_DL_LIBS`` CMake library to link library that provides dlopen (#68 <https://github.com/osrf/osrf_testing_tools_cpp/issues/68>)
* Contributors: Silvio Traversaro
```
