### PR TITLE
Add several gstreamer1 rules for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1570,6 +1570,7 @@ gstreamer1.0-gl:
     stretch: null
   fedora: [gstreamer1-plugins-base]
   nixos: [gst_all_1.gst-plugins-base]
+  rhel: [gstreamer1-plugins-base]
   ubuntu:
     '*': [gstreamer1.0-gl]
     xenial: null
@@ -1590,6 +1591,7 @@ gstreamer1.0-plugins-bad:
   nixos: [gst_all_1.gst-plugins-bad]
   openembedded: [gstreamer1.0-plugins-bad@openembedded-core]
   opensuse: [gstreamer-plugins-bad]
+  rhel: [gstreamer1-plugins-bad-free]
   ubuntu: [gstreamer1.0-plugins-bad]
 gstreamer1.0-plugins-base:
   arch: [gst-plugins-base]
@@ -1599,6 +1601,7 @@ gstreamer1.0-plugins-base:
   nixos: [gst_all_1.gst-plugins-base]
   openembedded: [gstreamer1.0-plugins-base@openembedded-core]
   opensuse: [gstreamer-plugins-base]
+  rhel: [gstreamer1-plugins-base]
   ubuntu: [gstreamer1.0-plugins-base, libgstreamer-plugins-base1.0-0, gir1.2-gst-plugins-base-1.0]
 gstreamer1.0-plugins-good:
   arch: [gst-plugins-good]
@@ -3434,6 +3437,7 @@ libgstreamer-plugins-base1.0-dev:
   nixos: [gst_all_1.gst-plugins-base]
   openembedded: [gstreamer1.0-plugins-base@openembedded-core]
   opensuse: [gstreamer-plugins-base-devel]
+  rhel: [gstreamer1-plugins-base-devel]
   ubuntu: [libgstreamer-plugins-base1.0-dev]
 libgstreamer0.10-0:
   arch: [gstreamer0.10]
@@ -3457,6 +3461,7 @@ libgstreamer1.0-dev:
   nixos: [gst_all_1.gstreamer]
   openembedded: [gstreamer1.0@openembedded-core]
   opensuse: [gstreamer-devel]
+  rhel: [gstreamer1-devel]
   ubuntu: [libgstreamer1.0-dev]
 libgstrtspserver-1.0-0:
   debian: [libgstrtspserver-1.0-0]


### PR DESCRIPTION
`gstreamer1.0-gl` / `gstreamer1.0-plugins-base`:
* 7: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/gstreamer1-plugins-base-1.10.4-2.el7.x86_64.rpm
* 8: https://repo.almalinux.org/almalinux/8/AppStream/x86_64/os/Packages/gstreamer1-plugins-base-1.16.1-2.el8.x86_64.rpm

`gstreamer1.0-plugins-bad`:
* 7: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/gstreamer1-plugins-bad-free-1.10.4-3.el7.x86_64.rpm
* 8: https://repo.almalinux.org/almalinux/8/AppStream/x86_64/os/Packages/gstreamer1-plugins-bad-free-1.16.1-1.el8.x86_64.rpm

`libgstreamer-plugins-base1.0-dev`:
* 7: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/gstreamer1-plugins-base-devel-1.10.4-2.el7.x86_64.rpm
* 8: https://repo.almalinux.org/almalinux/8/AppStream/x86_64/os/Packages/gstreamer1-plugins-base-devel-1.16.1-2.el8.x86_64.rpm

`libgstreamer1.0-dev`:
* 7: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/gstreamer1-devel-1.10.4-2.el7.x86_64.rpm
* 8: https://repo.almalinux.org/almalinux/8/AppStream/x86_64/os/Packages/gstreamer1-devel-1.16.1-2.el8.x86_64.rpm