### PR TITLE
nao_lola: 0.0.4-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1952,6 +1952,21 @@ repositories:
       url: https://github.com/ijnek/nao_interfaces.git
       version: rolling
     status: developed
+  nao_lola:
+    doc:
+      type: git
+      url: https://github.com/ijnek/nao_lola.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ijnek/nao_lola-release.git
+      version: 0.0.4-2
+    source:
+      type: git
+      url: https://github.com/ijnek/nao_lola.git
+      version: rolling
+    status: developed
   navigation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_lola` to `0.0.4-2`:

- upstream repository: https://github.com/ijnek/nao_lola.git
- release repository: https://github.com/ijnek/nao_lola-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## nao_lola

```
* fix cpplint warning
* add changes to ci to test all distros
* Contributors: Kenji Brameld, ijnek
```
