### PR TITLE
adding nlohmann-json3-dev key for jammy

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6244,6 +6244,7 @@ nlohmann-json-dev:
     bionic: [nlohmann-json-dev]
     focal: [nlohmann-json3-dev]
     groovy: [nlohmann-json3-dev]
+    jammy: [nlohmann-json3-dev]
     xenial: null
 nmap:
   archlinux: [nmap]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

nlohmann-json3-dev

## Package Upstream Source:

https://github.com/nlohmann/json/

## Purpose of using this:

Used by:

https://github.com/open-rmf/rmf_task/tree/main/rmf_task_sequence

and other packages from `open-rmf`.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Ubuntu Jammy:
   - https://packages.ubuntu.com/jammy/nlohmann-json3-dev
