### PR TITLE
tvm_vendor: 0.8.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5085,11 +5085,15 @@ repositories:
       version: galactic-devel
     status: maintained
   tvm_vendor:
+    doc:
+      type: git
+      url: https://github.com/autowarefoundation/tvm_vendor.git
+      version: main
     release:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/tvm_vendor-release.git
-      version: 0.7.3-1
+      version: 0.8.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/tvm_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tvm_vendor` to `0.8.0-1`:

- upstream repository: https://github.com/autowarefoundation/tvm_vendor.git
- release repository: https://github.com/ros2-gbp/tvm_vendor-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.3-1`

## tvm_vendor

```
* Update TVM version (#7 <https://github.com/autowarefoundation/tvm_vendor/issues/7>)
  This patch is needed to properly run the packages that
  use ML models from the modelzoo.
  Issue-Id: SCM-3720
  Change-Id: I331efb40337ac15ec6b84ed9b9050fa42e49dc0f
* CI: Add Galactic CI
* Contributors: Joshua Whitley, Luca Foschiani
```
