### PR TITLE
Adding python3-socketio rosdep rule

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8228,7 +8228,8 @@ python3-smc-pip:
       packages: [smc]
 python3-socketio:
   debian:
-    bullseye: [python3-socketio]
+    '*': [python3-socketio]
+    buster: null
   fedora: [python3-socketio]
   ubuntu:
     '*': [python3-socketio]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8232,8 +8232,8 @@ python3-socketio:
   fedora:
     packages: [python3-socketio]
   ubuntu:
-    focal: [python3-socketio]
-    jammy: [python3-socketio]
+    '*': [python3-socketio]
+    bionic: null
 python3-sortedcollections-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8228,7 +8228,9 @@ python3-smc-pip:
       packages: [smc]
 python3-socketio:
   debian: [python3-socketio]
-  ubuntu: [python3-socketio]
+  ubuntu: 
+    focal: [python3-socketio]
+    jammy: [python3-socketio]
 python3-sortedcollections-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8227,9 +8227,11 @@ python3-smc-pip:
     pip:
       packages: [smc]
 python3-socketio:
-  debian: 
+  debian:
     bullseye: [python3-socketio]
-  ubuntu: 
+  fedora:
+    packages: [python3-socketio]
+  ubuntu:
     focal: [python3-socketio]
     jammy: [python3-socketio]
 python3-sortedcollections-pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8227,7 +8227,8 @@ python3-smc-pip:
     pip:
       packages: [smc]
 python3-socketio:
-  debian: [python3-socketio]
+  debian: 
+    bullseye: [python3-socketio]
   ubuntu: 
     focal: [python3-socketio]
     jammy: [python3-socketio]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8229,8 +8229,7 @@ python3-smc-pip:
 python3-socketio:
   debian:
     bullseye: [python3-socketio]
-  fedora:
-    packages: [python3-socketio]
+  fedora: [python3-socketio]
   ubuntu:
     '*': [python3-socketio]
     bionic: null

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8226,6 +8226,9 @@ python3-smc-pip:
   ubuntu:
     pip:
       packages: [smc]
+python3-socketio:
+  debian: [python3-socketio]
+  ubuntu: [python3-socketio]
 python3-sortedcollections-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`python3-socketio`

## Package Upstream Source:

https://github.com/miguelgrinberg/python-socketio

## Purpose of using this:

This dependency is used in the `rmf_demos_bridges` package: https://github.com/open-rmf/rmf_demos/tree/main/rmf_demos_bridges

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/python3-socketio
- Fedora: https://packages.fedoraproject.org
  - https://packages.fedoraproject.org/pkgs/python-socketio/python3-socketio
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/impish/python3-socketio