### PR TITLE
locator_ros_bridge: 1.0.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4158,7 +4158,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/locator_ros_bridge-release.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `locator_ros_bridge` to `1.0.5-1`:

- upstream repository: https://github.com/boschglobal/locator_ros_bridge.git
- release repository: https://github.com/ros-gbp/locator_ros_bridge-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.4-1`

## bosch_locator_bridge

```
* update to ROKIT Locator version 1.4
* add interface for second laser
* Contributors: Stefan Laible
```
