### PR TITLE
visp: 3.5.0-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -14663,11 +14663,19 @@ repositories:
       version: melodic-devel
     status: maintained
   visp:
+    doc:
+      type: git
+      url: https://github.com/lagadic/visp.git
+      version: master
     release:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lagadic/visp-release.git
-      version: 3.4.0-4
+      version: 3.5.0-3
+    source:
+      type: git
+      url: https://github.com/lagadic/visp.git
+      version: master
     status: maintained
   visp_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `visp` to `3.5.0-3`:

- upstream repository: https://github.com/lagadic/visp.git
- release repository: https://github.com/lagadic/visp-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.4.0-4`
