### PR TITLE
visp: 3.5.0-3 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6248,7 +6248,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/lagadic/visp-release.git
-      version: 3.4.0-2
+      version: 3.5.0-3
     source:
       type: git
       url: https://github.com/lagadic/visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `visp` to `3.5.0-3`:

- upstream repository: https://github.com/lagadic/visp.git
- release repository: https://github.com/lagadic/visp-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.4.0-2`
