### PR TITLE
jackal: 0.8.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3476,7 +3476,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       type: git
       url: https://github.com/jackal/jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.8.2-1`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.8.1-1`

## jackal_control

```
* Updated control.launch to new microstrain envvars and moved definition of ekf-localization paramaters into it
* Added Microstrain GX5 to jackal_control
* Contributors: Luis Camero
```

## jackal_description

```
* Moved microstrain link to accessories.urdf and updated envvars
* Added velodyne tower mesh
* Added Microstrain GX5 to description
* Removed unnecessary URDF
* Added Wibotic mesh and STL
* Contributors: Luis Camero
```

## jackal_msgs

- No changes

## jackal_navigation

- No changes

## jackal_tutorials

- No changes
