### PR TITLE
robot_upstart: 0.4.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7195,7 +7195,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/robot_upstart-release.git
-      version: 0.4.1-1
+      version: 0.4.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/robot_upstart.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_upstart` to `0.4.2-1`:

- upstream repository: https://github.com/clearpathrobotics/robot_upstart.git
- release repository: https://github.com/clearpath-gbp/robot_upstart-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.1-1`

## robot_upstart

```
* Use setpriv instead of setuidgid
  Replicates change from melodic-devel.  Setpriv allows use of group permissions, reducing the need to globally apply r/w permissions to devices.
* empty -> EmPy
* Added License.
* Contributors: Chris I-B, Mikael Arguedas, Tony Baltovski
```
