### PR TITLE
robot_upstart: 1.0.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4172,6 +4172,21 @@ repositories:
       url: https://github.com/ros/robot_state_publisher.git
       version: foxy
     status: maintained
+  robot_upstart:
+    doc:
+      type: git
+      url: git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/clearpath-gbp/robot_upstart-release.git
+      version: 1.0.0-2
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/robot_upstart.git
+      version: foxy-devel
+    status: maintained
   ros1_bridge:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4175,7 +4175,7 @@ repositories:
   robot_upstart:
     doc:
       type: git
-      url: git
+      url: https://github.com/clearpathrobotics/robot_upstart.git
       version: foxy-devel
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_upstart` to `1.0.0-2`:

- upstream repository: https://github.com/clearpathrobotics/robot_upstart.git
- release repository: https://github.com/clearpath-gbp/robot_upstart-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## robot_upstart

```
* Fixed package.xml and setup.py information.
* Removed CMakeLists.txt.
* Removed src folder.
* ros2 foxy
* Contributors: Tony Baltovski, zifengqi123
```
