### PR TITLE
Update ignition keys for Ubuntu Jammy

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1790,6 +1790,7 @@ ignition-cmake2:
   nixos: [ignition.cmake2]
   ubuntu:
     focal: [libignition-cmake2-dev]
+    jammy: [libignition-cmake2-dev]
 ignition-common3:
   debian:
     buster: [libignition-common3-dev]
@@ -1888,12 +1889,14 @@ ignition-math6:
   nixos: [ignition.math6]
   ubuntu:
     focal: [libignition-math6-dev]
+    jammy: [libignition-math6-dev]
 ignition-math6-eigen3:
   debian:
     buster: [libignition-math6-eigen3-dev]
   nixos: [ignition.math6]
   ubuntu:
     focal: [libignition-math6-eigen3-dev]
+    jammy: [libignition-math6-eigen3-dev]
 ignition-msgs5:
   debian:
     buster: [libignition-msgs5-dev]


### PR DESCRIPTION
* Add definitions for ignition-cmake2 on Ubuntu Jammy
* Add definitions for ignition-math6 on Ubuntu Jammy
* Add definitions for ignition-math6-eigen3 on Ubuntu Jammy

All of these packages have been added to the ros_bootstrap repository

```
curl -s http://repos.ros.org/repos/ros_bootstrap/dists/jammy/main/binary-amd64/Packages.bz2 | bzcat | awk -v 'RS=\n\n' -F'(: )|\n' '/ignition/ { print $2}'
libignition-cmake2-dev
libignition-math6
libignition-math6-dbg
libignition-math6-dev
libignition-math6-eigen3-dev
python3-ignition-math6
ruby-ignition-math6
```