### PR TITLE
avt_vimba_camera: 1.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -767,7 +767,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/astuff/avt_vimba_camera-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/astuff/avt_vimba_camera.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -762,7 +762,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/astuff/avt_vimba_camera.git
-      version: master
+      version: ros1_master
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -771,7 +771,7 @@ repositories:
     source:
       type: git
       url: https://github.com/astuff/avt_vimba_camera.git
-      version: master
+      version: ros1_master
     status: maintained
   aws-robomaker-simulation-ros-pkgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `avt_vimba_camera` to `1.1.0-1`:

- upstream repository: https://github.com/astuff/avt_vimba_camera.git
- release repository: https://github.com/astuff/avt_vimba_camera-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.0-1`

## avt_vimba_camera

```
* Add missing default handlers for two switch statement (#78 <https://github.com/astuff/avt_vimba_camera/issues/78>)
* Fix a bug in function getTriggerModeInt() (#77 <https://github.com/astuff/avt_vimba_camera/issues/77>)
* Add missing frame_id to camera_info topic, add missing stamp to image topic (#70 <https://github.com/astuff/avt_vimba_camera/issues/70>)
* Remove sync node tidbit in README (#62 <https://github.com/astuff/avt_vimba_camera/issues/62>)
* Add license file (#66 <https://github.com/astuff/avt_vimba_camera/issues/66>)
* Clarify that this is the ROS1 driver README (#60 <https://github.com/astuff/avt_vimba_camera/issues/60>)
* Remove sync node (#59 <https://github.com/astuff/avt_vimba_camera/issues/59>)
* Added features required to run USB cameras (#54 <https://github.com/astuff/avt_vimba_camera/issues/54>)
* Contributors: Grzegorz Bartyzel, icolwell-as, jilinzhouas
```
