### PR TITLE
avt_vimba_camera: 1.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -342,7 +342,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/astuff/avt_vimba_camera.git
-      version: master
+      version: ros1_master
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -352,7 +352,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/astuff/avt_vimba_camera.git
-      version: master
+      version: ros1_master
     status: maintained
   azure-iot-sdk-c:
     release:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -347,7 +347,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/astuff/avt_vimba_camera-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `avt_vimba_camera` to `1.1.0-1`:

- upstream repository: https://github.com/astuff/avt_vimba_camera.git
- release repository: https://github.com/astuff/avt_vimba_camera-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.0-1`

## avt_vimba_camera

```
* Add missing default handlers for two switch statement (#78 <https://github.com/astuff/avt_vimba_camera/issues/78>)
* Fix a bug in function getTriggerModeInt() (#77 <https://github.com/astuff/avt_vimba_camera/issues/77>)
* Add missing frame_id to camera_info topic, add missing stamp to image topic (#70 <https://github.com/astuff/avt_vimba_camera/issues/70>)
* Remove sync node tidbit in README (#62 <https://github.com/astuff/avt_vimba_camera/issues/62>)
* Add license file (#66 <https://github.com/astuff/avt_vimba_camera/issues/66>)
* Clarify that this is the ROS1 driver README (#60 <https://github.com/astuff/avt_vimba_camera/issues/60>)
* Remove sync node (#59 <https://github.com/astuff/avt_vimba_camera/issues/59>)
* Added features required to run USB cameras (#54 <https://github.com/astuff/avt_vimba_camera/issues/54>)
* Contributors: Grzegorz Bartyzel, icolwell-as, jilinzhouas
```
