### PR TITLE
rviz: 10.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4209,7 +4209,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 9.1.1-3
+      version: 10.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `10.0.0-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `9.1.1-3`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Install headers to include/${PROJECT_NAME} (#829 <https://github.com/ros2/rviz/issues/829>)
* Remove definition of PLUGINLIB_DISABLE_BOOST. (#821 <https://github.com/ros2/rviz/issues/821>)
* Contributors: Chris Lalancette, Shane Loretz
```

## rviz_default_plugins

```
* Install headers to include/${PROJECT_NAME} (#829 <https://github.com/ros2/rviz/issues/829>)
* Remove definition of PLUGINLIB_DISABLE_BOOST. (#821 <https://github.com/ros2/rviz/issues/821>)
* Contributors: Chris Lalancette, Shane Loretz
```

## rviz_ogre_vendor

```
* Fix the build for Ubuntu Jammy arm64. (#828 <https://github.com/ros2/rviz/issues/828>)
* Contributors: Chris Lalancette
```

## rviz_rendering

```
* Install headers to include/${PROJECT_NAME} (#829 <https://github.com/ros2/rviz/issues/829>)
* Contributors: Shane Loretz
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

```
* Install headers to include/${PROJECT_NAME} (#829 <https://github.com/ros2/rviz/issues/829>)
* Contributors: Shane Loretz
```
