### PR TITLE
Add python3-pyftdi-pip package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7475,6 +7475,13 @@ python3-pydot:
     '*': ['python%{python3_pkgversion}-pydot']
     '7': null
   ubuntu: [python3-pydot]
+python3-pyftdi-pip:
+  debian:
+    pip:
+      packages: [pyftdi]
+  ubuntu:
+    pip:
+      packages: [pyftdi]
 python3-pyftpdlib:
   debian: [python3-pyftpdlib]
   gentoo: [dev-python/pyftpdlib]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

pyftdi

## Package Upstream Source:

https://github.com/eblot/pyftdi

## Purpose of using this:

FTDI USB devices using the pyftdi library.

Distro packaging links:

## Links to Distribution Packages

https://pypi.org/project/pyftdi/

Is not packaged on Ubuntu or Debian.