### PR TITLE
cloudwatch_logger: 2.3.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1302,7 +1302,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/cloudwatch_logger-release.git
-      version: 2.3.1-1
+      version: 2.3.2-1
     source:
       type: git
       url: https://github.com/aws-robotics/cloudwatchlogs-ros1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cloudwatch_logger` to `2.3.2-1`:

- upstream repository: https://github.com/jikawa-az/cloudwatchlogs-ros1.git
- release repository: https://github.com/aws-gbp/cloudwatch_logger-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.1-1`
