### PR TITLE
h264_encoder_core: 2.0.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4062,7 +4062,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/h264_encoder_core-release.git
-      version: 2.0.3-1
+      version: 2.0.4-1
     source:
       type: git
       url: https://github.com/aws-robotics/kinesisvideo-encoder-common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `h264_encoder_core` to `2.0.4-1`:

- upstream repository: https://github.com/jikawa-az/kinesisvideo-encoder-common.git
- release repository: https://github.com/aws-gbp/h264_encoder_core-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.3-1`
