### PR TITLE
lex_common: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5851,7 +5851,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/lex_common-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/aws-robotics/lex-common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lex_common` to `1.0.1-1`:

- upstream repository: https://github.com/jikawa-az/lex-common.git
- release repository: https://github.com/aws-gbp/lex_common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.0-1`
