### PR TITLE
lex_node: 2.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5869,7 +5869,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/lex_node-release.git
-      version: 2.0.2-1
+      version: 2.0.3-1
     source:
       type: git
       url: https://github.com/aws-robotics/lex-ros1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lex_node` to `2.0.3-1`:

- upstream repository: https://github.com/jikawa-az/lex-ros1.git
- release repository: https://github.com/aws-gbp/lex_node-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.2-1`
