### PR TITLE
rosbag_uploader: 1.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11189,7 +11189,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/rosbag_uploader-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/aws-robotics/rosbag-uploader-ros1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag_uploader` to `1.0.2-1`:

- upstream repository: https://github.com/jikawa-az/rosbag-uploader-ros1.git
- release repository: https://github.com/aws-gbp/rosbag_uploader-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.1-1`
