### PR TITLE
aws_ros1_common: 2.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -811,7 +811,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/aws_ros1_common-release.git
-      version: 2.0.1-2
+      version: 2.0.3-1
     source:
       type: git
       url: https://github.com/aws-robotics/utils-ros1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aws_ros1_common` to `2.0.3-1`:

- upstream repository: https://github.com/jikawa-az/utils-ros1.git
- release repository: https://github.com/aws-gbp/aws_ros1_common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.1-2`
