### PR TITLE
kinesis_video_streamer: 2.0.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5462,7 +5462,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/kinesis_video_streamer-release.git
-      version: 2.0.3-1
+      version: 2.0.4-1
     source:
       type: git
       url: https://github.com/aws-robotics/kinesisvideo-ros1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinesis_video_streamer` to `2.0.4-1`:

- upstream repository: https://github.com/jikawa-az/kinesisvideo-ros1.git
- release repository: https://github.com/aws-gbp/kinesis_video_streamer-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.3-1`
