### PR TITLE
ign_ros2_control: 0.2.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1234,6 +1234,24 @@ repositories:
       url: https://github.com/ros2-gbp/ifm3d-release.git
       version: 0.18.0-6
     status: developed
+  ign_ros2_control:
+    doc:
+      type: git
+      url: https://github.com/ignitionrobotics/ign_ros2_control.git
+      version: galactic
+    release:
+      packages:
+      - ign_ros2_control
+      - ign_ros2_control_demos
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/ign_ros2_control-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/ignitionrobotics/ign_ros2_control.git
+      version: galactic
+    status: maintained
   ign_rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ign_ros2_control` to `0.2.0-1`:

- upstream repository: https://github.com/ignitionrobotics/ign_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ign_ros2_control

```
* Merge pull request #36 <https://github.com/ignitionrobotics/ign_ros2_control/issues/36> from ignitionrobotics/ahcorde/foxy_to_galactic
  Foxy -> Galactic
* Merge remote-tracking branch 'origin/foxy' into ahcorde/foxy_to_galactic
* Fixed position control (#29 <https://github.com/ignitionrobotics/ign_ros2_control/issues/29>)
* typo fix. (#25 <https://github.com/ignitionrobotics/ign_ros2_control/issues/25>)
* Contributors: Alejandro Hernández Cordero, Tomoya Fujita
```

## ign_ros2_control_demos

```
* Merge pull request #36 <https://github.com/ignitionrobotics/ign_ros2_control/issues/36> from ignitionrobotics/ahcorde/foxy_to_galactic
  Foxy -> Galactic
* Fixed galactic dependency
* Merge remote-tracking branch 'origin/foxy' into ahcorde/foxy_to_galactic
* Contributors: Alejandro Hernández Cordero
```
