### PR TITLE
phidgets_drivers: 1.0.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5872,7 +5872,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `1.0.5-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.4-1`

## libphidget22

- No changes

## phidgets_accelerometer

- No changes

## phidgets_analog_inputs

- No changes

## phidgets_analog_outputs

- No changes

## phidgets_api

```
* spatial: Add attach + detach handlers
* Fix some clang-tidy warnings
* Contributors: Martin Günther
```

## phidgets_digital_inputs

- No changes

## phidgets_digital_outputs

- No changes

## phidgets_drivers

- No changes

## phidgets_gyroscope

- No changes

## phidgets_high_speed_encoder

- No changes

## phidgets_ik

- No changes

## phidgets_magnetometer

- No changes

## phidgets_motors

- No changes

## phidgets_msgs

- No changes

## phidgets_spatial

```
* spatial: Fix behavior after USB reattachment
  The Phidged Spatial never recovered after detaching and reattaching to
  the USB port. This commit fixes that.
  The cause of the failure was the following:
  * After reattachment, the device time stamp restarts from 0. This caused
  our driver to throw the following error messages:
  [ WARN]: Time went backwards [...]! Not publishing message.
  * However, the data interval is also reset to the default of 256 ms. If
  the parameter data_interval_ms is set to something else, this caused the
  arriving data to always be outside the acceptable window for
  synchronization. Therefore, synchronization never happened, and the
  driver never resumed publishing messages.
  This commit fixes the bug by setting the appropriate data interval after
  each reattachment and forcing a resynchronization immediately.
* spatial: Add attach + detach handlers
* spatial: Fix publishing of invalid mag readings
* spatial.launch: Remove use_magnetic_field_msg
* Contributors: Martin Günther
```

## phidgets_temperature

- No changes
