### PR TITLE
phidgets_drivers: 2.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2932,7 +2932,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/phidgets_drivers-release.git
-      version: 2.0.2-1
+      version: 2.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `2.1.1-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros2-gbp/phidgets_drivers-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.2-1`

## libphidget22

```
* Update to libphidget22-1.7.20210816 (#107 <https://github.com/ros-drivers/phidgets_drivers/issues/107>)
  This is required to support new devices such as the MOT0109.
  Fixes #99 <https://github.com/ros-drivers/phidgets_drivers/issues/99>, fixes #105 <https://github.com/ros-drivers/phidgets_drivers/issues/105>.
  This is a forward-port of #106 <https://github.com/ros-drivers/phidgets_drivers/issues/106> to ROS2.
* Make sure libphidget22 library can be found. (#97 <https://github.com/ros-drivers/phidgets_drivers/issues/97>)
  In Foxy and later, we need to provide the .dsv hook so that
  the library can be found.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_accelerometer

- No changes

## phidgets_analog_inputs

- No changes

## phidgets_api

```
* Merge pull request #119 <https://github.com/ros-drivers/phidgets_drivers/issues/119> from mintar/fix-reattachment-foxy
  spatial: Fix behavior after USB reattachment
* spatial: Add attach + detach handlers
* Fix some clang-tidy warnings
* Fix typo in error message (#104 <https://github.com/ros-drivers/phidgets_drivers/issues/104>)
* Contributors: Martin Günther
```

## phidgets_digital_inputs

- No changes

## phidgets_digital_outputs

- No changes

## phidgets_drivers

- No changes

## phidgets_gyroscope

- No changes

## phidgets_high_speed_encoder

- No changes

## phidgets_ik

- No changes

## phidgets_magnetometer

- No changes

## phidgets_motors

- No changes

## phidgets_msgs

- No changes

## phidgets_spatial

```
* Fix behavior after USB reattachment (#119 <https://github.com/ros-drivers/phidgets_drivers/issues/119>)
  The Phidged Spatial never recovered after detaching and reattaching to
  the USB port. This commit fixes that.
* Add attach + detach handlers
* Fix publishing of invalid mag readings (#116 <https://github.com/ros-drivers/phidgets_drivers/issues/116>)
* Contributors: Martin Günther
```

## phidgets_temperature

- No changes
