### PR TITLE
joint_state_publisher: 1.15.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3539,7 +3539,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/joint_state_publisher-release.git
-      version: 1.15.0-1
+      version: 1.15.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joint_state_publisher` to `1.15.1-1`:

- upstream repository: https://github.com/ros/joint_state_publisher.git
- release repository: https://github.com/ros-gbp/joint_state_publisher-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.15.0-1`

## joint_state_publisher

```
* The jsp can now use the zeros parameter when joint names have slashes. (#60 <https://github.com/ros/joint_state_publisher/issues/60>)
* Removed reference to removed use_gui parameter (#69 <https://github.com/ros/joint_state_publisher/issues/69>)
* Use setuptools instead of distutils (#45 <https://github.com/ros/joint_state_publisher/issues/45>)
* Contributors: Lucas Walter, Matthew Elwin, Shane Loretz
```

## joint_state_publisher_gui

```
* Use setuptools instead of distutils (#45 <https://github.com/ros/joint_state_publisher/issues/45>)
* Contributors: Shane Loretz
```
