### PR TITLE
Add a new rosdep key for abseil.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2182,6 +2182,17 @@ lib32asound2:
   fedora: ['alsa-lib(%{__isa_name}-32)', alsa-lib]
   gentoo: [media-libs/alsa-lib]
   ubuntu: [lib32asound2]
+libabsl-dev:
+  arch: [abseil-cpp]
+  debian:
+    '*': [libabsl-dev]
+    buster: null
+  fedora: [abseil-cpp-devel]
+  gentoo: [dev-cpp/abseil-cpp]
+  ubuntu:
+    '*': [libabsl-dev]
+    bionic: null
+    focal: null
 libalglib-dev:
   debian: [libalglib-dev]
   fedora: [alglib-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2189,6 +2189,9 @@ libabsl-dev:
     buster: null
   fedora: [abseil-cpp-devel]
   gentoo: [dev-cpp/abseil-cpp]
+  rhel:
+    '*': [abseil-cpp-devel]
+    '7': null
   ubuntu:
     '*': [libabsl-dev]
     bionic: null


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Please add the following dependency to the rosdep database.

## Package name:

libabsl-dev

## Package Upstream Source:

https://github.com/abseil/abseil-cpp

## Purpose of using this:

abseil is a dependency of newer versions of cartographer that we want to release into Humble.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=libabsl-dev&searchon=names&suite=all&section=all
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/search?keywords=libabsl-dev&searchon=names&suite=all&section=all
- Fedora: https://src.fedoraproject.org/browse/projects/
  - https://pkgs.org/search/?q=abseil
- Arch: https://www.archlinux.org/packages/
  - https://pkgs.org/search/?q=abseil
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-cpp/abseil-cpp