### PR TITLE
zbar_ros: 0.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5134,7 +5134,7 @@ repositories:
   zbar_ros:
     doc:
       type: git
-      url: https://github.com/ros-drivers-gbp/zbar_ros.git
+      url: https://github.com/ros-drivers/zbar_ros.git
       version: ros2
     release:
       tags:
@@ -5143,7 +5143,7 @@ repositories:
       version: 0.4.0-1
     source:
       type: git
-      url: https://github.com/ros-drivers-gbp/zbar_ros.git
+      url: https://github.com/ros-drivers/zbar_ros.git
       version: ros2
     status: maintained
   zenoh_bridge_dds:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5139,7 +5139,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/ros-drivers-gbp/zbar_ros-release.git
+      url: https://github.com/ros2-gbp/zbar_ros-release.git
       version: 0.4.0-1
     source:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5131,6 +5131,21 @@ repositories:
       url: https://github.com/ros2/yaml_cpp_vendor.git
       version: master
     status: maintained
+  zbar_ros:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers-gbp/zbar_ros.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/zbar_ros-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers-gbp/zbar_ros.git
+      version: ros2
+    status: maintained
   zenoh_bridge_dds:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `zbar_ros` to `0.4.0-1`:

- upstream repository: https://github.com/ros-drivers/zbar_ros.git
- release repository: https://github.com/ros-drivers-gbp/zbar_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## zbar_ros

```
* Port to ROS2
* Update package.xml
* Add LICENSE
* Add more information to README
* Contributors: Kenji Brameld, Paul Bovbel, ijnek
```
