### PR TITLE
nao_button_sim: 0.1.1-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1952,6 +1952,21 @@ repositories:
       url: https://github.com/KIT-MRT/mrt_cmake_modules.git
       version: master
     status: maintained
+  nao_button_sim:
+    doc:
+      type: git
+      url: https://github.com/ijnek/nao_button_sim.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/nao_button_sim-release.git
+      version: 0.1.1-3
+    source:
+      type: git
+      url: https://github.com/ijnek/nao_button_sim.git
+      version: rolling
+    status: developed
   nao_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_button_sim` to `0.1.1-3`:

- upstream repository: https://github.com/ijnek/nao_button_sim.git
- release repository: https://github.com/ros2-gbp/nao_button_sim-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## nao_button_sim

```
* Update README.md
* port everything across from naosoccer_sim
* Contributors: Kenji Brameld, ijnek
```
