### PR TITLE
nao_button_sim: 0.1.1-6 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1976,6 +1976,21 @@ repositories:
       url: https://github.com/KIT-MRT/mrt_cmake_modules.git
       version: master
     status: maintained
+  nao_button_sim:
+    doc:
+      type: git
+      url: https://github.com/ijnek/nao_button_sim.git
+      version: rolling
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/nao_button_sim-release.git
+      version: 0.1.1-6
+    source:
+      type: git
+      url: https://github.com/ijnek/nao_button_sim.git
+      version: rolling
+    status: developed
   nao_interfaces:
     doc:
       type: git


### PR DESCRIPTION
**Re-add nao_button_sim package temporarily removed in https://github.com/ros/rosdistro/pull/32057, but under it's own repository rather than under naosoccer_sim.**

Increasing version of package(s) in repository `nao_button_sim` to `0.1.1-6`:

- upstream repository: https://github.com/ijnek/nao_button_sim.git
- release repository: https://github.com/ros2-gbp/nao_button_sim-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## nao_button_sim

```
* Update README.md
* port everything across from naosoccer_sim
* Contributors: Kenji Brameld, ijnek
```
