### PR TITLE
PR test support for robot_localization in rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3241,6 +3241,7 @@ repositories:
       url: https://github.com/ros2-gbp/robot_localization-release.git
       version: 3.3.0-2
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/cra-ros-pkg/robot_localization.git
       version: ros2


### PR DESCRIPTION
We already have it enabled in other branches, so the GH permissions are set up.

https://github.com/ros/rosdistro/blob/45e4538642cca8dd6f172ba891d88b22f6b670e8/foxy/distribution.yaml#L4154
