### PR TITLE
ros2_control: 1.4.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3504,7 +3504,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 1.3.0-1
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `1.4.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.3.0-1`

## controller_interface

- No changes

## controller_manager

```
* added a fixed control period to loop (#647 <https://github.com/ros-controls/ros2_control/issues/647>) (#650 <https://github.com/ros-controls/ros2_control/issues/650>)
* Contributors: Jack Center
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Extend FakeHardware to support <gpio>-tag (#574 <https://github.com/ros-controls/ros2_control/issues/574>) (#634 <https://github.com/ros-controls/ros2_control/issues/634>)
* Contributors: Subhas Das
```

## ros2_control

```
* Use correct ros-controls/realtime_tools branch (#619 <https://github.com/ros-controls/ros2_control/issues/619>) (#621 <https://github.com/ros-controls/ros2_control/issues/621>)
* No need to get angles from source anymore, causes issues now (backport #616 <https://github.com/ros-controls/ros2_control/issues/616>) (#617 <https://github.com/ros-controls/ros2_control/issues/617>)
* Point ros-controls/ros2_control to galactic (#602 <https://github.com/ros-controls/ros2_control/issues/602>)
* fix typo in .repos control_msgs version (#601 <https://github.com/ros-controls/ros2_control/issues/601>)
* Contributors: Bence Magyar, Melvin Wang
```

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## transmission_interface

- No changes
