### PR TITLE
ros2_control: 2.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3312,7 +3312,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.1.0-3
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.3.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.0-3`

## controller_interface

- No changes

## controller_manager

```
* added a fixed control period to loop (#647 <https://github.com/ros-controls/ros2_control/issues/647>)
* install spawner/unspawner using console_script entrypoint (#607 <https://github.com/ros-controls/ros2_control/issues/607>)
* Add BEST_EFFORT in the controller switch tests. (#582 <https://github.com/ros-controls/ros2_control/issues/582>)
* Resolve unused parameter warnings (#636 <https://github.com/ros-controls/ros2_control/issues/636>)
* Contributors: Bence Magyar, Denis Štogl, Jack Center, Melvin Wang, Xi-Huang
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Add a warning if an initial_value is not found for any interface (#623 <https://github.com/ros-controls/ros2_control/issues/623>)
* Contributors: AndyZe
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## transmission_interface

```
* Port transmission loader plugins from ROS1 (#633 <https://github.com/ros-controls/ros2_control/issues/633>)
* Contributors: Márk Szitanics, Bence Magyar
```
