### PR TITLE
ros_emacs_utils: 0.4.17-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7486,7 +7486,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/code-iai-release/ros_emacs_utils-release.git
-      version: 0.4.15-1
+      version: 0.4.17-1
     source:
       type: git
       url: https://github.com/code-iai/ros_emacs_utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_emacs_utils` to `0.4.17-1`:

- upstream repository: https://github.com/code-iai/ros_emacs_utils.git
- release repository: https://github.com/code-iai-release/ros_emacs_utils-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.15-1`
