### PR TITLE
locator_ros_bridge: 2.0.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1999,7 +1999,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/locator_ros_bridge-release.git
-      version: 2.0.5-1
+      version: 2.0.6-1
     source:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `locator_ros_bridge` to `2.0.6-1`:

- upstream repository: https://github.com/boschglobal/locator_ros_bridge.git
- release repository: https://github.com/ros2-gbp/locator_ros_bridge-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.5-1`

## bosch_locator_bridge

```
* Remove ``required`` attribute from launch files
* Contributors: Stefan Laible
```
