### PR TITLE
Revert "rc_visard: 3.3.0-1 in 'melodic/distribution.yaml' [bloom] (#3…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10051,6 +10051,7 @@ repositories:
       packages:
       - rc_hand_eye_calibration_client
       - rc_pick_client
+      - rc_roi_manager_gui
       - rc_silhouettematch_client
       - rc_tagdetect_client
       - rc_visard
@@ -10059,7 +10060,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_visard-release.git
-      version: 3.3.0-1
+      version: 3.2.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
…2102)"

This reverts commit a81d8ee55ab61071e333d29ff661073d0593ff5b.

This hasn't built since it was merged in: https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__rc_pick_client__ubuntu_bionic_amd64__binary/.  @flixr FYI.