### PR TITLE
Revert "sbg_driver: 3.1.0-1 in 'melodic/distribution.yaml' [bloom] (#…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12624,7 +12624,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/SBG-Systems/sbg_ros_driver-release.git
-      version: 3.1.0-1
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/SBG-Systems/sbg_ros_driver.git


### PR DESCRIPTION
…30936)"

This reverts commit 402cfaaaa694ee39698105eab9e38b27be9d4b73.

This hasn't built since it was merged in: https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__sbg_driver__ubuntu_bionic_amd64__binary/177/console .  @mzembsbg FYI.