### PR TITLE
Remove pyros_utils from the distribution.

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9519,21 +9519,6 @@ repositories:
       url: https://github.com/asmodehn/pyros-test.git
       version: devel
     status: maintained
-  pyros_utils:
-    doc:
-      type: git
-      url: https://github.com/asmodehn/pyros-utils.git
-      version: devel
-    release:
-      tags:
-        release: release/melodic/{package}/{version}
-      url: https://github.com/pyros-dev/pyros-utils-release.git
-      version: 0.1.4-1
-    source:
-      type: git
-      url: https://github.com/asmodehn/pyros-utils.git
-      version: devel
-    status: maintained
   python_qt_binding:
     doc:
       type: git


### PR DESCRIPTION
It is failing to build because upstream pip dependencies are
expecting a Python 3 version.  This may be fixable with pinning
some versions, but as this is a leaf package, it may just be
easier to remove it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

@asmodehn FYI.  If you'd like to keep this in Melodic, please feel free to fix whatever needs to be fixed in the upstream pyros_utils and do another release.  If I don't otherwise hear from you by the end of next week, I'll go ahead and remove it from Melodic.