### PR TITLE
Revert "euslisp: 9.29.0-1 in 'melodic/distribution.yaml' [bloom] (#32…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2941,7 +2941,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/euslisp-release.git
-      version: 9.29.0-1
+      version: 9.27.0-1
     source:
       type: git
       url: https://github.com/euslisp/EusLisp.git


### PR DESCRIPTION
…111)"

This reverts commit 9232d2ee692901903f44ddeea7a12ccf2b96501f.

It hasn't built since it was merged in: https://build.ros.org/job/Mbin_ubhf_uBhf__euslisp__ubuntu_bionic_armhf__binary/ .  @k-okada FYI.