### PR TITLE
Skip releasing ros1_bridge.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3318,7 +3318,6 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros1_bridge-release.git
-      version: 0.10.2-2
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
The ros1_bridge relies on ROS Noetic packages which are not available in Ubuntu Jammy.