### PR TITLE
rosidl_typesupport: 1.4.2-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3780,7 +3780,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-      version: 1.4.2-2
+      version: 1.4.2-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport` to `1.4.2-3`:

- upstream repository: https://github.com/ros2/rosidl_typesupport.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.4.2-2`

## rosidl_typesupport_c

```
* Use FindPython3 (#118 <https://github.com/ros2/rosidl_typesupport/issues/118>)
* Contributors: Shane Loretz
```

## rosidl_typesupport_cpp

```
* Make sure to check typesupport handles against nullptr properly (#119 <https://github.com/ros2/rosidl_typesupport/issues/119>)
* Use FindPython3 (#118 <https://github.com/ros2/rosidl_typesupport/issues/118>)
* Contributors: Chris Lalancette, Shane Loretz
```
