### PR TITLE
image_transport_plugins: 2.3.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1316,7 +1316,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 2.3.1-2
+      version: 2.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `2.3.2-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.1-2`

## compressed_depth_image_transport

```
* Fix copyright year 20012 -> 2012 (#79 <https://github.com/ros-perception/image_transport_plugins/issues/79>)
* JPEG only supports 8 bits images (#73 <https://github.com/ros-perception/image_transport_plugins/issues/73>)
* Contributors: Ivan Santiago Paunovic, Michael Carroll
```

## compressed_image_transport

```
* Add tiff compression support. (#75 <https://github.com/ros-perception/image_transport_plugins/issues/75>)
* Fix copyright year 20012 -> 2012 (#79 <https://github.com/ros-perception/image_transport_plugins/issues/79>)
* JPEG only supports 8 bits images (#73 <https://github.com/ros-perception/image_transport_plugins/issues/73>)
* Contributors: Ivan Santiago Paunovic, Michael Carroll
```

## image_transport_plugins

- No changes

## theora_image_transport

```
* Fix copyright year 20012 -> 2012 (#79 <https://github.com/ros-perception/image_transport_plugins/issues/79>)
* mac fix (#76 <https://github.com/ros-perception/image_transport_plugins/issues/76>)
* JPEG only supports 8 bits images (#73 <https://github.com/ros-perception/image_transport_plugins/issues/73>)
* Contributors: Ivan Santiago Paunovic, Michael Carroll, Steve Nogar
```
