### PR TITLE
rc_visard packages are in maintenance mode

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10010,7 +10010,7 @@ repositories:
       type: git
       url: https://github.com/roboception/rc_visard_ros.git
       version: master
-    status: developed
+    status: maintained
   rcdiscover:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6610,7 +6610,7 @@ repositories:
       type: git
       url: https://github.com/roboception/rc_visard_ros.git
       version: master
-    status: developed
+    status: maintained
   rcdiscover:
     doc:
       type: git


### PR DESCRIPTION
The rc_visard packages are still maintained but not actively developed anymore and will only receive critical bugfixes, so set the status accordingly.

As listed on the wiki, these packages have been superseeded by rc_genicam_driver and rc_reason_clients.