### PR TITLE
rc_visard: 3.3.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6835,7 +6835,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_visard-release.git
-      version: 3.3.0-1
+      version: 3.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_visard` to `3.3.2-1`:

- upstream repository: https://github.com/roboception/rc_visard_ros.git
- release repository: https://github.com/roboception-gbp/rc_visard-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.3.0-1`

## rc_hand_eye_calibration_client

- No changes

## rc_pick_client

```
* actually remove dependency on shape_msgs
```

## rc_silhouettematch_client

- No changes

## rc_tagdetect_client

- No changes

## rc_visard

- No changes

## rc_visard_description

- No changes

## rc_visard_driver

```
* require at least rc_visard firmware version 22.04
```
