### PR TITLE
dynamic_reconfigure: 1.6.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2567,7 +2567,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-      version: 1.6.3-1
+      version: 1.6.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.6.4-1`:

- upstream repository: https://github.com/ros/dynamic_reconfigure.git
- release repository: https://github.com/ros-gbp/dynamic_reconfigure-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.6.3-1`

## dynamic_reconfigure

```
* fix: Race condition on quickly setting and getting config (#188 <https://github.com/ros/dynamic_reconfigure/issues/188>) (#190 <https://github.com/ros/dynamic_reconfigure/issues/190>)
* Contributors: Rokus Ottervanger
```
