### PR TITLE
dynamic_reconfigure: 1.7.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1736,7 +1736,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-      version: 1.7.1-1
+      version: 1.7.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.7.2-1`:

- upstream repository: https://github.com/ros/dynamic_reconfigure.git
- release repository: https://github.com/ros-gbp/dynamic_reconfigure-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.7.1-1`

## dynamic_reconfigure

```
* Remove calls to string.{join,lower,upper} (#174 <https://github.com/ros/dynamic_reconfigure/issues/174>)
* fix: Race condition on quickly setting and getting config (#188 <https://github.com/ros/dynamic_reconfigure/issues/188>)
* do not use system for generated messages or configs (#182 <https://github.com/ros/dynamic_reconfigure/issues/182>)
* Contributors: Gaël Écorchard, Rokus Ottervanger, Shingo Kitagawa
```
