### PR TITLE
vision_visp: 0.13.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10083,7 +10083,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/lagadic/vision_visp-release.git
-      version: 0.13.0-1
+      version: 0.13.1-1
     source:
       type: git
       url: https://github.com/lagadic/vision_visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_visp` to `0.13.1-1`:

- upstream repository: https://github.com/lagadic/vision_visp.git
- release repository: https://github.com/lagadic/vision_visp-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.13.0-1`

## vision_visp

- No changes

## visp_auto_tracker

- No changes

## visp_bridge

- No changes

## visp_camera_calibration

- No changes

## visp_hand2eye_calibration

- No changes

## visp_tracker

- No changes
