### PR TITLE
Add gnome-terminal to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1383,6 +1383,16 @@ gnat:
   debian: [gnat]
   nixos: [gnat]
   ubuntu: [gnat]
+gnome-terminal:
+  alpine: [gnome-terminal]
+  arch: [gnome-terminal]
+  debian: [gnome-terminal]
+  fedora: [gnome-terminal]
+  freebsd: [gnome-terminal]
+  gentoo: [x11-terms/gnome-terminal]
+  nixos: [gnome.gnome-terminal]
+  opensuse: [gnome-terminal]
+  ubuntu: [gnome-terminal]
 gnuplot:
   arch: [gnuplot]
   debian: [gnuplot]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1392,6 +1392,7 @@ gnome-terminal:
   gentoo: [x11-terms/gnome-terminal]
   nixos: [gnome.gnome-terminal]
   opensuse: [gnome-terminal]
+  rhel: [gnome-terminal]
   ubuntu: [gnome-terminal]
 gnuplot:
   arch: [gnuplot]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

gnome-terminal

## Package Upstream Source:

https://gitlab.gnome.org/GNOME/gnome-terminal

## Purpose of using this:

Terminal emulator from the GNOME project. This is useful to launch a rosnode with another terminal.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/gnome-terminal
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/impish/gnome-terminal
- Fedora: https://src.fedoraproject.org/browse/projects/
  - https://src.fedoraproject.org/rpms/gnome-terminal
- Alpine Lnux: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/community/x86_64/gnome-terminal
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/gnome-terminal/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/x11-terms/gnome-terminal
- FreeBSD: https://freshports.org/
  -  https://www.freshports.org/x11/gnome-terminal/
- OpenSUSE: https://software.opensuse.org/
  - https://software.opensuse.org/package/gnome-terminal
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=21.11&show=gnome.gnome-terminal&from=0&size=50&sort=relevance&type=packages&query=gnome-terminal


<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

