### PR TITLE
ros_inorbit_samples: 0.2.4-1 in 'noetic/distribution.yaml'

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7551,7 +7551,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/inorbit-ai/ros_inorbit_samples-release.git
-      version: 0.2.2-1
+      version: 0.2.4-1
     source:
       type: git
       url: https://github.com/inorbit-ai/ros_inorbit_samples.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_inorbit_samples` to `0.2.4-1`:

- upstream repository: https://github.com/inorbit-ai/ros_inorbit_samples.git
- release repository: https://github.com/inorbit-ai/ros_inorbit_samples-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.2-1`

## inorbit_republisher

```
0.2.4 (2022-02-21)
-----------
* Add conditionals in package.xml dependencies
* Contributors: FlorGrosso

0.2.3 (2022-02-21)
-----------
* Allow filtering single_value mappings
* Allow publishing package versions, environment variables or fixed strings
* Allow using config_file parameter instead of config
* Contributors: adamantivm
```