### PR TITLE
Skip releasing rosbag2_bag_v2 on Rolling.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3638,7 +3638,6 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2_bag_v2-release.git
-      version: 0.2.0-2
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
This package cannot build without a ROS 1 workspace and the ROS 1
bridge.

See https://github.com/ros2/rosbag2_bag_v2/issues/46 for details.
