### PR TITLE
librealsense2: 2.50.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1953,7 +1953,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/IntelRealSense/librealsense2-release.git
-      version: 2.50.0-1
+      version: 2.50.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense2` to `2.50.0-2`:

- upstream repository: https://github.com/IntelRealSense/librealsense.git
- release repository: https://github.com/IntelRealSense/librealsense2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.50.0-1`
