### PR TITLE
realsense2_camera: 4.0.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3012,7 +3012,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/IntelRealSense/realsense-ros.git
-      version: ros2
+      version: ros2-beta
     release:
       packages:
       - realsense2_camera
@@ -3026,7 +3026,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/IntelRealSense/realsense-ros.git
-      version: ros2
+      version: ros2-beta
     status: developed
   realtime_support:
     doc:

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3021,7 +3021,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
-      version: 3.2.3-1
+      version: 4.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `4.0.2-1`:

- upstream repository: https://github.com/IntelRealSense/realsense-ros.git
- release repository: https://github.com/IntelRealSense/realsense-ros-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.2.3-1`

## realsense2_camera

```
* Add frequency monitoring to /diagnostics topic.
* Fix topic_hz.py to recognize message type from topic name. (Naive)
* move diagnostic updater for stream frequencies into the RosSensor class.
* Add frequency monitoring to /diagnostics topic.
* fix galactic issue with undeclaring parameters
* Fix to support Rolling.
* Fix dynamic_params syntax.
* Fix issue with Galactic parameters set by default to static which prevents them from being undeclared.
* Fix clang compile errors
* Contributors: Haowei Wen, doronhi, remibettan
```

## realsense2_camera_msgs

- No changes

## realsense2_description

- No changes
