### PR TITLE
Add python3-moderngl-pip, python3-scipy-pip, python3-objloader-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8768,6 +8768,10 @@ rpy2:
   gentoo: [=dev-python/rpy-2*]
   opensuse: [python3-rpy2]
   ubuntu: [python-rpy2]
+scipy-pip:
+  ubuntu:
+    pip:
+      packages: [scipy]
 sphinxcontrib-bibtex-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8011,6 +8011,10 @@ python3-scipy:
       depends: [gfortran]
       packages: [scipy]
   ubuntu: [python3-scipy]
+python3-scipy-pip:
+  ubuntu:
+    pip:
+      packages: [scipy]
 python3-scp:
   debian: [python3-scp]
   fedora: [python3-scp]
@@ -8768,10 +8772,6 @@ rpy2:
   gentoo: [=dev-python/rpy-2*]
   opensuse: [python3-rpy2]
   ubuntu: [python-rpy2]
-scipy-pip:
-  ubuntu:
-    pip:
-      packages: [scipy]
 sphinxcontrib-bibtex-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -284,6 +284,10 @@ opcua-pip:
   ubuntu:
     pip:
       packages: [opcua]
+objloader-pip:
+  ubuntu:
+    pip:
+      packages: [objloader]
 paramiko:
   alpine: [py-paramiko]
   arch: [python2-paramiko]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8875,3 +8875,7 @@ yapf3:
   ubuntu:
     '*': [yapf3]
     xenial: null
+python-moderngl:
+  ubuntu:
+    pip:
+      packages: [moderngl]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -273,6 +273,10 @@ meson:
   opensuse: [meson]
   rhel: [meson]
   ubuntu: [meson]
+moderngl-pip:
+  ubuntu:
+    pip:
+      packages: [moderngl]
 nuitka:
   debian: [nuitka]
   ubuntu: [nuitka]
@@ -8875,7 +8879,3 @@ yapf3:
   ubuntu:
     '*': [yapf3]
     xenial: null
-moderngl-pip:
-  ubuntu:
-    pip:
-      packages: [moderngl]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8875,7 +8875,7 @@ yapf3:
   ubuntu:
     '*': [yapf3]
     xenial: null
-python-moderngl:
+moderngl-pip:
   ubuntu:
     pip:
       packages: [moderngl]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -273,10 +273,6 @@ meson:
   opensuse: [meson]
   rhel: [meson]
   ubuntu: [meson]
-moderngl-pip:
-  ubuntu:
-    pip:
-      packages: [moderngl]
 nuitka:
   debian: [nuitka]
   ubuntu: [nuitka]
@@ -7017,6 +7013,10 @@ python3-mock:
   opensuse: [python3-mock]
   rhel: ['python%{python3_pkgversion}-mock']
   ubuntu: [python3-mock]
+python3-moderngl-pip:
+  ubuntu:
+    pip:
+      packages: [moderngl]
 python3-more-itertools:
   arch: [python-more-itertools]
   debian: [python3-more-itertools]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -284,10 +284,6 @@ opcua-pip:
   ubuntu:
     pip:
       packages: [opcua]
-objloader-pip:
-  ubuntu:
-    pip:
-      packages: [objloader]
 paramiko:
   alpine: [py-paramiko]
   arch: [python2-paramiko]
@@ -7145,6 +7141,10 @@ python3-nuscenes-devkit-pip:
   ubuntu:
     pip:
       packages: [nuscenes-devkit]
+python3-objloader-pip:
+  ubuntu:
+    pip:
+      packages: [objloader]
 python3-open3d-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

-python3-moderngl-pip
-python3-scipy-pip
-python3-objloader-pip

## Package Upstream Source:

https://github.com/moderngl/moderngl
https://github.com/scipy/scipy
https://github.com/szabolcsdombi/objloader

## Purpose of using this:

python3-moderngl-pip - moderngl is a very helpful python wrapper for opengl that simplifies handling of vertex buffer and array binding.

python3-scipy-pip - the scipy version in apt package manager is outdated.  The newer version in pip was required for my project

python3-objloader-pip - this python package handles loading of .obj files, useful for building 3D applications in opengl, etc.
