### PR TITLE
Revert "realsense2_camera: 4.0.2-1 in 'galactic/distribution.yaml' [bloom]"

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3045,7 +3045,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/IntelRealSense/realsense-ros.git
-      version: ros2-beta
+      version: ros2
     release:
       packages:
       - realsense2_camera
@@ -3054,12 +3054,12 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
-      version: 4.0.2-1
+      version: 3.2.3-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/IntelRealSense/realsense-ros.git
-      version: ros2-beta
+      version: ros2
     status: developed
   realtime_support:
     doc:


### PR DESCRIPTION
This reverts #32266.

Something went wrong in the release process and the buildfarm can't build a source deb for this package. See [the jobs](https://build.ros2.org/job/Gsrc_uF__realsense2_camera__ubuntu_focal__source/37/) for details.