### PR TITLE
Add python3-numba

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7106,7 +7106,7 @@ python3-nose-yanc:
   ubuntu: [python3-nose-yanc]
 python3-numba:
   debian: [python3-numba]
-  ubuntu: 
+  ubuntu:
     bionic: [python3-numba]
     focal: [python3-numba]
 python3-numpy:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7104,6 +7104,9 @@ python3-nose-yanc:
   debian: [python3-nose-yanc]
   openembedded: [python3-nose-yanc@meta-ros-common]
   ubuntu: [python3-nose-yanc]
+python3-numba:
+  debian: [python3-numba]
+  ubuntu: [python3-numba]
 python3-numpy:
   alpine: [py3-numpy]
   debian: [python3-numpy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7106,7 +7106,9 @@ python3-nose-yanc:
   ubuntu: [python3-nose-yanc]
 python3-numba:
   debian: [python3-numba]
-  ubuntu: [python3-numba]
+  ubuntu: 
+    bionic: [python3-numba]
+    focal: [python3-numba]
 python3-numpy:
   alpine: [py3-numpy]
   debian: [python3-numpy]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

Python3 numba package.

## Package Upstream Source:

https://github.com/numba/numba

## Purpose of using this:

Numba provides high-performance numerics by generating machine code from python syntax.

## Distro packaging links:

- Debian: https://packages.debian.org/
  - https://packages.debian.org/sid/python3-numba
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/focal/python3-numba