### PR TITLE
ros2_control: 0.10.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4234,7 +4234,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 0.9.0-1
+      version: 0.10.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `0.10.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.9.0-1`

## controller_interface

- No changes

## controller_manager

```
* added a fixed control period to loop (backport #647 <https://github.com/ros-controls/ros2_control/issues/647>) (#651 <https://github.com/ros-controls/ros2_control/issues/651>)
* Contributors: Jack Center, Denis Štogl
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## ros2_control

```
* Use correct ros-controls/realtime_tools branch (#619 <https://github.com/ros-controls/ros2_control/issues/619>) (#620 <https://github.com/ros-controls/ros2_control/issues/620>)
* No need to get angles from source anymore, causes issues now (backport #616 <https://github.com/ros-controls/ros2_control/issues/616>) (#618 <https://github.com/ros-controls/ros2_control/issues/618>)
* Point ros2_control and ros2_controllers to foxy (#603 <https://github.com/ros-controls/ros2_control/issues/603>)
* Contributors: Melvin Wang
```

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## transmission_interface

- No changes
