### PR TITLE
ros2_control: 2.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3342,7 +3342,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.3.0-1
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.4.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.0-1`

## controller_interface

- No changes

## controller_manager

```
* Fixes of issue with seg-fault when checking interfaces on unconfigured controllers. (#580 <https://github.com/ros-controls/ros2_control/issues/580>)
* Update CM service QoS so that we don't lose service calls when using many controllers. (#643 <https://github.com/ros-controls/ros2_control/issues/643>)
* Contributors: Denis Štogl, Bence Magyar
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Fix transmission loader tests (#642 <https://github.com/ros-controls/ros2_control/issues/642>)
* Contributors: Bence Magyar, Denis Štogl
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## transmission_interface

```
* Fix transmission loader tests (#642 <https://github.com/ros-controls/ros2_control/issues/642>)
* Contributors: Bence Magyar, Denis Štogl
```
