### PR TITLE
ros2_controllers: 1.4.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3560,11 +3560,12 @@ repositories:
       - joint_trajectory_controller
       - position_controllers
       - ros2_controllers
+      - ros2_controllers_test_nodes
       - velocity_controllers
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 1.3.0-2
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `1.4.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.3.0-2`

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

- No changes

## position_controllers

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

```
* Move test nodes from the ros2_control_demos repository. (#294 <https://github.com/ros-controls/ros2_controllers/issues/294>) (#298 <https://github.com/ros-controls/ros2_controllers/issues/298>)
* Contributors: Denis Štogl, Lovro Ivanov
```

## velocity_controllers

- No changes
