### PR TITLE
Switch to the 'foxy' branch for Foxy and Galactic.

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -476,7 +476,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/cartographer.git
-      version: ros2
+      version: foxy
     release:
       tags:
         release: release/foxy/{package}/{version}
@@ -486,7 +486,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/cartographer.git
-      version: ros2
+      version: foxy
     status: maintained
   cartographer_ros:
     doc:

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -432,7 +432,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/cartographer.git
-      version: ros2
+      version: foxy
     release:
       tags:
         release: release/galactic/{package}/{version}
@@ -442,7 +442,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/cartographer.git
-      version: ros2
+      version: foxy
     status: maintained
   cartographer_ros:
     doc:


### PR DESCRIPTION
This is so we can use the 'ros2' branch for Rolling and
newer releases of cartographer.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>