### PR TITLE
Add 'zbar' rule for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8000,6 +8000,7 @@ zbar:
   gentoo: [media-gfx/zbar]
   nixos: [zbar]
   openembedded: [zbar@meta-oe]
+  rhel: [zbar-devel]
   ubuntu: [libzbar-dev]
 zenity:
   arch: [zenity]


### PR DESCRIPTION
This package is available in EPEL 7 and 8: https://src.fedoraproject.org/rpms/zbar#bodhi_updates