### PR TITLE
dbw_ros: 2.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -751,6 +751,43 @@ repositories:
       url: https://bitbucket.org/dataspeedinc/dataspeed_can.git
       version: ros2
     status: developed
+  dbw_ros:
+    doc:
+      type: git
+      url: https://bitbucket.org/dataspeedinc/dbw_ros.git
+      version: ros2
+    release:
+      packages:
+      - dataspeed_dbw_common
+      - dataspeed_dbw_gateway
+      - dataspeed_dbw_msgs
+      - dataspeed_ulc
+      - dataspeed_ulc_can
+      - dataspeed_ulc_msgs
+      - dbw_fca
+      - dbw_fca_can
+      - dbw_fca_description
+      - dbw_fca_joystick_demo
+      - dbw_fca_msgs
+      - dbw_ford
+      - dbw_ford_can
+      - dbw_ford_description
+      - dbw_ford_joystick_demo
+      - dbw_ford_msgs
+      - dbw_polaris
+      - dbw_polaris_can
+      - dbw_polaris_description
+      - dbw_polaris_joystick_demo
+      - dbw_polaris_msgs
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/DataspeedInc-release/dbw_ros-release.git
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://bitbucket.org/dataspeedinc/dbw_ros.git
+      version: ros2
+    status: developed
   demos:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_ros` to `2.0.1-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/dbw_ros.git
- release repository: https://github.com/DataspeedInc-release/dbw_ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## dataspeed_dbw_common

```
* Add Ford GE1 platform (Ford Mustang Mach-E)
* Change parameters to work in Foxy and Galactic
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```

## dataspeed_dbw_gateway

- No changes

## dataspeed_dbw_msgs

- No changes

## dataspeed_ulc

- No changes

## dataspeed_ulc_can

```
* Change parameters to work in Foxy and Galactic
* Export include directories from DBW CAN interface packages
* Contributors: Micho Radovnikovich
```

## dataspeed_ulc_msgs

- No changes

## dbw_fca

- No changes

## dbw_fca_can

```
* Change parameters to work in Foxy and Galactic
* Export include directories from DBW CAN interface packages
* Contributors: Micho Radovnikovich
```

## dbw_fca_description

```
* Change parameters to work in Foxy and Galactic
* Contributors: Micho Radovnikovich
```

## dbw_fca_joystick_demo

```
* Change parameters to work in Foxy and Galactic
* Contributors: Micho Radovnikovich
```

## dbw_fca_msgs

- No changes

## dbw_ford

- No changes

## dbw_ford_can

```
* Add Ford GE1 platform (Ford Mustang Mach-E)
* Add electric parking brake control
* Change parameters to work in Foxy and Galactic
* Export include directories from DBW CAN interface packages
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```

## dbw_ford_description

```
* Change parameters to work in Foxy and Galactic
* Contributors: Micho Radovnikovich
```

## dbw_ford_joystick_demo

```
* Change parameters to work in Foxy and Galactic
* Contributors: Micho Radovnikovich
```

## dbw_ford_msgs

```
* Add electric parking brake control
* Contributors: Kevin Hallenbeck
```

## dbw_polaris

- No changes

## dbw_polaris_can

```
* Change parameters to work in Foxy and Galactic
* Export include directories from DBW CAN interface packages
* Contributors: Micho Radovnikovich
```

## dbw_polaris_description

```
* Change parameters to work in Foxy and Galactic
* Contributors: Micho Radovnikovich
```

## dbw_polaris_joystick_demo

```
* Change parameters to work in Foxy and Galactic
* Contributors: Micho Radovnikovich
```

## dbw_polaris_msgs

- No changes
