### PR TITLE
rqt uses ros2 branch on Rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3854,7 +3854,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt.git
-      version: crystal-devel
+      version: ros2
     release:
       packages:
       - rqt
@@ -3870,7 +3870,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt.git
-      version: crystal-devel
+      version: ros2
     status: maintained
   rqt_action:
     doc:


### PR DESCRIPTION
https://github.com/ros-visualization/rqt/pull/258#issuecomment-1048962470

Release track was updated in https://github.com/ros2-gbp/rqt-release/commit/070a43783f47752c9dc026e4f33f9a281862c878

@mjeronimo FYI