### PR TITLE
gazebo_ros2_control: 0.0.8-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -931,6 +931,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
+      version: 0.0.8-2
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros2_control` to `0.0.8-2`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros2_control.git
- release repository: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## gazebo_ros2_control

```
* Enable setting default position of the simulated robot using ros2_control URDF tag. (#100 <https://github.com/ros-simulation/gazebo_ros2_control//issues/100>)
* Contributors: Denis Štogl
```

## gazebo_ros2_control_demos

```
* Enable setting default position of the simulated robot using ros2_control URDF tag. (#100 <https://github.com/ros-simulation/gazebo_ros2_control//issues/100>)
* Contributors: Denis Štogl
```
