### PR TITLE
fmilibrary_vendor: 1.0.1-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -893,6 +893,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fmilibrary_vendor-release.git
+      version: 1.0.1-2
     source:
       type: git
       url: https://github.com/boschresearch/fmilibrary_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fmilibrary_vendor` to `1.0.1-2`:

- upstream repository: https://github.com/boschresearch/fmilibrary_vendor.git
- release repository: https://github.com/ros2-gbp/fmilibrary_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## fmilibrary_vendor

```
* Suppressing update step so that CMake doesn't attempt to re-build the
  external project during the installation phase.
* Contributors: Scott K Logan
```
