### PR TITLE
usb_cam: 0.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4955,7 +4955,8 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/ros-gbp/usb_cam-release.git
+      url: https://github.com/ros2-gbp/usb_cam-release.git
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/ros-drivers/usb_cam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `usb_cam` to `0.4.1-1`:

- upstream repository: https://github.com/ros-drivers/usb_cam.git
- release repository: https://github.com/ros2-gbp/usb_cam-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## usb_cam

```
* update README, add compression section
* update package.xml to include image_transport_plugins
* clean up README instructions
* update README ros2 run executable name
* Contributors: Evan Flynn
```
