### PR TITLE
axis_camera: 0.3.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -354,6 +354,21 @@ repositories:
       url: https://github.com/astuff/avt_vimba_camera.git
       version: ros1_master
     status: maintained
+  axis_camera:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/axis_camera.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/axis_camera-release.git
+      version: 0.3.2-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/axis_camera.git
+      version: master
+    status: maintained
   azure-iot-sdk-c:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `axis_camera` to `0.3.2-1`:

- upstream repository: https://github.com/ros-drivers/axis_camera.git
- release repository: https://github.com/ros-drivers-gbp/axis_camera-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## axis_camera

```
* Improve support for the F34 and F44 multi-camera controllers by adding default values for the camera index (1-4). Change the camera arg in view_axis to camera_name, change its default IP address to better-match with the main axis.launch file
* Contributors: Chris Iverach-Brereton
```
