### PR TITLE
libhri: 0.4.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5933,6 +5933,23 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/libg2o-release.git
       version: 2018.3.25-0
+  libhri:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/libhri.git
+      version: main
+    release:
+      packages:
+      - hri
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros4hri/libhri-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/ros4hri/libhri.git
+      version: main
+    status: maintained
   libnabo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libhri` to `0.4.0-1`:

- upstream repository: https://github.com/ros4hri/libhri.git
- release repository: https://github.com/ros4hri/libhri-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## hri

```
* Facial Landmarks implementation
  Implementation of methods and structures required to access the
  facial landmarks
  Face Landmarks object size correction
* add tests for the person.face_id attribute
* actually subscribe to the person's face/body/voice id updates
* Contributors: Séverin Lemaignan, lorenzoferrini
```
