### PR TITLE
rqt_image_overlay: 0.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3969,7 +3969,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_overlay-release.git
-      version: 0.0.2-2
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/ros-sports/rqt_image_overlay.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_image_overlay` to `0.0.3-1`:

- upstream repository: https://github.com/ros-sports/rqt_image_overlay.git
- release repository: https://github.com/ros2-gbp/rqt_image_overlay-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.2-2`

## rqt_image_overlay

```
* Replace #!/usr/bin/env python with #!/usr/bin/env python3
* Delete the subscription if there are no publishers on the subscribed topic when refreshed
* Handle fake transports that end with a transport ending, but aren't actually image topics
* Handle multiple image transports
* Convert type used to store image topic from std::string to rqt_image_overlay::ImageTopic
* Use sensor qos for image subscription
* Contributors: Kenji Brameld, Scott K Logan, wep21
```

## rqt_image_overlay_layer

- No changes
