### PR TITLE
gscam: 2.0.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1176,7 +1176,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/gscam-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ros-drivers/gscam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gscam` to `2.0.1-1`:

- upstream repository: https://github.com/ros-drivers/gscam.git
- release repository: https://github.com/ros2-gbp/gscam-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-1`

## gscam

```
* feat: add yuv support (#78 <https://github.com/ros-drivers/gscam/issues/78>)
  * feat: add yuv support
  * docs: add parameter description about image encodings
* feat: add option to use sensor data qos (#79 <https://github.com/ros-drivers/gscam/issues/79>)
  * feat: add option to use sensor data qos
  * docs: add description about the new flag
* Improve Dockerfile (#77 <https://github.com/ros-drivers/gscam/issues/77>)
  * Use COPY instead of git clone
  * Copy source into gscam
  Co-authored-by: Daisuke Nishimatsu <mailto:42202095+wep21@users.noreply.github.com>
  * Small fixes
  Co-authored-by: Daisuke Nishimatsu <mailto:42202095+wep21@users.noreply.github.com>
* Merge pull request #76 <https://github.com/ros-drivers/gscam/issues/76> from clydemcqueen/ros2
  Fix uninitialized variable, adding more CI / test infrastructure.
* Merge pull request #9 <https://github.com/ros-drivers/gscam/issues/9> from clydemcqueen/clyde_fixes
  Several fixes
* feat: add Dockerfile
* chore: support multiple CLion build envs
* fix: initialize variable
* Contributors: Clyde McQueen, Daisuke Nishimatsu, Jonathan Bohren
```
