### PR TITLE
euslisp: 9.29.0-6 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2951,7 +2951,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/euslisp-release.git
-      version: 9.29.0-5
+      version: 9.29.0-6
     source:
       type: git
       url: https://github.com/euslisp/EusLisp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `euslisp` to `9.29.0-6`:

- upstream repository: https://github.com/euslisp/EusLisp
- release repository: https://github.com/tork-a/euslisp-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `9.29.0-5`
