### PR TITLE
Add pcl_msgs source section to galactic & rolling

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2471,6 +2471,10 @@ repositories:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/pcl_msgs-release.git
       version: 1.0.0-6
+    source:
+      type: git
+      url: https://github.com/ros-perception/pcl_msgs.git
+      version: ros2
     status: maintained
   perception_pcl:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2319,6 +2319,10 @@ repositories:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pcl_msgs-release.git
       version: 1.0.0-6
+    source:
+      type: git
+      url: https://github.com/ros-perception/pcl_msgs.git
+      version: ros2
     status: maintained
   perception_pcl:
     doc:


### PR DESCRIPTION
Hopefully I've understood how to do this, please correct me if not.

Adds the source section back for the Galactic and Rolling indexes of pcl_msgs (it's already present in the Foxy distribution.yaml).  Mentioned here: https://github.com/ros-perception/pcl_msgs/issues/17

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Update This Package's index in the rosdistro.

Galactic / Rolling

# The source is here: 

https://github.com/ros-perception/pcl_msgs



# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
