### PR TITLE
urdf: 2.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4830,7 +4830,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdf-release.git
-      version: 2.5.3-2
+      version: 2.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf` to `2.6.0-1`:

- upstream repository: https://github.com/ros2/urdf.git
- release repository: https://github.com/ros2-gbp/urdf-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.5.3-2`

## urdf

```
* Install headers to include/${PROJECT_NAME} (#31 <https://github.com/ros2/urdf/issues/31>)
* Contributors: Shane Loretz
```

## urdf_parser_plugin

```
* Install headers to include/${PROJECT_NAME} (#31 <https://github.com/ros2/urdf/issues/31>)
* Contributors: Shane Loretz
```
