### PR TITLE
rmw: 6.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3175,7 +3175,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 5.1.0-3
+      version: 6.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw` to `6.0.0-1`:

- upstream repository: https://github.com/ros2/rmw.git
- release repository: https://github.com/ros2-gbp/rmw-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `5.1.0-3`

## rmw

```
* Add EventsExecutor (#286 <https://github.com/ros2/rmw/issues/286>)
* Document that rmw_wait() SHOULD use a monotonic clock (#316 <https://github.com/ros2/rmw/issues/316>)
* Install headers to include/${PROJECT_NAME} (#317 <https://github.com/ros2/rmw/issues/317>)
* Update rmw_server_is_available() API documentation. (#277 <https://github.com/ros2/rmw/issues/277>)
* Contributors: Ivan Santiago Paunovic, Michel Hidalgo, Shane Loretz, iRobot ROS
```

## rmw_implementation_cmake

```
* Use FastDDS as default DDS (#315 <https://github.com/ros2/rmw/issues/315>)
* Contributors: Audrow Nash
```
