### PR TITLE
rviz: 11.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4262,7 +4262,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 10.0.0-1
+      version: 11.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `11.0.0-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `10.0.0-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* add implementation for cancel interface (#809 <https://github.com/ros2/rviz/issues/809>)
* Contributors: Chen Lihui
```

## rviz_default_plugins

```
* Drop ignition-math6 from rviz_default_plugins link interface (#833 <https://github.com/ros2/rviz/issues/833>)
* add implementation for cancel interface (#809 <https://github.com/ros2/rviz/issues/809>)
* Contributors: Chen Lihui, Scott K Logan
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Disable a warning when including Eigen. (#835 <https://github.com/ros2/rviz/issues/835>)
* Contributors: Chris Lalancette
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
