### PR TITLE
rosidl_python: 0.14.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3750,7 +3750,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.14.1-2
+      version: 0.14.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_python` to `0.14.2-1`:

- upstream repository: https://github.com/ros2/rosidl_python.git
- release repository: https://github.com/ros2-gbp/rosidl_python-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.14.1-2`

## rosidl_generator_py

```
* Removes erroneous unmatched closing parenthesis (#125 <https://github.com/ros2/rosidl_python/issues/125>)
* require Python 3.6 as we use format strings in various places (#152 <https://github.com/ros2/rosidl_python/issues/152>)
* Contributors: Charles Cross, William Woodall
```
