### PR TITLE
rosidl: 3.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3695,7 +3695,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 3.0.1-2
+      version: 3.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `3.1.0-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.0.1-2`

## rosidl_adapter

```
* rename nested loop index (#643 <https://github.com/ros2/rosidl/issues/643>)
* Contributors: ibnHatab
```

## rosidl_cli

- No changes

## rosidl_cmake

```
* Add introspection typesupport tests for C/C++ messages (#651 <https://github.com/ros2/rosidl/issues/651>)
* Contributors: Michel Hidalgo
```

## rosidl_generator_c

```
* Implement copy function for C messages (#650 <https://github.com/ros2/rosidl/issues/650>)
* Implement equality operator function for C messages. (#648 <https://github.com/ros2/rosidl/issues/648>)
* Generate documentation in generated C header files based on ROS interfaces comments (#593 <https://github.com/ros2/rosidl/issues/593>)
* Contributors: Ivan Santiago Paunovic, Michel Hidalgo
```

## rosidl_generator_cpp

```
* Add missing build_export_depend dependency (#665 <https://github.com/ros2/rosidl/issues/665>)
* Fix bug where rosidl_runtime_cpp wasn't depended upon (#660 <https://github.com/ros2/rosidl/issues/660>)
* Contributors: Jorge Perez, Shane Loretz
```

## rosidl_parser

```
* Set maybe_placeholders to False for lark 1.+ compatibility (#664 <https://github.com/ros2/rosidl/issues/664>)
* Generate documentation in generated C header files based on ROS interfaces comments (#593 <https://github.com/ros2/rosidl/issues/593>)
* Contributors: Ivan Santiago Paunovic, Shane Loretz
```

## rosidl_runtime_c

```
* De-duplicate Quality Level from README and QUALITY_DECLARATION (#661 <https://github.com/ros2/rosidl/issues/661>)
* Install headers to include/${PROJECT_NAME} (#658 <https://github.com/ros2/rosidl/issues/658>)
* Implement copy function for C messages (#650 <https://github.com/ros2/rosidl/issues/650>)
* Implement equality operator function for C messages. (#648 <https://github.com/ros2/rosidl/issues/648>)
* Contributors: Jose Luis Rivero, Michel Hidalgo, Shane Loretz
```

## rosidl_runtime_cpp

```
* Add missing dependency on rosidl_runtime_c (#666 <https://github.com/ros2/rosidl/issues/666>)
* De-duplicate Quality Level from README and QUALITY_DECLARATION (#661 <https://github.com/ros2/rosidl/issues/661>)
* Install headers to include/${PROJECT_NAME} (#658 <https://github.com/ros2/rosidl/issues/658>)
* Contributors: Jose Luis Rivero, Shane Loretz
```

## rosidl_typesupport_interface

```
* De-duplicate Quality Level from README and QUALITY_DECLARATION (#661 <https://github.com/ros2/rosidl/issues/661>)
* Install headers to include/${PROJECT_NAME} (#658 <https://github.com/ros2/rosidl/issues/658>)
* Add ROSIDL_TYPESUPPORT_INTERFACE__LIBRARY_NAME() macro (#649 <https://github.com/ros2/rosidl/issues/649>)
* Contributors: Jose Luis Rivero, Michel Hidalgo, Shane Loretz
```

## rosidl_typesupport_introspection_c

```
* De-duplicate Quality Level from README and QUALITY_DECLARATION (#661 <https://github.com/ros2/rosidl/issues/661>)
* Update Quality declaration to level 1 in README for instrospection pkgs (#659 <https://github.com/ros2/rosidl/issues/659>)
* Install headers to include/${PROJECT_NAME} (#658 <https://github.com/ros2/rosidl/issues/658>)
* Move rosidl_typesupport_introspection_cpp quality declaration to Q1 (#657 <https://github.com/ros2/rosidl/issues/657>)
* Move rosidl_typesupport_introspection_c quality declaration to Q1  (#656 <https://github.com/ros2/rosidl/issues/656>)
* add documentation for generators and API (#646 <https://github.com/ros2/rosidl/issues/646>)
* Rework nested types' items introspection in C and C++ (#652 <https://github.com/ros2/rosidl/issues/652>)
* Contributors: Jose Luis Rivero, Michel Hidalgo, Shane Loretz
```

## rosidl_typesupport_introspection_cpp

```
* De-duplicate Quality Level from README and QUALITY_DECLARATION (#661 <https://github.com/ros2/rosidl/issues/661>)
* Update Quality declaration to level 1 in README for instrospection pkgs (#659 <https://github.com/ros2/rosidl/issues/659>)
* Install headers to include/${PROJECT_NAME} (#658 <https://github.com/ros2/rosidl/issues/658>)
* Move rosidl_typesupport_introspection_cpp quality declaration to Q1 (#657 <https://github.com/ros2/rosidl/issues/657>)
* add documentation for generators and API (#646 <https://github.com/ros2/rosidl/issues/646>)
* Rework nested types' items introspection in C and C++ (#652 <https://github.com/ros2/rosidl/issues/652>)
* Contributors: Jose Luis Rivero, Michel Hidalgo, Shane Loretz
```
