### PR TITLE
ros2cli: 0.18.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3463,7 +3463,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.17.1-2
+      version: 0.18.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.18.0-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.17.1-2`

## ros2action

- No changes

## ros2cli

- No changes

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

- No changes

## ros2interface

- No changes

## ros2lifecycle

- No changes

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

- No changes

## ros2param

- No changes

## ros2pkg

```
* Use local git config instead of global (#693 <https://github.com/ros2/ros2cli/issues/693>)
* Contributors: Amro Al-Baali
```

## ros2run

- No changes

## ros2service

- No changes

## ros2topic

```
* support ros2topic echo once option. (#695 <https://github.com/ros2/ros2cli/issues/695>)
* Fix special case for fastrtps incompatible QoS. (#694 <https://github.com/ros2/ros2cli/issues/694>)
* Contributors: Chris Lalancette, Tomoya Fujita
```
