### PR TITLE
rmw_cyclonedds: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3212,7 +3212,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 1.1.2-2
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `1.2.0-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.2-2`

## rmw_cyclonedds_cpp

```
* Fix a warning by making a pointer nullptr. (#375 <https://github.com/ros2/rmw_cyclonedds/issues/375>)
* Bump QDs to QL2 (#371 <https://github.com/ros2/rmw_cyclonedds/issues/371>)
* Add EventsExecutor (#256 <https://github.com/ros2/rmw_cyclonedds/issues/256>)
* Call dissociate_reader in rmw_destroy_subscription
* Wrap creation of new serdata_rmw within a try-catch block
* Fix memory leak in error scenario on the publish side with SHM
* Fix memory leaks on the take side with SHM
* rename _cyclonedds_has_shm to follow the convention
* Add iceoryx_binding_c as dependency to rmw_cyclonedds_cpp
* Release iox_chunk to iceoryx in serdata_free if the iox_chunk is still available
* Update iceoryx_subscriber also when constructing the serdata from the iox chunk
* Contributors: Chris Lalancette, Christophe Bedard, Erik Boasson, Sumanth Nirmal, iRobot ROS
```
