### PR TITLE
rcl_interfaces: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2737,7 +2737,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_interfaces-release.git
-      version: 1.1.0-2
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_interfaces` to `1.2.0-1`:

- upstream repository: https://github.com/ros2/rcl_interfaces.git
- release repository: https://github.com/ros2-gbp/rcl_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.0-2`

## action_msgs

```
* Update maintainers to Chris Lalancette (#130 <https://github.com/ros2/rcl_interfaces/issues/130>)
* Contributors: Audrow Nash
```

## builtin_interfaces

```
* Update maintainers to Chris Lalancette (#130 <https://github.com/ros2/rcl_interfaces/issues/130>)
* Contributors: Audrow Nash
```

## composition_interfaces

```
* Update maintainers to Chris Lalancette (#130 <https://github.com/ros2/rcl_interfaces/issues/130>)
* Contributors: Audrow Nash
```

## lifecycle_msgs

```
* Update maintainers to Chris Lalancette (#130 <https://github.com/ros2/rcl_interfaces/issues/130>)
* Contributors: Audrow Nash
```

## rcl_interfaces

```
* Update maintainers to Chris Lalancette (#130 <https://github.com/ros2/rcl_interfaces/issues/130>)
* Contributors: Audrow Nash
```

## rosgraph_msgs

```
* Update maintainers to Chris Lalancette (#130 <https://github.com/ros2/rcl_interfaces/issues/130>)
* Contributors: Audrow Nash
```

## statistics_msgs

```
* Update maintainers to Chris Lalancette (#130 <https://github.com/ros2/rcl_interfaces/issues/130>)
* Contributors: Audrow Nash
```

## test_msgs

```
* Install headers to include/${PROJECT_NAME} and Depend on rosidl_typesupport_* targets directly (#133 <https://github.com/ros2/rcl_interfaces/issues/133>)
* Update maintainers to Chris Lalancette (#130 <https://github.com/ros2/rcl_interfaces/issues/130>)
* Contributors: Audrow Nash, Shane Loretz
```
