### PR TITLE
rcl: 5.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2712,7 +2712,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 5.0.1-2
+      version: 5.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `5.1.0-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `5.0.1-2`

## rcl

```
* Add Events Executor (#839 <https://github.com/ros2/rcl/issues/839>)
* Remove fastrtps customization on test_events (#960 <https://github.com/ros2/rcl/issues/960>)
* Add client/service QoS getters (#941 <https://github.com/ros2/rcl/issues/941>)
* introduce ROS_DISABLE_LOAN_MSG to disable can_loan_messages. (#949 <https://github.com/ros2/rcl/issues/949>)
* Install includes it include/${PROJECT_NAME} (#959 <https://github.com/ros2/rcl/issues/959>)
* Contributors: Miguel Company, Shane Loretz, Tomoya Fujita, iRobot ROS, mauropasse
```

## rcl_action

```
* Add Events Executor (#839 <https://github.com/ros2/rcl/issues/839>)
* Install includes it include/${PROJECT_NAME} (#959 <https://github.com/ros2/rcl/issues/959>)
* Contributors: Shane Loretz, iRobot ROS
```

## rcl_lifecycle

```
* Install includes it include/${PROJECT_NAME} (#959 <https://github.com/ros2/rcl/issues/959>)
* Contributors: Shane Loretz
```

## rcl_yaml_param_parser

```
* Install includes it include/${PROJECT_NAME} (#959 <https://github.com/ros2/rcl/issues/959>)
* Contributors: Shane Loretz
```
