### PR TITLE
python_cmake_module: 0.10.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2506,7 +2506,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/python_cmake_module-release.git
-      version: 0.8.1-2
+      version: 0.10.0-1
     source:
       type: git
       url: https://github.com/ros2/python_cmake_module.git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_cmake_module` to `0.10.0-1`:

- upstream repository: https://github.com/ros2/python_cmake_module.git
- release repository: https://github.com/ros2-gbp/python_cmake_module-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.8.1-2`

## python_cmake_module

```
* require Python 3.6 as we use format strings in various places (#10 <https://github.com/ros2/python_cmake_module/issues/10>)
* Document all variables set by this module (#5 <https://github.com/ros2/python_cmake_module/issues/5>)
* Add changelog (#4 <https://github.com/ros2/python_cmake_module/issues/4>)
* Contributors: Ivan Santiago Paunovic, Shane Loretz, William Woodall
```
