### PR TITLE
geometry2: 0.22.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1020,7 +1020,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.21.0-2
+      version: 0.22.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.22.0-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.21.0-2`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* clear relative callback of Buffer if MessageFilter is destroyed (#490 <https://github.com/ros2/geometry2/issues/490>)
* More info in tf2_echo output (#468 <https://github.com/ros2/geometry2/issues/468>)
* Contributors: Chen Lihui, simulacrus
```

## tf2_ros_py

```
* Add in one more destroy call that was missed in testing. (#504 <https://github.com/ros2/geometry2/issues/504>)
* Contributors: Chris Lalancette
```

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
