### PR TITLE
launch: 0.21.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1502,7 +1502,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.21.0-2
+      version: 0.21.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.21.1-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.21.0-2`

## launch

```
* 'output' is expanded as a substitution in XML/YAML files (#577 <https://github.com/ros2/launch/issues/577>)
* Skip warning test if warning already happend (#585 <https://github.com/ros2/launch/issues/585>)
* Contributors: Khush Jain, Shane Loretz
```

## launch_pytest

- No changes

## launch_testing

```
* Added case for instances of ExecuteLocal in resolveProcess function (#587 <https://github.com/ros2/launch/issues/587>)
* Add compatitibility with pytest 7 (#592 <https://github.com/ros2/launch/issues/592>)
* Contributors: Matt Lanting, Shane Loretz
```

## launch_testing_ament_cmake

```
* [launch_testing_ament_cmake] Add test label (#584 <https://github.com/ros2/launch/issues/584>)
* Contributors: Keisuke Shima
```

## launch_xml

```
* 'output' is expanded as a substitution in XML/YAML files (#577 <https://github.com/ros2/launch/issues/577>)
* Contributors: Khush Jain
```

## launch_yaml

```
* 'output' is expanded as a substitution in XML/YAML files (#577 <https://github.com/ros2/launch/issues/577>)
* Contributors: Khush Jain
```
