### PR TITLE
rmw_fastrtps: 6.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3248,7 +3248,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 6.1.2-2
+      version: 6.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `6.2.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `6.1.2-2`

## rmw_fastrtps_cpp

```
* Add EventsExecutor (#468 <https://github.com/ros2/rmw_fastrtps/issues/468>)
* Install headers to include/${PROJECT_NAME} (#578 <https://github.com/ros2/rmw_fastrtps/issues/578>)
* Contributors: Shane Loretz, iRobot ROS
```

## rmw_fastrtps_dynamic_cpp

```
* Add EventsExecutor (#468 <https://github.com/ros2/rmw_fastrtps/issues/468>)
* Install headers to include/${PROJECT_NAME} (#578 <https://github.com/ros2/rmw_fastrtps/issues/578>)
* Contributors: Shane Loretz, iRobot ROS
```

## rmw_fastrtps_shared_cpp

```
* Add EventsExecutor (#468 <https://github.com/ros2/rmw_fastrtps/issues/468>)
* Complete events support (#583 <https://github.com/ros2/rmw_fastrtps/issues/583>)
* Install headers to include/${PROJECT_NAME} (#578 <https://github.com/ros2/rmw_fastrtps/issues/578>)
* Change default to synchronous (#571 <https://github.com/ros2/rmw_fastrtps/issues/571>)
* Contributors: Audrow Nash, Miguel Company, Shane Loretz, iRobot ROS
```
