### PR TITLE
examples: 0.15.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -822,7 +822,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/examples-release.git
-      version: 0.14.0-2
+      version: 0.15.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `examples` to `0.15.0-1`:

- upstream repository: https://github.com/ros2/examples.git
- release repository: https://github.com/ros2-gbp/examples-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.14.0-2`

## examples_rclcpp_async_client

- No changes

## examples_rclcpp_cbg_executor

```
* Improve scheduling configuration of examples_rclcpp_cbg_executor package (#331 <https://github.com/ros2/examples/issues/331>)
* Added jitter measurement to examples_rclcpp_cbg_executor. (#328 <https://github.com/ros2/examples/issues/328>)
* Contributors: Ralph Lange
```

## examples_rclcpp_minimal_action_client

- No changes

## examples_rclcpp_minimal_action_server

- No changes

## examples_rclcpp_minimal_client

- No changes

## examples_rclcpp_minimal_composition

- No changes

## examples_rclcpp_minimal_publisher

```
* Add an example about how to use wait_for_all_acked (#316 <https://github.com/ros2/examples/issues/316>)
* Contributors: Barry Xu
```

## examples_rclcpp_minimal_service

- No changes

## examples_rclcpp_minimal_subscriber

```
* Use const& signature for read-only sub callbacks (#337 <https://github.com/ros2/examples/issues/337>)
* Contributors: Abrar Rahman Protyasha
```

## examples_rclcpp_minimal_timer

- No changes

## examples_rclcpp_multithreaded_executor

- No changes

## examples_rclcpp_wait_set

- No changes

## examples_rclpy_executors

- No changes

## examples_rclpy_guard_conditions

- No changes

## examples_rclpy_minimal_action_client

- No changes

## examples_rclpy_minimal_action_server

- No changes

## examples_rclpy_minimal_client

- No changes

## examples_rclpy_minimal_publisher

- No changes

## examples_rclpy_minimal_service

- No changes

## examples_rclpy_minimal_subscriber

- No changes

## examples_rclpy_pointcloud_publisher

- No changes

## launch_testing_examples

- No changes
