### PR TITLE
demos: 0.20.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -645,7 +645,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.19.0-2
+      version: 0.20.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.20.0-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.19.0-2`

## action_tutorials_cpp

- No changes

## action_tutorials_interfaces

- No changes

## action_tutorials_py

- No changes

## composition

- No changes

## demo_nodes_cpp

- No changes

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

```
* Cleanups in demo_nodes_py. (#555 <https://github.com/ros2/demos/issues/555>)
* Contributors: Chris Lalancette
```

## dummy_map_server

- No changes

## dummy_robot_bringup

- No changes

## dummy_sensors

- No changes

## image_tools

```
* Install includes to include/${PROJECT_NAME} (#548 <https://github.com/ros2/demos/issues/548>)
* Contributors: Shane Loretz
```

## intra_process_demo

```
* Add opencv_imgproc dependency for cv::putText (#554 <https://github.com/ros2/demos/issues/554>)
* Install includes to include/${PROJECT_NAME} (#548 <https://github.com/ros2/demos/issues/548>)
* Contributors: Shane Loretz
```

## lifecycle

```
* Use default on_activate()/on_deactivate() implemenetation of Node (#552 <https://github.com/ros2/demos/issues/552>)
* Contributors: Ivan Santiago Paunovic
```

## lifecycle_py

```
* Create changelog for lifecycle_py
* Contributors: Audrow Nash
```

## logging_demo

- No changes

## pendulum_control

- No changes

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

```
* Install includes to include/${PROJECT_NAME} (#548 <https://github.com/ros2/demos/issues/548>)
* Contributors: Shane Loretz
```

## quality_of_service_demo_py

- No changes

## topic_monitor

- No changes

## topic_statistics_demo

```
* Install includes to include/${PROJECT_NAME} (#548 <https://github.com/ros2/demos/issues/548>)
* Contributors: Shane Loretz
```
