### PR TITLE
Add 'file' package to RHEL.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -993,6 +993,7 @@ file:
   debian: [file]
   fedora: [file]
   nixos: [file]
+  rhel: [file]
   ubuntu: [file]
 filezilla:
   arch: [filezilla]


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This is now a requirement of resource_retriever in Rolling, so add it here.  I don't actually know where core RHEL packages are listed, so I don't have a link to the package.  But it is the venerable 'file' utility, and I confirmed that it is in the 'file' package on my local Almalinux container.