### PR TITLE
common_interfaces: 4.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -519,7 +519,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 4.0.0-2
+      version: 4.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_interfaces` to `4.1.0-1`:

- upstream repository: https://github.com/ros2/common_interfaces.git
- release repository: https://github.com/ros2-gbp/common_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `4.0.0-2`

## actionlib_msgs

```
* Interface packages should fully <depend> on the interface packages that they depend on (#173 <https://github.com/ros2/common_interfaces/issues/173>)
* Contributors: Grey
```

## common_interfaces

- No changes

## diagnostic_msgs

```
* Interface packages should fully <depend> on the interface packages that they depend on (#173 <https://github.com/ros2/common_interfaces/issues/173>)
* Contributors: Grey
```

## geometry_msgs

```
* Interface packages should fully <depend> on the interface packages that they depend on (#173 <https://github.com/ros2/common_interfaces/issues/173>)
* Contributors: Grey
```

## nav_msgs

```
* Interface packages should fully <depend> on the interface packages that they depend on (#173 <https://github.com/ros2/common_interfaces/issues/173>)
* Contributors: Grey
```

## sensor_msgs

```
* Interface packages should fully <depend> on the interface packages that they depend on (#173 <https://github.com/ros2/common_interfaces/issues/173>)
* Add YUV420 and YUV444 to image encodings (#172 <https://github.com/ros2/common_interfaces/issues/172>)
* Contributors: Grey, Hemal Shah
```

## sensor_msgs_py

- No changes

## shape_msgs

```
* Interface packages should fully <depend> on the interface packages that they depend on (#173 <https://github.com/ros2/common_interfaces/issues/173>)
* Contributors: Grey
```

## std_msgs

```
* Interface packages should fully <depend> on the interface packages that they depend on (#173 <https://github.com/ros2/common_interfaces/issues/173>)
* Contributors: Grey
```

## std_srvs

- No changes

## stereo_msgs

```
* Interface packages should fully <depend> on the interface packages that they depend on (#173 <https://github.com/ros2/common_interfaces/issues/173>)
* Contributors: Grey
```

## trajectory_msgs

```
* Interface packages should fully <depend> on the interface packages that they depend on (#173 <https://github.com/ros2/common_interfaces/issues/173>)
* Contributors: Grey
```

## visualization_msgs

```
* Interface packages should fully <depend> on the interface packages that they depend on (#173 <https://github.com/ros2/common_interfaces/issues/173>)
* Contributors: Grey
```
