### PR TITLE
qt_gui_core: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2555,7 +2555,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 2.1.1-2
+      version: 2.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `2.2.0-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.1-2`

## qt_dotgraph

- No changes

## qt_gui

- No changes

## qt_gui_app

- No changes

## qt_gui_core

- No changes

## qt_gui_cpp

```
* Install headers to include${PROJECT_NAME} (#259 <https://github.com/ros-visualization/qt_gui_core/issues/259>)
* Contributors: Shane Loretz
```

## qt_gui_py_common

- No changes
