### PR TITLE
resource_retriever: 3.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2919,7 +2919,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 3.0.0-2
+      version: 3.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `3.1.0-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros2-gbp/resource_retriever-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.0.0-2`

## libcurl_vendor

```
* Update to curl 7.81. (#74 <https://github.com/ros/resource_retriever/issues/74>)
* Contributors: Chris Lalancette
```

## resource_retriever

```
* Install headers to include/${PROJECT_NAME} (#72 <https://github.com/ros/resource_retriever/issues/72>)
* Contributors: Shane Loretz
```
