### PR TITLE
laser_geometry: 2.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1463,7 +1463,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/laser_geometry-release.git
-      version: 2.3.0-2
+      version: 2.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_geometry` to `2.4.0-1`:

- upstream repository: https://github.com/ros-perception/laser_geometry.git
- release repository: https://github.com/ros2-gbp/laser_geometry-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.0-2`

## laser_geometry

```
* Install headers to include/${PROJECT_NAME} (#86 <https://github.com/ros-perception/laser_geometry/issues/86>)
* Explicit cast to double to prevent loss of precision
* Fix Duration casting issue leading to no undistortion
* Contributors: Jonathan Binney, Marco Lampacrescia, Shane Loretz
```
