### PR TITLE
ament_index: 1.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -135,7 +135,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_index-release.git
-      version: 1.3.0-2
+      version: 1.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_index` to `1.4.0-1`:

- upstream repository: https://github.com/ament/ament_index.git
- release repository: https://github.com/ros2-gbp/ament_index-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.3.0-2`

## ament_index_cpp

```
* Install includes to include/ (#83 <https://github.com/ament/ament_index/issues/83>)
* Remove ament_export_include_directories and ament_export_libraries (#81 <https://github.com/ament/ament_index/issues/81>)
* Contributors: Shane Loretz
```

## ament_index_python

```
* Print warning when get_package_share_directory() does not exist (Fix #74 <https://github.com/ament/ament_index/issues/74>) (#77 <https://github.com/ament/ament_index/issues/77>)
* Fail lookups on invalid resource names (#69 <https://github.com/ament/ament_index/issues/69>)
* Add get_package_share_path method (#73 <https://github.com/ament/ament_index/issues/73>)
* Contributors: David V. Lu, rob-clarke
```
