### PR TITLE
removes ros2/qpoases_vendor (#32362)

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3294,17 +3294,6 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: crystal-devel
     status: maintained
-  qpoases_vendor:
-    release:
-      tags:
-        release: release/foxy/{package}/{version}
-      url: https://github.com/Autoware-AI/qpoases_vendor-release.git
-      version: 3.2.3-2
-    source:
-      type: git
-      url: https://github.com/Autoware-AI/qpoases_vendor.git
-      version: ros2
-    status: maintained
   qt_gui_core:
     doc:
       type: git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2695,17 +2695,6 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: galactic-devel
     status: maintained
-  qpoases_vendor:
-    release:
-      tags:
-        release: release/galactic/{package}/{version}
-      url: https://github.com/Autoware-AI/qpoases_vendor-release.git
-      version: 3.2.3-1
-    source:
-      type: git
-      url: https://github.com/Autoware-AI/qpoases_vendor.git
-      version: ros2
-    status: maintained
   qt_gui_core:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2528,17 +2528,6 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: main
     status: maintained
-  qpoases_vendor:
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/qpoases_vendor-release.git
-      version: 3.2.3-2
-    source:
-      type: git
-      url: https://github.com/Autoware-AI/qpoases_vendor.git
-      version: ros2
-    status: maintained
   qt_gui_core:
     doc:
       type: git


### PR DESCRIPTION
Remove `qpoases_vendor` until Autoware-AI/qpoases_vendor#5 is fixed. `qpoases_vendor` should not be released in ROS2. Tracked in issue #32362

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
