### PR TITLE
rqt_image_overlay: 0.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3969,7 +3969,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_overlay-release.git
-      version: 0.0.3-1
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/ros-sports/rqt_image_overlay.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_image_overlay` to `0.0.4-1`:

- upstream repository: https://github.com/ros-sports/rqt_image_overlay.git
- release repository: https://github.com/ros2-gbp/rqt_image_overlay-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.3-1`

## rqt_image_overlay

```
* Add message collection window, and synchronize image and layers using header timestamp if available
* use present tense for getReceivedStatus
* implement overlay using msg_storage and use mutexes to handle multithreading
* start implementing msg storage
* add msg storage class
* Contributors: Kenji Brameld
```

## rqt_image_overlay_layer

```
* Add message collection window, and synchronize image and layers using header timestamp if available
* implement overlay using msg_storage and use mutexes to handle multithreading
* Contributors: Kenji Brameld
```
