### PR TITLE
Add Fedora and RHEL rules for python3-rtree

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8036,6 +8036,10 @@ python3-rospkg-modules:
   ubuntu: [python3-rospkg-modules]
 python3-rtree:
   debian: [python3-rtree]
+  fedora: [python3-rtree]
+  rhel:
+    '*': [python3-rtree]
+    '7': null
   ubuntu: [python3-rtree]
 python3-ruamel.yaml:
   debian:


### PR DESCRIPTION
This package is provided by EPEL for RHEL 8 and is not available for RHEL 7.

https://src.fedoraproject.org/rpms/python-Rtree#bodhi_updates