### PR TITLE
Add RHEL rule for libfreenect-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3122,6 +3122,9 @@ libfreenect-dev:
   fedora: [libfreenect-devel]
   nixos: [freenect]
   openembedded: [libfreenect@meta-ros-common]
+  rhel:
+    '*': [libfreenect-devel]
+    '7': null
   ubuntu: [libfreenect-dev]
 libfreetype6:
   alpine: [freetype]


### PR DESCRIPTION
This package is provided by EPEL for RHEL 8 and is not available for RHEL 7.

https://src.fedoraproject.org/rpms/libfreenect#bodhi_updates