### PR TITLE
mavros: 2.1.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1755,7 +1755,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `2.1.1-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.0-1`

## libmavconn

- No changes

## mavros

```
* Merge pull request #1717 <https://github.com/mavlink/mavros/issues/1717> from rob-clarke/fix--sys-status-callbacks
  Maybe fix sys status callbacks
* uncrustify
* Cleanup for pr
* Initialise common client
* Add debug
* Use common client
  Add debug
* plugins: Fix misprint
  Fix #1709 <https://github.com/mavlink/mavros/issues/1709>
* Contributors: Rob Clarke, Vladimir Ermakov
```

## mavros_extras

```
* plugins: Fix misprint
  Fix #1709 <https://github.com/mavlink/mavros/issues/1709>
* Contributors: Vladimir Ermakov
```

## mavros_msgs

- No changes
