### PR TITLE
bno055: 0.3.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -429,7 +429,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/flynneva/bno055-release.git
-      version: 0.2.0-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/flynneva/bno055.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bno055` to `0.3.0-1`:

- upstream repository: https://github.com/flynneva/bno055.git
- release repository: https://github.com/flynneva/bno055-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.0-1`
