### PR TITLE
python-transitions is not available past bionic

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5249,7 +5249,7 @@ python-transitions:
       pip:
         packages: [transitions]
   ubuntu:
-    '*': [python-transitions]
+    bionic: [python-transitions]
     trusty:
       pip:
         packages: [transitions]


### PR DESCRIPTION
Fixes #31918
