### PR TITLE
add rosdep key for python3-schema

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8054,6 +8054,7 @@ python3-schema:
   debian: [python3-schema]
   fedora: [python3-schema]
   freebsd: [py38-schema-0.7.5]
+  nixos: [python38Packages.schema]
   osx:
     pip:
       packages: [schema]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8059,6 +8059,7 @@ python3-schema:
   osx:
     pip:
       packages: [schema]
+  rhel: [python3-schema]
   ubuntu: [python3-schema]
 python3-scipy:
   arch: [python-scipy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8055,9 +8055,10 @@ python3-schema:
   fedora: [python3-schema]
   freebsd: [py38-schema-0.7.5]
   nixos: [python38Packages.schema]
+  opensuse: [python3-schema]
   osx:
     pip:
-      packages: [schema]
+      packages: [schema]     
   ubuntu: [python3-schema]
 python3-scipy:
   arch: [python-scipy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8049,6 +8049,15 @@ python3-schedule:
   debian: [python3-schedule]
   nixos: [python3Packages.schedule]
   ubuntu: [python3-schedule]
+python3-schema:
+  arch: [python-schema]
+  debian: [python3-schema]
+  fedora: [python3-schema]
+  freebsd: [py38-schema-0.7.5]
+  osx:
+    pip:
+      packages: [schema]
+  ubuntu: [python3-schema]
 python3-scipy:
   arch: [python-scipy]
   debian: [python3-scipy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8058,7 +8058,7 @@ python3-schema:
   opensuse: [python3-schema]
   osx:
     pip:
-      packages: [schema]     
+      packages: [schema]
   ubuntu: [python3-schema]
 python3-scipy:
   arch: [python-scipy]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python-schema

## Package Upstream Source:

https://github.com/keleshev/schema

## Purpose of using this:

Lightweight schema verification in Python 

Distro packaging links:

## Links to Distribution Packages

- Debian: 
  - https://packages.debian.org/bullseye/python3-schema
- Ubuntu: 
   - https://packages.ubuntu.com/impish/python3-schema
- Fedora: 
  - https://packages.fedoraproject.org/pkgs/python-schema/python3-schema/
  - https://src.fedoraproject.org/rpms/python-schema
 - Gentoo:
   - not avaiable
- Alpine:
   - not available
- MacOs:  
   - not available (can be installed from pip)   
- Arch: 
  - https://archlinux.org/packages/community/any/python-schema/
- NixOS/nixpkgs:
  - https://search.nixos.org/packages?channel=21.11&show=python38Packages.schema&from=0&size=50&sort=relevance&type=packages&query=python38Packages.schema
- openSUSE:
   - https://software.opensuse.org/package/python3-schema

