### PR TITLE
urg_node: 0.1.17-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -14344,7 +14344,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/urg_node-release.git
-      version: 0.1.16-1
+      version: 0.1.17-1
     source:
       type: git
       url: https://github.com/ros-drivers/urg_node.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_node` to `0.1.17-1`:

- upstream repository: https://github.com/ros-drivers/urg_node.git
- release repository: https://github.com/ros-gbp/urg_node-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.16-1`

## urg_node

```
* Update UST10 (#96 <https://github.com/ros-drivers/urg_node/issues/96>)
  * Fix typo for package name
  * Replace UST10 URDF with one used in CPR robots ; remove lx suffix from UST10 files
  * Fix typo in package name
  * Add installation of urdf, meshes, and launch directories to CMakeLists.txt
* Add collision to URDF
* Add URDF and STL of Hokuyo UST-10LX
* Contributors: Joey Yang
```
