### PR TITLE
mrpt_bridge: 1.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4957,6 +4957,21 @@ repositories:
       url: https://github.com/mrpt/mrpt.git
       version: develop
     status: developed
+  mrpt_bridge:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_bridge.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/mrpt-ros-pkg-release/mrpt_bridge-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_bridge.git
+      version: ros1
+    status: maintained
   mrpt_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_bridge` to `1.0.0-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_bridge.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_bridge-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## mrpt_bridge

```
* update dep to mrpt2
* Merge pull request #12 <https://github.com/mrpt-ros-pkg/mrpt_bridge/issues/12> from MRo47/ros1
  Fixed build error for ubuntu 20.04, ros-noetic in imu.cpp
* fixed bug (array to vec conversion -> use auto)
* Build with opencv 4
* fix build against mrpt2
* update gitignore; add PUBLIC flags to deps
* Quaternion singularity
  Check for degenerate case when converting quaternion to angles.
* Ensure the real part of quaternions is real
  Fixes: https://github.com/mrpt-ros-pkg/pose_cov_ops/issues/7
* time convert: fix round error in nanoseconds
* Fix build against mrpt-2
* Copyright notices, clang-format.
  Also, avoid some bad practices: C includes vs C++ ones; using namespace
  in headers.
* fix build against mrpt2
  Fixed #5 <https://github.com/mrpt-ros-pkg/mrpt_bridge/issues/5>
* Contributors: Jose Luis Blanco Claraco, Jose Luis Blanco-Claraco, Jose-Luis Blanco, Julian Lopez Velasquez, MRo47, Mathieu Mege, cmorcan
```
