### PR TITLE
leo_robot: 2.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4033,7 +4033,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_robot-release.git
-      version: 2.0.3-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_robot` to `2.1.0-1`:

- upstream repository: https://github.com/LeoRover/leo_robot.git
- release repository: https://github.com/fictionlab-gbp/leo_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.3-1`

## leo_bringup

```
* Update parameter names
```

## leo_fw

```
* Update core2 and leocore firmwares
* Resolve pylint errors
* Reformat python code with black
* Reformat cpp code with clang-format
```

## leo_robot

- No changes
