### PR TITLE
pose_cov_ops: 0.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6176,6 +6176,21 @@ repositories:
       url: https://github.com/ros-drivers/pointgrey_camera_driver.git
       version: noetic-devel
     status: maintained
+  pose_cov_ops:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release.git
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
+      version: master
+    status: maintained
   power_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pose_cov_ops` to `0.3.0-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
- release repository: https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## pose_cov_ops

```
* Update URLs to https
* Update build dep to mrpt2
* update to mrpt2
* add basic unit test
* Set message to status again instead of warning
* Updating CMakeLists.txt to pass build on Ubuntu 16.04LTS with CMake 3.5 with the latest version of MRPT
* Add ros build farm badgets and links
* Contributors: Inounx, Jose Luis Blanco-Claraco, Julian Lopez Velasquez
```
