### PR TITLE
mvsim: 0.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5045,6 +5045,21 @@ repositories:
       type: git
       url: https://github.com/221eROS/muse_v2_driver.git
       version: main
+  mvsim:
+    doc:
+      type: git
+      url: https://github.com/ual-arm-ros-pkg/mvsim.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/ual-arm-ros-pkg/mvsim.git
+      version: master
+    status: developed
   navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.3.0-1`:

- upstream repository: https://github.com/ual-arm-ros-pkg/mvsim.git
- release repository: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## mvsim

```
* RGBD camera simulation
* MRPT 2.x is now required to build mvsim.
* Update build dep to mrpt2
* License changed to 3-clause BSD.
* Merge pull request #11 <https://github.com/ual-arm-ros-pkg/mvsim/issues/11> from SRai22/patch-1
  Update install.rst: needs libprotobuf-dev and libpython3-dev for building from source
* New checkboxes to see sensor poses and FOVs
* Lidar: ignore parent body option
* Lidar: realistic 3D raytrace mode
* enable textures in planes
* add support for ground and ceiling planes
* clean elevation mesh code
* save_to_rawlog option
* register callbacks instead of virtual functions
* New command "topic echo NAME"
* Add support for intangible blocks; publish relative poses
* Add support and example for standalone sensors
* allow changing the server IP or address
* add optional profiler to Client
* Protect main socket with mutex
* fix walls rendering; add new walls demo xml
* allow custom user 3D objects
* timelog format fix
* show class name in timelogger
* World: expose GUI object
* GUI and minor tweaks
* much faster models loading
* fix wrong collision resetting
* safer report collisions
* Fix usage of the update_fps parameter
* Fix build against mrpt 2.1.8
* force build against python3
* more standard python3 deb pkg generation
* solved python pkg problem in bionic
* fix python in bionic
* debian: fix python3 install dir
* add missing python3 dep
* fix deb python packaging
* remove useless cmake include
* first fully-working set_pose from python
* Progress with python wrappers
* Enhance python wrapper
* Document a minimum size limitation in box2d.
* small preliminary test for camera sensor
* Use newer mrpt-gui window manager
* Fix wallHeight wall parameter correct usage
* editor: basic rotate and move objects
* refactor gui code into smaller methods
* fix rendering of non-custom objects
* functional replace by coordinates
* Progress with replace GUI
* progress with bbox rendering
* progress with mouse move UI
* refactor: unify all simulable objects in one list
* update asserts to latest mrpt2 names
* Better service response
* safer multithread gui
* avoid possible exception in serialization
* Return collision state
* Detect and report collisions
* add setStatic method
* progress debugging ramps
* Add incremental set_pose srv
* add get_pose() service
* Import walls working
* walls progress
* progress loading wall models
* Start doxygen integration in docs
* fix not seeing the robot owns body
* subscription works; example updated
* Feature: XML variables parsing
* update pybind11
* done topic subscriptions; fix proper thread joinable checks.
* basic subscription works
* progress subscribe topics
* fix crash upon exit due to unjoined threads
* use -dbg postfix for debug libraries
* implemented command topic list
* docs on world xml parameters
* fix visualization of sensors in custom viz models
* add missing file
* Add ZMQ monitor to connections
* fix install include dir
* fix copy pb hdr files
* clear leftover traces
* auto bbox from visuals
* More modular debian packaging
* services and set_pose() is working
* progress implementing services
* Blocks and vehicles publishes their pose
* Large code refactor:
  - Use mrpt::math types for twist and points
  - Use smart pointers
  - Remove duplicated code via new methods in base class Simulable
* done with publishTopic()
* advertise topics
* done list nodes command
* implement query node list
* refactor Client without parallel thread
* refactor mvsim-cli sources
* progress server
* fix cmake exported targets
* fix install
* unregister nodes
* basic python bindings
* refactor into modules
* progress with server parsing messages
* verbosity levels in client
* ignore files
* refactor into one main cli tool: mvsim
* zmq forwards header
* add thread names
* fix build against zmq<4.4
* First zmq message interchanges
* basic server thread infraestructure
* progress defining client/server protocol
* Add alternative 3D visualization to blocks and vehicles
* start refactor for visual objects
* fix -Werror error in u18.04
* Add zmq and protobuf
* prefer std::move
* Enforce override keyword
* use system logger instead of cout
* avoid raw pointer for box2d instance
* refactor param structures
* fix opengl memory leak
* Port to nanogui
* done port to mrpt2
* prefer nullptr
* narrower mrpt dependencies
* port docs to sphinx
* add circle-ci
* reorganize badges
* fix main doc file
* fix debian installed files path
* use system libbox2d
* add debian packaging files
* modernize: cmake exported targets
* show box2d system library version
* cmake commands to lower case
* Contributors: Jose Luis Blanco-Claraco, Shravan S Rai
```
