### PR TITLE
novatel_oem7_driver: 4.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7812,7 +7812,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
-      version: 3.0.0-1
+      version: 4.0.0-1
     source:
       type: git
       url: https://github.com/novatel/novatel_oem7_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_oem7_driver` to `4.0.0-1`:

- upstream repository: https://github.com/novatel/novatel_oem7_driver.git
- release repository: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.0.0-1`

## novatel_oem7_driver

```
* Adding new messages
* Support BESTGNSSPOS log topic publish
```
