### PR TITLE
mrpt_msgs: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4981,7 +4981,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_msgs-release.git
-      version: 0.1.23-2
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_msgs` to `0.2.0-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.23-2`

## mrpt_msgs

```
* Add generic observation msg
* Merge pull request #1 <https://github.com/mrpt-ros-pkg/mrpt_msgs/issues/1> from tuw-robotics/master
  Add range-bearing object observations
* Update URLs to https
* Contributors: Felix König, Jose Luis Blanco Claraco, Jose Luis Blanco-Claraco
```
