### PR TITLE
mrpt_msgs: 0.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7155,7 +7155,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
-      version: master
+      version: ros1
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -7164,7 +7164,7 @@ repositories:
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
-      version: master
+      version: ros1
     status: maintained
   mrpt_navigation:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7160,7 +7160,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_msgs-release.git
-      version: 0.1.22-0
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_msgs` to `0.2.0-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.22-0`

## mrpt_msgs

```
* Add generic observation msg
* Merge pull request #1 <https://github.com/mrpt-ros-pkg/mrpt_msgs/issues/1> from tuw-robotics/master
  Add range-bearing object observations
* Update URLs to https
* Contributors: Felix König, Jose Luis Blanco Claraco, Jose Luis Blanco-Claraco
```
