### PR TITLE
moveit: 1.1.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4784,7 +4784,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 1.1.8-1
+      version: 1.1.9-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `1.1.9-1`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.8-1`

## chomp_motion_planner

- No changes

## moveit

- No changes

## moveit_chomp_optimizer_adapter

- No changes

## moveit_commander

```
* Fix move_group_commander.go(tuple(...)) (#3066 <https://github.com/ros-planning/moveit/issues/3066>)
* Contributors: Hongzhuo Liang, Michael Görner
```

## moveit_core

```
* Add special case for sphere bodies in sphere decomposition (#3056 <https://github.com/ros-planning/moveit/issues/3056>)
* Add Ptr definitions for TimeParameterization classes (#3078 <https://github.com/ros-planning/moveit/issues/3078>)
* Fix python-versioned dependency (#3063 <https://github.com/ros-planning/moveit/issues/3063>)
* Contributors: Jochen Sprickerhof, Martin Oehler, Michael Görner
```

## moveit_fake_controller_manager

- No changes

## moveit_kinematics

- No changes

## moveit_planners

- No changes

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

- No changes

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

- No changes

## moveit_ros_move_group

```
* Fix missing include (#3051 <https://github.com/ros-planning/moveit/issues/3051>)
* Contributors: Tobias Fischer
```

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

```
* Use GLEW::GLEW link target (#3079 <https://github.com/ros-planning/moveit/issues/3079>)
* Fix use of std::bind (#3048 <https://github.com/ros-planning/moveit/issues/3048>)
* Contributors: Michael Görner, Tobias Fischer
```

## moveit_ros_planning

- No changes

## moveit_ros_planning_interface

- No changes

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

```
* Add PS3 dual shock model to moveit joy (#3025 <https://github.com/ros-planning/moveit/issues/3025>)
* Add option to use simulation time for rviz trajectory display (#3055 <https://github.com/ros-planning/moveit/issues/3055>)
* Contributors: Job van Dieten, Martin Oehler
```

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_servo

- No changes

## moveit_setup_assistant

```
* Fix collisions_updater's set comparison (#3076 <https://github.com/ros-planning/moveit/issues/3076>)
* MSA: boost::bind -> std::bind (#3039 <https://github.com/ros-planning/moveit/issues/3039>)
* Do not automatically load robot description in move_group.launch (#3065 <https://github.com/ros-planning/moveit/issues/3065>)
* Contributors: Jochen Sprickerhof, Loy van Beek, Michael Görner
```

## moveit_simple_controller_manager

- No changes

## pilz_industrial_motion_planner

- No changes

## pilz_industrial_motion_planner_testutils

- No changes
