### PR TITLE
plotjuggler: 3.4.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6102,7 +6102,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.4.2-1
+      version: 3.4.3-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.4.3-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.4.2-1`

## plotjuggler

```
* Apply changes to reactive Scripts
* improve reactive Scripts
* clear selections when CustomSeries is created
* save batch function settings
* cleaning up #601 <https://github.com/facontidavide/PlotJuggler/issues/601>
* Timestampfield (#601 <https://github.com/facontidavide/PlotJuggler/issues/601>)
* add new batch editor
* check validity of the Lua function
* consolidate tree view
* add missing files and use CurveTree
* multifile prefix
* ReactiveLuaFunction cleanup
* adding absolute transform
* small UI fix
* Contributors: Davide Faconti, ngpbach
```
