### PR TITLE
navigation_experimental: 0.3.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7446,7 +7446,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/navigation_experimental-release.git
-      version: 0.3.3-1
+      version: 0.3.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_experimental` to `0.3.5-1`:

- upstream repository: https://github.com/ros-planning/navigation_experimental.git
- release repository: https://github.com/ros-gbp/navigation_experimental-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.3-1`

## assisted_teleop

- No changes

## goal_passer

- No changes

## navigation_experimental

- No changes

## pose_base_controller

- No changes

## pose_follower

- No changes

## sbpl_lattice_planner

```
* Add option to publish the sbpl footprint plan (#58 <https://github.com/ros-planning/navigation_experimental/issues/58>)
* Contributors: Lotfi Zeghmi, Martin Günther
```

## sbpl_recovery

- No changes

## twist_recovery

- No changes
