### PR TITLE
libhri: 0.4.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5944,7 +5944,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros4hri/libhri-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/ros4hri/libhri.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libhri` to `0.4.1-1`:

- upstream repository: https://github.com/ros4hri/libhri.git
- release repository: https://github.com/ros4hri/libhri-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.0-1`

## hri

```
* Fixed wrong feature subscribers indexing
* Contributors: lorenzoferrini
```
