### PR TITLE
leo_common: 1.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1918,6 +1918,26 @@ repositories:
       url: https://github.com/ros2/launch_ros.git
       version: foxy
     status: maintained
+  leo_common:
+    doc:
+      type: git
+      url: https://github.com/LeoRover/leo_common.git
+      version: ros2
+    release:
+      packages:
+      - leo
+      - leo_description
+      - leo_msgs
+      - leo_teleop
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/fictionlab-gbp/leo_common-ros2-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/LeoRover/leo_common.git
+      version: ros2
+    status: maintained
   lgsvl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_common` to `1.0.2-1`:

- upstream repository: https://github.com/LeoRover/leo_common.git
- release repository: https://github.com/fictionlab-gbp/leo_common-ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## leo

- No changes

## leo_description

- No changes

## leo_msgs

```
* Set interface dependencies in CMakeLists
* Don't set build export dependency for builtin_interfaces
```

## leo_teleop

- No changes
