### PR TITLE
Add python3-pyside2-pip to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7726,6 +7726,19 @@ python3-pyrr-pip:
   ubuntu:
     pip:
       packages: [pyrr]
+python3-pyside2-pip:
+  debian:
+    pip:
+      packages: [PySide2]
+  fedora:
+    pip:
+      packages: [PySide2]
+  osx:
+    pip:
+      packages: [PySide2]
+  ubuntu:
+    pip:
+      packages: [PySide2]
 python3-pyside2.qtopengl:
   arch: [pyside2]
   debian: [python3-pyside2.qtopengl]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-pyside2-pip

## Package Upstream Source:

None

## Purpose of using this:

There are already entries for pyside2 for apt, but the current version of some distros like ubuntu are experimental (e.g., `python3-pyside2.qtcore (5.14.0-1~exp1ubuntu5`) and present issues that do not allow a seamless switch between pyqt5 and pyside2.

Although the [guidelines](https://github.com/ros/rosdistro/blob/master/REVIEW_GUIDELINES.md) detail the preference of apt over pip, in this case I hope this request can be considered, since does not break any current packages, while allowing the correct execution of pyside.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- pip: https://pypi.org/
  - [Link](https://pypi.org/project/PySide2/) 
