### PR TITLE
Switch the google_benchmark_vendor branches for Foxy and Galactic.

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1416,7 +1416,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ament/google_benchmark_vendor.git
-      version: main
+      version: foxy
     status: maintained
   googletest:
     release:

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1085,7 +1085,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ament/google_benchmark_vendor.git
-      version: main
+      version: galactic
     status: maintained
   googletest:
     release:


### PR DESCRIPTION
This is so that the main branch is used for Rolling development
only.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>