### PR TITLE
jackal: 0.8.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3511,7 +3511,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.8.2-1
+      version: 0.8.3-1
     source:
       type: git
       url: https://github.com/jackal/jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.8.3-1`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.8.2-1`

## jackal_control

- No changes

## jackal_description

```
* Added the option to remove tower from VLP16 mount
* Added SICK TIM551 to URDF and package.xml
* Added UTM30 (#106 <https://github.com/jackal/jackal/issues/106>)
* Updated Navsat and LMS1xx mounts (#103 <https://github.com/jackal/jackal/issues/103>)
  * Updated hokuyo_ust10_mount to include min and max angle
  * Removed extra spaces
  * Updated SICK LMS1XX mount and NAVSAT mount
  * Maintained backward compatibility with LMS1xx standard upright poisition by adding mount types
* Updated hokuyo_ust10_mount to include min and max angle (#102 <https://github.com/jackal/jackal/issues/102>)
  * Updated hokuyo_ust10_mount to include min and max angle
  * Removed extra spaces
* Contributors: Luis Camero, luis-camero
```

## jackal_msgs

- No changes

## jackal_navigation

- No changes

## jackal_tutorials

- No changes
