### PR TITLE
fix mrpt branches failing in CI

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7140,7 +7140,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_bridge.git
-      version: master
+      version: ros1
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -7149,13 +7149,13 @@ repositories:
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_bridge.git
-      version: master
+      version: ros1
     status: maintained
   mrpt_msgs:
     doc:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
-      version: master
+      version: ros1
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -7164,7 +7164,7 @@ repositories:
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
-      version: master
+      version: ros1
     status: maintained
   mrpt_navigation:
     doc:


### PR DESCRIPTION
The branches were changed but not updated in the distro

@jlblancoc FYI Please make sure to update the index before removing branches. 

This caused #32422 CI to fail and anyone trying to use melodic from source would fail. 

Default branch is ros1:
https://github.com/mrpt-ros-pkg/mrpt_msgs
https://github.com/mrpt-ros-pkg/mrpt_bridge