### PR TITLE
ubiquity_motor: 0.14.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9791,11 +9791,15 @@ repositories:
       version: master
     status: maintained
   ubiquity_motor:
+    doc:
+      type: git
+      url: https://github.com/UbiquityRobotics/ubiquity_motor.git
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
-      version: 0.13.2-1
+      version: 0.14.0-1
     source:
       type: git
       url: https://github.com/UbiquityRobotics/ubiquity_motor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ubiquity_motor` to `0.14.0-1`:

- upstream repository: https://github.com/UbiquityRobotics/ubiquity_motor.git
- release repository: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.13.2-1`

## ubiquity_motor

```
* made upgrade_firmware be run with py2 because #149 <https://github.com/UbiquityRobotics/ubiquity_motor/issues/149>
* Rename v43 to no longer be beta2wd in the name
* Update4wd and gear ratio for noetic (#160 <https://github.com/UbiquityRobotics/ubiquity_motor/issues/160>)
* Updated readme to include new parameters and topics.
* Adding clarity in comments only to our interface to controller_manager and thus DiffDriveController
* Fix issue of i2c routine and a left over git merge marker failed make
* Update motor_hardware_test for changes to readInputs and MotorHardware interfaces.
* Major merge of 4WD features to Magni 2wd. This is include and message files
* Major merge of 4WD features to Magni 2wd. This is initial motor_hardware source changes.
* Major merge of 4WD features to Magni 2wd. This is initial motor_node source changes.
* Adding v43_20210829_beta2wd_enc.cyacd for testing
* Contributors: Janez Cimerman, Mark Johnston, Rohan Agrawal
```
