### PR TITLE
add python3-scipy for focal

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4458,15 +4458,18 @@ python-scipy:
       packages: [scipy]
   ubuntu:
     '*': [python-scipy]
-    artful_python3: [python3-scipy]
-    bionic_python3: [python3-scipy]
-    trusty_python3: [python3-scipy]
-    utopic_python3: [python3-scipy]
-    vivid_python3: [python3-scipy]
-    wily_python3: [python3-scipy]
-    xenial_python3: [python3-scipy]
-    yakkety_python3: [python3-scipy]
-    zesty_python3: [python3-scipy]
+python3-scipy:
+  ubuntu:
+    artful: [python3-scipy]
+    bionic: [python3-scipy]
+    focal: [python3-scipy]
+    trusty: [python3-scipy]
+    utopic: [python3-scipy]
+    vivid: [python3-scipy]
+    wily: [python3-scipy]
+    xenial: [python3-scipy]
+    yakkety: [python3-scipy]
+    zesty: [python3-scipy]
 python-scp:
   debian: [python-scp]
   fedora: [python-scp]


### PR DESCRIPTION
Moving rules with ``_python3`` suffix from python-scipy to python3-scipy following what is written in [guidelines](https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#python-3)

Also added focal rule for python3-scipy