### PR TITLE
rslidar_sdk: 1.3.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12320,7 +12320,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/nobleo/rslidar_sdk-release.git
-      version: 1.3.0-3
+      version: 1.3.2-1
     source:
       type: git
       url: https://github.com/RoboSense-LiDAR/rslidar_sdk.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rslidar_sdk` to `1.3.2-1`:

- upstream repository: https://github.com/RoboSense-LiDAR/rslidar_sdk.git
- release repository: https://github.com/nobleo/rslidar_sdk-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.3.0-3`
