### PR TITLE
rslidar_sdk: 1.3.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8685,7 +8685,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/nobleo/rslidar_sdk-release.git
-      version: 1.3.0-4
+      version: 1.3.2-1
     source:
       type: git
       url: https://github.com/RoboSense-LiDAR/rslidar_sdk.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rslidar_sdk` to `1.3.2-1`:

- upstream repository: https://github.com/RoboSense-LiDAR/rslidar_sdk.git
- release repository: https://github.com/nobleo/rslidar_sdk-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.3.0-4`
