### PR TITLE
Add python3-nlopt to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7101,6 +7101,12 @@ python3-networkx:
   fedora: [python3-networkx]
   nixos: [python3Packages.networkx]
   ubuntu: [python3-networkx]
+python3-nlopt:
+  arch: [nlopt]
+  debian: [python3-nlopt]
+  fedora: [NLopt]
+  gentoo: [sci-libs/nlopt]
+  ubuntu: [python3-nlopt]
 python3-nose:
   debian: [python3-nose]
   fedora: [python3-nose]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7107,7 +7107,7 @@ python3-nlopt:
     '*': [python3-nlopt]
     buster: null
     stretch: null
-  fedora: [NLopt]
+  fedora: [python3-NLopt]
   gentoo: [sci-libs/nlopt]
   ubuntu:
     '*': [python3-nlopt]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7103,10 +7103,16 @@ python3-networkx:
   ubuntu: [python3-networkx]
 python3-nlopt:
   arch: [nlopt]
-  debian: [python3-nlopt]
+    debian:
+    '*': [python3-nlopt]
+    buster: null
+    stretch: null
   fedora: [NLopt]
   gentoo: [sci-libs/nlopt]
-  ubuntu: [python3-nlopt]
+  ubuntu:
+    '*': [python3-nlopt]
+    bionic: null
+    xenial: null
 python3-nose:
   debian: [python3-nose]
   fedora: [python3-nose]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7103,7 +7103,7 @@ python3-networkx:
   ubuntu: [python3-networkx]
 python3-nlopt:
   arch: [nlopt]
-    debian:
+  debian:
     '*': [python3-nlopt]
     buster: null
     stretch: null


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-nlopt

## Package Upstream Source:

[Link](https://github.com/stevengj/nlopt)

## Purpose of using this:

In the `libnlopt-dev` some distros already include the python bindings for the library, but it is not the case for Ubuntu/Debian, so I would like to include them. 

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - [Link](https://packages.debian.org/bullseye/python3-nlopt)
- Ubuntu: https://packages.ubuntu.com/
   - [Link](https://packages.ubuntu.com/focal/python3-nlopt)
- Fedora: https://src.fedoraproject.org/browse/projects/
  - [Link](https://src.fedoraproject.org/rpms/NLopt)
- Arch: https://www.archlinux.org/packages/
  - [Link](https://archlinux.org/packages/community/x86_64/nlopt/)
- Gentoo: https://packages.gentoo.org/
  - [Link](https://packages.gentoo.org/packages/sci-libs/nlopt)
- macOS: https://formulae.brew.sh/
  - None
- Alpine: https://pkgs.alpinelinux.org/packages
  - None
- NixOS/nixpkgs: https://search.nixos.org/packages
  - None
