### PR TITLE
euslime: 1.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2936,7 +2936,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/jsk-ros-pkg/euslime-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/euslime.git


### PR DESCRIPTION
Increasing version of package(s) in repository `euslime` to `1.1.1-1`:

- upstream repository: https://github.com/jsk-ros-pkg/euslime.git
- release repository: https://github.com/jsk-ros-pkg/euslime-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.0-1`

## euslime

```
* Add recursive load tags
* Support method description
* Enable piped-fork function
* Generate comp/ and geo/ tags
* Add technical-report.md
* Bugfix
* Contributors: Guilherme Affonso
```
