### PR TITLE
euslime: 1.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2018,6 +2018,17 @@ repositories:
       url: https://github.com/shadow-robot/ethercat_grant.git
       version: noetic-devel
     status: maintained
+  euslime:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/jsk-ros-pkg/euslime-release.git
+      version: 1.1.1-1
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/euslime.git
+      version: master
+    status: developed
   euslisp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `euslime` to `1.1.1-1`:

- upstream repository: https://github.com/jsk-ros-pkg/euslime.git
- release repository: https://github.com/jsk-ros-pkg/euslime-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## euslime

```
* Add recursive load tags
* Support method description
* Enable piped-fork function
* Generate comp/ and geo/ tags
* Add technical-report.md
* Bugfix
* Contributors: Guilherme Affonso
```
