### PR TITLE
apriltag: 3.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -218,7 +218,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/AprilRobotics/apriltag-release.git
-      version: 3.1.6-1
+      version: 3.2.0-1
     source:
       type: git
       url: https://github.com/aprilrobotics/apriltag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag` to `3.2.0-1`:

- upstream repository: https://github.com/AprilRobotics/apriltag.git
- release repository: https://github.com/AprilRobotics/apriltag-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.1.6-1`
