### PR TITLE
apriltag: 3.2.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -272,7 +272,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag-release.git
-      version: 3.1.5-1
+      version: 3.2.0-1
     source:
       type: git
       url: https://github.com/AprilRobotics/apriltag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag` to `3.2.0-1`:

- upstream repository: https://github.com/AprilRobotics/apriltag.git
- release repository: https://github.com/ros2-gbp/apriltag-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.1.5-1`
