### PR TITLE
apriltag_ros: 3.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -233,7 +233,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/AprilRobotics/apriltag_ros-release.git
-      version: 3.1.2-1
+      version: 3.2.0-1
     source:
       type: git
       url: https://github.com/AprilRobotics/apriltag_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_ros` to `3.2.0-1`:

- upstream repository: https://github.com/AprilRobotics/apriltag_ros.git
- release repository: https://github.com/AprilRobotics/apriltag_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.1.2-1`

## apriltag_ros

```
* Add transport hint option (#108 <https://github.com/AprilRobotics/apriltag_ros/issues/108>)
* Move to using the apriltag CMake target (#104 <https://github.com/AprilRobotics/apriltag_ros/issues/104>)
* Set the tag's parent frame to the camera optical frame (#101 <https://github.com/AprilRobotics/apriltag_ros/issues/101>)
* Fix bug in K matrix in single_image_client (#103 <https://github.com/AprilRobotics/apriltag_ros/issues/103>)
* Add configurable max_hamming_distance for the AprilTag Detector (#93 <https://github.com/AprilRobotics/apriltag_ros/issues/93>)
* Introduce lazy processing for ContinuousDetector (#80 <https://github.com/AprilRobotics/apriltag_ros/issues/80>)
* Contributors: Akshay Prasad, Amal Nanavati, Christian Rauch, Hongzhuo Liang, Wolfgang Merkt
```
