### PR TITLE
apriltag_ros: 3.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -140,11 +140,15 @@ repositories:
       version: master
     status: maintained
   apriltag_ros:
+    doc:
+      type: git
+      url: https://github.com/AprilRobotics/apriltag_ros.git
+      version: master
     release:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/AprilRobotics/apriltag_ros-release.git
-      version: 3.1.2-1
+      version: 3.2.0-1
     source:
       type: git
       url: https://github.com/AprilRobotics/apriltag_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_ros` to `3.2.0-1`:

- upstream repository: https://github.com/AprilRobotics/apriltag_ros.git
- release repository: https://github.com/AprilRobotics/apriltag_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.1.2-1`

## apriltag_ros

```
* Add transport hint option (#108 <https://github.com/AprilRobotics/apriltag_ros/issues/108>)
* Move to using the apriltag CMake target (#104 <https://github.com/AprilRobotics/apriltag_ros/issues/104>)
* Set the tag's parent frame to the camera optical frame (#101 <https://github.com/AprilRobotics/apriltag_ros/issues/101>)
* Fix bug in K matrix in single_image_client (#103 <https://github.com/AprilRobotics/apriltag_ros/issues/103>)
* Add configurable max_hamming_distance for the AprilTag Detector (#93 <https://github.com/AprilRobotics/apriltag_ros/issues/93>)
* Introduce lazy processing for ContinuousDetector (#80 <https://github.com/AprilRobotics/apriltag_ros/issues/80>)
* Contributors: Akshay Prasad, Amal Nanavati, Christian Rauch, Hongzhuo Liang, Wolfgang Merkt
```
