### PR TITLE
topic_tools: 1.0.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5010,6 +5010,24 @@ repositories:
       url: https://github.com/ros2/tlsf.git
       version: galactic
     status: maintained
+  topic_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-tooling/topic_tools.git
+      version: main
+    release:
+      packages:
+      - topic_tools
+      - topic_tools_interfaces
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/topic_tools-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-tooling/topic_tools.git
+      version: main
+    status: developed
   tracetools_analysis:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_tools` to `1.0.0-1`:

- upstream repository: https://github.com/ros-tooling/topic_tools.git
- release repository: https://github.com/ros2-gbp/topic_tools-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## topic_tools

```
* Improve QoS detection robustness (#27 <https://github.com/wep21/topic_tools/issues/27>)
  * improve qos detection robustness
  Co-authored-by: Emerson Knapp <mailto:eknapp@amazon.com>
* Feature/mux (#26 <https://github.com/wep21/topic_tools/issues/26>)
  * feat: add mux
* Feature/transform (#17 <https://github.com/wep21/topic_tools/issues/17>)
  * Add transform
* Contributors: Daisuke Nishimatsu, Steve Nogar
```

## topic_tools_interfaces

```
* Feature/mux (#26 <https://github.com/wep21/topic_tools/issues/26>)
  * feat: add mux
* Contributors: Daisuke Nishimatsu
```
