### PR TITLE
fath_pivot_mount_description: 0.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3124,6 +3124,21 @@ repositories:
       url: https://gitlab.com/InstitutMaupertuis/fanuc_post_processor.git
       version: melodic
     status: developed
+  fath_pivot_mount_description:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/fath_pivot_mount_description.git
+      version: main
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/fath_pivot_mount_description-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/fath_pivot_mount_description.git
+      version: main
+    status: maintained
   fawkes_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fath_pivot_mount_description` to `0.1.1-1`:

- upstream repository: https://github.com/clearpathrobotics/lockmount_description.git
- release repository: https://github.com/clearpath-gbp/fath_pivot_mount_description-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## fath_pivot_mount_description

```
* Bump CMake version to avoid CMP0048 warning.
* Contributors: Tony Baltovski
```
