### PR TITLE
graceful_controller: 0.4.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2811,7 +2811,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mikeferguson/graceful_controller-gbp.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/mikeferguson/graceful_controller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `graceful_controller` to `0.4.1-1`:

- upstream repository: https://github.com/mikeferguson/graceful_controller.git
- release repository: https://github.com/mikeferguson/graceful_controller-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.0-1`

## graceful_controller

- No changes

## graceful_controller_ros

```
* add ability to disable orientation filtering (#26 <https://github.com/mikeferguson/graceful_controller/issues/26>)
  also make everything dynamic reconfigurable
* don't crash when path is empty (#25 <https://github.com/mikeferguson/graceful_controller/issues/25>)
* add min_lookahead parameter (#24 <https://github.com/mikeferguson/graceful_controller/issues/24>)
  when the pose is very close to the robot, we can get
  some instability (rapid side-to-side movement due to
  large angular errors over small linear distances). by
  adding this parameter, we can instead fallback to
  recovery behaviors and find a better path.
* fix occasional boost::lock crash (#23 <https://github.com/mikeferguson/graceful_controller/issues/23>)
* limit the distance between poses as filter runs (#21 <https://github.com/mikeferguson/graceful_controller/issues/21>)
* improve the orientation filter, add tests (#20 <https://github.com/mikeferguson/graceful_controller/issues/20>)
* Contributors: Michael Ferguson
```
