### PR TITLE
magic_enum: 0.7.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1654,6 +1654,21 @@ repositories:
       url: https://github.com/OUXT-Polaris/lua_vendor.git
       version: main
     status: developed
+  magic_enum:
+    doc:
+      type: git
+      url: https://github.com/Neargye/magic_enum.git
+      version: master
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/nobleo/magic_enum-release.git
+      version: 0.7.3-1
+    source:
+      type: git
+      url: https://github.com/Neargye/magic_enum.git
+      version: master
+    status: maintained
   mapviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `magic_enum` to `0.7.3-1`:

- upstream repository: https://github.com/Neargye/magic_enum.git
- release repository: https://github.com/nobleo/magic_enum-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
