### PR TITLE
Add OpenNI rules for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4192,6 +4192,7 @@ libopenni-dev:
   debian: [libopenni-dev]
   fedora: [openni-devel]
   gentoo: [dev-libs/OpenNI]
+  rhel: [openni-devel]
   ubuntu: [libopenni-dev]
 libopenni-nite-dev:
   arch: [primesense-nite]
@@ -6407,6 +6408,7 @@ openni-dev:
   debian: [libopenni-dev]
   fedora: [openni-devel]
   gentoo: [dev-libs/OpenNI]
+  rhel: [openni-devel]
   ubuntu: [libopenni-dev]
 openocd:
   debian: [openocd]


### PR DESCRIPTION
This package is provided by EPEL for both RHEL 7 and 8.

https://src.fedoraproject.org/rpms/openni#bodhi_updates