### PR TITLE
rmf_traffic_editor: 1.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3110,7 +3110,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
-      version: 1.4.0-2
+      version: 1.5.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic_editor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_traffic_editor` to `1.5.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_traffic_editor.git
- release repository: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.4.0-2`

## rmf_building_map_tools

```
* Always use ign=True and remove spaces when comparing model names (#412)
  * Always use ign=True and remove spaces when comparing model names
  * Pit crew makes model paths available, when checking for missing models, for exporting (#414)
  * Reverted the use of remove_spaces as model names with spaces are used for downloading models
* if map_version is present, copy it into GeoJSON (#415)
* Update package.xml (#406)
* Feature: serve BuildingMap message when loading GeoJSON file in building_map_server (#404)
  * Create a BuildingMap message when serving from GeoJSON file
  * use RTree to speed up BuildingMap creation from GeoJSON
  * use reasonable default scale for Cartesian maps
  * add python3-rtree dependency to GitHub workflow
* First steps towards GeoJSON (#403)
  * add GeoJSON support to building_map_server: to start, just vertices and lanes
  * compress GeoJSON output on-the-fly
  * add support for GeoJSON to building_map_converter, auto-detecting based on filename suffix
  * GeoJSON: include preferred projected CRS and suggested coordinate offset for simulation as top-level keys
  * sort GeoJSON keys in building map server for consistency in diffs
  * fix crash for non-geolocated/legacy maps
* Cartesian worlds (y=up) and steps towards using GeoPackage (#396)
  * create passthrough transform for cartesian_meters coordinate systems
  * pass coordinate system to vertex draw, to flip text as needed
  * correct deprecated setuptools key to fix warning
  * Fix errors when building maps with lifts / crowdsim
  * add speed limit param to generated nav-graph files
  * add site_map publishing to building_map_server for cartesian maps
  * publish lane speed limits
  * Change loader to CLoader for performance improvement on large maps
  * on-the-fly geopackage generation for cartesian maps
  * add fiona Python package dependency to package.xml and CI workflow
  * building_map_converter to generate a GeoPackage from a cartesian YAML map
  * add top-level metadata for building/site params
  * fix geopackage metadata extraction for geopackage SiteMap server
  * use json instead of yaml for geopackage parameters
  * assign a nonsense CRS if one doesn't exist
  * Change Legacy -> ReferenceImage throughout code
* fix lift model ele name conflict warning (#399)
* Add speed limit to navgraph (#397)
* Deprecate/http download (#395)
  * deprecate and remove http option
  * Add helpful warning
  * use argparse deprecation method
  * use function level variables
* Use yaml-cpp CLoader and CDumper from Python for speed (#394)
  * use CLoader and CDumper to speed up YAML save/load times
* Contributors: Charayaphan Nakorn Boon Han, Grey, Luca Della Vedova, Morgan Quigley, Yadu, youliang, Aaron Chong
```

## rmf_traffic_editor

```
* fix #419 by calculating transformed x/y in image-based maps (#421)
* validate reference level index before using it (avoid a crash)
* Use C++17 for std::optional
* move all CI to galactic on ubuntu 20.04
* move the C++ style check into the 'main' CI test workflow
* Feature/render OpenStreetMap tiles (#418)
  * "new building" dialog box which asks which coordinates to use
  * use a subdirectory in ~/.cache as the OSM tile cache
  * show the tile cache size on the status bar
  * use EPSG:3857 (meters) for rendering tile maps
  * WGS84 coordinate translation
  * render OSM tiles in grayscale, so the non-tile things are easier to see
  * populate lat, lon property fields in EPSG:3857 mode
  * remove obsolete "flattened" UI stuff
  * save global coords in wgs84 but render them in epsg3857 on OSM tiles
  * GUI box to set the local CRS for sim/nav generation
  * move all RMF keys into GeoJSON props. add start/end names
  * feature_type -> rmf_type in GeoJSON properties
  * translate robot spawn point along with the world
* Handle simulation offsets for models and cameras (#408)
  * lat/lon translation behavior for models (previously, builds break when adding models due to WGS84 translation not having a "rotation" variable)
  * change naming for wgs84 model positions to lat/lon instead of x/y for consistency
  * apply offsets to the camera, so the camera view appears over the working area
  * Handle simulation offsets for models and cameras
  * Pass transform in Model constructor; pass un-transformed variables for to_yaml
  * Add check if global_transform was initialized; fix wrong computation of xy
  * parse model coordinates in wgs84 and project for viewing/editing
  * move model projection/translation to generate phase
  * set user-agent string in HTTP tile requests
  * workaround for 32-bit scrollbar overflow at extreme zoom
  * introduce a simple queuing system for tiles
  * reset zoom when loading a different filename
* flip layer images right-side up in cartesian meters mode (#405)
* Improve behavior for Cartesian maps (#401)
  * Improve behavior for Cartesian maps
  * because Cartesian maps have 1-meter units, we need to compute
  a better default scale for them. Previously it was always using
  a default scale of 0.05.
  * somewhat related, also fix the edge-select implementation so it
  spins through all edges in the map rather than just selecting
  the first edge within 10 units... that was OK when we were always
  using pixel-based maps, but now that meter-based maps are in use,
  it was just choosing the first edge that was within 10 meters of
  the click, which was a lot of edges and felt somewhat random.
  * stop drawing a 1-unit border around the scene rectangle
  * rotate vertex icons to +Y for cartesian maps
* Cartesian worlds (y=up) and steps towards using GeoPackage (#396)
  * create passthrough transform for cartesian_meters coordinate systems
  * y-flip in traffic-editor GUI for cartesian worlds; only invert Y coordinate for legacy image-based maps
  * add coordinate system files for C++ GUI
  * pass coordinate system to vertex draw, to flip text as needed
  * correct deprecated setuptools key to fix warning
  * Fix errors when building maps with lifts / crowdsim
  * draw fewer arrowheads for increased speed on very large maps
  * add speed limit parameter to lane property-editor GUI
  * add speed limit param to generated nav-graph files
  * publish lane speed limits
  * add top-level metadata for building/site params
  * load/save top level building params. Zoom->reset to center map view if you get lost.
  * assign a nonsense CRS if one doesn't exist
  * Change Legacy -> ReferenceImage throughout code
* minor usability enhancements on traffic editor (#398)
  * revert lift vertex, and prevent delete of lift vertex
  * fix wall transparency models and update readme
* Contributors: Morgan Quigley, Youliang Tan, Luca Della Vedova, Charayaphan Nakorn Boon Han
```

## rmf_traffic_editor_assets

```
* minor usability enhancements on traffic editor (#398)
  * updates
  * style
  * revert lift vertex, and prevent delete of lift vertex
  * fix wall transparency models and update readme
  * nit
* Contributors: youliang
```

## rmf_traffic_editor_test_maps

- No changes
