### PR TITLE
aruco_ros: 3.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -172,6 +172,21 @@ repositories:
       url: https://github.com/vanadiumlabs/arbotix_ros.git
       version: noetic-devel
     status: maintained
+  aruco_ros:
+    release:
+      packages:
+      - aruco
+      - aruco_msgs
+      - aruco_ros
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/pal-gbp/aruco_ros-release.git
+      version: 3.0.1-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/aruco_ros.git
+      version: noetic-devel
+    status: developed
   astra_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository aruco_ros to 3.0.1-1:

- upstream repository: https://github.com/pal-robotics/aruco_ros.git
- release repository: https://github.com/pal-gbp/aruco_ros-release.git
- distro file: noetic/distribution.yaml
- bloom version: `0.10.7` ~~0.9.8~~
- previous version for package: null

## aruco

* fixes pal-robotics/aruco_ros/https://github.com/pal-robotics/aruco_ros/issues/89
* Contributors: 444lhc

## aruco_msgs

    No changes

## aruco_ros

* Merge branch 'fix_camera_matrix_gallium' into 'gallium-devel' fix the issue with the improper camera matrix with non rectified images See merge request ros-overlays/aruco_ros!2
* fix the issue with the improper camera matrix with non rectified images
* Contributors: Sai Kishor Kothakota, saikishor

* fixes pal-robotics/aruco_ros/https://github.com/pal-robotics/aruco_ros/issues/89
* Contributors: 444lhc
