### PR TITLE
frame_editor: 1.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3510,6 +3510,21 @@ repositories:
       url: https://github.com/ros-drivers/four_wheel_steering_msgs.git
       version: master
     status: maintained
+  frame_editor:
+    doc:
+      type: git
+      url: https://github.com/ipa320/rqt_frame_editor_plugin.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ipa320/rqt_frame_editor_plugin-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/ipa320/rqt_frame_editor_plugin.git
+      version: kinetic-devel
+    status: maintained
   franka_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `frame_editor` to `1.1.0-1`:

- upstream repository: https://github.com/ipa320/rqt_frame_editor_plugin.git
- release repository: https://github.com/ipa320/rqt_frame_editor_plugin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## frame_editor

```
* Added argparse option to change publishing rate
* frame_editor is now compatible to Python 3 (ROS Noetic)
* Use the previous file name and parent frame as defaults for save_yaml and the set_frame service
* Contributors: Daniel Bargmann, Martin Günther, Philipp Tenbrock
```