### PR TITLE
frame_editor: 1.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2413,6 +2413,21 @@ repositories:
       url: https://github.com/foxglove/ros_foxglove_msgs.git
       version: main
     status: developed
+  frame_editor:
+    doc:
+      type: git
+      url: https://github.com/ipa320/rqt_frame_editor_plugin.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ipa320/rqt_frame_editor_plugin-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/ipa320/rqt_frame_editor_plugin.git
+      version: kinetic-devel
+    status: maintained
   franka_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `frame_editor` to `1.1.0-1`:

- upstream repository: https://github.com/ipa320/rqt_frame_editor_plugin.git
- release repository: https://github.com/ipa320/rqt_frame_editor_plugin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## frame_editor

```
* Added argparse option to change publishing rate
* frame_editor is now compatible to Python 3 (ROS Noetic)
* Use the previous file name and parent frame as defaults for save_yaml and the set_frame service
* Contributors: Daniel Bargmann, Martin Günther, Philipp Tenbrock
```
