### PR TITLE
cob_command_tools: 0.6.28-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -813,7 +813,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_command_tools-release.git
-      version: 0.6.27-1
+      version: 0.6.28-1
     source:
       type: git
       url: https://github.com/ipa320/cob_command_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.28-1`:

- upstream repository: https://github.com/ipa320/cob_command_tools.git
- release repository: https://github.com/ipa320/cob_command_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.27-1`

## cob_command_gui

- No changes

## cob_command_tools

- No changes

## cob_dashboard

- No changes

## cob_helper_tools

```
* Merge pull request #310 <https://github.com/ipa320/cob_command_tools/issues/310> from HannesBachter/fix/sleep_init
  sleep for 1 second after unsuccessful try to initialize
* sleep for 1 second after unsuccessful try to initialize
* Contributors: Felix Messmer, HannesBachter
```

## cob_interactive_teleop

- No changes

## cob_monitoring

```
* Merge pull request #314 <https://github.com/ipa320/cob_command_tools/issues/314> from pgehring/feature/netdata_cpu_monitor
  [diagnostics] aquire all cpu data from netdata
* compatible format
* expose netdata_tools errors in diagnostics
* remove ipmi data aquisition
* check max clock speed
* parse netdata dict correctly
* fix typo
* pass interval to netdata
* fix strings in diag_vals
* parse netdata uptime
* parse netdata mem and swap util
* parse netdata cpu_util
* convert to int
* fix wrong keyword
* fix timer interval usage
* cleanup
* use cores detected by netdata
* get memory and swap usage from netdata
* handle empty netdata reponse correctly
* fix pylint
* proper python module for netdata_tools
* wip
* move netdata functions to module
* get core temperature from netdata
* check cpu utilisation with netdata
* Contributors: Felix Messmer, fmessmer, pgehring
```

## cob_script_server

```
* Merge pull request #316 <https://github.com/ipa320/cob_command_tools/issues/316> from fmessmer/speedup_sss
  commenting rospy.logdebug for performance reasons
* commenting rospy.logdebug for performance reasons
* Merge pull request #312 <https://github.com/ipa320/cob_command_tools/issues/312> from fmessmer/tune_close_tolerance
  tune close tolerance in calculate_point_velocities
* tune close tolerance in calculate_point_velocities
* Merge pull request #311 <https://github.com/ipa320/cob_command_tools/issues/311> from floweisshardt/feature/multiple_cob_consoles
  allow multiple cob_consoles to run in parallel
* allow multiple cob_consoles to run in parallel
* Contributors: Felix Messmer, floweisshardt, fmessmer
```

## cob_teleop

- No changes

## generic_throttle

- No changes

## scenario_test_tools

- No changes

## service_tools

- No changes
