### PR TITLE
cob_driver: 0.7.12-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -904,7 +904,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_driver-release.git
-      version: 0.7.11-1
+      version: 0.7.12-1
     source:
       type: git
       url: https://github.com/ipa320/cob_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_driver` to `0.7.12-1`:

- upstream repository: https://github.com/ipa320/cob_driver.git
- release repository: https://github.com/ipa320/cob_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.11-1`

## cob_base_drive_chain

- No changes

## cob_bms_driver

- No changes

## cob_canopen_motor

- No changes

## cob_driver

- No changes

## cob_elmo_homing

- No changes

## cob_generic_can

- No changes

## cob_light

```
* Merge pull request #430 <https://github.com/ipa320/cob_driver/issues/430> from benmaidel/feature/new_modes
  [cob_light] new features
* catkin lint
* updated license header
* add turn indicator mode
* decrease fade factor for kit
* fun kit mode
* Contributors: Benjamin Maidel, Felix Messmer
```

## cob_mimic

- No changes

## cob_phidget_em_state

- No changes

## cob_phidget_power_state

- No changes

## cob_phidgets

- No changes

## cob_relayboard

- No changes

## cob_scan_unifier

- No changes

## cob_sick_lms1xx

- No changes

## cob_sick_s300

- No changes

## cob_sound

- No changes

## cob_undercarriage_ctrl

- No changes

## cob_utilities

- No changes

## cob_voltage_control

- No changes

## laser_scan_densifier

- No changes
