### PR TITLE
rqt_robot_monitor: 1.0.5-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4326,7 +4326,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_robot_monitor-release.git
-      version: 1.0.4-2
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_monitor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_monitor` to `1.0.5-1`:

- upstream repository: https://github.com/ros-visualization/rqt_robot_monitor.git
- release repository: https://github.com/ros2-gbp/rqt_robot_monitor-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.4-2`

## rqt_robot_monitor

```
* Improve error and warning lists by only showing leaf-elements
```
