### PR TITLE
rclc: 1.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3635,10 +3635,11 @@ repositories:
       - rclc
       - rclc_examples
       - rclc_lifecycle
+      - rclc_parameter
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclc` to `1.1.1-1`:

- upstream repository: https://github.com/ros2/rclc.git
- release repository: https://github.com/ros2-gbp/rclc-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.0-1`

## rclc

```
* Fix enum naming for avoid collision (backport #242) (#243)
* Backport parameters (#263)
```

## rclc_examples

```
* Backport parameters (#263)
```

## rclc_lifecycle

```
* no changes
```

## rclc_parameter

```
* Backport parameters (#263)
```
