### PR TITLE
realsense2_camera: 4.0.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3058,7 +3058,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
-      version: 4.0.2-1
+      version: 4.0.3-1
     source:
       test_pull_requests: true
       type: git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3049,7 +3049,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/IntelRealSense/realsense-ros.git
-      version: ros2
+      version: ros2-beta
     release:
       packages:
       - realsense2_camera
@@ -3063,7 +3063,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/IntelRealSense/realsense-ros.git
-      version: ros2
+      version: ros2-beta
     status: developed
   realtime_support:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `4.0.3-1`:

- upstream repository: https://github.com/IntelRealSense/realsense-ros.git
- release repository: https://github.com/IntelRealSense/realsense-ros-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `4.0.2-1`

## realsense2_camera

```
* Support intra-process zero-copy
* Update README
* Fix Galactic deprecated-declarations compilation warning
* Fix Eloquent compilation error
* Contributors: Eran, Nir-Az, SamerKhshiboun
```

## realsense2_camera_msgs

- No changes

## realsense2_description

- No changes
