### PR TITLE
grepros: 0.4.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1522,7 +1522,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/suurjaak/grepros-release.git
-      version: 0.4.0-1
+      version: 0.4.4-1
     source:
       type: git
       url: https://github.com/suurjaak/grepros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grepros` to `0.4.4-1`:

- upstream repository: https://github.com/suurjaak/grepros.git
- release repository: https://github.com/suurjaak/grepros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.0-1`

## grepros

```
* add support for reading zstd-compressed bagfiles
* use message type definition from ROS1 live topics instead of locally installed package
* optimize partial printing of very long array fields
* optimize CSV output of very long array fields
* strip leading "./" from printed filename prefix if grepping working directory
* fix not skipping ROS2 bag if all topics filtered out
* fix making compatible QoS for ROS2 topic subscriptions
* fix making unique filename on error in HTML output
```
