### PR TITLE
ign_ros2_control: 0.4.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1246,7 +1246,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 0.3.0-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/ignitionrobotics/ign_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ign_ros2_control` to `0.4.0-1`:

- upstream repository: https://github.com/ignitionrobotics/ign_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.0-1`

## ign_ros2_control

```
* Fix default ign gazebo version Galactic (#44 <https://github.com/ignitionrobotics/ign_ros2_control/issues/44>)
* Contributors: Alejandro Hernández Cordero
```

## ign_ros2_control_demos

- No changes
