### PR TITLE
slider_publisher: 2.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5471,7 +5471,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/oKermorgant/slider_publisher-release.git
-      version: 2.0.1-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/oKermorgant/slider_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `slider_publisher` to `2.1.0-1`:

- upstream repository: https://github.com/oKermorgant/slider_publisher.git
- release repository: https://github.com/oKermorgant/slider_publisher-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.1-1`

## slider_publisher

```
* do not re-call service if request has not changed
* example Twist defaults to 0 velocity
* Contributors: Olivier Kermorgant
```
