### PR TITLE
Add Gazebo classic rosdep keys for Jammy

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3187,7 +3187,10 @@ libftgl-dev:
   gentoo: [media-libs/ftgl]
   ubuntu: [libftgl-dev]
 libgazebo-dev:
+  debian: [libgazebo-dev]
+  gentoo: [=sci-electronics/gazebo-11*]
   ubuntu:
+    focal: [libgazebo11-dev]
     jammy: [libgazebo-dev]
 libgazebo11-dev:
   debian:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1184,6 +1184,7 @@ gazebo11:
   nixos: [gazebo_11]
   ubuntu:
     focal: [gazebo11]
+    jammy: [gazebo]
 gazebo5:
   arch: [gazebo]
   gentoo: [=sci-electronics/gazebo-5*]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1167,6 +1167,7 @@ gazebo:
     disco: [gazebo9]
     eoan: [gazebo9]
     focal: [gazebo11]
+    jammy: [gazebo]
     precise: [gazebo]
     quantal: [gazebo]
     raring: [gazebo]
@@ -3184,6 +3185,9 @@ libftgl-dev:
   fedora: [ftgl-devel]
   gentoo: [media-libs/ftgl]
   ubuntu: [libftgl-dev]
+libgazebo-dev:
+  ubuntu:
+    jammy: [libgazebo-dev]
 libgazebo11-dev:
   debian:
     buster: [libgazebo11-dev]
@@ -3191,6 +3195,7 @@ libgazebo11-dev:
   nixos: [gazebo_11]
   ubuntu:
     focal: [libgazebo11-dev]
+    jammy: [libgazebo-dev]
 libgazebo5-dev:
   arch: [gazebo]
   gentoo: [=sci-electronics/gazebo-5*]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3187,7 +3187,9 @@ libftgl-dev:
   gentoo: [media-libs/ftgl]
   ubuntu: [libftgl-dev]
 libgazebo-dev:
-  debian: [libgazebo-dev]
+  debian:
+    bullseye: [libgazebo-dev]
+    buster: [libgazebo11-dev]
   gentoo: [=sci-electronics/gazebo-11*]
   ubuntu:
     focal: [libgazebo11-dev]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

This is a subset of

* #31560 

## Package name:

* `gazebo`
    * Both `gazebo` and `gazebo11` rosdep keys point to this package
* `libgazebo-dev`
    * Both `libgazebo-dev` and `libgazebo11-dev` rosdep keys point to this package

## Package Upstream Source:

* https://github.com/osrf/gazebo/

## Purpose of using this:

Pull Gazebo simulator from upstream Ubuntu Jammy.

## Links to Distribution Packages

- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/search?lang=cs&keywords=gazebo&searchon=names

