### PR TITLE
rosee_msg: 1.0.2-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7988,6 +7988,21 @@ repositories:
       url: https://github.com/ros-infrastructure/rosdoc_lite.git
       version: master
     status: maintained
+  rosee_msg:
+    doc:
+      type: git
+      url: https://github.com/ADVRHumanoids/rosee_msg.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ADVRHumanoids/rosee_msg-release.git
+      version: 1.0.2-2
+    source:
+      type: git
+      url: https://github.com/ADVRHumanoids/rosee_msg.git
+      version: master
+    status: maintained
   rosfmt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosee_msg` to `1.0.2-2`:

- upstream repository: https://github.com/ADVRHumanoids/rosee_msg.git
- release repository: https://github.com/ADVRHumanoids/rosee_msg-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## rosee_msg

```
* roscpp and rospy dependencies && authors and urls in package
* Contributors: Davide Torielli
```
