### PR TITLE
vision_msgs: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5061,7 +5061,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/vision_msgs-release.git
-      version: 3.0.0-5
+      version: 4.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_msgs` to `4.0.0-1`:

- upstream repository: https://github.com/ros-perception/vision_msgs.git
- release repository: https://github.com/ros2-gbp/vision_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.0.0-5`

## vision_msgs

```
* Merge pull request #67 <https://github.com/ros-perception/vision_msgs/issues/67> from ijnek/ijnek-point-2d
  Add Point2d message, and use it in Pose2D
* Update msg/Point2D.msg
  Co-authored-by: Adam Allevato <mailto:Kukanani@users.noreply.github.com>
* add Point2D message
* replace deprecated pose2d with pose (#64 <https://github.com/ros-perception/vision_msgs/issues/64>)
  * replace deprecated geometry_msgs/Pose2D with geometry_msgs/Pose
  * replace Pose2D with Pose.
  * add Pose2D.msg
  * undo some changes made
  * Update msg/Pose2D.msg
  Co-authored-by: Adam Allevato <mailto:Kukanani@users.noreply.github.com>
  Co-authored-by: Adam Allevato <mailto:Kukanani@users.noreply.github.com>
* Clarify array messages in readme
* Trailing newline in bbox2Darray
* Add bbox array msgs to CMakeLists
* Added BoundingBox2DArray message
* Contributors: Adam Allevato, Fruchtzwerg94, Kenji Brameld
```
