### PR TITLE
realsense2_camera: 4.0.4-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3073,7 +3073,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
-      version: 4.0.3-1
+      version: 4.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `4.0.4-1`:

- upstream repository: https://github.com/IntelRealSense/realsense-ros.git
- release repository: https://github.com/IntelRealSense/realsense-ros-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `4.0.3-1`

## realsense2_camera

```
* fix required packages for building debians for ros2-beta branch
* Contributors: NirAz
```

## realsense2_camera_msgs

- No changes

## realsense2_description

- No changes
