### PR TITLE
transport_drivers: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4678,7 +4678,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/transport_drivers-release.git
-      version: 1.0.1-2
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ros-drivers/transport_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `transport_drivers` to `1.1.0-1`:

- upstream repository: https://github.com/ros-drivers/transport_drivers.git
- release repository: https://github.com/ros2-gbp/transport_drivers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.1-2`

## asio_cmake_module

- No changes

## io_context

```
* Fix the converter Converter between std_msgs::msg::UInt8MultiArray and std::vector<uint8_t> (#73 <https://github.com/ros-drivers/transport_drivers/issues/73>)
  * example_interfaces is redundant as std_msgs includes UInt8MultiArray
  * udp_msgs.hpp should not include "converters.hpp"
  * Fix the converter std_msgs::msg::UInt8MultiArray <-> std::vector<uint8_t>
* Add a second constructor to avoid comparing size_t (unsigned int) and int (#70 <https://github.com/ros-drivers/transport_drivers/issues/70>)
* Fix cpplint error (#69 <https://github.com/ros-drivers/transport_drivers/issues/69>)
  See https://build.ros2.org/job/Gdev__transport_drivers__ubuntu_focal_amd64/9/testReport/junit/(root)/projectroot/cpplint/
* Contributors: ChenJun, Esteve Fernandez
```

## serial_driver

```
* Support serial_break (#76 <https://github.com/ros-drivers/transport_drivers/issues/76>)
  * Support serial_break
  * Add protection to serial break and unit tests
* Fix the converter Converter between std_msgs::msg::UInt8MultiArray and std::vector<uint8_t> (#73 <https://github.com/ros-drivers/transport_drivers/issues/73>)
  * example_interfaces is redundant as std_msgs includes UInt8MultiArray
  * udp_msgs.hpp should not include "converters.hpp"
  * Fix the converter std_msgs::msg::UInt8MultiArray <-> std::vector<uint8_t>
* Add support for Foxy (#68 <https://github.com/ros-drivers/transport_drivers/issues/68>)
  * Add support for Foxy
  * Use same API signature for all ROS distros
* Contributors: ChenJun, Esteve Fernandez, RFRIEDM-Trimble
```

## udp_driver

```
* Add missing header.
* Add new constructors and members to bind host endpoint (#65 <https://github.com/ros-drivers/transport_drivers/issues/65>)
  * Add new constructors and members to bind host endpoint
  * address review: fix constructor and endpoint
* Add support for Foxy (#68 <https://github.com/ros-drivers/transport_drivers/issues/68>)
  * Add support for Foxy
  * Use same API signature for all ROS distros
* Fix nullptr access in udp receiver node (#67 <https://github.com/ros-drivers/transport_drivers/issues/67>)
* Add reuse address function (#64 <https://github.com/ros-drivers/transport_drivers/issues/64>)
  * Add reuse address function
  * Address review: Enable reuse address in open function
* Contributors: Daisuke Nishimatsu, Esteve Fernandez, WhitleySoftwareServices
```
