### PR TITLE
transport_drivers: 1.1.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5072,7 +5072,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/transport_drivers-release.git
-      version: 1.0.1-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/ros-drivers/transport_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `transport_drivers` to `1.1.1-1`:

- upstream repository: https://github.com/ros-drivers/transport_drivers.git
- release repository: https://github.com/ros2-gbp/transport_drivers-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.1-1`

## asio_cmake_module

- No changes

## io_context

```
* Fix linter errors for galactic.
* Contributors: WhitleySoftwareServices
```

## serial_driver

```
* Disable broken test.
* Fix linter errors for galactic.
* Contributors: WhitleySoftwareServices
```

## udp_driver

```
* Fix linter errors for galactic.
* Contributors: WhitleySoftwareServices
```
