### PR TITLE
transport_drivers: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4678,7 +4678,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/transport_drivers-release.git
-      version: 1.0.1-2
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/ros-drivers/transport_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `transport_drivers` to `1.2.0-1`:

- upstream repository: https://github.com/ros-drivers/transport_drivers.git
- release repository: https://github.com/ros2-gbp/transport_drivers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.1-2`

## asio_cmake_module

- No changes

## io_context

```
* Fix linter errors.
* Contributors: WhitleySoftwareServices
```

## serial_driver

```
* Disable broken test.
* Fix linter errors.
* Contributors: WhitleySoftwareServices
```

## udp_driver

```
* Fix linter errors.
* Contributors: WhitleySoftwareServices
```
