### PR TITLE
steering_functions: 0.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9452,7 +9452,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/nobleo/steering_functions-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/hbanzhaf/steering_functions.git


### PR DESCRIPTION
Increasing version of package(s) in repository `steering_functions` to `0.1.1-1`:

- upstream repository: https://github.com/hbanzhaf/steering_functions.git
- release repository: https://github.com/nobleo/steering_functions-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.0-1`
