### PR TITLE
flir_camera_driver: 0.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2404,7 +2404,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_camera_driver` to `0.2.1-1`:

- upstream repository: https://github.com/ros-drivers/flir_camera_driver.git
- release repository: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.0-1`

## flir_camera_description

- No changes

## flir_camera_driver

- No changes

## spinnaker_camera_driver

```
* Removed check for build/usr/lib which would cause build to skip Spinnaker SDK install
* Contributors: Luis Camero
```
