### PR TITLE
realsense2_camera: 4.0.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3731,7 +3731,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
-      version: 4.0.2-1
+      version: 4.0.4-1
     source:
       test_pull_requests: true
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3722,7 +3722,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/IntelRealSense/realsense-ros.git
-      version: ros2
+      version: ros2-beta
     release:
       packages:
       - realsense2_camera
@@ -3736,7 +3736,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/IntelRealSense/realsense-ros.git
-      version: ros2
+      version: ros2-beta
     status: developed
   realsense_hardware_interface:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `4.0.4-1`:

- upstream repository: https://github.com/IntelRealSense/realsense-ros.git
- release repository: https://github.com/IntelRealSense/realsense-ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `4.0.2-1`

## realsense2_camera

```
* fix required packages for building debians for ros2-beta branch
* Contributors: NirAz
```

## realsense2_camera_msgs

- No changes

## realsense2_description

- No changes
