### PR TITLE
vision_opencv_python3: 1.13.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -14682,6 +14682,23 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: melodic
     status: maintained
+  vision_opencv_python3:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/vision_opencv_python3.git
+      version: melodic
+    release:
+      packages:
+      - cv_bridge_python3
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/vision_opencv_python3-release.git
+      version: 1.13.1-1
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/vision_opencv_python3.git
+      version: melodic
+    status: developed
   vision_visp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv_python3` to `1.13.1-1`:

- upstream repository: https://github.com/jsk-ros-pkg/vision_opencv_python3.git
- release repository: https://github.com/tork-a/vision_opencv_python3-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## cv_bridge_python3

```
* depends on python3, change package name to cv_bridge_python3
* Contributors: Kei Okada
```
