### PR TITLE
Update Pinocchio to 2.6.6 to include HPP-FCL support & build with Clang

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6177,7 +6177,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/stack-of-tasks/pinocchio-ros-release.git
-      version: 2.6.5-1
+      version: 2.6.6-2
     source:
       type: git
       url: https://github.com/stack-of-tasks/pinocchio.git


### PR DESCRIPTION
This PR updates Pinocchio to 2.6.6. It introduces a dependency on `hpp-fcl` and switches the compiler to clang, hopefully reducing the memory exhaustion issues we've seen in the past.