### PR TITLE
robotraconteur: 0.15.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7438,7 +7438,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/robotraconteur-packaging/robotraconteur-ros-release.git
-      version: 0.15.4-1
+      version: 0.15.5-1
     source:
       type: git
       url: https://github.com/robotraconteur/robotraconteur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotraconteur` to `0.15.5-1`:

- upstream repository: https://github.com/robotraconteur/robotraconteur.git
- release repository: https://github.com/robotraconteur-packaging/robotraconteur-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.15.4-1`
