### PR TITLE
add python3-transitions rosdep key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5257,15 +5257,24 @@ python-transitions:
       pip:
         packages: [transitions]
 python3-transitions:
-  debian: 
-    '*': [python3-transitions]
+  debian:
+    sid: [python3-transitions]
+    bookworm: [python3-transitions]
+    bullseye: [python3-transitions]
+    buster:
+      pip:
+        packages: [transitions]
     stretch:
       pip:
         packages: [transitions]
   ubuntu:
     '*': [python3-transitions]
-    xenial: null
-    trusty: null
+    xenial:
+        pip:
+          packages: [transitions]
+    trusty:
+        pip:
+          packages: [transitions]
 python-trep:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5257,23 +5257,6 @@ python-transitions:
     xenial:
       pip:
         packages: [transitions]
-python3-transitions:
-  debian:
-    '*': [python3-transitions]
-    buster:
-      pip:
-        packages: [transitions]
-    stretch:
-      pip:
-        packages: [transitions]
-  ubuntu:
-    '*': [python3-transitions]
-    xenial:
-      pip:
-        packages: [transitions]
-    trusty:
-      pip:
-        packages: [transitions]
 python-trep:
   debian:
     pip:
@@ -5285,6 +5268,23 @@ python-trep:
   ubuntu:
     pip:
       packages: [trep]
+python3-transitions:
+  debian:
+    '*': [python3-transitions]
+    buster:
+      pip:
+        packages: [transitions]
+    stretch:
+      pip:
+        packages: [transitions]
+  ubuntu:
+    '*': [python3-transitions]
+    trusty:
+      pip:
+        packages: [transitions]
+    xenial:
+      pip:
+        packages: [transitions]
 python-triangle-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5268,7 +5268,6 @@ python-trep:
   ubuntu:
     pip:
       packages: [trep]
-
 python-triangle-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5268,11 +5268,11 @@ python3-transitions:
   ubuntu:
     '*': [python3-transitions]
     xenial:
-        pip:
-          packages: [transitions]
+      pip:
+        packages: [transitions]
     trusty:
-        pip:
-          packages: [transitions]
+      pip:
+        packages: [transitions]
 python-trep:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5258,9 +5258,7 @@ python-transitions:
         packages: [transitions]
 python3-transitions:
   debian:
-    sid: [python3-transitions]
-    bookworm: [python3-transitions]
-    bullseye: [python3-transitions]
+    '*': [python3-transitions]
     buster:
       pip:
         packages: [transitions]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5257,6 +5257,11 @@ python-transitions:
       pip:
         packages: [transitions]
 python3-transitions:
+  debian: 
+    '*': [python3-transitions]
+    stretch:
+      pip:
+        packages: [transitions]
   ubuntu:
     '*': [python3-transitions]
     xenial: null

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5256,6 +5256,11 @@ python-transitions:
     xenial:
       pip:
         packages: [transitions]
+python3-transitions:
+  ubuntu:
+    '*': [python3-transitions]
+    xenial: null
+    trusty: null
 python-trep:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5268,23 +5268,7 @@ python-trep:
   ubuntu:
     pip:
       packages: [trep]
-python3-transitions:
-  debian:
-    '*': [python3-transitions]
-    buster:
-      pip:
-        packages: [transitions]
-    stretch:
-      pip:
-        packages: [transitions]
-  ubuntu:
-    '*': [python3-transitions]
-    trusty:
-      pip:
-        packages: [transitions]
-    xenial:
-      pip:
-        packages: [transitions]
+
 python-triangle-pip:
   debian:
     pip:
@@ -8589,6 +8573,23 @@ python3-tqdm:
   ubuntu:
     '*': [python3-tqdm]
     xenial: null
+python3-transitions:
+  debian:
+    '*': [python3-transitions]
+    buster:
+      pip:
+        packages: [transitions]
+    stretch:
+      pip:
+        packages: [transitions]
+  ubuntu:
+    '*': [python3-transitions]
+    trusty:
+      pip:
+        packages: [transitions]
+    xenial:
+      pip:
+        packages: [transitions]
 python3-triangle-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-transitions

## Package Upstream Source:

https://github.com/pytransitions/transitions

## Purpose of using this:

after(including) ubuntu:bionic， python transitions is updated to python3 version, I'm using it in my project

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=python3-transitions&searchon=names&suite=all&section=all
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=python3-transitions&searchon=names



<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->


