### PR TITLE
add pytyhon3.8-venv package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8647,6 +8647,15 @@ python3-venv:
     pip:
       packages: []
   ubuntu: [python3-venv]
+python3.8-venv:
+  debian: []
+  fedora: [python38-libs]
+  nixos: [python38]
+  opensuse: [python38-virtualenv]
+  osx:
+    pip:
+      packages: []
+  ubuntu: [python3.8-venv]
 python3-virtualserialports-pip:
   debian:
     pip:


### PR DESCRIPTION
https://packages.ubuntu.com/bionic/python3.8-venv
https://packages.debian.org/search?suite=all&arch=any&searchon=names&keywords=python3.8-venv
https://software.opensuse.org/package/python38-virtualenv
https://search.nixos.org/packages?channel=21.11&show=python38&from=0&size=50&sort=relevance&type=packages&query=python38