### PR TITLE
tesseract: 0.8.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9637,7 +9637,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-industrial-release/tesseract-release.git
-      version: 0.6.9-1
+      version: 0.8.5-1
     source:
       type: git
       url: https://github.com/ros-industrial-consortium/tesseract.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tesseract` to `0.8.5-1`:

- upstream repository: https://github.com/tesseract-robotics/tesseract.git
- release repository: https://github.com/ros-industrial-release/tesseract-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.9-1`

## tesseract_collision

```
* Add boost serialization for Environment commands and all underlying types (#726 <https://github.com/tesseract-robotics/tesseract/issues/726>)
  * Add serialization macros to tesseract_common
  * Add serialization for tesseract_geometry primatives
  * Add serialization for meshes and octree
  * Add serialization for Link and Joint
  * Add serialization for tesseract_common types
  * Add serialization for SceneGraph and SceneState
  * Add serialization for tesseract_srdf and tesseract_common types
  * Add serialization for environment commands
  * Fix bug in getCollisionObjectPairs
* Contributors: Matthew Powelson
```

## tesseract_common

```
* Add boost serialization for Environment commands and all underlying types (#726 <https://github.com/tesseract-robotics/tesseract/issues/726>)
  * Add serialization macros to tesseract_common
  * Add serialization for tesseract_geometry primatives
  * Add serialization for meshes and octree
  * Add serialization for Link and Joint
  * Add serialization for tesseract_common types
  * Add serialization for SceneGraph and SceneState
  * Add serialization for tesseract_srdf and tesseract_common types
  * Add serialization for environment commands
  * Fix bug in getCollisionObjectPairs
* Adjust for breaking change in Boost DLL 1.76
* Contributors: Josh Langsfeld, Matthew Powelson
```

## tesseract_environment

```
* Add boost serialization for Environment commands and all underlying types (#726 <https://github.com/tesseract-robotics/tesseract/issues/726>)
  * Add serialization macros to tesseract_common
  * Add serialization for tesseract_geometry primatives
  * Add serialization for meshes and octree
  * Add serialization for Link and Joint
  * Add serialization for tesseract_common types
  * Add serialization for SceneGraph and SceneState
  * Add serialization for tesseract_srdf and tesseract_common types
  * Add serialization for environment commands
  * Fix bug in getCollisionObjectPairs
* Add methods for getting link transform information from state solver
* Contributors: Levi Armstrong, Matthew Powelson
```

## tesseract_geometry

```
* Add boost serialization for Environment commands and all underlying types (#726 <https://github.com/tesseract-robotics/tesseract/issues/726>)
  * Add serialization macros to tesseract_common
  * Add serialization for tesseract_geometry primatives
  * Add serialization for meshes and octree
  * Add serialization for Link and Joint
  * Add serialization for tesseract_common types
  * Add serialization for SceneGraph and SceneState
  * Add serialization for tesseract_srdf and tesseract_common types
  * Add serialization for environment commands
  * Fix bug in getCollisionObjectPairs
* Contributors: Matthew Powelson
```

## tesseract_kinematics

- No changes

## tesseract_scene_graph

```
* Add boost serialization for Environment commands and all underlying types (#726 <https://github.com/tesseract-robotics/tesseract/issues/726>)
  * Add serialization macros to tesseract_common
  * Add serialization for tesseract_geometry primatives
  * Add serialization for meshes and octree
  * Add serialization for Link and Joint
  * Add serialization for tesseract_common types
  * Add serialization for SceneGraph and SceneState
  * Add serialization for tesseract_srdf and tesseract_common types
  * Add serialization for environment commands
  * Fix bug in getCollisionObjectPairs
* Fix incorrect linking to console_bridge for tesseract_scene_graph example
* Contributors: Josh Langsfeld, Matthew Powelson
```

## tesseract_srdf

```
* Add boost serialization for Environment commands and all underlying types (#726 <https://github.com/tesseract-robotics/tesseract/issues/726>)
  * Add serialization macros to tesseract_common
  * Add serialization for tesseract_geometry primatives
  * Add serialization for meshes and octree
  * Add serialization for Link and Joint
  * Add serialization for tesseract_common types
  * Add serialization for SceneGraph and SceneState
  * Add serialization for tesseract_srdf and tesseract_common types
  * Add serialization for environment commands
  * Fix bug in getCollisionObjectPairs
* Contributors: Matthew Powelson
```

## tesseract_state_solver

```
* Add methods for getting link transform information from state solver
* Contributors: Levi Armstrong
```

## tesseract_support

- No changes

## tesseract_urdf

- No changes

## tesseract_visualization

- No changes
