### PR TITLE
opw_kinematics: 0.4.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5821,7 +5821,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-industrial-release/opw_kinematics-release.git
-      version: 0.4.4-1
+      version: 0.4.5-1
     source:
       type: git
       url: https://github.com/Jmeyer1292/opw_kinematics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `opw_kinematics` to `0.4.5-1`:

- upstream repository: https://github.com/Jmeyer1292/opw_kinematics.git
- release repository: https://github.com/ros-industrial-release/opw_kinematics-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.4-1`

## opw_kinematics

```
* Upgrade to latest cmake boilerplate and add cmake formater
* Contributors: Levi Armstrong
```
