### PR TITLE
opw_kinematics: 0.4.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8418,7 +8418,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-industrial-release/opw_kinematics-release.git
-      version: 0.4.4-1
+      version: 0.4.5-1
     source:
       type: git
       url: https://github.com/Jmeyer1292/opw_kinematics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `opw_kinematics` to `0.4.5-1`:

- upstream repository: https://github.com/Jmeyer1292/opw_kinematics.git
- release repository: https://github.com/ros-industrial-release/opw_kinematics-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.4-1`

## opw_kinematics

```
* Upgrade to latest cmake boilerplate and add cmake formater
* Contributors: Levi Armstrong
```
