### PR TITLE
ifopt: 2.1.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3248,7 +3248,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ethz-adrl/ifopt-release.git
-      version: 2.1.2-1
+      version: 2.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ifopt` to `2.1.3-1`:

- upstream repository: https://github.com/ethz-adrl/ifopt.git
- release repository: https://github.com/ethz-adrl/ifopt-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.2-1`

## ifopt

```
* Enable building of static libs
* (#77 <https://github.com/ethz-adrl/ifopt/issues/77>) Implement Required Method
* Fix CMake install() rules for Windows DLLs
* Contributors: Josh Langsfeld, Konstantinos Chatzilygeroudis, Rafael Rojas
```
