### PR TITLE
launch_ros: 0.19.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1537,7 +1537,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.18.0-1
+      version: 0.19.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.19.0-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.18.0-1`

## launch_ros

```
* Use correct namespace when evaluating parameter files for composable nodes (#303 <https://github.com/ros2/launch_ros/issues/303>)
* Handle empty strings when evaluating parameters (#300 <https://github.com/ros2/launch_ros/issues/300>)
* Contributors: Jacob Perron
```

## launch_testing_ros

- No changes

## ros2launch

- No changes
