### PR TITLE
rviz: 11.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4266,7 +4266,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 11.0.0-1
+      version: 11.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `11.1.0-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `11.0.0-1`

## rviz2

- No changes

## rviz_assimp_vendor

```
* Make sure to pass compiler and flags down to assimp (#844 <https://github.com/ros2/rviz/issues/844>)
* Contributors: Chris Lalancette
```

## rviz_common

- No changes

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Make getVerticesPerPoint method public and improve tests (#843 <https://github.com/ros2/rviz/issues/843>)
* Disable class-memaccess warnings for Eigen (#838 <https://github.com/ros2/rviz/issues/838>)
* Contributors: Chris Lalancette, Jorge Perez
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
