### PR TITLE
rcl: 5.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2716,7 +2716,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 5.1.0-1
+      version: 5.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `5.2.0-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `5.1.0-1`

## rcl

```
* Allow forward slashes within a parameter name rule in argument parsing (#860 <https://github.com/ros2/rcl/issues/860>)
* Suppress false positive from clang-tidy (#951 <https://github.com/ros2/rcl/issues/951>)
* Fix missing terminating 0 in rcl_context_impl_t.argv (#969 <https://github.com/ros2/rcl/issues/969>)
* test_publisher_wait_all_ack depends on rcpputils (#968 <https://github.com/ros2/rcl/issues/968>)
* Micro-optimizations in rcl (#965 <https://github.com/ros2/rcl/issues/965>)
* If timer canceled, rcl_timer_get_time_until_next_call returns TIMER_CANCELED (#963 <https://github.com/ros2/rcl/issues/963>)
* Contributors: Chris Lalancette, Haowei Wen, Ivan Santiago Paunovic, Shane Loretz, William Woodall, mauropasse
```

## rcl_action

- No changes

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

- No changes
