### PR TITLE
tesseract: 0.8.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9637,7 +9637,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-industrial-release/tesseract-release.git
-      version: 0.6.9-1
+      version: 0.8.6-1
     source:
       type: git
       url: https://github.com/ros-industrial-consortium/tesseract.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tesseract` to `0.8.6-1`:

- upstream repository: https://github.com/tesseract-robotics/tesseract.git
- release repository: https://github.com/ros-industrial-release/tesseract-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.9-1`

## tesseract_collision

- No changes

## tesseract_common

```
* Add atomic serialization
* Contributors: Levi Armstrong
```

## tesseract_environment

- No changes

## tesseract_geometry

- No changes

## tesseract_kinematics

- No changes

## tesseract_scene_graph

- No changes

## tesseract_srdf

- No changes

## tesseract_state_solver

- No changes

## tesseract_support

- No changes

## tesseract_urdf

- No changes

## tesseract_visualization

- No changes
