### PR TITLE
rclcpp: 15.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2803,7 +2803,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 15.1.0-1
+      version: 15.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `15.2.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `15.1.0-1`

## rclcpp

```
* Add missing ament dependency on rcl_interfaces (#1903 <https://github.com/ros2/rclcpp/issues/1903>)
* Update data callback tests to account for all published samples (#1900 <https://github.com/ros2/rclcpp/issues/1900>)
* Increase timeout for acknowledgments to account for slower Connext settings (#1901 <https://github.com/ros2/rclcpp/issues/1901>)
* clang-tidy: explicit constructors (#1782 <https://github.com/ros2/rclcpp/issues/1782>)
* Add client/service QoS getters (#1784 <https://github.com/ros2/rclcpp/issues/1784>)
* Fix a bunch more rosdoc2 issues in rclcpp. (#1897 <https://github.com/ros2/rclcpp/issues/1897>)
* time_until_trigger returns max time if timer is cancelled (#1893 <https://github.com/ros2/rclcpp/issues/1893>)
* Micro-optimizations in rclcpp (#1896 <https://github.com/ros2/rclcpp/issues/1896>)
* Contributors: Andrea Sorbini, Chris Lalancette, Mauro Passerino, Scott K Logan, William Woodall
```

## rclcpp_action

```
* Fix rosdoc2 issues (#1897 <https://github.com/ros2/rclcpp/issues/1897>)
* Contributors: Chris Lalancette
```

## rclcpp_components

```
* Select executor in node registration (#1898 <https://github.com/ros2/rclcpp/issues/1898>)
* Fix rosdoc2 issues in rclcpp (#1897 <https://github.com/ros2/rclcpp/issues/1897>)
* Fix bugprone-exception-escape in node_main.cpp.in (#1895 <https://github.com/ros2/rclcpp/issues/1895>)
* Contributors: Alberto Soragna, Chris Lalancette, Hirokazu Ishida
```

## rclcpp_lifecycle

```
* Fix rosdoc2 issues (#1897 <https://github.com/ros2/rclcpp/issues/1897>)
* Contributors: Chris Lalancette
```
