### PR TITLE
image_common: 3.1.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1274,7 +1274,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 3.1.3-1
+      version: 3.1.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `3.1.4-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.1.3-1`

## camera_calibration_parsers

```
* Tests depend on rcpputils (#236 <https://github.com/ros-perception/image_common/issues/236>)
* Contributors: Shane Loretz
```

## camera_info_manager

- No changes

## image_common

- No changes

## image_transport

```
* Image transport publisher crash fixes (#235 <https://github.com/ros-perception/image_common/issues/235>)
* Contributors: RoboTech Vision
```
