### PR TITLE
ros2_control: 2.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3352,7 +3352,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.4.0-1
+      version: 2.5.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.5.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.4.0-1`

## controller_interface

```
* Use lifecycle nodes in controllers again (#538 <https://github.com/ros-controls/ros2_control/issues/538>)
  * Add lifecycle nodes
  * Add custom 'configure' to controller interface to get 'update_rate' parameter.
  * Disable external interfaces of LifecycleNode.
* Cleaning Controller Interface from obsolete code. (#655 <https://github.com/ros-controls/ros2_control/issues/655>)
* Contributors: Denis Štogl, Vatan Aksoy Tezer, Bence Magyar
```

## controller_manager

```
* Make ControllerManager tests more flexible and reusable for different scenarios. Use more parameterized tests regarding strictness. (#661 <https://github.com/ros-controls/ros2_control/issues/661>)
* Use lifecycle nodes in controllers again (#538 <https://github.com/ros-controls/ros2_control/issues/538>)
  * Add lifecycle nodes
  * Add custom 'configure' to controller interface to get 'update_rate' parameter.
  * Disable external interfaces of LifecycleNode.
* Small fixes in controller manager tests. (#660 <https://github.com/ros-controls/ros2_control/issues/660>)
* Enable controller manager services to control hardware lifecycle #abi-breaking (#637 <https://github.com/ros-controls/ros2_control/issues/637>)
  * Implement CM services for hardware lifecycle management.
  * Added default behavior to activate all controller and added description of CM parameters.
* Contributors: Denis Štogl, Vatan Aksoy Tezer, Bence Magyar
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Require lifecycle-msgs in hardware_interface package (#675 <https://github.com/ros-controls/ros2_control/issues/675>) (#678 <https://github.com/ros-controls/ros2_control/issues/678>)
* Using should be inside namespace and not global scope. (#673 <https://github.com/ros-controls/ros2_control/issues/673>)
* Modernize C++: Use for-each loops in Resource Manager. (#659 <https://github.com/ros-controls/ros2_control/issues/659>)
* Enable controller manager services to control hardware lifecycle #abi-breaking (#637 <https://github.com/ros-controls/ros2_control/issues/637>)
  * Implement CM services for hardware lifecycle management.
  * Added default behavior to activate all controller and added description of CM parameters.
* Contributors: Denis Štogl
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## transmission_interface

- No changes
