### PR TITLE
camera_aravis: 4.0.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -558,7 +558,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/FraunhoferIOSB/camera_aravis-release.git
-      version: 4.0.0-1
+      version: 4.0.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_aravis` to `4.0.1-2`:

- upstream repository: https://github.com/FraunhoferIOSB/camera_aravis.git
- release repository: https://github.com/FraunhoferIOSB/camera_aravis-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `4.0.0-1`

## camera_aravis

```
* Add ROS getter/setter services for camera features
* Add support for multistream encoding conversion
* Fix: Pass on the correct encoding for the additional streams of multisource cameras
* Fix: Continuously check the spawning_ flag
* Fix: Check spawning_ flag only once during spawnStream
* Contributors: Peter Mortimer, Thomas Emter, Dominik Kleiser
```
