### PR TITLE
rmw: 6.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3179,7 +3179,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 6.0.0-1
+      version: 6.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw` to `6.1.0-1`:

- upstream repository: https://github.com/ros2/rmw.git
- release repository: https://github.com/ros2-gbp/rmw-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `6.0.0-1`

## rmw

```
* Add content filtered topics support. (#302 <https://github.com/ros2/rmw/issues/302>)
* Add sequence numbers to rmw_message_info_t. (#318 <https://github.com/ros2/rmw/issues/318>)
* Add rmw_feature_supported(). (#318 <https://github.com/ros2/rmw/issues/318>)
* Contributors: Chen Lihui, Ivan Santiago Paunovic
```

## rmw_implementation_cmake

- No changes
