### PR TITLE
rmw_cyclonedds: 1.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3216,7 +3216,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 1.2.0-1
+      version: 1.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `1.3.0-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.0-1`

## rmw_cyclonedds_cpp

```
* Fix error message in rmw_init_options_copy(). (#380 <https://github.com/ros2/rmw_cyclonedds/issues/380>)
* Add content filter topic feature empty stub. (#289 <https://github.com/ros2/rmw_cyclonedds/issues/289>)
* Update to work with Cyclone 0.9.0 and Iceoryx 2.0 (#379 <https://github.com/ros2/rmw_cyclonedds/issues/379>)
* Fill message info sequence numbers as unsupported, add rmw_feature_supported() implementation. (#381 <https://github.com/ros2/rmw_cyclonedds/issues/381>)
* Contributors: Chen Lihui, Haowei Wen, Ivan Santiago Paunovic, Sumanth Nirmal
```
