### PR TITLE
common_interfaces: 4.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -519,7 +519,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 4.1.0-1
+      version: 4.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_interfaces` to `4.1.1-1`:

- upstream repository: https://github.com/ros2/common_interfaces.git
- release repository: https://github.com/ros2-gbp/common_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `4.1.0-1`

## actionlib_msgs

- No changes

## common_interfaces

- No changes

## diagnostic_msgs

- No changes

## geometry_msgs

- No changes

## nav_msgs

- No changes

## sensor_msgs

```
* Feedback on conditional sensor_msgs_library target (#1 <https://github.com/ros2/common_interfaces/issues/1>) (#183 <https://github.com/ros2/common_interfaces/issues/183>)
* [Fix] Fix image_encodings.hpp's URL in README (#184 <https://github.com/ros2/common_interfaces/issues/184>)
* [Fix] Fix fill_image.hpp's URL in README (#182 <https://github.com/ros2/common_interfaces/issues/182>)
* Add sensor_msgs_library target and install headers to include/${PROJECT_NAME} (#178 <https://github.com/ros2/common_interfaces/issues/178>)
* Contributors: Homalozoa X, Pablo Garrido, Shane Loretz
```

## sensor_msgs_py

- No changes

## shape_msgs

- No changes

## std_msgs

- No changes

## std_srvs

- No changes

## stereo_msgs

- No changes

## trajectory_msgs

- No changes

## visualization_msgs

- No changes
