### PR TITLE
rosbag2_storage_mcap: 0.1.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3885,6 +3885,21 @@ repositories:
       url: https://github.com/ros2/rosbag2_bag_v2.git
       version: galactic
     status: maintained
+  rosbag2_storage_mcap:
+    doc:
+      type: git
+      url: https://github.com/ros-tooling/rosbag2_storage_mcap.git
+      version: main
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/rosbag2_storage_mcap-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros-tooling/rosbag2_storage_mcap.git
+      version: main
+    status: developed
   rosbridge_suite:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2_storage_mcap` to `0.1.0-1`:

- upstream repository: https://github.com/ros-tooling/rosbag2_storage_mcap.git
- release repository: https://github.com/ros2-gbp/rosbag2_storage_mcap-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## rosbag2_storage_mcap

```
* [1.0.0] Use Summary section for get_metadata() and seek(), implement remaining methods (#17 <https://github.com/wep21/rosbag2_storage_mcap/issues/17>)
* feat: add play impl (#16 <https://github.com/wep21/rosbag2_storage_mcap/issues/16>)
* chore: refine package.xml (#15 <https://github.com/wep21/rosbag2_storage_mcap/issues/15>)
* Don't throw when READ_WRITE mode is used; add .mcap file extension to recorded files (#14 <https://github.com/wep21/rosbag2_storage_mcap/issues/14>)
  I may be missing something, but from a cursory glance at [this code](https://github.com/ros2/rosbag2/blob/342d8ed3c1c4ae0411a4a92b60e79a728b8974b8/rosbag2_storage/src/rosbag2_storage/impl/storage_factory_impl.hpp#L108-L135), it appears that the APPEND mode is never used. This means we need to support READ_WRITE.
  This also adds a .mcap extension to recorded file names.
* Add dynamic message definition lookup (#13 <https://github.com/wep21/rosbag2_storage_mcap/issues/13>)
  Currently, an exception will be thrown if lookup fails.
* Switch C++ formatter to clang-format (#12 <https://github.com/wep21/rosbag2_storage_mcap/issues/12>)
  Remove uncrustify linter in favor of clang-format, which is easier to configure for use in VS Code format-on-save.
* Merge pull request #7 <https://github.com/wep21/rosbag2_storage_mcap/issues/7> from ros-tooling/jhurliman/reader-writer
  Reader and writer implementation
* uninitialized struct
* lint
* lint
* lint
* Reader and writer implementation
* Merge pull request #6 <https://github.com/wep21/rosbag2_storage_mcap/issues/6> from wep21/add-metadata-impl
  feat: add metadata impl
* feat: add metadata impl
* Merge pull request #5 <https://github.com/wep21/rosbag2_storage_mcap/issues/5> from wep21/mcap-storage-impl
  feat: mcap storage impl
* chore: update cmake minimum version
* chore: install mcap header
* chore: include mcap header
* fix: move fetch content into rosbag2 storage mcap
* Merge pull request #3 <https://github.com/wep21/rosbag2_storage_mcap/issues/3> from ros-tooling/emersonknapp/mcap_plugin_skeleton
  Add mcap storage plugin skeleton and CI
* Add rosbag2_storage_mcap skeleton
* Contributors: Daisuke Nishimatsu, Emerson Knapp, Jacob Bandes-Storch, John Hurliman, wep21
```
