### PR TITLE
Adding rm_description to documentation index for distro

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7199,7 +7199,6 @@ repositories:
       - rm_common
       - rm_control
       - rm_dbus
-      - rm_description
       - rm_gazebo
       - rm_hw
       - rm_msgs
@@ -7233,6 +7232,12 @@ repositories:
     source:
       type: git
       url: https://github.com/rm-controls/rm_controllers.git
+      version: master
+    status: developed
+  rm_description:
+    doc:
+      type: git
+      url: https://github.com/rm-controls/rm_description.git
       version: master
     status: developed
   robot_body_filter:


### PR DESCRIPTION
I want to separate rm_description from rm_control. 