### PR TITLE
ros2_example: 0.0.1-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4326,6 +4326,14 @@ repositories:
       url: https://github.com/ros-controls/ros2_controllers.git
       version: foxy
     status: developed
+  ros2_example:
+    release:
+      packages:
+      - ros2_examples
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/dippingconda/ros2_example-release.git
+      version: 0.0.1-2
   ros2_intel_realsense:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_example` to `0.0.1-2`:

- upstream repository: https://github.com/dippingconda/ros2_example.git
- release repository: https://github.com/dippingconda/ros2_example-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
