### PR TITLE
libfranka: 0.9.0-2 in 'noetic/distribution.yaml'

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4170,7 +4170,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/frankaemika/libfranka-release.git
-      version: 0.8.0-4
+      version: 0.9.0-2
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Updates the libfranka version from 0.8.0-4 to 0.9.0-2
