### PR TITLE
toposens-library: 1.1.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9706,6 +9706,23 @@ repositories:
       url: https://gitlab.com/toposens/public/ros-packages.git
       version: master
     status: developed
+  toposens-library:
+    doc:
+      type: git
+      url: https://gitlab.com/toposens/public/toposens-library.git
+      version: master
+    release:
+      packages:
+      - toposens-sensor-library
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://gitlab.com/toposens/public/toposens-library-release.git
+      version: 1.1.3-1
+    source:
+      type: git
+      url: https://gitlab.com/toposens/public/toposens-library.git
+      version: master
+    status: developed
   trac_ik:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `toposens-library` to `1.1.3-1`:

- upstream repository: https://gitlab.com/toposens/public/toposens-library.git
- release repository: https://gitlab.com/toposens/public/toposens-library-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
