### PR TITLE
ros2_controllers: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3380,7 +3380,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.1.0-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.2.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.0-1`

## diff_drive_controller

```
* Use lifecycle node as base for controllers (#244 <https://github.com/ros-controls/ros2_controllers/issues/244>)
* Contributors: Denis Štogl, Vatan Aksoy Tezer, Bence Magyar
```

## effort_controllers

```
* Use lifecycle node as base for controllers (#244 <https://github.com/ros-controls/ros2_controllers/issues/244>)
* Contributors: Denis Štogl, Vatan Aksoy Tezer, Bence Magyar
```

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

```
* Use lifecycle node as base for controllers (#244 <https://github.com/ros-controls/ros2_controllers/issues/244>)
* Contributors: Denis Štogl, Vatan Aksoy Tezer, Bence Magyar
```

## gripper_controllers

```
* Use lifecycle node as base for controllers (#244 <https://github.com/ros-controls/ros2_controllers/issues/244>)
* Contributors: Denis Štogl, Vatan Aksoy Tezer, Bence Magyar
```

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

```
* Use lifecycle node as base for controllers (#244 <https://github.com/ros-controls/ros2_controllers/issues/244>)
* Contributors: Denis Štogl, Vatan Aksoy Tezer, Bence Magyar
```

## joint_trajectory_controller

```
* Use lifecycle node as base for controllers (#244 <https://github.com/ros-controls/ros2_controllers/issues/244>)
* JointTrajectoryController: added missing control_toolbox dependencies (#315 <https://github.com/ros-controls/ros2_controllers/issues/315>)
* Use time argument on update function instead of node time (#296 <https://github.com/ros-controls/ros2_controllers/issues/296>)
* Export dependency (#310 <https://github.com/ros-controls/ros2_controllers/issues/310>)
* Contributors: DasRoteSkelett, Erick G. Islas-Osuna, Jafar Abdi, Denis Štogl, Vatan Aksoy Tezer, Bence Magyar
```

## position_controllers

```
* Use lifecycle node as base for controllers (#244 <https://github.com/ros-controls/ros2_controllers/issues/244>)
* Contributors: Denis Štogl, Vatan Aksoy Tezer, Bence Magyar
```

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## velocity_controllers

```
* Use lifecycle node as base for controllers (#244 <https://github.com/ros-controls/ros2_controllers/issues/244>)
* Contributors: Denis Štogl, Vatan Aksoy Tezer, Bence Magyar
```
