### PR TITLE
ament_acceleration: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -50,6 +50,21 @@ repositories:
       url: https://github.com/ros-drivers/ackermann_msgs.git
       version: ros2
     status: maintained
+  ament_acceleration:
+    doc:
+      type: git
+      url: https://github.com/ros-acceleration/ament_acceleration.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_acceleration-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/ros-acceleration/ament_acceleration.git
+      version: main
+    status: developed
   ament_cmake:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_acceleration` to `0.2.0-1`:

- upstream repository: https://github.com/ros-acceleration/ament_acceleration.git
- release repository: https://github.com/ros2-gbp/ament_acceleration-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ament_acceleration

```
* Prepare for release, add minor clarifications.
* Update maintainer.
```
