### PR TITLE
google_benchmark_vendor: 0.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1055,7 +1055,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/google_benchmark_vendor-release.git
-      version: 0.0.7-2
+      version: 0.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `google_benchmark_vendor` to `0.1.0-1`:

- upstream repository: https://github.com/ament/google_benchmark_vendor.git
- release repository: https://github.com/ros2-gbp/google_benchmark_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.7-2`

## google_benchmark_vendor

```
* Use git hash for google_benchmark_vendor (#20 <https://github.com/ament/google_benchmark_vendor/issues/20>)
* Update to google benchmark version 1.6.1 (#19 <https://github.com/ament/google_benchmark_vendor/issues/19>)
* Contributors: Chris Lalancette, Shane Loretz
```
