### PR TITLE
rosidl_typesupport: 1.5.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3804,7 +3804,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-      version: 1.5.0-1
+      version: 1.5.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport` to `1.5.0-2`:

- upstream repository: https://github.com/ros2/rosidl_typesupport.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.5.0-1`

## rosidl_typesupport_c

```
* Install headers to include/${PROJECT_NAME} (#121 <https://github.com/ros2/rosidl_typesupport/issues/121>)
* Contributors: Shane Loretz
```

## rosidl_typesupport_cpp

```
* Install headers to include/${PROJECT_NAME} (#121 <https://github.com/ros2/rosidl_typesupport/issues/121>)
* Contributors: Shane Loretz
```
