### PR TITLE
pybind11_vendor: 2.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2494,7 +2494,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pybind11_vendor-release.git
-      version: 2.3.0-2
+      version: 2.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pybind11_vendor` to `2.4.0-1`:

- upstream repository: https://github.com/ros2/pybind11_vendor.git
- release repository: https://github.com/ros2-gbp/pybind11_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.0-2`

## pybind11_vendor

```
* Use sha256 hash instead of tag (#12 <https://github.com/ros2/pybind11_vendor/issues/12>)
* Install headers to include/${PROJECT_NAME} (#11 <https://github.com/ros2/pybind11_vendor/issues/11>)
* Contributors: Shane Loretz
```
