### PR TITLE
libyaml_vendor: 1.2.1-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1611,7 +1611,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libyaml_vendor-release.git
-      version: 1.2.0-2
+      version: 1.2.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libyaml_vendor` to `1.2.1-2`:

- upstream repository: https://github.com/ros2/libyaml_vendor.git
- release repository: https://github.com/ros2-gbp/libyaml_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.0-2`

## libyaml_vendor

```
* Install headers to include/${PROJECT_NAME} (#46 <https://github.com/ros2/libyaml_vendor/issues/46>)
* Merge pull request #43 <https://github.com/ros2/libyaml_vendor/issues/43> from ros2/update-maintainers
* Update maintainers to Audrow Nash
* Contributors: Audrow Nash, Shane Loretz
```
