### PR TITLE
launch: 0.22.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1502,7 +1502,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.21.1-1
+      version: 0.22.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.22.0-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.21.1-1`

## launch

```
* Support scoping environment variables (#601 <https://github.com/ros2/launch/issues/601>)
* Fix awaiting shutdown in launch context (#603 <https://github.com/ros2/launch/issues/603>)
* Fix parse respawn var (#569 <https://github.com/ros2/launch/issues/569>)
* Make the logged command pretty in ExecuteLocal (#594 <https://github.com/ros2/launch/issues/594>)
* Contributors: Jacob Perron, Kosuke Takeuchi
```

## launch_pytest

- No changes

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* Support scoping environment variables (#601 <https://github.com/ros2/launch/issues/601>)
* Contributors: Jacob Perron
```

## launch_yaml

```
* Support scoping environment variables (#601 <https://github.com/ros2/launch/issues/601>)
* Contributors: Jacob Perron
```
