### PR TITLE
morai_ros2_bridge_example: 0.0.1-3 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2331,6 +2331,14 @@ repositories:
       url: https://github.com/MOCAP4ROS2-Project/mocap_msgs.git
       version: master
     status: developed
+  morai_ros2_bridge_example:
+    release:
+      packages:
+      - ros2_examples
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/dippingconda/morai_ros2_bridge_example-release.git
+      version: 0.0.1-3
   moveit:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `morai_ros2_bridge_example` to `0.0.1-3`:

- upstream repository: https://github.com/dippingconda/ros2_example.git
- release repository: https://github.com/dippingconda/morai_ros2_bridge_example-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
