### PR TITLE
urdfdom_headers: 1.0.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4963,7 +4963,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom_headers-release.git
-      version: 1.0.5-3
+      version: 1.0.6-1
     source:
       type: git
       url: https://github.com/ros/urdfdom_headers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_headers` to `1.0.6-1`:

- upstream repository: https://github.com/ros/urdfdom_headers.git
- release repository: https://github.com/ros2-gbp/urdfdom_headers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.5-3`
