### PR TITLE
ros1_bridge: 0.10.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3328,6 +3328,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros1_bridge-release.git
+      version: 0.10.3-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros1_bridge` to `0.10.3-1`:

- upstream repository: https://github.com/ros2/ros1_bridge.git
- release repository: https://github.com/ros2-gbp/ros1_bridge-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ros1_bridge

```
* Cleanup of README.md (#342 <https://github.com/ros2/ros1_bridge/issues/342>)
* Parametrizing service execution timeout (#340 <https://github.com/ros2/ros1_bridge/issues/340>)
* Fix cpplint error (#341 <https://github.com/ros2/ros1_bridge/issues/341>)
* Update package maintainers (#335 <https://github.com/ros2/ros1_bridge/issues/335>)
* Contributors: Cem Karan, Geoffrey Biggs, Jorge Perez, Marco Bassa, Tim Clephas, Tomoya Fujita
```
