### PR TITLE
ignition_cmake2_vendor: 0.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1237,7 +1237,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ignition_cmake2_vendor-release.git
-      version: 0.0.1-2
+      version: 0.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ignition_cmake2_vendor` to `0.0.2-1`:

- upstream repository: https://github.com/ignition-release/ignition_cmake2_vendor.git
- release repository: https://github.com/ros2-gbp/ignition_cmake2_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.1-2`

## ignition_cmake2_vendor

```
* Fix an ament_lint warning. (#3 <https://github.com/ignition-release/ignition_cmake2_vendor/issues/3>)
* use --no-warn-unused-cli on MSVC (#2 <https://github.com/ignition-release/ignition_cmake2_vendor/issues/2>)
* Fix upstream URL and package reference in manifest
* Contributors: Chris Lalancette, Scott K Logan, Shane Loretz
```
