### PR TITLE
ignition_math6_vendor: 0.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1253,7 +1253,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ignition_math6_vendor-release.git
-      version: 0.0.1-2
+      version: 0.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ignition_math6_vendor` to `0.0.2-1`:

- upstream repository: https://github.com/ignition-release/ignition_math6_vendor.git
- release repository: https://github.com/ros2-gbp/ignition_math6_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.1-2`

## ignition_math6_vendor

```
* Update to 6.9.2 ign-math6. (#1 <https://github.com/ignition-release/ignition_math6_vendor/issues/1>)
* Contributors: Chris Lalancette
```
