### PR TITLE
libstatistics_collector: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1600,7 +1600,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libstatistics_collector-release.git
-      version: 1.1.0-3
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libstatistics_collector` to `1.2.0-1`:

- upstream repository: https://github.com/ros-tooling/libstatistics_collector.git
- release repository: https://github.com/ros2-gbp/libstatistics_collector-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.0-3`

## libstatistics_collector

```
* Bump pascalgn/automerge-action from 0.14.3 to 0.15.2
* Bump ros-tooling/setup-ros from 0.2.2 to 0.3.0
* Bump actions/upload-artifact from 2.3.1 to 3
* Bump actions/upload-artifact from 2.2.4 to 2.3.1
* Bump actions/checkout from 2 to 3
* Bump ros-tooling/setup-ros from 0.2.1 to 0.2.2 (#123 <https://github.com/ros-tooling/libstatistics_collector/issues/123>)
* Install includes to include/${PROJECT_NAME} (#122 <https://github.com/ros-tooling/libstatistics_collector/issues/122>)
* Bump codecov/codecov-action from 2.0.3 to 2.1.0
* Bump pascalgn/automerge-action from 0.14.2 to 0.14.3
* Bump codecov/codecov-action from 2.0.2 to 2.0.3
* Use rosidl_get_typesupport_target() (#116 <https://github.com/ros-tooling/libstatistics_collector/issues/116>)
* Bump codecov/codecov-action from 2.0.1 to 2.0.2
* Bump codecov/codecov-action from 1.5.2 to 2.0.1
* Bump actions/upload-artifact from 1 to 2.2.4
* Bump codecov/codecov-action from 1.5.1 to 1.5.2
* Remove cloudwatch reporting (#110 <https://github.com/ros-tooling/libstatistics_collector/issues/110>)
* Bump codecov/codecov-action from 1.3.1 to 1.5.1
* Bump ros-tooling/setup-ros from 0.2.0 to 0.2.1
* Bump pascalgn/automerge-action from 0.14.1 to 0.14.2
* Bump ros-tooling/setup-ros from 0.1 to 0.2.0
* Bump pascalgn/automerge-action from 0.13.1 to 0.14.1
* Fix autoapprove
* Package.json explicitly owned by emerson to minimize notifications
* Replace index.ros.org links -> docs.ros.org. (#94 <https://github.com/ros-tooling/libstatistics_collector/issues/94>)
* Bump hmarr/auto-approve-action from v2.0.0 to v2.1.0
* Bump codecov/codecov-action from v1.2.1 to v1.3.1
* Use latest versions of CI actions (#92 <https://github.com/ros-tooling/libstatistics_collector/issues/92>)
* Contributors: Chris Lalancette, Emerson Knapp, Shane Loretz, dependabot[bot]
```
