### PR TITLE
graceful_controller: 0.4.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2886,7 +2886,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mikeferguson/graceful_controller-gbp.git
-      version: 0.4.1-1
+      version: 0.4.2-1
     source:
       type: git
       url: https://github.com/mikeferguson/graceful_controller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `graceful_controller` to `0.4.2-1`:

- upstream repository: https://github.com/mikeferguson/graceful_controller.git
- release repository: https://github.com/mikeferguson/graceful_controller-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.1-1`

## graceful_controller

- No changes

## graceful_controller_ros

```
* fix goal tolerance reset (#29 <https://github.com/mikeferguson/graceful_controller/issues/29>)
* add latch_xy_goal_tolerance parameter (#28 <https://github.com/mikeferguson/graceful_controller/issues/28>)
* fix orientation issue with collision checking (#27 <https://github.com/mikeferguson/graceful_controller/issues/27>)
* Contributors: Michael Ferguson
```
