### PR TITLE
ros2_tracing: 4.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3466,7 +3466,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 4.0.0-2
+      version: 4.1.0-1
     source:
       type: git
       url: https://gitlab.com/ros-tracing/ros2_tracing.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `4.1.0-1`:

- upstream repository: https://gitlab.com/ros-tracing/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `4.0.0-2`

## ros2trace

```
* Fix 'ros2 trace' fini() error
* Contributors: Christophe Bedard
```

## tracetools

```
* Install headers to include/${PROJECT_NAME}
* Contributors: Christophe Bedard, Shane Loretz
```

## tracetools_test

```
* Allow providing additional actions for TraceTestCase
* Contributors: Christophe Bedard
```
