### PR TITLE
picovoice-ros: 1.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6063,7 +6063,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/reinzor/picovoice_ros-release.git
-      version: 0.0.4-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/reinzor/picovoice_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `picovoice-ros` to `1.0.0-1`:

- upstream repository: https://github.com/reinzor/picovoice_ros.git
- release repository: https://github.com/reinzor/picovoice_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.4-1`

## picovoice_driver

```
* feat: git submodules, pv_recorder, intent filter (#4 <https://github.com/reinzor/picovoice_ros/issues/4>)
* feat: Use v2.1 api
* Contributors: Rein Appeldoorn
```

## picovoice_msgs

```
* feat: git submodules, pv_recorder, intent filter (#4 <https://github.com/reinzor/picovoice_ros/issues/4>)
* feat: Use v2.1 api
* Contributors: Rein Appeldoorn
```
