### PR TITLE
Retarget ament_acceleration repos to rolling branch

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -54,7 +54,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-acceleration/ament_acceleration.git
-      version: main
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -63,7 +63,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-acceleration/ament_acceleration.git
-      version: main
+      version: rolling
     status: developed
   ament_cmake:
     doc:


### PR DESCRIPTION
Retargeting repo branch in `rolling/distribution.yaml` for the `ament_acceleration` package from `main` to `rolling`. (Done in advance since we'll be doing a release for humble as well.)

upstream repository: https://github.com/ros-acceleration/ament_acceleration.git
release repository: https://github.com/ros2-gbp/ament_acceleration-release.git
distro file: rolling/distribution.yaml