### PR TITLE
diffbot: 1.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1609,6 +1609,32 @@ repositories:
       url: https://github.com/ros/diagnostics.git
       version: noetic-devel
     status: maintained
+  diffbot:
+    doc:
+      type: git
+      url: https://github.com/ros-mobile-robots/diffbot.git
+      version: noetic-devel
+    release:
+      packages:
+      - diffbot_base
+      - diffbot_bringup
+      - diffbot_control
+      - diffbot_description
+      - diffbot_gazebo
+      - diffbot_mbf
+      - diffbot_msgs
+      - diffbot_navigation
+      - diffbot_robot
+      - diffbot_slam
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-mobile-robots-release/diffbot-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros-mobile-robots/diffbot.git
+      version: noetic-devel
+    status: developed
   dingo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diffbot` to `1.1.0-1`:

- upstream repository: https://github.com/ros-mobile-robots/diffbot.git
- release repository: https://github.com/ros-mobile-robots-release/diffbot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## diffbot_base

```
* fix: missing subscriber initialization (#54 <https://github.com/ros-mobile-robots/diffbot/issues/54>)
* feat: warn if eStop() is called on mcu
* Change base config: switch motor pins
* feat: add callbacks for low level pids on mcu #54 <https://github.com/ros-mobile-robots/diffbot/issues/54>
  For MCU firmware
  - Add subscribers for left and right motor pid controllers using
  diffbot_msgs::PIDStamped custom message
  - Update debug logging message (different formatting)
  - Update PID controller interface (provide proportional_, integral_ and
  derivative_ values)
* fix: missing diffbot namespace in test
* fix: test_encoders.cpp include name
* feat: add documentation link for unity
* Merge pull request #42 <https://github.com/ros-mobile-robots/diffbot/issues/42> from joeuser846/motor-defines
  Use MOTOR_LEFT/RIGHT from diffbot_base_config.h instead of hardcoding pin numbers
* Fix filenames
* Use MOTOR_LEFT/RIGHT instead of hardcoding pin numbers
* Contributors: Franz Pucher, Joe User
```

## diffbot_bringup

```
* fix rplidar_laser_link name issue (#40 <https://github.com/ros-mobile-robots/diffbot/issues/40>, #53 <https://github.com/ros-mobile-robots/diffbot/issues/53>)
  - Rename rplidar_gpu_laser_link to rplidar_laser_link in bringup_with_laser.launch
  - Add rplidar.launch to diffbot_bringup to support framed_id argument
  - Make use of new diffbot_bringup/launch/rplidar.launch in bringup_with_laser.launch
  This solves issues in RViz:
  Transform [sender=unknown_publisher]
  For frame [rplidar_gpu_laser_link]: Frame [rplidar_gpu_laser_link] does not exist
  and in the terminal from whic diffbot_slam is launched:
  [ WARN] [1635345613.864692611]: MessageFilter [target=odom ]: Dropped 100.00% of messages so far. Please turn the [ros.gmapping.message_filter] rosconsole logger to DEBUG for more information.
* Contributors: Franz Pucher
```

## diffbot_control

```
* fix robot spawning in world origin using pid gains (#57 <https://github.com/ros-mobile-robots/diffbot/issues/57>)
* include pid.yaml to avoid Gazebo error messages
* Contributors: Franz Pucher
```

## diffbot_description

```
* fix deprecated warning using load_yaml (#53 <https://github.com/ros-mobile-robots/diffbot/issues/53>)
  Using xacro.load_yaml instead of just load_yaml
* Contributors: Franz Pucher
```

## diffbot_gazebo

```
* Update diffbot_gazebo/diffbot_view.launch
  Use db_world as default instead of corridor world
* Contributors: Franz Pucher
```

## diffbot_mbf

- No changes

## diffbot_msgs

- No changes

## diffbot_navigation

```
* Fix minor error in amcl.launch
  The "kld_err" was initialized twice, and with the wrong value. Corrected to initialize the "kld_error" parameter to 0.01 and "kld_z" to 0.99.
* Contributors: Rodrigo Silverio
```

## diffbot_robot

- No changes

## diffbot_slam

- No changes
