### PR TITLE
mrpt_msgs: 0.3.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1965,7 +1965,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/mrpt-ros2-pkg-release/mrpt_msgs-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_msgs` to `0.3.2-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
- release repository: https://github.com/mrpt-ros2-pkg-release/mrpt_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.1-1`

## mrpt_msgs

```
* Fix missing ament_export_dependencies()
* Contributors: Jose Luis Blanco-Claraco
```
