### PR TITLE
tracetools_acceleration: 0.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4709,6 +4709,22 @@ repositories:
       url: https://github.com/ros-tooling/topic_tools.git
       version: main
     status: developed
+  tracetools_acceleration:
+    doc:
+      type: git
+      url: https://github.com/ros-acceleration/tracetools_acceleration.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/tracetools_acceleration-release.git
+      version: 0.4.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-acceleration/tracetools_acceleration.git
+      version: main
+    status: developed
   tracetools_analysis:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tracetools_acceleration` to `0.4.1-1`:

- upstream repository: https://github.com/ros-acceleration/tracetools_acceleration.git
- release repository: https://github.com/ros2-gbp/tracetools_acceleration-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
