### PR TITLE
ros2acceleration: 0.5.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3472,6 +3472,22 @@ repositories:
       url: https://gitlab.com/ros-tracing/ros2_tracing.git
       version: master
     status: developed
+  ros2acceleration:
+    doc:
+      type: git
+      url: https://github.com/ros-acceleration/ros2acceleration.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2acceleration-release.git
+      version: 0.5.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-acceleration/ros2acceleration.git
+      version: rolling
+    status: developed
   ros2cli:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2acceleration` to `0.5.1-1`:

- upstream repository: https://github.com/ros-acceleration/ros2acceleration.git
- release repository: https://github.com/ros2-gbp/ros2acceleration-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
