### PR TITLE
ament_vitis: 0.10.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -232,6 +232,22 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: master
     status: developed
+  ament_vitis:
+    doc:
+      type: git
+      url: https://github.com/ros-acceleration/ament_vitis.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_vitis-release.git
+      version: 0.10.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-acceleration/ament_vitis.git
+      version: rolling
+    status: developed
   angles:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_vitis` to `0.10.0-1`:

- upstream repository: https://github.com/ros-acceleration/ament_vitis.git
- release repository: https://github.com/ros2-gbp/ament_vitis-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ament_vitis

```
* Prepare for release, change maintainer
* Add usage examples
* Enrich ROS_VITIS to be enabled only by VITIS hardware platforms
* Add ROS_VITIS and ROS_XRT variables
* Clarify output of message after operation
```
