### PR TITLE
rosidl_typesupport: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3834,7 +3834,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-      version: 1.5.0-2
+      version: 2.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport` to `2.0.0-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.5.0-2`

## rosidl_typesupport_c

```
* Use target_link_libraries(... PRIVATE ...) in single typesupport case (#124 <https://github.com/ros2/rosidl_typesupport/issues/124>)
* rosidl CMake cleanup in rosidl_typesupport_c (#123 <https://github.com/ros2/rosidl_typesupport/issues/123>)
* Contributors: Shane Loretz
```
