### PR TITLE
rosidl_typesupport_fastrtps: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3854,7 +3854,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-      version: 2.1.0-1
+      version: 2.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_fastrtps` to `2.2.0-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.0-1`

## fastrtps_cmake_module

- No changes

## rosidl_typesupport_fastrtps_c

```
* Install generated headers to include/${PROJECT_NAME} (#88 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/88>)
* Misc fastrtps typesupport generator cleanup (#87 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/87>)
* Contributors: Shane Loretz
```

## rosidl_typesupport_fastrtps_cpp

```
* Install generated headers to include/${PROJECT_NAME} (#88 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/88>)
* Misc fastrtps typesupport generator cleanup (#87 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/87>)
* Contributors: Shane Loretz
```
