### PR TITLE
urdf_parser_py: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4945,7 +4945,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom_py-release.git
-      version: 1.1.0-2
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_parser_py` to `1.2.0-1`:

- upstream repository: https://github.com/ros/urdf_parser_py.git
- release repository: https://github.com/ros2-gbp/urdfdom_py-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.0-2`

## urdfdom_py

```
* Fix the binary install location. (#74 <https://github.com/ros/urdf_parser_py/issues/74>)
* Get Iterable from collections.abc. (#73 <https://github.com/ros/urdf_parser_py/issues/73>)
* Contributors: Chris Lalancette
```
