### PR TITLE
Add pytest-timeout rosdep key for RHEL.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7867,8 +7867,8 @@ python3-pytest-timeout:
   debian: [python3-pytest-timeout]
   fedora: [python3-pytest-timeout]
   gentoo: [dev-python/pytest-timeout]
-  rhel: ['python%{python3_pkgversion}-pytest-timeout']
   opensuse: [python3-pytest-timeout]
+  rhel: ['python%{python3_pkgversion}-pytest-timeout']
   ubuntu: [python3-pytest-timeout]
 python3-pytrinamic-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7867,6 +7867,7 @@ python3-pytest-timeout:
   debian: [python3-pytest-timeout]
   fedora: [python3-pytest-timeout]
   gentoo: [dev-python/pytest-timeout]
+  rhel: ['python%{python3_pkgversion}-pytest-timeout']
   opensuse: [python3-pytest-timeout]
   ubuntu: [python3-pytest-timeout]
 python3-pytrinamic-pip:


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

It's available in EPEL 8: https://pkgs.org/search/?q=python3-pytest-timeout , and is now needed by ros2cli in Rolling.