### PR TITLE
ros2cli: 0.18.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3497,7 +3497,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.18.1-1
+      version: 0.18.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.18.2-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.18.1-1`

## ros2action

```
* Add timeout to kill hanging tests (#701 <https://github.com/ros2/ros2cli/issues/701>)
* Contributors: Audrow Nash
```

## ros2cli

```
* Add timeout to kill hanging tests (#701 <https://github.com/ros2/ros2cli/issues/701>)
* Contributors: Audrow Nash
```

## ros2cli_test_interfaces

- No changes

## ros2component

```
* Add timeout to kill hanging tests (#701 <https://github.com/ros2/ros2cli/issues/701>)
* Contributors: Audrow Nash
```

## ros2doctor

```
* Add timeout to kill hanging tests (#701 <https://github.com/ros2/ros2cli/issues/701>)
* Contributors: Audrow Nash
```

## ros2interface

```
* Add timeout to kill hanging tests (#701 <https://github.com/ros2/ros2cli/issues/701>)
* Contributors: Audrow Nash
```

## ros2lifecycle

```
* Add timeout to kill hanging tests (#701 <https://github.com/ros2/ros2cli/issues/701>)
* Contributors: Audrow Nash
```

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

```
* Add timeout to kill hanging tests (#701 <https://github.com/ros2/ros2cli/issues/701>)
* Contributors: Audrow Nash
```

## ros2node

```
* Add timeout to kill hanging tests (#701 <https://github.com/ros2/ros2cli/issues/701>)
* Contributors: Audrow Nash
```

## ros2param

```
* Add timeout to kill hanging tests (#701 <https://github.com/ros2/ros2cli/issues/701>)
* Contributors: Audrow Nash
```

## ros2pkg

```
* Add timeout to kill hanging tests (#701 <https://github.com/ros2/ros2cli/issues/701>)
* Contributors: Audrow Nash
```

## ros2run

```
* Add timeout to kill hanging tests (#701 <https://github.com/ros2/ros2cli/issues/701>)
* Contributors: Audrow Nash
```

## ros2service

```
* Add timeout to kill hanging tests (#701 <https://github.com/ros2/ros2cli/issues/701>)
* Contributors: Audrow Nash
```

## ros2topic

```
* Add timeout to kill hanging tests (#701 <https://github.com/ros2/ros2cli/issues/701>)
* Contributors: Audrow Nash
```
