### PR TITLE
launch: 0.23.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1517,7 +1517,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.22.0-1
+      version: 0.23.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.23.0-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.22.0-1`

## launch

```
* Add boolean substitutions (#598 <https://github.com/ros2/launch/issues/598>)
* Contributors: Kenji Miyake
```

## launch_pytest

- No changes

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* Add boolean substitutions (#598 <https://github.com/ros2/launch/issues/598>)
* Contributors: Kenji Miyake
```

## launch_yaml

```
* Add boolean substitutions (#598 <https://github.com/ros2/launch/issues/598>)
* Contributors: Kenji Miyake
```
