### PR TITLE
ur_description: 2.0.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5318,6 +5318,21 @@ repositories:
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git
       version: master
     status: developed
+  ur_description:
+    doc:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
+      version: ros2
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/ur_description-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
+      version: ros2
+    status: developed
   urdf:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.0.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ur_description

```
* Migrated the description to ROS2
* Added support for Gazebo and Ignition
* Added ROS2_control definitions
* Contributors: AndyZe, Denis Stogl, Denis Štogl, Felix Exner, John Morris, Jorge Nicho, Lovro, Lukas Sackewitz, Marvin Große Besselmann, Robert Wilbrandt, Tirine, Vatan Aksoy Tezer, livanov93, urmahp
```
