### PR TITLE
Update python3-lark-parser dependency on NixOS

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6924,7 +6924,7 @@ python3-lark-parser:
     stretch: [python3-lark-parser]
   fedora: [python3-lark-parser]
   gentoo: [dev-python/lark]
-  nixos: [python3Packages.lark-parser]
+  nixos: [python3Packages.lark]
   openembedded: [python3-lark-parser@meta-ros-common]
   rhel: ['python%{python3_pkgversion}-lark-parser']
   ubuntu:


### PR DESCRIPTION
The NixOS package for `python3-lark-parser` was renamed from `lark-parser` to `lark`: https://github.com/NixOS/nixpkgs/commit/2f4b2e72d0f4c0d54e9567fb42165522298bc386
