### PR TITLE
leo_desktop: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1938,6 +1938,24 @@ repositories:
       url: https://github.com/LeoRover/leo_common.git
       version: ros2
     status: maintained
+  leo_desktop:
+    doc:
+      type: git
+      url: https://github.com/LeoRover/leo_desktop.git
+      version: ros2
+    release:
+      packages:
+      - leo_desktop
+      - leo_viz
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/fictionlab-gbp/leo_desktop-ros2-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/LeoRover/leo_desktop.git
+      version: ros2
+    status: maintained
   lgsvl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_desktop` to `1.0.0-1`:

- upstream repository: https://github.com/LeoRover/leo_desktop.git
- release repository: https://github.com/fictionlab-gbp/leo_desktop-ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## leo_desktop

```
* Initial port for ROS2
```

## leo_viz

```
* Initial port for ROS2
```
