### PR TITLE
end_effector: 1.0.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1992,6 +1992,21 @@ repositories:
       url: https://github.com/ros-gbp/eml-release.git
       version: 1.8.15-7
     status: unmaintained
+  end_effector:
+    doc:
+      type: git
+      url: https://github.com/ADVRHumanoids/ROSEndEffector.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ADVRHumanoids/ROSEndEffector-release.git
+      version: 1.0.5-1
+    source:
+      type: git
+      url: https://github.com/ADVRHumanoids/ROSEndEffector.git
+      version: master
+    status: maintained
   ensenso_driver:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2046,7 +2046,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ADVRHumanoids/ROSEndEffector-release.git
-      version: 1.0.5-1
+      version: 1.0.6-1
     source:
       type: git
       url: https://github.com/ADVRHumanoids/ROSEndEffector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `end_effector` to `1.0.5-1`:

- upstream repository: https://github.com/ADVRHumanoids/ROSEndEffector.git
- release repository: https://github.com/ADVRHumanoids/ROSEndEffector-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## end_effector

```
* Updated qb urdf to comply with new mesh name, but problems on gazebo
* Contributors: Davide Torielli
```
