### PR TITLE
irobot_create_msgs: 1.2.4-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1355,6 +1355,17 @@ repositories:
       url: https://github.com/ros-visualization/interactive_markers.git
       version: galactic
     status: maintained
+  irobot_create_msgs:
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/irobot_create_msgs-release.git
+      version: 1.2.4-1
+    source:
+      type: git
+      url: https://github.com/iRobotEducation/irobot_create_msgs.git
+      version: main
+    status: developed
   jlb_pid:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `irobot_create_msgs` to `1.2.4-1`:

- upstream repository: https://github.com/iRobotEducation/irobot_create_msgs.git
- release repository: https://github.com/ros2-gbp/irobot_create_msgs-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## irobot_create_msgs

```
* small comments cleanup
* Add action for audio sequence
* Contributors: Justin Kearns, Steven Shamlian
```
