### PR TITLE
backward_ros: 1.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -386,7 +386,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/backward_ros-release.git
-      version: 1.0.1-2
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/backward_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository backward_ros to 1.0.2-1:

- upstream repository: https://github.com/pal-robotics/backward_ros.git
- release repository: https://github.com/pal-gbp/backward_ros-release.git
- distro file: rolling/distribution.yaml
- bloom version: 0.10.7
- previous version for package: 1.0.1-2

    
# backward_ros
    Fix name mismatch warnings
    Contributors: Jordan Palacios, Vatan Aksoy Tezer