### PR TITLE
rosidl_defaults: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3814,7 +3814,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_defaults-release.git
-      version: 1.1.1-2
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_defaults` to `1.2.0-1`:

- upstream repository: https://github.com/ros2/rosidl_defaults.git
- release repository: https://github.com/ros2-gbp/rosidl_defaults-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.1-2`

## rosidl_default_generators

```
* Unroll group dependencies (#20 <https://github.com/ros2/rosidl_defaults/issues/20>)
* Contributors: Shane Loretz
```

## rosidl_default_runtime

```
* Unroll group dependencies (#20 <https://github.com/ros2/rosidl_defaults/issues/20>)
* Contributors: Shane Loretz
```
