### PR TITLE
Add RHEL 8 rule for python3-lttng

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6936,6 +6936,9 @@ python3-lttng:
   debian: [python3-lttng]
   fedora: [python3-lttng]
   openembedded: [lttng-tools@openembedded-core]
+  rhel:
+    '*': [python3-lttng]
+    '7': null
   ubuntu: [python3-lttng]
 python3-lxml:
   alpine: [py3-lxml]


### PR DESCRIPTION
This package is provided by EPEL for RHEL 8, and is not available for RHEL 7 (lttng-tools is available, but the python3 subpackage is not enabled).

https://src.fedoraproject.org/rpms/lttng-tools#bodhi_updates