### PR TITLE
rm_description: 0.1.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7293,6 +7293,10 @@ repositories:
         release: release/noetic/{package}/{version}
       url: https://github.com/rm-controls/rm_description-release.git
       version: 0.1.9-1
+    source:
+      type: git
+      url: https://github.com/rm-decription.git
+      version: master
     status: developed
   robot_body_filter:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7295,7 +7295,7 @@ repositories:
       version: 0.1.9-1
     source:
       type: git
-      url: https://github.com/rm-decription.git
+      url: https://github.com/rm-controls/rm_description.git
       version: master
     status: developed
   robot_body_filter:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7288,6 +7288,11 @@ repositories:
       type: git
       url: https://github.com/rm-controls/rm_description.git
       version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/rm-controls/rm_description-release.git
+      version: 0.1.9-1
     status: developed
   robot_body_filter:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rm_description` to `0.1.9-1`:

- upstream repository: https://github.com/rm-controls/rm_description.git
- release repository: https://github.com/rm-controls/rm_description-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## rm_description

```
* Add omni wheel urdf
* Complete omni wheel urdf
* Add test launch file to check urdf
* Rename launch file.Delete roller_type in urdf.Change args of hook
* Merge pull request #21 <https://github.com/rm-controls/rm_control/pull/21> from ye-luo-xi-tui/omni_wheel
* Fix errors of swerve urdf
* Add CI/CD action
* Create Doxyfile
* Create .pre-commit-config.yaml
* Add permissions to script
* Delete pre_release.yml
* Merge pull request #3 <https://github.com/rm-controls/rm_description/pull/3> from YuuinlH/-master
* Merge pull request #4 <https://github.com/rm-controls/rm_description/pull/4> from YuuinlH/-master
* Update deb_package.yml
* Merge pull request #5 <https://github.com/rm-controls/rm_description/pull/5> from YuuinlH/-master
* Update package.sh
* Delete doxygen action(Uesless)
* Add"none"type of omni_wheel roller.Set"none"for real robot
* Fix error in check_joint.launch.Add rviz launch.
* Merge pull request #8 <https://github.com/rm-controls/rm_description/pull/8> from ye-luo-xi-tui/-master
* Add LICENSE file
* Update the hero description files
* Modify the format error of hero urdf files
* Merge pull request #11 <https://github.com/rm-controls/rm_description/pull/11> from Edwinlinks/-hero_urdf
* Contributors: Edwinlinks, QiayuanLiao, YuuinIH, qiayuan, yezi, mlione
```
