### PR TITLE
Retarget branch for tracetools_acceleration in rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4747,7 +4747,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-acceleration/tracetools_acceleration.git
-      version: main
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -4757,7 +4757,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-acceleration/tracetools_acceleration.git
-      version: main
+      version: rolling
     status: developed
   tracetools_analysis:
     doc:


### PR DESCRIPTION
tracks.yaml also updated here: https://github.com/ros2-gbp/tracetools_acceleration-release/commit/cc1e1f017cf6e8e836d804e6a6f539748b8fd8b5