### PR TITLE
rosbag2_storage_mcap: 0.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3728,7 +3728,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2_storage_mcap-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/ros-tooling/rosbag2_storage_mcap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2_storage_mcap` to `0.1.1-1`:

- upstream repository: https://github.com/ros-tooling/rosbag2_storage_mcap.git
- release repository: https://github.com/ros2-gbp/rosbag2_storage_mcap-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.0-1`

## rosbag2_storage_mcap

```
* CMake build script will now execute pip install conan automatically.
* Contributors: Daisuke Nishimatsu
```
