### PR TITLE
rot_conv_lib: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3911,6 +3911,21 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_gurumdds.git
       version: master
     status: developed
+  rot_conv_lib:
+    doc:
+      type: git
+      url: https://github.com/ros2-gbp/rot_conv_lib-release.git
+      version: release/rolling/rot_conv_lib
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rot_conv_lib-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros2-gbp/rot_conv_lib-release.git
+      version: release/rolling/rot_conv_lib
+    status: maintained
   rplidar_ros:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rot_conv_lib` to `1.0.1-1`:

- upstream repository: https://github.com/AIS-Bonn/rot_conv_lib.git
- release repository: https://github.com/ros2-gbp/rot_conv_lib-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

This is my first time releasing a third party package, so please tell me if something is wrong. I'll update the bloom docs accordingly