### PR TITLE
rot_conv_lib: 1.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3911,6 +3911,17 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_gurumdds.git
       version: master
     status: developed
+  rot_conv_lib:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rot_conv_lib-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/ros2-gbp/rot_conv_lib-release.git
+      version: releases/rolling/rot_conv_lib
+    status: maintained
   rplidar_ros:
     release:
       tags:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3920,7 +3920,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2-gbp/rot_conv_lib-release.git
-      version: releases/rolling/rot_conv_lib
+      version: release/rolling/rot_conv_lib
     status: maintained
   rplidar_ros:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `rot_conv_lib` to `1.0.2-1`:

- upstream repository: https://github.com/AIS-Bonn/rot_conv_lib.git
- release repository: https://github.com/ros2-gbp/rot_conv_lib-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

This is my first time releasing a third party package, so please tell me if something is wrong. I'll update the bloom docs accordingly.

Resolves: https://github.com/ros-sports/humanoid_base_footprint/issues/23