### PR TITLE
smacc2: 0.2.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5495,6 +5495,25 @@ repositories:
       url: https://github.com/oKermorgant/slider_publisher.git
       version: ros2
     status: maintained
+  smacc2:
+    doc:
+      type: git
+      url: https://github.com/robosoft-ai/SMACC2.git
+      version: foxy
+    release:
+      packages:
+      - smacc2
+      - smacc2_msgs
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/robosoft-ai/SMACC2-release.git
+      version: 0.2.0-2
+    source:
+      type: git
+      url: https://github.com/robosoft-ai/SMACC2.git
+      version: foxy
+    status: maintained
+    status_description: Focusing on Galactic and Rolling versions.
   snowbot_operating_system:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `smacc2` to `0.2.0-2`:

- upstream repository: https://github.com/robosoft-ai/SMACC2.git
- release repository: https://github.com/robosoft-ai/SMACC2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## smacc2

```
* improvements in smacc core adding more components mostly developed for autoware demo
* Foxy backport (#206 <https://github.com/StoglRobotics-forks/SMACC2/issues/206>)
* Feature/testing moveit behaviors (#167 <https://github.com/StoglRobotics-forks/SMACC2/issues/167>)
* Add QOS durability to SmaccPublisherClient (#163 <https://github.com/StoglRobotics-forks/SMACC2/issues/163>)
* initial state machine transition timestamp (#165 <https://github.com/StoglRobotics-forks/SMACC2/issues/165>)
* Feature/migration moveit client (#151 <https://github.com/StoglRobotics-forks/SMACC2/issues/151>)
* Remove node creation and create only a logger. (#149 <https://github.com/StoglRobotics-forks/SMACC2/issues/149>)
* Feature/slam toggle and smacc deep history (#122 <https://github.com/StoglRobotics-forks/SMACC2/issues/122>)
* Feature/core and navigation fixes (#78 <https://github.com/StoglRobotics-forks/SMACC2/issues/78>)
* Merge pull request #40 <https://github.com/StoglRobotics-forks/SMACC2/issues/40> from pabloinigoblasco/feature/navigation_rolling
* Merge pull request #41 <https://github.com/StoglRobotics-forks/SMACC2/issues/41> from DecDury/renameTracingEvents
  renamed tracing events
* Merge branch 'renameTracingEvents' of https://github.com/DecDury/SMACC2 into DecDury-renameTracingEvents
* Contributors: David Revay, DecDury, Denis Štogl, Pablo Iñigo Blasco, pabloinigoblasco, reelrbtx
```

## smacc2_msgs

```
* Backporting features from rolling and galactic
* Contributors: Pablo Iñigo Blasco
```
