### PR TITLE
smacc2: 0.3.0-3 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -12,7 +12,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/robosoft-ai/SMACC2.git
-      version: master
+      version: galactic
     release:
       packages:
       - smacc2
@@ -20,11 +20,11 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/robosoft-ai/SMACC2-release.git
-      version: 0.1.0-1
+      version: 0.3.0-3
     source:
       type: git
       url: https://github.com/robosoft-ai/SMACC2.git
-      version: master
+      version: galactic
     status: developed
   acado_vendor:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `smacc2` to `0.3.0-3`:

- upstream repository: https://github.com/robosoft-ai/SMACC2.git
- release repository: https://github.com/robosoft-ai/SMACC2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.0-1`

## smacc2

```
* Fixing performance issues and API changes for galactic
* Contributors: David Revay, DecDury, Denis Štogl, Pablo Iñigo Blasco, pabloinigoblasco, reelrbtx
```

## smacc2_msgs

```
* Backporting features from rolling
* Contributors: Pablo Iñigo Blasco
```
