### PR TITLE
SMACC2: 0.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -22,7 +22,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/SMACC2-release.git
-      version: 0.1.0-2
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/robosoft-ai/SMACC2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `SMACC2` to `0.4.0-1`:

- upstream repository: https://github.com/robosoft-ai/SMACC2.git
- release repository: https://github.com/ros2-gbp/SMACC2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.0-2`

## smacc2

```
* Feature/fixing type string walker (#263 <https://github.com/StoglRobotics-forks/SMACC2/issues/263>)
* Feature/fixing husky build rolling (#258 <https://github.com/StoglRobotics-forks/SMACC2/issues/258>)
* Merging code from backport foxy and updates about autoware (#208 <https://github.com/StoglRobotics-forks/SMACC2/issues/208>)
* wharehouse2 progress (#179 <https://github.com/StoglRobotics-forks/SMACC2/issues/179>)
* Feature/aws navigation sm dance bot (#174 <https://github.com/StoglRobotics-forks/SMACC2/issues/174>)
* Feature/sm dance bot strikes back refactoring (#152 <https://github.com/StoglRobotics-forks/SMACC2/issues/152>)
* Feature/cb pause slam (#98 <https://github.com/StoglRobotics-forks/SMACC2/issues/98>)
* Merge branch 'renameTracingEvents' of https://github.com/DecDury/SMACC2 into DecDury-renameTracingEvents
* Contributors: David Revay, DecDury, Denis Štogl, Pablo Iñigo Blasco, pabloinigoblasco, reelrbtx
```

## smacc2_msgs

```
* Contributors: Pablo Iñigo Blasco
```
