### PR TITLE
end-effector: 1.0.6-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2871,13 +2871,17 @@ repositories:
       url: https://github.com/ros-gbp/eml-release.git
       version: 1.8.15-2
   end-effector:
+    doc:
+      type: git
+      url: https://github.com/ADVRHumanoids/ROSEndEffector.git
+      version: master
     release:
       packages:
       - end_effector
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ADVRHumanoids/ROSEndEffector-release.git
-      version: 1.0.4-1
+      version: 1.0.6-2
     source:
       type: git
       url: https://github.com/ADVRHumanoids/ROSEndEffector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `end-effector` to `1.0.6-2`:

- upstream repository: https://github.com/ADVRHumanoids/ROSEndEffector.git
- release repository: https://github.com/ADVRHumanoids/ROSEndEffector-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.4-1`

## end_effector

```
* urdf and srdf path from ros param and not from conf file
* Cmake installing missing things
* renamed include directory according to package name
* Contributors: Davide Torielli
```
