### PR TITLE
end-effector: 1.0.6-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2037,6 +2037,23 @@ repositories:
       url: https://github.com/ros-gbp/eml-release.git
       version: 1.8.15-7
     status: unmaintained
+  end-effector:
+    doc:
+      type: git
+      url: https://github.com/ADVRHumanoids/ROSEndEffector.git
+      version: master
+    release:
+      packages:
+      - end_effector
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ADVRHumanoids/ROSEndEffector-release.git
+      version: 1.0.6-2
+    source:
+      type: git
+      url: https://github.com/ADVRHumanoids/ROSEndEffector.git
+      version: master
+    status: maintained
   ensenso_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `end-effector` to `1.0.6-2`:

- upstream repository: https://github.com/ADVRHumanoids/ROSEndEffector.git
- release repository: https://github.com/ADVRHumanoids/ROSEndEffector-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## end_effector

```
* urdf and srdf path from ros param and not from conf file
* Cmake installing missing things
* renamed include directory according to package name
* Contributors: Davide Torielli
```
