### PR TITLE
backward_ros: 1.0.2-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -402,7 +402,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/backward_ros-release.git
-      version: 1.0.1-2
+      version: 1.0.2-2
     source:
       type: git
       url: https://github.com/pal-robotics/backward_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `backward_ros` to `1.0.2-2`:

- upstream repository: git@github.com:pal-robotics/backward_ros.git
- release repository: https://github.com/ros2-gbp/backward_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.1-2`

## backward_ros

```
* Merge pull request #11 from vatanaksoytezer/vatan/fix_fphsa
  Fix name mismatch warnings
* Fix name mismatch warnings
* Contributors: Jordan Palacios, Vatan Aksoy Tezer
```
