### PR TITLE
qt_advanced_docking_system: 3.8.2-4 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6833,6 +6833,23 @@ repositories:
       url: https://github.com/autoware-ai/qpoases_vendor.git
       version: master
     status: maintained
+  qt_advanced_docking_system:
+    doc:
+      type: git
+      url: https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System.git
+      version: master
+    release:
+      packages:
+      - qt_advanced_docking
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/tesseract-robotics-release/qt_advanced_docking_system-release.git
+      version: 3.8.2-4
+    source:
+      type: git
+      url: https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System.git
+      version: master
+    status: developed
   qt_gui_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_advanced_docking_system` to `3.8.2-4`:

- upstream repository: https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System
- release repository: https://github.com/tesseract-robotics-release/qt_advanced_docking_system-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
