### PR TITLE
ament_vitis: 0.10.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -242,7 +242,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_vitis-release.git
-      version: 0.10.0-1
+      version: 0.10.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_vitis` to `0.10.1-1`:

- upstream repository: https://github.com/ros-acceleration/ament_vitis.git
- release repository: https://github.com/ros2-gbp/ament_vitis-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.10.0-1`

---

This fixes a missing dependency in the package's `package.xml` that was causing binary builds to fail.