### PR TITLE
orocos_kdl_vendor: 0.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2279,6 +2279,21 @@ repositories:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
       version: 1.5.2-2
+  orocos_kdl_vendor:
+    release:
+      packages:
+      - orocos_kdl_vendor
+      - python_orocos_kdl_vendor
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/orocos_kdl_vendor.git
+      version: main
+    status: developed
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_kdl_vendor` to `0.1.0-1`:

- upstream repository: https://github.com/ros2/orocos_kdl_vendor.git
- release repository: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## orocos_kdl_vendor

```
* Add vendor package for orocos_kdl (#1 <https://github.com/ros2/orocos_kdl_vendor/issues/1>)
* Contributors: Jacob Perron, Shane Loretz
```

## python_orocos_kdl_vendor

```
* Add vendor package for python_orocos_kdl (#1 <https://github.com/ros2/orocos_kdl_vendor/issues/1>)
* Contributors: Jacob Perron, Shane Loretz
```
