### PR TITLE
apriltag_ros: 3.2.1-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -148,7 +148,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/AprilRobotics/apriltag_ros-release.git
-      version: 3.2.0-1
+      version: 3.2.1-3
     source:
       type: git
       url: https://github.com/AprilRobotics/apriltag_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_ros` to `3.2.1-3`:

- upstream repository: https://github.com/AprilRobotics/apriltag_ros.git
- release repository: https://github.com/AprilRobotics/apriltag_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.2.0-1`

## apriltag_ros

```
* Fixed propagation of apriltag and Eigen headers and libraries (#124 <https://github.com/AprilRobotics/apriltag_ros/issues/124>)
* Drop old C++11 as it breaks with new log4cxx.
* Contributors: Jochen Sprickerhof, Remo Diethelm, Wolfgang Merkt
```
