### PR TITLE
apriltag_ros: 3.2.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -233,7 +233,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/AprilRobotics/apriltag_ros-release.git
-      version: 3.2.0-1
+      version: 3.2.1-1
     source:
       type: git
       url: https://github.com/AprilRobotics/apriltag_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_ros` to `3.2.1-1`:

- upstream repository: https://github.com/AprilRobotics/apriltag_ros.git
- release repository: https://github.com/AprilRobotics/apriltag_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.2.0-1`

## apriltag_ros

```
* Fixed propagation of apriltag and Eigen headers and libraries (#124 <https://github.com/AprilRobotics/apriltag_ros/issues/124>)
* Drop old C++11 as it breaks with new log4cxx.
* Contributors: Jochen Sprickerhof, Remo Diethelm, Wolfgang Merkt
```
