### PR TITLE
test_interface_files: 0.9.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4674,7 +4674,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/test_interface_files-release.git
-      version: 0.9.0-2
+      version: 0.9.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `test_interface_files` to `0.9.1-1`:

- upstream repository: https://github.com/ros2/test_interface_files.git
- release repository: https://github.com/ros2-gbp/test_interface_files-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.9.0-2`

## test_interface_files

```
* Revert "Update package.xml (#18 <https://github.com/ros2/test_interface_files/issues/18>)" (#19 <https://github.com/ros2/test_interface_files/issues/19>)
* Update package.xml (#18 <https://github.com/ros2/test_interface_files/issues/18>)
* Update maintainers to Audrow Nash (#17 <https://github.com/ros2/test_interface_files/issues/17>)
* Contributors: Audrow Nash, Chris Lalancette, Nikolai Morin
```
