### PR TITLE
sdformat_urdf: ros2 -> galactic

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4630,7 +4630,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/sdformat_urdf.git
-      version: ros2
+      version: galactic
     release:
       packages:
       - sdformat_test_files
@@ -4643,7 +4643,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/sdformat_urdf.git
-      version: ros2
+      version: galactic
     status: maintained
   sick_safetyscanners2:
     doc:


### PR DESCRIPTION
This updates the galactic branch for `sdformat_urdf`: https://github.com/ros/sdformat_urdf/tree/galactic