### PR TITLE
sdformat on Jammy: libsdformat-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7042,6 +7042,7 @@ sdformat:
     bionic: [libsdformat6-dev]
     cosmic: [libsdformat6-dev]
     focal: [libsdformat9-dev]
+    jammy: [libsdformat-dev]
     precise: [sdformat]
     quantal: [sdformat]
     raring: [sdformat]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

sdformat

## Package Upstream Source:

https://github.com/ignitionrobotics/sdformat

## Purpose of using this:

Used by sdformat_urdf: https://github.com/ros/sdformat_urdf/

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - up to date
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/jammy/libsdformat-dev
- Fedora: https://src.fedoraproject.org/browse/projects/
  - up to date
- Arch: https://www.archlinux.org/packages/
  - up to date
- Gentoo: https://packages.gentoo.org/
  - up to date
- macOS: https://formulae.brew.sh/
  - :shrug: 
- Alpine: https://pkgs.alpinelinux.org/packages
  - :shrug:
- NixOS/nixpkgs: https://search.nixos.org/packages
  - up to date