### PR TITLE
rclcpp: 15.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2866,7 +2866,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 15.3.0-1
+      version: 15.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `15.4.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `15.3.0-1`

## rclcpp

```
* add take_data_by_entity_id API to waitable (#1892 <https://github.com/ros2/rclcpp/issues/1892>)
* add content-filtered-topic interfaces (#1561 <https://github.com/ros2/rclcpp/issues/1561>)
* Contributors: Alberto Soragna, Chen Lihui
```

## rclcpp_action

```
* add take_data_by_entity_id API to waitable (#1892 <https://github.com/ros2/rclcpp/issues/1892>)
* Contributors: Alberto Soragna
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
