### PR TITLE
kdl_parser: 2.6.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1427,7 +1427,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/kdl_parser-release.git
-      version: 2.6.1-2
+      version: 2.6.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kdl_parser` to `2.6.2-1`:

- upstream repository: https://github.com/ros/kdl_parser.git
- release repository: https://github.com/ros2-gbp/kdl_parser-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.6.1-2`

## kdl_parser

```
* Depend on orocos-kdl vendor packages  (#58 <https://github.com/ros/kdl_parser/issues/58>)
* Contributors: Jacob Perron
```
