### PR TITLE
rot_conv_lib: 1.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3927,6 +3927,19 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_gurumdds.git
       version: master
     status: developed
+  rot_conv_lib:
+    release:
+      packages:
+      - rotconv
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rot_conv_lib-release.git
+      version: 1.0.4-1
+    source:
+      type: git
+      url: https://github.com/AIS-Bonn/rot_conv_lib.git
+      version: master
+    status: maintained
   rplidar_ros:
     release:
       tags:


### PR DESCRIPTION
This fixes issues in #32633 pointed out by @hidmic.

This is my first time releasing a third party package, so please tell me if something is wrong. I'll update the bloom docs accordingly.

**I'm also wondering what benefits there are of doing this release as a vendor package**, as I see it being done more commonly, like in [ros2/darknet_vendor](https://github.com/ros2/darknet_vendor).

Increasing version of package(s) in repository `rot_conv_lib` to `1.0.4-1`:

- upstream repository: https://github.com/AIS-Bonn/rot_conv_lib.git
- release repository: https://github.com/ros2-gbp/rot_conv_lib-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

Resolves: https://github.com/ros-sports/humanoid_base_footprint/issues/23