### PR TITLE
vitis_common: 0.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5247,6 +5247,22 @@ repositories:
       url: https://github.com/lagadic/visp.git
       version: master
     status: maintained
+  vitis_common:
+    doc:
+      type: git
+      url: https://github.com/ros-acceleration/vitis_common.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/vitis_common-release.git
+      version: 0.4.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-acceleration/vitis_common.git
+      version: rolling
+    status: developed
   warehouse_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vitis_common` to `0.4.2-1`:

- upstream repository: https://github.com/ros-acceleration/vitis_common.git
- release repository: https://github.com/ros2-gbp/vitis_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

# Note
The release config for RHEL was not generated, because this package depends on `ocl-icd-opencl-dev`, which doesn't exist [in the `rosdep` listings for RHEL/Fedora.](https://github.com/ros/rosdistro/blob/master/rosdep/base.yaml#L6343)

I was going to send along a PR to add it, but I realized the Fedora repo list only contains `ocl-icd` (which seems to be a superset that contains `ocl-icd-opencl-dev`, but doesn't have the `ocl-icd-opencl-dev` as a standalone `.rpm`), so I didn't try to add to the rosdep keys and skipped the configuration instead.

If I should just add `ocl-icd` to the rosdep keys to support RHEL, do let me know, and I'll do that and regenerate the release configs.