### PR TITLE
example_interfaces: 0.9.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -816,7 +816,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/example_interfaces-release.git
-      version: 0.9.2-2
+      version: 0.9.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `example_interfaces` to `0.9.3-1`:

- upstream repository: https://github.com/ros2/example_interfaces.git
- release repository: https://github.com/ros2-gbp/example_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.9.2-2`

## example_interfaces

```
* Update maintainers to Mabel Zhang (#15 <https://github.com/ros2/example_interfaces/issues/15>)
* Add changelog (#14 <https://github.com/ros2/example_interfaces/issues/14>)
* Contributors: Audrow Nash, Ivan Santiago Paunovic
```
