### PR TITLE
rqt_msg: 1.0.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4114,7 +4114,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_msg-release.git
-      version: 1.0.5-2
+      version: 1.0.6-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_msg.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_msg` to `1.0.6-1`:

- upstream repository: https://github.com/ros-visualization/rqt_msg.git
- release repository: https://github.com/ros2-gbp/rqt_msg-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.5-2`

## rqt_msg

```
* Update maintainers to Audrow Nash (#14 <https://github.com/ros-visualization/rqt_msg/issues/14>)
* Contributors: Audrow Nash
```
