### PR TITLE
rmf_utils: 1.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3189,7 +3189,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_utils-release.git
-      version: 1.3.0-3
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_utils` to `1.4.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_utils.git
- release repository: https://github.com/ros2-gbp/rmf_utils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.3.0-3`

## rmf_utils

```
* Add a class to help with limiting rates of events (`#18 <https://github.com/open-rmf/rmf_utils/pull/18>)
```
