### PR TITLE
rosidl_runtime_py: 0.9.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3865,7 +3865,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
-      version: 0.9.1-3
+      version: 0.9.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_runtime_py` to `0.9.2-1`:

- upstream repository: https://github.com/ros2/rosidl_runtime_py.git
- release repository: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.9.1-3`

## rosidl_runtime_py

```
* add yaml dump flow style. (#16 <https://github.com/ros2/rosidl_runtime_py/issues/16>)
* Update maintainers (#15 <https://github.com/ros2/rosidl_runtime_py/issues/15>)
  * Update maintainers to Shane Loretz
  * Update Shane's email
  Co-authored-by: Shane Loretz <mailto:sloretz@openrobotics.org>
* Contributors: Audrow Nash, Tomoya Fujita
```
