### PR TITLE
Add ocl-icd-opencl-dev rule for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6344,6 +6344,7 @@ ocl-icd-opencl-dev:
   debian: [ocl-icd-opencl-dev]
   fedora: [ocl-icd-devel]
   gentoo: [virtual/opencl]
+  rhel: [ocl-icd-devel]
   ubuntu: [ocl-icd-opencl-dev]
 odb:
   debian: [odb]


### PR DESCRIPTION
The ocl-icd-devel package is part of AppStream in RHEL 8 and is provided by EPEL for RHEL 7.

For Fedora and RHEL, there is not a separate package for providing libOpenCL.so like there is on Debian and Ubuntu.

RHEL 7: https://src.fedoraproject.org/rpms/ocl-icd#bodhi_updates
RHEL 8: https://repo.almalinux.org/almalinux/8/PowerTools/x86_64/os/Packages/ocl-icd-devel-2.2.12-1.el8.i686.rpm