### PR TITLE
rosbag2: 0.15.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3710,7 +3710,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.14.1-1
+      version: 0.15.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.15.1-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.14.1-1`

## ros2bag

```
* support to publish as loaned message (#981 <https://github.com/ros2/rosbag2/issues/981>)
* Revert "Add the ability to record any key/value pair in the 'custom' field in metadata.yaml (#976 <https://github.com/ros2/rosbag2/issues/976>)" (#984 <https://github.com/ros2/rosbag2/issues/984>)
* Add the ability to record any key/value pair in the 'custom' field in metadata.yaml (#976 <https://github.com/ros2/rosbag2/issues/976>)
* Contributors: Audrow Nash, Barry Xu, Jorge Perez, Tony Peng
```

## rosbag2

- No changes

## rosbag2_compression

- No changes

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Revert "Add the ability to record any key/value pair in the 'custom' field in metadata.yaml (#976 <https://github.com/ros2/rosbag2/issues/976>)" (#984 <https://github.com/ros2/rosbag2/issues/984>)
* Add the ability to record any key/value pair in the 'custom' field in metadata.yaml (#976 <https://github.com/ros2/rosbag2/issues/976>)
* Contributors: Audrow Nash, Jorge Perez, Tony Peng
```

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_py

```
* support to publish as loaned message (#981 <https://github.com/ros2/rosbag2/issues/981>)
* Revert "Add the ability to record any key/value pair in the 'custom' field in metadata.yaml (#976 <https://github.com/ros2/rosbag2/issues/976>)" (#984 <https://github.com/ros2/rosbag2/issues/984>)
* Add the ability to record any key/value pair in the 'custom' field in metadata.yaml (#976 <https://github.com/ros2/rosbag2/issues/976>)
* Contributors: Audrow Nash, Barry Xu, Jorge Perez, Tony Peng
```

## rosbag2_storage

```
* Revert "Add the ability to record any key/value pair in the 'custom' field in metadata.yaml (#976 <https://github.com/ros2/rosbag2/issues/976>)" (#984 <https://github.com/ros2/rosbag2/issues/984>)
* Add the ability to record any key/value pair in the 'custom' field in metadata.yaml (#976 <https://github.com/ros2/rosbag2/issues/976>)
* Contributors: Audrow Nash, Jorge Perez, Tony Peng
```

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

```
* Revert "Add the ability to record any key/value pair in the 'custom' field in metadata.yaml (#976 <https://github.com/ros2/rosbag2/issues/976>)" (#984 <https://github.com/ros2/rosbag2/issues/984>)
* Add the ability to record any key/value pair in the 'custom' field in metadata.yaml (#976 <https://github.com/ros2/rosbag2/issues/976>)
* Contributors: Audrow Nash, Jorge Perez, Tony Peng
```

## rosbag2_transport

```
* support to publish as loaned message (#981 <https://github.com/ros2/rosbag2/issues/981>)
* Contributors: Audrow Nash, Barry Xu
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
