### PR TITLE
Add pylatexenc-pip rosdep key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3669,23 +3669,6 @@ python-pylibftdi-pip:
     pip: [pylibftdi]
   ubuntu:
     pip: [pylibftdi]
-python3-pylatexenc:
-  debian:
-    '*': [python3-pylatexenc]
-    bullseye:
-      pip:
-        packages: [pylatexenc]
-    buster:
-      pip:
-        packages: [pylatexenc]
-  ubuntu:
-    '*': [python3-pylatexenc]
-    bionic:
-      pip:
-        packages: [pylatexenc]
-    focal:
-      pip:
-        packages: [pylatexenc]
 python-pylint:
   debian: [pylint]
   fedora: [pylint]
@@ -7674,6 +7657,23 @@ python3-pykdl:
     '*': [python3-pykdl]
     bionic: null
     xenial: null
+python3-pylatexenc:
+  debian:
+    '*': [python3-pylatexenc]
+    bullseye:
+      pip:
+        packages: [pylatexenc]
+    buster:
+      pip:
+        packages: [pylatexenc]
+  ubuntu:
+    '*': [python3-pylatexenc]
+    bionic:
+      pip:
+        packages: [pylatexenc]
+    focal:
+      pip:
+        packages: [pylatexenc]
 python3-pylibdmtx:
   debian:
     '*': [python3-pylibdmtx]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -352,16 +352,6 @@ pyflakes3:
       packages: [pyflakes]
   rhel: ['python%{python3_pkgversion}-pyflakes']
   ubuntu: [pyflakes3]
-pylatexenc-pip:
-  debian:
-    pip:
-      packages: [pylatexenc]
-  fedora:
-    pip:
-      packages: [pylatexenc]
-  ubuntu:
-    pip:
-      packages: [pylatexenc]
 pymap3d-pip:
   debian:
     pip:
@@ -3670,6 +3660,23 @@ python-pykalman:
   ubuntu:
     pip:
       packages: [pykalman]
+python3-pylatexenc:
+  debian:
+    '*': [python3-pylatexenc]
+    bullseye:
+      pip:
+        packages: [pylatexenc]
+    buster:
+      pip:
+        packages: [pylatexenc]
+  ubuntu:
+    '*': [python3-pylatexenc]
+    bionic:
+      pip:
+        packages: [pylatexenc]
+    focal:
+      pip:
+        packages: [pylatexenc]
 python-pylibftdi-pip:
   debian:
     pip: [pylibftdi]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3660,6 +3660,15 @@ python-pykalman:
   ubuntu:
     pip:
       packages: [pykalman]
+python-pylibftdi-pip:
+  debian:
+    pip: [pylibftdi]
+  fedora:
+    pip: [pylibftdi]
+  osx:
+    pip: [pylibftdi]
+  ubuntu:
+    pip: [pylibftdi]
 python3-pylatexenc:
   debian:
     '*': [python3-pylatexenc]
@@ -3677,15 +3686,6 @@ python3-pylatexenc:
     focal:
       pip:
         packages: [pylatexenc]
-python-pylibftdi-pip:
-  debian:
-    pip: [pylibftdi]
-  fedora:
-    pip: [pylibftdi]
-  osx:
-    pip: [pylibftdi]
-  ubuntu:
-    pip: [pylibftdi]
 python-pylint:
   debian: [pylint]
   fedora: [pylint]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -352,6 +352,16 @@ pyflakes3:
       packages: [pyflakes]
   rhel: ['python%{python3_pkgversion}-pyflakes']
   ubuntu: [pyflakes3]
+pylatexenc-pip:
+  debian:
+    pip:
+      packages: [pylatexenc]
+  fedora:
+    pip:
+      packages: [pylatexenc]
+  ubuntu:
+    pip:
+      packages: [pylatexenc]
 pymap3d-pip:
   debian:
     pip:


### PR DESCRIPTION
Adding the pip key such that we can the `pylatexenc` pip package during buildfarm/CI builds

PyPi Link: https://pypi.org/project/pylatexenc/