### PR TITLE
Add pydocstyle rule for RHEL 8

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -326,6 +326,9 @@ pydocstyle:
   osx:
     pip:
       packages: [pydocstyle]
+  rhel:
+    '*': [python3-pydocstyle]
+    '7': null
   ubuntu: [pydocstyle]
 pydrive-pip:
   debian:


### PR DESCRIPTION
This package is provided by EPEL for RHEL 8, and is not available for RHEL 7.

https://src.fedoraproject.org/rpms/python-pydocstyle#bodhi_updates
https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2022-a3872adeee