### PR TITLE
libcreate: 3.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4223,6 +4223,21 @@ repositories:
       url: https://github.com/lgsvl/lgsvl_msgs.git
       version: noetic-devel
     status: developed
+  libcreate:
+    doc:
+      type: git
+      url: https://github.com/AutonomyLab/libcreate.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/AutonomyLab/libcreate-release.git
+      version: 3.0.0-1
+    source:
+      type: git
+      url: https://github.com/AutonomyLab/libcreate.git
+      version: master
+    status: maintained
   libfranka:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libcreate` to `3.0.0-1`:

- upstream repository: https://github.com/AutonomyLab/libcreate.git
- release repository: https://github.com/AutonomyLab/libcreate-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## libcreate

```
* Add option to workaround bug where firmware reports unexpected OI mode (#67 <https://github.com/AutonomyLab/libcreate/issues/67>)
* Update links to serial protocol documentation
* Add option to disable signal handlers (#65 <https://github.com/AutonomyLab/libcreate/issues/65>)
* Fix 'maybe-uninitialized' warnings
* Remove travis.yml
* Add GitHub workflow for CI
* Fix motor setting (#62 <https://github.com/AutonomyLab/libcreate/issues/62>)
* Use average dt values for velocity calculation (#60 <https://github.com/AutonomyLab/libcreate/issues/60>)
* Use steady clock for computing velocity (#59 <https://github.com/AutonomyLab/libcreate/issues/59>)
* Replace boost features with C++11 equivalents (#58 <https://github.com/AutonomyLab/libcreate/issues/58>)
* Implement methods for getting overcurrent status (#57 <https://github.com/AutonomyLab/libcreate/issues/57>)
* Use OC_MOTORS instead of OC_MOTORS_PWM on V_1 models (#55 <https://github.com/AutonomyLab/libcreate/issues/55>)
* Contributors: Daniel Smith, Jacob Perron, Josh Gadeken, Stefan Krupop, tim-fan
```
