### PR TITLE
openrtm_aist: 1.1.2-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5844,6 +5844,21 @@ repositories:
       url: https://github.com/ros-drivers/openni2_camera.git
       version: ros1
     status: maintained
+  openrtm_aist:
+    doc:
+      type: git
+      url: https://github.com/tork-a/openrtm_aist-release.git
+      version: release/melodic/openrtm_aist
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/tork-a/openrtm_aist-release.git
+      version: 1.1.2-2
+    source:
+      type: git
+      url: https://github.com/tork-a/openrtm_aist-release.git
+      version: release/melodic/openrtm_aist
+    status: maintained
   openslam_gmapping:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_aist` to `1.1.2-2`:

- upstream repository: https://github.com/OpenRTM/OpenRTM-aist.git
- release repository: https://github.com/tork-a/openrtm_aist-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
