### PR TITLE
khi_robot: 1.3.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3944,6 +3944,33 @@ repositories:
       url: https://github.com/ros/kdl_parser.git
       version: noetic-devel
     status: maintained
+  khi_robot:
+    doc:
+      type: git
+      url: https://github.com/Kawasaki-Robotics/khi_robot.git
+      version: master
+    release:
+      packages:
+      - khi_duaro_description
+      - khi_duaro_gazebo
+      - khi_duaro_ikfast_plugin
+      - khi_duaro_moveit_config
+      - khi_robot
+      - khi_robot_bringup
+      - khi_robot_control
+      - khi_robot_msgs
+      - khi_robot_test
+      - khi_rs007l_moveit_config
+      - khi_rs007n_moveit_config
+      - khi_rs013n_moveit_config
+      - khi_rs080n_moveit_config
+      - khi_rs_description
+      - khi_rs_gazebo
+      - khi_rs_ikfast_plugin
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/Kawasaki-Robotics/khi_robot-release.git
+      version: 1.3.0-2
   knowledge_representation:
     release:
       tags:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3971,6 +3971,11 @@ repositories:
         release: release/noetic/{package}/{version}
       url: https://github.com/Kawasaki-Robotics/khi_robot-release.git
       version: 1.3.0-2
+    source:
+      type: git
+      url: https://github.com/Kawasaki-Robotics/khi_robot.git
+      version: master
+    status: developed
   knowledge_representation:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `khi_robot` to `1.3.0-2`:

- upstream repository: https://github.com/Kawasaki-Robotics/khi_robot.git
- release repository: https://github.com/Kawasaki-Robotics/khi_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## khi_duaro_description

- No changes

## khi_duaro_gazebo

- No changes

## khi_duaro_ikfast_plugin

- No changes

## khi_duaro_moveit_config

```
* Merge pull request #52 <https://github.com/Kawasaki-Robotics/khi_robot/issues/52> from k-okada/add_ikfast_plugin
  add khi_*_ikfast_plugin to moveit_config
* add khi_*_ikfast_plugin to moveit_config
* Contributors: HirokiTakami, Kei Okada
```

## khi_robot

```
* Add rs013n (#50 <https://github.com/Kawasaki-Robotics/khi_robot/issues/50>)
  * Add rs013n
  * Update rs013n pkgs
  * Update libkrnx
  * Fixed rs013n_bringup.launch to use xacro
  * Update libkrnx to 2.2.0
  * Modify test program for RS series robots
  * Remove kinetic from travis.yml
* Contributors: Hiroki Matsui
```

## khi_robot_bringup

```
* Add rs013n (#50 <https://github.com/Kawasaki-Robotics/khi_robot/issues/50>)
  * Add rs013n
  * Update rs013n pkgs
  * Update libkrnx
  * Fixed rs013n_bringup.launch to use xacro
  * Update libkrnx to 2.2.0
  * Modify test program for RS series robots
  * Remove kinetic from travis.yml
* Bugfix for noetic release (#44 <https://github.com/Kawasaki-Robotics/khi_robot/issues/44>)
  * update .travis.yml to add noetic test
  * update .travis.yml to change ubuntu version for noetic test
  * Changed to use xacro instead of xacro.py which is deprecated. like https://github.com/ros/urdf_sim_tutorial/pull/8
  * fixed "except A, a:" to "except A as a:" for python3 compatibility
  * add version checking of moveit_commander to the test script due to changes of the return value of MoveGroupCommander.plan() in 1.1.0
  * remove armhf build test for ubuntu 20.04
* Contributors: Hiroki Matsui, Koki Shinjo
```

## khi_robot_control

```
* Add rs013n (#50 <https://github.com/Kawasaki-Robotics/khi_robot/issues/50>)
  * Add rs013n
  * Update rs013n pkgs
  * Update libkrnx
  * Fixed rs013n_bringup.launch to use xacro
  * Update libkrnx to 2.2.0
  * Modify test program for RS series robots
  * Remove kinetic from travis.yml
* Contributors: Hiroki Matsui
```

## khi_robot_msgs

- No changes

## khi_robot_test

```
* Add rs013n (#50 <https://github.com/Kawasaki-Robotics/khi_robot/issues/50>)
  * Add rs013n
  * Update rs013n pkgs
  * Update libkrnx
  * Fixed rs013n_bringup.launch to use xacro
  * Update libkrnx to 2.2.0
  * Modify test program for RS series robots
  * Remove kinetic from travis.yml
* Bugfix for noetic release (#44 <https://github.com/Kawasaki-Robotics/khi_robot/issues/44>)
  * update .travis.yml to add noetic test
  * update .travis.yml to change ubuntu version for noetic test
  * Changed to use xacro instead of xacro.py which is deprecated. like https://github.com/ros/urdf_sim_tutorial/pull/8
  * fixed "except A, a:" to "except A as a:" for python3 compatibility
  * add version checking of moveit_commander to the test script due to changes of the return value of MoveGroupCommander.plan() in 1.1.0
  * remove armhf build test for ubuntu 20.04
* Contributors: Hiroki Matsui, Koki Shinjo
```

## khi_rs007l_moveit_config

```
* Merge pull request #52 <https://github.com/Kawasaki-Robotics/khi_robot/issues/52> from k-okada/add_ikfast_plugin
  add khi_*_ikfast_plugin to moveit_config
* add khi_*_ikfast_plugin to moveit_config
* Contributors: HirokiTakami, Kei Okada
```

## khi_rs007n_moveit_config

```
* Merge pull request #52 <https://github.com/Kawasaki-Robotics/khi_robot/issues/52> from k-okada/add_ikfast_plugin
  add khi_*_ikfast_plugin to moveit_config
* add khi_*_ikfast_plugin to moveit_config
* Contributors: HirokiTakami, Kei Okada
```

## khi_rs013n_moveit_config

```
* Merge pull request #52 <https://github.com/Kawasaki-Robotics/khi_robot/issues/52> from k-okada/add_ikfast_plugin
  add khi_*_ikfast_plugin to moveit_config
* add khi_*_ikfast_plugin to moveit_config
* Add rs013n (#50 <https://github.com/Kawasaki-Robotics/khi_robot/issues/50>)
  * Add rs013n
  * Update rs013n pkgs
  * Update libkrnx
  * Fixed rs013n_bringup.launch to use xacro
  * Update libkrnx to 2.2.0
  * Modify test program for RS series robots
  * Remove kinetic from travis.yml
* Contributors: Hiroki Matsui, HirokiTakami, Kei Okada
```

## khi_rs080n_moveit_config

```
* Merge pull request #52 <https://github.com/Kawasaki-Robotics/khi_robot/issues/52> from k-okada/add_ikfast_plugin
  add khi_*_ikfast_plugin to moveit_config
* add khi_*_ikfast_plugin to moveit_config
* Contributors: HirokiTakami, Kei Okada
```

## khi_rs_description

```
* Add rs013n (#50 <https://github.com/Kawasaki-Robotics/khi_robot/issues/50>)
  * Add rs013n
  * Update rs013n pkgs
  * Update libkrnx
  * Fixed rs013n_bringup.launch to use xacro
  * Update libkrnx to 2.2.0
  * Modify test program for RS series robots
  * Remove kinetic from travis.yml
* Bugfix for noetic release (#44 <https://github.com/Kawasaki-Robotics/khi_robot/issues/44>)
  * update .travis.yml to add noetic test
  * update .travis.yml to change ubuntu version for noetic test
  * Changed to use xacro instead of xacro.py which is deprecated. like https://github.com/ros/urdf_sim_tutorial/pull/8
  * fixed "except A, a:" to "except A as a:" for python3 compatibility
  * add version checking of moveit_commander to the test script due to changes of the return value of MoveGroupCommander.plan() in 1.1.0
  * remove armhf build test for ubuntu 20.04
* Contributors: Hiroki Matsui, Koki Shinjo
```

## khi_rs_gazebo

```
* Add rs013n (#50 <https://github.com/Kawasaki-Robotics/khi_robot/issues/50>)
  * Add rs013n
  * Update rs013n pkgs
  * Update libkrnx
  * Fixed rs013n_bringup.launch to use xacro
  * Update libkrnx to 2.2.0
  * Modify test program for RS series robots
  * Remove kinetic from travis.yml
* Contributors: Hiroki Matsui
```

## khi_rs_ikfast_plugin

```
* Add rs013n (#50 <https://github.com/Kawasaki-Robotics/khi_robot/issues/50>)
  * Add rs013n
  * Update rs013n pkgs
  * Update libkrnx
  * Fixed rs013n_bringup.launch to use xacro
  * Update libkrnx to 2.2.0
  * Modify test program for RS series robots
  * Remove kinetic from travis.yml
* Contributors: Hiroki Matsui
```
