### PR TITLE
rqt_image_view: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4083,7 +4083,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_view-release.git
-      version: 1.1.2-2
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_image_view` to `1.2.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_image_view.git
- release repository: https://github.com/ros2-gbp/rqt_image_view-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.2-2`

## rqt_image_view

```
* Install headers to include/${PROJECT_NAME} (#63 <https://github.com/ros-visualization/rqt_image_view/issues/63>)
* Using "sensor data" QoS profile with BEST_EFFORT (#67 <https://github.com/ros-visualization/rqt_image_view/issues/67>)
* fix: modify qt deprecation warning (#68 <https://github.com/ros-visualization/rqt_image_view/issues/68>)
* [FIX] add missing QComboBox to ui (#66 <https://github.com/ros-visualization/rqt_image_view/issues/66>)
* [Rolling] Remember color scheme (#64 <https://github.com/ros-visualization/rqt_image_view/issues/64>)
* Remember color scheme
* Contributors: Daisuke Nishimatsu, Karl Schulz, Matthijs van der Burgh, Shane Loretz, wodtko
```
