### PR TITLE
audio_common: 0.3.13-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -693,7 +693,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/audio_common-release.git
-      version: 0.3.12-1
+      version: 0.3.13-1
     source:
       type: git
       url: https://github.com/ros-drivers/audio_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common` to `0.3.13-1`:

- upstream repository: https://github.com/ros-drivers/audio_common.git
- release repository: https://github.com/ros-gbp/audio_common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.3.12-1`

## audio_capture

- No changes

## audio_common

- No changes

## audio_common_msgs

- No changes

## audio_play

```
* Merge pull request #179 <https://github.com/ros-drivers/audio_common/issues/179> from tkmtnt7000/PR-remap-audio-topic
* audio_play: add audio_topic option
* Contributors: Naoto Tsukamoto, Shingo Kitagawa
```

## sound_play

```
* Merge pull request #176 <https://github.com/ros-drivers/audio_common/issues/176> from iory/is-speeching
* Add is_speaking.py to catkin_install_python
* Fixed name speeching to speaking
* Add is_speeching node for checking robot is speaking
* Contributors: Shingo Kitagawa, iory
```
