### PR TITLE
chore: update velodyne ros2 release repo

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6292,7 +6292,7 @@ repositories:
       - velodyne_pointcloud
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/ros-drivers-gbp/velodyne-release.git
+      url: https://github.com/ros2-gbp/velodyne-release.git
       version: 2.1.1-1
     source:
       type: git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5544,7 +5544,7 @@ repositories:
       - velodyne_pointcloud
       tags:
         release: release/galactic/{package}/{version}
-      url: https://github.com/ros-drivers-gbp/velodyne-release.git
+      url: https://github.com/ros2-gbp/velodyne-release.git
       version: 2.2.0-1
     source:
       type: git


### PR DESCRIPTION
I updated ros2 release repository for velodyne.
See https://github.com/ros2-gbp/velodyne-release/issues/1.
