### PR TITLE
vision_opencv_python3: 1.13.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -14701,7 +14701,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/vision_opencv_python3-release.git
-      version: 1.13.1-1
+      version: 1.13.2-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/vision_opencv_python3.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv_python3` to `1.13.2-1`:

- upstream repository: https://github.com/jsk-ros-pkg/vision_opencv_python3.git
- release repository: https://github.com/tork-a/vision_opencv_python3-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.13.1-1`

## cv_bridge_python3

```
* add buildtool_depend for catkin-pkg-modules (#2 <https://github.com/jsk-ros-pkg/vision_opencv_python3/issues/2>)
* Contributors: Shingo Kitagawa
```
