### PR TITLE
[dep] python*-elasticsearch

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1563,6 +1563,13 @@ python-easygui:
   debian: [python-easygui]
   fedora: [python-easygui]
   ubuntu: [python-easygui]
+python-elasticsearch:
+  debian:
+    buster: [python-elasticsearch]
+    stretch: [python-elasticsearch]
+  opensuse: [python-elasticsearch]
+  ubuntu:
+    bionic: [python-elasticsearch]
 python-empy:
   arch: [python2-empy]
   debian: [python-empy]
@@ -6349,6 +6356,14 @@ python3-dubins-pip:
   ubuntu:
     pip:
       packages: [dubins]
+python3-elasticsearch:
+  debian: [python3-elasticsearch]
+  fedora: [python3-elasticsearch]
+  opensuse: [python3-elasticsearch]
+  rhel:
+    '*': [python3-elasticsearch]
+    '7': null
+  ubuntu: [python3-elasticsearch]
 python3-empy:
   alpine: [py3-empy]
   arch: [python-empy]


### PR DESCRIPTION
## Package name:

`python-elasticsearch`, `python3-elasticsearch`

## Package Upstream Source:

https://github.com/elastic/elasticsearch-py

## Purpose of using this:

Handling JSON formated data.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=%20elasticsearch
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/search?keywords=elasticsearch
- Fedora: https://src.fedoraproject.org/browse/projects/
  - https://src.fedoraproject.org/rpms/python-elasticsearch
- Opensuse
  - https://software.opensuse.org/package/python-elasticsearch
- RHEL
  - https://src.fedoraproject.org/rpms/python-elasticsearch#bodhi_updates