### PR TITLE
avt_vimba_camera: 1.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -370,7 +370,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/astuff/avt_vimba_camera-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `avt_vimba_camera` to `1.2.0-1`:

- upstream repository: https://github.com/astuff/avt_vimba_camera.git
- release repository: https://github.com/astuff/avt_vimba_camera-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.0-1`

## avt_vimba_camera

```
* Add note about permanent buffer settings to the README (#91 <https://github.com/astuff/avt_vimba_camera/issues/91>)
* Remove triggermode check (#84 <https://github.com/astuff/avt_vimba_camera/issues/84>)
* Contributors: icolwell-as
```
