### PR TITLE
launch: 0.23.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1535,7 +1535,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.23.0-1
+      version: 0.23.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.23.1-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.23.0-1`

## launch

```
* Start Python faster in test_execute_processs_shutdown to avoid flakey failures (#608 <https://github.com/ros2/launch/issues/608>)
* Fix warnings from importlib_metdata on Python 3.10. (#606 <https://github.com/ros2/launch/issues/606>)
* Contributors: Chris Lalancette, Shane Loretz
```

## launch_pytest

- No changes

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* Fix sphinx directive to cross-ref Launch method (#605 <https://github.com/ros2/launch/issues/605>)
* Contributors: Abrar Rahman Protyasha
```

## launch_yaml

```
* Fix sphinx directive to cross-ref Launch method (#605 <https://github.com/ros2/launch/issues/605>)
* Contributors: Abrar Rahman Protyasha
```
