### PR TITLE
launch_ros: 0.19.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1570,7 +1570,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.19.1-1
+      version: 0.19.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.19.2-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.19.1-1`

## launch_ros

```
* Fix importlib_metadata warning on Python 3.10. (#307 <https://github.com/ros2/launch_ros/issues/307>)
* Contributors: Chris Lalancette
```

## launch_testing_ros

```
* Add hz param to talker.py to fix wait_for_topic_launch_test (#309 <https://github.com/ros2/launch_ros/issues/309>)
* Contributors: Shane Loretz
```

## ros2launch

- No changes
