### PR TITLE
sros2: 0.10.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4532,7 +4532,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.10.3-2
+      version: 0.10.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.10.4-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.10.3-2`

## sros2

```
* Increase the shutdown timeout for test_generate_policy_no_nodes. (#278 <https://github.com/ros2/sros2/issues/278>)
* Contributors: Chris Lalancette
```

## sros2_cmake

- No changes
