### PR TITLE
rclcpp: 16.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2866,7 +2866,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 15.4.0-1
+      version: 16.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `16.0.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `15.4.0-1`

## rclcpp

```
* remove things that were deprecated during galactic (#1913 <https://github.com/ros2/rclcpp/issues/1913>)
* Contributors: William Woodall
```

## rclcpp_action

```
* remove things that were deprecated during galactic (#1913 <https://github.com/ros2/rclcpp/issues/1913>)
* Contributors: William Woodall
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* remove things that were deprecated during galactic (#1913 <https://github.com/ros2/rclcpp/issues/1913>)
* Contributors: William Woodall
```
