### PR TITLE
rmw_connextdds: 0.11.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3263,7 +3263,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 0.10.0-1
+      version: 0.11.0-1
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `0.11.0-1`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.10.0-1`

## rmw_connextdds

```
* Exclude missing sample info fields when building rmw_connextddsmicro (#79 <https://github.com/ros2/rmw_connextdds/issues/79>)
* Update launch_testing_ros output filter prefixes for Connext6 (#80 <https://github.com/ros2/rmw_connextdds/issues/80>)
* Contributors: Andrea Sorbini, Ivan Santiago Paunovic
```

## rmw_connextdds_common

```
* Exclude missing sample info fields when building rmw_connextddsmicro (#79 <https://github.com/ros2/rmw_connextdds/issues/79>)
* Properly initialize CDR stream before using it for filtering (#81 <https://github.com/ros2/rmw_connextdds/issues/81>)
* Contributors: Andrea Sorbini
```

## rti_connext_dds_cmake_module

- No changes
