### PR TITLE
image_transport_plugins: 2.3.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1659,7 +1659,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 2.3.1-1
+      version: 2.3.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `2.3.3-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.1-1`

## compressed_depth_image_transport

```
* Avoid parameter exception for compressed image transport (#86 <https://github.com/ros-perception/image_transport_plugins/issues/86>)
* Contributors: Daisuke Nishimatsu
```

## compressed_image_transport

```
* Avoid parameter exception for compressed image transport (#86 <https://github.com/ros-perception/image_transport_plugins/issues/86>)
* Contributors: Daisuke Nishimatsu
```

## image_transport_plugins

- No changes

## theora_image_transport

```
* Avoid parameter exception for compressed image transport (#86 <https://github.com/ros-perception/image_transport_plugins/issues/86>)
* Contributors: Daisuke Nishimatsu
```
