### PR TITLE
vision_msgs: 0.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10450,7 +10450,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/Kukanani/vision_msgs-release.git
-      version: 0.0.1-1
+      version: 0.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_msgs` to `0.0.2-1`:

- upstream repository: https://github.com/Kukanani/vision_msgs.git
- release repository: https://github.com/Kukanani/vision_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.1-1`

## vision_msgs

```
* Added BoundingBox2DArray message #60 <https://github.com/ros-perception/vision_msgs/issues/60> from Fruchtzwerg94/array_for_2d_bounding_box
* Upgrade CMake version to avoid CMP0048 warning
* add BoundingBox3DArray message (#30 <https://github.com/ros-perception/vision_msgs/issues/30>)
  * add BoundingBoxArray message
* Make message_generation and message_runtime use more specific depend tags (#24 <https://github.com/ros-perception/vision_msgs/issues/24>)
* Fix dependency of unit test. (#14 <https://github.com/ros-perception/vision_msgs/issues/14>)
* Minor bugfixes and code style updates
* Contributors: Adam Allevato, Fruchtzwerg94, Leroy Rügemer, Masaya Kataoka, Ronald Ensing, mistermult
```
