### PR TITLE
pr2_mechanism: 1.8.19-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6587,11 +6587,12 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_mechanism-release.git
-      version: 1.8.18-1
+      version: 1.8.19-1
     source:
       type: git
       url: https://github.com/pr2/pr2_mechanism.git
       version: kinetic-devel
+    status: maintained
   pr2_mechanism_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_mechanism` to `1.8.19-1`:

- upstream repository: https://github.com/pr2/pr2_mechanism.git
- release repository: https://github.com/pr2-gbp/pr2_mechanism-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.8.18-1`

## pr2_controller_interface

- No changes

## pr2_controller_manager

```
* add noetic to .travis.yml, remove indigo/lunar (#342 <https://github.com/PR2/pr2_mechanism/issues/342>)
  use '2to3-2.7 -w -fprint -fraise -fexcept -fdict .' to fix python2 to python3
* Added missing dependencies for catkin_EXPORTED_TARGETS (#341 <https://github.com/PR2/pr2_mechanism/issues/341>)
  This fixes race conditions when compiling from scratch.
  Co-authored-by: Lasse Einig <mailto:einig@informatik.uni-hamburg.de>
* Contributors: Kei Okada, Michael Görner
```

## pr2_hardware_interface

- No changes

## pr2_mechanism

- No changes

## pr2_mechanism_diagnostics

```
* Merge pull request #342 <https://github.com/PR2/pr2_mechanism/issues/342> from k-okada/add_noetic
  add noetic to .travis.yml, remove indigo/lunar
* use '2to3-2.7 -w -fprint -fraise -fexcept -fdict .' to fix python2 to python3
* Added missing dependencies for catkin_EXPORTED_TARGETS (#341 <https://github.com/PR2/pr2_mechanism/issues/341>)
  This fixes race conditions when compiling from scratch.
  Co-authored-by: Lasse Einig <mailto:einig@informatik.uni-hamburg.de>
* Contributors: Kei Okada, Michael Görner
```

## pr2_mechanism_model

- No changes
