### PR TITLE
arch: add missing core dependenices

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2825,7 +2825,6 @@ libconfig-dev:
   ubuntu: [libconfig-dev]
 libconsole-bridge-dev:
   alpine: [console_bridge-dev]
-  arch: [console-bridge]
   debian: [libconsole-bridge-dev]
   fedora: [console-bridge-devel]
   freebsd: [ros-console_bridge]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6206,6 +6206,7 @@ python3-crcmod:
   ubuntu: [python3-crcmod]
 python3-cryptography:
   alpine: [py3-cryptography]
+  arch: [python-cryptography]
   debian: [python3-cryptography]
   fedora: [python3-cryptography]
   gentoo: [dev-python/cryptography]
@@ -6945,6 +6946,7 @@ python3-lttng:
   ubuntu: [python3-lttng]
 python3-lxml:
   alpine: [py3-lxml]
+  arch: [python-lxml]
   debian: [python3-lxml]
   fedora: [python3-lxml]
   freebsd: [py36-lxml]
@@ -7110,6 +7112,7 @@ python3-netcdf4:
   ubuntu: [python3-netcdf4]
 python3-netifaces:
   alpine: [py3-netifaces]
+  arch: [python-netifaces]
   debian: [python3-netifaces]
   fedora: [python3-netifaces]
   gentoo: [dev-python/netifaces]
@@ -7278,6 +7281,7 @@ python3-owlready2-pip:
       packages: [owlready2]
 python3-packaging:
   alpine: [py3-packaging]
+  arch: [python-packaging]
   debian: [python3-packaging]
   fedora: [python3-packaging]
   gentoo: [dev-python/packaging]
@@ -7880,6 +7884,7 @@ python3-pytest-mock:
   rhel: ['python%{python3_pkgversion}-pytest-mock']
   ubuntu: [python3-pytest-mock]
 python3-pytest-timeout:
+  arch: [python-pytest-timeout]
   debian: [python3-pytest-timeout]
   fedora: [python3-pytest-timeout]
   gentoo: [dev-python/pytest-timeout]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

I missed these in the first run #32532  because rosdep didn't complete its recursive search or something. I have completed a rosdep install this time so this is all of them, except `console-bridge`. `console-bridge` is no longer available in the arch repositories so I have removed that key, a ros vendor package exists for it which is more than good enough for my needs. 

## Purpose of using this:

ROS2 Core dependencies for arch linux.

## Links to Distribution Packages

- https://archlinux.org/packages/community/any/python-pytest-timeout/
- https://archlinux.org/packages/extra/x86_64/python-cryptography/
- https://archlinux.org/packages/extra/x86_64/python-lxml/
- https://archlinux.org/packages/community/x86_64/python-netifaces/
- https://archlinux.org/packages/extra/any/python-packaging/
