### PR TITLE
pr2_mechanism: 1.8.20-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9285,7 +9285,11 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_mechanism-release.git
-      version: 1.8.18-0
+      version: 1.8.20-1
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_mechanism.git
+      version: melodic-devel
     status: unmaintained
   pr2_mechanism_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_mechanism` to `1.8.20-1`:

- upstream repository: https://github.com/pr2/pr2_mechanism.git
- release repository: https://github.com/pr2-gbp/pr2_mechanism-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.8.18-0`

## pr2_controller_interface

- No changes

## pr2_controller_manager

```
* add missing package (robot_state_publisher) to package.xml (#339 <https://github.com/PR2/pr2_mechanism//issues/339>)
* Contributors: Kei Okada
```

## pr2_hardware_interface

- No changes

## pr2_mechanism

- No changes

## pr2_mechanism_diagnostics

- No changes

## pr2_mechanism_model

- No changes
