### PR TITLE
laser_filters: 2.0.4-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1481,7 +1481,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/laser_filters-release.git
-      version: 2.0.1-2
+      version: 2.0.4-4
     source:
       type: git
       url: https://github.com/ros-perception/laser_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters` to `2.0.4-4`:

- upstream repository: https://github.com/ros-perception/laser_filters.git
- release repository: https://github.com/ros2-gbp/laser_filters-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.1-2`

## laser_filters

```
* Add a sensor_msgs dependency to test_scan_filter_chain
* adding support for invert-parameter to select if points within or outside of box are kept
* Contributors: Chris Lalancette, Jonathan Binney, Nikolas Engelhard
```
