### PR TITLE
novatel_gps_driver: 3.9.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5549,6 +5549,24 @@ repositories:
       url: https://github.com/SteveMacenski/nonpersistent_voxel_layer.git
       version: melodic-devel
     status: maintained
+  novatel_gps_driver:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/novatel_gps_driver.git
+      version: master
+    release:
+      packages:
+      - novatel_gps_driver
+      - novatel_gps_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
+      version: 3.9.0-2
+    source:
+      type: git
+      url: https://github.com/swri-robotics/novatel_gps_driver.git
+      version: master
+    status: developed
   novatel_oem7_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `3.9.0-2`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## novatel_gps_driver

```
* Use GPGGA quality to set GPSFix status (#55 <https://github.com/swri-robotics/novatel_gps_driver/issues/55>)
* Publish INSPVAX logs (#54 <https://github.com/swri-robotics/novatel_gps_driver/issues/54>)
* Add GPHDT message (#51 <https://github.com/swri-robotics/novatel_gps_driver/issues/51>)
* Fix ascii header message id in novatel_gps.cpp (#50 <https://github.com/swri-robotics/novatel_gps_driver/issues/50>)
* Correctly convert novatel header flags to bool and add tests for them (#48 <https://github.com/swri-robotics/novatel_gps_driver/issues/48>)
* Add DUALANTENNAHEADING msg (#46 <https://github.com/swri-robotics/novatel_gps_driver/issues/46>)
* Add HEADING2 msg (#43 <https://github.com/swri-robotics/novatel_gps_driver/issues/43>)
* Add BESTXYZ msg (#42 <https://github.com/swri-robotics/novatel_gps_driver/issues/42>)
* Contributors: Marcel Zeilinger, Matthew, Michael McConnell, P. J. Reed
```

## novatel_gps_msgs

```
* Use GPGGA quality to set GPSFix status (#55 <https://github.com/swri-robotics/novatel_gps_driver/issues/55>)
* Add GPHDT message (#51 <https://github.com/swri-robotics/novatel_gps_driver/issues/51>)
* Add DUALANTENNAHEADING msg (#46 <https://github.com/swri-robotics/novatel_gps_driver/issues/46>)
* Add HEADER2 msg (#43 <https://github.com/swri-robotics/novatel_gps_driver/issues/43>)
* Add BESTXYZ msg (#42 <https://github.com/swri-robotics/novatel_gps_driver/issues/42>)
* Contributors: Marcel Zeilinger, Michael McConnell, P. J. Reed
```
