### PR TITLE
novatel_gps_driver: 4.1.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2149,6 +2149,24 @@ repositories:
       url: https://github.com/osrf/nodl_to_policy.git
       version: master
     status: maintained
+  novatel_gps_driver:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/novatel_gps_driver.git
+      version: dashing-devel
+    release:
+      packages:
+      - novatel_gps_driver
+      - novatel_gps_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
+      version: 4.1.0-2
+    source:
+      type: git
+      url: https://github.com/swri-robotics/novatel_gps_driver.git
+      version: dashing-devel
+    status: developed
   ntpd_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `4.1.0-2`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## novatel_gps_driver

```
* Add param to disable invalid GPSFixes, replace GPRMC with BESTVEL (ROS2) (#94 <https://github.com/swri-robotics/novatel_gps_driver/issues/94>)
* Use rclcpp::WallRate to sleep instead of boost (ROS2) (#86 <https://github.com/swri-robotics/novatel_gps_driver/issues/86>)
* Refactor GPSFix generation (ROS2) (#73 <https://github.com/swri-robotics/novatel_gps_driver/issues/73>)
* Contributors: P. J. Reed
```

## novatel_gps_msgs

```
* Refactor GPSFix generation (ROS2) (#73 <https://github.com/swri-robotics/novatel_gps_driver/issues/73>)
* Contributors: P. J. Reed
```
