### PR TITLE
pr2_simulator: 2.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6692,6 +6692,26 @@ repositories:
       url: https://github.com/PR2/pr2_self_test.git
       version: kinetic-devel
     status: unmaintained
+  pr2_simulator:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_simulator.git
+      version: kinetic-devel
+    release:
+      packages:
+      - pr2_controller_configuration_gazebo
+      - pr2_gazebo
+      - pr2_gazebo_plugins
+      - pr2_simulator
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_simulator-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_simulator.git
+      version: kinetic-devel
+    status: unmaintained
   prbt_grippers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_simulator` to `2.1.0-1`:

- upstream repository: https://github.com/pr2/pr2_simulator.git
- release repository: https://github.com/pr2-gbp/pr2_simulator-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## pr2_controller_configuration_gazebo

- No changes

## pr2_gazebo

```
* Support Noetic (#150 <https://github.com/pr2/pr2_simulator/issues/150>)
  test/sensors/test_camera.py: noetic does not need to str(image.data) and rotate()
  use bigger cup
  relax hztest in hztest_pr2_scan.launch
  fix for python3: 2to3 -w -f except .
  fix for python3: 2to3 -w -f print .
  remove rosdep update from CMakeLists.txt
  hztest_pr2_image.launch: relax hzerror for caemra test
  add robot_state_publisher to pr2_gazebo/package.xml
* Contributors: Kei Okada
```

## pr2_gazebo_plugins

```
* Support Noetic (#150 <https://github.com/pr2/pr2_simulator/issues/150>) from k-okada/ga
  use catkin_dev to use default veresion of Gazebo, see https://github.com/ros-simulation/gazebo_ros_pkgs/pull/571 for more info
  package.xml: use liborocos-kdl for ROS_PYTHON_VERSION=3
* Contributors: Kei Okada
```

## pr2_simulator

- No changes
