### PR TITLE
Specify how to handle python packages only available in recent distributions.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -276,7 +276,7 @@ See above for the Gentoo specific guidelines.
 #### pip mixed with system packages
 
 Some packages are only available as system packages in newer distributions.
-In such case, you can specify the default as system package, and pip for older distributions.
+In such case, you can specify the default as system package, and pip for older distributions for which the system packages are not available.
 
 For example:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -273,6 +273,23 @@ The `-pip` key should be removed when the package becomes available on all platf
 As a reminder `pip` rules should not be used on Gentoo.
 See above for the Gentoo specific guidelines.
 
+#### pip mixed with system packages
+
+Some packages are only available as system packages in newer distributions.
+
+In such case, you can specify the default as system package, and pip for older distributions.
+
+For example:
+
+```yaml
+python3-relatively-new-package
+  ubuntu:
+    '*': [python3-relatively-new-package]
+    bionic:
+      pip:
+        packages: [relatively-new-package]
+```
+
 How to submit pull requests
 ---------------------------
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -276,7 +276,6 @@ See above for the Gentoo specific guidelines.
 #### pip mixed with system packages
 
 Some packages are only available as system packages in newer distributions.
-
 In such case, you can specify the default as system package, and pip for older distributions.
 
 For example:


### PR DESCRIPTION
Based on the information I got from #32698, I added instructions to add packages that are pip only in older distributions.

I'm not sure if this file is the right place to write, so I'm open for edits.