### PR TITLE
imu_tools: 1.2.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3443,7 +3443,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/uos-gbp/imu_tools-release.git
-      version: 1.2.3-1
+      version: 1.2.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `1.2.4-1`:

- upstream repository: https://github.com/ccny-ros-pkg/imu_tools.git
- release repository: https://github.com/uos-gbp/imu_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.3-1`

## imu_complementary_filter

```
* Manually reformat licenses + defines
* Reformat everything using clang-format
* Fix package dependencies
* Fix trailing whitespace
* Contributors: Martin Günther
```

## imu_filter_madgwick

```
* Reformat everything using clang-format
* Fix package dependencies
* Fix trailing whitespace
* Fix typo
* Add declination and yaw offset. (#121 <https://github.com/CCNYRoboticsLab/imu_tools/issues/121>)
  Fixes #120 <https://github.com/CCNYRoboticsLab/imu_tools/issues/120>.
* Add license files
  The "COPYING" file incorrectly had the text of the LGPL, but the
  original Madgwick filter [1], [2] is GPL licensed. The source code
  headers correctly have the GPLv3 license text.
  [1]: https://x-io.co.uk/open-source-imu-and-ahrs-algorithms/
  [2]: https://github.com/xioTechnologies/Fusion
* Contributors: Martin Günther, tgreier
```

## imu_tools

- No changes

## rviz_imu_plugin

```
* Reformat everything using clang-format
* Fix package dependencies
* Fix trailing whitespace
* Contributors: Martin Günther
```
