### PR TITLE
robot_upstart: 1.0.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3579,6 +3579,21 @@ repositories:
       url: https://github.com/ros/robot_state_publisher.git
       version: galactic
     status: maintained
+  robot_upstart:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/robot_upstart.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/clearpath-gbp/robot_upstart-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/robot_upstart.git
+      version: foxy-devel
+    status: maintained
   ros1_bridge:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_upstart` to `1.0.1-1`:

- upstream repository: https://github.com/clearpathrobotics/robot_upstart.git
- release repository: https://github.com/clearpath-gbp/robot_upstart-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## robot_upstart

```
* Added ament_index_python as run dep.
* Removed un-used import.
* Switched setup.cfg parameters to use underscores.
* Updated setup.py to version 1.0.0.
* Contributors: Tony Baltovski
```
