### PR TITLE
rot_conv_lib: 1.0.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3955,7 +3955,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rot_conv_lib-release.git
-      version: 1.0.5-1
+      version: 1.0.7-1
     source:
       type: git
       url: https://github.com/AIS-Bonn/rot_conv_lib.git


### PR DESCRIPTION
Fixes up the Eigen3 dependency error in https://build.ros2.org/job/Rdev__rot_conv_lib__ubuntu_jammy_amd64/1/

Increasing version of package(s) in repository `rot_conv_lib` to `1.0.7-1`:

- upstream repository: https://github.com/AIS-Bonn/rot_conv_lib.git
- release repository: https://github.com/ros2-gbp/rot_conv_lib-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.5-1`
