### PR TITLE
Switch the rolling pcl_conversions branches to ros2.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2409,7 +2409,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/perception_pcl.git
-      version: foxy-devel
+      version: ros2
     release:
       packages:
       - pcl_conversions
@@ -2423,7 +2423,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/perception_pcl.git
-      version: foxy-devel
+      version: ros2
     status: maintained
   performance_test_fixture:
     release:


### PR DESCRIPTION
This seems to be what the releases are using.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>