### PR TITLE
Switch the ublox branch for rolling to a dedicated branch.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4941,7 +4941,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/KumarRobotics/ublox.git
-      version: foxy-devel
+      version: ros2
     release:
       packages:
       - ublox
@@ -4956,7 +4956,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/KumarRobotics/ublox.git
-      version: foxy-devel
+      version: ros2
     status: maintained
   udp_msgs:
     doc:


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>