### PR TITLE
Switch the ublox foxy release repo to ros2-gbp.

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6019,7 +6019,7 @@ repositories:
       - ublox_serialization
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/KumarRobotics/ublox-release.git
+      url: https://github.com/ros2-gbp/ublox-release.git
       version: 2.0.0-1
     source:
       test_pull_requests: true


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>
