### PR TITLE
ublox: 2.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6020,7 +6020,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ublox-release.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ublox` to `2.1.0-1`:

- upstream repository: https://github.com/KumarRobotics/ublox.git
- release repository: https://github.com/ros2-gbp/ublox-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-1`

## ublox

- No changes

## ublox_gps

```
* Add UDP support (#140 <https://github.com/KumarRobotics/ublox/issues/140>)
* add Ublox ZED_F9P config (#131 <https://github.com/KumarRobotics/ublox/issues/131>)
* Fix warnings in launch.
* [FEAT]: add launch and config directories to 'intall' package to avoid wrong launch location (#125 <https://github.com/KumarRobotics/ublox/issues/125>)
* Fix wrong variable name in launch (#120 <https://github.com/KumarRobotics/ublox/issues/120>)
* Contributors: CHAIWIT PHONKHEN, Chao Qu, Chris Lalancette, Daisuke Nishimatsu, Davidson Daniel Rojas Cediel, Kevin Hallenbeck
```

## ublox_msgs

- No changes

## ublox_serialization

- No changes
