### PR TITLE
adaptive_component: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -50,6 +50,18 @@ repositories:
       url: https://github.com/ros-drivers/ackermann_msgs.git
       version: ros2
     status: maintained
+  adaptive_component:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/adaptive_component-release.git
+      version: 0.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-acceleration/adaptive_component.git
+      version: main
+    status: developed
   ament_acceleration:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `adaptive_component` to `0.2.0-1`:

- upstream repository: https://github.com/ros-acceleration/adaptive_component.git
- release repository: https://github.com/ros2-gbp/adaptive_component-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## adaptive_component

```
* Release 0.2.0
* Add extra ament exports
* Fix links to acceleration_examples
* Add rclcpp_components dependency
* Add extra ament exports
* Add rclcpp_components dependency
* Add a few examples to README
* Minor improvements
```
