### PR TITLE
interactive_marker_twist_server: 2.0.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1666,6 +1666,21 @@ repositories:
       url: https://github.com/ros-perception/image_transport_plugins.git
       version: foxy-devel
     status: maintained
+  interactive_marker_twist_server:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/interactive_marker_twist_server.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros-gbp/interactive_marker_twist_server-release.git
+      version: 2.0.0-2
+    source:
+      type: git
+      url: https://github.com/ros-visualization/interactive_marker_twist_server.git
+      version: foxy-devel
+    status: maintained
   interactive_markers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_marker_twist_server` to `2.0.0-2`:

- upstream repository: https://github.com/ros-visualization/interactive_marker_twist_server.git
- release repository: https://github.com/ros-gbp/interactive_marker_twist_server-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## interactive_marker_twist_server

```
* Add license, contributing, and copyright headers for linter
* Style changes for linter
* List dependencies in alphabetical order
* add missing tick
* add basic usage instructions
* create ROS2 XML launch file
* add config argument
* initial README
* Re-include standard library headers
* Cleanup
* Use SingleThreadedExecutor; change topic name from global to relative; remove logging
* Remove duplicate imports
* Change default config file to linear
* Cleanup CMakeLists.txt and package.xml
* Rename launch file to follow ROS2 naming convention
* Disable requirement for declared parameters via node options; uncomment lines to make node work
* Change values from int to double
* Launch file
* Initial launch file
* Recover descriptions
* Initialize server in constructor initialization list, readd marker_size_scale, fix getParameters()
* Make processFeedback() publicly accessible
* Init createInteractiveMarkers() and processFeedback() methods
* Initial getParameters() method
* Port methods
* Initial functional skeleton ros2 node
* Remove unused cmd_vel_topic variable (#18 <https://github.com/ros-visualization/interactive_marker_twist_server/issues/18>)
* Initial migration CMakeLists.txt and package.xml
* Contributors: Joey Yang, jyang, jyang-cpr
```
