### PR TITLE
Change the phidgets_drivers branch for rolling.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2453,7 +2453,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/phidgets_drivers.git
-      version: galactic
+      version: rolling
     release:
       packages:
       - libphidget22
@@ -2479,7 +2479,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-drivers/phidgets_drivers.git
-      version: galactic
+      version: rolling
     status: maintained
   picknik_ament_copyright:
     release:


### PR DESCRIPTION
There is a new set of branches for Rolling now.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>