### PR TITLE
kdl_parser: 1.14.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3957,7 +3957,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/kdl_parser-release.git
-      version: 1.14.1-1
+      version: 1.14.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kdl_parser` to `1.14.2-1`:

- upstream repository: https://github.com/ros/kdl_parser.git
- release repository: https://github.com/ros-gbp/kdl_parser-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.14.1-1`

## kdl_parser

- No changes

## kdl_parser_py

```
* Restored compatibility with Orocos KDL after Joint.None was removed (#45 <https://github.com/ros/kdl_parser/issues/45>)
* Contributors: Julian Förster
```
