### PR TITLE
um7: 0.0.6-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10190,6 +10190,21 @@ repositories:
       url: https://github.com/anqixu/ueye_cam.git
       version: master
     status: developed
+  um7:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/um7.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/um7-release.git
+      version: 0.0.6-3
+    source:
+      type: git
+      url: https://github.com/ros-drivers/um7.git
+      version: indigo-devel
+    status: maintained
   unique_identifier:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `um7` to `0.0.6-3`:

- upstream repository: https://github.com/ros-drivers/um7
- release repository: https://github.com/ros-drivers-gbp/um7-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## um7

```
* Fix error of mag topic not publish
* Contributors: Nicolas SIMON
```
