### PR TITLE
phidgets_drivers: 2.1.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3022,7 +3022,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/phidgets_drivers-release.git
-      version: 2.1.1-1
+      version: 2.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `2.1.2-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros2-gbp/phidgets_drivers-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.1-1`

## libphidget22

- No changes

## phidgets_accelerometer

- No changes

## phidgets_analog_inputs

- No changes

## phidgets_api

- No changes

## phidgets_digital_inputs

- No changes

## phidgets_digital_outputs

- No changes

## phidgets_drivers

- No changes

## phidgets_gyroscope

- No changes

## phidgets_high_speed_encoder

```
* Merge pull request #131 <https://github.com/ros-drivers/phidgets_drivers/issues/131> from mintar/feat-pre-commit-foxy
  [foxy] Add pre-commit, move from travis to GitHub actions, fix style
* Fix clang-format
* BUGFIX: duplicated values for all encoders (#125 <https://github.com/ros-drivers/phidgets_drivers/issues/125>)
* Contributors: Martin Günther
```

## phidgets_ik

- No changes

## phidgets_magnetometer

- No changes

## phidgets_motors

- No changes

## phidgets_msgs

```
* Merge pull request #131 <https://github.com/ros-drivers/phidgets_drivers/issues/131> from mintar/feat-pre-commit-foxy
  [foxy] Add pre-commit, move from travis to GitHub actions, fix style
* Fix trailing whitespace
* Contributors: Martin Günther
```

## phidgets_spatial

- No changes

## phidgets_temperature

- No changes
