### PR TITLE
phidgets_drivers: 2.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2474,7 +2474,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/phidgets_drivers-release.git
-      version: 2.2.2-1
+      version: 2.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `2.3.0-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros2-gbp/phidgets_drivers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.2.2-1`

## libphidget22

```
* Update to libphidgets 20220203 (#138 <https://github.com/ros-drivers/phidgets_drivers/issues/138>)
* Contributors: Chris Lalancette
```

## phidgets_accelerometer

- No changes

## phidgets_analog_inputs

- No changes

## phidgets_api

- No changes

## phidgets_digital_inputs

- No changes

## phidgets_digital_outputs

- No changes

## phidgets_drivers

- No changes

## phidgets_gyroscope

- No changes

## phidgets_high_speed_encoder

```
* Merge pull request #132 <https://github.com/ros-drivers/phidgets_drivers/issues/132> from mintar/feat-pre-commit-ros2
  [galactic] Add pre-commit, move from travis to GitHub actions, fix style
* Fix clang-format
* BUGFIX: duplicated values for all encoders (#126 <https://github.com/ros-drivers/phidgets_drivers/issues/126>)
* Contributors: Martin Günther
```

## phidgets_ik

- No changes

## phidgets_magnetometer

```
* Merge pull request #132 <https://github.com/ros-drivers/phidgets_drivers/issues/132> from mintar/feat-pre-commit-ros2
  [galactic] Add pre-commit, move from travis to GitHub actions, fix style
* Fix clang-format
* Contributors: Martin Günther
```

## phidgets_motors

- No changes

## phidgets_msgs

```
* Merge pull request #132 <https://github.com/ros-drivers/phidgets_drivers/issues/132> from mintar/feat-pre-commit-ros2
  [galactic] Add pre-commit, move from travis to GitHub actions, fix style
* Fix trailing whitespace
* Contributors: Martin Günther
```

## phidgets_spatial

- No changes

## phidgets_temperature

- No changes
