### PR TITLE
ur_msgs: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5042,6 +5042,21 @@ repositories:
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
       version: ros2
     status: developed
+  ur_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/ur_msgs.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ur_msgs-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-industrial/ur_msgs.git
+      version: foxy
+    status: developed
   urdf:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_msgs` to `2.0.0-1`:

- upstream repository: https://github.com/ros-industrial/ur_msgs.git
- release repository: https://github.com/ros2-gbp/ur_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ur_msgs

```
* Porting to ros2 (#12 <https://github.com/destogl/ur_msgs/issues/12>)
* Document pin mapping in SetIO service (#16 <https://github.com/destogl/ur_msgs/issues/16>)
* Contributors: Denis Štogl, Felix Exner, gavanderhoorn
```
