### PR TITLE
adaptive_component: 0.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -51,11 +51,15 @@ repositories:
       version: ros2
     status: maintained
   adaptive_component:
+    doc:
+      type: git
+      url: https://github.com/ros-acceleration/adaptive_component.git
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/adaptive_component-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -64,7 +64,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-acceleration/adaptive_component.git
-      version: main
+      version: rolling
     status: developed
   ament_acceleration:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `adaptive_component` to `0.2.1-1`:

- upstream repository: https://github.com/ros-acceleration/adaptive_component.git
- release repository: https://github.com/ros2-gbp/adaptive_component-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.0-1`
