### PR TITLE
rclc: 3.0.8-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2875,7 +2875,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
-      version: 3.0.7-1
+      version: 3.0.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclc` to `3.0.8-1`:

- upstream repository: https://github.com/ros2/rclc.git
- release repository: https://github.com/ros2-gbp/rclc-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.0.7-1`

## rclc

```
* Remove duplicate typedefs. (#249)
* Add rmw dependencies due to EventsExecutor PR in rcl (#255)
* Fix action client & server deallocation (#257)
* updated documentation: build status for Rolling (#266)
* Update action client goal callback signature (#282)
* Upgrade parameters (#274)
```

## rclc_examples

```
* Fix RCLC int parameter get (cherry-pick) (#272)
* Upgrade parameters (#274)
```

## rclc_lifecycle

```
* Fix rclc lifecyle header (#279) (#281)
```

## rclc_parameter

```
* Parameters fini memory (#253)
* Fix RCLC int parameter get (cherry-pick) (#272)
* rclc_parameter: Fix rcl return values (#270)
* Upgrade parameters (#274)
```
