### PR TITLE
rm_controllers: 0.1.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7442,12 +7442,13 @@ repositories:
       - rm_chassis_controllers
       - rm_controllers
       - rm_gimbal_controllers
+      - rm_orientation_controller
       - rm_shooter_controllers
       - robot_state_controller
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/rm-controls/rm_controllers-release.git
-      version: 0.1.2-1
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/rm-controls/rm_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rm_controllers` to `0.1.3-1`:

- upstream repository: https://github.com/rm-controls/rm_controllers.git
- release repository: https://github.com/rm-controls/rm_controllers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.2-1`

## rm_calibration_controllers

```
* Merge branch 'master' into forward_feed
* Merge branch 'master' into standard3
* Merge remote-tracking branch 'origin/master'
* Contributors: qiayuan, ye-luo-xi-tui, yezi
```

## rm_chassis_controllers

```
* Merge branch 'master' into forward_feed
* Merge pull request #40 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/40> from ye-luo-xi-tui/maintain
  Delete configuration of robot_state_controller in each of controllers' config file
* Merge branch 'master' into maintain
  # Conflicts:
  #     rm_chassis_controllers/config/standard3.yaml
* Merge pull request #41 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/41> from ye-luo-xi-tui/standard3
  Update standard3 config
* Merge branch 'master' into 'standard3'.
* Merge branch 'master' into maintain
  # Conflicts:
  #     rm_chassis_controllers/config/standard3.yaml
  #     rm_chassis_controllers/config/standard4.yaml
* Delete configuration of robot_state_controller in each of controllers' config file
* Merge branch 'master' into standard3
* Add missing parameters and format rm_chassis_controllers
* Update standard3 config
* Merge remote-tracking branch 'origin/master'
* Update standard3 chassis_controller config.
* Contributors: QiayuanLiao, qiayuan, ye-luo-xi-tui, yezi
```

## rm_controllers

```
* Deprecated imu_filter_controller(Since the update frequency of the control loop is not stable, some of
  the camera trigger signals of imu will be lost. We put the imu filter down to the hardware resource layer, so
  imu_extra_handle is breaking. )
* Contributors: qiayuan, ye-luo-xi-tui, yezi
```

## rm_gimbal_controllers

```
* Merge pull request #42 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/42> from ye-luo-xi-tui/fix_gimbal
  Fix bug in gimbal_controller
* Merge pull request #37 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/37> from ye-luo-xi-tui/forward_feed
  Add feedforward in gimbal control
* Merge branch 'master' into forward_feed
* Simplify the codes. Set vel_target under rate mode.
* Fix bug which relative to limit in gimbal_controller.
* Merge pull request #40 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/40> from ye-luo-xi-tui/maintain
  Delete configuration of robot_state_controller in each of controllers' config file
* Merge branch 'master' into 'standard3'.
* Merge branch 'master' into maintain
  # Conflicts:
  #     rm_chassis_controllers/config/standard3.yaml
  #     rm_chassis_controllers/config/standard4.yaml
* Delete configuration of robot_state_controller in each of controllers' config file
* Merge branch 'master' into standard3
* Delete eigen, tf2_eigen instead.
* chore: add missing deps
* Merge remote-tracking branch 'origin/master'
* Change frame id of gimbal while transforming angular_vel form imu to pitch/yaw for engineer or sentry.
* Add feedforward in gimbal control.
* Contributors: QiayuanLiao, StarHeart, qiayuan, ye-luo-xi-tui, yezi
```

## rm_orientation_controller

```
* Merge branch 'master' into forward_feed
* Merge pull request #40 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/40> from ye-luo-xi-tui/maintain
  Delete configuration of robot_state_controller in each of controllers' config file
* Delete configuration of robot_state_controller in each of controllers' config file
* Merge branch 'master' into standard3
* Merge remote-tracking branch 'origin/master'
* Contributors: QiayuanLiao, qiayuan, ye-luo-xi-tui, yezi
```

## rm_shooter_controllers

```
* Merge branch 'master' into forward_feed
* Merge pull request #40 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/40> from ye-luo-xi-tui/maintain
  Delete configuration of robot_state_controller in each of controllers' config file
* Merge branch 'master' into maintain
  # Conflicts:
  #     rm_chassis_controllers/config/standard3.yaml
* Merge pull request #41 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/41> from ye-luo-xi-tui/standard3
  Update standard3 config
* Delete configuration of robot_state_controller in each of controllers' config file
* Merge branch 'master' into standard3
* Update standard3 config
* Merge remote-tracking branch 'origin/master'
* Contributors: QiayuanLiao, qiayuan, ye-luo-xi-tui, yezi
```

## robot_state_controller

```
* Merge branch 'master' into forward_feed
* Merge branch 'master' into standard3
* Merge remote-tracking branch 'origin/master'
* Contributors: qiayuan, ye-luo-xi-tui, yezi
```
