### PR TITLE
um7: 0.0.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10219,7 +10219,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/um7-release.git
-      version: 0.0.6-3
+      version: 0.0.7-1
     source:
       type: git
       url: https://github.com/ros-drivers/um7.git


### PR DESCRIPTION
Increasing version of package(s) in repository `um7` to `0.0.7-1`:

- upstream repository: https://github.com/ros-drivers/um7
- release repository: https://github.com/ros-drivers-gbp/um7-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.6-3`

## um7

```
* Add output in robot frame option (#26 <https://github.com/ros-drivers/um7/issues/26>)
  * Correctly convert quaternion to ROS frame
  * Rename tf_ned_to_enu to tf_ned_to_nwu
  * Cleanup
  * Update to handle two options
  * lint
  * Change indentation
  * Fix formatting issues + add namespace to enum
* Contributors: Bianca Homberg
```
