### PR TITLE
um6: 1.1.3-4 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10210,6 +10210,21 @@ repositories:
       url: https://github.com/anqixu/ueye_cam.git
       version: master
     status: developed
+  um6:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/um6.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/um6-release.git
+      version: 1.1.3-4
+    source:
+      type: git
+      url: https://github.com/ros-drivers/um6.git
+      version: indigo-devel
+    status: maintained
   um7:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `um6` to `1.1.3-4`:

- upstream repository: https://github.com/ros-drivers/um6.git
- release repository: https://github.com/ros-drivers-gbp/um6-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## um6

```
* Disabled using MagneticField message by default.
* Updated to be able to use MagneticField message.
* Updated TravisCI to use Industrial CI for Kinetic and Melodic.
* Contributors: Tony Baltovski
```
