### PR TITLE
openni_camera: 1.11.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5944,6 +5944,27 @@ repositories:
       url: https://github.com/ros-drivers/openni2_camera.git
       version: ros1
     status: maintained
+  openni_camera:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/openni_camera.git
+      version: ros1
+    release:
+      packages:
+      - openni_camera
+      - openni_description
+      - openni_launch
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/openni_camera-release.git
+      version: 1.11.1-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/openni_camera.git
+      version: ros1
+    status: unmaintained
+    status_description: It is still usable for an old device i.e. MS Kinect, but for
+      other openni devices, use openni2 instead.
   openrtm_aist:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_camera` to `1.11.1-1`:

- upstream repository: https://github.com/ros-drivers/openni_camera.git
- release repository: https://github.com/ros-gbp/openni_camera-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## openni_camera

```
* [improve] Python 3 conformity #67 <https://github.com/ros-drivers/openni_camera/issues/67>
* Contributors: Isaac I.Y. Saito, cclauss
```

## openni_description

```
* Remove a test_depend on pkg that are not guaranteed to be available in newer distro. #70 <https://github.com/ros-drivers/openni_camera/issues/70>
* Contributors: Isaac I.Y. Saito
```

## openni_launch

- No changes
