### PR TITLE
noetic: Add catkin_lint_cmake as source

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -676,6 +676,13 @@ repositories:
       url: https://github.com/ros/catkin.git
       version: noetic-devel
     status: maintained
+  catkin_lint_cmake:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/tue-robotics/catkin_lint_cmake.git
+      version: master
+    status: maintained
   catkin_virtualenv:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:
catkin_lint_cmake

## Package Upstream Source:
[github.com/tue-robotics/catkin_lint_cmake](https://github.com/tue-robotics/catkin_lint_cmake)

## Purpose of using this:
CMake macro to run catkin_lint as a catkin_run_test.

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
