### PR TITLE
soccer_interfaces: 0.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4496,6 +4496,25 @@ repositories:
       url: https://github.com/PickNikRobotics/snowbot_operating_system.git
       version: ros2
     status: maintained
+  soccer_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/soccer_interfaces.git
+      version: rolling
+    release:
+      packages:
+      - soccer_vision_2d_msgs
+      - soccer_vision_3d_msgs
+      - soccer_vision_attribute_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/soccer_interfaces-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-sports/soccer_interfaces.git
+      version: rolling
+    status: developed
   soccer_object_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `soccer_interfaces` to `0.0.1-1`:

- upstream repository: https://github.com/ros-sports/soccer_interfaces.git
- release repository: https://github.com/ros2-gbp/soccer_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## soccer_vision_2d_msgs

```
* Initial soccer vision 2d msgs package including Ball.msg, BallArray.msg, FieldBoundary.msg, Goalpost.msg, GoalpostArray.msg, MarkingArray.msg, MarkingEllipse.msg, MarkingIntersection.msg, MarkingSegment.msg, Obstacle.msg, ObstacleArray.msg, Robot.msg, RobotArray.msg
* Contributors: Kenji Brameld
```

## soccer_vision_3d_msgs

```
* Initial soccer vision 3d msgs package including Ball.msg, BallArray.msg, FieldBoundary.msg, Goalpost.msg, GoalpostArray.msg, MarkingArray.msg, MarkingEllipse.msg, MarkingIntersection.msg, MarkingSegment.msg, Obstacle.msg, ObstacleArray.msg, Robot.msg, RobotArray.msg
* Contributors: Kenji Brameld
```

## soccer_vision_attribute_msgs

```
* Initial soccer vision attribute msgs package, including Confidence.msg, Goalpost.msg, Robot.msg
* Contributors: Kenji Brameld
```
