### PR TITLE
nlohmann_json_schema_validator_vendor: 0.1.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2104,7 +2104,7 @@ repositories:
   nlohmann_json_schema_validator_vendor:
     doc:
       type: git
-      url: https://github.com/ros2-gbp/nlohmann_json_schema_validator_vendor-release.git
+      url: https://github.com/open-rmf/nlohmann_json_schema_validator_vendor.git
       version: main
     release:
       tags:
@@ -2113,7 +2113,7 @@ repositories:
       version: 0.1.0-2
     source:
       type: git
-      url: https://github.com/ros2-gbp/nlohmann_json_schema_validator_vendor-release.git
+      url: https://github.com/open-rmf/nlohmann_json_schema_validator_vendor.git
       version: main
     status: developed
   nmea_hardware_interface:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2101,6 +2101,21 @@ repositories:
       url: https://github.com/neobotix/neo_simulation2.git
       version: main
     status: maintained
+  nlohmann_json_schema_validator_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros2-gbp/nlohmann_json_schema_validator_vendor-release.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/nlohmann_json_schema_validator_vendor-release.git
+      version: 0.1.0-2
+    source:
+      type: git
+      url: https://github.com/ros2-gbp/nlohmann_json_schema_validator_vendor-release.git
+      version: main
+    status: developed
   nmea_hardware_interface:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nlohmann_json_schema_validator_vendor` to `0.1.0-2`:

- upstream repository: https://github.com/open-rmf/nlohmann_json_schema_validator_vendor
- release repository: https://github.com/ros2-gbp/nlohmann_json_schema_validator_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
