### PR TITLE
pybind11_json_vendor: 0.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2582,6 +2582,21 @@ repositories:
       url: https://github.com/ros-perception/pointcloud_to_laserscan.git
       version: rolling
     status: maintained
+  pybind11_json_vendor:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/pybind11_json_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/pybind11_json_vendor-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/pybind11_json_vendor.git
+      version: main
+    status: developed
   pybind11_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pybind11_json_vendor` to `0.1.0-1`:

- upstream repository: https://github.com/open-rmf/pybind11_json_vendor
- release repository: https://github.com/ros2-gbp/pybind11_json_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
