### PR TITLE
Adding python3-jinja2 for rhel

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6883,6 +6883,9 @@ python3-jinja2:
   fedora: [python3-jinja2]
   gentoo: [=dev-python/jinja-2*]
   nixos: [python3Packages.jinja2]
+  rhel:
+    '*': [python3-jinja2]
+    '7': [python36-jinja2]
   ubuntu: [python3-jinja2]
 python3-jmespath:
   arch: [python-jmespath]


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>

<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-jinja2

## Package Upstream Source:

https://github.com/pallets/jinja/

## Purpose of using this:

Needed for packaging [rmf_api_msgs](https://github.com/open-rmf/rmf_api_msgs) for rhel.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->
- RHEL 8:
https://centos.pkgs.org/8/centos-appstream-x86_64/python3-jinja2-2.10.1-3.el8.noarch.rpm.html
- RHEL 7:
https://centos.pkgs.org/7/epel-x86_64/python36-jinja2-2.11.1-1.el7.noarch.rpm.html
