### PR TITLE
add rosdep key: pickleDB

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5257,15 +5257,24 @@ python-transitions:
       pip:
         packages: [transitions]
 python3-transitions:
-  debian: 
-    '*': [python3-transitions]
+  debian:
+    sid: [python3-transitions]
+    bookworm: [python3-transitions]
+    bullseye: [python3-transitions]
+    buster:
+      pip:
+        packages: [transitions]
     stretch:
       pip:
         packages: [transitions]
   ubuntu:
     '*': [python3-transitions]
-    xenial: null
-    trusty: null
+    xenial:
+        pip:
+          packages: [transitions]
+    trusty:
+        pip:
+          packages: [transitions]
 python-trep:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5257,23 +5257,6 @@ python-transitions:
     xenial:
       pip:
         packages: [transitions]
-python3-transitions:
-  debian:
-    '*': [python3-transitions]
-    buster:
-      pip:
-        packages: [transitions]
-    stretch:
-      pip:
-        packages: [transitions]
-  ubuntu:
-    '*': [python3-transitions]
-    xenial:
-      pip:
-        packages: [transitions]
-    trusty:
-      pip:
-        packages: [transitions]
 python-trep:
   debian:
     pip:
@@ -5285,6 +5268,23 @@ python-trep:
   ubuntu:
     pip:
       packages: [trep]
+python3-transitions:
+  debian:
+    '*': [python3-transitions]
+    buster:
+      pip:
+        packages: [transitions]
+    stretch:
+      pip:
+        packages: [transitions]
+  ubuntu:
+    '*': [python3-transitions]
+    trusty:
+      pip:
+        packages: [transitions]
+    xenial:
+      pip:
+        packages: [transitions]
 python-triangle-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5268,7 +5268,6 @@ python-trep:
   ubuntu:
     pip:
       packages: [trep]
-
 python-triangle-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5268,11 +5268,11 @@ python3-transitions:
   ubuntu:
     '*': [python3-transitions]
     xenial:
-        pip:
-          packages: [transitions]
+      pip:
+        packages: [transitions]
     trusty:
-        pip:
-          packages: [transitions]
+      pip:
+        packages: [transitions]
 python-trep:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3358,6 +3358,16 @@ python-pexpect:
   debian: [python-pexpect]
   gentoo: [dev-python/pexpect]
   ubuntu: [python-pexpect]
+python-pickleDB:
+  debian:
+    pip:
+      packages: [pickleDB]
+  fedora:
+    pip:
+      packages: [pickleDB]
+  ubuntu:
+    pip:
+      packages: [pickleDB]
 python-pip:
   arch: [python2-pip]
   debian: [python-pip]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3358,16 +3358,6 @@ python-pexpect:
   debian: [python-pexpect]
   gentoo: [dev-python/pexpect]
   ubuntu: [python-pexpect]
-python-pickleDB-pip:
-  debian:
-    pip:
-      packages: [pickleDB]
-  fedora:
-    pip:
-      packages: [pickleDB]
-  ubuntu:
-    pip:
-      packages: [pickleDB]
 python-pip:
   arch: [python2-pip]
   debian: [python-pip]
@@ -7388,6 +7378,16 @@ python3-pexpect:
   debian: [python3-pexpect]
   opensuse: [python3-pexpect]
   ubuntu: [python3-pexpect]
+python3-pickleDB-pip:
+  debian:
+    pip:
+      packages: [pickleDB]
+  fedora:
+    pip:
+      packages: [pickleDB]
+  ubuntu:
+    pip:
+      packages: [pickleDB]
 python3-pika:
   debian: [python3-pika]
   ubuntu: [python3-pika]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5258,9 +5258,7 @@ python-transitions:
         packages: [transitions]
 python3-transitions:
   debian:
-    sid: [python3-transitions]
-    bookworm: [python3-transitions]
-    bullseye: [python3-transitions]
+    '*': [python3-transitions]
     buster:
       pip:
         packages: [transitions]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3358,7 +3358,7 @@ python-pexpect:
   debian: [python-pexpect]
   gentoo: [dev-python/pexpect]
   ubuntu: [python-pexpect]
-python-pickleDB:
+python-pickleDB-pip:
   debian:
     pip:
       packages: [pickleDB]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5257,6 +5257,11 @@ python-transitions:
       pip:
         packages: [transitions]
 python3-transitions:
+  debian: 
+    '*': [python3-transitions]
+    stretch:
+      pip:
+        packages: [transitions]
   ubuntu:
     '*': [python3-transitions]
     xenial: null

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5256,6 +5256,11 @@ python-transitions:
     xenial:
       pip:
         packages: [transitions]
+python3-transitions:
+  ubuntu:
+    '*': [python3-transitions]
+    xenial: null
+    trusty: null
 python-trep:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5268,23 +5268,7 @@ python-trep:
   ubuntu:
     pip:
       packages: [trep]
-python3-transitions:
-  debian:
-    '*': [python3-transitions]
-    buster:
-      pip:
-        packages: [transitions]
-    stretch:
-      pip:
-        packages: [transitions]
-  ubuntu:
-    '*': [python3-transitions]
-    trusty:
-      pip:
-        packages: [transitions]
-    xenial:
-      pip:
-        packages: [transitions]
+
 python-triangle-pip:
   debian:
     pip:
@@ -8589,6 +8573,23 @@ python3-tqdm:
   ubuntu:
     '*': [python3-tqdm]
     xenial: null
+python3-transitions:
+  debian:
+    '*': [python3-transitions]
+    buster:
+      pip:
+        packages: [transitions]
+    stretch:
+      pip:
+        packages: [transitions]
+  ubuntu:
+    '*': [python3-transitions]
+    trusty:
+      pip:
+        packages: [transitions]
+    xenial:
+      pip:
+        packages: [transitions]
 python3-triangle-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python-pickleDB

## Package Upstream Source:

https://pypi.org/project/pickleDB/

## Purpose of using this:

I use pickleDB to do lightweight data persistence

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  -  not found https://search.debian.org/cgi-bin/omega?DB=zh-cn&P=pickleDB
- Ubuntu: https://packages.ubuntu.com/
   - not found https://packages.ubuntu.com/search?suite=impish&section=all&arch=any&keywords=pickleDB&searchon=names




