### PR TITLE
image_transport_plugins: 2.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1369,7 +1369,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 2.4.0-1
+      version: 2.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `2.5.0-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.4.0-1`

## compressed_depth_image_transport

- No changes

## compressed_image_transport

- No changes

## image_transport_plugins

- No changes

## theora_image_transport

```
* Cleanup the cmake code to be more modern (#96 <https://github.com/ros-perception/image_transport_plugins/issues/96>)
* Contributors: Chris Lalancette
```
