### PR TITLE
Error early on migrating repositories with no current release.

### DIFF
--- a/migration-tools/migrate-rosdistro.py
+++ b/migration-tools/migrate-rosdistro.py
@@ -127,6 +127,8 @@ for repo_name in sorted(new_repositories + repositories_to_retry):
         print('Adding repo:', repo_name)
         if release_spec.type != 'git':
             raise ValueError('This script can only handle git repositories.')
+        if release_spec.version is None:
+            raise ValueError(f'{repo_name} is not released in the source distribution (release version is missing or blank).')
         remote_url = release_spec.url
         release_repo = remote_url.split('/')[-1]
         if release_repo.endswith('.git'):


### PR DESCRIPTION
This uses a "bail out" condition to loudly error on a repository with no
release version (Such as from a previous migration).
I could see a case being made to silently skip these repositories rather
than raising an error but I think that since the script is rarely run
and the list of repositories with errors is one of the major
communication outputs I wanted to start with an error condition (which
still allows the rest of the migration to proceed).

Adding this check will also prevent bugs when trying to release packages
with an empty version since some later operations require a version
string.