### PR TITLE
imu_tools: 2.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1666,6 +1666,27 @@ repositories:
       url: https://github.com/ros-perception/image_transport_plugins.git
       version: foxy-devel
     status: maintained
+  imu_tools:
+    doc:
+      type: git
+      url: https://github.com/ccny-ros-pkg/imu_tools.git
+      version: foxy
+    release:
+      packages:
+      - imu_complementary_filter
+      - imu_filter_madgwick
+      - imu_tools
+      - rviz_imu_plugin
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/imu_tools-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ccny-ros-pkg/imu_tools.git
+      version: foxy
+    status: maintained
   interactive_marker_twist_server:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `2.0.0-1`:

- upstream repository: https://github.com/ccny-ros-pkg/imu_tools.git
- release repository: https://github.com/ros2-gbp/imu_tools-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## imu_complementary_filter

```
* Initial release into ROS2 foxy, galactic and rolling
* Fix gcc warnings + clang-tidy suggestions
* Fix CMakeLists
* Reformat python code using black
* Manually reformat licenses + defines
* Reformat everything using clang-format
* Fix trailing whitespace
* Add launch directory to CMakeLists.txt (#146 <https://github.com/CCNYRoboticsLab/imu_tools/issues/146>)
* Port imu_complementary_filter to ROS2 (#138 <https://github.com/CCNYRoboticsLab/imu_tools/issues/138>)
* Madgwick for eloquent (#110 <https://github.com/CCNYRoboticsLab/imu_tools/issues/110>)
* Contributors: Guido Sanchez, Martin Günther, Maximilian Schik, tgreier
```

## imu_filter_madgwick

```
* Initial release into ROS2 foxy, galactic and rolling
* Fix gcc warnings + clang-tidy suggestions
* Fix CMakeLists
* Reformat python code using black
* Manually reformat licenses + defines
* Reformat everything using clang-format
* Add license files
  The "COPYING" file incorrectly had the text of the LGPL, but the
  original Madgwick filter [1], [2] is GPL licensed. The source code
  headers correctly have the GPLv3 license text.
  [1]: https://x-io.co.uk/open-source-imu-and-ahrs-algorithms/
  [2]: https://github.com/xioTechnologies/Fusion
* Change to allow the usage of imu_filter_madgwick as a library (#129 <https://github.com/CCNYRoboticsLab/imu_tools/issues/129>)
* imu_filter_madgwick: Install headers
* Remove double configuration steps. (#122 <https://github.com/CCNYRoboticsLab/imu_tools/issues/122>)
  Fixes #118 <https://github.com/CCNYRoboticsLab/imu_tools/issues/118>.
* Add declination and yaw offset. (#121 <https://github.com/CCNYRoboticsLab/imu_tools/issues/121>)
  Fixes #120 <https://github.com/CCNYRoboticsLab/imu_tools/issues/120>.
* Madgwick for eloquent (#110 <https://github.com/CCNYRoboticsLab/imu_tools/issues/110>)
* Update maintainers in package.xml
* Fix warnings: reordering and unused vars
* Contributors: Martin Günther, boiscljo, tgreier
```

## imu_tools

```
* Initial release into ROS2 foxy, galactic and rolling
* Contributors: Martin Günther, tgreier
```

## rviz_imu_plugin

```
* Initial release into ROS2 foxy, galactic and rolling
* Fix gcc warnings + clang-tidy suggestions
* Fix CMakeLists
* Reformat everything using clang-format
* rviz_imu_plugin: Fix include paths
* rviz_imu_plugin: Use C++14
* Fix package.xml dependencies
* Port rviz plugin to ROS2, add new plugin (#125 <https://github.com/CCNYRoboticsLab/imu_tools/issues/125>)
* Add MagneticField plugin
* Update imu rviz plugin to ROS2
* Update maintainers in package.xml
* Contributors: Martin Günther, tgreier
```
