### PR TITLE
flir_camera_driver: 0.2.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2466,7 +2466,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git
-      version: 0.2.2-1
+      version: 0.2.3-1
     source:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_camera_driver` to `0.2.3-1`:

- upstream repository: https://github.com/ros-drivers/flir_camera_driver.git
- release repository: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.2-1`

## flir_camera_description

```
* 0.2.2
* Changes.
* 0.2.1
* Changes.
* 0.2.0
* Changes.
* Bump CMake version to avoid CMP0048 warning.
* Bumped flir_camera_description verison.
* Changes.
* Removed launch and rviz folders from CMakeLists
* URDF Description, Diagnostics, ISP Enable, and Launch Files (#81 <https://github.com/ros-drivers/flir_camera_driver/issues/81>)
  * Changes required to use GigE Blackfly S version
  * Added blackfly mesh
  * Added URDF of blackflys and CHANGELOG
  * Added new_line at end of flir_blackflys.urdf.xacro
  * Added DiagnosticAnalyzers and more detailed diagnostic messages
  * Added ISP enable and disable config and updated camera launch file to be more descriptive
  * Switched order of configuration to put ISP enable next to color encoding
  * Updated config to include enumeration for Off, Once, Continuous parameters, and udpated diagnostics.launch
  * Handled issue where no namespace prevents diagnostics_agg from loading from analyzer paramaters
* Contributors: Tony Baltovski, luis-camero
```

## flir_camera_driver

```
* 0.2.2
* Changes.
* 0.2.1
* Changes.
* 0.2.0
* Changes.
* Bump CMake version to avoid CMP0048 warning.
* Changes.
* Include flir_camera_description as dependency in metapackage
* Contributors: Joey Yang, Tony Baltovski
```

## spinnaker_camera_driver

```
* Only install necessary libraries
* 0.2.2
* Changes.
* Added new-line at EOF
* Spinnaker libraries are now all copied to usr/lib
* Reordered definitions to prevent compiler warnings
* 0.2.1
* Changes.
* Removed check for build/usr/lib which would cause build to skip Spinnaker SDK install
* 0.2.0
* Changes.
* Changes.
* Fixed all issues reported by roslint
* Updated file paths to /opt/spinnaker instead of /usr/spinnaker
* Updated download_spinnaker look-up table
* Add readable check to SDK parameters
* URDF Description, Diagnostics, ISP Enable, and Launch Files (#81 <https://github.com/ros-drivers/flir_camera_driver/issues/81>)
  * Changes required to use GigE Blackfly S version
  * Added blackfly mesh
  * Added URDF of blackflys and CHANGELOG
  * Added new_line at end of flir_blackflys.urdf.xacro
  * Added DiagnosticAnalyzers and more detailed diagnostic messages
  * Added ISP enable and disable config and updated camera launch file to be more descriptive
  * Switched order of configuration to put ISP enable next to color encoding
  * Updated config to include enumeration for Off, Once, Continuous parameters, and udpated diagnostics.launch
  * Handled issue where no namespace prevents diagnostics_agg from loading from analyzer paramaters
* Branch to Support GigE Cameras (#79 <https://github.com/ros-drivers/flir_camera_driver/issues/79>)
  * Changes required to use GigE Blackfly S version
  * Update SpinnakerCamera.cpp
* Add new parameter to apply an offset to image time stamps (#56 <https://github.com/ros-drivers/flir_camera_driver/issues/56>)
* Fixes SpinnakerCamera teardown (#16 <https://github.com/ros-drivers/flir_camera_driver/issues/16>)
  * fixes error on destroying SpinnakerCamera with multiple cameras
  * adds clarifying comment
* Add /opt/spinnaker to spinnaker discovery options (#63 <https://github.com/ros-drivers/flir_camera_driver/issues/63>)
* increase maximum value of exposure_time/auto_exposure_time_upper_limit (#55 <https://github.com/ros-drivers/flir_camera_driver/issues/55>)
* add option to set queue_size for ros publisher (#54 <https://github.com/ros-drivers/flir_camera_driver/issues/54>)
* Added support for Grasshopper3. Identical to Chameleon3, split into separate files for clarity. (#26 <https://github.com/ros-drivers/flir_camera_driver/issues/26>)
* Feature: horizontal and vertical image reverse (#41 <https://github.com/ros-drivers/flir_camera_driver/issues/41>)
  * Add horizontal/vertical inverse to reconfigure cfg
  * Add ReverseX/ReverseY with setProperty
  Co-authored-by: Fabian Schilling <mailto:fabian.schilling@me.com>
* Update Spinnaker.cfg (#50 <https://github.com/ros-drivers/flir_camera_driver/issues/50>)
  Fix for correct spelling with capital letter for bool type
* Add auto exposure ROI parameters (#52 <https://github.com/ros-drivers/flir_camera_driver/issues/52>)
  * spinnaker_camera_driver: setProperty: report available enum values
  Only done on failure. This helps to figure out which enum values are
  available on a particular camera model.
  * spinnaker_camera_driver: expose AE ROI parameters
  This is highly useful when using fisheye lenses, which illuminate only
  a circle in the center of the image. The AE gets confused by the black
  regions around it and overexposes the image.
  This also exposes the "AutoExposureLightingMode" parameter, which allows
  the user to choose a lighting preset (front/back/normal).
* Fix/frame rate params (#20 <https://github.com/ros-drivers/flir_camera_driver/issues/20>)
  * [spinnaker_camera_driver] Fixed naming of frame rate control params
  * [spinnaker_camera_driver] Format of mono and stereo launchfiles
  * [spinnaker_camera_driver] Updated diagnostics launchfile
* Removed opencv as depend. (#46 <https://github.com/ros-drivers/flir_camera_driver/issues/46>)
* Changed the download script to check for destination folder and moved unpack directory. (#44 <https://github.com/ros-drivers/flir_camera_driver/issues/44>)
* Create the directory if it doesn't exist
* Remove an unnecessary deb
* Spinnaker driver now successfully downloads & builds
* Start overhauling the spinnaker download script so it works with the correct endpoint & matches the general structure of the pointgrey_camera_driver
* Contributors: Adam Romlein, Chris I-B, Evan Bretl, Fabian Schilling, Ferdinand, Joseph Curtis, Luis Camero, Max Schwarz, Stephan, Tony Baltovski, Yoshua Nava, Yuki Furuta, luis-camero
```
