### PR TITLE
static_transform_mux: 1.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9713,6 +9713,21 @@ repositories:
       url: https://github.com/ros-simulation/stage_ros.git
       version: lunar-devel
     status: unmaintained
+  static_transform_mux:
+    doc:
+      type: git
+      url: https://github.com/tradr-project/static_transform_mux.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/peci1/static_transform_mux-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/tradr-project/static_transform_mux.git
+      version: master
+    status: maintained
   std_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `static_transform_mux` to `1.1.0-1`:

- upstream repository: https://github.com/tradr-project/static_transform_mux.git
- release repository: https://github.com/peci1/static_transform_mux-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## static_transform_mux

```
* Changed the cache key to allow restructuring the TF tree.
* Contributors: Martin Pecka
```
