### PR TITLE
[migration-tools] Set stdin to /dev/null for git-bloom-release.

### DIFF
--- a/migration-tools/migrate-rosdistro.py
+++ b/migration-tools/migrate-rosdistro.py
@@ -213,7 +213,7 @@ for repo_name in sorted(new_repositories + repositories_to_retry):
 
         # Bloom will not run with multiple remotes.
         subprocess.check_call(['git', 'remote', 'remove', 'oldorigin'])
-        subprocess.check_call(['git', 'bloom-release', '--non-interactive', '--release-increment', release_inc, '--unsafe', args.dest], env=os.environ)
+        subprocess.check_call(['git', 'bloom-release', '--non-interactive', '--release-increment', release_inc, '--unsafe', args.dest], stdin=subprocess.DEVNULL, env=os.environ)
         subprocess.check_call(['git', 'push', 'origin', '--all', '--force'])
         subprocess.check_call(['git', 'push', 'origin', '--tags', '--force'])
         subprocess.check_call(['git', 'checkout', 'master'])


### PR DESCRIPTION
Bloom's non-interactive flags don't penetrate into the deeper subcommands run by bloom internally. Work is being done to adapt bloom so that it better handles these non-interactive contexts but rely on stdin not being an interactive terminal. By default these subprocesses are inheriting stdin from the parent script but for git bloom-release in particular we want stdin to be null.