### PR TITLE
grepros: 0.4.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1522,7 +1522,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/suurjaak/grepros-release.git
-      version: 0.4.4-1
+      version: 0.4.5-1
     source:
       type: git
       url: https://github.com/suurjaak/grepros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grepros` to `0.4.5-1`:

- upstream repository: https://github.com/suurjaak/grepros.git
- release repository: https://github.com/suurjaak/grepros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.4-1`

## grepros

```
* fix forcing all numeric array fields to integer lists regardless of type
* fix error on subscribing to defunct topic
```
