### PR TITLE
[migration-tools] Don't assume that every release repository has a tracks.yaml.

### DIFF
--- a/migration-tools/migrate-rosdistro.py
+++ b/migration-tools/migrate-rosdistro.py
@@ -21,7 +21,11 @@ from rosdistro.writer import yaml_from_distribution_file
 # make assumptions about the release repository that are not true during the
 # manipulation of the release repository for this script.
 def read_tracks_file():
-    return yaml.safe_load(show('master', 'tracks.yaml'))
+    tracks_yaml = show('master', 'tracks.yaml')
+    if tracks_yaml:
+        return yaml.safe_load(tracks_yaml)
+    else:
+        raise ValueError('repository is missing tracks.yaml in master branch.')
 
 @inbranch('master')
 def write_tracks_file(tracks, commit_msg=None):


### PR DESCRIPTION
A malformed release repository could be missing its tracks.yaml
configuration file. When this happens it should raise a ValueError as
with any other failure during the release process so that the migration
can continue.
