### PR TITLE
tango_icons_vendor: 0.1.1-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4675,7 +4675,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tango_icons_vendor-release.git
-      version: 0.1.1-1
+      version: 0.1.1-2
     source:
       type: git
       url: https://github.com/ros-visualization/tango_icons_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tango_icons_vendor` to `0.1.1-2`:

- upstream repository: https://github.com/ros-visualization/tango_icons_vendor.git
- release repository: https://github.com/ros2-gbp/tango_icons_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.1-1`

## tango_icons_vendor

```
* Update maintainers to Audrow Nash (#9 <https://github.com/ros-visualization/tango_icons_vendor/issues/9>)
* Contributors: Audrow Nash
```
