### PR TITLE
Update release repository urls in Rolling.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2176,7 +2176,7 @@ repositories:
       - novatel_gps_msgs
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
+      url: https://github.com/ros2-gbp/novatel_gps_driver-release.git
       version: 4.1.0-2
     source:
       type: git
@@ -4390,7 +4390,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/introlab/rtabmap-release.git
+      url: https://github.com/ros2-gbp/rtabmap-release.git
       version: 0.20.18-1
     source:
       type: git
@@ -5058,7 +5058,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
+      url: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
       version: 1.0.0-2
     source:
       type: git


### PR DESCRIPTION
These repositories have previously been migrated and have up-to-date release repositories in the ros2-gbp organization.

We should switch to using these repositories before the Humble migration in order to avoid overwriting release artifacts from those repositories.
