### PR TITLE
[migration-tools] Bump the minimum versions of bloom and rosdep to the latest.

### DIFF
--- a/migration-tools/requirements.txt
+++ b/migration-tools/requirements.txt
@@ -1,5 +1,5 @@
-bloom>=0.9.4
+bloom>=0.11.0
 pygithub>=1.45
 rosdistro>=0.8.0
-rosdep>=0.18.0
+rosdep>=0.21.0
 pyyaml>=5.3


### PR DESCRIPTION
We want to use bloom 0.11.0 for the Humble migration.

The rosdep release isn't strictly necessary but is coming along for the ride.