### PR TITLE
rmf_traffic_editor: 1.5.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3226,7 +3226,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
-      version: 1.5.0-1
+      version: 1.5.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic_editor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_traffic_editor` to `1.5.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_traffic_editor.git
- release repository: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.5.0-1`

## rmf_building_map_tools

```
* Floor information for floor toggling plugin in Ignition (#424)
* Use the Ignition Gazebo floor visibility plugin when generating worlds.
* navgraph visualizer (#426)
  * new verb for building_map_generator that will generate navgraph visualization OBJ files, which can then be dropped into a Gazebo simulation to help understand what's going on.
* update versions of pure python packages
* Contributors: Luca Della Vedova, Morgan Quigley
```

## rmf_traffic_editor

```
* update OSM tile server URL to full planet data (#430)
* fix cmake ament_index_cpp dependency
* add a github CI job for rolling
* don't double-trigger CI runs
* update qt packages for jammy github workflow
* build/install rmf_utils from source in ci_rolling
* Contributors: Morgan Quigley, Youliang Tan
```

## rmf_traffic_editor_assets

- No changes

## rmf_traffic_editor_test_maps

- No changes
