### PR TITLE
ros_babel_fish: 0.9.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10767,7 +10767,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/StefanFabian/ros_babel_fish-release.git
-      version: 0.9.2-1
+      version: 0.9.3-1
     source:
       type: git
       url: https://github.com/StefanFabian/ros_babel_fish.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_babel_fish` to `0.9.3-1`:

- upstream repository: https://github.com/StefanFabian/ros_babel_fish.git
- release repository: https://github.com/StefanFabian/ros_babel_fish-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.0`
- previous version for package: `0.9.2-1`

## ros_babel_fish

```
* Added some more information to exception messages.
* Add libssl-dev as a build-export dependency
* Contributors: AR Dabbour, Stefan Fabian
```

## ros_babel_fish_test_msgs

- No changes
