### PR TITLE
ros_workspace: 1.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3716,6 +3716,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_workspace-release.git
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ros2/ros_workspace.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_workspace` to `1.0.2-1`:

- upstream repository: https://github.com/ros2/ros_workspace.git
- release repository: https://github.com/ros2-gbp/ros_workspace-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.0`
- previous version for package: `null`

## ros_workspace

```
* Use GNUInstallDirs to determine multiarch library dir (#20 <https://github.com/ros2/ros_workspace/issues/20>)
* Contributors: Scott K Logan
```
