### PR TITLE
rmw_connextdds: 0.11.0-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3302,6 +3302,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
+      version: 0.11.0-2
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `0.11.0-2`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.0`
- previous version for package: `null`

## rmw_connextdds

```
* Exclude missing sample info fields when building rmw_connextddsmicro (#79 <https://github.com/ros2/rmw_connextdds/issues/79>)
* Update launch_testing_ros output filter prefixes for Connext6 (#80 <https://github.com/ros2/rmw_connextdds/issues/80>)
* Contributors: Andrea Sorbini, Ivan Santiago Paunovic
```

## rmw_connextdds_common

```
* Exclude missing sample info fields when building rmw_connextddsmicro (#79 <https://github.com/ros2/rmw_connextdds/issues/79>)
* Properly initialize CDR stream before using it for filtering (#81 <https://github.com/ros2/rmw_connextdds/issues/81>)
* Contributors: Andrea Sorbini
```

## rti_connext_dds_cmake_module

- No changes
