### PR TITLE
ignition_math6_vendor: 0.0.2-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1296,6 +1296,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ignition_math6_vendor-release.git
+      version: 0.0.2-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ignition_math6_vendor` to `0.0.2-2`:

- upstream repository: https://github.com/ignition-release/ignition_math6_vendor.git
- release repository: https://github.com/ros2-gbp/ignition_math6_vendor-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.0`
- previous version for package: `null`

## ignition_math6_vendor

```
* Update to 6.9.2 ign-math6. (#1 <https://github.com/ignition-release/ignition_math6_vendor/issues/1>)
* Contributors: Chris Lalancette
```
