### PR TITLE
locator_ros_bridge: 2.1.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1672,6 +1672,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/locator_ros_bridge-release.git
+      version: 2.1.5-1
     source:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `locator_ros_bridge` to `2.1.5-1`:

- upstream repository: https://github.com/boschglobal/locator_ros_bridge.git
- release repository: https://github.com/ros2-gbp/locator_ros_bridge-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.0`
- previous version for package: `null`

## bosch_locator_bridge

```
* update to ROKIT Locator version 1.4
* add interface for second laser
* Contributors: Stefan Laible
```
