### PR TITLE
rosbag2_storage_mcap: 0.1.4-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3985,10 +3985,13 @@ repositories:
       url: https://github.com/ros-tooling/rosbag2_storage_mcap.git
       version: main
     release:
+      packages:
+      - mcap_vendor
+      - rosbag2_storage_mcap
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2_storage_mcap-release.git
-      version: 0.1.1-1
+      version: 0.1.4-1
     source:
       type: git
       url: https://github.com/ros-tooling/rosbag2_storage_mcap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2_storage_mcap` to `0.1.4-1`:

- upstream repository: https://github.com/ros-tooling/rosbag2_storage_mcap.git
- release repository: https://github.com/ros2-gbp/rosbag2_storage_mcap-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.1-1`

## mcap_vendor

```
* fix: minor issues (#31 <https://github.com/wep21/rosbag2_storage_mcap/issues/31>)
  * remove unnecessary block
  * use target_link_libraries instead of ament_target_dependencies
  * remove ros environment
  * add prefix to compile definition
* Update email address for Foxglove maintainers (#32 <https://github.com/wep21/rosbag2_storage_mcap/issues/32>)
* Contributors: Daisuke Nishimatsu, Jacob Bandes-Storch
```

## rosbag2_storage_mcap

```
* fix: minor issues (#31 <https://github.com/wep21/rosbag2_storage_mcap/issues/31>)
  * remove unnecessary block
  * use target_link_libraries instead of ament_target_dependencies
  * remove ros environment
  * add prefix to compile definition
* Update email address for Foxglove maintainers (#32 <https://github.com/wep21/rosbag2_storage_mcap/issues/32>)
* Contributors: Daisuke Nishimatsu, Jacob Bandes-Storch
```
