### PR TITLE
ompl: 1.5.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2307,6 +2307,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
+      version: 1.5.2-1
   orocos_kdl_vendor:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl` to `1.5.2-1`:

- upstream repository: https://github.com/ompl/ompl.git
- release repository: https://github.com/ros2-gbp/ompl-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.0`
- previous version for package: `null`
