### PR TITLE
rosbag2: 0.15.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3758,6 +3758,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
+      version: 0.15.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.15.1-2`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.0`
- previous version for package: `null`

## ros2bag

```
* support to publish as loaned message (#981 <https://github.com/ros2/rosbag2/issues/981>)
* Revert "Add the ability to record any key/value pair in the 'custom' field in metadata.yaml (#976 <https://github.com/ros2/rosbag2/issues/976>)" (#984 <https://github.com/ros2/rosbag2/issues/984>)
* Add the ability to record any key/value pair in the 'custom' field in metadata.yaml (#976 <https://github.com/ros2/rosbag2/issues/976>)
* Contributors: Audrow Nash, Barry Xu, Jorge Perez, Tony Peng
```

## rosbag2

- No changes

## rosbag2_compression

- No changes

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Revert "Add the ability to record any key/value pair in the 'custom' field in metadata.yaml (#976 <https://github.com/ros2/rosbag2/issues/976>)" (#984 <https://github.com/ros2/rosbag2/issues/984>)
* Add the ability to record any key/value pair in the 'custom' field in metadata.yaml (#976 <https://github.com/ros2/rosbag2/issues/976>)
* Contributors: Audrow Nash, Jorge Perez, Tony Peng
```

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_py

```
* support to publish as loaned message (#981 <https://github.com/ros2/rosbag2/issues/981>)
* Revert "Add the ability to record any key/value pair in the 'custom' field in metadata.yaml (#976 <https://github.com/ros2/rosbag2/issues/976>)" (#984 <https://github.com/ros2/rosbag2/issues/984>)
* Add the ability to record any key/value pair in the 'custom' field in metadata.yaml (#976 <https://github.com/ros2/rosbag2/issues/976>)
* Contributors: Audrow Nash, Barry Xu, Jorge Perez, Tony Peng
```

## rosbag2_storage

```
* Revert "Add the ability to record any key/value pair in the 'custom' field in metadata.yaml (#976 <https://github.com/ros2/rosbag2/issues/976>)" (#984 <https://github.com/ros2/rosbag2/issues/984>)
* Add the ability to record any key/value pair in the 'custom' field in metadata.yaml (#976 <https://github.com/ros2/rosbag2/issues/976>)
* Contributors: Audrow Nash, Jorge Perez, Tony Peng
```

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

```
* Revert "Add the ability to record any key/value pair in the 'custom' field in metadata.yaml (#976 <https://github.com/ros2/rosbag2/issues/976>)" (#984 <https://github.com/ros2/rosbag2/issues/984>)
* Add the ability to record any key/value pair in the 'custom' field in metadata.yaml (#976 <https://github.com/ros2/rosbag2/issues/976>)
* Contributors: Audrow Nash, Jorge Perez, Tony Peng
```

## rosbag2_transport

```
* support to publish as loaned message (#981 <https://github.com/ros2/rosbag2/issues/981>)
* Contributors: Audrow Nash, Barry Xu
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
