### PR TITLE
control_msgs: 3.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -616,6 +616,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/control_msgs-release.git
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `3.0.0-1`:

- upstream repository: https://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros2-gbp/control_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.0`
- previous version for package: `null`

## control_msgs

```
* Extend FollowJointTrajectoryAction with multi_dof_trajectory variable
  https://github.com/ros-controls/control_msgs/pull/55
* Refractor dependency list for better overview.
* Contributors: Bence Magyar, David V. Lu, Denis Štogl, JafarAbdi
```
