### PR TITLE
Ignition Fortress rosdep keys for Jammy

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1815,6 +1815,7 @@ ignition-common4:
     buster: [libignition-common4-dev]
   ubuntu:
     focal: [libignition-common4-dev]
+    jammy: [libignition-common4-dev]
 ignition-edifice:
   debian:
     buster: [ignition-edifice]
@@ -1825,6 +1826,7 @@ ignition-fortress:
     buster: [ignition-fortress]
   ubuntu:
     focal: [ignition-fortress]
+    jammy: [ignition-fortress]
 ignition-fuel-tools4:
   debian:
     buster: [libignition-fuel-tools4-dev]
@@ -1841,6 +1843,7 @@ ignition-fuel-tools7:
     buster: [libignition-fuel-tools7-dev]
   ubuntu:
     focal: [libignition-fuel-tools7-dev]
+    jammy: [libignition-fuel-tools7-dev]
 ignition-gazebo3:
   debian:
     buster: [libignition-gazebo3-dev]
@@ -1861,11 +1864,13 @@ ignition-gazebo6:
     buster: [libignition-gazebo6-dev]
   ubuntu:
     focal: [libignition-gazebo6-dev]
+    jammy: [libignition-gazebo6-dev]
 ignition-gazebo6-plugins:
   debian:
     buster: [libignition-gazebo6-plugins]
   ubuntu:
     focal: [libignition-gazebo6-plugins]
+    jammy: [libignition-gazebo6-plugins]
 ignition-gui3:
   debian:
     buster: [libignition-gui3-dev]
@@ -1881,6 +1886,7 @@ ignition-gui6:
     buster: [libignition-gui6-dev]
   ubuntu:
     focal: [libignition-gui6-dev]
+    jammy: [libignition-gui6-dev]
 ignition-launch2:
   debian:
     buster: [libignition-launch2-dev]
@@ -1896,6 +1902,7 @@ ignition-launch5:
     buster: [libignition-launch5-dev]
   ubuntu:
     focal: [libignition-launch5-dev]
+    jammy: [libignition-launch5-dev]
 ignition-math6:
   debian:
     buster: [libignition-math6-dev]
@@ -1926,6 +1933,7 @@ ignition-msgs8:
     buster: [libignition-msgs8-dev]
   ubuntu:
     focal: [libignition-msgs8-dev]
+    jammy: [libignition-msgs8-dev]
 ignition-physics2:
   debian:
     buster: [libignition-physics2-dev]
@@ -1941,11 +1949,13 @@ ignition-physics5:
     buster: [libignition-physics5-dev]
   ubuntu:
     focal: [libignition-physics5-dev]
+    jammy: [libignition-physics5-dev]
 ignition-plugin:
   debian:
     buster: [libignition-plugin-dev]
   ubuntu:
     focal: [libignition-plugin-dev]
+    jammy: [libignition-plugin-dev]
 ignition-rendering3:
   debian:
     buster: [libignition-rendering3-dev]
@@ -1961,6 +1971,7 @@ ignition-rendering6:
     buster: [libignition-rendering6-dev]
   ubuntu:
     focal: [libignition-rendering6-dev]
+    jammy: [libignition-rendering6-dev]
 ignition-sensors3:
   debian:
     buster: [libignition-sensors3-dev]
@@ -1976,12 +1987,14 @@ ignition-sensors6:
     buster: [libignition-sensors6-dev]
   ubuntu:
     focal: [libignition-sensors6-dev]
+    jammy: [libignition-sensors6-dev]
 ignition-tools:
   debian:
     buster: [libignition-tools-dev]
   nixos: [ignition.tools]
   ubuntu:
     focal: [libignition-tools-dev]
+    jammy: [libignition-tools-dev]
 ignition-transport10:
   debian:
     buster: [libignition-transport10-dev]
@@ -1992,6 +2005,7 @@ ignition-transport11:
     buster: [libignition-transport11-dev]
   ubuntu:
     focal: [libignition-transport11-dev]
+    jammy: [libignition-transport11-dev]
 ignition-transport8:
   debian:
     buster: [libignition-transport8-dev]
@@ -2003,11 +2017,13 @@ ignition-utils1:
     buster: [libignition-utils1-dev]
   ubuntu:
     focal: [libignition-utils1-dev]
+    jammy: [libignition-utils1-dev]
 ignition-utils1-cli:
   debian:
     buster: [libignition-utils1-cli-dev]
   ubuntu:
     focal: [libignition-utils1-cli-dev]
+    jammy: [libignition-utils1-cli-dev]
 imagemagick:
   arch: [imagemagick]
   debian: [imagemagick]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6780,14 +6780,14 @@ python3-ifcfg:
   ubuntu:
     bionic: [python3-ifcfg]
     focal: [python3-ifcfg]
-python3-ignition-math6:
-  ubuntu:
-    focal: [python3-ignition-math6]
-    jammy: [python3-ignition-math6]
 python3-ignition-gazebo6:
   ubuntu:
     focal: [python3-ignition-gazebo6]
     jammy: [python3-ignition-gazebo6]
+python3-ignition-math6:
+  ubuntu:
+    focal: [python3-ignition-math6]
+    jammy: [python3-ignition-math6]
 python3-imageio:
   debian: [python3-imageio]
   gentoo: [dev-python/imageio]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6780,6 +6780,10 @@ python3-ifcfg:
   ubuntu:
     bionic: [python3-ifcfg]
     focal: [python3-ifcfg]
+python3-ignition-math6:
+  ubuntu:
+    focal: [python3-ignition-math6]
+    jammy: [python3-ignition-math6]
 python3-imageio:
   debian: [python3-imageio]
   gentoo: [dev-python/imageio]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6784,6 +6784,10 @@ python3-ignition-math6:
   ubuntu:
     focal: [python3-ignition-math6]
     jammy: [python3-ignition-math6]
+python3-ignition-gazebo6:
+  ubuntu:
+    focal: [python3-ignition-gazebo6]
+    jammy: [python3-ignition-gazebo6]
 python3-imageio:
   debian: [python3-imageio]
   gentoo: [dev-python/imageio]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

* Part of https://github.com/ignition-tooling/release-tools/issues/459
* Depends on https://github.com/ros-infrastructure/reprepro-updater/pull/153
* Follow up to https://github.com/ros/rosdistro/pull/31591

## Package name:

[Ignition Fortress libraries](https://ignitionrobotics.org/docs/fortress)

## Package Upstream Source:

All libraries are on this org: https://github.com/ignitionrobotics/

## Purpose of using this:

As defined on [REP-2000](https://www.ros.org/reps/rep-2000.html#humble-hawksbill-may-2022-may-2027), Ignition Fortress will be the official Ignition version to be used with ROS Humble. This adds keys for Ubuntu Jammy.

Once the rosdep keys are available, we'll make a release of [ros_ign](https://github.com/ignitionrobotics/ros_ign/) into Rolling using Fortress. ROS packages can interface with Ignition Gazebo through `ros_ign`, and they can also use Ignition libraries directly.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/
  - http://packages.osrfoundation.org/gazebo/debian-stable/
- Ubuntu: https://packages.ubuntu.com/
   - http://packages.osrfoundation.org/gazebo/ubuntu-stable/
- macOS: https://formulae.brew.sh/
  - https://github.com/osrf/homebrew-simulation/
