### PR TITLE
foxglove_msgs: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -971,6 +971,21 @@ repositories:
       url: https://github.com/ros-drivers/four_wheel_steering_msgs.git
       version: ros2
     status: maintained
+  foxglove_msgs:
+    doc:
+      type: git
+      url: https://github.com/foxglove/ros_foxglove_msgs.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_foxglove_msgs-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/foxglove/ros_foxglove_msgs.git
+      version: main
+    status: maintained
   gazebo_ros2_control:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_msgs` to `1.1.0-1`:

- upstream repository: https://github.com/foxglove/ros_foxglove_msgs.git
- release repository: https://github.com/ros2-gbp/ros_foxglove_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## foxglove_msgs

```
* Provide foxglove_msgs for ROS1 and ROS2
* Contributors: Daisuke Nishimatsu, John Hurliman, wep21
```
