### PR TITLE
ros2_controllers: 2.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3496,7 +3496,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.2.0-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.3.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.2.0-1`

## diff_drive_controller

```
* Use CallbackReturn from controller_interface namespace (#333 <https://github.com/ros-controls/ros2_controllers/issues/333>)
* Contributors: Bence Magyar, Denis Štogl
```

## effort_controllers

```
* Use CallbackReturn from controller_interface namespace (#333 <https://github.com/ros-controls/ros2_controllers/issues/333>)
* Contributors: Bence Magyar, Denis Štogl
```

## force_torque_sensor_broadcaster

```
* Use CallbackReturn from controller_interface namespace (#333 <https://github.com/ros-controls/ros2_controllers/issues/333>)
* Contributors: Bence Magyar, Denis Štogl
```

## forward_command_controller

```
* Use CallbackReturn from controller_interface namespace (#333 <https://github.com/ros-controls/ros2_controllers/issues/333>)
* Contributors: Bence Magyar, Denis Štogl
```

## gripper_controllers

```
* Use CallbackReturn from controller_interface namespace (#333 <https://github.com/ros-controls/ros2_controllers/issues/333>)
* Contributors: Bence Magyar, Denis Štogl
```

## imu_sensor_broadcaster

```
* Use CallbackReturn from controller_interface namespace (#333 <https://github.com/ros-controls/ros2_controllers/issues/333>)
* Contributors: Bence Magyar, Denis Štogl
```

## joint_state_broadcaster

```
* Use CallbackReturn from controller_interface namespace (#333 <https://github.com/ros-controls/ros2_controllers/issues/333>)
* Contributors: Bence Magyar, Denis Štogl
```

## joint_trajectory_controller

```
* [JTC] Allow integration of states in goal trajectories (#190 <https://github.com/ros-controls/ros2_controllers/issues/190>)
  * Added position and velocity deduction to trajectory.
  * Added support for deduction of states from their derivatives.
* Use CallbackReturn from controller_interface namespace (#333 <https://github.com/ros-controls/ros2_controllers/issues/333>)
* [JTC] Implement effort-only command interface (#225 <https://github.com/ros-controls/ros2_controllers/issues/225>)
  * Fix trajectory tolerance parameters
  * Implement effort command interface for JTC
  * Use auto_declare for pid params
  * Set effort to 0 on deactivate
* [JTC] Variable renaming for clearer API (#323 <https://github.com/ros-controls/ros2_controllers/issues/323>)
* Remove unused include to fix JTC test (#319 <https://github.com/ros-controls/ros2_controllers/issues/319>)
* Contributors: Akash, Andy Zelenak, Bence Magyar, Denis Štogl, Jafar Abdi, Victor Lopez
```

## position_controllers

```
* Use CallbackReturn from controller_interface namespace (#333 <https://github.com/ros-controls/ros2_controllers/issues/333>)
* Contributors: Bence Magyar, Denis Štogl
```

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## velocity_controllers

```
* Use CallbackReturn from controller_interface namespace (#333 <https://github.com/ros-controls/ros2_controllers/issues/333>)
* Contributors: Bence Magyar, Denis Štogl
```
