### PR TITLE
Add python3-pip rule for RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7411,6 +7411,7 @@ python3-pip:
   nixos: [python3Packages.pip]
   openembedded: [python3-pip@openembedded-core]
   opensuse: [python3-pip]
+  rhel: [python3-pip]
   ubuntu: [python3-pip]
 python3-pkg-resources:
   alpine: [py3-setuptools]


### PR DESCRIPTION
In RHEL 7, this is provided by the `os` repository: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/python3-pip-9.0.3-8.el7.noarch.rpm
In RHEL 8, this is provided by the `AppStream` repository: https://repo.almalinux.org/almalinux/8/AppStream/x86_64/os/Packages/python3-pip-9.0.3-20.el8.noarch.rpm