### PR TITLE
Fix ros2cli_common_extensions source branch

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3619,7 +3619,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/ros2cli_common_extensions.git
-      version: galactic
+      version: master
     status: maintained
   ros2launch_security:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3619,7 +3619,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/ros2cli_common_extensions.git
-      version: galactic
+      version: master
     status: maintained
   ros2launch_security:
     doc:


### PR DESCRIPTION
This seems like an error where rolling and humble are referring to the wrong source branch for `ros2cli_common_extensions`.