### PR TITLE
robot_upstart: 1.0.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3609,7 +3609,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/clearpath-gbp/robot_upstart-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/robot_upstart.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_upstart` to `1.0.2-1`:

- upstream repository: https://github.com/clearpathrobotics/robot_upstart.git
- release repository: https://github.com/clearpath-gbp/robot_upstart-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.1-1`

## robot_upstart

```
* Removed whitespace
* Use a single rmw_config arg for both fastrtps and cyclonedds
* Added ROS_DOMAIN_ID arg
* Removed master_uri, added rmw, cyclonedds_config, and fastrtps_config
* Contributors: Roni Kreinin
```
