### PR TITLE
ur_client_library: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5059,7 +5059,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
-      version: 1.0.0-2
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `1.1.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.0.0-2`

## ur_client_library

```
* Support starting the driver, before the robot is booted (#98 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/98>)
* Clear the queue when consumer reads from it (#96 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/96>)
* Fix build with newer glibc
* Doxygen check (#77 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/77>)
* Added target_frequency to RTDEClient (#85 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/85>)
* Removed console_bridge dependency (#74 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/74>)
* Added "On behalf of Universal Robots A/S" notice (#81 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/81>)
  to all files that have been created by FZI
* Always install package.xml file (#78 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/78>)
* register package with ament index
* Corrected smaller doxygen errors
* Added rosdoc_lite check
* Contributors: Cory Crean, Felix Exner, Jørn Bersvendsen, Mads Holm Peters, Martin Jansa, Stefan Scherzinger
```
