### PR TITLE
ntrip_client: 1.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5641,7 +5641,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/LORD-MicroStrain/ntrip_client-release.git
-      version: 1.0.1-1
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ntrip_client` to `1.1.0-1`:

- upstream repository: https://github.com/LORD-MicroStrain/ntrip_client.git
- release repository: https://github.com/LORD-MicroStrain/ntrip_client-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.1-1`

## ntrip_client

```
* ROS Ntrip Version Configuration (#8 <https://github.com/LORD-MicroStrain/ntrip_client/issues/8>)
  * No longer sends Ntrip-Version header if not specified
  * Adds some hopefully helpful debug logging
  * Properly handles responses that have both a failure response and success response
  * Adds ability to print debug logs via launch parameter
* Contributors: robbiefish
```
