### PR TITLE
Revert "lex_node: 2.0.3-1 in 'melodic/distribution.yaml' [bloom] (#32…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5917,7 +5917,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/lex_node-release.git
-      version: 2.0.3-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/aws-robotics/lex-ros1.git


### PR DESCRIPTION
…209)"

This reverts commit 6235e0a028fbfeac2a12c2e7dc42f20049550d4c.

This has failed to build since it was merged: https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__lex_common_msgs__ubuntu_bionic_amd64__binary/ .

@jikawa-az FYI.