### PR TITLE
Revert "tts: 1.0.3-1 in 'melodic/distribution.yaml' [bloom] (#32212)"

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13754,7 +13754,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/tts-release.git
-      version: 1.0.3-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/aws-robotics/tts-ros1.git


### PR DESCRIPTION
This reverts commit 795710ef7321ba9c32629921d7dbb0f8db111831.

This has failed to build since it was merged: https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__tts__ubuntu_bionic_amd64__binary/

@jikawa-az FYI