### PR TITLE
Revert "[melodic] Update Pinocchio to v2.6.6 (HPP-FCL support; build …

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8926,7 +8926,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/stack-of-tasks/pinocchio-ros-release.git
-      version: 2.6.6-2
+      version: 2.6.5-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/pinocchio.git


### PR DESCRIPTION
…with Clang) (#32523)"

This reverts commit cc7f421c0bd63bb547baff2a51a9b44a3b3f68d6.

This hasn't built successfully on Melodic arm hard-float since it was merged: https://build.ros.org/view/Mbin_ubhf_uBhf/job/Mbin_ubhf_uBhf__pinocchio__ubuntu_bionic_armhf__binary/buildTimeTrend .

@wxmerkt The older version had trouble building too, but it would always *eventually* build.  This new version doesn't seem to be able to do even that.  So we can either go back to the old version, or just declare pinocchio support on Ubuntu arm hard float a lost cause.  What would you like to do?