### PR TITLE
rcss3d_agent: 0.0.7-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3130,8 +3130,8 @@ repositories:
       - rcss3d_agent_msgs
       tags:
         release: release/galactic/{package}/{version}
-      url: https://github.com/ros-sports/rcss3d_agent-release.git
-      version: 0.0.6-1
+      url: https://github.com/ros2-gbp/rcss3d_agent-release.git
+      version: 0.0.7-1
     source:
       type: git
       url: https://github.com/ros-sports/rcss3d_agent.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcss3d_agent` to `0.0.7-1`:

- upstream repository: https://github.com/ros-sports/rcss3d_agent.git
- release repository: https://github.com/ros2-gbp/rcss3d_agent-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.0`
- previous version for package: `0.0.6-1`

## rcss3d_agent

```
* fix phi and theta being swapped around
* Update package.xml maintainer
* Contributors: Kenji Brameld, ijnek
```

## rcss3d_agent_basic

- No changes

## rcss3d_agent_msgs

```
* fix phi and theta being swapped around
* Update package.xml maintainer
* Contributors: Kenji Brameld
```
