### PR TITLE
qt_advanced_docking_system: 3.8.2-7 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7008,7 +7008,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tesseract-robotics-release/qt_advanced_docking_system-release.git
-      version: 3.8.2-6
+      version: 3.8.2-7
     source:
       type: git
       url: https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_advanced_docking_system` to `3.8.2-7`:

- upstream repository: https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System
- release repository: https://github.com/tesseract-robotics-release/qt_advanced_docking_system-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.8.2-6`
