### PR TITLE
mvsim: 0.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5280,7 +5280,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/ual-arm-ros-pkg/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.3.1-1`:

- upstream repository: https://github.com/ual-arm-ros-pkg/mvsim.git
- release repository: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.3.0-1`

## mvsim

```
* update 2 robots demo
* Add pybind11 as build dep
* fix ros node compilation
* fix build w/o ros
* Fix compilation of the ROS1 node against the latest mvsim libraries
* Fix cmake policy error in pybind11
* Add missing ros deps
* Add missing build dep box2d-dev
* Update README.md
* Contributors: Jose Luis Blanco Claraco, Jose Luis Blanco-Claraco
```
