### PR TITLE
Revert "aws_common: 2.2.1-1 in 'melodic/distribution.yaml' [bloom] (#…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -796,7 +796,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/aws_common-release.git
-      version: 2.2.1-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/aws-robotics/utils-common.git


### PR DESCRIPTION
…32213)"

This reverts commit bc0a9c70b657ac69cc52a1897f807a0d38742ef7.

This has failed to build since it was updated: https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__aws_common__ubuntu_bionic_amd64__binary/

@jikawa-az FYI