### PR TITLE
add python3-kivy, python3-marshmallow-dataclass-pip and python3-tables to to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8588,7 +8588,11 @@ python3-systemd:
   nixos: [python3Packages.systemd]
   ubuntu: [python3-systemd]
 python3-tables:
-  debian: [python3-tables]
+  debian:
+    '*': [python3-tables]
+    buster:
+      pip:
+        packages: [Kivy]
   fedora: [python3-tables]
   ubuntu: [python3-tables]
 python3-tabulate:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8592,7 +8592,7 @@ python3-tables:
     '*': [python3-tables]
     buster:
       pip:
-        packages: [Kivy]
+        packages: [tables]
   fedora: [python3-tables]
   ubuntu: [python3-tables]
 python3-tabulate:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6956,7 +6956,11 @@ python3-kitchen:
     '*': [python3-kitchen]
     xenial: null
 python3-kivy:
-  debian: [python3-kivy]
+  debian:
+    '*': [python3-kivy]
+    buster:
+      pip:
+        packages: [Kivy]
   ubuntu: [python3-kivy]
 python3-lark-parser:
   alpine: [py3-lark-parser]
@@ -8588,11 +8592,7 @@ python3-systemd:
   nixos: [python3Packages.systemd]
   ubuntu: [python3-systemd]
 python3-tables:
-  debian:
-    '*': [python3-tables]
-    buster:
-      pip:
-        packages: [tables]
+  debian: [python3-tables]
   fedora: [python3-tables]
   ubuntu: [python3-tables]
 python3-tabulate:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2542,6 +2542,10 @@ python-kitchen:
     pip:
       packages: [kitchen]
   ubuntu: [python-kitchen]
+python-kivy:
+  ubuntu:
+    pip:
+      packages: [Kivy]
 python-kml:
   debian: [python-kml]
   ubuntu: [python-kml]
@@ -2673,6 +2677,10 @@ python-marshmallow:
   ubuntu:
     pip:
       packages: [marshmallow]
+python-marshmallow-dataclass:
+  ubuntu:
+    pip:
+      packages: [marshmallow-dataclass]
 python-math3d-pip:
   ubuntu:
     pip:
@@ -4939,6 +4947,10 @@ python-systemd:
 python-sysv-ipc:
   debian: [python-sysv-ipc]
   ubuntu: [python-sysv-ipc]
+python-tables:
+  ubuntu:
+    pip:
+      packages: [tables]
 python-tablib:
   debian: [python-tablib]
   fedora: [python-tablib]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2542,10 +2542,6 @@ python-kitchen:
     pip:
       packages: [kitchen]
   ubuntu: [python-kitchen]
-python-kivy:
-  ubuntu:
-    pip:
-      packages: [Kivy]
 python-kml:
   debian: [python-kml]
   ubuntu: [python-kml]
@@ -2677,10 +2673,6 @@ python-marshmallow:
   ubuntu:
     pip:
       packages: [marshmallow]
-python-marshmallow-dataclass:
-  ubuntu:
-    pip:
-      packages: [marshmallow-dataclass]
 python-math3d-pip:
   ubuntu:
     pip:
@@ -4947,10 +4939,6 @@ python-systemd:
 python-sysv-ipc:
   debian: [python-sysv-ipc]
   ubuntu: [python-sysv-ipc]
-python-tables:
-  ubuntu:
-    pip:
-      packages: [tables]
 python-tablib:
   debian: [python-tablib]
   fedora: [python-tablib]
@@ -6967,6 +6955,10 @@ python3-kitchen:
   ubuntu:
     '*': [python3-kitchen]
     xenial: null
+python3-kivy-pip:
+  ubuntu:
+    pip:
+      packages: [Kivy]
 python3-lark-parser:
   alpine: [py3-lark-parser]
   arch: [python-lark-parser]
@@ -7027,6 +7019,10 @@ python3-markdown:
   gentoo: [dev-python/markdown]
   nixos: [python3Packages.markdown]
   ubuntu: [python3-markdown]
+python3-marshmallow-dataclass-pip:
+  ubuntu:
+    pip:
+      packages: [marshmallow-dataclass]
 python3-matplotlib:
   alpine: [py3-matplotlib]
   arch: [python-matplotlib]
@@ -8592,6 +8588,10 @@ python3-systemd:
   debian: [python3-systemd]
   nixos: [python3Packages.systemd]
   ubuntu: [python3-systemd]
+python3-tables-pip:
+  ubuntu:
+    pip:
+      packages: [tables]
 python3-tabulate:
   debian: [python3-tabulate]
   fedora: [python3-tabulate]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6955,10 +6955,9 @@ python3-kitchen:
   ubuntu:
     '*': [python3-kitchen]
     xenial: null
-python3-kivy-pip:
-  ubuntu:
-    pip:
-      packages: [Kivy]
+python3-kivy:
+  debian: [python3-kivy]
+  ubuntu: [python3-kivy]
 python3-lark-parser:
   alpine: [py3-lark-parser]
   arch: [python-lark-parser]
@@ -8588,10 +8587,10 @@ python3-systemd:
   debian: [python3-systemd]
   nixos: [python3Packages.systemd]
   ubuntu: [python3-systemd]
-python3-tables-pip:
-  ubuntu:
-    pip:
-      packages: [tables]
+python3-tables:
+  debian: [python3-tables]
+  fedora: [python3-tables]
+  ubuntu: [python3-tables]
 python3-tabulate:
   debian: [python3-tabulate]
   fedora: [python3-tabulate]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-kivy
python3-marshmallow-dataclass-pip
python3-tables

## Package Upstream Source:

kivy: https://github.com/kivy/kivy
marshmallow-dataclass: https://github.com/lovasoa/marshmallow_dataclass
tables: https://github.com/PyTables/PyTables

## Purpose of using this:

Kivy: open source Python framework for rapid development of applications that make use of innovative user interfaces, such as multi-touch apps.
Marshmallow-dataclass: Automatic generation of marshmallow schemas from dataclasses.
Tables: managing hierarchical datasets and designed to efficiently and easily cope with extremely large amounts of data. 

Distro packaging links:

## Links to Distribution Packages

Kivy:
- Debian: https://www.debian.org/distrib/packages
  - https://packages.debian.org/bullseye/python3-kivy
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/focal/python3-kivy

marshmallow-dataclass:
- PiPy: https://pypi.org/
  - https://pypi.org/project/marshmallow-dataclass/

PyTables:
- Debian: https://www.debian.org/distrib/packages
  - https://packages.debian.org/bullseye/python3-tables
  - Buster:
    - PiPy: https://pypi.org/
      - https://pypi.org/project/Kivy/
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-tables/python3-tables/
- Ubuntu: https://packages.ubuntu.com/
  -  https://packages.ubuntu.com/focal/python3-tables