### PR TITLE
Revert "aws_ros1_common: 2.0.3-1 in 'melodic/distribution.yaml' [bloo…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -811,7 +811,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/aws_ros1_common-release.git
-      version: 2.0.3-1
+      version: 2.0.1-2
     source:
       type: git
       url: https://github.com/aws-robotics/utils-ros1.git


### PR DESCRIPTION
…m] (#32214)"

This reverts commit 39b7fd5167f82009887d85e65716a3607df38340.

This has failed to build since it was merged: https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__aws_ros1_common__ubuntu_bionic_amd64__binary/ .  @jikawa-az FYI.