### PR TITLE
Revert "cloudwatch_common: 1.1.6-1 in 'melodic/distribution.yaml' [bl…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1287,7 +1287,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/cloudwatch_common-release.git
-      version: 1.1.6-1
+      version: 1.1.5-1
     source:
       type: git
       url: https://github.com/aws-robotics/cloudwatch-common.git


### PR DESCRIPTION
…oom] (#32202)"

This reverts commit 34e32e20e728c20c34917a2713a571a73f62ceb6.

Some of the packages in here have failed to build since it was updated: https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__dataflow_lite__ubuntu_bionic_amd64__binary/

@jikawa-az FYI.