### PR TITLE
Revert "cloudwatch_logger: 2.3.2-1 in 'melodic/distribution.yaml' [bl…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1302,7 +1302,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/cloudwatch_logger-release.git
-      version: 2.3.2-1
+      version: 2.3.1-1
     source:
       type: git
       url: https://github.com/aws-robotics/cloudwatchlogs-ros1.git


### PR DESCRIPTION
…oom] (#32203)"

This reverts commit 34230400b31fc013b314a078645157c3c7333065.

This has been failing to build: https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__cloudwatch_logger__ubuntu_bionic_amd64__binary/ .  @jikawa-az FYI