### PR TITLE
Revert "ros_monitoring_msgs: 1.0.2-1 in 'melodic/distribution.yaml' […

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11042,7 +11042,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/ros_monitoring_msgs-release.git
-      version: 1.0.2-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/aws-robotics/monitoringmessages-ros1.git


### PR DESCRIPTION
…bloom] (#32210)"

This reverts commit d7b9dbcc4401507f4813caffb1fc7377546975a6.

This has been failing since it was merged: https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__ros_monitoring_msgs__ubuntu_bionic_amd64__binary/  @jikawa-az FYI