### PR TITLE
Revert "h264_encoder_core: 2.0.4-1 in 'melodic/distribution.yaml' [bl…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4106,7 +4106,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/h264_encoder_core-release.git
-      version: 2.0.4-1
+      version: 2.0.3-1
     source:
       type: git
       url: https://github.com/aws-robotics/kinesisvideo-encoder-common.git


### PR DESCRIPTION
…oom] (#32207)"

This reverts commit 9ad5ef52fc0e215d90f68124225f7cf3795a94ca.

This has been failing to build since it was merged: https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__h264_encoder_core__ubuntu_bionic_amd64__binary/ .  @jikawa-az FYI