### PR TITLE
Revert "kinesis_manager: 2.0.4-1 in 'melodic/distribution.yaml' [bloo…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5492,7 +5492,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/kinesis_manager-release.git
-      version: 2.0.4-1
+      version: 2.0.3-1
     source:
       type: git
       url: https://github.com/aws-robotics/kinesisvideo-common.git


### PR DESCRIPTION
…m] (#32206)"

This reverts commit b93cbfa8377e2b154e379df0926df4e929b33820.

This has been failing to build since it was merged: https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__kinesis_manager__ubuntu_bionic_amd64__binary/ .  @jikawa-az FYI