### PR TITLE
Revert "lex_common: 1.0.1-1 in 'melodic/distribution.yaml' [bloom] (#…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5899,7 +5899,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/lex_common-release.git
-      version: 1.0.1-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/aws-robotics/lex-common.git


### PR DESCRIPTION
…32208)"

This reverts commit 5a47c9d30477767968425bb8451b8f63923042ac.

This has been failing since it was merged: https://build.ros.org/view/Mbin_ubhf_uBhf/job/Mbin_ubhf_uBhf__lex_common__ubuntu_bionic_armhf__binary/  @jikawa-az FYI