### PR TITLE
Revert "rosbag_uploader: 1.0.2-1 in 'melodic/distribution.yaml' [bloo…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11243,7 +11243,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/rosbag_uploader-release.git
-      version: 1.0.2-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/aws-robotics/rosbag-uploader-ros1.git


### PR DESCRIPTION
…m] (#32211)"

This reverts commit 43f4b10e750d1a0b607b0cda301c929a715b8972.

This has been failing to build since it was merged: https://build.ros.org/view/Mbin_ubhf_uBhf/job/Mbin_ubhf_uBhf__s3_common__ubuntu_bionic_armhf__binary/  @jikawa-az FYI