### PR TITLE
Revert "cloudwatch_metrics_collector: 2.2.2-1 in 'melodic/distributio…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1317,7 +1317,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/cloudwatch_metrics_collector-release.git
-      version: 2.2.2-1
+      version: 2.2.1-2
     source:
       type: git
       url: https://github.com/aws-robotics/cloudwatchmetrics-ros1.git


### PR DESCRIPTION
…n.yaml' [bloom] (#32204)"

This reverts commit d6d962fc77a9f0b98bb6c1e9457f19e8869ac4ef.

This hasn't built since it was merged: https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__cloudwatch_metrics_collector__ubuntu_bionic_amd64__binary/ .  @jikawa-az FYI