### PR TITLE
Revert "health_metric_collector: 2.0.3-1 in 'melodic/distribution.yam…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4176,7 +4176,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/health_metric_collector-release.git
-      version: 2.0.3-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/aws-robotics/health-metrics-collector-ros1.git


### PR DESCRIPTION
…l' [bloom] (#32205)"

This reverts commit d21a7cda3d084930a7a4dd6428fcc6a1f087e18b.

This hasn't built since it was merged: https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__health_metric_collector__ubuntu_bionic_amd64__binary/ .  @jikawa-az FYI