### PR TITLE
Revert "kinesis_video_streamer: 2.0.4-1 in 'melodic/distribution.yaml…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5510,7 +5510,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/kinesis_video_streamer-release.git
-      version: 2.0.4-1
+      version: 2.0.3-1
     source:
       type: git
       url: https://github.com/aws-robotics/kinesisvideo-ros1.git


### PR DESCRIPTION
…' [bloom] (#32215)"

This reverts commit cecdeb7da16444fd5579463f8e916c3cc32e4733.

This hasn't built since it was merged: https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__kinesis_video_msgs__ubuntu_bionic_amd64__binary/ .  @jikawa-az FYI