### PR TITLE
[google-cloud-pubsub] add pip google cloud pubsub package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6704,6 +6704,16 @@ python3-gnupg:
   openembedded: [python3-gnupg@meta-python]
   opensuse: [python3-python-gnupg]
   ubuntu: [python3-gnupg]
+python3-google-cloud-pubsub-pip:
+  debian:
+    pip:
+      packages: [google-cloud-pubsub]
+  fedora:
+    pip:
+      packages: [google-cloud-pubsub]
+  ubuntu:
+    pip:
+      packages: [google-cloud-pubsub]
 python3-google-cloud-storage-pip: *migrate_eol_2025_04_30_python3_google_cloud_storage_pip
 python3-google-cloud-texttospeech-pip: *migrate_eol_2025_04_30_python3_google_cloud_texttospeech_pip
 python3-googleapi:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

pip/pip3 google-cloud-pubsub

## Package Upstream Source:

https://github.com/googleapis/python-pubsub

## Purpose of using this:

I want to release the package which depends this library.

Distro packaging links: https://github.com/jsk-ros-pkg/jsk_3rdparty

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Pip: https://pypi.org/project/google-cloud-pubsub/