### PR TITLE
tf_remapper_cpp: 1.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9947,6 +9947,21 @@ repositories:
       url: https://github.com/RobotWebTools/tf2_web_republisher.git
       version: master
     status: unmaintained
+  tf_remapper_cpp:
+    doc:
+      type: git
+      url: https://github.com/tradr-project/tf_remapper_cpp.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/peci1/tf_remapper_cpp-release.git
+      version: 1.1.1-1
+    source:
+      type: git
+      url: https://github.com/tradr-project/tf_remapper_cpp.git
+      version: master
+    status: maintained
   thunder_line_follower_pmr3100:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `tf_remapper_cpp` to `1.1.1-1`:

- upstream repository: https://github.com/tradr-project/tf_remapper_cpp.git
- release repository: https://github.com/peci1/tf_remapper_cpp-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`
