### PR TITLE
rviz: 11.2.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4426,7 +4426,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 11.2.0-2
+      version: 11.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `11.2.1-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `11.2.0-2`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Make sure not to dereference a null Renderable pointer. (#850 <https://github.com/ros2/rviz/issues/850>)
* Contributors: Chris Lalancette
```

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Stop using glsl150 resources for now. (#851 <https://github.com/ros2/rviz/issues/851>)
* Contributors: Chris Lalancette
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
