### PR TITLE
Add odrive pip package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7238,6 +7238,16 @@ python3-nuscenes-devkit-pip:
   ubuntu:
     pip:
       packages: [nuscenes-devkit]
+python3-odrive-pip:
+  debian:
+    pip:
+      packages: [odrive]
+  fedora:
+    pip:
+      packages: [odrive]
+  ubuntu:
+    pip:
+      packages: [odrive]
 python3-onnxruntime-gpu-pip:
   arch:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

pip/pip3 odrive

## Package Upstream Source:

https://github.com/odriverobotics/ODrive

## Purpose of using this:

This dependency is used for interacting with the [ODrive](https://odriverobotics.com/) brushless DC motor control boards.


## Links to Distribution Packages

- Pip: https://pypi.org/project/odrive/
