### PR TITLE
Add python fastkml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6453,6 +6453,9 @@ python3-fastapi:
     focal:
       pip:
         packages: [fastapi]
+python3-fastkml:
+  debian: [python3-fastkml]
+  ubuntu: [python3-fastkml]
 python3-fastnumbers-pip:
   arch:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:
python3-fastkml

## Package Upstream Source:
https://github.com/cleder/fastkml

## Purpose of using this:

This dependency is being used as a library to read, write and manipulate [KML](https://en.wikipedia.org/wiki/Keyhole_Markup_Language) files.

## Links to Distribution Packages

- Debian:
  - https://packages.debian.org/bullseye/python3-fastkml
- Ubuntu:
   - https://packages.ubuntu.com/focal/python3-fastkml
- Fedora: https://src.fedoraproject.org/browse/projects/
  - not available
- Arch: https://www.archlinux.org/packages/
  - not available

Technically fastkml is available through pip for those other distributions though, should I provide the pip definition for these? If so, what is the correct format to do this?

