### PR TITLE
Adding clpe_ros clpe_ros_msgs to documentation index for distro

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -596,6 +596,38 @@ repositories:
       url: https://github.com/CLOBOT-Co-Ltd/clober_msgs.git
       version: foxy-devel
     status: developed
+  clpe_ros:
+    doc:
+      type: git
+      url: https://github.com/canlab-co/clpe_ros.git
+      version: 0.1.0
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/canlab-co/clpe_ros-release.git
+      version: 0.1.0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/canlab-co/clpe_ros.git
+      version: main
+    status: maintained
+  clpe_ros_msgs:
+    doc:
+      type: git
+      url: https://github.com/canlab-co/clpe_ros_msgs.git
+      version: 0.1.0
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/canlab-co/clpe_ros_msgs-release.git
+      version: 0.1.0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/canlab-co/clpe_ros_msgs.git
+      version: main
+    status: maintained
   color_names:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -601,11 +601,6 @@ repositories:
       type: git
       url: https://github.com/canlab-co/clpe_ros.git
       version: main
-    release:
-      tags:
-        release: release/foxy/{package}/{version}
-      url: https://github.com/canlab-co/clpe_ros-release.git
-      version: main
     source:
       test_pull_requests: true
       type: git
@@ -616,11 +611,6 @@ repositories:
     doc:
       type: git
       url: https://github.com/canlab-co/clpe_ros_msgs.git
-      version: main
-    release:
-      tags:
-        release: release/foxy/{package}/{version}
-      url: https://github.com/canlab-co/clpe_ros_msgs-release.git
       version: main
     source:
       test_pull_requests: true

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -600,12 +600,12 @@ repositories:
     doc:
       type: git
       url: https://github.com/canlab-co/clpe_ros.git
-      version: 0.1.0
+      version: main
     release:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/canlab-co/clpe_ros-release.git
-      version: 0.1.0
+      version: main
     source:
       test_pull_requests: true
       type: git
@@ -616,12 +616,12 @@ repositories:
     doc:
       type: git
       url: https://github.com/canlab-co/clpe_ros_msgs.git
-      version: 0.1.0
+      version: main
     release:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/canlab-co/clpe_ros_msgs-release.git
-      version: 0.1.0
+      version: main
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
I'd like my_repo to be indexed and documented on ros.org.