### PR TITLE
Add nxt-python pip package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7238,6 +7238,16 @@ python3-nuscenes-devkit-pip:
   ubuntu:
     pip:
       packages: [nuscenes-devkit]
+python3-nxt-python-pip:
+  debian:
+    pip:
+      packages: [nxt-python]
+  fedora:
+    pip:
+      packages: [nxt-python]
+  ubuntu:
+    pip:
+      packages: [nxt-python]
 python3-onnxruntime-gpu-pip:
   arch:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

# Package name:
pip/pip3 nxt-python

# Package Upstream Source:
https://github.com/schodet/nxt-python

# Purpose of using this:
Used for controlling the LEGO NXT robot.

# Links to Distribution Packages
Pip: https://pypi.org/project/nxt-python/