### PR TITLE
libhri: 0.4.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4331,7 +4331,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros4hri/libhri-release.git
-      version: 0.4.1-1
+      version: 0.4.2-1
     source:
       type: git
       url: https://github.com/ros4hri/libhri.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libhri` to `0.4.2-1`:

- upstream repository: https://github.com/ros4hri/libhri.git
- release repository: https://github.com/ros4hri/libhri-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.4.1-1`

## hri

```
* add callback support for faces, bodies, voices, persons.
  Eg, call onFace(cb) to register callback invoked everytime a face is detected
* expose the aligned face in the Face class
* Contributors: Séverin Lemaignan
```
