### PR TITLE
mvsim: 0.3.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7347,7 +7347,7 @@ repositories:
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/ual-arm-ros-pkg/mvsim.git
+      url: https://github.com/MRPT/mvsim.git
       version: master
     status: maintained
   nanomsg:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7343,7 +7343,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
-      version: 0.2.1-0
+      version: 0.3.1-1
     source:
       test_pull_requests: true
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7337,7 +7337,7 @@ repositories:
   mvsim:
     doc:
       type: git
-      url: https://github.com/ual-arm-ros-pkg/mvsim.git
+      url: https://github.com/MRPT/mvsim.git
       version: master
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.3.1-1`:

- upstream repository: https://github.com/MRPT/mvsim.git
- release repository: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.2.1-0`

## mvsim

```
* update 2 robots demo
* Add pybind11 as build dep
* fix ros node compilation
* fix build w/o ros
* Fix compilation of the ROS1 node against the latest mvsim libraries
* Fix cmake policy error in pybind11
* Add missing ros deps
* Add missing build dep box2d-dev
* Update README.md
* Contributors: Jose Luis Blanco Claraco, Jose Luis Blanco-Claraco
```
