### PR TITLE
libhri: 0.4.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5982,7 +5982,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros4hri/libhri-release.git
-      version: 0.4.1-1
+      version: 0.4.3-1
     source:
       type: git
       url: https://github.com/ros4hri/libhri.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libhri` to `0.4.3-1`:

- upstream repository: https://github.com/ros4hri/libhri.git
- release repository: https://github.com/ros4hri/libhri-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.4.1-1`

## hri

```
* fix gmock 'Call' syntax for older version of gmock (1.8). This was causing
  issues on ubuntu 18.04 (ROS melodic)
* Contributors: Séverin Lemaignan
```
