### PR TITLE
rviz: 8.5.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4685,7 +4685,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 8.5.0-3
+      version: 8.5.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `8.5.1-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `8.5.0-3`

## rviz2

- No changes

## rviz_assimp_vendor

```
* Fix support for assimp 5.1.0 (#827 <https://github.com/ros2/rviz/issues/827>)
* Contributors: Akash
```

## rviz_common

```
* Removed traces in renderPanel (#777 <https://github.com/ros2/rviz/issues/777>) (#778 <https://github.com/ros2/rviz/issues/778>)
* Update displays_panel.cpp (#745 <https://github.com/ros2/rviz/issues/745>) (#771 <https://github.com/ros2/rviz/issues/771>)
* Efficiently handle 3-bytes pixel formats (#743 <https://github.com/ros2/rviz/issues/743>) (#750 <https://github.com/ros2/rviz/issues/750>)
* Add rviz_rendering dependency to rviz_common (#727 <https://github.com/ros2/rviz/issues/727>) (#748 <https://github.com/ros2/rviz/issues/748>)
* Removed some memory leaks in rviz_rendering and rviz_rendering_tests (#710 <https://github.com/ros2/rviz/issues/710>)
* Contributors: Alejandro Hernández Cordero, Rebecca Butler
```

## rviz_default_plugins

```
* Add underscores to material names (#811 <https://github.com/ros2/rviz/issues/811>) (#823 <https://github.com/ros2/rviz/issues/823>)
* Change image display to not rely on TF (#781 <https://github.com/ros2/rviz/issues/781>) (#825 <https://github.com/ros2/rviz/issues/825>)
* Export Qt5 dependencies properly (#687 <https://github.com/ros2/rviz/issues/687>) (#789 <https://github.com/ros2/rviz/issues/789>)
* Fixed crash when changing rendering parameters for pointcloud2 while 'Selectable' box is unchecked (#768 <https://github.com/ros2/rviz/issues/768>) (#769 <https://github.com/ros2/rviz/issues/769>)
* Yuv to rgb changes (#733 <https://github.com/ros2/rviz/issues/733>)
* Duplicated code RobotJoint (#702 <https://github.com/ros2/rviz/issues/702>)
* Contributors: Alejandro Hernández Cordero, Jacob Perron, Michel Hidalgo, cturcotte-qnx
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Fix support for assimp 5.1.0 (#827 <https://github.com/ros2/rviz/issues/827>)
* Export Qt5 dependencies properly (#687 <https://github.com/ros2/rviz/issues/687>) (#789 <https://github.com/ros2/rviz/issues/789>)
* fixed windows test
* Removed some memory leaks in rviz_rendering and rviz_rendering_tests (#710 <https://github.com/ros2/rviz/issues/710>)
* Contributors: Akash, Alejandro Hernández Cordero, Michel Hidalgo, ahcorde
```

## rviz_rendering_tests

```
* Removed some memory leaks in rviz_rendering and rviz_rendering_tests (#710 <https://github.com/ros2/rviz/issues/710>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_visual_testing_framework

- No changes
