### PR TITLE
rosidl_python: 0.11.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4111,7 +4111,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.11.1-1
+      version: 0.11.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_python` to `0.11.2-1`:

- upstream repository: https://github.com/ros2/rosidl_python.git
- release repository: https://github.com/ros2-gbp/rosidl_python-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.11.1-1`

## rosidl_generator_py

```
* Removes erroneous unmatched closing parenthesis (#125 <https://github.com/ros2/rosidl_python/issues/125>) (#159 <https://github.com/ros2/rosidl_python/issues/159>)
* Contributors: mergify[bot]
```
