### PR TITLE
rosidl: 2.2.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4056,7 +4056,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 2.2.1-2
+      version: 2.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `2.2.2-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.2.1-2`

## rosidl_adapter

```
* Fix escaping in string literals (#595 <https://github.com/ros2/rosidl/issues/595>) (#617 <https://github.com/ros2/rosidl/issues/617>)
* Contributors: Jacob Perron
```

## rosidl_cli

- No changes

## rosidl_cmake

- No changes

## rosidl_generator_c

```
* Galactic backport of #648 <https://github.com/ros2/rosidl/issues/648> and #650 <https://github.com/ros2/rosidl/issues/650> (#668 <https://github.com/ros2/rosidl/issues/668>)
* Contributors: Nikolai Morin
```

## rosidl_generator_cpp

- No changes

## rosidl_parser

```
* Fix escaping in string literals (#595 <https://github.com/ros2/rosidl/issues/595>) (#617 <https://github.com/ros2/rosidl/issues/617>)
* Contributors: Jacob Perron
```

## rosidl_runtime_c

```
* Galactic backport of #648 <https://github.com/ros2/rosidl/issues/648> and #650 <https://github.com/ros2/rosidl/issues/650> (#668 <https://github.com/ros2/rosidl/issues/668>)
* Contributors: Nikolai Morin
```

## rosidl_runtime_cpp

- No changes

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

- No changes

## rosidl_typesupport_introspection_cpp

- No changes
