### PR TITLE
rmw_fastrtps: 5.0.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3548,7 +3548,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 5.0.1-1
+      version: 5.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `5.0.2-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `5.0.1-1`

## rmw_fastrtps_cpp

- No changes

## rmw_fastrtps_dynamic_cpp

- No changes

## rmw_fastrtps_shared_cpp

```
* Export rmw_dds_common as an rmw_fastrtps_shared_cpp dependency (#530 <https://github.com/ros2/rmw_fastrtps/issues/530>) (#567 <https://github.com/ros2/rmw_fastrtps/issues/567>)
* Contributors: Michel Hidalgo
```
