### PR TITLE
rmw_cyclonedds: 0.22.5-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3512,7 +3512,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 0.22.4-1
+      version: 0.22.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `0.22.5-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.22.4-1`

## rmw_cyclonedds_cpp

```
* Free with the same allocator in rmw_destroy_node (#355 <https://github.com/ros2/rmw_cyclonedds/issues/355>) (#368 <https://github.com/ros2/rmw_cyclonedds/issues/368>)
* Contributors: Jacob Perron
```
