### PR TITLE
rclcpp: 9.2.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3079,7 +3079,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 9.2.0-1
+      version: 9.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `9.2.1-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `9.2.0-1`

## rclcpp

```
* Add test-dep ament_cmake_google_benchmark (#1904 <https://github.com/ros2/rclcpp/issues/1904>) (#1909 <https://github.com/ros2/rclcpp/issues/1909>)
* Use parantheses around logging macro parameter (#1820 <https://github.com/ros2/rclcpp/issues/1820>) (#1822 <https://github.com/ros2/rclcpp/issues/1822>)
* Contributors: mergify[bot]
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
