### PR TITLE
launch_ros: 0.14.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1613,7 +1613,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.14.2-1
+      version: 0.14.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.14.3-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.14.2-1`

## launch_ros

```
* Handle empty strings when evaluating parameters (#300 <https://github.com/ros2/launch_ros/issues/300>) (#301 <https://github.com/ros2/launch_ros/issues/301>)
* Fix TypeError accessing name and value of SetParameter (#299 <https://github.com/ros2/launch_ros/issues/299>)
* More Helpful Error Messages (#275 <https://github.com/ros2/launch_ros/issues/275>) (#290 <https://github.com/ros2/launch_ros/issues/290>)
* Contributors: Jacob Perron, mergify[bot]
```

## launch_testing_ros

- No changes

## ros2launch

```
* Simplify logic to fix absolute paths (#230 <https://github.com/ros2/launch_ros/issues/230>) (#296 <https://github.com/ros2/launch_ros/issues/296>)
* Contributors: Jacob Perron
```
