### PR TITLE
launch: 0.17.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1578,7 +1578,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.17.0-2
+      version: 0.17.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.17.1-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.17.0-2`

## launch

```
* Evaluate math symbols and functions in python expression (#557 <https://github.com/ros2/launch/issues/557>) (#563 <https://github.com/ros2/launch/issues/563>)
* Allow for raw path specification in IncludeLaunchDescription (#544 <https://github.com/ros2/launch/issues/544>) (#549 <https://github.com/ros2/launch/issues/549>)
* Contributors: David V. Lu!!, Immanuel Martini
```

## launch_testing

```
* Fix launch_testing README.md proc keyword to process. (#554 <https://github.com/ros2/launch/issues/554>) (#561 <https://github.com/ros2/launch/issues/561>)
  Co-authored-by: Michael McConnell <mailto:Michael.McConnell-2@leidos.com>
* Contributors: Jacob Perron
```

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
