### PR TITLE
image_common: 2.3.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1325,7 +1325,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 2.3.0-3
+      version: 2.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `2.3.1-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.3.0-3`

## camera_calibration_parsers

```
* Update maintainers (#173 <https://github.com/ros-perception/image_common/issues/173>)
* Contributors: Alejandro Hernández Cordero
```

## camera_info_manager

```
* Update maintainers (#173 <https://github.com/ros-perception/image_common/issues/173>)
* Contributors: Alejandro Hernández Cordero
```

## image_common

- No changes

## image_transport

```
* Simple IT plugins shutdown (#225 <https://github.com/ros-perception/image_common/issues/225>) (#228 <https://github.com/ros-perception/image_common/issues/228>)
* Update maintainers (#173 <https://github.com/ros-perception/image_common/issues/173>)
* make CameraPublisher::getNumSubscribers() work (#163 <https://github.com/ros-perception/image_common/issues/163>)
* Contributors: Alejandro Hernández Cordero, Geoffrey Biggs, Michael Ferguson
```
