### PR TITLE
geometry2: 0.17.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1088,7 +1088,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.17.2-1
+      version: 0.17.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.17.3-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.17.2-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* Workaround with pragma push and pop for NO_ERROR collison (#456 <https://github.com/ros2/geometry2/issues/456>) (#458 <https://github.com/ros2/geometry2/issues/458>)
* Contributors: Abrar Rahman Protyasha
```

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

```
* tf2_geometry_msgs: Fixing covariance transformation in doTransform<PoseWithCovarianceStamped, TransformStamped> (#430 <https://github.com/ros2/geometry2/issues/430>) (#488 <https://github.com/ros2/geometry2/issues/488>)
* Contributors: mergify[bot]
```

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Fix tf2_echo does not work with ros-args (#407 <https://github.com/ros2/geometry2/issues/407>) (#408 <https://github.com/ros2/geometry2/issues/408>) (#410 <https://github.com/ros2/geometry2/issues/410>)
* Contributors: mergify[bot]
```

## tf2_ros_py

- No changes

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
