### PR TITLE
rcl_logging: 2.1.4-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3037,7 +3037,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 2.1.2-2
+      version: 2.1.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `2.1.4-1`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.1.2-2`

## rcl_logging_interface

- No changes

## rcl_logging_log4cxx

```
* Change C++ version to 17 in rcl_logging_log4cxx (#79 <https://github.com/ros2/rcl_logging/issues/79>)
* Contributors: Homalozoa X
```

## rcl_logging_noop

- No changes

## rcl_logging_spdlog

- No changes
