### PR TITLE
rclpy: 1.9.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3095,7 +3095,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 1.9.0-1
+      version: 1.9.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `1.9.1-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.9.0-1`

## rclpy

```
* Remove -> bool annotation for destroy_node #886 <https://github.com/ros2/rclpy/issues/886> (#891 <https://github.com/ros2/rclpy/issues/891>)
* Fix memory leak. (#840 <https://github.com/ros2/rclpy/issues/840>)
* Fix automatically declared parameters descriptor type. (backport #853 <https://github.com/ros2/rclpy/issues/853>) (#854 <https://github.com/ros2/rclpy/issues/854>)
* Only add one done callback to a future (#816 <https://github.com/ros2/rclpy/issues/816>) (#821 <https://github.com/ros2/rclpy/issues/821>)
* Remove unused function make_mock_subscription (#809 <https://github.com/ros2/rclpy/issues/809>) (#810 <https://github.com/ros2/rclpy/issues/810>)
* Convert Node and Context to use C++ Classes (#771 <https://github.com/ros2/rclpy/issues/771>)
* Pybind11 actionserver nitpicks and docblock improvements (#774 <https://github.com/ros2/rclpy/issues/774>)
* Pybind11 action goal handle nitpicks (#767 <https://github.com/ros2/rclpy/issues/767>)
* Convert Guardcondition to use C++ classes (#772 <https://github.com/ros2/rclpy/issues/772>)
* Removed unused structs (#770 <https://github.com/ros2/rclpy/issues/770>)
* Convert WaitSet to use C++ Classes (#769 <https://github.com/ros2/rclpy/issues/769>)
* Convert ActionServer to use C++ Classes (#766 <https://github.com/ros2/rclpy/issues/766>)
* Convert ActionClient to use C++ classes (#759 <https://github.com/ros2/rclpy/issues/759>)
* Use py::class_ for rcl_action_goal_handle_t (#751 <https://github.com/ros2/rclpy/issues/751>)
* Convert Publisher and Subscription to use C++ Classes (#756 <https://github.com/ros2/rclpy/issues/756>)
* Contributors: Alejandro Hernández Cordero, Greg Balke, Shane Loretz, Suraj Pattar, mergify[bot]
```
