### PR TITLE
rosbag2_storage_mcap: 0.1.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3794,9 +3794,13 @@ repositories:
       url: https://github.com/ros-tooling/rosbag2_storage_mcap.git
       version: main
     release:
+      packages:
+      - mcap_vendor
+      - rosbag2_storage_mcap
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2_storage_mcap-release.git
+      version: 0.1.5-1
     source:
       type: git
       url: https://github.com/ros-tooling/rosbag2_storage_mcap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2_storage_mcap` to `0.1.5-1`:

- upstream repository: https://github.com/ros-tooling/rosbag2_storage_mcap.git
- release repository: https://github.com/ros2-gbp/rosbag2_storage_mcap-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## mcap_vendor

```
* Test Foxy & Galactic in CI, fix missing test_depends in mcap_vendor/package.xml (#33 <https://github.com/ros-tooling/rosbag2_storage_mcap/issues/33>)
* Contributors: Jacob Bandes-Storch
```

## rosbag2_storage_mcap

```
* Fix build for Foxy (#34 <https://github.com/ros-tooling/rosbag2_storage_mcap/issues/34>)
* Contributors: Jacob Bandes-Storch
```
