### PR TITLE
minas: 1.0.10-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6647,6 +6647,28 @@ repositories:
       url: https://github.com/peci1/mikrotik_swos_tools.git
       version: master
     status: developed
+  minas:
+    doc:
+      type: git
+      url: https://github.com/tork-a/minas.git
+      version: master
+    release:
+      packages:
+      - ethercat_manager
+      - minas
+      - minas_control
+      - tra1_bringup
+      - tra1_description
+      - tra1_moveit_config
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/minas-release.git
+      version: 1.0.10-1
+    source:
+      type: git
+      url: https://github.com/tork-a/minas.git
+      version: master
+    status: maintained
   mir_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `minas` to `1.0.10-1`:

- upstream repository: https://github.com/tork-a/minas
- release repository: https://github.com/tork-a/minas-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## ethercat_manager

- No changes

## minas

- No changes

## minas_control

```
* Add dependency on realtime_tools(#72 <https://github.com/tork-a/minas/issues/72>)
* Contributors: Ryosuke Tajima, Tokyo Opensource Robotics Developer 534
```

## tra1_bringup

- No changes

## tra1_description

- No changes

## tra1_moveit_config

- No changes
