### PR TITLE
Mark mrpt1 as deprecated

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5637,7 +5637,8 @@ repositories:
       type: git
       url: https://github.com/mrpt/mrpt.git
       version: mrpt-1.5
-    status: maintained
+    status: end-of-life
+    status_description: Deprecated by package mrpt2
   mrpt2:
     doc:
       type: git


### PR DESCRIPTION
This package is EOL and deprecated by `mrpt2`, so mark it as such in the only non-EOL distribution where it still exists.