### PR TITLE
Index mrpt_* packages for noetic from melodic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5213,6 +5213,36 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
       version: ros1
     status: developed
+  mrpt_navigation:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
+      version: ros1
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
+      version: ros1
+    status: maintained
+  mrpt_sensors:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
+      version: ros1
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
+      version: master
+    status: ros1
+  mrpt_slam:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_slam.git
+      version: ros1
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_slam.git
+      version: ros1
+    status: maintained    
   mrt_cmake_modules:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5242,7 +5242,7 @@ repositories:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_slam.git
       version: ros1
-    status: maintained    
+    status: maintained
   mrt_cmake_modules:
     doc:
       type: git


### PR DESCRIPTION
Port three repositories from melodic, in `doc` and `source` only for now.
