### PR TITLE
Correct the branch name for these 3 repositories

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7208,7 +7208,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
-      version: master
+      version: ros1
     release:
       packages:
       - mrpt_local_obstacles
@@ -7225,23 +7225,23 @@ repositories:
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
-      version: master
+      version: ros1
     status: maintained
   mrpt_sensors:
     doc:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
-      version: master
+      version: ros1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
-      version: master
+      version: ros1
     status: maintained
   mrpt_slam:
     doc:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_slam.git
-      version: master
+      version: ros1
     release:
       packages:
       - mrpt_ekf_slam_2d
@@ -7257,7 +7257,7 @@ repositories:
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_slam.git
-      version: master
+      version: ros1
     status: maintained
   mrt_cmake_modules:
     doc:


### PR DESCRIPTION
The development branch for RIS1 versions of these packages is now `ros1` instead of `master`.
