### PR TITLE
rmf_api_msgs: 0.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3072,6 +3072,21 @@ repositories:
       url: https://github.com/ros/resource_retriever.git
       version: ros2
     status: maintained
+  rmf_api_msgs:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_api_msgs.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_api_msgs-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_api_msgs.git
+      version: main
+    status: developed
   rmf_battery:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_api_msgs` to `0.0.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_api_msgs
- release repository: https://github.com/ros2-gbp/rmf_api_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
