### PR TITLE
cob_robots: 0.7.6-4 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1094,14 +1094,16 @@ repositories:
       version: kinetic_release_candidate
     release:
       packages:
+      - cob_bringup
       - cob_default_robot_behavior
       - cob_default_robot_config
       - cob_hardware_config
       - cob_moveit_config
+      - cob_robots
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_robots-release.git
-      version: 0.7.6-1
+      version: 0.7.6-4
     source:
       type: git
       url: https://github.com/ipa320/cob_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_robots` to `0.7.6-4`:

- upstream repository: https://github.com/ipa320/cob_robots.git
- release repository: https://github.com/ipa320/cob_robots-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.7.6-1`

## cob_bringup

```
* Merge pull request #820 <https://github.com/ipa320/cob_robots/issues/820> from ipa-foj/fixup_cob4-25
  Fixup cob4-25
* fixup cob4-25 for noetic
* realsense2_camera released into noetic
* Merge pull request #817 <https://github.com/ipa320/cob_robots/issues/817> from fmessmer/beverage_nav_test
  NODE testing config
* conditional dependencies
* remove rplidar
* tmp: comment unreleased dependencies
* dummy beverage robot for navigation - cob4-18 with torso cam3d bottom and top
* remove rplidar dependency
* Merge pull request #816 <https://github.com/ipa320/cob_robots/issues/816> from HannesBachter/update_cob4-8
  Update cob4-8
* D435 sensorring cam
* Contributors: Felix Messmer, HannesBachter, fmessmer, mailto:robot@cob4-25
```

## cob_default_robot_behavior

- No changes

## cob_default_robot_config

```
* Merge pull request #820 <https://github.com/ipa320/cob_robots/issues/820> from ipa-foj/fixup_cob4-25
  Fixup cob4-25
* fixup cob4-25 for noetic
* Merge pull request #816 <https://github.com/ipa320/cob_robots/issues/816> from HannesBachter/update_cob4-8
  Update cob4-8
* update head joint config for Aalto
* Contributors: Felix Messmer, HannesBachter, mailto:robot@cob4-25
```

## cob_hardware_config

```
* Merge pull request #820 <https://github.com/ipa320/cob_robots/issues/820> from ipa-foj/fixup_cob4-25
  Fixup cob4-25
* fixup cob4-25 for noetic
* Merge pull request #819 <https://github.com/ipa320/cob_robots/issues/819> from ipa-foj/kinetic_dev
  corrected cameras for cob4-7 urdf
* removed old xacro arg
* corrected cameras for cob4-7 urdf
* Merge pull request #817 <https://github.com/ipa320/cob_robots/issues/817> from fmessmer/beverage_nav_test
  NODE testing config
* remove rplidar
* dummy beverage robot for navigation - cob4-18 with torso cam3d bottom and top
* Merge pull request #816 <https://github.com/ipa320/cob_robots/issues/816> from HannesBachter/update_cob4-8
  Update cob4-8
* D435 sensorring cam
* Contributors: Felix Messmer, HannesBachter, fmessmer, foj, mailto:robot@cob4-25
```

## cob_moveit_config

- No changes

## cob_robots

- No changes
