### PR TITLE
ros2_control: 1.5.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3664,7 +3664,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 1.4.0-1
+      version: 1.5.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `1.5.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.4.0-1`

## controller_interface

- No changes

## controller_manager

```
* Spawner waits for services (#683 <https://github.com/ros-controls/ros2_control/issues/683>) (#697 <https://github.com/ros-controls/ros2_control/issues/697>)
* Contributors: Tyler Weaver
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Require lifecycle-msgs in hardware_interface package (#675 <https://github.com/ros-controls/ros2_control/issues/675>)
* Contributors: Martin Wudenka
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## transmission_interface

- No changes
