### PR TITLE
image_pipeline: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1360,10 +1360,11 @@ repositories:
       - image_rotate
       - image_view
       - stereo_image_proc
+      - tracetools_image_pipeline
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 2.2.1-4
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `3.0.0-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.2.1-4`

## camera_calibration

```
* Some small fixes noticed while reviewing.
* fix premature camera model change in camera_calibration
* Fix shebang lines for noetic python3
* Update fisheye distortion model definition
* Fix calibration yaml formatting (#580 <https://github.com/ros-perception/image_pipeline/issues/580>) (#585 <https://github.com/ros-perception/image_pipeline/issues/585>)
* updated linear_error function to handle partial board views (#561 <https://github.com/ros-perception/image_pipeline/issues/561>)
* Fix missing detected checkerboard points (#558 <https://github.com/ros-perception/image_pipeline/issues/558>)
* ChArUco board, Noetic (#549 <https://github.com/ros-perception/image_pipeline/issues/549>)
* fix #503 <https://github.com/ros-perception/image_pipeline/issues/503>: (#545 <https://github.com/ros-perception/image_pipeline/issues/545>)
* Minimal Noetic (#530 <https://github.com/ros-perception/image_pipeline/issues/530>)
* Apply #509 <https://github.com/ros-perception/image_pipeline/issues/509> and #526 <https://github.com/ros-perception/image_pipeline/issues/526> to Noetic Branch (#528 <https://github.com/ros-perception/image_pipeline/issues/528>)
* Add Fisheye calibration tool (#440 <https://github.com/ros-perception/image_pipeline/issues/440>)
* camera_calibration: Improve YAML formatting, make config dumping methods static (#438 <https://github.com/ros-perception/image_pipeline/issues/438>)
* camera_calibration: Fix all-zero distortion coeffs returned for a rational_polynomial model (#433 <https://github.com/ros-perception/image_pipeline/issues/433>)
* Make sure 'calibrate' button works even if not receiving images anymore
* Add a comment
* Replace deque with a modified Queue, add --queue-size param
* Remove print statement
* Cosmetic changes
* Add max-chessboard-speed option to allow more accurate calibration of rolling shutter cameras.
* revert back
* added missing imports
* update pytest.ini
* fixes to pass tests
* rebase change
* implemented fisheye mono and stereo calibration based on the melodic branch
* trimmed whitespace at line endings
* Update camera_calibration setup.cfg to use underscores (#688 <https://github.com/ros-perception/image_pipeline/issues/688>)
* Add maintainer (#667 <https://github.com/ros-perception/image_pipeline/issues/667>)
* Fixed crash when rosargs are given (#597 <https://github.com/ros-perception/image_pipeline/issues/597>)
* Contributors: Chris Lalancette, David Torres Ocaña, DavidTorresOcana, Gabor Soros, Jacob Perron, John Stechschulte, Joshua Whitley, Martin Valgur, Matthijs den Toom, Michael Carroll, Patrick Musau, Photon, Spiros Evangelatos, Victor Dubois, jaiveersinghNV, soeroesg
```

## depth_image_proc

```
* Cleanup of depth_image_proc.
* Fix linker error caused by templating in the conversions.cpp file (#718 <https://github.com/ros-perception/image_pipeline/issues/718>)
* Port upsampling interpolation from #363 <https://github.com/ros-perception/image_pipeline/issues/363> to ROS2 (#692 <https://github.com/ros-perception/image_pipeline/issues/692>)
* Fix uncrustify errors
* allow loading depth_image_proc::RegisterNode as a component
* Replace deprecated geometry2 headers
* Fixed typo in pointcloudxyz launch file
* use unique_ptrs, remove unused code, add back in missing initMatrix call
* add xyzrgb radial node
* Use RCLCPP_WARN_THROTTLE (10 secs) to avoid terminal spam
* Fix tiny error in comment
* Warning instead of fatal error when frames are differents
* revert a293252
* Replace deprecated geometry2 headers
* Add maintainer (#667 <https://github.com/ros-perception/image_pipeline/issues/667>)
* move to hpp/cpp structure, create conversions file
* Fix deprecation warning calling declare_parameter
* Contributors: Chris Lalancette, Evan Flynn, Francisco Martin Rico, Francisco Martín Rico, Harshal Deshpande, Jacob Perron, Joe Schornak, Joseph Schornak, Joshua Whitley, Patrick Musau
```

## image_pipeline

```
* Add maintainer (#667 <https://github.com/ros-perception/image_pipeline/issues/667>)
* Contributors: Jacob Perron
```

## image_proc

```
* Cleanup of image_proc.
* Some small fixes noticed while reviewing.
* Remove unnecessary find_package
* Deal with uncrustify and cpplint
* LTTng instrument image_proc::RectifyNode and image_proc::ResizeNode
* bring over ros1 fix for missing roi resize
* Add maintainer (#667 <https://github.com/ros-perception/image_pipeline/issues/667>)
* Fix build with later versions of OpenCV 3
* Refactor image_proc and stereo_image_proc launch files (#583 <https://github.com/ros-perception/image_pipeline/issues/583>)
* Contributors: Chris Lalancette, Evan Flynn, Jacob Perron, Scott K Logan, Víctor Mayoral Vilches
```

## image_publisher

```
* Cleanup image_publisher.
* image_publisher: Fix out_img timestamp for using with sim time (#735 <https://github.com/ros-perception/image_pipeline/issues/735>)
* Add retry video capture feature with timeout
* changes per comments
* fix for stereo_image_proc_tests
* Add maintainer (#667 <https://github.com/ros-perception/image_pipeline/issues/667>)
* Contributors: Ashwin Sushil, Chris Lalancette, Jacob Perron, Nikita Stolyarov, Patrick Musau
```

## image_rotate

```
* Cleanup the image_rotate package.
* Replace deprecated geometry2 headers
* revert a293252
* Replace deprecated geometry2 headers
* Add maintainer (#667 <https://github.com/ros-perception/image_pipeline/issues/667>)
* Contributors: Chris Lalancette, Jacob Perron, Patrick Musau
```

## image_view

```
* Cleanup image_view.
* reformat for the uncrustify linter
* fix code style divergence
* reduce number of lines under 100
* print correct topics, remap according to ros2 capabilities, print help with correct ros2 syntax
* declare and get parameters for value replacement
* transport shoudl be used as a ros arg parameter
* use ros2 syntax
* transport should be use as a ros-arg parameter
* Fix image saver bug and time-based image saving
* replace ROSTIME
* Changing to RCL_SYSTEM_TIME
* Fix timestamp creation
* changes per comments
* fix for stereo_image_proc_tests
* Add maintainer (#667 <https://github.com/ros-perception/image_pipeline/issues/667>)
* please linters
* Fix wrong usage of rclcpp::Duration constructor
* Contributors: Chris Lalancette, Erwin Lejeune, Ivan Santiago Paunovic, Jacob Perron, Lars Lorentz Ludvigsen, Patrick Musau
```

## stereo_image_proc

```
* Fix the tests for stereo_image_proc.
* Cleanup stereo_image_proc
* Populate CameraInfo camera matrix in test fixture
* Use with_default_policies
* Improve formatting
* Use SubscriptionOptions
* Add subscriber qos overrides
* Remove QosPolicyKind::Invalid
* Allow QoS overrides for publishers
* Add missing test dependency
* Add color param to stereo_image_proc (#661 <https://github.com/ros-perception/image_pipeline/issues/661>)
* changes per comments
* fix for stereo_image_proc_tests
* Add maintainer (#667 <https://github.com/ros-perception/image_pipeline/issues/667>)
* Add disparity node parameters to launch file
* Fix disparity node parameter name
* Expose avoid_point_cloud_padding parameter in stereo_image_proc launch file (#599 <https://github.com/ros-perception/image_pipeline/issues/599>)
* Refactor image_proc and stereo_image_proc launch files (#583 <https://github.com/ros-perception/image_pipeline/issues/583>)
* Contributors: Audrow Nash, Chris Lalancette, Jacob Perron, Patrick Musau, Rebecca Butler
```

## tracetools_image_pipeline

```
* tracetools_image_pipeline version consistent with repo
* Omit changelogfile
* Deal with uncrustify and cpplint
* Add tracetools_image_pipeline package to the pipeline
* Contributors: Víctor Mayoral Vilches
```
