### PR TITLE
ros2_controllers: 2.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3526,7 +3526,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.3.0-1
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.4.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.0-1`

## diff_drive_controller

```
* updated to use node getter functions (#329 <https://github.com/ros-controls/ros2_controllers/issues/329>)
* Contributors: Bence Magyar, Denis Štogl, Jack Center
```

## effort_controllers

```
* Multi-interface Forward Controller (#154 <https://github.com/ros-controls/ros2_controllers/issues/154>)
* Contributors: Denis Štogl
```

## force_torque_sensor_broadcaster

```
* updated to use node getter functions (#329 <https://github.com/ros-controls/ros2_controllers/issues/329>)
* Contributors: Bence Magyar, Denis Štogl, Jack Center
```

## forward_command_controller

```
* Multi-interface Forward Controller (#154 <https://github.com/ros-controls/ros2_controllers/issues/154>)
* updated to use node getter functions (#329 <https://github.com/ros-controls/ros2_controllers/issues/329>)
* Contributors: Bence Magyar, Denis Štogl, Jack Center
```

## gripper_controllers

```
* updated to use node getter functions (#329 <https://github.com/ros-controls/ros2_controllers/issues/329>)
* Contributors: Bence Magyar, Denis Štogl, Jack Center
```

## imu_sensor_broadcaster

```
* updated to use node getter functions (#329 <https://github.com/ros-controls/ros2_controllers/issues/329>)
* Contributors: Bence Magyar, Denis Štogl, Jack Center
```

## joint_state_broadcaster

```
* updated to use node getter functions (#329 <https://github.com/ros-controls/ros2_controllers/issues/329>)
* Contributors: Bence Magyar, Denis Štogl, Jack Center
```

## joint_trajectory_controller

```
* Fix a gtest deprecation warning (#341 <https://github.com/ros-controls/ros2_controllers/issues/341>)
* Delete unused variable in joint_traj_controller (#339 <https://github.com/ros-controls/ros2_controllers/issues/339>)
* updated to use node getter functions (#329 <https://github.com/ros-controls/ros2_controllers/issues/329>)
* Fix JTC state tolerance and goal_time tolerance check bug (#316 <https://github.com/ros-controls/ros2_controllers/issues/316>)
  * fix state tolerance check bug
  * hold position when canceling or aborting. update state tolerance test
  * add goal tolerance fail test
  * better state tolerance test
  * use predefined constants
  * fix goal_time logic and tests
  * add comments
* Contributors: Andy Zelenak, Jack Center, Michael Wiznitzer, Bence Magyar, Denis Štogl
```

## position_controllers

```
* Multi-interface Forward Controller (#154 <https://github.com/ros-controls/ros2_controllers/issues/154>)
* Contributors: Denis Štogl
```

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## velocity_controllers

```
* Multi-interface Forward Controller (#154 <https://github.com/ros-controls/ros2_controllers/issues/154>)
* Contributors: Denis Štogl
```
