### PR TITLE
example_interfaces: 0.10.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -832,7 +832,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/example_interfaces-release.git
-      version: 0.9.3-1
+      version: 0.10.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `example_interfaces` to `0.10.0-2`:

- upstream repository: https://github.com/ros2/example_interfaces.git
- release repository: https://github.com/ros2-gbp/example_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.9.3-1`

## example_interfaces

- No changes
