### PR TITLE
launch_ros: 0.20.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1602,7 +1602,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.19.2-1
+      version: 0.20.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.20.0-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.19.2-1`

## launch_ros

```
* Run condition for composable nodes (#311 <https://github.com/ros2/launch_ros/issues/311>)
* Contributors: Aditya Pande
```

## launch_testing_ros

```
* Fix long wait during shutdown in WaitForTopics (#314 <https://github.com/ros2/launch_ros/issues/314>)
* Contributors: Keng12
```

## ros2launch

- No changes
