### PR TITLE
libyaml_vendor: 1.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1676,7 +1676,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libyaml_vendor-release.git
-      version: 1.2.2-1
+      version: 1.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libyaml_vendor` to `1.3.0-1`:

- upstream repository: https://github.com/ros2/libyaml_vendor.git
- release repository: https://github.com/ros2-gbp/libyaml_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.2.2-1`

## libyaml_vendor

- No changes
