### PR TITLE
rclpy: 3.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2962,7 +2962,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 3.3.2-1
+      version: 3.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `3.4.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `3.3.2-1`

## rclpy

```
* remove feedback callback when the goal has been completed. (#927 <https://github.com/ros2/rclpy/issues/927>)
* Allow to create a subscription with a callback that also receives the message info (#922 <https://github.com/ros2/rclpy/issues/922>)
* Contributors: Ivan Santiago Paunovic, Tomoya Fujita
```
