### PR TITLE
ros_testing: 0.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3750,7 +3750,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_testing-release.git
-      version: 0.4.0-2
+      version: 0.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_testing` to `0.5.0-1`:

- upstream repository: https://github.com/ros2/ros_testing.git
- release repository: https://github.com/ros2-gbp/ros_testing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.4.0-2`

## ros2test

- No changes

## ros_testing

- No changes
