### PR TITLE
mrpt_navigation: 1.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5215,6 +5215,29 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
       version: ros1
     status: developed
+  mrpt_navigation:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
+      version: ros1
+    release:
+      packages:
+      - mrpt_local_obstacles
+      - mrpt_localization
+      - mrpt_map
+      - mrpt_navigation
+      - mrpt_rawlog
+      - mrpt_reactivenav2d
+      - mrpt_tutorials
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
+      version: ros1
+    status: developed
   mrt_cmake_modules:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `1.0.0-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## mrpt_local_obstacles

```
* Update URLs to https
* Update build dep to mrpt2
* Fix build against mrpt2
* Contributors: Jose Luis Blanco Claraco, Jose Luis Blanco-Claraco, Jose-Luis Blanco
```

## mrpt_localization

```
* Update URLs to https
* Update build dep to mrpt2
* Merge pull request #118 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/118> from mx-robotics/ag-remove_laser_tf_cache
  continuous laser pose update from tf tree fag added
* added ROS parameter continuous sensor pose update
* Fix incorrect publication of estimated pose (Closes: #117 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/117>)
* Contributors: Jose Luis Blanco Claraco, Markus Bader
```

## mrpt_map

```
* Update URLs to https
* Update build dep to mrpt2
* Contributors: Jose Luis Blanco Claraco
```

## mrpt_navigation

```
* Update URLs to https
* Contributors: Jose Luis Blanco Claraco
```

## mrpt_rawlog

```
* Update URLs to https
* Update build dep to mrpt2
* Merge pull request #126 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/126> from lukschwalb/master
  Fix incorrect class check
* Fix incorrect class name
* Merge pull request #119 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/119> from mx-robotics/develop
  rawlog_record: fnc call fileNameStripInvalidChars removed
* Contributors: Jose Luis Blanco Claraco, Markus Bader, Schwalb, Luk
```

## mrpt_reactivenav2d

```
* Update URLs to https
* Update build dep to mrpt2
* Contributors: Jose Luis Blanco Claraco
```

## mrpt_tutorials

- No changes
