### PR TITLE
imu_tools: 2.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1695,7 +1695,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/imu_tools-release.git
-      version: 2.0.0-2
+      version: 2.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `2.0.1-1`:

- upstream repository: https://github.com/CCNYRoboticsLab/imu_tools.git
- release repository: https://github.com/ros2-gbp/imu_tools-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.0.0-2`

## imu_complementary_filter

```
* complementary: Add missing dependency on geometry_msgs
* Contributors: Martin Günther
```

## imu_filter_madgwick

```
* Add missing test dependency
* Contributors: Martin Günther
```

## imu_tools

- No changes

## rviz_imu_plugin

- No changes
