### PR TITLE
imu_tools: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1392,6 +1392,27 @@ repositories:
       url: https://github.com/ros-perception/image_transport_plugins.git
       version: ros2
     status: maintained
+  imu_tools:
+    doc:
+      type: git
+      url: https://github.com/CCNYRoboticsLab/imu_tools.git
+      version: rolling
+    release:
+      packages:
+      - imu_complementary_filter
+      - imu_filter_madgwick
+      - imu_tools
+      - rviz_imu_plugin
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/imu_tools-release.git
+      version: 2.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/CCNYRoboticsLab/imu_tools.git
+      version: rolling
+    status: maintained
   interactive_markers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `2.1.0-1`:

- upstream repository: https://github.com/CCNYRoboticsLab/imu_tools.git
- release repository: https://github.com/ros2-gbp/imu_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## imu_complementary_filter

```
* complementary: Add missing dependency on geometry_msgs
* Contributors: Martin Günther
```

## imu_filter_madgwick

```
* Switch to non-deprecated hpp header
  The .h header became deprecated after galactic.
* Add missing test dependency
* Contributors: Martin Günther
```

## imu_tools

- No changes

## rviz_imu_plugin

- No changes
