### PR TITLE
simple_launch: 1.3.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4511,7 +4511,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/simple_launch-release.git
-      version: 1.2.1-3
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/oKermorgant/simple_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_launch` to `1.3.1-1`:

- upstream repository: https://github.com/oKermorgant/simple_launch.git
- release repository: https://github.com/ros2-gbp/simple_launch-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.2.1-3`

## simple_launch

```
* use underscores in setup.cfg
* typo in included_launch example
* Merge pull request #4 <https://github.com/oKermorgant/simple_launch/issues/4> from yushijinhun/patch-1
  Add package & executable parameter to container
* [readme] add doc for container.package
* Add package & executable param to container
  This allows the user to use a component container implementation
  other than component_container, such as component_container_isolated
  and component_container_mt.
* Contributors: Haowei Wen, Olivier Kermorgant
```
