### PR TITLE
Update foxy and galactic branches for variants

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6387,7 +6387,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/variants.git
-      version: master
+      version: foxy
     status: maintained
   velodyne:
     doc:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6373,7 +6373,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/variants.git
-      version: master
+      version: foxy
     release:
       packages:
       - desktop

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5666,7 +5666,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/variants.git
-      version: master
+      version: galactic
     status: maintained
   velodyne:
     doc:

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5652,7 +5652,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/variants.git
-      version: master
+      version: galactic
     release:
       packages:
       - desktop


### PR DESCRIPTION
Updating the branch for the variants repository: https://github.com/ros2/variants

I noticed that there are `foxy` and `galactic` branches on that repo and releases have been made from them, but `rosdistro` had not been updated yet. This means that  CI is being triggered for the wrong branches.

CC `variants` maintainer @nuclearsandwich 
