### PR TITLE
fogros2: 0.1.2-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -949,6 +949,15 @@ repositories:
       url: https://github.com/boschresearch/fmilibrary_vendor.git
       version: master
     status: maintained
+  fogros2:
+    release:
+      packages:
+      - fogros2
+      - fogros2_examples
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/fogros2-release.git
+      version: 0.1.2-2
   foonathan_memory_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `fogros2` to `0.1.2-2`:

- upstream repository: https://github.com/BerkeleyAutomation/FogROS2.git
- release repository: https://github.com/ros2-gbp/fogros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## fogros2

```
* removed unique name generator and fixed package.xml
```
