### PR TITLE
slider_publisher: 2.1.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4853,7 +4853,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/oKermorgant/slider_publisher-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/oKermorgant/slider_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `slider_publisher` to `2.1.1-1`:

- upstream repository: https://github.com/oKermorgant/slider_publisher.git
- release repository: https://github.com/oKermorgant/slider_publisher-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.1.0-1`

## slider_publisher

```
* underscores in setup.cfg
* Contributors: Olivier Kermorgant
```
