### PR TITLE
mrpt_bridge: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7206,7 +7206,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_bridge-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_bridge` to `1.0.1-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_bridge.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_bridge-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.0.0-1`

## mrpt_bridge

```
* Add License file
* Formatting fixes
* Update README.md
* Contributors: Jose Luis Blanco Claraco
```
