### PR TITLE
Add python3 google-auth-*-pip, python3-oauth2client

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6780,6 +6780,7 @@ python3-google-auth-httplib2:
   debian:
     '*': [python3-google-auth-httplib2]
     buster: null
+  fedora: [python3-google-auth-httplib2]
   opensuse: [python3-google-auth-httplib2]
   ubuntu:
     '*': [python3-google-auth-httplib2]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6789,6 +6789,7 @@ python3-google-auth-oauthlib:
   debian:
     '*': [python3-google-auth-oauthlib]
     buster: null
+  fedora: [python3-google-auth-oauthlib]
   rhel:
     '*': [python3-google-auth-oauthlib]
     '7': null

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6768,6 +6768,12 @@ python3-gnupg:
   openembedded: [python3-gnupg@meta-python]
   opensuse: [python3-python-gnupg]
   ubuntu: [python3-gnupg]
+python3-google-auth:
+  debian:
+    '*': null
+    bullseye:
+      packages: [python3-google-auth]
+  ubuntu: [python3-google-auth]
 python3-google-auth-pip:
   debian:
     pip:
@@ -6778,26 +6784,46 @@ python3-google-auth-pip:
   ubuntu:
     pip:
       packages: [google-auth]
-python3-google-auth-httplib2-pip:
+python3-google-auth-httplib2:
   debian:
-    pip:
-      packages: [google-auth-httplib2]
+    stretch:
+      pip:
+        packages: [google-auth-httplib2]
+    buster:
+      pip:
+        packages: [google-auth-httplib2]
+    bullseye:
+      packages: [python3-google-auth-httplib2]
   fedora:
     pip:
       packages: [google-auth-httplib2]
   ubuntu:
-    pip:
-      packages: [google-auth-httplib2]
-python3-google-auth-oauthlib-pip:
+    bionic:
+      pip:
+        packages: [google-auth-httplib2]
+    focal: [python3-google-auth-httplib2]
+    jammy: [python3-google-auth-httplib2]
+python3-google-auth-oauthlib:
   debian:
-    pip:
-      packages: [google-auth-oauthlib]
+    stretch:
+      pip:
+        packages: [google-auth-oauthlib]
+    buster:
+      pip:
+        packages: [google-auth-oauthlib]
+    bullseye:
+      packages: [python3-google-auth-oauthlib]
   fedora:
     pip:
       packages: [google-auth-oauthlib]
   ubuntu:
-    pip:
-      packages: [google-auth-oauthlib]
+    bionic:
+      pip:
+        packages: [google-auth-oauthlib]
+    focal:
+      pip:
+        packages: [google-auth-oauthlib]
+    jammy: [python3-google-auth-oauthlib]
 python3-google-cloud-pubsub-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6773,6 +6773,9 @@ python3-google-auth:
     '*': null
     bullseye:
       packages: [python3-google-auth]
+  fedora: [python3-google-auth]
+  opensuse: [python3-google-auth]
+  rhel: [python3-google-auth]
   ubuntu: [python3-google-auth]
 python3-google-auth-pip:
   debian:
@@ -6797,6 +6800,7 @@ python3-google-auth-httplib2:
   fedora:
     pip:
       packages: [google-auth-httplib2]
+  opensuse: [python3-google-auth-httplib2]
   ubuntu:
     bionic:
       pip:
@@ -6816,6 +6820,7 @@ python3-google-auth-oauthlib:
   fedora:
     pip:
       packages: [google-auth-oauthlib]
+  rhel: [python3-google-auth-oauthlib]
   ubuntu:
     bionic:
       pip:
@@ -7391,6 +7396,9 @@ python3-nxt-python-pip:
       packages: [nxt-python]
 python3-oauth2client:
   debian: [python3-oauth2client]
+  fedora: [python3-oauth2client]
+  rhel: [python3-oauth2client]
+  opensuse: [python3-oauth2client]
   ubuntu: [python3-oauth2client]
 python3-odrive-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6769,11 +6769,7 @@ python3-gnupg:
   opensuse: [python3-python-gnupg]
   ubuntu: [python3-gnupg]
 python3-google-auth:
-  debian:
-    '*': [python3-google-auth]
-    stretch:
-      pip:
-        packages: [google-auth]
+  debian: [python3-google-auth]
   fedora: [python3-google-auth]
   opensuse: [python3-google-auth]
   rhel:
@@ -6783,44 +6779,22 @@ python3-google-auth:
 python3-google-auth-httplib2:
   debian:
     '*': [python3-google-auth-httplib2]
-    buster:
-      pip:
-        packages: [google-auth-httplib2]
-    stretch:
-      pip:
-        packages: [google-auth-httplib2]
-  fedora:
-    pip:
-      packages: [google-auth-httplib2]
+    buster: null
   opensuse: [python3-google-auth-httplib2]
   ubuntu:
     '*': [python3-google-auth-httplib2]
-    bionic:
-      pip:
-        packages: [google-auth-httplib2]
+    bionic: null
 python3-google-auth-oauthlib:
   debian:
     '*': [python3-google-auth-oauthlib]
-    buster:
-      pip:
-        packages: [google-auth-oauthlib]
-    stretch:
-      pip:
-        packages: [google-auth-oauthlib]
-  fedora:
-    pip:
-      packages: [google-auth-oauthlib]
+    buster: null
   rhel:
     '*': [python3-google-auth-oauthlib]
     '7': null
   ubuntu:
     '*': [python3-google-auth-oauthlib]
-    bionic:
-      pip:
-        packages: [google-auth-oauthlib]
-    focal:
-      pip:
-        packages: [google-auth-oauthlib]
+    bionic: null
+    focal: null
 python3-google-cloud-pubsub-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6775,7 +6775,9 @@ python3-google-auth:
       packages: [python3-google-auth]
   fedora: [python3-google-auth]
   opensuse: [python3-google-auth]
-  rhel: [python3-google-auth]
+  rhel:
+    '*': [python3-google-auth]
+    '7': null
   ubuntu: [python3-google-auth]
 python3-google-auth-pip:
   debian:
@@ -6820,7 +6822,9 @@ python3-google-auth-oauthlib:
   fedora:
     pip:
       packages: [google-auth-oauthlib]
-  rhel: [python3-google-auth-oauthlib]
+  rhel:
+    '*': [python3-google-auth-oauthlib]
+    '7': null
   ubuntu:
     bionic:
       pip:
@@ -7397,7 +7401,9 @@ python3-nxt-python-pip:
 python3-oauth2client:
   debian: [python3-oauth2client]
   fedora: [python3-oauth2client]
-  rhel: [python3-oauth2client]
+  rhel:
+    '*': [python3-oauth2client]
+    '7': null
   opensuse: [python3-oauth2client]
   ubuntu: [python3-oauth2client]
 python3-odrive-pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6770,9 +6770,13 @@ python3-gnupg:
   ubuntu: [python3-gnupg]
 python3-google-auth:
   debian:
-    '*': null
-    bullseye:
-      packages: [python3-google-auth]
+    '*': [python3-google-auth]
+    buster:
+      pip:
+        packages: [google-auth]
+    stretch:
+      pip:
+        packages: [google-auth]
   fedora: [python3-google-auth]
   opensuse: [python3-google-auth]
   rhel:
@@ -6781,8 +6785,7 @@ python3-google-auth:
   ubuntu: [python3-google-auth]
 python3-google-auth-httplib2:
   debian:
-    bullseye:
-      packages: [python3-google-auth-httplib2]
+    '*': [python3-google-auth-httplib2]
     buster:
       pip:
         packages: [google-auth-httplib2]
@@ -6794,15 +6797,13 @@ python3-google-auth-httplib2:
       packages: [google-auth-httplib2]
   opensuse: [python3-google-auth-httplib2]
   ubuntu:
+    '*': [python3-google-auth-httplib2]
     bionic:
       pip:
         packages: [google-auth-httplib2]
-    focal: [python3-google-auth-httplib2]
-    jammy: [python3-google-auth-httplib2]
 python3-google-auth-oauthlib:
   debian:
-    bullseye:
-      packages: [python3-google-auth-oauthlib]
+    '*': [python3-google-auth-oauthlib]
     buster:
       pip:
         packages: [google-auth-oauthlib]
@@ -6816,23 +6817,13 @@ python3-google-auth-oauthlib:
     '*': [python3-google-auth-oauthlib]
     '7': null
   ubuntu:
+    '*': [python3-google-auth-oauthlib]
     bionic:
       pip:
         packages: [google-auth-oauthlib]
     focal:
       pip:
         packages: [google-auth-oauthlib]
-    jammy: [python3-google-auth-oauthlib]
-python3-google-auth-pip:
-  debian:
-    pip:
-      packages: [google-auth]
-  fedora:
-    pip:
-      packages: [google-auth]
-  ubuntu:
-    pip:
-      packages: [google-auth]
 python3-google-cloud-pubsub-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6771,9 +6771,6 @@ python3-gnupg:
 python3-google-auth:
   debian:
     '*': [python3-google-auth]
-    buster:
-      pip:
-        packages: [google-auth]
     stretch:
       pip:
         packages: [google-auth]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6779,26 +6779,16 @@ python3-google-auth:
     '*': [python3-google-auth]
     '7': null
   ubuntu: [python3-google-auth]
-python3-google-auth-pip:
-  debian:
-    pip:
-      packages: [google-auth]
-  fedora:
-    pip:
-      packages: [google-auth]
-  ubuntu:
-    pip:
-      packages: [google-auth]
 python3-google-auth-httplib2:
   debian:
-    stretch:
-      pip:
-        packages: [google-auth-httplib2]
+    bullseye:
+      packages: [python3-google-auth-httplib2]
     buster:
       pip:
         packages: [google-auth-httplib2]
-    bullseye:
-      packages: [python3-google-auth-httplib2]
+    stretch:
+      pip:
+        packages: [google-auth-httplib2]
   fedora:
     pip:
       packages: [google-auth-httplib2]
@@ -6811,14 +6801,14 @@ python3-google-auth-httplib2:
     jammy: [python3-google-auth-httplib2]
 python3-google-auth-oauthlib:
   debian:
-    stretch:
-      pip:
-        packages: [google-auth-oauthlib]
+    bullseye:
+      packages: [python3-google-auth-oauthlib]
     buster:
       pip:
         packages: [google-auth-oauthlib]
-    bullseye:
-      packages: [python3-google-auth-oauthlib]
+    stretch:
+      pip:
+        packages: [google-auth-oauthlib]
   fedora:
     pip:
       packages: [google-auth-oauthlib]
@@ -6833,6 +6823,16 @@ python3-google-auth-oauthlib:
       pip:
         packages: [google-auth-oauthlib]
     jammy: [python3-google-auth-oauthlib]
+python3-google-auth-pip:
+  debian:
+    pip:
+      packages: [google-auth]
+  fedora:
+    pip:
+      packages: [google-auth]
+  ubuntu:
+    pip:
+      packages: [google-auth]
 python3-google-cloud-pubsub-pip:
   debian:
     pip:
@@ -7401,10 +7401,10 @@ python3-nxt-python-pip:
 python3-oauth2client:
   debian: [python3-oauth2client]
   fedora: [python3-oauth2client]
+  opensuse: [python3-oauth2client]
   rhel:
     '*': [python3-oauth2client]
     '7': null
-  opensuse: [python3-oauth2client]
   ubuntu: [python3-oauth2client]
 python3-odrive-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6768,6 +6768,36 @@ python3-gnupg:
   openembedded: [python3-gnupg@meta-python]
   opensuse: [python3-python-gnupg]
   ubuntu: [python3-gnupg]
+python3-google-auth-pip:
+  debian:
+    pip:
+      packages: [google-auth]
+  fedora:
+    pip:
+      packages: [google-auth]
+  ubuntu:
+    pip:
+      packages: [google-auth]
+python3-google-auth-httplib2-pip:
+  debian:
+    pip:
+      packages: [google-auth-httplib2]
+  fedora:
+    pip:
+      packages: [google-auth-httplib2]
+  ubuntu:
+    pip:
+      packages: [google-auth-httplib2]
+python3-google-auth-oauthlib-pip:
+  debian:
+    pip:
+      packages: [google-auth-oauthlib]
+  fedora:
+    pip:
+      packages: [google-auth-oauthlib]
+  ubuntu:
+    pip:
+      packages: [google-auth-oauthlib]
 python3-google-cloud-pubsub-pip:
   debian:
     pip:
@@ -7333,6 +7363,9 @@ python3-nxt-python-pip:
   ubuntu:
     pip:
       packages: [nxt-python]
+python3-oauth2client:
+  debian: [python3-oauth2client]
+  ubuntu: [python3-oauth2client]
 python3-odrive-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:
- python3-google-auth-pip
- python3-google-auth-httplib2-pip
- python3-google-auth-oauthlib-pip
- python3-oauth2client

## Package Upstream Source:
- [google-auth](https://github.com/googleapis/google-auth-library-python)
- [google-auth-httplib2](https://github.com/googleapis/google-auth-library-python-httplib2)
- [google-auth-oauthlib](https://github.com/googleapis/google-auth-library-python-oauthlib)
- [oauth2client](https://github.com/googleapis/oauth2client)

## Purpose of using this:
For releasing https://github.com/jsk-ros-pkg/jsk_3rdparty/pull/323

## Links to Distribution Packages

- Debian: https://packages.debian.org/
- Ubuntu: https://packages.ubuntu.com/
  - oauth2client
    - https://packages.ubuntu.com/bionic/python3-oauth2client
    - https://packages.ubuntu.com/focal/python3-oauth2client
    - https://packages.ubuntu.com/jammy/python3-oauth2client
- pip: https://pypi.org/
   - https://pypi.org/project/google-auth/
   - https://pypi.org/project/google-auth-httplib2/
   - https://pypi.org/project/google-auth-oauthlib/
