### PR TITLE
dynamic_robot_state_publisher: 1.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1829,6 +1829,21 @@ repositories:
       url: https://github.com/ros/dynamic_reconfigure.git
       version: noetic-devel
     status: maintained
+  dynamic_robot_state_publisher:
+    doc:
+      type: git
+      url: https://github.com/peci1/dynamic_robot_state_publisher.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/peci1/dynamic_robot_state_publisher-release.git
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://github.com/peci1/dynamic_robot_state_publisher.git
+      version: master
+    status: maintained
   dynamixel-workbench:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_robot_state_publisher` to `1.2.0-1`:

- upstream repository: https://github.com/peci1/dynamic_robot_state_publisher.git
- release repository: https://github.com/peci1/dynamic_robot_state_publisher-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## dynamic_robot_state_publisher

```
* Added Noetic support (thanks @Kokjix).
* Contributors: Martin Pecka, Baran Berk Bağcı
```
