### PR TITLE
ros2can: 0.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7739,6 +7739,22 @@ repositories:
       url: https://github.com/ros/ros.git
       version: noetic-devel
     status: maintained
+  ros2can:
+    doc:
+      type: git
+      url: https://github.com/febu1300/roscan-documentation.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: ' https://github.com/febu1300/ros2can.git'
+      version: 0.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/febu1300/ros2can.git
+      version: 0.0.1
+    status: developed
   ros_babel_fish:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2can` to `0.0.1-1`:

- upstream repository: https://github.com/febu1300/ros2can.git
- release repository:  https://github.com/febu1300/ros2can.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## ros2can

```
* release created
* second commit
* first commit
* Contributors: febu1300
```
