### PR TITLE
septentrio_gnss_driver: 1.1.0-7 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9359,7 +9359,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/septentrio-users/septentrio_gnss_driver-release.git
-      version: 1.1.0-6
+      version: 1.1.0-7
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `septentrio_gnss_driver` to `1.1.0-7`:

- upstream repository: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
- release repository: https://github.com/septentrio-users/septentrio_gnss_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.1.0-6`

## septentrio_gnss_driver

```
* New Features
  
  Add option to use ROS axis orientations according to REP103
  
  Add frame_id parameters
  
  Add option to get frames from tf
  
  Publishing of cartesian localization in UTM (topic and/or tf) for INS
  
  Publishing of IMU topic for INS
  
  Publishing of MeasEpoch
  
  ROS2 branch
* Improvements
  
  Add multi antenna option
  
  Increase number of SBF streams
  
  Add option to set polling_period to "on change"
  
  Increased buffer size from 8192 to 131072 bytes
  
  Add endianess aware parsers
  
  Only publish topics set to true
  
  Add parameter to switch DEBUG logging on and off
  
  Change GPxxx messages to ROS built-in types
  
  Remove duplicate INS msg types
* Fixes
  
  Setting of antenna type
  
  Publishing rate interconnections of gpsfix and velcovgeodetic
  
  Missing quotes for antenna type
  
  Broken attitude parsing pose and gpsfix from INS
  
  IMU orientation was not sent to Rx
  
  Graceful shutdown of threads
* Commits
  
  Merge branch 'dev'
  
  Prepare new release
  
  Prepare new release
  
  Merge pull request #53 from thomasemter/dev/refactor
  Very last changes
  
  Add geographic lib dependency to package.xml
  
  Add comment for frame of main antenna
  
  Move utm zone locking section in readme
  
  Reformulate readme section on frames
  
  Merge pull request #52 from thomasemter/dev/refactor
  Last changes
  
  Change frame id back to poi_frame_id
  
  Make error log more explicit
  
  Merge pull request #49 from thomasemter/dev/refactor
  Improve IMU blocks sync and do-not-use value handling
  
  Fix buffer size in changelog
  
  Turn off Nagle's algorithm for TCP
  
  Fix changelog formatting
  
  Fix readme
  
  Set default base frame to base_link
  
  Fix valid tow check logic
  
  Increase buffer size for extreme stress tests
  
  Fix crc check
  
  Fix and streamline tf handling
  
  Add checks for validity of values
  
  Fix rad vs deg
  
  Update changelog
  
  Add some comments
  
  Set stdDevMask to values > 0.0 in node
  
  Set stdDevMask to values > 0.0
  
  Add info on RNDIS and set it to default
  
  Increase default serial baud rate
  
  Add parameter to set log level to debug
  
  Change defaults for publishers in node
  
  Put publish params together and fix mismatch in readme
  
  Improve IMU blocks sync and do-not-use value handling
  
  Merge pull request #48 from thomasemter/dev/refactor
  Fix measepoch not publishing without gpsfix
  
  Fix measepoch not publishing without gpsfix
  
  Merge pull request #47 from thomasemter/dev/refactor
  Dev/refactor
  
  Publish only messages set to true
  
  Remove leftover declaration
  
  Merge branch 'dev/endianess_agnostic' into dev/refactor
  
  Update readme to reflect endianess aware parsing
  
  Remove msg smart pointers
  
  Fix array assertion failure
  
  Cleanup
  
  Add ReceiverStatus parser
  
  Add QualityInd parser
  
  Add DOP parser
  
  Add ReceiverSetup parser
  
  Fix MeasEpoch and ChannelStatus parsers, add measepoch publishing
  
  Add ChannelStatus parser
  
  Add MeasEpoch parser
  
  Add IMU and VelSensor setup parsers
  
  Add Cov SBF parsers
  
  Add templated qi parser function
  
  Add AttEuler+Cov parser
  
  Revert ordering change inside INSNav ROS msgs
  
  Add ExtSensorMeas parser
  
  Add PVT parsers
  
  Add range checks to parsers
  
  Replace INSNav grammar with parsers
  
  Test parser vs. grammar for better performance
  
  Fix sb_list check
  
  Add IMU and VelSensor setup grammars
  
  Move adapt ROS header to typedefs.h
  
  Add revision check to MeasEpoch
  
  Fix ReceiverStatus grammar
  
  Extend ReceiverSetup and add revision checks
  
  Change logger and fix loop range
  
  Remove reserved bytes from parsing
  
  Remove obsolete structs
  
  Directly parse Cov SBFs to ROS msg
  
  Directly parse PVT SBFs, remove obsolete ids
  
  Rename rev to revision
  
  Fix block header parsing
  
  Directly parse AttEuler to ROS msg
  
  Directly parse to ROS msgs for INSNavXxx
  
  Exchange pow with square function and remove casts
  
  Merge pull request #46 from thomasemter/dev/refactor
  Dev/refactor
  
  Simplify sync bytes check
  
  Move tow/wnc to BlockHeader
  
  Adjust order in INSNav ros msgs
  
  Fix INSNav grammars
  
  Change BlockHeader structure
  
  Remove length ref from header
  
  Rectify sb_list check of INSNavXxx
  
  Add automtatic activation of multi-antenna mode
  
  Merge branch 'dev/refactor' of https://github.com/thomasemter/septentrio_gnss_driver into dev/refactor
  
  Add automtatic activation of multi-antenna mode
  
  Fix wrong scope of phoenix::ref variables
  
  Fix AttEuler grammar
  
  Add max size checks to QualityInd and ReceiverStatus
  
  Replace locals with phoenix::ref in grammars
  
  Add revision dependent parsing to PVTs
  
  Change offset check to epsilon
  
  Change offset check to epsilon
  
  Fix parsing checks
  
  Set has arrived to false on parsing error
  
  Add INSNav grammars
  
  Add abs to offset check
  
  Add abs to offset check
  
  Add Cov grammars
  
  Remove superfluous typdefs of structs
  
  Add ReceiverStatus grammar
  
  Add QualityINd grammar
  
  Merge pull request #45 from thomasemter/dev/refactor
  Dev/refactor
  
  Add id check to header grammar
  
  Add id check to header grammar
  
  Add ReceiverSetup grammar
  
  Add DOP grammar
  
  Directly intialize vector to parse
  
  Add MeasEpoch grammar
  
  Remove duplicate msg types
  
  Remove obsolete include
  
  Add revision and length return to header grammar
  
  Merge branch 'feature/endianess_agnostic' into dev/endianess_agnostic
  
  Make multi_antenna option also usable for gnss
  
  Add typedefs plus some minor changes
  
  Add warning concerning pitch angle if antennas are rotated
  
  Add multi antenna option to ins and fix antenna offset decimal places trimming
  
  Fix identation
  
  Distinguish between gnss and ins for spatial config from tf
  
  Merge pull request #43 from thomasemter/dev/refactor
  Dev/refactor
  
  Add vehicle frame for clarity
  
  Handle missing tf more gently
  
  Merge branch 'dev/spatial_config_via_tf' into dev/refactor
  
  Update readme
  
  Fix antenna offset from tf
  
  Add automatic publishing of localization if tf is activated
  
  Add automatic publishing of localization if tf is activated
  
  Add spatial config via tf, to be tested
  
  Fix crashes due to parsing errors (replacing uncatched throws)
  
  Add tf broadcasting
  
  Add comments
  
  Add localization in UTM output
  
  Add check to IMU msg sync
  
  Change msg sync to allow for 200 Hz IMU msgs
  
  Add ROS IMU msg
  
  Fix IMU setup message attitude conversion
  
  Fix pose from INS data
  
  Fix IMU raw data rotation compensation
  
  Make antenna attitude offset usable by GNSS
  
  Add ros directions option to pose and fix covariances
  
  Update readme
  
  Merge branch 'feature/ros_axis_orientation' into dev/refactor
  
  Add nmea_msgs dependencies
  
  Merge branch 'dev/nmea' into dev/refactor
  
  Update readme
  
  Update readme
  
  Add antenna offsets to conversions
  
  Fix IMU orientation conversion
  
  Change ExtSensorMead temperature to deg C
  
  Add axis orientation info to readme
  
  Fix IMU axis orientation
  
  Change get int param
  
  Update readme to reflect removal of aux antenna offset
  
  Fix different antenna setup message for INS and remove obsolete aux1 antenna offset for GNSS
  
  Fix ExtSensorMeas message filling
  
  Fix ExtSensorMeas message to reflect available fields
  
  Fix missing INS blocks
  
  Fix missing INS blocks
  
  WIP, introduce ros axis orientation option, to be tested
  
  Add option to set pvt rate to OnChange
  
  Add comment on NTP to readme
  
  Change to nmea_msgs
  
  Add automatic addition of needed sub messages
  
  Comment out setting debug level
  
  Add comments and fix spelling errors
  
  Merge pull request #42 from thomasemter/dev/refactor
  Dev/refactor
  
  Change to quaternion msg typedef
  
  Comment out debug logging
  
  Remove filling of seq field
  
  Change msg definitions to be compatible with ROS2
  
  Update readme
  
  Change make_shared for portability and add more typedefs
  
  Add get param int fallback for numeric antenna serial numbers
  
  Change Attitude to be published with pvt rate
  
  Add log identifier
  
  Add checks for relevant ros params
  
  Concatenate multiple SBF blocks in streams
  
  Move main into own file
  
  Move get ros time to AsyncManager
  
  Remove obsolete param comment
  
  Move get ros params to base class
  
  Change to nsec timestamp internally
  
  Add publishing functionality to node base class
  
  Move node handle ptr and functions to base class and rename
  
  Add stamp to nmea parsing
  
  Add logging in PcapReader
  
  Add logging in CircularBuffer
  
  Add missed logging
  
  Add logging in AsyncManager
  
  Add getTime function
  
  Add logging in RxMessage
  
  Add logging in CallbackHandlers
  
  Add log function to node by polymorphism, logging in Comm_OI
  
  Fix wait function and force use_gnss_time when reading from file
  
  Add thread shutdown and remove spurious delete
  
  Add typedefs for ins messages
  
  Add typedefs for gnss messages
  
  Add typedefs for ros messages
  
  Refine shutdown
  
  Fix shutdown escalating to SIGTERM
  
  Move waiting for response in send function
  
  Make functions private
  
  Change crc to C++
  
  Fix variable name
  
  Remove global variables from node cpp file
  
  Move more global settings to settings struct
  
  Move more global settings to settings struct
  
  Move global settings to settings struct
  
  Move more functions to Comm_IO
  
  Move settings to struct and configuration to Comm_IO
  
  Merge branch 'dev/change_utc_calculation' into dev/refactor
  
  Remove obsolete global variables
  
  Move g_unix_time to class
  
  Make has_arrived booleans class memebers and rx_message a persistent class
  
  Make node handle a class member
  
  Fix parsing of ID and rev
  
  Finish ChannelStatusGrammar, to be tested
  
  WIP, partially fix ChannelStatusGrammar
  
  Add SBF length parsing utility
  
  Insert spirit parsers
  
  WIP, add omission of padding bytes
  
  WIP, add more spirit parsers
  
  Add parsing utilities for tow, wnc and ID
  
  Move getId/Tow/Wnc to parsing utilities
  
  Change UTC calculation to use tow and wnc
  
  WIP, add boost spirit and endian buffers
  
  Change UTC calculation to use tow and wnc
* Update Readme and Changelog
* Contributors: Thomas Emter, Tibor Dome
```
