### PR TITLE
turtlebot4: 0.1.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5319,6 +5319,26 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
       version: galactic-devel
     status: developed
+  turtlebot4:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4.git
+      version: galactic
+    release:
+      packages:
+      - turtlebot4_description
+      - turtlebot4_msgs
+      - turtlebot4_navigation
+      - turtlebot4_node
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot4-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4.git
+      version: galactic
+    status: developed
   turtlesim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4` to `0.1.0-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4.git
- release repository: https://github.com/ros2-gbp/turtlebot4-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## turtlebot4_description

```
* First Galactic release
* Contributors: Roni Kreinin
```

## turtlebot4_msgs

```
* First Galactic release
* Contributors: Roni Kreinin
```

## turtlebot4_navigation

```
* First Galactic release
* Contributors: Roni Kreinin
```

## turtlebot4_node

```
* First Galactic release
* Contributors: Roni Kreinin, ahcorde
```
