### PR TITLE
Remove orocos_kinematics_dynamics from Rolling and Humble.

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2360,24 +2360,6 @@ repositories:
       url: https://github.com/ros2/orocos_kdl_vendor.git
       version: humble
     status: developed
-  orocos_kinematics_dynamics:
-    doc:
-      type: git
-      url: https://github.com/ros2/orocos_kinematics_dynamics.git
-      version: ros2
-    release:
-      packages:
-      - orocos_kdl
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/ros2-gbp/orocos_kinematics_dynamics-release.git
-      version: 3.3.3-3
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/ros2/orocos_kinematics_dynamics.git
-      version: ros2
-    status: maintained
   osqp_vendor:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2391,24 +2391,6 @@ repositories:
       url: https://github.com/ros2/orocos_kdl_vendor.git
       version: main
     status: developed
-  orocos_kinematics_dynamics:
-    doc:
-      type: git
-      url: https://github.com/ros2/orocos_kinematics_dynamics.git
-      version: ros2
-    release:
-      packages:
-      - orocos_kdl
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/orocos_kinematics_dynamics-release.git
-      version: 3.3.3-2
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/ros2/orocos_kinematics_dynamics.git
-      version: ros2
-    status: maintained
   osqp_vendor:
     doc:
       type: git


### PR DESCRIPTION
It has been superceded by orocos_kdl_vendor.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>