### PR TITLE
rmw: 6.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3358,7 +3358,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 6.2.0-1
+      version: 6.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw` to `6.3.0-1`:

- upstream repository: https://github.com/ros2/rmw.git
- release repository: https://github.com/ros2-gbp/rmw-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `6.2.0-1`

## rmw

```
* Add 'best available' QoS policies (#320 <https://github.com/ros2/rmw/issues/320>)
  The best available policy should select the highest level of service for the QoS setting while matching with the majority of endpoints.
  For example, in the case of a DDS middleware subscription, this means:
  * Prefer reliable reliability if all existing publishers on the same topic are reliable, otherwise use best effort.
  * Prefer transient local durability if all existing publishers on the same topic are transient local, otherwise use volatile.
  * Prefer manual by topic liveliness if all existing publishers on the same topic are manual by topic, otherwise use automatic.
  * Use a deadline that is equal to the largest deadline of existing publishers on the same topic.
  * Use a liveliness lease duration that is equal to the largest lease duration of existing publishers on the same topic.
* Contributors: Jacob Perron
```

## rmw_implementation_cmake

- No changes
