### PR TITLE
rmw_dds_common: 1.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3411,7 +3411,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_dds_common-release.git
-      version: 1.6.0-1
+      version: 1.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_dds_common` to `1.7.0-1`:

- upstream repository: https://github.com/ros2/rmw_dds_common.git
- release repository: https://github.com/ros2-gbp/rmw_dds_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.6.0-1`

## rmw_dds_common

```
* Add functions for resolving 'best available' QoS policies (#60 <https://github.com/ros2/rmw_dds_common/issues/60>)
  Given a QoS profile and set of endpoints for the same topic, overwrite any policies set to
  BEST_AVAILABLE with a policy such that it matches all endpoints while maintaining a high
  level of service.
  Add testable functions for updating BEST_AVAILABLE policies,
  * qos_profile_get_best_available_for_subscription
  * qos_profile_get_best_available_for_publisher
  and add convenience functions that actual query the graph for RMW implementations to use,
  * qos_profile_get_best_available_for_topic_subscription
  * qos_profile_get_best_available_for_topic_publisher
* Contributors: Jacob Perron
```
