### PR TITLE
rmw_connextdds: 0.12.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3378,7 +3378,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 0.11.0-1
+      version: 0.12.0-1
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `0.12.0-1`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.11.0-1`

## rmw_connextdds

```
* Switch ROS2 -> ROS 2 everywhere (#83 <https://github.com/ros2/rmw_connextdds/issues/83>)
* Contributors: Chris Lalancette
```

## rmw_connextdds_common

```
* Handle 'best_available' QoS policies in common  (#85 <https://github.com/ros2/rmw_connextdds/issues/85>)
* Contributors: Jose Luis Rivero
```

## rti_connext_dds_cmake_module

- No changes
