### PR TITLE
turtlebot4_desktop: 0.1.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5339,6 +5339,24 @@ repositories:
       url: https://github.com/turtlebot/turtlebot4.git
       version: galactic
     status: developed
+  turtlebot4_desktop:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4_desktop.git
+      version: galactic
+    release:
+      packages:
+      - turtlebot4_desktop
+      - turtlebot4_viz
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot4_desktop-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4_desktop.git
+      version: galactic
+    status: developed
   turtlesim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4_desktop` to `0.1.0-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4_desktop.git
- release repository: https://github.com/ros2-gbp/turtlebot4_desktop-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## turtlebot4_desktop

```
* First Galactic release
* Contributors: Roni Kreinin
```

## turtlebot4_viz

```
* First Galactic release
* Contributors: Roni Kreinin
```
