### PR TITLE
rclcpp: 16.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2978,7 +2978,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 16.1.0-1
+      version: 16.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `16.2.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `16.1.0-1`

## rclcpp

```
* Update get_parameter_from_event to follow the function description (#1922 <https://github.com/ros2/rclcpp/issues/1922>)
* Add 'best available' QoS enum values and methods (#1920 <https://github.com/ros2/rclcpp/issues/1920>)
* Contributors: Barry Xu, Jacob Perron
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
