### PR TITLE
rclpy: 3.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2994,7 +2994,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 3.4.0-1
+      version: 3.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `3.5.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `3.4.0-1`

## rclpy

```
* Avoid causing infinite loop when message is empty (#935 <https://github.com/ros2/rclpy/issues/935>)
* Expose 'best available' QoS policies (#928 <https://github.com/ros2/rclpy/issues/928>)
* Contributors: Jacob Perron, Takeshi Ishita
```
