### PR TITLE
ros2_ouster_drivers: 0.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3559,7 +3559,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_ouster_drivers-release.git
-      version: 0.3.0-2
+      version: 0.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_ouster_drivers` to `0.4.0-1`:

- upstream repository: https://github.com/SteveMacenski/ros2_ouster_drivers.git
- release repository: https://github.com/ros2-gbp/ros2_ouster_drivers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.3.0-2`
