### PR TITLE
Update branches for tracetools_analysis @ humble & galactic

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5227,7 +5227,7 @@ repositories:
     doc:
       type: git
       url: https://gitlab.com/ros-tracing/tracetools_analysis.git
-      version: foxy
+      version: galactic
     release:
       packages:
       - ros2trace_analysis
@@ -5239,7 +5239,7 @@ repositories:
     source:
       type: git
       url: https://gitlab.com/ros-tracing/tracetools_analysis.git
-      version: foxy
+      version: galactic
     status: developed
   transport_drivers:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4901,7 +4901,7 @@ repositories:
     doc:
       type: git
       url: https://gitlab.com/ros-tracing/tracetools_analysis.git
-      version: master
+      version: humble
     release:
       packages:
       - ros2trace_analysis
@@ -4913,7 +4913,7 @@ repositories:
     source:
       type: git
       url: https://gitlab.com/ros-tracing/tracetools_analysis.git
-      version: master
+      version: humble
     status: developed
   transport_drivers:
     doc:


### PR DESCRIPTION
I've made the corresponding changes in the release repository: https://github.com/ros2-gbp/tracetools_analysis-release/commit/827582e3b312467774e1f6a43b1b7b9f495b4596

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>