### PR TITLE
hri_msgs: 0.5.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4454,7 +4454,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros4hri/hri_msgs-release.git
-      version: 0.4.1-1
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/ros4hri/hri_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hri_msgs` to `0.5.2-1`:

- upstream repository: https://github.com/ros4hri/hri_msgs.git
- release repository: https://github.com/ros4hri/hri_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.4.1-1`

## hri_msgs

Since 0.4.1:

```
0.5.2 (2022-05-04)
------------------
* omitted to update CMakeLists
* Contributors: Séverin Lemaignan

0.5.1 (2022-05-04)
------------------
* add more info about the EngagementLevel msg
* Contributors: antonioandriella

0.5.0 (2022-05-02)
------------------
* add social engagement msg with 5 discrete levels
* add confidence to Expression message
* update README
* Contributors: Séverin Lemaignan
```