### PR TITLE
Add libtool system dependency for ubuntu jammy

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5219,6 +5219,7 @@ libtool:
     artful: [libtool, libltdl-dev, libtool-bin]
     bionic: [libtool, libltdl-dev, libtool-bin]
     focal: [libtool, libltdl-dev, libtool-bin]
+    jammy: [libtool, libltdl-dev, libtool-bin]
     lucid: [libtool, libltdl-dev]
     maverick: [libtool, libltdl-dev]
     natty: [libtool, libltdl-dev]


### PR DESCRIPTION
Signed-off-by: Christoph Hellmann Santos <christoph.hellmann.santos@ipa.fraunhofer.de>

<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

libtool

## Package Upstream Source:
https://savannah.gnu.org/git/?group=libtool


## Purpose of using this:

This dependency is being used for ros2_canopen and many other packages and is necessary for humble and rolling. This is why I think it's valuable to be added to the rosdep database. 

[ros2_canopen](https://github.com/ros-industrial/ros2_canopen)

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - already in rosdistro
- Ubuntu: https://packages.ubuntu.com/
    libtool - jammy: [link](https://packages.ubuntu.com/jammy/libtool)
    libltdl-dev - jammy: [link](https://packages.ubuntu.com/jammy/libltdl-dev)
    libtool-bin - jammy: [link](https://packages.ubuntu.com/jammy/libtool-bin)



