### PR TITLE
ros2_planning_system: 2.0.8-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3751,7 +3751,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release.git
-      version: 2.0.7-1
+      version: 2.0.8-1
     source:
       type: git
       url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_planning_system` to `2.0.8-1`:

- upstream repository: https://github.com/IntelligentRoboticsLabs/ros2_planning_system.git
- release repository: https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.7-1`

## plansys2_bringup

- No changes

## plansys2_bt_actions

- No changes

## plansys2_core

```
* Add missing dependency
* Contributors: Francisco Martín Rico
```

## plansys2_domain_expert

- No changes

## plansys2_executor

- No changes

## plansys2_lifecycle_manager

- No changes

## plansys2_msgs

- No changes

## plansys2_pddl_parser

```
* Add missing dependency
* Contributors: Francisco Martín Rico
* Add missing dependency
* Contributors: Francisco Martín Rico
```

## plansys2_planner

- No changes

## plansys2_popf_plan_solver

- No changes

## plansys2_problem_expert

- No changes

## plansys2_terminal

- No changes

## plansys2_tools

```
* Add missing dependency
* Contributors: Francisco Martín Rico
```
