### PR TITLE
turtlebot4_simulator: 0.1.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5357,6 +5357,26 @@ repositories:
       url: https://github.com/turtlebot/turtlebot4_desktop.git
       version: galactic
     status: developed
+  turtlebot4_simulator:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4_simulator.git
+      version: galactic
+    release:
+      packages:
+      - turtlebot4_ignition_bringup
+      - turtlebot4_ignition_gui_plugins
+      - turtlebot4_ignition_toolbox
+      - turtlebot4_simulator
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot4_simulator-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4_simulator.git
+      version: galactic
+    status: developed
   turtlesim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4_simulator` to `0.1.0-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4_simulator.git
- release repository: https://github.com/ros2-gbp/turtlebot4_simulator-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## turtlebot4_ignition_bringup

```
* First Galactic release
* Contributors: Katherine Scott, Roni Kreinin
```

## turtlebot4_ignition_gui_plugins

```
* First Galactic release
* Contributors: Roni Kreinin
```

## turtlebot4_ignition_toolbox

```
* First Galactic release
* Contributors: Roni Kreinin
```

## turtlebot4_simulator

```
* First Galactic release
* Contributors: Roni Kreinin
```
