### PR TITLE
rosidl_runtime_py: 0.10.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3981,7 +3981,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
-      version: 0.9.2-1
+      version: 0.10.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_runtime_py` to `0.10.0-1`:

- upstream repository: https://github.com/ros2/rosidl_runtime_py.git
- release repository: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.9.2-1`

## rosidl_runtime_py

- No changes
