### PR TITLE
tinyxml_vendor: 0.9.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4877,7 +4877,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tinyxml_vendor-release.git
-      version: 0.8.3-1
+      version: 0.9.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tinyxml_vendor` to `0.9.0-1`:

- upstream repository: https://github.com/ros2/tinyxml_vendor.git
- release repository: https://github.com/ros2-gbp/tinyxml_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.8.3-1`
