### PR TITLE
urdf: 2.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5182,7 +5182,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdf-release.git
-      version: 2.6.0-1
+      version: 2.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf` to `2.7.0-1`:

- upstream repository: https://github.com/ros2/urdf.git
- release repository: https://github.com/ros2-gbp/urdf-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.6.0-1`

## urdf

- No changes

## urdf_parser_plugin

- No changes
