### PR TITLE
Renaming galactic branch for robot_localization

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3604,7 +3604,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/cra-ros-pkg/robot_localization.git
-      version: galactic
+      version: galactic-devel
     release:
       tags:
         release: release/galactic/{package}/{version}


### PR DESCRIPTION
Apologies for not using a template, but this PR doesn't conform to the use cases assumed by them. I am just renaming the `doc` branch for `robot_localization`.

https://github.com/cra-ros-pkg/robot_localization/tree/galactic-devel