### PR TITLE
create3_sim: 1.0.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -623,7 +623,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/create3_sim-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/iRobotEducation/create3_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `create3_sim` to `1.0.2-1`:

- upstream repository: https://github.com/iRobotEducation/create3_sim.git
- release repository: https://github.com/ros2-gbp/create3_sim-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.0.1-1`

## irobot_create_common_bringup

```
* update changelog
* Contributors: Alberto Soragna
```

## irobot_create_control

```
* fix dependency tree of create3_sim packages (#177 <https://github.com/iRobotEducation/create3_sim/issues/177>)
* update changelog
* remove minimum version requirement
* Contributors: Alberto Soragna
```

## irobot_create_description

```
* fix dependency tree of create3_sim packages (#177 <https://github.com/iRobotEducation/create3_sim/issues/177>)
* update changelog
* Contributors: Alberto Soragna
```

## irobot_create_gazebo_bringup

```
* fix dependency tree of create3_sim packages (#177 <https://github.com/iRobotEducation/create3_sim/issues/177>)
* fix setting environment variable GAZEBO_MODEL_PATH for aws models (#174 <https://github.com/iRobotEducation/create3_sim/issues/174>)
* 1.0.1
* update changelog
* Contributors: Alberto Soragna, crthilakraj
```

## irobot_create_gazebo_plugins

```
* update changelog
* Contributors: Alberto Soragna
```

## irobot_create_gazebo_sim

```
* fix dependency tree of create3_sim packages (#177 <https://github.com/iRobotEducation/create3_sim/issues/177>)
* 1.0.1
* update changelog
* Contributors: Alberto Soragna
```

## irobot_create_ignition_bringup

```
* fix dependency tree of create3_sim packages (#177 <https://github.com/iRobotEducation/create3_sim/issues/177>)
* update changelog
* Contributors: Alberto Soragna
```

## irobot_create_ignition_plugins

```
* 1.0.1
* update changelog
* Contributors: Alberto Soragna
```

## irobot_create_ignition_sim

```
* fix dependency tree of create3_sim packages (#177 <https://github.com/iRobotEducation/create3_sim/issues/177>)
* update changelog
* Contributors: Alberto Soragna
```

## irobot_create_ignition_toolbox

```
* Renamed Ignition Toolbox libraries (#178 <https://github.com/iRobotEducation/create3_sim/issues/178>)
  * Renamed Ignition Toolbox libraries
  * Pre-pend library names with irobot_create_ignition
* update changelog
* Contributors: Alberto Soragna, roni-kreinin
```

## irobot_create_nodes

```
* update changelog
* Contributors: Alberto Soragna
```

## irobot_create_toolbox

```
* update changelog
* Contributors: Alberto Soragna
```
