### PR TITLE
Remove rqt_top from Rolling and Humble.

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4390,21 +4390,6 @@ repositories:
       url: https://github.com/ros-visualization/rqt_srv.git
       version: humble
     status: maintained
-  rqt_top:
-    doc:
-      type: git
-      url: https://github.com/ros-visualization/rqt_top.git
-      version: humble
-    release:
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/ros2-gbp/rqt_top-release.git
-      version: 1.0.2-3
-    source:
-      type: git
-      url: https://github.com/ros-visualization/rqt_top.git
-      version: humble
-    status: maintained
   rqt_topic:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4426,21 +4426,6 @@ repositories:
       url: https://github.com/ros-visualization/rqt_srv.git
       version: crystal-devel
     status: maintained
-  rqt_top:
-    doc:
-      type: git
-      url: https://github.com/ros-visualization/rqt_top.git
-      version: crystal-devel
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/rqt_top-release.git
-      version: 1.0.2-2
-    source:
-      type: git
-      url: https://github.com/ros-visualization/rqt_top.git
-      version: crystal-devel
-    status: maintained
   rqt_topic:
     doc:
       type: git


### PR DESCRIPTION
It currently isn't useful, so there is no reason to release it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>