### PR TITLE
create3_sim: 1.0.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -623,7 +623,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/create3_sim-release.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/iRobotEducation/create3_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `create3_sim` to `1.0.3-1`:

- upstream repository: https://github.com/iRobotEducation/create3_sim.git
- release repository: https://github.com/ros2-gbp/create3_sim-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.0.2-1`

## irobot_create_common_bringup

- No changes

## irobot_create_control

- No changes

## irobot_create_description

- No changes

## irobot_create_gazebo_bringup

```
* make gazebo classic and ignition build time dependency if they are needed by CMakeLists.txt (#179 <https://github.com/iRobotEducation/create3_sim/issues/179>)
* Contributors: Alberto Soragna
```

## irobot_create_gazebo_plugins

- No changes

## irobot_create_gazebo_sim

- No changes

## irobot_create_ignition_bringup

```
* make gazebo classic and ignition build time dependency if they are needed by CMakeLists.txt (#179 <https://github.com/iRobotEducation/create3_sim/issues/179>)
* Contributors: Alberto Soragna
```

## irobot_create_ignition_plugins

```
* make gazebo classic and ignition build time dependency if they are needed by CMakeLists.txt (#179 <https://github.com/iRobotEducation/create3_sim/issues/179>)
* Contributors: Alberto Soragna
```

## irobot_create_ignition_sim

- No changes

## irobot_create_ignition_toolbox

- No changes

## irobot_create_nodes

- No changes

## irobot_create_toolbox

- No changes
