### PR TITLE
mocap_nokov:0.0.1-1 in in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4941,6 +4941,21 @@ repositories:
       url: https://github.com/nobleo/mobile_robot_simulator.git
       version: master
     status: maintained
+  mocap_nokov:
+    doc:
+      type: git
+      url: https://github.com/NOKOV-MOCAP/mocap_nokov.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/NOKOV-MOCAP/mocap_nokov_release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/NOKOV-MOCAP/mocap_nokov.git
+      version: master
+    status: developed
   mocap_optitrack:
     doc:
       type: git


### PR DESCRIPTION
upstream repository: https://github.com/NOKOV-MOCAP/mocap_nokov.git
release repository: https://github.com/NOKOV-MOCAP/mocap_nokov_release.git
distro file: noetic/distribution.yaml
bloom version: 0.11.1
previous version for package: null
