### PR TITLE
care-o-bot: 0.7.8-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -600,6 +600,25 @@ repositories:
       url: https://github.com/osrf/capabilities.git
       version: master
     status: maintained
+  care-o-bot:
+    doc:
+      type: git
+      url: https://github.com/ipa320/care-o-bot.git
+      version: kinetic_release_candidate
+    release:
+      packages:
+      - care_o_bot
+      - care_o_bot_robot
+      - care_o_bot_simulation
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ipa320/care-o-bot-release.git
+      version: 0.7.8-2
+    source:
+      type: git
+      url: https://github.com/ipa320/care-o-bot.git
+      version: kinetic_dev
+    status: maintained
   carla_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `care-o-bot` to `0.7.8-2`:

- upstream repository: https://github.com/ipa320/care-o-bot.git
- release repository: https://github.com/ipa320/care-o-bot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## care_o_bot

- No changes

## care_o_bot_robot

- No changes

## care_o_bot_simulation

- No changes
