### PR TITLE
Index package pose_cov_ops in rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2627,6 +2627,16 @@ repositories:
       url: https://github.com/ros-perception/pointcloud_to_laserscan.git
       version: rolling
     status: maintained
+  pose_cov_ops:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
+      version: master
+    status: maintained
   pybind11_json_vendor:
     doc:
       type: git


### PR DESCRIPTION
Add this package to rolling too, in "doc" and "sources". 

The branch is the same than for ROS1 distros since I managed to get unified cmake scripts for both.