### PR TITLE
Add python3-crc16-pip to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6201,6 +6201,16 @@ python3-coverage:
   opensuse: [python3-coverage]
   rhel: ['python%{python3_pkgversion}-coverage']
   ubuntu: [python3-coverage]
+python3-crc16-pip:
+  debian:
+    pip:
+      packages: [crc16]
+  fedora:
+    pip:
+      packages: [crc16]
+  ubuntu:
+    pip:
+      packages: [crc16]
 python3-crcmod:
   debian: [python3-crcmod]
   fedora:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-crc16-pip

## Package Upstream Source:

Source: https://github.com/gtrafimenkov/pycrc16
Webpage: https://code.google.com/archive/p/pycrc16/

## Purpose of using this:

CRC16-XMODEM is a simple checksum algorithm, and the crc16 package has a very straightforward API to use it.

## Links to Distribution Packages

As far as I know, this package is only carried by PyPI.