### PR TITLE
Add in a rosdep key for python3-transforms3d.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5251,8 +5251,13 @@ python-transforms3d-pip:
     pip:
       packages: [transforms3d]
   ubuntu:
-    pip:
-      packages: [transforms3d]
+    '*': null
+    bionic:
+      pip:
+        packages: [transforms3d]
+    focal:
+      pip:
+        packages: [transforms3d]
 python-transitions:
   debian:
     '*': [python-transitions]
@@ -8723,6 +8728,9 @@ python3-tqdm:
     '*': [python3-tqdm]
     xenial: null
 python3-transforms3d:
+  debian:
+    pip:
+      packages: [transforms3d]
   fedora: [python3-transforms3d]
   ubuntu:
     '*': [python3-transforms3d]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8722,6 +8722,16 @@ python3-tqdm:
   ubuntu:
     '*': [python3-tqdm]
     xenial: null
+python3-transforms3d:
+  fedora: [python3-transforms3d]
+  ubuntu:
+    '*': [python3-transforms3d]
+    bionic:
+      pip:
+        packages: [transforms3d]
+    focal:
+      pip:
+        packages: [transforms3d]
 python3-transitions:
   debian:
     '*': [python3-transitions]


### PR DESCRIPTION
It is available in Ubuntu since Jammy, in Fedora since at
least Fedora 34.  It is also available in Debian Sid and Bookworm,
but not any released Debian distribution yet.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

transforms3d

## Package Upstream Source:

https://github.com/matthew-brett/transforms3d

## Purpose of using this:

This dependency is being used by https://github.com/DLu/tf_transformations (which is released into all of Foxy, Galactic, Humble, and Rolling), though it is not currently declared as a dependency.  Thus, it doesn't work out-of-the-box.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - Not available in any released Debian distribution yet: https://packages.debian.org/search?keywords=transforms3d&searchon=names&suite=all&section=all
- Ubuntu: https://packages.ubuntu.com/
   - Released from Jammy onwards: https://packages.ubuntu.com/search?keywords=transforms3d&searchon=names&suite=all&section=all
- Fedora: https://src.fedoraproject.org/browse/projects/
  - Available since at least Fedora 34: https://pkgs.org/search/?q=transforms3d