### PR TITLE
navigation2: 1.0.9-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2183,7 +2183,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/SteveMacenski/navigation2-release.git
-      version: 1.0.8-1
+      version: 1.0.9-1
     source:
       type: git
       url: https://github.com/ros-planning/navigation2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation2` to `1.0.9-1`:

- upstream repository: https://github.com/ros-planning/navigation2.git
- release repository: https://github.com/SteveMacenski/navigation2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.0.8-1`
