### PR TITLE
ros_controllers: 0.20.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7991,7 +7991,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.19.0-1
+      version: 0.20.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.20.0-1`:

- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.19.0-1`

## ackermann_steering_controller

```
* Drop old C++ standard
* Updated ackermann_steering_controller tests launch file to use robot_state_publisher rather than state_publisher which is no longer available in Noetic.
* Add <?xml version=1.0?> to every .launch and .test file
* Contributors: Jochen Sprickerhof, Lucas Walter, Tony Baltovski
```

## diff_drive_controller

```
* Drop old C++ standard
* Use new boost bind placeholders
* Add <?xml version=1.0?> to every .launch and .test file
* Contributors: Jochen Sprickerhof, Lucas Walter
```

## effort_controllers

```
* Drop old C++ standard
* Add <?xml version=1.0?> to every .launch and .test file
* Contributors: Jochen Sprickerhof, Lucas Walter
```

## force_torque_sensor_controller

```
* Drop old C++ standard
* Add <?xml version=1.0?> to every .launch and .test file
* Contributors: Jochen Sprickerhof, Lucas Walter
```

## forward_command_controller

```
* Drop old C++ standard
* Contributors: Jochen Sprickerhof
```

## four_wheel_steering_controller

```
* Drop old C++ standard
* Add <?xml version=1.0?> to every .launch and .test file
* Contributors: Jochen Sprickerhof, Lucas Walter
```

## gripper_action_controller

```
* Drop old C++ standard
* Use new boost bind placeholders
* Contributors: Jochen Sprickerhof
```

## imu_sensor_controller

```
* Drop old C++ standard
* Add <?xml version=1.0?> to every .launch and .test file
* Contributors: Jochen Sprickerhof, Lucas Walter
```

## joint_state_controller

```
* Drop old C++ standard
* Add <?xml version=1.0?> to every .launch and .test file
* Contributors: Jochen Sprickerhof, Lucas Walter
```

## joint_trajectory_controller

```
* Fix joint trajectory controller so results message is returned on tolerance failures
* added description for joint trajectory controller path/goal tolerance violation to action result, include which joint violated tolerance and by how much
* I think this was responsible for at least some std::runtime_errors
  Duration is out of dual 32-bit range
  that came from initializing a ros::Duration with an uninitialized double
* Drop old C++ standard
* Use new boost bind placeholders
* Add <?xml version=1.0?> to every .launch and .test file
* Contributors: Jochen Sprickerhof, Levi Armstrong, Lucas Walter, grejj
```

## position_controllers

```
* Drop old C++ standard
* Contributors: Jochen Sprickerhof
```

## ros_controllers

- No changes

## rqt_joint_trajectory_controller

```
* Increase spin box to six decimals
* trivial cleanup & fix for python3.10
  probably relevant for earlier versions of python3 as well.
* Contributors: Levi Armstrong, v4hn
```

## velocity_controllers

```
* Drop old C++ standard
* Contributors: Jochen Sprickerhof
```
