### PR TITLE
nixos: use opencv instead of opencv3

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4198,7 +4198,7 @@ libopencv-dev:
   freebsd: [opencv-core]
   gentoo: [media-libs/opencv]
   macports: [opencv]
-  nixos: [opencv3]
+  nixos: [opencv]
   openembedded: [opencv@meta-oe]
   opensuse: [opencv-devel]
   rhel: [opencv-devel]


### PR DESCRIPTION
All supported ROS distros except melodic expect at least OpenCV 4 now. For melodic, I can override the opencv package to point to OpenCV 3 in nix-ros-overlay.
