### PR TITLE
rosidl_typesupport_gurumdds: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4048,6 +4048,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_gurumdds-release.git
+      version: 4.0.0-1
     source:
       type: git
       url: https://github.com/ros2/rosidl_typesupport_gurumdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_gurumdds` to `4.0.0-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_gurumdds.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_gurumdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## gurumdds_cmake_module

- No changes
