### PR TITLE
srdfdom: 2.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4669,7 +4669,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/srdfdom-release.git
-      version: 2.0.3-2
+      version: 2.0.4-1
     source:
       type: git
       url: https://github.com/ros-planning/srdfdom.git


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom` to `2.0.4-1`:

- upstream repository: https://github.com/ros-planning/srdfdom.git
- release repository: https://github.com/ros2-gbp/srdfdom-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.0.3-2`

## srdfdom

```
* Parse <disable_default_collisions> and <enable_collisions> tags (#101, from #97)
* Fix Windows .dll install location (#98)
* Contributors: Robert Haschke, Abishalini Sivaraman, Akash, Henning Kayser
```
