### PR TITLE
Please add the following dependency to the rosdep database.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2312,6 +2312,13 @@ libb64-dev:
   gentoo: [libb64]
   nixos: [libb64]
   ubuntu: [libb64-dev]
+libbackward-cpp-dev:
+  debian: [libbackward-cpp-dev]
+  opensuse: [backward-cpp]
+  ubuntu:
+    '*': [libbackward-cpp-dev]
+    bionic: null
+    xenial: null
 libbison-dev:
   debian: [libbison-dev]
   fedora: [bison-devel]


### PR DESCRIPTION
## Package name: libbackward-cpp-dev

## Package Upstream Source:

https://github.com/bombela/backward-cpp

## Purpose of using this:

Used in osrf_testing_tools_cpp.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/libbackward-cpp-dev
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/libbackward-cpp-dev