### PR TITLE
eigenpy: 2.7.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2842,7 +2842,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/stack-of-tasks/eigenpy-ros-release.git
-      version: 2.7.2-1
+      version: 2.7.4-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/eigenpy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `eigenpy` to `2.7.4-1`:

- upstream repository: https://github.com/stack-of-tasks/eigenpy.git
- release repository: https://github.com/stack-of-tasks/eigenpy-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.7.2-1`
