### PR TITLE
warehouse_ros_sqlite: 0.9.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -15046,6 +15046,21 @@ repositories:
       url: https://github.com/ros-planning/warehouse_ros_mongo.git
       version: melodic-devel
     status: maintained
+  warehouse_ros_sqlite:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros_sqlite.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/moveit/warehouse_ros_sqlite-release.git
+      version: 0.9.1-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros_sqlite.git
+      version: master
+    status: maintained
   warthog:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros_sqlite` to `0.9.1-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros_sqlite.git
- release repository: https://github.com/moveit/warehouse_ros_sqlite-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## warehouse_ros_sqlite

```
* Update package.xml
  Version bump backwards to 0.9.0
  To distinguish between ROS1 and ROS2, the ROS1 version major stays at 0.
* Add busy handler for concurrent writes to db
* Export interfaces (dllexport/visibility=hidden)
* Versioning of the database scheme
* Adapt scheme to be more precise
* Fix query with ordering
* Use proper exception types
* Implemented dropping databases
* Support multiple databases with name mangling
  The collection name and the database name are mangled and concatenated
  to support multiple databases.
  SQLite only supports one database per file.
* Rollback on initialization error
* Fix validation of stored MD5 sum
* SQL String escaping
* Contributors: Bjar Ne, Jafar Abdi
```
