### PR TITLE
turtlebot4_simulator: 0.1.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5382,7 +5382,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4_simulator-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot4_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4_simulator` to `0.1.1-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4_simulator.git
- release repository: https://github.com/ros2-gbp/turtlebot4_simulator-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.0-1`

## turtlebot4_ignition_bringup

```
* Added irobot_create_nodes dependency
* Contributors: Roni Kreinin
```

## turtlebot4_ignition_gui_plugins

- No changes

## turtlebot4_ignition_toolbox

- No changes

## turtlebot4_simulator

- No changes
