### PR TITLE
fogros2: 0.1.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -961,7 +961,7 @@ repositories:
     source:
       type: git
       url: https://github.com/BerkeleyAutomation/FogROS2.git
-      version: 0.1.3
+      version: humble
     status: developed
   foonathan_memory_vendor:
     release:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -957,7 +957,12 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/fogros2-release.git
-      version: 0.1.2-2
+      version: 0.1.3-1
+    source:
+      type: git
+      url: https://github.com/BerkeleyAutomation/FogROS2.git
+      version: 0.1.3
+    status: developed
   foonathan_memory_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `fogros2` to `0.1.3-1`:

- upstream repository: https://github.com/BerkeleyAutomation/FogROS2.git
- release repository: https://github.com/ros2-gbp/fogros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.2-2`

## fogros2

```
* readded human readable instance name generation
* added checks and interterpretable feedback for client errors
* added environment variable checks
* updated documentation to include new potential issues and remove unnecessary instructions
* fixed colcon warning message about arg parsing in the cloud instance
```

## fogros2_examples

```
* fixed talker and listener example naming
```
