### PR TITLE
control_toolbox: 1.19.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1909,7 +1909,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/control_toolbox-release.git
-      version: 1.18.2-1
+      version: 1.19.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `1.19.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros-gbp/control_toolbox-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.18.2-1`

## control_toolbox

```
* Switch to std::bind
* Increased integral gains & windup limits from +-1000 to +-100000
* Update README build status badge
* Remove Travis CI config
* Add GH actions CI workflow
* Update include/control_toolbox/pid.h
* code review fixes
* Allow smoother resets
  1. Currently after a reset (or init), since p_error_last is_ set to 0, the first computeCommand is calculating
  a false large derivative error. Proposed fix: only calculate error_dot if p_error_last_ contains a real value.
  The PR leaves reset() behavior untouched, and provides an additional reset function that allows setting
  the initial values for d_error and i_error
  2. Allow setting initial i_error. This allows PID to be used in a smoother manner in systems switching from
  manual to automatic modes. See: http://brettbeauregard.com/blog/2011/04/improving-the-beginner%E2%80%99s-pid-initialization/
  3. Improve cases where dt==0 or invalid errors were given (return last cmd_ instead of 0)
* Contributors: Jochen Sprickerhof, Koby Aizer, Matt Reynolds, Steve Golton, Bence Magyar
```
