### PR TITLE
blacklist buster and stretch for curpp-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -717,7 +717,7 @@ curl:
       packages: [curl]
   ubuntu: [libcurl4-openssl-dev, curl]
 curlpp-dev:
-  debian: 
+  debian:
     '*': [libcurlpp-dev]
     buster: null
     stretch: null

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -717,7 +717,10 @@ curl:
       packages: [curl]
   ubuntu: [libcurl4-openssl-dev, curl]
 curlpp-dev:
-  debian: [libcurlpp-dev]
+  debian: 
+    '*': [libcurlpp-dev]
+    buster: null
+    stretch: null
   fedora: [curlpp-devel]
   openembedded: [curlpp@meta-networking]
   ubuntu: [libcurlpp-dev]


### PR DESCRIPTION
[Jenkins job](https://build.ros.org/job/Nbin_dbv8_dBv8__pf_driver__debian_buster_arm64__binary/3/) failed since it could not find the key `libcurlpp-dev`:
```
Looking for the '.dsc' file of package 'ros-noetic-pf-driver' with version '1.2.0-1'
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/apt/cache.py", line 297, in __getitem__
    rawpkg = self._cache[key]
KeyError: 'libcurlpp-dev'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tmp/ros_buildfarm/scripts/release/create_binarydeb_task_generator.py", line 216, in <module>
    main()
  File "/tmp/ros_buildfarm/scripts/release/create_binarydeb_task_generator.py", line 92, in main
    apt_cache, debian_pkg_names)
  File "/tmp/ros_buildfarm/ros_buildfarm/common.py", line 175, in get_binary_package_versions
    pkg = apt_cache[debian_pkg_name]
  File "/usr/lib/python3/dist-packages/apt/cache.py", line 299, in __getitem__
    raise KeyError('The cache has no package named %r' % key)
KeyError: "The cache has no package named 'libcurlpp-dev'"
Build step 'Execute shell' marked build as failure
```

 As seen [here](https://packages.debian.org/sid/libcurlpp-dev), it has not been released for `buster` and `stretch`. 

Related PR: https://github.com/ros-infrastructure/ros_buildfarm_config/pull/218

refer https://answers.ros.org/question/400344/buildfarm-fails-for-noetic-with-keyerror-libcurlpp-dev/ for details