### PR TITLE
warehouse_ros_sqlite: 0.9.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10958,8 +10958,8 @@ repositories:
     release:
       tags:
         release: release/noetic/{package}/{version}
-      url: https://github.com/moveit/warehouse_ros_sqlite-release.git
-      version: 0.9.1-1
+      url: https://github.com/ros-gbp/warehouse_ros_sqlite-release.git
+      version: 0.9.0-1
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros_sqlite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros_sqlite` to `0.9.0-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros_sqlite.git
- release repository: https://github.com/ros-gbp/warehouse_ros_sqlite-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.9.1-1`
