### PR TITLE
depthai: 1.5.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -697,6 +697,11 @@ repositories:
       type: git
       url: https://github.com/luxonis/depthai-core.git
       version: ros-release
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/luxonis/depthai-core-release.git
+      version: 1.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai` to `1.5.0-1`:

- upstream repository: https://github.com/luxonis/depthai-core.git
- release repository: https://github.com/luxonis/depthai-core-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## depthai

```
* Gen2: Release 1.5.0
* Test Release
```
