### PR TITLE
rqt_action: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4138,7 +4138,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_action-release.git
-      version: 2.0.1-2
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_action.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_action` to `2.1.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_action.git
- release repository: https://github.com/ros2-gbp/rqt_action-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.0.1-2`

## rqt_action

- No changes
