### PR TITLE
rqt: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4122,7 +4122,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
-      version: 1.1.3-1
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `1.2.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros2-gbp/rqt-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.1.3-1`

## rqt

```
* Fix up the package description. (#250 <https://github.com/ros-visualization/rqt/issues/250>)
* Contributors: Chris Lalancette
```

## rqt_gui

```
* Display basic help information when no plugins are loaded (#268 <https://github.com/ros-visualization/rqt/issues/268>)
* Contributors: Michael Jeronimo
```

## rqt_gui_cpp

- No changes

## rqt_gui_py

- No changes

## rqt_py_common

- No changes
