### PR TITLE
rqt_console: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4186,7 +4186,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_console-release.git
-      version: 2.0.2-2
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_console` to `2.1.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_console.git
- release repository: https://github.com/ros2-gbp/rqt_console-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.0.2-2`

## rqt_console

```
* added new maintainer
* Contributors: Arne Hitzmann
```
