### PR TITLE
rqt_topic: 1.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4447,7 +4447,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_topic-release.git
-      version: 1.2.3-1
+      version: 1.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_topic` to `1.3.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_topic.git
- release repository: https://github.com/ros2-gbp/rqt_topic-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.2.3-1`

## rqt_topic

```
* Fix the display of array type elements. (#41 <https://github.com/ros-visualization/rqt_topic/issues/41>)
* Fix removal of topics while they are being monitored. (#39 <https://github.com/ros-visualization/rqt_topic/issues/39>)
* Contributors: Chris Lalancette
```
