### PR TITLE
rqt_bag: 1.1.3-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4115,7 +4115,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
-      version: 1.1.1-4
+      version: 1.1.3-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `1.1.3-2`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros2-gbp/rqt_bag-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.1.1-4`

## rqt_bag

```
* Fix the types being passed into QFont and QColor. (#109 <https://github.com/ros-visualization/rqt_bag/issues/109>)
* Contributors: Chris Lalancette
```

## rqt_bag_plugins

- No changes
