### PR TITLE
qt_gui_core: 2.2.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2700,7 +2700,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 2.2.0-2
+      version: 2.2.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `2.2.1-2`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.2.0-2`

## qt_dotgraph

- No changes

## qt_gui

```
* Fix flake8 errors introduced by the previous commit. (#262 <https://github.com/ros-visualization/qt_gui_core/issues/262>)
* Enable basic help information if no plugins are running (#261 <https://github.com/ros-visualization/qt_gui_core/issues/261>)
* Contributors: Chris Lalancette, Michael Jeronimo
```

## qt_gui_app

- No changes

## qt_gui_core

- No changes

## qt_gui_cpp

- No changes

## qt_gui_py_common

- No changes
