### PR TITLE
rviz: 11.2.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4457,7 +4457,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 11.2.1-1
+      version: 11.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `11.2.2-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `11.2.1-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Add time jump handler (#791 <https://github.com/ros2/rviz/issues/791>) (#854 <https://github.com/ros2/rviz/issues/854>)
* Contributors: Jacob Perron
```

## rviz_default_plugins

```
* Fix include order (#858 <https://github.com/ros2/rviz/issues/858>) (#859 <https://github.com/ros2/rviz/issues/859>)
* Contributors: Jacob Perron
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
