### PR TITLE
mrpt_msgs: switch branch to new common ros1/2 branch

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2041,7 +2041,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
-      version: ros2
+      version: master
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -2050,7 +2050,7 @@ repositories:
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
-      version: ros2
+      version: master
     status: maintained
   mrt_cmake_modules:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7236,7 +7236,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
-      version: ros1
+      version: master
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -7245,7 +7245,7 @@ repositories:
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
-      version: ros1
+      version: master
     status: maintained
   mrpt_navigation:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5277,7 +5277,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
-      version: ros1
+      version: master
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -5286,7 +5286,7 @@ repositories:
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
-      version: ros1
+      version: master
     status: developed
   mrpt_navigation:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2042,7 +2042,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
-      version: ros2
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2051,7 +2051,7 @@ repositories:
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
-      version: ros2
+      version: master
     status: maintained
   mrt_cmake_modules:
     doc:


### PR DESCRIPTION
Switch `doc` and `source` branch.