### PR TITLE
gazebo_ros_pkgs: 3.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1019,6 +1019,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
+      version: 3.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `3.6.0-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs
- release repository: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## gazebo_dev

```
* Fix test failures (#1380 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1380>)
* Include TBB in gazebo-dev cmake to fix #1372 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1372> (#1373 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1373>)
* Contributors: Daisuke Nishimatsu, Jose Luis Rivero, Steve Peters
```

## gazebo_msgs

```
* gazebo_ros_wheel_slip: publish wheel slip (#1331 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1331>)
* Contributors: Audrow Nash
```

## gazebo_plugins

```
* Initialize wheel slip parameters directly from SDF (#1365 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1365>)
* Fix test failures (#1380 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1380>)
* gazebo_ros_ft_sensor_demo.world: use world solver (#1354 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1354>)
* gazebo_ros_wheel_slip: set lateral slip to zero at low speed (#1338 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1338>)
* gazebo_ros_wheel_slip: publish wheel slip (#1331 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1331>)
* Add slip values for individual wheels (#1312 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1312>)
* Default slip values fix for wheel slip plugin (#1308 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1308>)
* Add runtime warning when user sets use_sim_time parameter
* Fix warnings when building against the latest sources (#1282 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1282>)
* Add method to get ROS node from GazeboRosCameraPlugin (#1299 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1299>)
* Improve robustness of joint state publisher test (#1259 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1259>)
* Avoid rejecting QoS overrides parameters (#1258 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1258>)
* Publish with QoS reliable as default (#1224 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1224>) (#1235 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1235>)
* Contributors: Aditya Pande, Audrow Nash, Brett Downing, Chris Lalancette, Daisuke Nishimatsu, Dharini Dutia, Jacob Perron, Steve Peters
```

## gazebo_ros

```
* Fixes gazebo shutdown error when using nested launch files (#1376 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1376>)
* Fix test failures (#1380 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1380>)
* Fix spawn_entity_demo: use executable (#1349 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1349>)
* Add runtime warning when user sets use_sim_time parameter
* Add ROS parameter to toggle performance metrics in gazebo_ros (#1295 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1295>)
* Deprecate -spawn_service_timeout option (#1238 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1238>)
* Contributors: Aditya Pande, Daisuke Nishimatsu, Felix Exner, Jacob Perron
```

## gazebo_ros_pkgs

- No changes
