### PR TITLE
variants: 0.10.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5295,12 +5295,15 @@ repositories:
     release:
       packages:
       - desktop
+      - desktop_full
+      - perception
       - ros_base
       - ros_core
+      - simulation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/variants-release.git
-      version: 0.9.3-3
+      version: 0.10.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `variants` to `0.10.0-1`:

- upstream repository: https://github.com/ros2/variants.git
- release repository: https://github.com/ros2-gbp/variants-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.9.3-3`

## desktop

- No changes

## desktop_full

```
* Add desktop_full, perception, and simulation variants. (#34 <https://github.com/ros2/variants/issues/34>)
* Contributors: Louise Poubel
```

## perception

```
* Add desktop_full, perception, and simulation variants. (#34 <https://github.com/ros2/variants/issues/34>)
* Contributors: Louise Poubel
```

## ros_base

- No changes

## ros_core

```
* Add rclcpp_action to core. (#36 <https://github.com/ros2/variants/issues/36>)
* Contributors: Russ
```

## simulation

```
* Add desktop_full, perception, and simulation variants. (#34 <https://github.com/ros2/variants/issues/34>)
* Contributors: Louise Poubel
```
