### PR TITLE
rqt_common_plugins: 1.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4130,7 +4130,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_common_plugins-release.git
-      version: 1.1.0-3
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins` to `1.2.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_common_plugins.git
- release repository: https://github.com/ros2-gbp/rqt_common_plugins-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.1.0-3`

## rqt_common_plugins

```
* Remove unreleased plugins from rqt_common_plugins. (#465 <https://github.com/ros-visualization/rqt_common_plugins/issues/465>)
* Update maintainers (#464 <https://github.com/ros-visualization/rqt_common_plugins/issues/464>)
* Contributors: Chris Lalancette, Ivan Santiago Paunovic
```
