### PR TITLE
Change the branch for Galactic rqt_common_plugins.

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4315,7 +4315,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git
-      version: ros2
+      version: galactic
     release:
       tags:
         release: release/galactic/{package}/{version}
@@ -4324,7 +4324,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git
-      version: ros2
+      version: galactic
     status: maintained
   rqt_console:
     doc:


### PR DESCRIPTION
Use the newly created 'galactic' branch.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>