### PR TITLE
rosbag2: 0.15.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3793,7 +3793,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.15.1-2
+      version: 0.15.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.15.2-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.15.1-2`

## ros2bag

- No changes

## rosbag2

- No changes

## rosbag2_compression

- No changes

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

- No changes

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_py

```
* Fix test rosbag2_py test compatibility with Python < 3.8 (#987 <https://github.com/ros2/rosbag2/issues/987>)
* Contributors: Scott K Logan
```

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

```
* Make peek_next_message_from_queue return a SharedPtr. (#993 <https://github.com/ros2/rosbag2/issues/993>)
* Change the topic names in test_record.cpp (#988 <https://github.com/ros2/rosbag2/issues/988>)
* Contributors: Chris Lalancette
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
