### PR TITLE
rclc: changed version to humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2913,7 +2913,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rclc.git
-      version: master
+      version: humble
     release:
       packages:
       - rclc
@@ -2928,7 +2928,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclc.git
-      version: master
+      version: humble
     status: developed
   rclcpp:
     doc:


### PR DESCRIPTION
updated version to humble. 
I provided this new version with bloom-release with `--edit`, but it did not update `humble/distribution.yaml`in PR https://github.com/ros/rosdistro/pull/33182. Hence this manual PR. 


