### PR TITLE
octomap_ros: 0.4.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2349,7 +2349,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/octomap_ros-release.git
-      version: 0.4.2-2
+      version: 0.4.3-1
     source:
       type: git
       url: https://github.com/OctoMap/octomap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_ros` to `0.4.3-1`:

- upstream repository: https://github.com/OctoMap/octomap_ros.git
- release repository: https://github.com/ros2-gbp/octomap_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.4.2-2`

## octomap_ros

```
* Fix include order (#15 <https://github.com/OctoMap/octomap_ros/issues/15>)
* Contributors: wep21
```
