### PR TITLE
toposens-library: 1.2.4-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13714,7 +13714,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-library-release.git
-      version: 1.1.4-1
+      version: 1.2.4-2
     source:
       type: git
       url: https://gitlab.com/toposens/public/toposens-library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toposens-library` to `1.2.4-2`:

- upstream repository: https://gitlab.com/toposens/public/toposens-libraries.git
- release repository: https://gitlab.com/toposens/public/toposens-library-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.4-1`
