### PR TITLE
toposens-library: 1.2.4-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10125,7 +10125,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-library-release.git
-      version: 1.1.4-1
+      version: 1.2.4-3
     source:
       type: git
       url: https://gitlab.com/toposens/public/toposens-library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toposens-library` to `1.2.4-3`:

- upstream repository: https://gitlab.com/toposens/public/toposens-libraries.git
- release repository: https://gitlab.com/toposens/public/toposens-library-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.4-1`
