### PR TITLE
domain_bridge: 0.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -766,7 +766,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/domain_bridge-release.git
-      version: 0.3.0-2
+      version: 0.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `domain_bridge` to `0.5.0-1`:

- upstream repository: https://github.com/ros2/domain_bridge.git
- release repository: https://github.com/ros2-gbp/domain_bridge-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.3.0-2`

## domain_bridge

```
* Fix API docs link (#67 <https://github.com/ros2/domain_bridge/issues/67>)
* Fixes for Ubuntu Jammy (#66 <https://github.com/ros2/domain_bridge/issues/66>)
* Support loading domain bridge settings from multiple yaml files (#64 <https://github.com/ros2/domain_bridge/issues/64>)
* Auto remove bridge when endpoint removed (#63 <https://github.com/ros2/domain_bridge/issues/63>)
* Do not associate test library with export (#61 <https://github.com/ros2/domain_bridge/issues/61>)
* Add option to wait for subscription before bridging a topic (#52 <https://github.com/ros2/domain_bridge/issues/52>)
* Add missing dependency in test_component_lib (#53 <https://github.com/ros2/domain_bridge/issues/53>)
* Domain bridge container (#32 <https://github.com/ros2/domain_bridge/issues/32>)
* Make some end to end tests more reliable (#51 <https://github.com/ros2/domain_bridge/issues/51>)
* Install CLI parsing header (#45 <https://github.com/ros2/domain_bridge/issues/45>)
* Wait for multiple publishers in get_topic_qos() (#47 <https://github.com/ros2/domain_bridge/issues/47>)
* Use defered service support in rclcpp (#49 <https://github.com/ros2/domain_bridge/issues/49>)
* Use testing repo for CI (#50 <https://github.com/ros2/domain_bridge/issues/50>)
* Run communication-related tests with all available RMWs (#43 <https://github.com/ros2/domain_bridge/issues/43>)
* Fix bug when waiting for service to be available (#42 <https://github.com/ros2/domain_bridge/issues/42>)
* Add reverse option to swap from and to domain IDs (#40 <https://github.com/ros2/domain_bridge/issues/40>)
* Allow bi-directional topic bridging (#39 <https://github.com/ros2/domain_bridge/issues/39>)
* Add --mode argument to domain_bridge (#35 <https://github.com/ros2/domain_bridge/issues/35>)
* Add template method to help bridging services (#26 <https://github.com/ros2/domain_bridge/issues/26>)
* Fix library target install (#36 <https://github.com/ros2/domain_bridge/issues/36>)
* Update CI workflow (#34 <https://github.com/ros2/domain_bridge/issues/34>)
* Prevent bridging from/to same domain id (#33 <https://github.com/ros2/domain_bridge/issues/33>)
* Rti qos profiles patch (#25 <https://github.com/ros2/domain_bridge/issues/25>)
* Add compressing and decompressing modes (#24 <https://github.com/ros2/domain_bridge/issues/24>)
* Refactor to use generic pub/sub from rclcpp (#30 <https://github.com/ros2/domain_bridge/issues/30>)
* Fix bug in generic subscription (#27 <https://github.com/ros2/domain_bridge/issues/27>)
* Contributors: Abrar Rahman Protyasha, Ivan Santiago Paunovic, Jacob Perron, Rebecca Butler
```
