### PR TITLE
rosbag2: 0.16.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3835,7 +3835,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.15.1-1
+      version: 0.16.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.16.0-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.15.1-1`

## ros2bag

```
* Make unpublished topics unrecorded by default (#968 <https://github.com/ros2/rosbag2/issues/968>)
* Contributors: Michael Orlov, Sean Kelly
```

## rosbag2

- No changes

## rosbag2_compression

- No changes

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

- No changes

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_py

```
* Make unpublished topics unrecorded by default (#968 <https://github.com/ros2/rosbag2/issues/968>)
* Fix test rosbag2_py test compatibility with Python < 3.8 (#987 <https://github.com/ros2/rosbag2/issues/987>)
* Contributors: Michael Orlov, Scott K Logan, Sean Kelly
```

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

```
* Add the /bigobj flag to Windows Debug builds. (#1009 <https://github.com/ros2/rosbag2/issues/1009>)
* Make unpublished topics unrecorded by default (#968 <https://github.com/ros2/rosbag2/issues/968>)
* Make peek_next_message_from_queue return a SharedPtr. (#993 <https://github.com/ros2/rosbag2/issues/993>)
* Change the topic names in test_record.cpp (#988 <https://github.com/ros2/rosbag2/issues/988>)
* Contributors: Chris Lalancette, Michael Orlov, Sean Kelly
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
