### PR TITLE
ublox_dgnss: 0.3.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5040,6 +5040,17 @@ repositories:
       url: https://github.com/KumarRobotics/ublox.git
       version: ros2
     status: maintained
+  ublox_dgnss:
+    release:
+      packages:
+      - ublox_dgnss
+      - ublox_dgnss_node
+      - ublox_ubx_interfaces
+      - ublox_ubx_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/aussierobots/ublox_dgnss-release.git
+      version: 0.3.1-1
   udp_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ublox_dgnss` to `0.3.1-1`:

- upstream repository: https://github.com/aussierobots/ublox_dgnss
- release repository: https://github.com/aussierobots/ublox_dgnss-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`
