### PR TITLE
zmqpp_vendor: 0.0.1-3 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6629,5 +6629,20 @@ repositories:
       url: https://github.com/ros2/yaml_cpp_vendor.git
       version: foxy
     status: maintained
+  zmqpp_vendor:
+    doc:
+      type: git
+      url: git
+      version: https://github.com/tier4/zmqpp_vendor.git
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/tier4/zmqpp_vendor-release.git
+      version: 0.0.1-3
+    source:
+      type: git
+      url: https://github.com/tier4/zmqpp_vendor.git
+      version: main
+    status: developed
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `zmqpp_vendor` to `0.0.1-3`:

- upstream repository: https://github.com/tier4/zmqpp_vendor.git
- release repository: https://github.com/tier4/zmqpp_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## zmqpp_vendor

```
* add export libraries line
* add status budge
* configure triggers
* use matrix build
* remove unused lines
* fix cmake
* fix CONTRIBUTING.md
* remove repos file in build test
* Create Build.yaml
  add buildtest workflow
* add CONTRIBUTING.md
* add package.xml and cmakelist.txt
* Initial commit
* Contributors: Masaya Kataoka
```
