### PR TITLE
zmqpp_vendor: 0.0.1-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5968,5 +5968,20 @@ repositories:
       url: https://github.com/ros2/yaml_cpp_vendor.git
       version: galactic
     status: maintained
+  zmqpp_vendor:
+    doc:
+      type: git
+      url: https://github.com/tier4/zmqpp_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/tier4/zmqpp_vendor-release.git
+      version: 0.0.1-2
+    source:
+      type: git
+      url: https://github.com/tier4/zmqpp_vendor.git
+      version: main
+    status: developed
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `zmqpp_vendor` to `0.0.1-2`:

- upstream repository: https://github.com/tier4/zmqpp_vendor.git
- release repository: https://github.com/tier4/zmqpp_vendor-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## zmqpp_vendor

```
* add export libraries line
* add status budge
* configure triggers
* use matrix build
* remove unused lines
* fix cmake
* fix CONTRIBUTING.md
* remove repos file in build test
* Create Build.yaml
  add buildtest workflow
* add CONTRIBUTING.md
* add package.xml and cmakelist.txt
* Initial commit
* Contributors: Masaya Kataoka
```
