### PR TITLE
openrtm_aist: 1.1.2-4 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6079,7 +6079,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tork-a/openrtm_aist-release.git
-      version: 1.1.2-2
+      version: 1.1.2-4
     source:
       type: git
       url: https://github.com/tork-a/openrtm_aist-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_aist` to `1.1.2-4`:

- upstream repository: https://github.com/OpenRTM/OpenRTM-aist.git
- release repository: https://github.com/tork-a/openrtm_aist-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.2-2`
