### PR TITLE
octomap: 1.9.8-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2302,7 +2302,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/octomap-release.git
-      version: 1.9.7-2
+      version: 1.9.8-1
     source:
       type: git
       url: https://github.com/octomap/octomap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap` to `1.9.8-1`:

- upstream repository: https://github.com/OctoMap/octomap.git
- release repository: https://github.com/ros2-gbp/octomap-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.9.7-2`
