### PR TITLE
ros2_control: 2.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3540,7 +3540,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.7.0-1
+      version: 2.8.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.8.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.7.0-1`

## controller_interface

- No changes

## controller_manager

```
* Pass time and period to read() and write() (#715 <https://github.com/ros-controls/ros2_control/issues/715>)
* Contributors: Bence Magyar
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Pass time and period to read() and write() (#715 <https://github.com/ros-controls/ros2_control/issues/715>)
* Contributors: Bence Magyar
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## transmission_interface

- No changes
