### PR TITLE
mrpt_msgs: 0.4.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2544,6 +2544,21 @@ repositories:
       url: https://github.com/MRPT/mrpt.git
       version: develop
     status: developed
+  mrpt_msgs:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/mrpt_msgs-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
+      version: master
+    status: developed
   mrt_cmake_modules:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_msgs` to `0.4.0-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
- release repository: https://github.com/ros2-gbp/mrpt_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## mrpt_msgs

```
* Linter fixes
* Unify ROS1 / ROS2 builds in one branch
* Add License file
* Contributors: Jose Luis Blanco Claraco
```
