### PR TITLE
depthai: 2.15.4-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -701,7 +701,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/luxonis/depthai-core-release.git
-      version: 1.5.0-1
+      version: 2.15.4-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai` to `2.15.4-2`:

- upstream repository: https://github.com/luxonis/depthai-core.git
- release repository: https://github.com/luxonis/depthai-core-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.5.0-1`

## depthai

```
* Release 2.15.4
* add ament package:
* Cleanup
* Added ament found condition
* CHnaged version for testing
* Added author
* Json fix (#478 <https://github.com/luxonis/depthai-core/issues/478>)
  * Fixed nlohmann json < v3.9.0 compat and toolchain generation
  * turn off clang format
  Co-authored-by: Martin Peterlin <mailto:martin.peterlin7@gmail.com>
  Co-authored-by: TheMarpe <mailto:martin@luxonis.com>
* Empty-Commit
* Update package.xml
* ROS2 release test commit (#475 <https://github.com/luxonis/depthai-core/issues/475>)
  * Empty-Commit
  * Change libusb versions
* Change libsub to libusb-dev
* Empty-Commit
* Updated sub modules
* Modified json in package.xml and changed the changelog"
* Added Changelog file
* Merge remote-tracking branch 'origin/main' into ros-release
* Updatedf package xml, cmake list to include json from system install
* WIP package.xml
* Update docs; removed unsupported AprilTag families
* FW: VideoEncoder: fix keyframe rate config, fix resource computations for JPEG
  (e.g: MJPEG for 4K video 30fps + MJPEG for still 12MP ~1fps)
  properly set resources used to allow
* Update FW
* Update FW; change behavior of stereo rectification based on stereo camera FOV
* Merge 'origin/poe_mtu_sysctl' into develop - #428 <https://github.com/luxonis/depthai-core/issues/428>
  Improve PoE throughput and latency for some usecases
* Update XLink to set TCP_NODELAY, reducing latency
* Merge 'origin/develop' into poe_mtu_sysctl
* Merge branch 'eeprom_version_v7' into develop
* Merge branch 'develop' into eeprom_version_v7
* Merge branch 'json_compat' into develop
* Lowered minimum required nlohmann json version to 3.6.0
* Set RGB aligned depth output to match mono camera
* Merge 'ov7251_configurable_fps' into develop - #455 <https://github.com/luxonis/depthai-core/issues/455>
* Update FW: fix overriding useHomographyRectification behaviour specified in docs when custom mesh is provided
* Merge remote-tracking branch 'origin/main' into HEAD
* Merge pull request #459 <https://github.com/luxonis/depthai-core/issues/459> from diablodale/fix458-cmaketest-flags
  reduce num conforming tests; add missing _conforming test suffix
* reduce tests for MSVC conforming preprocessor
  - drastically reduce number of tests run for
  MSVC conforming preprocessor
  https://github.com/luxonis/depthai-core/pull/459#issuecomment-1108649206
  - add option to test harness that indicates
  when a test is run with the MSVC conforming preprocessor
* Updated flashing permissions
* Fix RGB alignment remapping when configured color camera resolution is different from calibration one
* Updated Bootloader to v0.0.18
* Updated FW with device EEPROM handling fixes
* strengthen test for device construct+q+frame
* Updated bootloader with PCIe internal clock fixes
* Added capability to create CalibrationHandler from json
* Fixed factory reset functionality and exposed more functions
* Updated BL with more build information and new EEPROM data support
* Updated EEPROM and added another level of permissions
* add missing _conforming suffix to tests cmake
  - fixes luxonis/depthai-core#458 <https://github.com/luxonis/depthai-core/issues/458>
* Merge pull request #457 <https://github.com/luxonis/depthai-core/issues/457> from luxonis/rgb_alignment
  Enable RGB alignment for spatial detection examples
* Enable RGB alignment for spatial detection examples
* Merge pull request #454 <https://github.com/luxonis/depthai-core/issues/454> from diablodale/test-device-queues1
  test case for Device constructor not calling tryStartPipeline()
* test case for Device constructor not tryStartPipeline()
  - catch bug and prevent regression as discussed
  https://github.com/luxonis/depthai-core/commit/7257b95ecfb8dcb77c075e196ac774cc05cb8bc6#commitcomment-71730879
* Merge remote-tracking branch 'origin/main' into HEAD
* Update FW: configurable FPS for OV7251: max 99 for 480p, 117 for 400p
* Added bindings and support for new EEPROM version
* WIP - modify behavior to be backwards compatible and add checks if calibration is available
* Added additional EEPROM functionality
* Applied formatting
* Merge branch 'main' into develop
* Update FW: improve PoE throughput and latency (set net.inet.tcp.delayed_ack=0),
  add config for MTU (not advised to change for now) and other sysctl params
* Contributors: Dale Phurrough, SzabolcsGergely, TheMarpe, alex-luxonis, szabi-luxonis, Sachin Guruswamy
```
