### PR TITLE
add flite key in rosdep/base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1029,10 +1029,12 @@ flex:
   rhel: [flex]
   ubuntu: [flex]
 flite:
+  alpine: [flite]
   arch: [flite]
   debian: [flite]
   fedora: [flite]
   gentoo: [app-accessibility/flite]
+  rhel: [alpine]
   ubuntu: [flite]
 fltk:  # Consider using the libfltk-dev and fluid (fltk runtime) keys instead.
   arch: [fltk]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1034,7 +1034,7 @@ flite:
   debian: [flite]
   fedora: [flite]
   gentoo: [app-accessibility/flite]
-  rhel: [alpine]
+  rhel: [flite]
   ubuntu: [flite]
 fltk:  # Consider using the libfltk-dev and fluid (fltk runtime) keys instead.
   arch: [fltk]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1028,6 +1028,12 @@ flex:
   opensuse: [flex]
   rhel: [flex]
   ubuntu: [flex]
+flite:
+  arch: [flite]
+  debian: [flite]
+  fedora: [flite]
+  gentoo: [app-accessibility/flite]
+  ubuntu: [flite]
 fltk:  # Consider using the libfltk-dev and fluid (fltk runtime) keys instead.
   arch: [fltk]
   debian: [libfltk1.1-dev]


### PR DESCRIPTION
this PR add `flite` key in `rosdep/base.yaml`
Flite (festival-lite) is a small, fast run-time speech synthesis engine developed at CMU.
https://github.com/festvox/flite

- Debian: https://packages.debian.org/stretch/flite
- Ubuntu: http://manpages.ubuntu.com/manpages/bionic/man1/flite.1.html
- Fedora: https://src.fedoraproject.org/rpms/flite
- Arch: https://archlinux.org/packages/community/x86_64/flite/
- Gentoo: https://packages.gentoo.org/packages/app-accessibility/flite
- RHEL: https://repo.almalinux.org/almalinux/8/PowerTools/x86_64/os/Packages/flite-1.3-31.el8.i686.rpm
- Alpine: https://pkgs.alpinelinux.org/package/edge/main/x86_64/flite