### PR TITLE
plotjuggler: 3.4.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3113,7 +3113,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.4.3-1
+      version: 3.4.4-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.4.4-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.4.3-1`

## plotjuggler

```
* fix issue #561 <https://github.com/facontidavide/PlotJuggler/issues/561>
* add STATUS to CmakeLists.txt message() to avoid 'message called with incorrect number of arguments' (#649 <https://github.com/facontidavide/PlotJuggler/issues/649>)
  cmake 3.22.1 errors on this
* Passing CI on ROS2 Rolling (#629 <https://github.com/facontidavide/PlotJuggler/issues/629>)
  * fix ament-index-cpp dependency on ubuntu jammy
  * add rolling ci
* Modify install command and make it easier to install (#620 <https://github.com/facontidavide/PlotJuggler/issues/620>)
* Contributors: Davide Faconti, Kenji Brameld, Krishna, Lucas Walter
```
