### PR TITLE
clpe_ros: 0.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -601,6 +601,11 @@ repositories:
       type: git
       url: https://github.com/canlab-co/clpe_ros.git
       version: main
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/canlab-co/clpe_ros-ros2-release.git
+      version: 0.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clpe_ros` to `0.1.0-1`:

- upstream repository: https://github.com/canlab-co/clpe_ros.git
- release repository: https://github.com/canlab-co/clpe_ros-ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## clpe_ros

```
* Provides ROS 2 driver for CANLAB CLPE-G-NVP2650D vision system
* Support ROS 2 Foxy and ROS 2 Galactic
* By default the driver will publish three topics for each camera X.
  * /clpe/cam_X/image_raw: The raw image published as sensor_msgs::msg::Image. The default encoding is yuv422. For other supported encodings, see Configuration.
  * /clpe/cam_X/camera_info: The intrinsics of the camera published as a sensor_msgs::msg::CameraInfo message.
  * /clpe/cam_X/clpe_camera_info: The intrinsics of the camera published as a clpe_ros_msgs::msg::ClpeCameraInfo message.
* Contributors: Teo Koon Peng, Yadunund Vijay
```
