### PR TITLE
quaternion_operation: 0.0.11-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2717,7 +2717,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/quaternion_operation-release.git
-      version: 0.0.7-3
+      version: 0.0.11-1
     source:
       type: git
       url: https://github.com/OUXT-Polaris/quaternion_operation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `quaternion_operation` to `0.0.11-1`:

- upstream repository: https://github.com/OUXT-Polaris/quaternion_operation.git
- release repository: https://github.com/ros2-gbp/quaternion_operation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.0.7-3`

## quaternion_operation

```
* Add ament_lint_auto dependency to package.xml. (#58 <https://github.com/OUXT-Polaris/quaternion_operation/issues/58>)
* Setup workflow (#59 <https://github.com/OUXT-Polaris/quaternion_operation/issues/59>)
* Release 0.0.10 (#57 <https://github.com/OUXT-Polaris/quaternion_operation/issues/57>)
  * Update changelog
  * 0.0.10
* Contributors: Steven! Ragnarök, wam-v-tan
```
