### PR TITLE
fogros2: 0.1.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -957,7 +957,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/fogros2-release.git
-      version: 0.1.3-1
+      version: 0.1.4-1
     source:
       type: git
       url: https://github.com/BerkeleyAutomation/FogROS2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fogros2` to `0.1.4-1`:

- upstream repository: https://github.com/BerkeleyAutomation/FogROS2.git
- release repository: https://github.com/ros2-gbp/fogros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.3-1`

## fogros2

```
* fixed QUICKSTART.md documentation and removed unnecessary dependencies
* prepared package.xml with list of authors and maintainers for release
* changed environment variable checks from asserts to exceptions
* cleaned up README.md
```

## fogros2_examples

```
* prepared package.xml with list of authors and maintainers for release
* removed non-talker examples
```
