### PR TITLE
septentrio_gnss_driver: 1.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12902,7 +12902,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/septentrio-users/septentrio_gnss_driver-release.git
-      version: 1.1.0-8
+      version: 1.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `septentrio_gnss_driver` to `1.1.1-1`:

- upstream repository: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
- release repository: https://github.com/septentrio-users/septentrio_gnss_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.1.0-8`

## septentrio_gnss_driver

```
* New Features
  
  Add login credentials
  
  Activate NTP server if use_gnss_time is set to true
* Improvements
  
  Add NED option to localization
* Fixes
  
  IMU orientation for ROS axis convention
* Commits
  
  Merge pull request #62 from thomasemter/dev/next
  Small fixes and additions
  
  Amend readme regarding robot_localization
  
  Add more explanations for IMU orientation in ROS convention
  
  Fix formatting in readme
  
  Fix package name in readme
  
  Update readme
  
  Update changelog
  
  Fix IMU orientation for ROS axis orientation
  
  Activate NTP only if GNSS time is used
  
  Add NED option to localization
  
  Set NMEA header to
  
  Fix logging causing crash
  
  Update readme and changelog
  
  Activate NTP server
  
  Add credentials for access control
  
  Contributors: Thomas Emter, Tibor Dome
```
