### PR TITLE
septentrio_gnss_driver: 1.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4539,6 +4539,22 @@ repositories:
       url: https://github.com/ros/sdformat_urdf.git
       version: ros2
     status: maintained
+  septentrio_gnss_driver:
+    doc:
+      type: git
+      url: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/septentrio-users/septentrio_gnss_driver_ros2-release.git
+      version: 1.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
+      version: ros2
+    status: maintained
   simple_launch:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `septentrio_gnss_driver` to `1.2.1-1`:

- upstream repository: https://github.com/septentrio-gnss/septentrio_gnss_driver
- release repository: https://github.com/septentrio-users/septentrio_gnss_driver_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## septentrio_gnss_driver

```
* New Features
  
  Add login credentials
  
  Activate NTP server if use_gnss_time is set to true
* Improvements
  
  Add NED option to localization
* Fixes
  
  IMU orientation for ROS axis convention
* Commits
  
  Merge pull request #63 from thomasemter/dev/next2
  Small fixes and additions
  
  Merge pull request #60 from wep21/support-rolling
  fix: modify build error for rolling/humble
  
  Revert change for deprecation warning in Humble
  
  Change links to reflect ROS2
  
  Amend readme regarding robot_localization
  
  Fix compiler warnings for humble
  
  Add more explanations for IMU orientation in ROS convention
  
  Fix formatting in readme
  
  Fix package name in readme
  
  Update readme
  
  Update changelog
  
  Fix IMU orientation for ROS axis orientation
  
  Activate NTP only if GNSS time is used
  
  Add NED option to localization
  
  Set NMEA header to GP
  
  Update readme and changelog
  
  Activate NTP server
  
  Add credentials for access control
  
  fix: modify build error for rolling/humble
  
  Contributors: Daisuke Nishimatsu, Thomas Emter, Tibor Dome
```
