### PR TITLE
husky: 0.6.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3328,7 +3328,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 0.6.2-1
+      version: 0.6.3-1
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `0.6.3-1`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.2-1`

## husky_control

```
* Enable subst_value when loading config_extras. (#226 <https://github.com/husky/husky/issues/226>)
* Remove whitespace
* Re-add base_frame_id and velocity_rolling_window_size
* Update DiffDriveController params
  - Remove estimate_velocity_from_position: false because it does not exist as a param in DiffDriveController, or anywhere in ros-controllers
  - Remove base_frame_id: base_link because the default value of base_frame_id is already base_link, as per http://wiki.ros.org/diff_drive_controller
  - Remove velocity_rolling_window_size: 2 so velocity_rolling_window_size can take on the default value of 10. A higher value reduces the amount of noise in the odometry, as per: https://docs.google.com/document/d/1x1HOtLs9Z9jfuKdtSMM_YWOrWM4p08LJVt6vQVohVWI/edit#
* Contributors: Chris I-B, Joey Yang
```

## husky_description

```
* Added Blackfly
* Added blackfly description dependancy
* Realsense will no longer add the Sensor Arch (#220 <https://github.com/husky/husky/issues/220>)
  * Add parent link env-var to imu
  * Sensor Arch is only enabled by HUSKY_SENSOR_ARCH, changed default realsense mount frame to
* Contributors: Luis Camero, luis-camero
```

## husky_desktop

- No changes

## husky_gazebo

- No changes

## husky_msgs

- No changes

## husky_navigation

- No changes

## husky_simulator

- No changes

## husky_viz

- No changes
