### PR TITLE
performance_test-release: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3070,7 +3070,7 @@ repositories:
       url: https://github.com/ros-perception/perception_pcl.git
       version: foxy-devel
     status: maintained
-  performance_test-release:
+  performance_test:
     doc:
       type: git
       url: https://gitlab.com/ApexAI/performance_test.git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3071,6 +3071,10 @@ repositories:
       version: foxy-devel
     status: maintained
   performance_test-release:
+    doc:
+      type: git
+      url: https://gitlab.com/ApexAI/performance_test.git
+      version: 1.0.0
     release:
       packages:
       - performance_report
@@ -3079,6 +3083,10 @@ repositories:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/performance_test-release.git
       version: 1.0.0-1
+    source:
+      type: git
+      url: https://gitlab.com/ApexAI/performance_test.git
+      version: master
     status: maintained
   performance_test_fixture:
     release:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3070,6 +3070,16 @@ repositories:
       url: https://github.com/ros-perception/perception_pcl.git
       version: foxy-devel
     status: maintained
+  performance_test-release:
+    release:
+      packages:
+      - performance_report
+      - performance_test
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/performance_test-release.git
+      version: 1.0.0-1
+    status: maintained
   performance_test_fixture:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `performance_test-release` to `1.0.0-1`:

- upstream repository: https://gitlab.com/ApexAI/performance_test.git
- release repository: https://github.com/ros2-gbp/performance_test-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`
