### PR TITLE
performance_test-release: 1.0.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1695,6 +1695,16 @@ repositories:
       url: https://github.com/ros-perception/perception_pcl.git
       version: eloquent-devel
     status: developed
+  performance_test-release:
+    release:
+      packages:
+      - performance_report
+      - performance_test
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/performance_test-release.git
+      version: 1.0.0-1
+    status: maintained
   phidgets_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `performance_test-release` to `1.0.0-1`:

- upstream repository: https://gitlab.com/ApexAI/performance_test.git
- release repository: https://github.com/ros2-gbp/performance_test-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`
