### PR TITLE
rmf_api_msgs: 0.0.1-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3107,7 +3107,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_api_msgs-release.git
-      version: 0.0.1-1
+      version: 0.0.1-3
     source:
       type: git
       url: https://github.com/open-rmf/rmf_api_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_api_msgs` to `0.0.1-3`:

- upstream repository: https://github.com/open-rmf/rmf_api_msgs
- release repository: https://github.com/ros2-gbp/rmf_api_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.1-1`
