### PR TITLE
[emoji] Add pip emoji package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6381,6 +6381,9 @@ python3-elasticsearch:
 python3-emoji:
   debian:
     '*': [python3-emoji]
+    bullseye:
+      pip:
+        packages: [emoji]
     buster:
       pip:
         packages: [emoji]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1573,6 +1573,16 @@ python-elasticsearch:
   opensuse: [python-elasticsearch]
   ubuntu:
     bionic: [python-elasticsearch]
+python-emoji-pip:
+  debian:
+    pip:
+      packages: [emoji]
+  fedora:
+    pip:
+      packages: [emoji]
+  ubuntu:
+    pip:
+      packages: [emoji]
 python-empy:
   arch: [python2-empy]
   debian: [python-empy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6388,6 +6388,10 @@ python3-emoji:
       pip:
         packages: [emoji]
   fedora: [python3-emoji]
+  opensuse: [python3-emoji]
+  rhel:
+    '*': [python3-emoji]
+    '7': null
   ubuntu:
     '*': [python3-emoji]
     bionic:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6380,8 +6380,13 @@ python3-elasticsearch:
   ubuntu: [python3-elasticsearch]
 python3-emoji:
   debian:
-    pip:
-      packages: [emoji]
+    '*': [python3-emoji]
+    buster:
+      pip:
+        packages: [emoji]
+    stretch:
+      pip:
+        packages: [emoji]
   fedora: [python3-emoji]
   ubuntu:
     '*': [python3-emoji]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1573,16 +1573,6 @@ python-elasticsearch:
   opensuse: [python-elasticsearch]
   ubuntu:
     bionic: [python-elasticsearch]
-python-emoji-pip:
-  debian:
-    pip:
-      packages: [emoji]
-  fedora:
-    pip:
-      packages: [emoji]
-  ubuntu:
-    pip:
-      packages: [emoji]
 python-empy:
   arch: [python2-empy]
   debian: [python-empy]
@@ -6388,6 +6378,19 @@ python3-elasticsearch:
     '*': [python3-elasticsearch]
     '7': null
   ubuntu: [python3-elasticsearch]
+python3-emoji:
+  debian:
+    pip:
+      packages: [emoji]
+  fedora: [python3-emoji]
+  ubuntu:
+    '*': [python3-emoji]
+    bionic:
+      pip:
+        packages: [emoji]
+    focal:
+      pip:
+        packages: [emoji]
 python3-empy:
   alpine: [py3-empy]
   arch: [python-empy]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-emoji
pip/pip3 emoji

## Package Upstream Source:

https://github.com/carpedm20/emoji/

## Purpose of using this:

I want to release the package that depends on this library. 

Distro packaging links: https://github.com/jsk-ros-pkg/jsk_robot

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->
- Ubuntu: https://packages.ubuntu.com/jammy/python3-emoji
- Debian: https://packages.debian.org/bookworm/python3-emoji
- Fedora: https://packages.fedoraproject.org/pkgs/python-emoji/python3-emoji/
- opensuse: https://software.opensuse.org/package/python3-emoji
- rhel: https://src.fedoraproject.org/rpms/python-emoji
- Pip: https://pypi.org/project/emoji/

