### PR TITLE
warehouse_ros_sqlite: 1.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5435,7 +5435,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/warehouse_ros_sqlite-release.git
-      version: 1.0.2-3
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros_sqlite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros_sqlite` to `1.0.3-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros_sqlite.git
- release repository: https://github.com/ros2-gbp/warehouse_ros_sqlite-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.0.2-3`

## warehouse_ros_sqlite

```
* Add humble testing CI (#37 <https://github.com/ros-planning/warehouse_ros_sqlite/issues/37>)
* add missing stdlib include
* disable header include order check
* don't build warehouse_ros from source
* Contributors: Bjar Ne, Vatan Aksoy Tezer
```
