### PR TITLE
ridgeback: 0.3.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10317,7 +10317,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback` to `0.3.2-1`:

- upstream repository: https://github.com/ridgeback/ridgeback.git
- release repository: https://github.com/clearpath-gbp/ridgeback-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.1-1`

## ridgeback_control

```
* Enable subst_value when loading config_extras (#48 <https://github.com/ridgeback/ridgeback/issues/48>)
* Add twist_mux
* Bump CMake version to avoid CMP0048 warning.
* Contributors: Chris I-B, Joey Yang, Tony Baltovski
```

## ridgeback_description

```
* Bump CMake version to avoid CMP0048 warning.
* Contributors: Tony Baltovski
```

## ridgeback_msgs

```
* Bump CMake version to avoid CMP0048 warning.
* Contributors: Tony Baltovski
```

## ridgeback_navigation

```
* Bump CMake version to avoid CMP0048 warning.
* Contributors: Tony Baltovski
```
