### PR TITLE
pr2_navigation: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6824,6 +6824,33 @@ repositories:
       url: https://github.com/pr2/pr2_mechanism_msgs.git
       version: master
     status: unmaintained
+  pr2_navigation:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_navigation.git
+      version: kinetic-devel
+    release:
+      packages:
+      - laser_tilt_controller_filter
+      - pr2_move_base
+      - pr2_navigation
+      - pr2_navigation_config
+      - pr2_navigation_global
+      - pr2_navigation_local
+      - pr2_navigation_perception
+      - pr2_navigation_self_filter
+      - pr2_navigation_slam
+      - pr2_navigation_teleop
+      - semantic_point_annotator
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_navigation-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_navigation.git
+      version: kinetic-devel
+    status: maintained
   pr2_power_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_navigation` to `0.2.0-1`:

- upstream repository: https://github.com/PR2/pr2_navigation.git
- release repository: https://github.com/pr2-gbp/pr2_navigation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## laser_tilt_controller_filter

```
* updated maintainer
* fixed CMake files for compile in kinetic
* Contributors: Dave Feil-Seifer
```

## pr2_move_base

```
* update .travis.yml (#45 <https://github.com/pr2/pr2_navigation/issues/45>)
  
    * 2to3 -w -f except .
  
* updated maintainer
* fixed CMake files for compile in kinetic
* Contributors: David Feil-Seifer, Kei Okada, Michael Görner
```

## pr2_navigation

```
* updated maintainer
* Contributors: Dave Feil-Seifer
```

## pr2_navigation_config

```
* remove sim_period parameter: it does not exist (anymore?) (#42 <https://github.com/pr2/pr2_navigation/issues/42>)
* updated maintainer
* fixed CMake files for compile in kinetic
* Contributors: Dave Feil-Seifer, Michael Görner
```

## pr2_navigation_global

```
* do not publish voxelmap (#43 <https://github.com/pr2/pr2_navigation/issues/43>)
  This saves some cycles of the memcpy to the message
  and thus frees some resources in move_base.
* updated maintainer
* fixed CMake files for compile in kinetic
* Contributors: Dave Feil-Seifer, Michael Görner
```

## pr2_navigation_local

```
* updated maintainer
* fixed CMake files for compile in kinetic
* Contributors: Dave Feil-Seifer
```

## pr2_navigation_perception

```
* updated maintainer
* Contributors: Dave Feil-Seifer
```

## pr2_navigation_self_filter

```
* fix build in noetic (#44 <https://github.com/pr2/pr2_navigation/issues/44>)
  I'm not claiming that any of these packages work as they should on
  noetic. Claiming they worked on kinetic might be a stretch.
* fixed CMake files for compile in kinetic (#38 <https://github.com/pr2/pr2_navigation/issues/38>)
  
    * updated pr2_navigation_self_filter to fix unstable build warning with c++11 arg to gcc
    * updated CMakeLists.txt to fix CMake warnings and compile warnigns causing unstable build:
      * removed eigen dependency from semantic_point_aggregator
      * added c++11 compile option to pr2_navigation_self_filter
  
* updated maintainer
* Contributors: David Feil-Seifer, Michael Görner
```

## pr2_navigation_slam

```
* updated maintainer
* fixed CMake files for compile in kinetic
* Contributors: Dave Feil-Seifer, David Feil-Seifer
```

## pr2_navigation_teleop

```
* updated maintainer
* fixed CMake files for compile in kinetic
* Contributors: Dave Feil-Seifer
```

## semantic_point_annotator

```
* fix build in noetic (#44 <https://github.com/pr2/pr2_navigation/issues/44>)
  I'm not claiming that any of these packages work as they should on
  noetic. Claiming they worked on kinetic might be a stretch.
* updated CMakeLists.txt to fix CMake warnings and compile warnigns causing unstable build: (#38 <https://github.com/pr2/pr2_navigation/issues/38>)
  * removed eigen dependency from semantic_point_aggregator
  * added c++11 compile option to pr2_navigation_self_filter
  * updated maintainer
* Contributors: David Feil-Seifer, Michael Görner
```
