### PR TITLE
Add RHEL rule for python3-selenium

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8310,6 +8310,9 @@ python3-selenium:
   osx:
     pip:
       packages: [selenium]
+  rhel:
+    '*': [python3-selenium]
+    '7': null
   ubuntu: [python3-selenium]
 python3-semantic-version:
   debian: [python3-semantic-version]


### PR DESCRIPTION
This package is provided by EPEL in RHEL 8 and is not available for RHEL 7.

https://src.fedoraproject.org/rpms/python-selenium#bodhi_updates