### PR TITLE
Add rosdep rules for xdg-utils

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7932,6 +7932,16 @@ xclip:
     homebrew:
       packages: [xclip]
   ubuntu: [xclip]
+xdg-utils:
+  alpine: [xdg-utils]
+  arch: [xdg-utils]
+  debian: [xdg-utils]
+  fedora: [xdg-utils]
+  gentoo: [x11-misc/xdg-utils]
+  nixos: [xdg-utils]
+  opensuse: [xdg-utils]
+  rhel: [xdg-utils]
+  ubuntu: [xdg-utils]
 xdotool:
   arch: [xdotool]
   debian: [xdotool]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

xdg-utils

## Package Upstream Source:

https://cgit.freedesktop.org/xdg/xdg-utils/

## Purpose of using this:

The `xdg-open` executable is a great way to open a file or URL in a user's preferred application or browser, rather than calling a specific browser to do so.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=xdg-utils&searchon=names&exact=1&suite=all&section=all
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/search?keywords=xdg-utils&searchon=names&exact=1&suite=all&section=all
- Fedora: https://src.fedoraproject.org/browse/projects/
  - https://src.fedoraproject.org/rpms/xdg-utils#bodhi_updates
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/any/xdg-utils/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/x11-misc/xdg-utils
- macOS: https://formulae.brew.sh/
  - NOT AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/community/x86_64/xdg-utils
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=21.11&show=xdg-utils&from=0&size=50&sort=relevance&type=packages&query=xdg-utils
- openSUSE:
  - https://software.opensuse.org/package/xdg-utils
- RHEL:
  - 7: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/xdg-utils-1.1.0-0.17.20120809git.el7.noarch.rpm
  - 8: https://repo.almalinux.org/almalinux/8/AppStream/x86_64/os/Packages/xdg-utils-1.1.2-5.el8.noarch.rpm