### PR TITLE
Add RHEL rules for chromium

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -491,6 +491,7 @@ chromium-browser:
   fedora: [chromium]
   gentoo: [www-client/chromium]
   nixos: [chromium]
+  rhel: [chromium]
   ubuntu: [chromium-browser]
 chrony:
   arch: [chrony]


### PR DESCRIPTION
In both RHEL 7 and RHEL 8, this package is provided by EPEL.

https://src.fedoraproject.org/rpms/chromium#bodhi_updates