### PR TITLE
Add RHEL 8 rule for python3-scp

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8294,6 +8294,9 @@ python3-scp:
   debian: [python3-scp]
   fedora: [python3-scp]
   opensuse: [python3-scp]
+  rhel:
+    '*': [python3-scp]
+    '7': null
   ubuntu: [python3-scp]
 python3-seaborn:
   arch: [python-seaborn]


### PR DESCRIPTION
In RHEL 8, this package is provided by EPEL: https://src.fedoraproject.org/rpms/python-scp#bodhi_updates

This package is not available in RHEL 7.