### PR TITLE
Mark Humble as active

### DIFF
--- a/index-v4.yaml
+++ b/index-v4.yaml
@@ -54,7 +54,7 @@ distributions:
   humble:
     distribution: [humble/distribution.yaml]
     distribution_cache: http://repo.ros2.org/rosdistro_cache/humble-cache.yaml.gz
-    distribution_status: pre-release
+    distribution_status: active
     distribution_type: ros2
     python_version: 3
   hydro:


### PR DESCRIPTION
Move Humble's distribution status from `pre-release` to `active`.