### PR TITLE
frame_editor: 1.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2608,7 +2608,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ipa320/rqt_frame_editor_plugin.git
-      version: kinetic-devel
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -2617,7 +2617,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ipa320/rqt_frame_editor_plugin.git
-      version: kinetic-devel
+      version: noetic-devel
     status: maintained
   franka_ros:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2613,7 +2613,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/rqt_frame_editor_plugin-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/ipa320/rqt_frame_editor_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `frame_editor` to `1.1.1-1`:

- upstream repository: https://github.com/ipa320/rqt_frame_editor_plugin.git
- release repository: https://github.com/ipa320/rqt_frame_editor_plugin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.1.0-1`

## frame_editor

```
* Bug fix: Empty frame list on noetic now gets displayed
* Add some more Python -> Python3 conversions
* Contributors: Martin Günther, Philipp Tenbrock
```
