### PR TITLE
husky: 1.0.7-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1626,6 +1626,32 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
       version: foxy-devel
     status: developed
+  husky:
+    doc:
+      type: git
+      url: https://github.com/husky/husky.git
+      version: foxy-devel
+    release:
+      packages:
+      - husky_base
+      - husky_bringup
+      - husky_control
+      - husky_description
+      - husky_desktop
+      - husky_gazebo
+      - husky_msgs
+      - husky_robot
+      - husky_simulator
+      - husky_viz
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/clearpath-gbp/husky-release.git
+      version: 1.0.7-1
+    source:
+      type: git
+      url: https://github.com/husky/husky.git
+      version: foxy-devel
+    status: developed
   ifm3d_core:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `1.0.7-1`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## husky_base

```
* Renamed all launch files to *.launch.py.
* Contributors: Tony Baltovski
```

## husky_bringup

```
* Renamed all launch files to *.launch.py.
* Contributors: Tony Baltovski
```

## husky_control

```
* [husky_control] Fixed joy device param.
* Renamed all launch files to *.launch.py.
* Contributors: Tony Baltovski
```

## husky_description

```
* Renamed all launch files to *.launch.py.
* Contributors: Tony Baltovski
```

## husky_desktop

- No changes

## husky_gazebo

```
* Renamed all launch files to *.launch.py.
* Contributors: Tony Baltovski
```

## husky_msgs

- No changes

## husky_robot

- No changes

## husky_simulator

- No changes

## husky_viz

```
* Renamed all launch files to *.launch.py.
* Contributors: Tony Baltovski
```
