### PR TITLE
Add Orocos KDL rules for RHEL 8

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4334,6 +4334,9 @@ liborocos-kdl:
   gentoo: [sci-libs/orocos_kdl]
   nixos: [orocos-kdl]
   openembedded: [orocos-kdl@meta-ros1-noetic]
+  rhel:
+    '*': [orocos-kdl]
+    '7': null
   ubuntu:
     '*': [liborocos-kdl1.4]
     bionic: [liborocos-kdl1.3]
@@ -4344,6 +4347,9 @@ liborocos-kdl-dev:
   gentoo: [sci-libs/orocos_kdl]
   nixos: [orocos-kdl]
   openembedded: [orocos-kdl@meta-ros1-noetic]
+  rhel:
+    '*': [orocos-kdl-devel]
+    '7': null
   ubuntu: [liborocos-kdl-dev]
 libosmesa6-dev:
   arch: [mesa]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7784,6 +7784,9 @@ python3-pykdl:
   gentoo: [dev-python/python_orocos_kdl]
   nixos: [python3Packages.pykdl]
   openembedded: [python3-pykdl@meta-ros1-noetic]
+  rhel:
+    '*': [python3-pykdl]
+    '7': null
   ubuntu:
     '*': [python3-pykdl]
     bionic: null


### PR DESCRIPTION
This package is provided by EPEL for RHEL 8 and is not currently available for RHEL 7.

The `orocos-kdl` source package produces the `orocos-kdl`, `orocos-kdl-devel`, and `python3-pykdl` binary packages.

https://src.fedoraproject.org/rpms/orocos-kdl#bodhi_updates