### PR TITLE
ros_system_fingerprint: 0.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8251,6 +8251,22 @@ repositories:
       url: https://github.com/ros/ros_realtime.git
       version: noetic-devel
     status: maintained
+  ros_system_fingerprint:
+    doc:
+      type: git
+      url: https://github.com/MetroRobots/ros_system_fingerprint.git
+      version: noetic
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/MetroRobots/ros_system_fingerprint-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/MetroRobots/ros_system_fingerprint.git
+      version: noetic
+    status: developed
   ros_tutorials:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_system_fingerprint` to `0.1.0-1`:

- upstream repository: https://github.com/MetroRobots/ros_system_fingerprint.git
- release repository: https://github.com/MetroRobots/ros_system_fingerprint-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
