### PR TITLE
ros2_controllers: 2.5.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3527,7 +3527,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.2.0-2
+      version: 2.5.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.5.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.2.0-2`

## diff_drive_controller

```
* [diff_drive_controller] Made odom topic name relative as it was in ROS1. (#343 <https://github.com/ros-controls/ros2_controllers/issues/343>)
* Fix wrong integration of velocity feedback in odometry in diff_drive_controller (#331 <https://github.com/ros-controls/ros2_controllers/issues/331>)
* Contributors: Patrick Roncagliolo, Tony Baltovski
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

```
* fix: :bug: make force_torque_sensor_broadcaster wait for realtime_publisher (#327 <https://github.com/ros-controls/ros2_controllers/issues/327>)
* Contributors: Jaron Lundwall, Denis Štogl
```

## forward_command_controller

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

```
* fix: :bug: make force_torque_sensor_broadcaster wait for realtime_publisher (#327 <https://github.com/ros-controls/ros2_controllers/issues/327>)
* Contributors: Jaron Lundwall, Denis Štogl
```

## joint_state_broadcaster

```
* fix: :bug: make force_torque_sensor_broadcaster wait for realtime_publisher (#327 <https://github.com/ros-controls/ros2_controllers/issues/327>)
* Contributors: Jaron Lundwall, Denis Štogl
```

## joint_trajectory_controller

```
* check for nans in command interface (#346 <https://github.com/ros-controls/ros2_controllers/issues/346>)
* Contributors: Michael Wiznitzer
```

## position_controllers

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## velocity_controllers

- No changes
