### PR TITLE
Use packages.fedoraproject.org instead of src.fedoraproject.org

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,7 +32,7 @@ More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidel
   - REQUIRED
 - Ubuntu: https://packages.ubuntu.com/
    - REQUIRED
-- Fedora: https://src.fedoraproject.org/browse/projects/
+- Fedora: https://packages.fedoraproject.org/
   - IF AVAILABLE
 - Arch: https://www.archlinux.org/packages/
   - IF AVAILABLE

--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -42,7 +42,7 @@ package_dashboards:
 - pattern: !regular_expression .*//deb.debian.org/debian/.*
   url: https://packages.debian.org/{os_code_name}/{binary_name}
 - pattern: !regular_expression .*//dl.fedoraproject.org/pub/.*
-  url: https://src.fedoraproject.org/rpms/{source_name}#bodhi_updates
+  url: https://packages.fedoraproject.org/pkgs/{source_name}/{binary_name}/
 - pattern: !regular_expression .*//download.opensuse.org/.*
   url: https://software.opensuse.org/package/{source_name}
 - pattern: !regular_expression .*//archive.ubuntu.com/ubuntu/.*


### PR DESCRIPTION
The new Fedora packaging dashboard has been stable for a while now. It represents the subpackage relationships much better than src.fedoraproject.org does.