### PR TITLE
rosbridge_suite: 1.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3854,7 +3854,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 1.1.2-3
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `1.2.0-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.1.2-3`

## rosapi

```
* Added /rosapi/get_ros_version service (#708 <https://github.com/RobotWebTools/rosbridge_suite/issues/708>)
* Fixed node name collision with websocket launch file (#707 <https://github.com/RobotWebTools/rosbridge_suite/issues/707>)
* Contributors: Jacob Bandes-Storch, Kedus Mathewos, rob-clarke
```

## rosapi_msgs

```
* Added /rosapi/get_ros_version service (#708 <https://github.com/RobotWebTools/rosbridge_suite/issues/708>)
* Contributors: Jacob Bandes-Storch, Kedus Mathewos
```

## rosbridge_library

```
* Fixed float arrays conversion (#730 <https://github.com/RobotWebTools/rosbridge_suite/issues/730>)
* Fixed multiple subscriber on transient_local topic (#723 <https://github.com/RobotWebTools/rosbridge_suite/issues/723>)
* Fix translation of time and time arrays (#691 <https://github.com/RobotWebTools/rosbridge_suite/issues/691>)
* Fix array behavior (#692 <https://github.com/RobotWebTools/rosbridge_suite/issues/692>)
* Contributors: Jacob Bandes-Storch, José Castelo, Kenji Miyake, Will, p0rys
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* Fixed multiple subscriber on transient_local topic (#723 <https://github.com/RobotWebTools/rosbridge_suite/issues/723>)
* use uuid to ensure client id uniqueness (#713 <https://github.com/RobotWebTools/rosbridge_suite/issues/713>)
* Contributors: Jacob Bandes-Storch, Will, p0rys
```

## rosbridge_suite

- No changes

## rosbridge_test_msgs

- No changes
