### PR TITLE
foxglove_msgs: 1.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1338,7 +1338,7 @@ repositories:
   foxglove_msgs:
     doc:
       type: git
-      url: https://github.com/foxglove/ros_foxglove_msgs.git
+      url: https://github.com/foxglove/schemas.git
       version: main
     release:
       tags:
@@ -1347,7 +1347,7 @@ repositories:
       version: 1.2.0-1
     source:
       type: git
-      url: https://github.com/foxglove/ros_foxglove_msgs.git
+      url: https://github.com/foxglove/schemas.git
       version: main
     status: maintained
   gazebo_ros2_control:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1344,7 +1344,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_foxglove_msgs-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/foxglove/ros_foxglove_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_msgs` to `1.2.0-1`:

- upstream repository: https://github.com/foxglove/schemas.git
- release repository: https://github.com/ros2-gbp/ros_foxglove_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.1.0-1`

## foxglove_msgs

```
* Add new Foxglove message types to foxglove_msgs
* Contributors: Jacob Bandes-Storch
```
