### PR TITLE
foxglove_msgs: 1.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2592,7 +2592,7 @@ repositories:
   foxglove_msgs:
     doc:
       type: git
-      url: https://github.com/foxglove/schema.git
+      url: https://github.com/foxglove/schemas.git
       version: main
     release:
       tags:
@@ -2601,7 +2601,7 @@ repositories:
       version: 1.2.0-1
     source:
       type: git
-      url: https://github.com/foxglove/schema.git
+      url: https://github.com/foxglove/schemas.git
       version: main
     status: developed
   frame_editor:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2598,7 +2598,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/foxglove/ros_foxglove_msgs-release.git
-      version: 1.0.0-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/foxglove/ros_foxglove_msgs.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2592,8 +2592,8 @@ repositories:
   foxglove_msgs:
     doc:
       type: git
-      url: https://github.com/foxglove/ros_foxglove_msgs.git
-      version: 1.0.0
+      url: https://github.com/foxglove/schema.git
+      version: main
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -2601,7 +2601,7 @@ repositories:
       version: 1.2.0-1
     source:
       type: git
-      url: https://github.com/foxglove/ros_foxglove_msgs.git
+      url: https://github.com/foxglove/schema.git
       version: main
     status: developed
   frame_editor:


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_msgs` to `1.2.0-1`:

- upstream repository: https://github.com/foxglove/schemas.git
- release repository: https://github.com/foxglove/ros_foxglove_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.0.0-1`

## foxglove_msgs

```
* Add new Foxglove message types to foxglove_msgs
* Contributors: Jacob Bandes-Storch
```
