### PR TITLE
depthai-ros: 2.5.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -878,6 +878,27 @@ repositories:
       url: https://github.com/luxonis/depthai-core.git
       version: ros-release
     status: developed
+  depthai-ros:
+    doc:
+      type: git
+      url: https://github.com/luxonis/depthai-ros.git
+      version: ros-release
+    release:
+      packages:
+      - depthai-ros
+      - depthai_bridge
+      - depthai_examples
+      - depthai_ros_msgs
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/luxonis/depthai-ros-release.git
+      version: 2.5.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/luxonis/depthai-ros.git
+      version: ros-release
+    status: developed
   depthimage_to_laserscan:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai-ros` to `2.5.0-2`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: https://github.com/luxonis/depthai-ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## depthai-ros

```
* packaging all the depthai pacakges
```

## depthai_bridge

```
* Release 2.15.4
* add ament package:
* created Bridge and Coverters to handle images, IMU and camera Info
```

## depthai_examples

```
* Release 2.15.4
* add ament package:
* added sample nodes example codes to work with depthai devices
```

## depthai_ros_msgs

```
* Release 2.15.4
* add ament package:
* additional custom interfaces needed to publish depthai structures
```
