### PR TITLE
monkeywrench: 0.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5016,7 +5016,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/cst0/ros-monkeywrench.git
-      version: master
+      version: main
     release:
       tags:
         release: release/noetic/{package}/{version}

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5013,6 +5013,10 @@ repositories:
       version: master
     status: maintained
   monkeywrench:
+    doc:
+      type: git
+      url: https://github.com/cst0/ros-monkeywrench.git
+      version: master
     release:
       tags:
         release: release/noetic/{package}/{version}

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5012,6 +5012,17 @@ repositories:
       url: https://github.com/ros-drivers/mocap_optitrack.git
       version: master
     status: maintained
+  monkeywrench:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/cst0/ros-monkeywrench-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/cst0/ros-monkeywrench.git
+      version: noetic_devel
+    status: developed
   move_base_flex:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `monkeywrench` to `0.1.0-1`:

- upstream repository: https://github.com/cst0/ros-monkeywrench.git
- release repository: https://github.com/cst0/ros-monkeywrench-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## monkeywrench

```
* Initial code release, demo
* Update documentation
* Create LICENSE
```
