### PR TITLE
depthai-ros: 2.5.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -892,7 +892,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/luxonis/depthai-ros-release.git
-      version: 2.5.0-2
+      version: 2.5.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai-ros` to `2.5.1-1`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: https://github.com/luxonis/depthai-ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.5.0-2`

## depthai-ros

```
* Fix Build farm issues
```

## depthai_bridge

```
* Fix Build farm issues
```

## depthai_examples

```
* Fix Build farm issues
```

## depthai_ros_msgs

```
* Fix Build farm issues
```
