### PR TITLE
depthai-ros: 2.5.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1646,6 +1646,16 @@ repositories:
       type: git
       url: https://github.com/luxonis/depthai-ros.git
       version: main
+    release:
+      packages:
+      - depthai-ros
+      - depthai_bridge
+      - depthai_examples
+      - depthai_ros_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/luxonis/depthai-ros-release.git
+      version: 2.5.1-1
     source:
       type: git
       url: https://github.com/luxonis/depthai-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai-ros` to `2.5.1-1`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: https://github.com/luxonis/depthai-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## depthai-ros

```
* Fix Build farm issues
```

## depthai_bridge

```
* Fix Build farm issues
```

## depthai_examples

```
* Fix Build farm issues
```

## depthai_ros_msgs

```
* Fix Build farm issues
```
