### PR TITLE
depthai-ros: 2.5.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1661,7 +1661,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/luxonis/depthai-ros.git
-      version: main
+      version: ros-release
     release:
       packages:
       - depthai-ros
@@ -1673,9 +1673,10 @@ repositories:
       url: https://github.com/luxonis/depthai-ros-release.git
       version: 2.5.1-2
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/luxonis/depthai-ros.git
-      version: main
+      version: ros-release
     status: developed
   depthimage_to_laserscan:
     release:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1671,7 +1671,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/luxonis/depthai-ros-release.git
-      version: 2.5.1-1
+      version: 2.5.1-2
     source:
       type: git
       url: https://github.com/luxonis/depthai-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai-ros` to `2.5.1-2`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: https://github.com/luxonis/depthai-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.5.1-1`

## depthai-ros

```
* Fix Build farm issues
```

## depthai_bridge

```
* Fix Build farm issues
```

## depthai_examples

```
* Fix Build farm issues
```

## depthai_ros_msgs

```
* Fix Build farm issues
```
