### PR TITLE
ecl_lite: 1.1.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1065,7 +1065,6 @@ repositories:
       url: https://github.com/yujinrobot-release/ecl_core-release.git
       version: 1.2.0-1
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/stonier/ecl_core.git
       version: devel
@@ -1090,7 +1089,6 @@ repositories:
       url: https://github.com/yujinrobot-release/ecl_lite-release.git
       version: 1.1.0-1
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/stonier/ecl_lite.git
       version: devel

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -821,6 +821,30 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
       version: galactic-devel
     status: developed
+  ecl_lite:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_lite.git
+      version: release/1.1.x
+    release:
+      packages:
+      - ecl_config
+      - ecl_console
+      - ecl_converters_lite
+      - ecl_errors
+      - ecl_io
+      - ecl_lite
+      - ecl_sigslots_lite
+      - ecl_time_lite
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_lite-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/stonier/ecl_lite.git
+      version: devel
+    status: maintained
   ecl_tools:
     doc:
       type: git
@@ -836,7 +860,6 @@ repositories:
       url: https://github.com/yujinrobot-release/ecl_tools-release.git
       version: 1.0.2-1
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/stonier/ecl_tools.git
       version: devel


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_lite` to `1.1.0-1`:

- upstream repository: https://github.com/stonier/ecl_lite.git
- release repository: https://github.com/yujinrobot-release/ecl_lite-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`
