### PR TITLE
geomerty_python3: 1.12.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3804,6 +3804,15 @@ repositories:
       url: https://github.com/ros-geographic-info/geographic_info.git
       version: master
     status: maintained
+  geomerty_python3:
+    release:
+      packages:
+      - tf_conversions_python3
+      - tf_python3
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/geometry_python3-release.git
+      version: 1.12.2-1
   geometric_shapes:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geomerty_python3` to `1.12.2-1`:

- upstream repository: https://github.com/jsk-ros-pkg/geometry_python3.git
- release repository: https://github.com/tork-a/geometry_python3-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`
