### PR TITLE
orocos-kdl_python3: 1.4.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8485,6 +8485,14 @@ repositories:
       url: https://github.com/appliedAI-Initiative/orb_slam_2_ros.git
       version: master
     status: maintained
+  orocos-kdl_python3:
+    release:
+      packages:
+      - python_orocos_kdl_python3
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/orocos-kdl_python3-release.git
+      version: 1.4.1-1
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos-kdl_python3` to `1.4.1-1`:

- upstream repository: https://github.com/jsk-ros-pkg/orocos_kinematics_dynamics_python3.git
- release repository: https://github.com/tork-a/orocos-kdl_python3-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`
