### PR TITLE
geomerty2_python3: 0.6.8-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3804,6 +3804,14 @@ repositories:
       url: https://github.com/ros-geographic-info/geographic_info.git
       version: master
     status: maintained
+  geomerty2_python3:
+    release:
+      packages:
+      - tf2_py_python3
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/geometry2_python3-release.git
+      version: 0.6.8-1
   geometric_shapes:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geomerty2_python3` to `0.6.8-1`:

- upstream repository: https://github.com/jsk-ros-pkg/geometry2_python3.git
- release repository: https://github.com/tork-a/geometry2_python3-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`
