### PR TITLE
zmqpp_vendor: 0.0.2-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6738,5 +6738,20 @@ repositories:
       url: https://github.com/ros2/yaml_cpp_vendor.git
       version: foxy
     status: maintained
+  zmqpp_vendor:
+    doc:
+      type: git
+      url: https://github.com/tier4/zmqpp_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/tier4/zmqpp_vendor-release.git
+      version: 0.0.2-2
+    source:
+      type: git
+      url: https://github.com/tier4/zmqpp_vendor.git
+      version: main
+    status: developed
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `zmqpp_vendor` to `0.0.2-2`:

- upstream repository: https://github.com/tier4/zmqpp_vendor.git
- release repository: https://github.com/tier4/zmqpp_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## zmqpp_vendor

```
* Merge pull request #5 <https://github.com/tier4/zmqpp_vendor/issues/5> from tier4/fix/default_branch_name
* fix default branch name
* Merge pull request #3 <https://github.com/tier4/zmqpp_vendor/issues/3> from tier4/feature/add_22_04_support
* Merge pull request #2 <https://github.com/tier4/zmqpp_vendor/issues/2> from tier4/feature/release_action
* remove 22.04 support
* add 22.04/18.04 support
* add release action
* Merge pull request #1 <https://github.com/tier4/zmqpp_vendor/issues/1> from cottsay/git_dep
* Add missing buildtool_depend on git
* Contributors: Masaya Kataoka, MasayaKataoka, Scott K Logan
```
