### PR TITLE
zmqpp_vendor: 0.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5649,7 +5649,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/tier4/zmqpp_vendor-release.git
-      version: 0.0.1-2
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/tier4/zmqpp_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `zmqpp_vendor` to `0.0.2-1`:

- upstream repository: https://github.com/tier4/zmqpp_vendor.git
- release repository: https://github.com/tier4/zmqpp_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.1-2`

## zmqpp_vendor

```
* Merge pull request #5 <https://github.com/tier4/zmqpp_vendor/issues/5> from tier4/fix/default_branch_name
* fix default branch name
* Merge pull request #3 <https://github.com/tier4/zmqpp_vendor/issues/3> from tier4/feature/add_22_04_support
* Merge pull request #2 <https://github.com/tier4/zmqpp_vendor/issues/2> from tier4/feature/release_action
* remove 22.04 support
* add 22.04/18.04 support
* add release action
* Merge pull request #1 <https://github.com/tier4/zmqpp_vendor/issues/1> from cottsay/git_dep
* Add missing buildtool_depend on git
* Contributors: Masaya Kataoka, MasayaKataoka, Scott K Logan
```
