### PR TITLE
moveit_resources: 2.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2022,8 +2022,8 @@ repositories:
       - moveit_resources_pr2_description
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/moveit_resources-release.git
-      version: 2.0.3-2
+      url: https://github.com/ros2-gbp/moveit_resources-release
+      version: 2.0.4-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_resources.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `2.0.4-1`:

- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros2-gbp/moveit_resources-release
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.0.3-2`

## moveit_resources

```
* Change ROS2 Maintainer (#114 <https://github.com/ros-planning/moveit_resources/issues/114>)
* Contributors: Dave Coleman
```

## moveit_resources_fanuc_description

- No changes

## moveit_resources_fanuc_moveit_config

```
* Update FANUC launch file and cleanup of deprecated XML files (#120 <https://github.com/ros-planning/moveit_resources/issues/120>)
* Delete deprecated Panda config and launch files (#98 <https://github.com/ros-planning/moveit_resources/issues/98>)
* Update yaml parameters for moveit_configs_utils (#108 <https://github.com/ros-planning/moveit_resources/issues/108>)
* Port PRBT packages for PILZ planner tests (#101 <https://github.com/ros-planning/moveit_resources/issues/101>)
* Adding RPBT config (#43 <https://github.com/ros-planning/moveit_resources/issues/43>)
* Contributors: AndyZe, Christian Henkel, Henning Kayser, Jafar Abdi, Sebastian Jahr, Stephanie Eng
```

## moveit_resources_panda_description

- No changes

## moveit_resources_panda_moveit_config

```
* Explicitly use CHOMP and OMPL planners (#135 <https://github.com/ros-planning/moveit_resources/issues/135>)
* Rename Panda Controller Files (#127 <https://github.com/ros-planning/moveit_resources/issues/127>)
* Fix controller_manager node's output type (#129 <https://github.com/ros-planning/moveit_resources/issues/129>)
* Black Formatting for Launch Files (#128 <https://github.com/ros-planning/moveit_resources/issues/128>)
* Refactor panda demo.launch to use moveit_configs_utils (#119 <https://github.com/ros-planning/moveit_resources/issues/119>)
* Remove stomp configuration file (#126 <https://github.com/ros-planning/moveit_resources/issues/126>)
* Restore panda_gripper_controllers.yaml. Rename panda_moveit_controllers.yaml (#117 <https://github.com/ros-planning/moveit_resources/issues/117>)
* Delete deprecated Panda config and launch files (#98 <https://github.com/ros-planning/moveit_resources/issues/98>)
* No initial velocity conditions (#111 <https://github.com/ros-planning/moveit_resources/issues/111>)
* ros2_control update: initial_position -> initial_value (#110 <https://github.com/ros-planning/moveit_resources/issues/110>)
* Update yaml parameters for moveit_configs_utils (#108 <https://github.com/ros-planning/moveit_resources/issues/108>)
* Port PRBT packages for PILZ planner tests (#101 <https://github.com/ros-planning/moveit_resources/issues/101>)
* Adding RPBT config (#43 <https://github.com/ros-planning/moveit_resources/issues/43>)
  to speed up test time by skipping trajectory in fake execution
* Contributors: AndyZe, Christian Henkel, David V. Lu!!, Henning Kayser, Jafar, Jafar Abdi, Sebastian Jahr, Stephanie Eng
```

## moveit_resources_pr2_description

- No changes
