### PR TITLE
Drop release stanza for performance_test.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2512,14 +2512,6 @@ repositories:
       type: git
       url: https://gitlab.com/ApexAI/performance_test.git
       version: 1.0.0
-    release:
-      packages:
-      - performance_report
-      - performance_test
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/performance_test-release.git
-      version: 1.0.0-1
     source:
       type: git
       url: https://gitlab.com/ApexAI/performance_test.git


### PR DESCRIPTION
This package has a pip dependency preventing bloom from creating
release data for Ubuntu Jammy, which is currently a required platform
for Rolling. With the repository configured as-is, sourcepkg jobs are
currently running and failing since they cannot find the tags required
to create platform-specific source packages.

Removing the release stanza stops the attempted source package creation
and indicates that the package is not currently releasable for Rolling's
target platforms. If a future version of the package becomes
releasable, running bloom again will repopulate the stanza.