### PR TITLE
imu_tools: 2.0.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1472,7 +1472,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/imu_tools-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `2.0.2-1`:

- upstream repository: https://github.com/CCNYRoboticsLab/imu_tools.git
- release repository: https://github.com/ros2-gbp/imu_tools-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.0.1-1`

## imu_complementary_filter

```
* Add missing build dependency to package.xml. (#161 <https://github.com/CCNYRoboticsLab/imu_tools/issues/161>)
* Contributors: Martin Günther, Steven! Ragnarök
```

## imu_filter_madgwick

- No changes

## imu_tools

- No changes

## rviz_imu_plugin

- No changes
