### PR TITLE
turtlebot4_robot: 0.1.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5470,6 +5470,27 @@ repositories:
       url: https://github.com/turtlebot/turtlebot4_desktop.git
       version: galactic
     status: developed
+  turtlebot4_robot:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4_robot.git
+      version: galactic
+    release:
+      packages:
+      - turtlebot4_base
+      - turtlebot4_bringup
+      - turtlebot4_diagnostics
+      - turtlebot4_robot
+      - turtlebot4_tests
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot4_robot-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4_robot.git
+      version: galactic
+    status: developed
   turtlebot4_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4_robot` to `0.1.0-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4_robot.git
- release repository: https://github.com/ros2-gbp/turtlebot4_robot-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## turtlebot4_base

```
* First Galactic release
* Contributors: Roni Kreinin
```

## turtlebot4_bringup

```
* First Galactic release
* Contributors: Roni Kreinin
```

## turtlebot4_diagnostics

```
* First Galactic release
* Contributors: Roni Kreinin
```

## turtlebot4_robot

```
* First Galactic release
* Contributors: Roni Kreinin
```

## turtlebot4_tests

```
* First Galactic release
* Contributors: Roni Kreinin
```
