### PR TITLE
leo_desktop: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1665,6 +1665,24 @@ repositories:
       url: https://github.com/LeoRover/leo_common-ros2.git
       version: humble
     status: maintained
+  leo_desktop:
+    doc:
+      type: git
+      url: https://github.com/LeoRover/leo_desktop-ros2.git
+      version: humble
+    release:
+      packages:
+      - leo_desktop
+      - leo_viz
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/fictionlab-gbp/leo_desktop-ros2-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/LeoRover/leo_desktop-ros2.git
+      version: humble
+    status: maintained
   lgsvl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_desktop` to `1.0.0-1`:

- upstream repository: https://github.com/LeoRover/leo_desktop-ros2.git
- release repository: https://github.com/fictionlab-gbp/leo_desktop-ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## leo_desktop

```
* Initial port for ROS2
```

## leo_viz

```
* Initial port for ROS2
```
