### PR TITLE
microstrain_inertial: 2.6.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2465,7 +2465,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/microstrain_inertial-release.git
-      version: 2.5.1-1
+      version: 2.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `2.6.0-1`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/ros2-gbp/microstrain_inertial-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.5.1-1`

## microstrain_inertial_driver

```
* ROS Fixes NMEA parsing to not fail when we find certain MIP packets (#159 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/159>)
  * Fixes NMEA parsing to not fail when we find certain MIP packets
* Runs roslint on the buildfarm (#154 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/154>)
* Fixed reporting of filter pitch and yaw when using ENU frame for ROS (#150 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/150>)
* Adds velocity covarianve for the GNSS odometry message for ROS (#149 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/149>)
* Adds ability to publish velocity in the vehicle frame for ROS (#145 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/145>)
* ROS More granular data rates (#131 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/131>)
  * Adds more granular data rates to ROS
* ROS Check supported aiding measurements (#140 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/140>)
  * Checks if the device supports the requested aiding measurements before enabling/disabling
* Adds ability to switch between compensated and linear acceleration for filtered IMU (#128 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/128>)
* Contributors: Lucas Walter, robbiefish
```

## microstrain_inertial_examples

- No changes

## microstrain_inertial_msgs

```
* Converts message definitions to use unix line endings (#138 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/138>)
* Contributors: Lucas Walter
```

## microstrain_inertial_rqt

- No changes
