### PR TITLE
ublox_dgnss: 0.3.5-4 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5105,7 +5105,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/aussierobots/ublox_dgnss-release.git
-      version: 0.3.2-3
+      version: 0.3.5-4
     source:
       type: git
       url: https://github.com/aussierobots/ublox_dgnss.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ublox_dgnss` to `0.3.5-4`:

- upstream repository: https://github.com/aussierobots/ublox_dgnss
- release repository: https://github.com/aussierobots/ublox_dgnss-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.3.2-3`

## ublox_dgnss

```
* fixed title underline
* Contributors: Nick Hortovanyi
```

## ublox_dgnss_node

```
* uncrustify changes
* reverted uncrustify to ros ament default
* fixed title underline
* Contributors: Nick Hortovanyi
```

## ublox_ubx_interfaces

```
* fixed title underline
* Contributors: Nick Hortovanyi
```

## ublox_ubx_msgs

```
* fixed title underline
* Contributors: Nick Hortovanyi
```
