### PR TITLE
ublox_dgnss: 0.3.5-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5153,6 +5153,26 @@ repositories:
       url: https://github.com/KumarRobotics/ublox.git
       version: ros2
     status: maintained
+  ublox_dgnss:
+    doc:
+      type: git
+      url: https://github.com/aussierobots/ublox_dgnss.git
+      version: main
+    release:
+      packages:
+      - ublox_dgnss
+      - ublox_dgnss_node
+      - ublox_ubx_interfaces
+      - ublox_ubx_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/aussierobots/ublox_dgnss-release.git
+      version: 0.3.5-3
+    source:
+      type: git
+      url: https://github.com/aussierobots/ublox_dgnss.git
+      version: main
+    status: maintained
   udp_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ublox_dgnss` to `0.3.5-3`:

- upstream repository: https://github.com/aussierobots/ublox_dgnss
- release repository: https://github.com/aussierobots/ublox_dgnss-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## ublox_dgnss

```
* fixed title underline
* Contributors: Nick Hortovanyi
```

## ublox_dgnss_node

```
* uncrustify changes
* reverted uncrustify to ros ament default
* fixed title underline
* Contributors: Nick Hortovanyi
```

## ublox_ubx_interfaces

```
* fixed title underline
* Contributors: Nick Hortovanyi
```

## ublox_ubx_msgs

```
* fixed title underline
* Contributors: Nick Hortovanyi
```
