### PR TITLE
Python3 unidiff

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8857,6 +8857,13 @@ python3-ubjson:
   ubuntu:
     '*': [python3-ubjson]
     xenial: null
+python3-unidiff:
+  arch: [python-unidiff]
+  debian: [python3-unidiff]
+  ubuntu: [python3-unidiff]
+  fedora: [python3-unidiff]
+  gentoo: [dev-python/unidiff]
+  nixos: [python39Packages.unidiff]
 python3-urdfpy-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8860,10 +8860,12 @@ python3-ubjson:
 python3-unidiff:
   arch: [python-unidiff]
   debian: [python3-unidiff]
-  ubuntu: [python3-unidiff]
   fedora: [python3-unidiff]
   gentoo: [dev-python/unidiff]
   nixos: [python39Packages.unidiff]
+  opensuse: [python-unidiff]
+  rhel: [python3-unidiff]
+  ubuntu: [python3-unidiff]
 python3-urdfpy-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-unidiff

## Package Upstream Source:

https://github.com/matiasb/python-unidiff

## Purpose of using this:

Used by [ament_black](https://github.com/tylerjw/ament_black)

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/python3-unidiff
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/search?keywords=unidiff&searchon=names&suite=jammy&section=all
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-unidiff/python36-unidiff/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/community/any/python-unidiff/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/unidiff
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/mecab-unidic#default
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/packages?name=unidiff&branch=edge
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=21.11&show=python39Packages.unidiff&from=0&size=50&sort=relevance&type=packages&query=unidiff
