### PR TITLE
turtlebot4_examples: 0.1.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5470,6 +5470,25 @@ repositories:
       url: https://github.com/turtlebot/turtlebot4_desktop.git
       version: galactic
     status: developed
+  turtlebot4_examples:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4_examples.git
+      version: galactic
+    release:
+      packages:
+      - turtlebot4_cpp_examples
+      - turtlebot4_examples
+      - turtlebot4_python_examples
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot4_examples-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4_examples.git
+      version: galactic
+    status: developed
   turtlebot4_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4_examples` to `0.1.0-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4_examples.git
- release repository: https://github.com/ros2-gbp/turtlebot4_examples-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## turtlebot4_cpp_examples

```
* First Galactic release
* Contributors: Roni Kreinin
```

## turtlebot4_examples

```
* First Galactic release
* Contributors: Roni Kreinin
```

## turtlebot4_python_examples

```
* First Galactic release
* Contributors: Roni Kreinin
```
