### PR TITLE
turtlebot4_tutorials: 0.1.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5511,6 +5511,25 @@ repositories:
       url: https://github.com/turtlebot/turtlebot4_simulator.git
       version: galactic
     status: developed
+  turtlebot4_tutorials:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4_tutorials.git
+      version: galactic
+    release:
+      packages:
+      - turtlebot4_cpp_tutorials
+      - turtlebot4_python_tutorials
+      - turtlebot4_tutorials
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot4_tutorials-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4_tutorials.git
+      version: galactic
+    status: developed
   turtlesim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4_tutorials` to `0.1.0-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4_tutorials.git
- release repository: https://github.com/ros2-gbp/turtlebot4_tutorials-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## turtlebot4_cpp_tutorials

```
* First Galactic release
* Contributors: Roni Kreinin
```

## turtlebot4_python_tutorials

```
* First Galactic release
* Contributors: Roni Kreinin
```

## turtlebot4_tutorials

```
* First Galactic release
* Contributors: Roni Kreinin
```
