### PR TITLE
deptha-ros: 2.5.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -701,6 +701,27 @@ repositories:
       url: https://github.com/ros2/demos.git
       version: humble
     status: developed
+  deptha-ros:
+    doc:
+      type: git
+      url: https://github.com/luxonis/depthai-ros.git
+      version: ros-release
+    release:
+      packages:
+      - depthai-ros
+      - depthai_bridge
+      - depthai_examples
+      - depthai_ros_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/luxonis/depthai-ros-release.git
+      version: 2.5.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/luxonis/depthai-ros.git
+      version: ros-release
+    status: developed
   depthimage_to_laserscan:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -701,7 +701,7 @@ repositories:
       url: https://github.com/ros2/demos.git
       version: humble
     status: developed
-  deptha-ros:
+  depthai-ros:
     doc:
       type: git
       url: https://github.com/luxonis/depthai-ros.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -720,6 +720,8 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/luxonis/depthai-ros.git
+      version: ros-release
+    status: developed
   depthai:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -701,6 +701,22 @@ repositories:
       url: https://github.com/ros2/demos.git
       version: humble
     status: developed
+  depthai:
+    doc:
+      type: git
+      url: https://github.com/luxonis/depthai-core.git
+      version: ros-release
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/luxonis/depthai-core-release.git
+      version: 2.15.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/luxonis/depthai-core.git
+      version: ros-release
+    status: developed
   depthai-ros:
     doc:
       type: git
@@ -720,22 +736,6 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/luxonis/depthai-ros.git
-      version: ros-release
-    status: developed
-  depthai:
-    doc:
-      type: git
-      url: https://github.com/luxonis/depthai-core.git
-      version: ros-release
-    release:
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/luxonis/depthai-core-release.git
-      version: 2.15.4-1
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/luxonis/depthai-core.git
       version: ros-release
     status: developed
   depthimage_to_laserscan:


### PR DESCRIPTION
Increasing version of package(s) in repository `deptha-ros` to `2.5.1-1`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: https://github.com/luxonis/depthai-ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## depthai-ros

```
* Fix Build farm issues
```

## depthai_bridge

```
* Fix Build farm issues
```

## depthai_examples

```
* Fix Build farm issues
```

## depthai_ros_msgs

```
* Fix Build farm issues
```
