### PR TITLE
leo_common: 1.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1659,7 +1659,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_common-ros2-release.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_common-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_common` to `1.0.3-1`:

- upstream repository: https://github.com/LeoRover/leo_common-ros2.git
- release repository: https://github.com/fictionlab-gbp/leo_common-ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.0.2-1`

## leo

- No changes

## leo_description

- No changes

## leo_msgs

```
* Remove architecture_independent from leo_msgs (#1 <https://github.com/LeoRover/leo_common-ros2/issues/1>)
* Contributors: Scott K Logan
```

## leo_teleop

- No changes
