### PR TITLE
cascade_lifecycle: 1.0.1-3 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -514,6 +514,24 @@ repositories:
       url: https://github.com/ros2/cartographer_ros.git
       version: ros2
     status: maintained
+  cascade_lifecycle:
+    doc:
+      type: git
+      url: https://github.com/fmrico/cascade_lifecycle.git
+      version: humble-devel
+    release:
+      packages:
+      - cascade_lifecycle_msgs
+      - rclcpp_cascade_lifecycle
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/fmrico/cascade_lifecycle-release.git
+      version: 1.0.1-3
+    source:
+      type: git
+      url: https://github.com/fmrico/cascade_lifecycle.git
+      version: humble-devel
+    status: developed
   class_loader:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cascade_lifecycle` to `1.0.1-3`:

- upstream repository: https://github.com/fmrico/cascade_lifecycle.git
- release repository: https://github.com/fmrico/cascade_lifecycle-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## cascade_lifecycle_msgs

- No changes

## rclcpp_cascade_lifecycle

- No changes
