### PR TITLE
moveit: 2.5.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2002,6 +2002,7 @@ repositories:
       - moveit
       - moveit_chomp_optimizer_adapter
       - moveit_common
+      - moveit_configs_utils
       - moveit_core
       - moveit_hybrid_planning
       - moveit_kinematics
@@ -2033,6 +2034,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/moveit/moveit2-release.git
+      version: 2.5.0-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.5.0-1`:

- upstream repository: https://github.com/ros-planning/moveit2.git
- release repository: https://github.com/moveit/moveit2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## chomp_motion_planner

```
* Make moveit_common a 'depend' rather than 'build_depend' (#1226 <https://github.com/ros-planning/moveit2/issues/1226>)
* Merge https://github.com/ros-planning/moveit/commit/424a5b7b8b774424f78346d1e98bf1c9a33f0e78
* MSA: Add STOMP + OMPL-CHOMP configs (#2955 <https://github.com/ros-planning/moveit2/issues/2955>)
* Contributors: Abishalini, Jafar, Rick Staa, Robert Haschke, jeoseo
```

## moveit

```
* Fix copyright notice in README script (#1115 <https://github.com/ros-planning/moveit2/issues/1115>)
* Contributors: Abishalini, Henning Kayser, Robert Haschke
```

## moveit_chomp_optimizer_adapter

```
* Make TOTG the default time-parameterization algorithm everywhere (#1218 <https://github.com/ros-planning/moveit2/issues/1218>)
* Make moveit_common a 'depend' rather than 'build_depend' (#1226 <https://github.com/ros-planning/moveit2/issues/1226>)
* Remove unused parameters. (#1018 <https://github.com/ros-planning/moveit2/issues/1018>)
* Contributors: AndyZe, Cory Crean, Jafar, Robert Haschke, jeoseo
```

## moveit_common

- No changes

## moveit_configs_utils

```
* Add options to config for publishing description (#1265 <https://github.com/ros-planning/moveit2/issues/1265>)
* Flexibility in moveit_configs_utils reading of .setup_assistant (#1264 <https://github.com/ros-planning/moveit2/issues/1264>)
* Alternate Package Name Specification (#1244 <https://github.com/ros-planning/moveit2/issues/1244>)
* Change condition for loading default OMPL config (#1222 <https://github.com/ros-planning/moveit2/issues/1222>)
* Demo launch for moveit_configs_utils (#1189 <https://github.com/ros-planning/moveit2/issues/1189>)
  * Demo launch for moveit_configs_utils
  * Don't respawn rviz
* move_group launch for moveit_configs_utils (#1131 <https://github.com/ros-planning/moveit2/issues/1131>)
* Add launch file configurations for static tfs and spawning controllers (#1176 <https://github.com/ros-planning/moveit2/issues/1176>)
* Fix Moveit Configs Utils Bug (#1174 <https://github.com/ros-planning/moveit2/issues/1174>)
* New Launch Files using moveit_configs_utils (#1113 <https://github.com/ros-planning/moveit2/issues/1113>)
  * Add Package Path
  * Launch Utils
  * Some Basic Launch Files
  * Remove circular dependencies
* [moveit_configs_utils] Minor fixes (#1103 <https://github.com/ros-planning/moveit2/issues/1103>)
* Add moveit_configs_utils package to simplify loading paramters (#591 <https://github.com/ros-planning/moveit2/issues/591>)
  Co-authored-by: AndyZe <mailto:zelenak@picknik.ai>
  Co-authored-by: Stephanie Eng <mailto:stephanie-eng@users.noreply.github.com>
  Co-authored-by: Tyler Weaver <mailto:tyler@picknik.ai>
* Contributors: David V. Lu!!, Jafar Abdi, Stephanie Eng, Tyler Weaver
* Add options to config for publishing description (#1265 <https://github.com/ros-planning/moveit2/issues/1265>)
* Flexibility in moveit_configs_utils reading of .setup_assistant (#1264 <https://github.com/ros-planning/moveit2/issues/1264>)
* Alternate Package Name Specification (#1244 <https://github.com/ros-planning/moveit2/issues/1244>)
* Change condition for loading default OMPL config (#1222 <https://github.com/ros-planning/moveit2/issues/1222>)
* Demo launch for moveit_configs_utils (#1189 <https://github.com/ros-planning/moveit2/issues/1189>)
* move_group launch for moveit_configs_utils (#1131 <https://github.com/ros-planning/moveit2/issues/1131>)
* Add launch file configurations for static tfs and spawning controllers (#1176 <https://github.com/ros-planning/moveit2/issues/1176>)
* Fix Moveit Configs Utils Bug (#1174 <https://github.com/ros-planning/moveit2/issues/1174>)
* New Launch Files using moveit_configs_utils (#1113 <https://github.com/ros-planning/moveit2/issues/1113>)
* Contributors: David V. Lu!!, Jafar Abdi, Stephanie Eng, Tyler Weaver
```

## moveit_core

```
* Fix a bug when checking a pose is empty and TOTG corner case (#1274 <https://github.com/ros-planning/moveit2/issues/1274>)
  * Fix having empty object pose would use the shape pose as the object pose
  * TOTG: Fix parameterizing a trajectory would produce a different last waypoint than the input last waypoint
* Add missing dependencies to cmake (#1258 <https://github.com/ros-planning/moveit2/issues/1258>)
* Fix bug in applying planning scene diffs that have attached collision objects (#3124 <https://github.com/ros-planning/moveit2/issues/3124>) (#1251 <https://github.com/ros-planning/moveit2/issues/1251>)
* Merge https://github.com/ros-planning/moveit/commit/72d919299796bffc21f5eb752d66177841dc3442
* Allow custom velocity/accel/jerk limits for Ruckig smoothing (#1221 <https://github.com/ros-planning/moveit2/issues/1221>)
* Allow custom velocity/acceleration limits for TOTG time-parameterization algorithm (#1195 <https://github.com/ros-planning/moveit2/issues/1195>)
* Make moveit_common a 'depend' rather than 'build_depend' (#1226 <https://github.com/ros-planning/moveit2/issues/1226>)
* Remove unused includes for boost::bind (#1220 <https://github.com/ros-planning/moveit2/issues/1220>)
* Avoid bind(), use lambdas instead (#1204 <https://github.com/ros-planning/moveit2/issues/1204>)
* Fix clang-tidy warning (#1208 <https://github.com/ros-planning/moveit2/issues/1208>)
* banish bind()
  source:https://github.com/ros-planning/moveit/pull/3106/commits/a2911c80c28958c1fce8fb52333d770248c4ec05; required minor updates compared to original source commit in order to ensure compatibility with ROS2
* various: prefer object and references over pointers
  source: https://github.com/ros-planning/moveit/pull/3106/commits/1a8e5715e3142a92977ac585031b9dc1871f8718; this commit contains minor changes when compared to the source commit which it is based on, these changes are limited to ensuring compatibility with ROS2.
* migrate PRA internals to lambdas
  source: https://github.com/ros-planning/moveit/pull/3106/commits/6436597d5113a02dcfc976c85a2710fe7cd4c69e; in addition to the original commit I updated logging to support ros2 logging standards.
* drop unused arguments not needed for lambda binding
  source: https://github.com/ros-planning/moveit/pull/3106/commits/6805b7edc248a1e4557977f45722997bbbef5b22 ; I have also had to update how moveit_msgs is referenced (movit_msgs:: -> moveit_msgs::msg:: ) and I  added the changes to this commit that correspond to tests for the constraint samplers package.
* simplify distance field method binding
  source: https://github.com/ros-planning/moveit/pull/3106/commits/0322d63242d9990a9f93debd72085ede94efe0e9
* Use orocos_kdl_vendor package (#1207 <https://github.com/ros-planning/moveit2/issues/1207>)
* Clamp inputs to Ruckig. Use current waypoint as input for next iteration (#1202 <https://github.com/ros-planning/moveit2/issues/1202>)
  * Clamp inputs to Ruckig. Use the current waypoint as input for next iteration.
  * Fix the usage of std::clamp()
* Add a warning for TOTG if vel/accel limits aren't specified. (#1186 <https://github.com/ros-planning/moveit2/issues/1186>)
* RCLCPP Upgrade Bugfixes (#1181 <https://github.com/ros-planning/moveit2/issues/1181>)
* Ruckig smoothing cleanup (#1111 <https://github.com/ros-planning/moveit2/issues/1111>)
* Replace num_dof and idx variables with JointGroup API (#1152 <https://github.com/ros-planning/moveit2/issues/1152>)
* Merge https://github.com/ros-planning/moveit/commit/424a5b7b8b774424f78346d1e98bf1c9a33f0e78
* Remove new operators (#1135 <https://github.com/ros-planning/moveit2/issues/1135>)
  replace new operator with make_shared
* ACM: Consider default entries when packing a ROS message (#3096 <https://github.com/ros-planning/moveit2/issues/3096>)
  Previously, getAllEntryNames() just returned names occurring in the collision pair list.
  Now, also consider names in default_entries_.
* Merge https://github.com/ros-planning/moveit/commit/a25515b73d682df03ed3eccd839110c296aa79fc
* Off by one in getAverageSegmentDuration (#1079 <https://github.com/ros-planning/moveit2/issues/1079>)
* Fix missing boost::ref -> std::ref
* Merge https://github.com/ros-planning/moveit/commit/ab42a1d7017b27eb6c353fb29331b2da08ab0039
* Add special case for sphere bodies in sphere decomposition (#3056 <https://github.com/ros-planning/moveit2/issues/3056>)
* Add Ptr definitions for TimeParameterization classes (#3078 <https://github.com/ros-planning/moveit2/issues/3078>)
  Follow up on #3021 <https://github.com/ros-planning/moveit2/issues/3021>.
* Fix Python versioned dependency (#3063 <https://github.com/ros-planning/moveit2/issues/3063>)
* Merge https://github.com/ros-planning/moveit/commit/25a63b920adf46f0a747aad92ada70d8afedb3ec
* Merge https://github.com/ros-planning/moveit/commit/0d7462f140e03b4c319fa8cce04a47fe3f650c60
* Avoid downgrading default C++ standard (#3043 <https://github.com/ros-planning/moveit2/issues/3043>)
* Delete profiler (#998 <https://github.com/ros-planning/moveit2/issues/998>)
* Initalize RobotState in Ruckig test (#1032 <https://github.com/ros-planning/moveit2/issues/1032>)
* Remove unused parameters. (#1018 <https://github.com/ros-planning/moveit2/issues/1018>)
* Merge PR #2938 <https://github.com/ros-planning/moveit2/issues/2938>: Rework ACM
  Implement ACM defaults as a fallback instead of an override.
  Based on ros-planning/srdfdom#97 <https://github.com/ros-planning/srdfdom/issues/97>, this allows disabling collisions for specific links/objects by default and re-enabling individual pairs if necessary.
* Make TimeParameterization classes polymorphic (#3021 <https://github.com/ros-planning/moveit2/issues/3021>)
* Fix wrong transform in distance fields' determineCollisionSpheres() (#3022 <https://github.com/ros-planning/moveit2/issues/3022>)
* collision_distance_field: Fix undefined behavior vector insertion (#3017 <https://github.com/ros-planning/moveit2/issues/3017>)
  Co-authored-by: andreas-botbuilt <mailto:94128674+andreas-botbuilt@users.noreply.github.com>
* Unify initialization of ACM from SRDF
* Adapt to API changes in srdfdom
  @v4hn requested splitting of collision_pairs into (re)enabled and disabled.
* ACM:print(): show default value
* Adapt message passing of AllowedCollisionMatrix
  - Serialize full current state (previously pairs with a default, but no entry were skipped)
  - Only initialize matrix entries that deviate from the default.
* Optimization: Check for most common case first
* Add comment to prefer setDefaultEntry() over setEntry()
  ... because the former will consider future collision entries as well.
* ACM: specific pair entries take precedence over defaults
  Reverts c72a8570d420a23a9fe4715705ed617f18836634
* Improve formatting of comments
* Don't fill all ACM entries by default
* Adapt to API changes in srdfdom
* Move MoveItErrorCode class to moveit_core (#3009 <https://github.com/ros-planning/moveit2/issues/3009>)
  ... reducing code duplication and facilitating re-use
* Disable (flaky) timing tests in DEBUG mode (#3012 <https://github.com/ros-planning/moveit2/issues/3012>)
* RobotState::attachBody: Migrate to unique_ptr argument (#3011 <https://github.com/ros-planning/moveit2/issues/3011>)
  ... to indicate transfer of ownership and simplify pointer handling
* Add API stress tests for TOTG, fix undefined behavior (#2957 <https://github.com/ros-planning/moveit2/issues/2957>)
* TOTG: catch division by 0
  This bug is already in the original implementation:
  https://github.com/tobiaskunz/trajectories/blob/master/Path.cpp
  In case the dot product between the two vectors is close to +/-1,
  angle becomes +/-PI and cos/tan of 0.5 * PI in the lines below will
  produce a division by 0.
  This happens easily if a optimal trajectory is processed by TOTG, i.e.,
  if a trajectory is processed by TOTG twice.
* Add API stress tests for TOTG
* Do not assert on printTransform with non-isometry (#3005 <https://github.com/ros-planning/moveit2/issues/3005>)
  instead print a tag and the matrix
  building a Quaternion from non-isometries is undefined behavior in Eigen, thus the split.
* Provide MOVEIT_VERSION_CHECK macro (#2997 <https://github.com/ros-planning/moveit2/issues/2997>)
  - Rename MOVEIT_VERSION -> MOVEIT_VERSION_STR
  - MOVEIT_VERSION becomes a numeric identifier
  - Use like: #if MOVEIT_VERSION >= MOVEIT_VERSION_CHECK(1, 0, 0)
* quietly use backward_cpp/ros if available (#2988 <https://github.com/ros-planning/moveit2/issues/2988>)
  This is simply convenient and you always need it when you did not explicitly add it.
  Follow @tylerjw's initiative to add it to MoveIt2:
  https://github.com/ros-planning/moveit2/pull/794
* Allow restricting collision pairs to a group (#2987 <https://github.com/ros-planning/moveit2/issues/2987>)
* Add backwards compatibility for old scene serialization format (#2986 <https://github.com/ros-planning/moveit2/issues/2986>)
  * [moveit_core] test_planning_scene: Add failing unit test for old scene format
  The serialization format for the .scene files changed in
  https://github.com/ros-planning/moveit/pull/2037. This commits a
  testcase using the old scene format. It will fail and a subsequent
  commit to introduce backwards compatibility to the scene-file parsing
  will make it pass.
  * [moveit_core] PlanningScene: Add backwards compatibility for old scene version format
  This commit adds a mechanism for detecting the version of the scene file
  format to enable the loadGeometryFromStream method to read old version
  scene files without having to migrate them. To detect the version of the
  scene format, we use the content of the line following the start of an
  object: In the old version of the format, this specified the number of
  shapes in the object (a single int). In the new version of the format,
  it is the translational part of the pose of the object (i.e. three
  double values separated by spaces). To detect the format, we check for
  the number of spaces after trimming the string.
  * Simplify code: Avoid reading full stream
  Co-authored-by: Robert Haschke <mailto:rhaschke@techfak.uni-bielefeld.de>
* Switch to std::bind (#2967 <https://github.com/ros-planning/moveit2/issues/2967>)
  * boost::bind -> std::bind
  grep -rlI --exclude-dir=.git "boost::bind" | xargs sed -i 's/boost::bind/std::bind/g'
  * Convert bind placeholders
  grep -rlI --exclude-dir=.git " _[0-9]" | xargs sed -i 's/ _([0-9])/ std::placeholders::_1/g'
  * Update bind include header
  grep -rlI --exclude-dir=.git "boost/bind" | xargs sed -i 's#boost/bind.hpp#functional#'
* Add waypoint duration to the trajectory deep copy unit test (#2961 <https://github.com/ros-planning/moveit2/issues/2961>)
  * Add waypoint duration to the trajectory deep copy test
  * Slightly more accurate comments
* 1.1.6
* Silent warning about virtual_joint in Gazebo setups
  Gazebo requires a fixed joint from world to the first robot link.
  This resembles the virtual_joint of SRDF.
  However, the RobotModel parser issues the following warning:
  Skipping virtual joint 'xxx' because its child frame 'xxx' does not match the URDF frame 'world'
* Drop the minimum velocity/acceleration limits for TOTG (#2937 <https://github.com/ros-planning/moveit2/issues/2937>)
  Just complain about negative / zero values.
* Fix Debug build: re-add seemingly unused arguments
* Merge #2918 <https://github.com/ros-planning/moveit2/issues/2918> (add RobotState::getRigidlyAttachedParentLink)
  Merge branch 'pr-master-state-rigidly-attached-parent'
* add RS::getRigidlyConnectedParentLinkModel
  to resolve links for attached objects as well
* consistent parameter names for AttachedBody constructor
  "attach_posture" is plain wrong.
  I don't see why clang-tidy did not find this before.
* Contributors: Abishalini, AndyZe, Burak Payzun, Cory Crean, David V. Lu!!, Henning Kayser, Jafar, Jafar Abdi, Jochen Sprickerhof, Jonathan Grebe, Martin Oehler, Michael Görner, Robert Haschke, Sencer Yazıcı, Simon Schmeisser, Stephanie Eng, Tyler Weaver, Wolfgang Merkt, jeoseo, pvanlaar, v4hn
```

## moveit_hybrid_planning

```
* Fix hybrid planning launching (#1271 <https://github.com/ros-planning/moveit2/issues/1271>)
* Enable cppcheck (#1224 <https://github.com/ros-planning/moveit2/issues/1224>)
  Co-authored-by: jeoseo <mailto:jeongwooseo2012@gmail.com>
* Make moveit_common a 'depend' rather than 'build_depend' (#1226 <https://github.com/ros-planning/moveit2/issues/1226>)
* Avoid bind(), use lambdas instead (#1204 <https://github.com/ros-planning/moveit2/issues/1204>)
  Adaption of https://github.com/ros-planning/moveit/pull/3106
* banish bind()
  source:https://github.com/ros-planning/moveit/pull/3106/commits/a2911c80c28958c1fce8fb52333d770248c4ec05; required minor updates compared to original source commit in order to ensure compatibility with ROS2
* RCLCPP Upgrade Bugfixes (#1181 <https://github.com/ros-planning/moveit2/issues/1181>)
* Enable rolling / jammy CI (again) (#1134 <https://github.com/ros-planning/moveit2/issues/1134>)
  * Use ros2_control binaries
  * Use output screen instead of explicitly stating stderr
* [hybrid planning] Adjust planning scene locking (#1087 <https://github.com/ros-planning/moveit2/issues/1087>)
  * Create a copy of the planning scene. const robot state.
  * Use LockedPlanningSceneRO over lockSceneRead()
  * Use lambda function
* [Hybrid Planning] configurable planning scene topics (#1052 <https://github.com/ros-planning/moveit2/issues/1052>)
* [hybrid planning] Use a map of expected feedback codes (#1065 <https://github.com/ros-planning/moveit2/issues/1065>)
  * Use a map of expected feedback codes
  * Use a constexpr function instead of unordered_map
  * Don't need this #include
  * Minor function renaming
* Disable hybrid planning test, don't cache ci docker at all and don't cache upstream_ws if repos file is changed (#1051 <https://github.com/ros-planning/moveit2/issues/1051>)
  * Don't cache docker builds
  * Don't cache upstream ws
  * Use new action for getting the latest timestamp .repos file has been edited
  * Debug
  * Fix repos path
  * Disable hybrid planning test
  * Use more verbose name
  Co-authored-by: Tyler Weaver <mailto:tylerjw@gmail.com>
* [hybrid planning] Add action abortion and test; improve the existing test (#980 <https://github.com/ros-planning/moveit2/issues/980>)
  * Add action abortion and test; improve the existing test
  * Add controller run-dependency
  * Fix the clearing of robot trajectory when a collision would occur
  * Fix replanning if local planner is stuck
  * Lambda function everything
  * Thread safety for stop_hybrid_planning_
  * Thread-safe state_
  * Clang tidy
  * Update the planning scene properly
  * Update Servo test initial_positions.yaml
  Co-authored-by: Tyler Weaver <mailto:tyler@picknik.ai>
* [hybrid planning] Delete the pass-through option (#986 <https://github.com/ros-planning/moveit2/issues/986>)
  * Delete the pass-through option
  * Suppress clang warning
  * Handle (waypoint_count < 0) possibility
  Co-authored-by: Tyler Weaver <mailto:tyler@picknik.ai>
* Remove unused parameters. (#1018 <https://github.com/ros-planning/moveit2/issues/1018>)
  Co-authored-by: Tyler Weaver <mailto:tyler@picknik.ai>
  Co-authored-by: Vatan Aksoy Tezer <mailto:vatan@picknik.ai>
* Contributors: AndyZe, Cory Crean, David V. Lu!!, Henning Kayser, Jafar, Vatan Aksoy Tezer, jeoseo, v4hn
```

## moveit_kinematics

```
* Fix reading joint weights in KDLKinematicsPlugin (#1216 <https://github.com/ros-planning/moveit2/issues/1216>)
* Make moveit_common a 'depend' rather than 'build_depend' (#1226 <https://github.com/ros-planning/moveit2/issues/1226>)
* Avoid bind(), use lambdas instead (#1204 <https://github.com/ros-planning/moveit2/issues/1204>)
  Adaption of https://github.com/ros-planning/moveit/pull/3106
* remove unused arguments from kinematics test
  source https://github.com/ros-planning/moveit/pull/3106/commits/ddb68b6178ecfde267b5c7c9734aa47f6c4c4a5f; I also had to amend moveit_msgs to moveit_msgs::msg in this commit, otherwise everything remains the same as source commit. When I ran the kinematics plugin test locally it threw an error both before and after this change. Hopefully we can revisit this point as part of the code review, the error related to the robot description.
* Use orocos_kdl_vendor package (#1207 <https://github.com/ros-planning/moveit2/issues/1207>)
* Use a steady clock for timeout for IK (#795 <https://github.com/ros-planning/moveit2/issues/795>)
* Merge https://github.com/ros-planning/moveit/commit/a25515b73d682df03ed3eccd839110c296aa79fc
* Merge https://github.com/ros-planning/moveit/commit/ab42a1d7017b27eb6c353fb29331b2da08ab0039
* Compilation fixes for Jammy and bring back Rolling CI (#1095 <https://github.com/ros-planning/moveit2/issues/1095>)
* Add moveit_configs_utils package to simplify loading paramters (#591 <https://github.com/ros-planning/moveit2/issues/591>)
* round_collada_numbers.py: python 2/3 compatibility (#2983 <https://github.com/ros-planning/moveit2/issues/2983>)
  Python3 requires the files to be opened in binary mode read a bytes object instead of a string, which is needed in turn by etree.parse().
  Co-authored-by: Robert Haschke <mailto:rhaschke@techfak.uni-bielefeld.de>
* Switch to std::bind (#2967 <https://github.com/ros-planning/moveit2/issues/2967>)
* Contributors: Abishalini, Gaël Écorchard, Henning Kayser, Jafar, Jafar Abdi, Jochen Sprickerhof, Robert Haschke, Tomislav Bazina, Vatan Aksoy Tezer, jeoseo, v4hn
```

## moveit_planners

```
* Merge pr #3000 <https://github.com/ros-planning/moveit2/issues/3000>: Pilz planner: improve reporting of invalid start joints
* add pilz planner to moveit_planners dependency
* Contributors: Robert Haschke, v4hn
```

## moveit_planners_chomp

```
* Make TOTG the default time-parameterization algorithm everywhere (#1218 <https://github.com/ros-planning/moveit2/issues/1218>)
* Make moveit_common a 'depend' rather than 'build_depend' (#1226 <https://github.com/ros-planning/moveit2/issues/1226>)
* Merge https://github.com/ros-planning/moveit/commit/424a5b7b8b774424f78346d1e98bf1c9a33f0e78
* Merge https://github.com/ros-planning/moveit/commit/ab42a1d7017b27eb6c353fb29331b2da08ab0039
* Remove unused parameters. (#1018 <https://github.com/ros-planning/moveit2/issues/1018>)
* MSA: Add STOMP + OMPL-CHOMP configs (#2955 <https://github.com/ros-planning/moveit2/issues/2955>)
* Move MoveItErrorCode class to moveit_core (#3009 <https://github.com/ros-planning/moveit2/issues/3009>)
* Merge PRs #2948 <https://github.com/ros-planning/moveit2/issues/2948> (improve CI) and #2949 <https://github.com/ros-planning/moveit2/issues/2949> (simplify ROS .test files)
* Use test_environment.launch in unittests
* Contributors: Abishalini, AndyZe, Cory Crean, Jafar, Jafar Abdi, Rick Staa, Robert Haschke, jeoseo
```

## moveit_planners_ompl

```
* Make moveit_common a 'depend' rather than 'build_depend' (#1226 <https://github.com/ros-planning/moveit2/issues/1226>)
* Avoid bind(), use lambdas instead (#1204 <https://github.com/ros-planning/moveit2/issues/1204>)
* banish bind()
  source:https://github.com/ros-planning/moveit/pull/3106/commits/a2911c80c28958c1fce8fb52333d770248c4ec05; required minor updates compared to original source commit in order to ensure compatibility with ROS2
* planning_context_manager: rename protected methods
  sources: https://github.com/ros-planning/moveit/pull/3106/commits/a183bc16f0b5490b1b40789ad2709d1cdbba7453, https://github.com/ros-planning/moveit/pull/3106/commits/c07be63b6cd5cfcea51e91e613bea9be68950754;
* Revert OMPL parameter loading
* [ompl] Small code refactor (#1138 <https://github.com/ros-planning/moveit2/issues/1138>)
* Remove new operators (#1135 <https://github.com/ros-planning/moveit2/issues/1135>)
* Merge https://github.com/ros-planning/moveit/commit/a25515b73d682df03ed3eccd839110c296aa79fc
* Delete profiler (#998 <https://github.com/ros-planning/moveit2/issues/998>)
* Use termination condition for simplification step (#2981 <https://github.com/ros-planning/moveit2/issues/2981>)
  ... to allow canceling the simplification step
* Switch to std::bind (#2967 <https://github.com/ros-planning/moveit2/issues/2967>)
* Contributors: Abishalini, Gaël Écorchard, Henning Kayser, Jafar, Jochen Sprickerhof, Robert Haschke, Sencer Yazıcı, Simon Schmeisser, Tyler Weaver, Vatan Aksoy Tezer, jeoseo, rhaschke, v4hn
```

## moveit_plugins

```
* 1.1.9
* 1.1.8
* 1.1.7
* 1.1.6
* Contributors: Robert Haschke
```

## moveit_resources_prbt_ikfast_manipulator_plugin

```
* Fix prbt_ikfast win compilation (#1161 <https://github.com/ros-planning/moveit2/issues/1161>)
* Remove new operators (#1135 <https://github.com/ros-planning/moveit2/issues/1135>)
  replace new operator with make_shared
* Remove unused parameters. (#1018 <https://github.com/ros-planning/moveit2/issues/1018>)
  Co-authored-by: Tyler Weaver <mailto:tyler@picknik.ai>
  Co-authored-by: Vatan Aksoy Tezer <mailto:vatan@picknik.ai>
* Contributors: Cory Crean, Sencer Yazıcı, Tobias Fischer
```

## moveit_resources_prbt_moveit_config

```
* Enable rolling / jammy CI (again) (#1134 <https://github.com/ros-planning/moveit2/issues/1134>)
  * Use ros2_control binaries
  * Use output screen instead of explicitly stating stderr
* Merge https://github.com/ros-planning/moveit/commit/25a63b920adf46f0a747aad92ada70d8afedb3ec
* Contributors: Abishalini, Vatan Aksoy Tezer
```

## moveit_resources_prbt_pg70_support

- No changes

## moveit_resources_prbt_support

- No changes

## moveit_ros

```
* 1.1.9
* 1.1.8
* 1.1.7
* 1.1.6
* Contributors: Robert Haschke
```

## moveit_ros_benchmarks

```
* Merge https://github.com/ros-planning/moveit/commit/72d919299796bffc21f5eb752d66177841dc3442
* Enable cppcheck (#1224 <https://github.com/ros-planning/moveit2/issues/1224>)
  Co-authored-by: jeoseo <mailto:jeongwooseo2012@gmail.com>
* Make moveit_common a 'depend' rather than 'build_depend' (#1226 <https://github.com/ros-planning/moveit2/issues/1226>)
* Avoid bind(), use lambdas instead (#1204 <https://github.com/ros-planning/moveit2/issues/1204>)
  Adaption of https://github.com/ros-planning/moveit/pull/3106
* banish bind()
  source:https://github.com/ros-planning/moveit/pull/3106/commits/a2911c80c28958c1fce8fb52333d770248c4ec05; required minor updates compared to original source commit in order to ensure compatibility with ROS2
* [moveit_ros_benchmarks] Add missing moveit_core dependency (#1157 <https://github.com/ros-planning/moveit2/issues/1157>)
* Merge https://github.com/ros-planning/moveit/commit/a25515b73d682df03ed3eccd839110c296aa79fc
* Merge https://github.com/ros-planning/moveit/commit/ab42a1d7017b27eb6c353fb29331b2da08ab0039
* Filter more invalid values in moveit_benchmark_statistics.py (#3084 <https://github.com/ros-planning/moveit2/issues/3084>)
  Count "-nan" and "-inf" as null value in the database.
* 1.1.9
* 1.1.8
* Remove unused parameters. (#1018 <https://github.com/ros-planning/moveit2/issues/1018>)
  Co-authored-by: Tyler Weaver <mailto:tyler@picknik.ai>
  Co-authored-by: Vatan Aksoy Tezer <mailto:vatan@picknik.ai>
* Add moveit_configs_utils package to simplify loading paramters (#591 <https://github.com/ros-planning/moveit2/issues/591>)
  Co-authored-by: AndyZe <mailto:zelenak@picknik.ai>
  Co-authored-by: Stephanie Eng <mailto:stephanie-eng@users.noreply.github.com>
  Co-authored-by: Tyler Weaver <mailto:tyler@picknik.ai>
* 1.1.7
* Provide MOVEIT_VERSION_CHECK macro (#2997 <https://github.com/ros-planning/moveit2/issues/2997>)
  - Rename MOVEIT_VERSION -> MOVEIT_VERSION_STR
  - MOVEIT_VERSION becomes a numeric identifier
  - Use like: #if MOVEIT_VERSION >= MOVEIT_VERSION_CHECK(1, 0, 0)
* Switch to std::bind (#2967 <https://github.com/ros-planning/moveit2/issues/2967>)
  * boost::bind -> std::bind
  grep -rlI --exclude-dir=.git "boost::bind" | xargs sed -i 's/boost::bind/std::bind/g'
  * Convert bind placeholders
  grep -rlI --exclude-dir=.git " _[0-9]" | xargs sed -i 's/ _([0-9])/ std::placeholders::_1/g'
  * Update bind include header
  grep -rlI --exclude-dir=.git "boost/bind" | xargs sed -i 's#boost/bind.hpp#functional#'
* 1.1.6
* Contributors: Abishalini, Cory Crean, Gaël Écorchard, Henning Kayser, Hugal31, Jafar, Jafar Abdi, Jochen Sprickerhof, Robert Haschke, jeoseo, v4hn
```

## moveit_ros_control_interface

```
* Enable cppcheck (#1224 <https://github.com/ros-planning/moveit2/issues/1224>)
  Co-authored-by: jeoseo <mailto:jeongwooseo2012@gmail.com>
* Make moveit_common a 'depend' rather than 'build_depend' (#1226 <https://github.com/ros-planning/moveit2/issues/1226>)
* 1.1.9
* 1.1.8
* 1.1.7
* 1.1.6
* Contributors: Jafar, Robert Haschke, jeoseo
```

## moveit_ros_move_group

```
* Merge https://github.com/ros-planning/moveit/commit/72d919299796bffc21f5eb752d66177841dc3442
* Enable cppcheck (#1224 <https://github.com/ros-planning/moveit2/issues/1224>)
  Co-authored-by: jeoseo <mailto:jeongwooseo2012@gmail.com>
* Make TOTG the default time-parameterization algorithm everywhere (#1218 <https://github.com/ros-planning/moveit2/issues/1218>)
  Co-authored-by: Jafar <mailto:cafer.abdi@gmail.com>
* Make moveit_common a 'depend' rather than 'build_depend' (#1226 <https://github.com/ros-planning/moveit2/issues/1226>)
* Avoid bind(), use lambdas instead (#1204 <https://github.com/ros-planning/moveit2/issues/1204>)
  Adaption of https://github.com/ros-planning/moveit/pull/3106
* banish bind()
  source:https://github.com/ros-planning/moveit/pull/3106/commits/a2911c80c28958c1fce8fb52333d770248c4ec05; required minor updates compared to original source commit in order to ensure compatibility with ROS2
* Merge https://github.com/ros-planning/moveit/commit/ab42a1d7017b27eb6c353fb29331b2da08ab0039
* 1.1.9
* Fix missing include (#3051 <https://github.com/ros-planning/moveit2/issues/3051>)
* 1.1.8
* Improve loading of planning pipelines (#3036 <https://github.com/ros-planning/moveit2/issues/3036>)
  Ensure that planning pipelines considered in ~/planning_pipelines/* actually have a planning_plugin parameter defined.
  Otherwise, issue an error message.
* Remove unused parameters. (#1018 <https://github.com/ros-planning/moveit2/issues/1018>)
  Co-authored-by: Tyler Weaver <mailto:tyler@picknik.ai>
  Co-authored-by: Vatan Aksoy Tezer <mailto:vatan@picknik.ai>
* 1.1.7
* Switch to std::bind (#2967 <https://github.com/ros-planning/moveit2/issues/2967>)
  * boost::bind -> std::bind
  grep -rlI --exclude-dir=.git "boost::bind" | xargs sed -i 's/boost::bind/std::bind/g'
  * Convert bind placeholders
  grep -rlI --exclude-dir=.git " _[0-9]" | xargs sed -i 's/ _([0-9])/ std::placeholders::_1/g'
  * Update bind include header
  grep -rlI --exclude-dir=.git "boost/bind" | xargs sed -i 's#boost/bind.hpp#functional#'
* 1.1.6
* Contributors: Abishalini, AndyZe, Cory Crean, Henning Kayser, Jafar, Jochen Sprickerhof, Robert Haschke, Tobias Fischer, jeoseo, v4hn
```

## moveit_ros_occupancy_map_monitor

```
* Enable cppcheck (#1224 <https://github.com/ros-planning/moveit2/issues/1224>)
  Co-authored-by: jeoseo <mailto:jeongwooseo2012@gmail.com>
* Make moveit_common a 'depend' rather than 'build_depend' (#1226 <https://github.com/ros-planning/moveit2/issues/1226>)
* Remove unused includes for boost::bind (#1220 <https://github.com/ros-planning/moveit2/issues/1220>)
* Avoid bind(), use lambdas instead (#1204 <https://github.com/ros-planning/moveit2/issues/1204>)
  Adaption of https://github.com/ros-planning/moveit/pull/3106
* banish bind()
  source:https://github.com/ros-planning/moveit/pull/3106/commits/a2911c80c28958c1fce8fb52333d770248c4ec05; required minor updates compared to original source commit in order to ensure compatibility with ROS2
* various: prefer object and references over pointers
  source: https://github.com/ros-planning/moveit/pull/3106/commits/1a8e5715e3142a92977ac585031b9dc1871f8718; this commit contains minor changes when compared to the source commit which it is based on, these changes are limited to ensuring compatibility with ROS2.
* Disable separate TransformListener thread in OccupancyMapServer (#1130 <https://github.com/ros-planning/moveit2/issues/1130>)
* Merge https://github.com/ros-planning/moveit/commit/ab42a1d7017b27eb6c353fb29331b2da08ab0039
* 1.1.9
* Misc fixes for time and transforms (#768 <https://github.com/ros-planning/moveit2/issues/768>)
  * Fix setting shape_transform_cache_lookup_wait_time from seconds
  * Fix setting last_update_time from seconds
  * Check the return value of canTransform
* 1.1.8
* Remove unused parameters. (#1018 <https://github.com/ros-planning/moveit2/issues/1018>)
  Co-authored-by: Tyler Weaver <mailto:tyler@picknik.ai>
  Co-authored-by: Vatan Aksoy Tezer <mailto:vatan@picknik.ai>
* 1.1.7
* Switch to std::bind (#2967 <https://github.com/ros-planning/moveit2/issues/2967>)
  * boost::bind -> std::bind
  grep -rlI --exclude-dir=.git "boost::bind" | xargs sed -i 's/boost::bind/std::bind/g'
  * Convert bind placeholders
  grep -rlI --exclude-dir=.git " _[0-9]" | xargs sed -i 's/ _([0-9])/ std::placeholders::_1/g'
  * Update bind include header
  grep -rlI --exclude-dir=.git "boost/bind" | xargs sed -i 's#boost/bind.hpp#functional#'
* 1.1.6
* Contributors: Abishalini, Cory Crean, Henning Kayser, Jafar, Jafar Abdi, Jochen Sprickerhof, Robert Haschke, Stephanie Eng, jeoseo, v4hn
```

## moveit_ros_perception

```
* Enable cppcheck (#1224 <https://github.com/ros-planning/moveit2/issues/1224>)
  Co-authored-by: jeoseo <mailto:jeongwooseo2012@gmail.com>
* Make moveit_common a 'depend' rather than 'build_depend' (#1226 <https://github.com/ros-planning/moveit2/issues/1226>)
* Remove unused includes for boost::bind (#1220 <https://github.com/ros-planning/moveit2/issues/1220>)
* Avoid bind(), use lambdas instead (#1204 <https://github.com/ros-planning/moveit2/issues/1204>)
  Adaption of https://github.com/ros-planning/moveit/pull/3106
* banish bind()
  source:https://github.com/ros-planning/moveit/pull/3106/commits/a2911c80c28958c1fce8fb52333d770248c4ec05; required minor updates compared to original source commit in order to ensure compatibility with ROS2
* various: prefer object and references over pointers
  source: https://github.com/ros-planning/moveit/pull/3106/commits/1a8e5715e3142a92977ac585031b9dc1871f8718; this commit contains minor changes when compared to the source commit which it is based on, these changes are limited to ensuring compatibility with ROS2.
* Remove new operators (#1135 <https://github.com/ros-planning/moveit2/issues/1135>)
  replace new operator with make_shared
* Merge https://github.com/ros-planning/moveit/commit/ab42a1d7017b27eb6c353fb29331b2da08ab0039
* 1.1.9
* Use GLEW::GLEW link target (#3079 <https://github.com/ros-planning/moveit2/issues/3079>)
  While ${GLEW_LIBRARIES} works on Ubuntu, it fails on newer installs of GLEW.
* Misc fixes for time and transforms (#768 <https://github.com/ros-planning/moveit2/issues/768>)
  * Fix setting shape_transform_cache_lookup_wait_time from seconds
  * Fix setting last_update_time from seconds
  * Check the return value of canTransform
* Fix use of std::bind (#3048 <https://github.com/ros-planning/moveit2/issues/3048>)
  Fixup for ab42a1d7017b27eb6c353fb29331b2da08ab0039 (#2967 <https://github.com/ros-planning/moveit2/issues/2967>)
* 1.1.8
* 1.1.7
* Switch to std::bind (#2967 <https://github.com/ros-planning/moveit2/issues/2967>)
  * boost::bind -> std::bind
  grep -rlI --exclude-dir=.git "boost::bind" | xargs sed -i 's/boost::bind/std::bind/g'
  * Convert bind placeholders
  grep -rlI --exclude-dir=.git " _[0-9]" | xargs sed -i 's/ _([0-9])/ std::placeholders::_1/g'
  * Update bind include header
  grep -rlI --exclude-dir=.git "boost/bind" | xargs sed -i 's#boost/bind.hpp#functional#'
* Add ns for depth image & pointcloud octomap updaters (#2916 <https://github.com/ros-planning/moveit2/issues/2916>)
* 1.1.6
* Contributors: Abishalini, Henning Kayser, Jafar, Jafar Abdi, Jochen Sprickerhof, Michael Görner, Robert Haschke, Sencer Yazıcı, Stephanie Eng, Tim Redick, Tobias Fischer, jeoseo, v4hn
```

## moveit_ros_planning

```
* Enable cppcheck (#1224 <https://github.com/ros-planning/moveit2/issues/1224>)
  Co-authored-by: jeoseo <mailto:jeongwooseo2012@gmail.com>
* Make moveit_common a 'depend' rather than 'build_depend' (#1226 <https://github.com/ros-planning/moveit2/issues/1226>)
* Remove unused includes for boost::bind (#1220 <https://github.com/ros-planning/moveit2/issues/1220>)
* Avoid bind(), use lambdas instead (#1204 <https://github.com/ros-planning/moveit2/issues/1204>)
  Adaption of https://github.com/ros-planning/moveit/pull/3106
* banish bind()
  source:https://github.com/ros-planning/moveit/pull/3106/commits/a2911c80c28958c1fce8fb52333d770248c4ec05; required minor updates compared to original source commit in order to ensure compatibility with ROS2
* various: prefer object and references over pointers
  source: https://github.com/ros-planning/moveit/pull/3106/commits/1a8e5715e3142a92977ac585031b9dc1871f8718; this commit contains minor changes when compared to the source commit which it is based on, these changes are limited to ensuring compatibility with ROS2.
* Delete an unused variable and a redundant log message (#1179 <https://github.com/ros-planning/moveit2/issues/1179>)
  Co-authored-by: Vatan Aksoy Tezer <mailto:vatan@picknik.ai>
* Fix failing test
* Comment failing rdf integration test
* Merge https://github.com/ros-planning/moveit/commit/424a5b7b8b774424f78346d1e98bf1c9a33f0e78
* Return ExecutionStatus from MoveItCpp::execute() (#1147 <https://github.com/ros-planning/moveit2/issues/1147>)
  Return an ExecutionStatus from MoveItCpp::execute(), which is
  convertible to a bool in the caller code.
  This change is forward compatible.
* Set controller status before it is checked on trajectory execution (#1014 <https://github.com/ros-planning/moveit2/issues/1014>)
* Remove new operators (#1135 <https://github.com/ros-planning/moveit2/issues/1135>)
  replace new operator with make_shared
* RDFLoader Broken with Xacro Files (#1132 <https://github.com/ros-planning/moveit2/issues/1132>)
  * A broken RDFLoader test
  * Bugfix: Add space between executable and path (if no arguments)
* Simply MoveItCpp::getPlanningPipelineNames() (#1114 <https://github.com/ros-planning/moveit2/issues/1114>)
* [moveit_cpp] Fix config of multiple pipelines (#1096 <https://github.com/ros-planning/moveit2/issues/1096>)
* Merge https://github.com/ros-planning/moveit/commit/a25515b73d682df03ed3eccd839110c296aa79fc
* Merge https://github.com/ros-planning/moveit/commit/ab42a1d7017b27eb6c353fb29331b2da08ab0039
* Make lockSceneRead() and lockSceneWrite() protected member functions (#1100 <https://github.com/ros-planning/moveit2/issues/1100>)
  * No lock in planning_component.cpp
  * Make lockSceneRead(), lockSceneWrite() protected
  * Add a migration note
* Temporarily add galactic CI (#1107 <https://github.com/ros-planning/moveit2/issues/1107>)
  * Add galactic CI
  * Comment out rolling
  * panda_ros_controllers -> panda_ros2_controllers
  * Ignore flake8 tests
* 1.1.9
* Compilation fixes for Jammy and bring back Rolling CI (#1095 <https://github.com/ros-planning/moveit2/issues/1095>)
  * Use jammy dockers and clang-format-12
  * Fix unused depend, and move to python3-lxml
  * add ompl to repos, fix versions and ogre
  * Remove ogre keys
  * Fix boolean node operator
  * Stop building dockers on branch and fix servo null pointer
  * update pre-commit to clang-format-12 and pre-commit fixes
  * clang-format workaround and more pre-commit fixes
* Fix mixed-up implementations in TfSubscription creation (#1073 <https://github.com/ros-planning/moveit2/issues/1073>)
  Co-authored-by: Jean-Christophe Ruel <mailto:jeanchristophe.ruel@elmec.ca>
* Get parameter on initialize (rebased version of #893 <https://github.com/ros-planning/moveit2/issues/893>) (#996 <https://github.com/ros-planning/moveit2/issues/996>)
  Get parameter trajectory_execution.execution_duration_monitoring in
  initialize().
  Co-authored-by: Gaël Écorchard <mailto:gael.ecorchard@cvut.cz>
* Misc fixes for time and transforms (#768 <https://github.com/ros-planning/moveit2/issues/768>)
  * Fix setting shape_transform_cache_lookup_wait_time from seconds
  * Fix setting last_update_time from seconds
  * Check the return value of canTransform
* Fix race condition in SynchronizedStringParameter::waitForMessage (#1050 <https://github.com/ros-planning/moveit2/issues/1050>)
  Co-authored-by: Tyler Weaver <mailto:squirrel428@protonmail.com>
* 1.1.8
* Delete profiler (#998 <https://github.com/ros-planning/moveit2/issues/998>)
  * Delete profiler and evaluator tools
* Remove unused parameters. (#1018 <https://github.com/ros-planning/moveit2/issues/1018>)
  Co-authored-by: Tyler Weaver <mailto:tyler@picknik.ai>
  Co-authored-by: Vatan Aksoy Tezer <mailto:vatan@picknik.ai>
* Fix deprecation warning in moveit_cpp (#3019 <https://github.com/ros-planning/moveit2/issues/3019>)
  Fixup for #3009 <https://github.com/ros-planning/moveit2/issues/3009>.
* 1.1.7
* Move MoveItErrorCode class to moveit_core (#3009 <https://github.com/ros-planning/moveit2/issues/3009>)
  ... reducing code duplication and facilitating re-use
* Merge #2944 <https://github.com/ros-planning/moveit2/issues/2944>: various fixes to the rviz plugins
* Switch to std::bind (#2967 <https://github.com/ros-planning/moveit2/issues/2967>)
  * boost::bind -> std::bind
  grep -rlI --exclude-dir=.git "boost::bind" | xargs sed -i 's/boost::bind/std::bind/g'
  * Convert bind placeholders
  grep -rlI --exclude-dir=.git " _[0-9]" | xargs sed -i 's/ _([0-9])/ std::placeholders::_1/g'
  * Update bind include header
  grep -rlI --exclude-dir=.git "boost/bind" | xargs sed -i 's#boost/bind.hpp#functional#'
* MoveitCpp - added ability to set path constraints for PlanningComponent. (#2959 <https://github.com/ros-planning/moveit2/issues/2959>)
* RDFLoader: clear buffer before reading content (#2963 <https://github.com/ros-planning/moveit2/issues/2963>)
* 1.1.6
* Reset markers on display_contacts topic after a new planning attempt
* Contributors: Abishalini, AndyZe, Colin Kohler, Cory Crean, David V. Lu!!, Denis Štogl, Gaël Écorchard, Henning Kayser, Jafar, Jafar Abdi, JafarAbdi, Jean-Christophe Ruel, Jeroen, Jochen Sprickerhof, Rick Staa, Robert Haschke, Sencer Yazıcı, Stephanie Eng, Tyler Weaver, Vatan Aksoy Tezer, jeoseo, v4hn
```

## moveit_ros_planning_interface

```
* move_group_interface: No need to spin after publishing (#1250 <https://github.com/ros-planning/moveit2/issues/1250>)
* Enable cppcheck (#1224 <https://github.com/ros-planning/moveit2/issues/1224>)
  Co-authored-by: jeoseo <mailto:jeongwooseo2012@gmail.com>
* Make moveit_common a 'depend' rather than 'build_depend' (#1226 <https://github.com/ros-planning/moveit2/issues/1226>)
* Fix deprecated namespace (#1228 <https://github.com/ros-planning/moveit2/issues/1228>)
* Avoid bind(), use lambdas instead (#1204 <https://github.com/ros-planning/moveit2/issues/1204>)
  Adaption of https://github.com/ros-planning/moveit/pull/3106
* banish bind()
  source:https://github.com/ros-planning/moveit/pull/3106/commits/a2911c80c28958c1fce8fb52333d770248c4ec05; required minor updates compared to original source commit in order to ensure compatibility with ROS2
* RCLCPP Upgrade Bugfixes (#1181 <https://github.com/ros-planning/moveit2/issues/1181>)
* Rename panda controllers
* Merge https://github.com/ros-planning/moveit/commit/424a5b7b8b774424f78346d1e98bf1c9a33f0e78
* Enable rolling / jammy CI (again) (#1134 <https://github.com/ros-planning/moveit2/issues/1134>)
  * Use ros2_control binaries
  * Use output screen instead of explicitly stating stderr
* Update black version, formatting changes (#1148 <https://github.com/ros-planning/moveit2/issues/1148>)
* Merge https://github.com/ros-planning/moveit/commit/a25515b73d682df03ed3eccd839110c296aa79fc
* Merge https://github.com/ros-planning/moveit/commit/ab42a1d7017b27eb6c353fb29331b2da08ab0039
* Temporarily add galactic CI (#1107 <https://github.com/ros-planning/moveit2/issues/1107>)
  * Add galactic CI
  * Comment out rolling
  * panda_ros_controllers -> panda_ros2_controllers
  * Ignore flake8 tests
* 1.1.9
* 1.1.8
* Add moveit_configs_utils package to simplify loading paramters (#591 <https://github.com/ros-planning/moveit2/issues/591>)
  Co-authored-by: AndyZe <mailto:zelenak@picknik.ai>
  Co-authored-by: Stephanie Eng <mailto:stephanie-eng@users.noreply.github.com>
  Co-authored-by: Tyler Weaver <mailto:tyler@picknik.ai>
* 1.1.7
* Move MoveItErrorCode class to moveit_core (#3009 <https://github.com/ros-planning/moveit2/issues/3009>)
  ... reducing code duplication and facilitating re-use
* Fix MoveGroupInterface uninitialized RobotState (#3008 <https://github.com/ros-planning/moveit2/issues/3008>)
* Switch to std::bind (#2967 <https://github.com/ros-planning/moveit2/issues/2967>)
  * boost::bind -> std::bind
  grep -rlI --exclude-dir=.git "boost::bind" | xargs sed -i 's/boost::bind/std::bind/g'
  * Convert bind placeholders
  grep -rlI --exclude-dir=.git " _[0-9]" | xargs sed -i 's/ _([0-9])/ std::placeholders::_1/g'
  * Update bind include header
  grep -rlI --exclude-dir=.git "boost/bind" | xargs sed -i 's#boost/bind.hpp#functional#'
* 1.1.6
* Merge PRs #2948 <https://github.com/ros-planning/moveit2/issues/2948> (improve CI) and #2949 <https://github.com/ros-planning/moveit2/issues/2949> (simplify ROS .test files)
* Use test_environment.launch in unittests
* Contributors: Abishalini, Captain Yoshi, David V. Lu!!, Henning Kayser, Jafar, Jafar Abdi, Jochen Sprickerhof, Robert Haschke, Stephanie Eng, Tyler Weaver, Vatan Aksoy Tezer, jeoseo, v4hn
```

## moveit_ros_robot_interaction

```
* Merge https://github.com/ros-planning/moveit/commit/72d919299796bffc21f5eb752d66177841dc3442
* Enable cppcheck (#1224 <https://github.com/ros-planning/moveit2/issues/1224>)
  Co-authored-by: jeoseo <mailto:jeongwooseo2012@gmail.com>
* Make moveit_common a 'depend' rather than 'build_depend' (#1226 <https://github.com/ros-planning/moveit2/issues/1226>)
* Avoid bind(), use lambdas instead (#1204 <https://github.com/ros-planning/moveit2/issues/1204>)
  Adaption of https://github.com/ros-planning/moveit/pull/3106
* banish bind()
  source:https://github.com/ros-planning/moveit/pull/3106/commits/a2911c80c28958c1fce8fb52333d770248c4ec05; required minor updates compared to original source commit in order to ensure compatibility with ROS2
* various: prefer object and references over pointers
  source: https://github.com/ros-planning/moveit/pull/3106/commits/1a8e5715e3142a92977ac585031b9dc1871f8718; this commit contains minor changes when compared to the source commit which it is based on, these changes are limited to ensuring compatibility with ROS2.
* Merge https://github.com/ros-planning/moveit/commit/424a5b7b8b774424f78346d1e98bf1c9a33f0e78
* Remove new operators (#1135 <https://github.com/ros-planning/moveit2/issues/1135>)
  replace new operator with make_shared
* Consider eef's parent group when creating eef markers (#3095 <https://github.com/ros-planning/moveit2/issues/3095>)
  If we have end-effector(s) defined, a corresponding rviz marker for IK
  should be created only if the eef's group matches the considered JMG.
* Merge https://github.com/ros-planning/moveit/commit/a25515b73d682df03ed3eccd839110c296aa79fc
* Merge https://github.com/ros-planning/moveit/commit/ab42a1d7017b27eb6c353fb29331b2da08ab0039
* 1.1.9
* 1.1.8
* 1.1.7
* Disable slow robot_interaction tests in DEBUG mode (#3014 <https://github.com/ros-planning/moveit2/issues/3014>)
  These tests are known to run for a very long time in debug builds. So let's disable them in this case.
  If you still insist to run them, you can do so via locked_robot_state_test --gtest_also_run_disabled_tests
* Add marker for subgroups even if no endeffector is defined for them (#2977 <https://github.com/ros-planning/moveit2/issues/2977>)
  For single groups, the old logic fell back to add a marker
  for the last link if IK is supported for it and no endeffector is defined.
  That (quite reasonable) fallback did not yet work for subgroups though.
* Switch to std::bind (#2967 <https://github.com/ros-planning/moveit2/issues/2967>)
  * boost::bind -> std::bind
  grep -rlI --exclude-dir=.git "boost::bind" | xargs sed -i 's/boost::bind/std::bind/g'
  * Convert bind placeholders
  grep -rlI --exclude-dir=.git " _[0-9]" | xargs sed -i 's/ _([0-9])/ std::placeholders::_1/g'
  * Update bind include header
  grep -rlI --exclude-dir=.git "boost/bind" | xargs sed -i 's#boost/bind.hpp#functional#'
* 1.1.6
* Contributors: Abishalini, Henning Kayser, Jafar, Jochen Sprickerhof, Michael Görner, Robert Haschke, Sencer Yazıcı, jeoseo, v4hn
```

## moveit_ros_visualization

```
* Declare the default_planning_pipeline parameter (#1227 <https://github.com/ros-planning/moveit2/issues/1227>)
  Co-authored-by: AndyZe <mailto:zelenak@picknik.ai>
* Merge https://github.com/ros-planning/moveit/commit/72d919299796bffc21f5eb752d66177841dc3442
* Enable cppcheck (#1224 <https://github.com/ros-planning/moveit2/issues/1224>)
  Co-authored-by: jeoseo <mailto:jeongwooseo2012@gmail.com>
* Make TOTG the default time-parameterization algorithm everywhere (#1218 <https://github.com/ros-planning/moveit2/issues/1218>)
  Co-authored-by: Jafar <mailto:cafer.abdi@gmail.com>
* Make moveit_common a 'depend' rather than 'build_depend' (#1226 <https://github.com/ros-planning/moveit2/issues/1226>)
* Avoid bind(), use lambdas instead (#1204 <https://github.com/ros-planning/moveit2/issues/1204>)
  Adaption of https://github.com/ros-planning/moveit/pull/3106
* banish bind()
  source:https://github.com/ros-planning/moveit/pull/3106/commits/a2911c80c28958c1fce8fb52333d770248c4ec05; required minor updates compared to original source commit in order to ensure compatibility with ROS2
* Merge https://github.com/ros-planning/moveit/commit/424a5b7b8b774424f78346d1e98bf1c9a33f0e78
* Remove new operators (#1135 <https://github.com/ros-planning/moveit2/issues/1135>)
  replace new operator with make_shared
* Merge https://github.com/ros-planning/moveit/commit/a25515b73d682df03ed3eccd839110c296aa79fc
* Remove include of OgrePrerequisites header (#1099 <https://github.com/ros-planning/moveit2/issues/1099>)
  * Remove OgrePrerequisites include
  * octomap_render.h includes itself
  * Include OgrePrerequisites.h
* Merge https://github.com/ros-planning/moveit/commit/ab42a1d7017b27eb6c353fb29331b2da08ab0039
* 1.1.9
* moveit joy: add PS3 dual shock model (#3025 <https://github.com/ros-planning/moveit2/issues/3025>)
  * Added PS3 dual shock
  * Simplified if-else statements with as one-liners
* Compilation fixes for Jammy and bring back Rolling CI (#1095 <https://github.com/ros-planning/moveit2/issues/1095>)
  * Use jammy dockers and clang-format-12
  * Fix unused depend, and move to python3-lxml
  * add ompl to repos, fix versions and ogre
  * Remove ogre keys
  * Fix boolean node operator
  * Stop building dockers on branch and fix servo null pointer
  * update pre-commit to clang-format-12 and pre-commit fixes
  * clang-format workaround and more pre-commit fixes
* Add option to use simulation time for rviz trajectory display (#3055 <https://github.com/ros-planning/moveit2/issues/3055>)
* Fix object interactive marker in wrong pose after changing the fixed frame (#680 <https://github.com/ros-planning/moveit2/issues/680>)
* Merge https://github.com/ros-planning/moveit/commit/0d7462f140e03b4c319fa8cce04a47fe3f650c60
* 1.1.8
* Remove unused parameters. (#1018 <https://github.com/ros-planning/moveit2/issues/1018>)
  Co-authored-by: Tyler Weaver <mailto:tyler@picknik.ai>
  Co-authored-by: Vatan Aksoy Tezer <mailto:vatan@picknik.ai>
* 1.1.7
* Move MoveItErrorCode class to moveit_core (#3009 <https://github.com/ros-planning/moveit2/issues/3009>)
  ... reducing code duplication and facilitating re-use
* RobotState::attachBody: Migrate to unique_ptr argument (#3011 <https://github.com/ros-planning/moveit2/issues/3011>)
  ... to indicate transfer of ownership and simplify pointer handling
* Merge PR #2925 <https://github.com/ros-planning/moveit2/issues/2925>: Fix "ClassLoader: SEVERE WARNING" on reset of MPD
  Resetting the MotionPlanningDisplay in rviz (or disabling+enabling it) issues a warning, because the IK plugin is unloaded (when resetting the RobotModelLoader) while there are still pending references to the RobotModel.
* Remove all remaining usage of robot_model
* Merge #2944 <https://github.com/ros-planning/moveit2/issues/2944>: various fixes to the rviz plugins
* Switch to std::bind (#2967 <https://github.com/ros-planning/moveit2/issues/2967>)
  * boost::bind -> std::bind
  grep -rlI --exclude-dir=.git "boost::bind" | xargs sed -i 's/boost::bind/std::bind/g'
  * Convert bind placeholders
  grep -rlI --exclude-dir=.git " _[0-9]" | xargs sed -i 's/ _([0-9])/ std::placeholders::_1/g'
  * Update bind include header
  grep -rlI --exclude-dir=.git "boost/bind" | xargs sed -i 's#boost/bind.hpp#functional#'
* MPD: Avoid flickering of the progress bar
  The progress bar shows the number of pending background jobs.
  If there is only one job pending, the progress bar is shown and
  immediately hidden as soon as the process is finished.
  Thus, we shouldn't show the progress bar if there is only one job
  and thus no actual progress to show.
  Use the default size and color scheme.
* Joints widget: avoid flickering of the nullspace slider
  Show a (disabled) dummy slider if there is no nullspace.
  This avoids flickering between zero and one slider, which is the most common case.
  Also provide some tooltips to explain the usage.
* 1.1.6
* Fix MotionPlanningFrame's namespace handling (#2922 <https://github.com/ros-planning/moveit2/issues/2922>)
  * waitForAction(): remove NodeHandle argument
  * The NodeHandle was just for NodeHandle::ok(), which can be handled by ros::ok() as well.
  * Fix initialization of params, etc. that depend on MoveGroupNS
  * When the MoveGroupNS has changed, we should re-initialize all these
  params, subscribers, and topics.
  Thus having them in a central place is helpful ;-)
  * Fix namespaces as pointed out by @v4hn
  * Simplify nh_ naming
  * update comments
* Fix ClassLoader: SEVERE WARNING
  Clear all references to RobotModel before destroying the corresponding
  RobotModelLoader.
* Modernize: std::make_shared
* Contributors: Abishalini, AndyZe, Cory Crean, Henning Kayser, Jafar, Jafar Abdi, JafarAbdi, Job van Dieten, Jochen Sprickerhof, Martin Oehler, Robert Haschke, Sencer Yazıcı, Stephanie Eng, Vatan Aksoy Tezer, jeoseo, pvanlaar, v4hn
```

## moveit_ros_warehouse

```
* Enable cppcheck (#1224 <https://github.com/ros-planning/moveit2/issues/1224>)
  Co-authored-by: jeoseo <mailto:jeongwooseo2012@gmail.com>
* Make moveit_common a 'depend' rather than 'build_depend' (#1226 <https://github.com/ros-planning/moveit2/issues/1226>)
* Avoid bind(), use lambdas instead (#1204 <https://github.com/ros-planning/moveit2/issues/1204>)
  Adaption of https://github.com/ros-planning/moveit/pull/3106
* various: prefer object and references over pointers
  source: https://github.com/ros-planning/moveit/pull/3106/commits/1a8e5715e3142a92977ac585031b9dc1871f8718; this commit contains minor changes when compared to the source commit which it is based on, these changes are limited to ensuring compatibility with ROS2.
* Merge https://github.com/ros-planning/moveit/commit/ab42a1d7017b27eb6c353fb29331b2da08ab0039
* 1.1.9
* Compilation fixes for Jammy and bring back Rolling CI (#1095 <https://github.com/ros-planning/moveit2/issues/1095>)
  * Use jammy dockers and clang-format-12
  * Fix unused depend, and move to python3-lxml
  * add ompl to repos, fix versions and ogre
  * Remove ogre keys
  * Fix boolean node operator
  * Stop building dockers on branch and fix servo null pointer
  * update pre-commit to clang-format-12 and pre-commit fixes
  * clang-format workaround and more pre-commit fixes
* 1.1.8
* 1.1.7
* Switch to std::bind (#2967 <https://github.com/ros-planning/moveit2/issues/2967>)
  * boost::bind -> std::bind
  grep -rlI --exclude-dir=.git "boost::bind" | xargs sed -i 's/boost::bind/std::bind/g'
  * Convert bind placeholders
  grep -rlI --exclude-dir=.git " _[0-9]" | xargs sed -i 's/ _([0-9])/ std::placeholders::_1/g'
  * Update bind include header
  grep -rlI --exclude-dir=.git "boost/bind" | xargs sed -i 's#boost/bind.hpp#functional#'
* 1.1.6
* Contributors: Abishalini, Henning Kayser, Jafar, Jochen Sprickerhof, Robert Haschke, Vatan Aksoy Tezer, jeoseo, v4hn
```

## moveit_runtime

```
* 1.1.9
* 1.1.8
* 1.1.7
* 1.1.6
* Contributors: Robert Haschke
```

## moveit_servo

```
* Enable cppcheck (#1224 <https://github.com/ros-planning/moveit2/issues/1224>)
  Co-authored-by: jeoseo <mailto:jeongwooseo2012@gmail.com>
* Make moveit_common a 'depend' rather than 'build_depend' (#1226 <https://github.com/ros-planning/moveit2/issues/1226>)
* Avoid bind(), use lambdas instead (#1204 <https://github.com/ros-planning/moveit2/issues/1204>)
  Adaption of https://github.com/ros-planning/moveit/pull/3106
* banish bind()
  source:https://github.com/ros-planning/moveit/pull/3106/commits/a2911c80c28958c1fce8fb52333d770248c4ec05; required minor updates compared to original source commit in order to ensure compatibility with ROS2
* Delete an unused variable and a redundant log message (#1179 <https://github.com/ros-planning/moveit2/issues/1179>)
  Co-authored-by: Vatan Aksoy Tezer <mailto:vatan@picknik.ai>
* [Servo] Add override parameter to set constant velocity scaling in Servo (#1169 <https://github.com/ros-planning/moveit2/issues/1169>)
* Rename panda controllers
* Enable rolling / jammy CI (again) (#1134 <https://github.com/ros-planning/moveit2/issues/1134>)
  * Use ros2_control binaries
  * Use output screen instead of explicitly stating stderr
* Temporarily add galactic CI (#1107 <https://github.com/ros-planning/moveit2/issues/1107>)
  * Add galactic CI
  * Comment out rolling
  * panda_ros_controllers -> panda_ros2_controllers
  * Ignore flake8 tests
* 1.1.9
* Compilation fixes for Jammy and bring back Rolling CI (#1095 <https://github.com/ros-planning/moveit2/issues/1095>)
  * Use jammy dockers and clang-format-12
  * Fix unused depend, and move to python3-lxml
  * add ompl to repos, fix versions and ogre
  * Remove ogre keys
  * Fix boolean node operator
  * Stop building dockers on branch and fix servo null pointer
  * update pre-commit to clang-format-12 and pre-commit fixes
  * clang-format workaround and more pre-commit fixes
* Explicitly set is_primary_planning_scene_monitor in Servo example config (#1060 <https://github.com/ros-planning/moveit2/issues/1060>)
* 1.1.8
* [hybrid planning] Add action abortion and test; improve the existing test (#980 <https://github.com/ros-planning/moveit2/issues/980>)
  * Add action abortion and test; improve the existing test
  * Add controller run-dependency
  * Fix the clearing of robot trajectory when a collision would occur
  * Fix replanning if local planner is stuck
  * Lambda function everything
  * Thread safety for stop_hybrid_planning_
  * Thread-safe state_
  * Clang tidy
  * Update the planning scene properly
  * Update Servo test initial_positions.yaml
  Co-authored-by: Tyler Weaver <mailto:tyler@picknik.ai>
* Remove unused parameters. (#1018 <https://github.com/ros-planning/moveit2/issues/1018>)
  Co-authored-by: Tyler Weaver <mailto:tyler@picknik.ai>
  Co-authored-by: Vatan Aksoy Tezer <mailto:vatan@picknik.ai>
* Add moveit_configs_utils package to simplify loading paramters (#591 <https://github.com/ros-planning/moveit2/issues/591>)
  Co-authored-by: AndyZe <mailto:zelenak@picknik.ai>
  Co-authored-by: Stephanie Eng <mailto:stephanie-eng@users.noreply.github.com>
  Co-authored-by: Tyler Weaver <mailto:tyler@picknik.ai>
* 1.1.7
* 1.1.6
* Servo: sync position limit enforcement with MoveIt2 (#2898 <https://github.com/ros-planning/moveit2/issues/2898>)
  * fix enforce position bug
  * remove unnecessary variable
  * make clang tidy happy
  * Update my comment
  * implement same logic as in the moveit2! repo
  * fix copy-pase error
  Co-authored-by: Michael Wiznitzer <mailto:michael.wiznitzer@resquared.com>
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
* Contributors: AndyZe, Cory Crean, Henning Kayser, Jafar, Jafar Abdi, Joseph Schornak, Marq Rasmussen, Michael Wiznitzer, Robert Haschke, Vatan Aksoy Tezer, jeoseo, v4hn
```
...