### PR TITLE
launch_param_builder: 0.1.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1674,7 +1674,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/PickNikRobotics/launch_param_builder-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/launch_param_builder.git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_param_builder` to `0.1.1-1`:

- upstream repository: https://github.com/PickNikRobotics/launch_param_builder.git
- release repository: https://github.com/PickNikRobotics/launch_param_builder-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.0-1`

## launch_param_builder

```
* Reset parameters explicity when object is constructed to remove copied data. (#4 <https://github.com/PickNikRobotics/launch_param_builder/issues/4>)
* Add path_parameter to ParameterBuilder & get_path to utils (#3 <https://github.com/PickNikRobotics/launch_param_builder/issues/3>)
* Contributors: Jafar, Denis Štogl, Vatan Aksoy Tezer, livanov93
```
