### PR TITLE
libhri: 0.5.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5985,7 +5985,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros4hri/libhri-release.git
-      version: 0.4.3-1
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/ros4hri/libhri.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libhri` to `0.5.0-1`:

- upstream repository: https://github.com/ros4hri/libhri.git
- release repository: https://github.com/ros4hri/libhri-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.4.3-1`

## hri

```
* expose the current TF frame + transform of the person
* expose engagement status of people
* expose softbiometrics (age/gender) in faces
* add support for persons' aliases
  if a /humans/persons/<id>/alias points to another person id, libhri will use
  return the same pointer
* add callbacks when face/body/... are lost + support for known vs tracked persons
* add support for 'anonymous' persons
  Anonymous persons are persons that *may* disappear at any point.
  They are typically created because we *know* that a person is there (eg,
  we've detected a face), but that person is not yet permanently
  identified.
  API change: HriListener::getPersons() now returns *weak* pointers that
  need to be locked before being used.
* ensure the cropped and aligned face do not re-use the same underlying data
* add simple libhri example to display aligned faces
* remove spurious logging on cout
* Contributors: Séverin Lemaignan
```
