### PR TITLE
laser_filters: 2.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1565,7 +1565,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/laser_filters-release.git
-      version: 2.0.4-5
+      version: 2.0.5-1
     source:
       type: git
       url: https://github.com/ros-perception/laser_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters` to `2.0.5-1`:

- upstream repository: https://github.com/ros-perception/laser_filters.git
- release repository: https://github.com/ros2-gbp/laser_filters-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.0.4-5`

## laser_filters

```
* Remove remaining uses of boost.
  All of that functionality is now available in std:: .  Also, this
  should fix the build on RHEL.
* Contributors: Chris Lalancette
```
