### PR TITLE
ign_ros2_control: 0.1.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1706,7 +1706,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 0.1.2-1
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/ignitionrobotics/ign_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ign_ros2_control` to `0.1.3-1`:

- upstream repository: https://github.com/ignitionrobotics/ign_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.2-1`

## ign_ros2_control

```
* Remove URDF dependency (#56 <https://github.com/ignitionrobotics/ign_ros2_control/issues/56>)
* typo in citadel name (#54 <https://github.com/ignitionrobotics/ign_ros2_control/issues/54>)
* Contributors: Alejandro Hernández Cordero, Guillaume Beuzeboc
```

## ign_ros2_control_demos

```
* Remove URDF dependency (#56 <https://github.com/ignitionrobotics/ign_ros2_control/issues/56>)
* Contributors: Alejandro Hernández Cordero
```
