### PR TITLE
gazebo_ros2_control: 0.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1381,7 +1381,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.0.5-1
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros2_control` to `0.1.0-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros2_control/
- release repository: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.0.5-1`

## gazebo_ros2_control

```
* Declare dependency of gazebo_hardware_plugins to urdf in CMakeLists.txt (#117 <https://github.com/ros-simulation/gazebo_ros2_control/issues/117>) (#119 <https://github.com/ros-simulation/gazebo_ros2_control/issues/119>)
  Co-authored-by: Martin Wudenka <mailto:Martin.Wudenka@gmx.de>
* Contributors: Alejandro Hernández Cordero
```

## gazebo_ros2_control_demos

```
* Added diff drive example (#113 <https://github.com/ros-simulation/gazebo_ros2_control/issues/113>)
* Contributors: Alejandro Hernández Cordero
```
