### PR TITLE
gazebo_ros2_control: 0.2.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1081,7 +1081,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.0.7-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros2_control` to `0.2.0-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros2_control/
- release repository: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.0.7-1`

## gazebo_ros2_control

```
* Declare dependency of gazebo_hardware_plugins to urdf in CMakeLists.txt (#117 <https://github.com/ros-simulation/gazebo_ros2_control/issues/117>)
* Contributors: Martin Wudenka
```

## gazebo_ros2_control_demos

```
* Added diff drive example (#113 <https://github.com/ros-simulation/gazebo_ros2_control/issues/113>) (#128 <https://github.com/ros-simulation/gazebo_ros2_control/issues/128>)
* Contributors: Alejandro Hernández Cordero
```
