### PR TITLE
gazebo_ros2_control: 0.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1043,7 +1043,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.0.8-2
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros2_control` to `0.3.0-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros2_control.git
- release repository: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.0.8-2`

## gazebo_ros2_control

```
* Merge pull request #120 <https://github.com/ros-simulation/gazebo_ros2_control/issues/120> from ros-simulation/ahcorde/main/117
  Adapted to Humble
* make linters happy
* Merge remote-tracking branch 'denis/using-under-namespace' into ahcorde/main/117
* update read/write interface functions of ros2_control parts
  This is needed since the ros2_control interfaces have been update
* Declare dependency of gazebo_hardware_plugins to urdf in CMakeLists.txt (#117 <https://github.com/ros-simulation/gazebo_ros2_control/issues/117>)
* ros2_control is now having usings under its namespace.
* Fix mimic joint for effort command (#109 <https://github.com/ros-simulation/gazebo_ros2_control/issues/109>)
* Support for mimic joints and example with gripper. (#107 <https://github.com/ros-simulation/gazebo_ros2_control/issues/107>)
* Contributors: Alejandro Hernández Cordero, Christoph Fröhlich, Denis Štogl, Manuel M, Martin Wudenka, ahcorde
```

## gazebo_ros2_control_demos

```
* [Forward port main] Added diff drive example (#113 <https://github.com/ros-simulation/gazebo_ros2_control/issues/113>) (#129 <https://github.com/ros-simulation/gazebo_ros2_control/issues/129>)
* Merge pull request #120 <https://github.com/ros-simulation/gazebo_ros2_control/issues/120> from ros-simulation/ahcorde/main/117
  Adapted to Humble
* make linters happy
* Update to Humble API
* Support for mimic joints and example with gripper. (#107 <https://github.com/ros-simulation/gazebo_ros2_control/issues/107>)
* Contributors: Alejandro Hernández Cordero, Denis Štogl, ahcorde
```
