### PR TITLE
Add libfreeimage keys.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3140,6 +3140,18 @@ libfontconfig1-dev:
   fedora: [fontconfig-devel]
   gentoo: [media-libs/fontconfig]
   ubuntu: [libfontconfig1-dev]
+libfreeimage:
+  arch: [freeimage]
+  debian: [libfreeimage3]
+  fedora: [freeimage]
+  rhel: [freeimage]
+  ubuntu: [libfreeimage3]
+libfreeimage-dev:
+  arch: [freeimage]
+  debian: [libfreeimage-dev]
+  fedora: [freeimage-devel]
+  rhel: [freeimage-devel]
+  ubuntu: [libfreeimage-dev]
 libfreenect-dev:
   arch: [libfreenect]
   debian: [libfreenect-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3141,15 +3141,19 @@ libfontconfig1-dev:
   gentoo: [media-libs/fontconfig]
   ubuntu: [libfontconfig1-dev]
 libfreeimage:
+  alpine: [freeimage]
   arch: [freeimage]
   debian: [libfreeimage3]
   fedora: [freeimage]
+  opensuse: [libfreeimage3]
   rhel: [freeimage]
   ubuntu: [libfreeimage3]
 libfreeimage-dev:
+  alpine: [freeimage-dev]
   arch: [freeimage]
   debian: [libfreeimage-dev]
   fedora: [freeimage-devel]
+  opensuse: [freeimage-devel]
   rhel: [freeimage-devel]
   ubuntu: [libfreeimage-dev]
 libfreenect-dev:


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

freeimage

## Package Upstream Source:

https://freeimage.sourceforge.io/

## Purpose of using this:

This will be needed by rviz2 once we get https://github.com/ros2/rviz/pull/863 landed.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=freeimage&searchon=names&suite=all&section=all
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/search?keywords=freeimage&searchon=names&suite=all&section=all
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/freeimage/freeimage/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/community/x86_64/freeimage/