### PR TITLE
rviz: 1.13.25-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12603,7 +12603,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.13.24-1
+      version: 1.13.25-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.13.25-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.13.24-1`

## rviz

```
* RobotLink: Simplify material mode handling (#1732 <https://github.com/ros-visualization/rviz/issues/1732>)
* Drop OGRE/ from #include directives (#1730 <https://github.com/ros-visualization/rviz/issues/1730>)
* Fix segfault when no tools are available (#1729 <https://github.com/ros-visualization/rviz/issues/1729>)
* GridCells: implement setTopic() (#1722 <https://github.com/ros-visualization/rviz/issues/1722>)
* Contributors: Brosong, Jochen Sprickerhof, Robert Haschke
```
