### PR TITLE
add libopen3d-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4138,6 +4138,11 @@ libopal-dev:
   fedora: [opal-devel]
   gentoo: [net-libs/opal]
   ubuntu: [libopal-dev]
+libopen3d-dev:
+  debian:
+    bullseye: [libopen3d-dev]
+  ubuntu:
+    jammy: [libopen3d-dev]
 libopenal-dev:
   arch: [openal]
   debian: [libopenal-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4143,7 +4143,9 @@ libopen3d-dev:
     '*': [libopen3d-dev]
     buster: null
   ubuntu:
-    jammy: [libopen3d-dev]
+    *: [libopen3d-dev]
+    focal: null
+    bionic: null
 libopenal-dev:
   arch: [openal]
   debian: [libopenal-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4140,7 +4140,8 @@ libopal-dev:
   ubuntu: [libopal-dev]
 libopen3d-dev:
   debian:
-    bullseye: [libopen3d-dev]
+    '*': [libopen3d-dev]
+    buster: null
   ubuntu:
     jammy: [libopen3d-dev]
 libopenal-dev:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4143,7 +4143,7 @@ libopen3d-dev:
     '*': [libopen3d-dev]
     buster: null
   ubuntu:
-    *: [libopen3d-dev]
+    '*': [libopen3d-dev]
     focal: null
     bionic: null
 libopenal-dev:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4144,8 +4144,8 @@ libopen3d-dev:
     buster: null
   ubuntu:
     '*': [libopen3d-dev]
-    focal: null
     bionic: null
+    focal: null
 libopenal-dev:
   arch: [openal]
   debian: [libopenal-dev]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

libopen3d-dev

## Package Upstream Source:

https://github.com/isl-org/Open3D

## Purpose of using this:

Open3D is an open-source library that supports rapid development of software that deals with 3D data.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/libopen3d-dev
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/jammy/libopen3d-dev
- Fedora: https://packages.fedoraproject.org/
  - IF AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL