### PR TITLE
mrpt_msgs: 0.4.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2629,7 +2629,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_msgs-release.git
-      version: 0.4.2-1
+      version: 0.4.3-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_msgs` to `0.4.3-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
- release repository: https://github.com/ros2-gbp/mrpt_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.4.2-1`

## mrpt_msgs

```
* Fix lint errors
* Add contributing.md file
* Rename license file as "LICENSE"
* Contributors: Jose Luis Blanco-Claraco
```
