### PR TITLE
pose_cov_ops: 0.3.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6679,7 +6679,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release.git
-      version: 0.3.2-1
+      version: 0.3.3-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pose_cov_ops` to `0.3.3-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
- release repository: https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.3.2-1`

## pose_cov_ops

```
* Fix build for ros2
* Rename license as "LICENSE"
* Add contributing.md file
* Contributors: Jose Luis Blanco-Claraco
```
