### PR TITLE
ecl_core: 1.2.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -821,6 +821,47 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
       version: galactic-devel
     status: developed
+  ecl_core:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_core.git
+      version: release/1.2.x
+    release:
+      packages:
+      - ecl_command_line
+      - ecl_concepts
+      - ecl_containers
+      - ecl_converters
+      - ecl_core
+      - ecl_core_apps
+      - ecl_devices
+      - ecl_eigen
+      - ecl_exceptions
+      - ecl_filesystem
+      - ecl_formatters
+      - ecl_geometry
+      - ecl_ipc
+      - ecl_linear_algebra
+      - ecl_manipulators
+      - ecl_math
+      - ecl_mobile_robot
+      - ecl_mpl
+      - ecl_sigslots
+      - ecl_statistics
+      - ecl_streams
+      - ecl_threads
+      - ecl_time
+      - ecl_type_traits
+      - ecl_utilities
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_core-release.git
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://github.com/stonier/ecl_core.git
+      version: devel
+    status: maintained
   ecl_lite:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_core` to `1.2.0-1`:

- upstream repository: https://github.com/stonier/ecl_core.git
- release repository: https://github.com/yujinrobot-release/ecl_core-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`
