### PR TITLE
orocos_kdl_vendor: 0.2.2-3 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2458,7 +2458,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
-      version: 0.2.2-2
+      version: 0.2.2-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_kdl_vendor` to `0.2.2-3`:

- upstream repository: https://github.com/ros2/orocos_kdl_vendor.git
- release repository: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.2.2-2`

## orocos_kdl_vendor

- No changes

## python_orocos_kdl_vendor

```
* Add python_cmake_module as a dependency. (#5 <https://github.com/ros2/orocos_kdl_vendor/issues/5>)
* Contributors: Chris Lalancette
```
