### PR TITLE
Add black

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -102,11 +102,14 @@ azure-storage-file-share-pip:
     pip:
       packages: [azure-storage-file-share]
 black:
+  alpine: [black]
+  arch: [python-black]
   debian: [black]
   fedora: [black]
   gentoo: [dev-python/black]
   nixos: [pythonPackages.black]
   ubuntu: [black]
+  brew: [black]
 canopen-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -101,6 +101,12 @@ azure-storage-file-share-pip:
   ubuntu:
     pip:
       packages: [azure-storage-file-share]
+black:
+  debian: [black]
+  fedora: [black]
+  gentoo: [dev-python/black]
+  nixos: [pythonPackages.black]
+  ubuntu: [black]
 canopen-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -108,7 +108,9 @@ black:
   fedora: [black]
   gentoo: [dev-python/black]
   nixos: [pythonPackages.black]
-  ubuntu: [black]
+  ubuntu:
+    '*': [black]
+    bionic: null
   brew: [black]
 canopen-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -104,6 +104,7 @@ azure-storage-file-share-pip:
 black:
   alpine: [black]
   arch: [python-black]
+  brew: [black]
   debian: [black]
   fedora: [black]
   gentoo: [dev-python/black]
@@ -111,7 +112,6 @@ black:
   ubuntu:
     '*': [black]
     bionic: null
-  brew: [black]
 canopen-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

black

## Package Upstream Source:

https://black.readthedocs.io/en/stable/

## Purpose of using this:

Used by [ament_black](https://github.com/Timple/ament_black)

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=black&searchon=names&suite=stable&section=all
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/jammy/black
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-black/black/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/community/any/python-black/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/black
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/black#default
  - Unsure about the syntax here
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/packages?name=black&branch=edge
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=21.11&show=black&from=0&size=50&sort=relevance&type=packages&query=black
  - Unsure about the syntax here
