### PR TITLE
ros2_control: 0.10.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4503,7 +4503,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 0.10.0-1
+      version: 0.10.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `0.10.1-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.10.0-1`

## controller_interface

```
* Make interface_list_contains_interface_type inline (#721 <https://github.com/ros-controls/ros2_control/issues/721>) (#722 <https://github.com/ros-controls/ros2_control/issues/722>)
* Contributors: Bence Magyar
```

## controller_manager

- No changes

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## transmission_interface

- No changes
