### PR TITLE
ros2_controllers: 0.8.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4531,7 +4531,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 0.7.0-1
+      version: 0.8.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `0.8.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.0-1`

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

```
* joint_state_broadcaster to use realtime tools (#308 <https://github.com/ros-controls/ros2_controllers/issues/308>)
  * joint_state_broadcaster to use realtime tools (#276 <https://github.com/ros-controls/ros2_controllers/issues/276>)
  * Use RealtimePublisher for joint_states
  * Use RealtimePublisher for dynamic joint states
* Contributors: John Morris
```

## joint_state_controller

- No changes

## joint_trajectory_controller

- No changes

## position_controllers

- No changes

## ros2_controllers

- No changes

## velocity_controllers

- No changes
