### PR TITLE
pose_cov_ops: 0.3.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2716,6 +2716,21 @@ repositories:
       url: https://github.com/fmrico/popf.git
       version: humble-devel
     status: developed
+  pose_cov_ops:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
+      version: master
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/pose_cov_ops-release.git
+      version: 0.3.4-1
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
+      version: master
+    status: maintained
   pybind11_json_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pose_cov_ops` to `0.3.4-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
- release repository: https://github.com/ros2-gbp/pose_cov_ops-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## pose_cov_ops

```
* Fix missing cmake xmllint at configure time.
* Contributors: Jose Luis Blanco-Claraco
```
