### PR TITLE
moveit: 2.5.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2052,7 +2052,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/moveit/moveit2-release.git
-      version: 2.5.0-1
+      version: 2.5.1-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.5.1-1`:

- upstream repository: https://github.com/ros-planning/moveit2.git
- release repository: https://github.com/moveit/moveit2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.5.0-1`

## chomp_motion_planner

- No changes

## moveit

- No changes

## moveit_chomp_optimizer_adapter

- No changes

## moveit_common

- No changes

## moveit_configs_utils

- No changes

## moveit_core

- No changes

## moveit_hybrid_planning

```
* Remove position controllers from CMake (#1285 <https://github.com/ros-planning/moveit2/issues/1285>)
* Contributors: Vatan Aksoy Tezer
```

## moveit_kinematics

- No changes

## moveit_planners

- No changes

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

- No changes

## moveit_plugins

- No changes

## moveit_resources_prbt_ikfast_manipulator_plugin

- No changes

## moveit_resources_prbt_moveit_config

- No changes

## moveit_resources_prbt_pg70_support

- No changes

## moveit_resources_prbt_support

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

- No changes

## moveit_ros_move_group

- No changes

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

- No changes

## moveit_ros_planning

- No changes

## moveit_ros_planning_interface

- No changes

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

- No changes

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_servo

- No changes

## moveit_setup_assistant

- No changes

## moveit_simple_controller_manager

- No changes

## pilz_industrial_motion_planner

```
* Fix exporting PILZ's move_group capabilities (#1281 <https://github.com/ros-planning/moveit2/issues/1281>)
* Contributors: Jafar
```

## pilz_industrial_motion_planner_testutils

- No changes
