### PR TITLE
webots_ros2: 1.2.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -6161,7 +6161,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/webots_ros2-release.git
-      version: 1.2.2-1
+      version: 1.2.3-1
     source:
       test_pull_requests: true
       type: git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -6142,7 +6142,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/cyberbotics/webots_ros2.git
-      version: rolling
+      version: master
     release:
       packages:
       - webots_ros2


### PR DESCRIPTION
Increasing version of package(s) in repository `webots_ros2` to `1.2.3-1`:

- upstream repository: https://github.com/cyberbotics/webots_ros2.git
- release repository: https://github.com/ros2-gbp/webots_ros2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.2.2-1`

## webots_ros2

```
* Fixed support for Humble and Rolling.
```

## webots_ros2_control

```
* Fixed support for Humble and Rolling.
```

## webots_ros2_core

```
* This package shows now deprecation warnings and will be removed with the release of Webots R2023a.
* Users of webots_ros2_core should migrate to webots_ros2_driver.
```

## webots_ros2_driver

```
* Add option to set 'robot_description' parameter for 'robot_state_publisher' node.
* Fix recognition camera.
* Add a 'PointCloud2' publisher for the 'RangeFinder' device.
```

## webots_ros2_epuck

```
* Fixed support for Humble and Rolling.
```

## webots_ros2_importer

```
* Upgraded to urdf2webots 1.0.18
```

## webots_ros2_tesla

```
* Fixed support for Humble and Rolling.
```

## webots_ros2_turtlebot

```
* Fix warnings with the example plugin.
```
