### PR TITLE
Add python3-depthai-pip dependency

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6285,6 +6285,16 @@ python3-defusedxml:
   opensuse: [python3-defusedxml]
   rhel: ['python%{python3_pkgversion}-defusedxml']
   ubuntu: [python3-defusedxml]
+python3-depthai-pip:
+  debian:
+    pip:
+      packages: [depthai]
+  fedora:
+    pip:
+      packages: [depthai]
+  ubuntu:
+    pip:
+      packages: [depthai]
 python3-dev:
   alpine: [python3-dev]
   arch: [python]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

pip/pip3 depthai

## Package Upstream Source:

https://github.com/luxonis/depthai-python

## Purpose of using this:

This dependency is used for interacting with the [DepthAI](https://docs.luxonis.com/en/latest/) spatial AI platform.

## Links to Distribution Packages

- Pip: https://pypi.org/project/depthai/
