### PR TITLE
Add python3-playsound-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7537,6 +7537,16 @@ python3-pkg-resources:
   opensuse: [python3-setuptools]
   rhel: ['python%{python3_pkgversion}-setuptools']
   ubuntu: [python3-pkg-resources]
+python3-playsound-pip:
+  debian:
+    pip:
+      packages: [playsound]
+  fedora:
+    pip:
+      packages: [playsound]
+  ubuntu:
+    pip:
+      packages: [playsound]
 python3-ply:
   arch: [python-ply]
   debian: [python3-ply]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

pip/pip3 playsound

## Package Upstream Source:

https://github.com/TaylorSMarks/playsound

## Purpose of using this:

This dependency is used as a pure Python, cross platform, single function module for playing sounds.

## Links to Distribution Packages

- Pip: https://pypi.org/project/playsound/
