### PR TITLE
ament_black: 0.1.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -48,6 +48,20 @@ repositories:
       url: https://github.com/ros-drivers/ackermann_msgs.git
       version: ros2
     status: maintained
+  ament_black:
+    release:
+      packages:
+      - ament_black
+      - ament_cmake_black
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/Timple/ament_black-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/Timple/ament_black.git
+      version: main
+    status: maintained
   ament_cmake:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_black` to `0.1.0-1`:

- upstream repository: https://github.com/Timple/ament_black.git
- release repository: https://github.com/Timple/ament_black-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`
