### PR TITLE
Added humble branches for fmi_adapter and fmilibrary_vendor.

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -979,7 +979,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git
-      version: master
+      version: humble
     release:
       packages:
       - fmi_adapter
@@ -991,7 +991,7 @@ repositories:
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git
-      version: master
+      version: humble
     status: maintained
   fmilibrary_vendor:
     release:
@@ -1002,7 +1002,7 @@ repositories:
     source:
       type: git
       url: https://github.com/boschresearch/fmilibrary_vendor.git
-      version: master
+      version: humble
     status: maintained
   fogros2:
     release:


### PR DESCRIPTION
Replaced the 'master' in doc and source of fmi_adapter and fmilibrary_vendor with the new 'humble' branches.