### PR TITLE
mir_robot: 1.1.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5013,7 +5013,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/uos-gbp/mir_robot-release.git
-      version: 1.1.5-1
+      version: 1.1.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mir_robot` to `1.1.6-1`:

- upstream repository: https://github.com/dfki-ric/mir_robot.git
- release repository: https://github.com/uos-gbp/mir_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.1.5-1`

## mir_actions

```
* Rename mir_100 -> mir
  This is in preparation of mir_250 support.
* Contributors: Martin Günther
```

## mir_description

```
* URDF: Downsize inertia box, move to lower back
* URDF: Pull out inertia properties
* URDF: Update masses according to data sheet
* URDF: Add mir_250
* Add arg mir_type to launch files and urdfs
* Add mir_250 meshes
* URDF: Make wheels black
* Add mir_100_v1.urdf.xacro for backwards compatibility
* Rename mir_100 -> mir
* Refactor URDF to prepare for MiR250 support
* Gazebo: Don't manually specify wheel params for diffdrive controller
* Simplify mir_100 collision mesh further
* Contributors: Martin Günther
```

## mir_driver

```
* Add arg mir_type to launch files and urdfs
* Rename mir_100 -> mir
  This is in preparation of mir_250 support.
* Contributors: Martin Günther
```

## mir_dwb_critics

- No changes

## mir_gazebo

```
* Add arg mir_type to launch files and urdfs
* Rename mir_100 -> mir
  This is in preparation of mir_250 support.
* Contributors: Martin Günther
```

## mir_msgs

```
* Rename mir_100 -> mir
  This is in preparation of mir_250 support.
* Contributors: Martin Günther
```

## mir_navigation

```
* navigation: Reduce footprint to actual size
  This reduces the footprint:
  * 18 mm in front
  * 42 mm in the back
  * 27 mm at the sides
  Now the footprint exactly matches the bounding box of the mesh, with no
  padding. This should make navigation in tight spaces easier; let's hope
  it doesn't lead to collisions.
* navigation: Move footprint_padding to proper namespace
  The footprint_padding parameter in the upper namespace was ignored,
  needed to be moved into local_costmap/global_costmap to take effect.
* genmprim: Remove obsolete plt.hold()
  This fixes the following error:
  AttributeError: module 'matplotlib.pyplot' has no attribute 'hold'
* mir_navigation: Remove static_map parameter
  This fixes the following warning:
  [ WARN] local_costmap: Pre-Hydro parameter "static_map" unused since "plugins" is provided
* Contributors: Martin Günther
```

## mir_robot

```
* Rename mir_100 -> mir
  This is in preparation of mir_250 support.
* Contributors: Martin Günther
```

## sdc21x0

- No changes
