### PR TITLE
grpc: 0.0.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3151,7 +3151,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/CogRobRelease/catkin_grpc-release.git
-      version: 0.0.10-2
+      version: 0.0.11-1
     source:
       type: git
       url: https://github.com/CogRob/catkin_grpc.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grpc` to `0.0.11-1`:

- upstream repository: https://github.com/CogRob/catkin_grpc.git
- release repository: https://github.com/CogRobRelease/catkin_grpc-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.0.10-2`

## grpc

```
* Update package.xml
* Fix build failure (#45 <https://github.com/CogRob/catkin_grpc/issues/45>)
* Update package.xml (#44 <https://github.com/CogRob/catkin_grpc/issues/44>)
* Support finding libraries for grpc v1.34.1 (#43 <https://github.com/CogRob/catkin_grpc/issues/43>)
* Bump grpc version to v1.34.1 for supporting noetic (#42 <https://github.com/CogRob/catkin_grpc/issues/42>)
  * use git to fetch external project grpc
  * bump grpc version to v1.34.1
  Co-authored-by: Shengye Wang <mailto:BillWSY@users.noreply.github.com>
* use git to fetch external project grpc (#41 <https://github.com/CogRob/catkin_grpc/issues/41>)
  * use git to fetch external project grpc
  * Specify Cmake version for using GIT_REPOSITORY and GIT_CONFIG
  Co-authored-by: Shengye Wang <mailto:BillWSY@users.noreply.github.com>
* use absolute path for RELATIVE_BASE_DIR (#37 <https://github.com/CogRob/catkin_grpc/issues/37>)
* Contributors: JaeyoungLim, Shengye Wang, Tom Lankhorst, Yuki Furuta
```
