### PR TITLE
performance_test-release: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2595,7 +2595,6 @@ repositories:
       url: https://github.com/ros2-gbp/performance_test-release.git
       version: 1.1.0-1
     source:
-      test_pull_requests: true
       type: git
       url: https://gitlab.com/ApexAI/performance_test.git
       version: master

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2581,6 +2581,25 @@ repositories:
       url: https://github.com/ros-perception/perception_pcl.git
       version: ros2
     status: maintained
+  performance_test-release:
+    doc:
+      type: git
+      url: https://gitlab.com/ApexAI/performance_test.git
+      version: 1.1.0
+    release:
+      packages:
+      - performance_report
+      - performance_test
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/performance_test-release.git
+      version: 1.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://gitlab.com/ApexAI/performance_test.git
+      version: master
+    status: maintained
   performance_test_fixture:
     release:
       tags:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2581,7 +2581,7 @@ repositories:
       url: https://github.com/ros-perception/perception_pcl.git
       version: ros2
     status: maintained
-  performance_test-release:
+  performance_test:
     doc:
       type: git
       url: https://gitlab.com/ApexAI/performance_test.git


### PR DESCRIPTION
Increasing version of package(s) in repository `performance_test-release` to `1.1.0-1`:

- upstream repository: https://gitlab.com/ApexAI/performance_test.git
- release repository: https://github.com/ros2-gbp/performance_test-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`
