### PR TITLE
perception_open3d: 0.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2561,6 +2561,19 @@ repositories:
       url: https://github.com/ros-perception/pcl_msgs.git
       version: ros2
     status: maintained
+  perception_open3d:
+    release:
+      packages:
+      - open3d_conversions
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros-gbp/perception_open3d-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/perception_open3d.git
+      version: humble
+    status: developed
   perception_pcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_open3d` to `0.2.0-1`:

- upstream repository: https://github.com/ros-perception/perception_open3d.git
- release repository: https://github.com/ros-gbp/perception_open3d-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`
