### PR TITLE
perception_open3d: 0.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2514,6 +2514,19 @@ repositories:
       url: https://github.com/ros-perception/pcl_msgs.git
       version: ros2
     status: maintained
+  perception_open3d:
+    release:
+      packages:
+      - open3d_conversions
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros-gbp/perception_open3d-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/perception_open3d.git
+      version: ros2
+    status: developed
   perception_pcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_open3d` to `0.1.1-1`:

- upstream repository: https://github.com/ros-perception/perception_open3d.git
- release repository: https://github.com/ros-gbp/perception_open3d-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`
