### PR TITLE
depthai: 2.15.5-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -701,7 +701,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/luxonis/depthai-core-release.git
-      version: 2.15.4-2
+      version: 2.15.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai` to `2.15.5-1`:

- upstream repository: https://github.com/luxonis/depthai-core.git
- release repository: https://github.com/luxonis/depthai-core-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.15.4-2`

## depthai

```
* EEPROM FIX
* Json fix (#478 <https://github.com/luxonis/depthai-core/issues/478>)
  * Fixed nlohmann json < v3.9.0 compat and toolchain generation
  * turn off clang format
  Co-authored-by: Martin Peterlin <mailto:martin.peterlin7@gmail.com>
  Co-authored-by: TheMarpe <mailto:martin@luxonis.com>
* Empty-Commit
* Update package.xml
* Contributors: Sachin, Sachin Guruswamy
```
