### PR TITLE
depthai-ros: 2.5.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -722,7 +722,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/luxonis/depthai-ros-release.git
-      version: 2.5.1-1
+      version: 2.5.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai-ros` to `2.5.2-1`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: https://github.com/luxonis/depthai-ros-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.5.1-1`

## depthai-ros

```
* Upgraded examples
* Fixed bugs for Noetic
```

## depthai_bridge

```
* Upgraded examples
* Fixed bugs for Noetic
```

## depthai_examples

```
* Upgraded examples
* Fixed bugs for Noetic
```

## depthai_ros_msgs

```
* Upgraded examples
* Fixed bugs for Noetic
```
