### PR TITLE
depthai-ros: 2.5.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1682,7 +1682,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/luxonis/depthai-ros-release.git
-      version: 2.5.1-2
+      version: 2.5.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai-ros` to `2.5.2-1`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: https://github.com/luxonis/depthai-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.5.1-2`

## depthai-ros

```
* Upgraded examples
* Fixed bugs for Noetic
```

## depthai_bridge

```
* Upgraded examples
* Fixed bugs for Noetic
```

## depthai_examples

```
* Upgraded examples
* Fixed bugs for Noetic
```

## depthai_ros_msgs

```
* Upgraded examples
* Fixed bugs for Noetic
```
