### PR TITLE
dynamixel_sdk: 3.7.60-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -841,7 +841,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_sdk-release.git
-      version: 3.7.40-3
+      version: 3.7.60-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_sdk` to `3.7.60-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
- release repository: https://github.com/ros2-gbp/dynamixel_sdk-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `3.7.40-3`

## dynamixel_sdk

```
* ROS2 Humble Hawksbill supported
```

## dynamixel_sdk_custom_interfaces

```
* ROS2 Humble Hawksbill supported
```

## dynamixel_sdk_examples

```
* ROS2 Humble Hawksbill supported
```
