### PR TITLE
rosee_msg: 0.0.2-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4926,6 +4926,21 @@ repositories:
       url: https://github.com/RobotWebTools/rosbridge_suite.git
       version: ros2
     status: maintained
+  rosee_msg:
+    doc:
+      type: git
+      url: https://github.com/ADVRHumanoids/rosee_msg.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ADVRHumanoids/rosee2_msg-release.git
+      version: 0.0.2-2
+    source:
+      type: git
+      url: https://github.com/ADVRHumanoids/rosee_msg.git
+      version: ros2
+    status: maintained
   rosidl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosee_msg` to `0.0.2-2`:

- upstream repository: https://github.com/ADVRHumanoids/rosee_msg
- release repository: https://github.com/ADVRHumanoids/rosee2_msg-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## rosee_msg

```
* Merge branch 'ros2' of https://github.com/ADVRHumanoids/rosee_msg into ros2
* added ObjectModelMsg message for rosee grasp planner package
* Dependincies must be set even if they are missing from tutorial
* some dep
* updates for ros2
* first ros2 commit
* Contributors: Davide Torielli, Liana Bertoni
```
