### PR TITLE
mqtt_client: 1.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5347,7 +5347,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ika-rwth-aachen/mqtt_client.git
-      version: v1.0.0
+      version: main
     status: maintained
   mrpt2:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5338,6 +5338,17 @@ repositories:
       url: https://github.com/groove-x/mqtt_bridge.git
       version: master
     status: maintained
+  mqtt_client:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ika-rwth-aachen/mqtt_client-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ika-rwth-aachen/mqtt_client.git
+      version: v1.0.0
+    status: maintained
   mrpt2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mqtt_client` to `1.0.0-1`:

- upstream repository: https://github.com/ika-rwth-aachen/mqtt_client.git
- release repository: https://github.com/ika-rwth-aachen/mqtt_client-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`
