### PR TITLE
Readding AWS Warehouse world to build in Rolling / Jammy

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -404,6 +404,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/aws-gbp/aws_robomaker_small_warehouse_world-release.git
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/aws-robotics/aws-robomaker-small-warehouse-world.git
@@ -5625,7 +5626,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/cyberbotics/webots_ros2.git
-      version: master
+      version: rolling
     release:
       packages:
       - webots_ros2
@@ -5644,7 +5645,6 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/webots_ros2-release.git
-      version: 1.2.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Per https://github.com/aws-robotics/aws-robomaker-small-warehouse-world/issues/23, I'm readding AWS Warehouse world to build on Rolling now that Gazebo dependency is met to trigger release jobs. Was disabled in https://github.com/ros/rosdistro/pull/32036/files#diff-a79d50d14101a47dfc4ea7b0dd7b9446f34b544807d8f0c48cc6a8f07fc3b36aL357. 