### PR TITLE
Add sdformat12 (Fortress) rosdep key for Jammy

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7078,6 +7078,7 @@ sdformat12:
     buster: [libsdformat12-dev]
   ubuntu:
     focal: [libsdformat12-dev]
+    jammy: [libsdformat12-dev]
 sdl:
   arch: [sdl]
   debian: [libsdl1.2-dev]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

* Part of https://github.com/ignition-tooling/release-tools/issues/459
* Follow up to https://github.com/ros/rosdistro/pull/32838

## Package name:

[Gazebo Fortress libraries](https://gazebosim.org/docs/fortress)

## Package Upstream Source:

https://github.com/gazebosim/sdformat

## Purpose of using this:

As defined on [REP-2000](https://www.ros.org/reps/rep-2000.html#humble-hawksbill-may-2022-may-2027), Gazebo Fortress is the official Gazebo version to be used with ROS Humble. This adds the `sdformat12` keys for Ubuntu Jammy, which I forgot on my previous PR.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/
  - http://packages.osrfoundation.org/gazebo/debian-stable/
- Ubuntu: https://packages.ubuntu.com/
   - http://packages.osrfoundation.org/gazebo/ubuntu-stable/
- macOS: https://formulae.brew.sh/
  - https://github.com/osrf/homebrew-simulation/
