### PR TITLE
joint_state_publisher: 2.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1511,7 +1511,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/joint_state_publisher-release.git
-      version: 2.2.0-4
+      version: 2.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joint_state_publisher` to `2.3.0-1`:

- upstream repository: https://github.com/ros/joint_state_publisher.git
- release repository: https://github.com/ros2-gbp/joint_state_publisher-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.2.0-4`

## joint_state_publisher

```
* Use underscores in setup.cfg. (#76 <https://github.com/ros/joint_state_publisher/issues/76>)
* Fix the mimic_cycle test to always succeed. (#74 <https://github.com/ros/joint_state_publisher/issues/74>)
* Remove deprecated policy warning (#67 <https://github.com/ros/joint_state_publisher/issues/67>)
* Clarify docs on 'mapped parameters' in README (#66 <https://github.com/ros/joint_state_publisher/issues/66>) (#71 <https://github.com/ros/joint_state_publisher/issues/71>)
  * Clarify docs on 'mapped parameters' in README
  Co-authored-by: Binit Shah <mailto:bshah@hello-robot.com>
* Contributors: Binit Shah, Chris Lalancette
```

## joint_state_publisher_gui

```
* Fix use of joint_state_publisher on Ubuntu Jammy. (#78 <https://github.com/ros/joint_state_publisher/issues/78>)
* Use underscores in setup.cfg. (#76 <https://github.com/ros/joint_state_publisher/issues/76>)
* Automatically resize window based on number of joints (#68 <https://github.com/ros/joint_state_publisher/issues/68>)
* Contributors: Andy McEvoy, Chris Lalancette
```
