### PR TITLE
slam_toolbox: 2.6.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4675,6 +4675,17 @@ repositories:
       url: https://github.com/oKermorgant/simple_launch.git
       version: devel
     status: maintained
+  slam_toolbox:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/SteveMacenski/slam_toolbox-release.git
+      version: 2.6.0-1
+    source:
+      type: git
+      url: https://github.com/SteveMacenski/slam_toolbox.git
+      version: humble
+    status: maintained
   slider_publisher:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4682,6 +4682,7 @@ repositories:
       url: https://github.com/SteveMacenski/slam_toolbox-release.git
       version: 2.6.0-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/SteveMacenski/slam_toolbox.git
       version: humble


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_toolbox` to `2.6.0-1`:

- upstream repository: https://github.com/SteveMacenski/slam_toolbox.git
- release repository: https://github.com/SteveMacenski/slam_toolbox-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`
