### PR TITLE
foxglove_msgs: 1.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2636,7 +2636,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/foxglove/ros_foxglove_msgs-release.git
-      version: 1.2.0-1
+      version: 1.2.1-1
     source:
       type: git
       url: https://github.com/foxglove/schemas.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_msgs` to `1.2.1-1`:

- upstream repository: https://github.com/foxglove/schemas.git
- release repository: https://github.com/foxglove/ros_foxglove_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.2.0-1`

## foxglove_msgs

```
* Fix CMake install share directory
* Contributors: Jacob Bandes-Storch
```
