### PR TITLE
system_modes: 0.9.0-3 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5217,11 +5217,10 @@ repositories:
       - system_modes
       - system_modes_examples
       - system_modes_msgs
-      - test_launch_system_modes
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/system_modes-release.git
-      version: 0.9.0-1
+      version: 0.9.0-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `system_modes` to `0.9.0-3`:

- upstream repository: https://github.com/micro-ROS/system_modes.git
- release repository: https://github.com/ros2-gbp/system_modes-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.9.0-1`

## launch_system_modes

```
* More flexibility in specifying the default mode, any mode can be now default mode
  https://github.com/micro-ROS/system_modes/issues/69
```

## system_modes

```
* More flexibility in specifying the default mode, any mode can be now default mode
  https://github.com/micro-ROS/system_modes/issues/69
```

## system_modes_examples

```
* More flexibility in specifying the default mode, any mode can be now default mode
  https://github.com/micro-ROS/system_modes/issues/69
```

## system_modes_msgs

```
* More flexibility in specifying the default mode, any mode can be now default mode
  https://github.com/micro-ROS/system_modes/issues/69
```
