### PR TITLE
end_effector: 0.0.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1195,6 +1195,21 @@ repositories:
       url: https://github.com/OUXT-Polaris/embree_vendor.git
       version: master
     status: developed
+  end_effector:
+    doc:
+      type: git
+      url: https://github.com/ADVRHumanoids/ROSEndEffector2.git
+      version: main
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ADVRHumanoids/ROSEndEffector2-release.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/ADVRHumanoids/ROSEndEffector2.git
+      version: main
+    status: maintained
   espeak_ros:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `end_effector` to `0.0.3-1`:

- upstream repository: https://github.com/ADVRHumanoids/ROSEndEffector2
- release repository: https://github.com/ADVRHumanoids/ROSEndEffector2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## end_effector

```
* c++17 to remove boost dep && some solved warnings
* Contributors: Davide Torielli
```
