### PR TITLE
ros_amr_interop: 1.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7984,6 +7984,14 @@ repositories:
       url: https://github.com/ros/ros.git
       version: noetic-devel
     status: maintained
+  ros_amr_interop:
+    release:
+      packages:
+      - massrobotics_amr_sender
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/inorbit-ai/ros_amr_interop-release.git
+      version: 1.0.1-1
   ros_babel_fish:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_amr_interop` to `1.0.1-1`:

- upstream repository: https://github.com/inorbit-ai/ros_amr_interop.git
- release repository: https://github.com/inorbit-ai/ros_amr_interop-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## massrobotics_amr_sender

```
* First version of the package in ROS Noetic (#25 <https://github.com/inorbit-ai/ros_amr_interop/issues/25>)
  * Update schema to latest version
  * Fix issue with click dependency
  * Apply formatting with black
  * Translate the package to ROS 1 Noetic
  * Remove references to ROS2
* Contributors: Florencia Grosso
```
