### PR TITLE
tvm_vendor: 0.8.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6254,7 +6254,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/tvm_vendor-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       type: git
       url: https://github.com/autowarefoundation/tvm_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tvm_vendor` to `0.8.2-1`:

- upstream repository: https://github.com/autowarefoundation/tvm_vendor.git
- release repository: https://github.com/ros2-gbp/tvm_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.8.1-1`

## tvm_vendor

```
* fix: modify patch issue (#10 <https://github.com/autowarefoundation/tvm_vendor/issues/10>)
  * fix: update patch
  * fix: add workaround to avoid multiple patch apply
* Contributors: Daisuke Nishimatsu
```
