### PR TITLE
ign_ros2_control: 0.4.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1406,7 +1406,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/ignitionrobotics/ign_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ign_ros2_control` to `0.4.1-1`:

- upstream repository: https://github.com/ignitionrobotics/ign_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.4.0-1`

## ign_ros2_control

```
* Remove URDF dependency (#56 <https://github.com/ignitionrobotics/ign_ros2_control/issues/56>)
* typo in citadel name (#54 <https://github.com/ignitionrobotics/ign_ros2_control/issues/54>)
* Contributors: Alejandro Hernández Cordero, Guillaume Beuzeboc, ahcorde
```

## ign_ros2_control_demos

```
* ign_ros2_control_demos: Install urdf dir (#61 <https://github.com/ignitionrobotics/ign_ros2_control/issues/61>)
* Remove URDF dependency (#56 <https://github.com/ignitionrobotics/ign_ros2_control/issues/56>)
* Contributors: Alejandro Hernández Cordero, Andrej Orsula
```
