### PR TITLE
rmw_connextdds: 0.11.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3532,7 +3532,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 0.11.1-1
+      version: 0.11.1-2
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `0.11.1-2`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.11.1-1`

## rmw_connextdds

- No changes

## rmw_connextdds_common

```
* Resolve build error with RTI Connext DDS 5.3.1 (#82 <https://github.com/ros2/rmw_connextdds/issues/82>)
* Contributors: Andrea Sorbini
```

## rti_connext_dds_cmake_module

- No changes
