### PR TITLE
maliput: 1.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2284,6 +2284,11 @@ repositories:
       type: git
       url: https://github.com/maliput/maliput.git
       version: main
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/maliput-release.git
+      version: 1.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput` to `1.0.2-1`:

- upstream repository: https://github.com/maliput/maliput.git
- release repository: https://github.com/ros2-gbp/maliput-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## maliput

```
* Preparing for binary release
```
