### PR TITLE
mocap_nokov:0.0.1-1 in in 'melodic/distribution.yaml' 

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6738,6 +6738,21 @@ repositories:
       url: https://github.com/nobleo/mobile_robot_simulator.git
       version: master
     status: maintained
+  mocap_nokov:
+    doc:
+      type: git
+      url: https://github.com/NOKOV-MOCAP/mocap_nokov.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/NOKOV-MOCAP/mocap_nokov_release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/NOKOV-MOCAP/mocap_nokov.git
+      version: master
+    status: developed
   mocap_optitrack:
     doc:
       type: git


### PR DESCRIPTION
upstream repository: https://github.com/NOKOV-MOCAP/mocap_nokov.git
release repository: https://github.com/NOKOV-MOCAP/mocap_nokov_release.git
distro file: melodic/distribution.yaml
bloom version: 0.11.1
previous version for package: null