### PR TITLE
jsk_common: 2.2.12-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5197,6 +5197,7 @@ repositories:
       version: master
     release:
       packages:
+      - audio_video_recorder
       - dynamic_tf_publisher
       - image_view2
       - jsk_common
@@ -5210,7 +5211,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 2.2.11-1
+      version: 2.2.12-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `2.2.12-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.2.11-1`

## audio_video_recorder

```
* add audio_video_recorder (#1672 <https://github.com/jsk-ros-pkg/jsk_common/issues/1672>)
* Contributors: Shingo Kitagawa
```

## dynamic_tf_publisher

```
* run 2to3 -w -f has_key for python3 compatibility (#1695 <https://github.com/jsk-ros-pkg/jsk_common/issues/1695>)
* install tf_reconfigure_publisher.py (#1654 <https://github.com/jsk-ros-pkg/jsk_common/issues/1654>)
* Contributors: Shingo Kitagawa
```

## image_view2

```
* set ccache prefix only for cmake <= 3.4 (#1694 <https://github.com/jsk-ros-pkg/jsk_common/issues/1694>)
* Contributors: Yuki Furuta
```

## jsk_common

```
* add audio_video_recorder in jsk_common (#1672 <https://github.com/jsk-ros-pkg/jsk_common/issues/1672>)
* Contributors: Shingo Kitagawa
```

## jsk_data

```
* [jsk_data/tess_data_collection_server] Check if text and yaml or text and image are saved in the subdirectory of save_dir. (#1734 <https://github.com/jsk-ros-pkg/jsk_common/issues/1734>)
* [test/data_collection_server] Wait until data saved for test. (#1728 <https://github.com/jsk-ros-pkg/jsk_common/issues/1728>)
* [jsk_data] Strip newline at test code. (#1726 <https://github.com/jsk-ros-pkg/jsk_common/issues/1726>)
* [data_collection_server] Add rosbag to data collection server (#1708 <https://github.com/jsk-ros-pkg/jsk_common/issues/1708>)
  
    * add rosbag_options param
    * delete sample launch file
    * remove rosbag param
    * add rosbag_prefix param
    * remove print and avoid error if end is called before start
    * add minimal functions about rosbag record in data_collection_server
  
* [jsk_data] add wait_timer for timer method (#1697 <https://github.com/jsk-ros-pkg/jsk_common/issues/1697>)
  
    * rename to wait_msgs_update
    * add wait_timer rosparam for timer waiting
    * remove wait in sync_sub_and_save_cb
    * check all msg stamp in self.msgs for wait_msgs_update
    * add wait_service_request for timer and all method
  
* use raw_input for python2 c.f. (#1695 <https://github.com/jsk-ros-pkg/jsk_common/issues/1695>)
* [jsk_data] add wait_save_request in data_collection_server (#1669 <https://github.com/jsk-ros-pkg/jsk_common/issues/1669>)
* fix TOPICS arg (#1689 <https://github.com/jsk-ros-pkg/jsk_common/issues/1689>)
* Update jsk_data/src/jsk_data/download_data.py (#1685 <https://github.com/jsk-ros-pkg/jsk_common/issues/1685>)
  
    * [jsk_data] fix bugs in download_data.py
    * [jsk_data] update download_data.py to remove front './' from extracted file names
  
* check if openni_launch exits to run roslaunch-check pr2_play.launch (#1662 <https://github.com/jsk-ros-pkg/jsk_common/issues/1662>)
  
    * use xacro instead of xacro.py
  
* Contributors: Iori Yanokura, Naoaki Kanazawa, Koki Shinjo, Shingo Kitagawa, Shumpei Wakabayashi, Shun Hasegawa, Iori Yanokura, Ren Kunita
```

## jsk_network_tools

```
* add skip_interfaces param in network_status.py (#1664 <https://github.com/jsk-ros-pkg/jsk_common/issues/1664>)
* Contributors: Shingo Kitagawa
```

## jsk_tilt_laser

- No changes

## jsk_tools

```
* [jsk_tools] change default ROS_MASTER_URI of rossetmaster to localhost (#1729 <https://github.com/jsk-ros-pkg/jsk_common/issues/1729>)
* Add test for topic connection test after killing nodes (#1725 <https://github.com/jsk-ros-pkg/jsk_common/issues/1725>)
  
    * [jsk_tools] Add comment for avoiding rospy.exceptions.ROSTimeMovedBackwardsException
    * [jsk_tools] Fixed E713 error for membership should be "not in"
    * Add not received topic infos
    * [jsk_tools] Add test for namespace
    * [jsk_tools] Add test for topic connection test after killing nodes
    * [jsk_tools] Add check_after_kill_node option for checking topic connection after killing nodes
  
* [jsk_tools] Add node to publish diagnostics based on topic and node status (#1727 <https://github.com/jsk-ros-pkg/jsk_common/issues/1727>)
  
    * [jsk_tools] Set longer timeout for sanity_diagnostics test
    * [jsk_tools] Fix test name for sanity_diagnostics
    * [jsk_tools] Install sample directory
    * [jsk_tools] Set longer timeout for low frequency topics
    * [jsk_tools] Unregister subscriber at the end of checkTopicIsPublished to reduce CPU load
    * [jsk_tools] Do not check topic type until the first topic comes in
    * [jsk_tools] Use topic name as default value
    * [jsk_tools] Fix typo
    * [jsk_tools] Add test for sanity_diagnostics
    * [jsk_tools] Add sample for sanity_diagnostics
    * [jsk_tools] Add diagnostic dependency
    * [jsk_tools] Add node to publish /diagnostics based on topic and node status
    * [jsk_tools] Return value of checkNodeState
  
* [jsk_tools] use python3-progressbar and python3-rosdep for noetic (#1722 <https://github.com/jsk-ros-pkg/jsk_common/issues/1722>)
* jsk_tools: add python3-tabulate to exec_depends (#1721 <https://github.com/jsk-ros-pkg/jsk_common/issues/1721>)
* add test code to check #1715 <https://github.com/jsk-ros-pkg/jsk_common/issues/1715> (#1717 <https://github.com/jsk-ros-pkg/jsk_common/issues/1717>)
  
    * kinetic rostopic._rostopic_list_groyp_by_host did not work correctly
    * use rostopic.get_topic_list instead of master.getSystemState
  https://github.com/ros/ros_comm/commit/e96c407c64e1c17b0dd2bb85b67f388380527097#diff-21f05efee85a56a5b34825bb4fcfb53db99e38304206ddad7d50d6d4881696b2L1207
  changes
  ```
  -        state = master.getSystemState()
  +        pubs, subs, _ = state
  +        pubs, subs = get_topic_list(master=master)
  ```
  * add test to check rostopic_host_sanity
* use raw_input for python2 c.f. (#1695 <https://github.com/jsk-ros-pkg/jsk_common/issues/1695>)
  
    * run 2to3 -w -f has_key for python3 compatibility
  
* [jsk_topic_tools/master_util.py] add default args to isMasterAlivef( #1684 <https://github.com/jsk-ros-pkg/jsk_common/issues/1684>)
  
    * [jsk_tools, jsk_topic_tools] fix urlparse import for python3
  
* Contributors: Shimpei Sato, Iori Yanokura, Kei Okada, Koki Shinjo, Naoki Hiraoka, Naoya Yamaguchi, Shingo Kitagawa
```

## jsk_topic_tools

```
* [jsk_topic_tools] add non static_tf mode to static_tf_republisher (#1709 <https://github.com/jsk-ros-pkg/jsk_common/issues/1709>)
  
    * [jsk_topic_tools] add USE_SOURCE_PERMISSIONS
    * [jsk_topic_tools] remove install_sample_data.py
    * [jsk_topic_tools] remove jsk_data from dependencies
    * [jsk_topic_tools] download sample tf data with catkin_download()
    * [jsk_topic_tools] add jsk_data to package.xml
    * [jsk_topic_tools] update static_tf_republisher to add param
    * [jsk_topic_tools] add test for static_tf_republisher
    * [jsk_topic_tools] add sample_static_tf_republisher.launch
    * [jsk_topic_tools] add sample data
    * [jsk_topic_tools] add non static_tf mode
  
* [jsk_topic_tools/connection_based_transport] Update the time of last_published_time (#1740 <https://github.com/jsk-ros-pkg/jsk_common/issues/1740>)
  
    * [jsk_topic_tools/connection_based_transport] Make poke function
  
* [jsk_topic_tools] add rostopic_connection_list #1699 <https://github.com/jsk-ros-pkg/jsk_common/issues/1699> from knorth55/rostopic-connect-list
  
    * add -s and -p arguments
    * add rostopic_connection_list
  
* [jsk_topic_tools/connection_based_transport] Update the time of last_published_time to make it possible to take the difference time between the time of start subscribing and the current time.
* [jsk_topic_tools] Add transform wrench stamped node (#1724 <https://github.com/jsk-ros-pkg/jsk_common/issues/1724>)
  
    * Add re-calculate transformed wrench
    * Fixed torque calculation
    * [jsk_tools/SynchronizedThrottle] Add test for topic connection test after killing nodes
    * [jsk_tools/SynchronizedThrottle] Add test for topic connection test after killing nodes
    * [jsk_topic_tools] Use np.dot instead of np.matmul for lower numpy
    * [jsk_topic_tools] Add test for transform wrench
    * [jsk_topic_tools] Add sample for transform wrench
    * [jsk_topic_tools] Add transform_wrench.py node
    * [jsk_topic_tools] Add wrench stamped sampled data
  
* Add test for topic connection test after killing nodes (#1725 <https://github.com/jsk-ros-pkg/jsk_common/issues/1725>)
  
    * [jsk_tools/SynchronizedThrottle] Add test for topic connection test after killing nodes
  
* [jsk_topic_tools/diagnostics_nodelet] Poke when start subscribing. (#1735 <https://github.com/jsk-ros-pkg/jsk_common/issues/1735>)
* Loose test failed (#1734 <https://github.com/jsk-ros-pkg/jsk_common/issues/1734>)
  
    * [jsk_topic_tools/test_topic_buffer_update_rate] Extend duration time for chatter_update for low latency
    * [jsk_topic_tools/test_connection_based] Add wait_for_disconnection param
    * [jsk_topic_tools/test_stealth_relay] Increased stealth relay time and retry count
    * [jsk_topic_tools/test_stealth_relay] Fix test by waiting topic connection istead of rospy.sleep
  
* [jsk_topic_tools] Add diagnostic transport to ConnectionBasedTransport (#1711 <https://github.com/jsk-ros-pkg/jsk_common/issues/1711>)
  
    * [jsk_topic_tools/relay_nodelet] Poke when start subscribing
    * [jsk_topic_tools/diagnostics_nodelet] Poke when start subscribing.
    * [jsk_topic_tools] Add checking subscribed topics are published
    * [jsk_topic_tools] Add diagnostics_aggregator to dpendencies
    * [jsk_topic_tools] Delete duplicated test
    * [jsk_topic_tools] Add diagnostics sample and split test
    * [jsk_topic_tools] Fixed diagnositc message
    * [jsk_topic_tools] Add Diagnostic function to  ConnectionBasedTransport
    * Remove vital_checker.py Add _Publisher class to check last published time.
    * [jsk_topic_tools] Add diagnostic transport test
    * [jsk_topic_tools] Add diagnostic transport
    * [jsk_topic_tools] Add timered diagnostic updater for python
    * [jsk_topic_tools] Add vital checker for python
  
* jsk_topic_tools/CMakeLists.txt: add diagnostic_updater to find_package(catkin (#1718 <https://github.com/jsk-ros-pkg/jsk_common/issues/1718>)
  
    * jsk_topic_tools/CMakeLists.txt: add diagnostic_updater to find_package(catkin
      jsk_topic_tools fails if we install diagnostic_udpate only within workspace
  ```
  In file included from /home/pi/jsk_catkin_ws/src/jsk_topic_tools-release/include/jsk_topic_tools/relay_nodelet.h:45,
  from /home/pi/jsk_catkin_ws/src/jsk_topic_tools-release/src/relay_nodelet.cpp:35:
  /home/pi/jsk_catkin_ws/src/jsk_topic_tools-release/include/jsk_topic_tools/timered_diagnostic_updater.h:41:10: fatal error: diagnostic_updater/diagnostic_updater.h: No such file or directory
  #include <diagnostic_updater/diagnostic_updater.h>
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ```
* run 2to3 -w -f has_key for python3 compatibilityf (#1695 <https://github.com/jsk-ros-pkg/jsk_common/issues/1695>)
* [jsk_topic_tools] add static_tf_republisher.py and documentation (#1667 <https://github.com/jsk-ros-pkg/jsk_common/issues/1667>)
  
    * [jsk_topic_tools] add static_tf_republisher.py and documentation
  
* Set ccache prefix only for cmake <= 3.4 (#1694 <https://github.com/jsk-ros-pkg/jsk_common/issues/1694>)
* test_topic_buffer_fixed_rate_and_update_rate.te: increase retry to 5 (#1693 <https://github.com/jsk-ros-pkg/jsk_common/issues/1693>)
* 
  
    * [jsk_topic_tools/master_util.py] add default args to isMasterAlive (#1684 <https://github.com/jsk-ros-pkg/jsk_common/issues/1684>)
    * jsk_tools, jsk_topic_tools] fix urlparse import for python3
    * [jsk_topic_tools] add iputils-ping to package.xml
    * [jsk_topic_tools] fix test_python_master_util
    * [jsk_topic_tools] add test_python_master_util
  
* jsk_topic_tools/test/test_connection_based_transport.test: increase wait_for_connection from 3 to 10 (#1692 <https://github.com/jsk-ros-pkg/jsk_common/issues/1692>)
* Update jsk_travis to 0.5.21 (#1691 <https://github.com/jsk-ros-pkg/jsk_common/issues/1691>)
  
    * jsk_topic_tools/test/test_topic_buffer_fixed_rate.test jsk_topic_tools/test/test_topic_buffer.test increase test_duration
    * jsk_topic_tools/test/test_topic_buffer_fixed_rate.test increase test_duration
    * jsk_topic_tools/test/test_topic_buffer_fixed_rate_and_update_rate.test increase test_duration and herror
    * jsk_topic_tools/test/test_topic_buffer_update_rate.test: relax test for GA
    * jsk_topic_tools/test/test_topic_buffer_update_rate.test: relax test for GA
    * jsk_topic_tools/test/test_topic_buffer_fixed_rate.test, jsk_topic_tools/test/test_topic_buffer_update_rate.teste: relax test for GA
    * test_topic_buffer_fixed_rate.test: relax test for GA
  
* Add latch mode to jsk_topic_tools/Relay (#1675 <https://github.com/jsk-ros-pkg/jsk_common/issues/1675>)
* Add latch argument to advetiseImage and advertiseCamera (#1673 <https://github.com/jsk-ros-pkg/jsk_common/issues/1673>)
  
    * Add new advertise method which expose latch parameter as an argument
    * Remove duplicated latch variable in advertiseCamera method
    * Add latch argument to advetiseImage and advertiseCamera
      * Add latch argument to advetiseImage and advertiseCamera instead of
      reading latch parameter from ros server in order to set different latch
      parameter for each publisher in one nodelet.
  
* Add passthrough_nodelet documentation (#1657 <https://github.com/jsk-ros-pkg/jsk_common/issues/1657>)
* add parameters queue_size and slop (#1658 <https://github.com/jsk-ros-pkg/jsk_common/issues/1658>)
* check nodelet version with NODELET_VERSION_MINIMUM (#1665 <https://github.com/jsk-ros-pkg/jsk_common/issues/1665>)
  
    * return true for warnNoRemap if nodelet<1.9.11
    * add warnNoRemap function
    * remove version_gte for nodelet
    * just do not load nodelet getRemappings
    * add nodelet_version.h
  
* Contributors: Iori Yanokura, Kei Okada, Kentaro Wada, Koki Shinjo, Miyabi Tanemoto, Naoki Hiraoka, Naoya Yamaguchi, Ryohei Ueda, Shingo Kitagawa, Yuki Furuta
```

## multi_map_server

- No changes

## virtual_force_publisher

```
* Calcualte sr-inverse (#1731 <https://github.com/jsk-ros-pkg/jsk_common/issues/1731>)
* use ROS_DEBUG to suppress log output (#1674 <https://github.com/jsk-ros-pkg/jsk_common/issues/1674>)
* add left and right force launch (#1656 <https://github.com/jsk-ros-pkg/jsk_common/issues/1656>)
* Contributors: Naoaki Kanazawa, Shingo Kitagawa, Iori Yanokura
```
