### PR TITLE
Add rosdep key for `libbsd-dev`

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2723,6 +2723,17 @@ libboost-timer-dev:
   opensuse: [libboost_timer1_66_0-devel]
   rhel: [boost-devel]
   ubuntu: [libboost-timer-dev]
+libbsd-dev:
+  alpine: [libbsd]
+  arch: [libbsd]
+  debian: [libbsd-dev]
+  fedora: [libbsd-devel]
+  gentoo: [dev-libs/libbsd]
+  nixos: [libbsd]
+  osx:
+    homebrew:
+      packages: [libbsd]
+  ubuntu: [libbsd-dev]
 libcairo2-dev:
   arch: [cairo]
   debian: [libcairo2-dev]


### PR DESCRIPTION
Package name:
-------------

`libbsd-dev`

Package Upstream Source:
------------------------

https://libbsd.freedesktop.org/wiki/

Purpose of using this:
----------------------

We use it mainly for their
[arithmetic macros on time stamps](https://man.netbsd.org/timeradd.3)
but there are probably even better usages, especially when making a
package portable between BSD and Linux.

Links to Distribution Packages
------------------------------

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/libbsd-dev
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/jammy/libbsd-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/libbsd/libbsd-devel/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/libbsd/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-libs/libbsd
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/libbsd
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/main/x86_64/libbsd
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?type=packages&query=libbsd