### PR TITLE
ethercat_grant: 0.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2196,7 +2196,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/shadow-robot/ethercat_grant-release.git
-      version: 0.2.5-8
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/shadow-robot/ethercat_grant.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ethercat_grant` to `0.3.1-1`:

- upstream repository: https://github.com/shadow-robot/ethercat_grant.git
- release repository: https://github.com/shadow-robot/ethercat_grant-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.2.5-8`

## ethercat_grant

```
* Updating README file
* Create postinst
* Delete postinst
* Create LICENSE
* Delete LICENSE.md
* Create LICENSE.md
* Migrating to Noetic
* Create CODEOWNERS (#8 <https://github.com/shadow-robot/ethercat_grant/issues/8>)
* Contributors: Fotios, maxzieba, mikramarc
```
