### PR TITLE
fluent_rviz: 0.0.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1058,6 +1058,17 @@ repositories:
       url: https://github.com/ros/filters.git
       version: ros2
     status: maintained
+  fluent_rviz:
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/fluent_rviz-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/ForteFibre/FluentRviz.git
+      version: ros2
+    status: developed
   fmi_adapter:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fluent_rviz` to `0.0.2-1`:

- upstream repository: https://github.com/ForteFibre/FluentRviz.git
- release repository: https://github.com/ros2-gbp/fluent_rviz-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`
