### PR TITLE
movie_publisher: 1.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5303,6 +5303,21 @@ repositories:
       url: https://github.com/ros-planning/moveit_visual_tools.git
       version: noetic-devel
     status: developed
+  movie_publisher:
+    doc:
+      type: git
+      url: https://github.com/peci1/movie_publisher.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/peci1/movie_publisher-release.git
+      version: 1.4.0-1
+    source:
+      type: git
+      url: https://github.com/peci1/movie_publisher.git
+      version: melodic-devel
+    status: maintained
   mpc_local_planner:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `movie_publisher` to `1.4.0-1`:

- upstream repository: https://github.com/peci1/movie_publisher.git
- release repository: https://github.com/peci1/movie_publisher-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## movie_publisher

```
* Compatibility with Noetic
* Contributors: Martin Pecka
```
