### PR TITLE
mikrotik_swos_tools: 1.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4994,6 +4994,21 @@ repositories:
       url: https://github.com/LORD-MicroStrain/microstrain_inertial.git
       version: ros
     status: developed
+  mikrotik_swos_tools:
+    doc:
+      type: git
+      url: https://github.com/peci1/mikrotik_swos_tools.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/peci1/mikrotik_swos_tools-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/peci1/mikrotik_swos_tools.git
+      version: master
+    status: maintained
   mir_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mikrotik_swos_tools` to `1.1.0-1`:

- upstream repository: https://github.com/peci1/mikrotik_swos_tools.git
- release repository: https://github.com/peci1/mikrotik_swos_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## mikrotik_swos_tools

```
* Noetic compatibility
* Contributors: Martin Pecka
```
