### PR TITLE
ubnt_airos_tools: 1.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10539,6 +10539,21 @@ repositories:
       url: https://github.com/KumarRobotics/ublox.git
       version: master
     status: maintained
+  ubnt_airos_tools:
+    doc:
+      type: git
+      url: https://github.com/peci1/ubnt_airos_tools.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/peci1/ubnt_airos_tools-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/peci1/ubnt_airos_tools.git
+      version: master
+    status: maintained
   udp_com:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ubnt_airos_tools` to `1.1.0-1`:

- upstream repository: https://github.com/peci1/ubnt_airos_tools.git
- release repository: https://github.com/peci1/ubnt_airos_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## ubnt_airos_tools

```
* Noetic compatibility
* Contributors: Martin Pecka
```
