### PR TITLE
simple_launch: 1.4.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5762,7 +5762,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/oKermorgant/simple_launch-release.git
-      version: 1.3.1-1
+      version: 1.4.1-1
     source:
       type: git
       url: https://github.com/oKermorgant/simple_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_launch` to `1.4.1-1`:

- upstream repository: https://github.com/oKermorgant/simple_launch.git
- release repository: https://github.com/oKermorgant/simple_launch-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.3.1-1`

## simple_launch

```
* more handling of param types
* Contributors: Olivier Kermorgant
```
