### PR TITLE
release robot_controllers into humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3630,7 +3630,7 @@ repositories:
       url: https://github.com/ros2/rmw_implementation.git
       version: humble
     status: developed
-robot_controllers:
+  robot_controllers:
     doc:
       type: git
       url: https://github.com/fetchrobotics/robot_controllers.git
@@ -3650,7 +3650,7 @@ robot_controllers:
       url: https://github.com/fetchrobotics/robot_controllers.git
       version: ros2
     status: maintained
-robot_localization:
+  robot_localization:
     release:
       tags:
         release: release/humble/{package}/{version}

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3630,7 +3630,27 @@ repositories:
       url: https://github.com/ros2/rmw_implementation.git
       version: humble
     status: developed
-  robot_localization:
+robot_controllers:
+    doc:
+      type: git
+      url: https://github.com/fetchrobotics/robot_controllers.git
+      version: ros2
+    release:
+      packages:
+      - robot_controllers
+      - robot_controllers_interface
+      - robot_controllers_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/robot_controllers-ros2-release.git
+      version: 0.9.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/fetchrobotics/robot_controllers.git
+      version: ros2
+    status: maintained
+robot_localization:
     release:
       tags:
         release: release/humble/{package}/{version}


### PR DESCRIPTION
I'm unable to get bloom to pull the rosdistro without a timeout, so creating a PR directly (using the suggested diff from bloom).

Repository currently lacks a LICENSE file - but every source file has a license at the top (I will work on adding a LICENSE file shortly - but I'll need to scrape all the headers to get ALL of the various copyright attributions right).

# Checks
 - [x] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
