### PR TITLE
perception_open3d: 0.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2521,7 +2521,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros-gbp/perception_open3d-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/ros-perception/perception_open3d.git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_open3d` to `0.1.2-1`:

- upstream repository: https://github.com/ros-perception/perception_open3d.git
- release repository: https://github.com/ros-gbp/perception_open3d-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.1-1`
