### PR TITLE
maliput: 1.0.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2288,7 +2288,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput-release.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput` to `1.0.3-1`:

- upstream repository: https://github.com/maliput/maliput.git
- release repository: https://github.com/ros2-gbp/maliput-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.0.2-1`

## maliput

```
* moving maliput to the root (#506 <https://github.com/maliput/maliput/issues/506>)
* Contributors: Tully Foote
```
