### PR TITLE
Drop Python 2 rules for RHEL releases beyond 8

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -456,7 +456,9 @@ python:
   nixos: [python]
   openembedded: [python@meta-python2]
   opensuse: [python-devel]
-  rhel: [python2-devel]
+  rhel:
+    '7': [python2-devel]
+    '8': [python2-devel]
   slackware:
     slackpkg:
       packages: [python]
@@ -582,7 +584,9 @@ python-argparse:
   osx:
     pip:
       packages: [argparse]
-  rhel: [python2]
+  rhel:
+    '7': [python2]
+    '8': [python2]
   slackware:
     pip:
       packages: [argparse]
@@ -859,8 +863,8 @@ python-cairo:
   nixos: [pythonPackages.pycairo]
   opensuse: [python2-cairo]
   rhel:
-    '*': [python2-cairo]
     '7': [pycairo]
+    '8': [python2-cairo]
   slackware:
     slackpkg:
       packages: [pycairo]
@@ -1254,8 +1258,8 @@ python-coverage:
     pip:
       packages: [coverage]
   rhel:
-    '*': [python2-coverage]
     '7': [python-coverage]
+    '8': [python2-coverage]
   slackware: [coverage]
   ubuntu:
     artful: [python-coverage]
@@ -1824,7 +1828,9 @@ python-ftdi1:
 python-funcsigs:
   debian: [python-funcsigs]
   fedora: [python-funcsigs]
-  rhel: [python2-funcsigs]
+  rhel:
+    '7': [python2-funcsigs]
+    '8': [python2-funcsigs]
   ubuntu: [python-funcsigs]
 python-future:
   debian: [python-future]
@@ -2258,7 +2264,9 @@ python-gtk2:
   osx:
     pip:
       packages: []
-  rhel: [pygtk2]
+  rhel:
+    '7': [pygtk2]
+    '8': [pygtk2]
   ubuntu:
     '*': null
     bionic: [python-gtk2]
@@ -2649,8 +2657,8 @@ python-lxml:
     pip:
       packages: [lxml]
   rhel:
-    '*': [python2-lxml]
     '7': [python-lxml]
+    '8': [python2-lxml]
   ubuntu:
     bionic: [python-lxml]
     focal: [python-lxml]
@@ -2750,7 +2758,9 @@ python-mock:
   osx:
     pip:
       packages: [mock]
-  rhel: [python2-mock]
+  rhel:
+    '7': [python2-mock]
+    '8': [python2-mock]
   slackware: [mock]
   ubuntu:
     artful: [python-mock]
@@ -2985,7 +2995,9 @@ python-nose:
   osx:
     pip:
       packages: [nose]
-  rhel: [python2-nose]
+  rhel:
+    '7': [python2-nose]
+    '8': [python2-nose]
   slackware: [nose]
   ubuntu:
     '*': [python-nose]
@@ -3011,7 +3023,9 @@ python-numpy:
   osx:
     pip:
       packages: [numpy]
-  rhel: [python2-numpy]
+  rhel:
+    '7': [python2-numpy]
+    '8': [python2-numpy]
   slackware: [numpy]
   ubuntu:
     bionic: [python-numpy]
@@ -3283,7 +3297,9 @@ python-pathtools:
 python-pbr:
   debian: [python-pbr]
   fedora: [python-pbr]
-  rhel: [python2-pbr]
+  rhel:
+    '7': [python2-pbr]
+    '8': [python2-pbr]
   ubuntu: [python-pbr]
 python-pcapy:
   arch: [python2-pcapy]
@@ -3486,7 +3502,9 @@ python-psutil:
   osx:
     pip:
       packages: [psutil]
-  rhel: [python2-psutil]
+  rhel:
+    '7': [python2-psutil]
+    '8': [python2-psutil]
   slackware: [psutil]
   ubuntu:
     '*': [python-psutil]
@@ -3550,7 +3568,9 @@ python-pycodestyle:
   fedora: [python-pycodestyle]
   gentoo: [dev-python/pycodestyle]
   nixos: [pythonPackages.pycodestyle]
-  rhel: [python2-pycodestyle]
+  rhel:
+    '7': [python2-pycodestyle]
+    '8': [python2-pycodestyle]
   ubuntu:
     '*': null
     bionic: [python-pycodestyle]
@@ -3575,7 +3595,9 @@ python-pycryptodome:
   osx:
     pip:
       packages: [pycryptodome]
-  rhel: [python2-pycryptodomex]
+  rhel:
+    '7': [python2-pycryptodomex]
+    '8': [python2-pycryptodomex]
   ubuntu: [python-pycryptodome]
 python-pycurl:
   debian: [python-pycurl]
@@ -4591,7 +4613,9 @@ python-setuptools:
   osx:
     pip:
       packages: [setuptools]
-  rhel: [python2-setuptools]
+  rhel:
+    '7': [python2-setuptools]
+    '8': [python2-setuptools]
   ubuntu:
     artful: [python-setuptools]
     bionic: [python-setuptools]
@@ -5190,8 +5214,8 @@ python-tk:
   openembedded: ['${PYTHON_PN}-tkinter@openembedded-core']
   opensuse: [python-tk]
   rhel:
-    '*': [python2-tkinter]
     '7': [tkinter]
+    '8': [python2-tkinter]
   ubuntu:
     '*': [python-tk]
     bionic_python3: [python3-tk]
@@ -5495,8 +5519,8 @@ python-virtualenv:
   nixos: [pythonPackages.virtualenv]
   openembedded: ['${PYTHON_PN}-virtualenv@meta-ros2']
   rhel:
-    '*': [python2-virtualenv]
     '7': [python-virtualenv]
+    '8': [python2-virtualenv]
   ubuntu: [python-virtualenv]
 python-visual:
   debian: [python-visual]
@@ -5737,8 +5761,8 @@ python-yaml:
       depends: [yaml]
       packages: [PyYAML]
   rhel:
-    '*': [python2-pyyaml]
     '7': [PyYAML]
+    '8': [python2-pyyaml]
   slackware: [PyYAML]
   ubuntu:
     artful: [python-yaml]


### PR DESCRIPTION
RHEL 9 has absolutely no Python 2 system packages.