### PR TITLE
Switch to a modern python3-yaml rule for RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9097,7 +9097,7 @@ python3-yaml:
   osx:
     pip:
       packages: [pyyaml]
-  rhel: ['python%{python3_pkgversion}-PyYAML']
+  rhel: ['python%{python3_pkgversion}-yaml']
   ubuntu: [python3-yaml]
 python3-yappi:
   debian:


### PR DESCRIPTION
The `python3-PyYAML` virtual package listed here is no longer provided in RHEL 9. The package is currently called `python3-pyyaml` in modern Fedora and RHEL, but RHEL 7 doesn't provide a virtual package under that name.

`python3-yaml` seems to satisfy all of RHEL 7, 8, and 9.

Since this is a virtual package, there aren't any dashboards that demonstrate that the change is valid, so we'll need to rely on the automation to catch any mistakes.

That said, here's where the virtual package is provided in Fedora: https://src.fedoraproject.org/rpms/PyYAML/blob/5fa165ab820fd62b38f3e60ce0283d1dc5ff03ac/f/PyYAML.spec#_63