### PR TITLE
Update current Fedora releases

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -127,7 +127,6 @@ aravis-dev:
 arduino-core:
   arch: [arduino]
   debian: [arduino-core]
-  fedora: [arduino-core]
   gentoo: [dev-embedded/arduino]
   nixos: [arduino]
   ubuntu: [arduino-core]
@@ -852,7 +851,6 @@ e2fsprogs:
 eclipse:
   arch: [eclipse, eclipse-rcp, eclipse-emf, eclipse-pde]
   debian: [eclipse, eclipse-rcp, eclipse-xsd, eclipse-pde]
-  fedora: [eclipse-pde, eclipse-emf]
   gentoo: [dev-java/ant-eclipse-ecj, dev-java/eclipse-ecj]
   ubuntu:
     karmic: [eclipse, eclipse-platform, eclipse-rcp, eclipse-pde]

--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -57,8 +57,8 @@ supported_versions:
   - buster
   - bullseye
   fedora:
-  - '34'
   - '35'
+  - '36'
   opensuse:
   - '15.2'
   rhel:
@@ -85,9 +85,9 @@ supported_arches:
 
 name_replacements:
   fedora:
-    '34':
-      '%{__isa_name}': 'x86'
     '35':
+      '%{__isa_name}': 'x86'
+    '36':
       '%{__isa_name}': 'x86'
   rhel:
     '7':


### PR DESCRIPTION
* Fedora 36 has been released (2022-05-10)
* Fedora 34 is EOL (2022-06-07)
* Drop rules which are no longer valid under any released Fedora
  - https://src.fedoraproject.org/rpms/arduino/c/f4fb4666ea22070a7cf9f91ac9c3708ea6db80ad?branch=rawhide
  - https://src.fedoraproject.org/rpms/eclipse/c/d0fa072ba4f4c5a7c3296e47748c116ec50d5abc?branch=rawhide
