### PR TITLE
fogros2: 0.1.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1012,7 +1012,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/fogros2-release.git
-      version: 0.1.4-1
+      version: 0.1.5-1
     source:
       type: git
       url: https://github.com/BerkeleyAutomation/FogROS2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fogros2` to `0.1.5-1`:

- upstream repository: https://github.com/BerkeleyAutomation/FogROS2.git
- release repository: https://github.com/ros2-gbp/fogros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.4-1`

## fogros2

```
* added dependencies to package.xml to reduce those that are manually downloaded
```

## fogros2_examples

```
* added dependencies to package.xml to reduce those that are manually downloaded
```
