### PR TITLE
Added arch references for clang

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -502,6 +502,7 @@ chrony:
   opensuse: [chrony]
   ubuntu: [chrony]
 clang:
+  arch: [clang]
   debian: [clang]
   fedora: [clang]
   gentoo: [sys-devel/clang]
@@ -511,6 +512,7 @@ clang:
     '7': null
   ubuntu: [clang]
 clang-format:
+  arch: [clang]
   alpine: [clang]
   debian:
     bullseye: [clang-format]
@@ -525,6 +527,7 @@ clang-format:
   rhel: [clang]
   ubuntu: [clang-format]
 clang-tidy:
+  arch: [clang]
   alpine: [clang-extra-tools]
   debian:
     bullseye: [clang-tidy]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -526,8 +526,8 @@ clang-format:
   rhel: [clang]
   ubuntu: [clang-format]
 clang-tidy:
-  arch: [clang]
   alpine: [clang-extra-tools]
+  arch: [clang]
   debian:
     bullseye: [clang-tidy]
     buster: [clang-tidy]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -511,8 +511,8 @@ clang:
     '7': null
   ubuntu: [clang]
 clang-format:
-  arch: [clang]
   alpine: [clang]
+  arch: [clang]
   debian:
     bullseye: [clang-format]
     buster: [clang-format]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -501,6 +501,7 @@ chrony:
   opensuse: [chrony]
   ubuntu: [chrony]
 clang:
+  arch: [clang]
   debian: [clang]
   fedora: [clang]
   gentoo: [sys-devel/clang]
@@ -510,6 +511,7 @@ clang:
     '7': null
   ubuntu: [clang]
 clang-format:
+  arch: [clang]
   alpine: [clang]
   debian:
     bullseye: [clang-format]
@@ -524,6 +526,7 @@ clang-format:
   rhel: [clang]
   ubuntu: [clang-format]
 clang-tidy:
+  arch: [clang]
   alpine: [clang-extra-tools]
   debian:
     bullseye: [clang-tidy]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

clang

## Package Upstream Source:

[link](https://github.com/llvm/llvm-project) to source repository

## Purpose of using this:

This system dependency is required for micro-ros. Previously keys for Arch Linux were not present and rosdep threw error for installation of micro-ros.

Distro packaging links:

## Links to Distribution Packages

- Arch: https://www.archlinux.org/packages/
  - [AVAILABLE](https://archlinux.org/packages/extra/x86_64/clang/)
