### PR TITLE
orocos_kdl_vendor: 0.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2432,7 +2432,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
-      version: 0.3.0-2
+      version: 0.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_kdl_vendor` to `0.3.1-1`:

- upstream repository: https://github.com/ros2/orocos_kdl_vendor.git
- release repository: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.3.0-2`

## orocos_kdl_vendor

```
* Ensure orocos-kdl target references Eigen (#6 <https://github.com/ros2/orocos_kdl_vendor/issues/6>)
* Contributors: Scott K Logan
```

## python_orocos_kdl_vendor

- No changes
