### PR TITLE
clpe: 0.1.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -596,6 +596,21 @@ repositories:
       url: https://github.com/CLOBOT-Co-Ltd/clober_msgs.git
       version: foxy-devel
     status: developed
+  clpe:
+    doc:
+      type: git
+      url: https://github.com/canlab-co/CLPE_G_NVP2650D_SDK.git
+      version: ros2-0.1.0
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/canlab-co/CLPE_G_NVP2650D_SDK-ros2-release.git
+      version: 0.1.0-2
+    source:
+      type: git
+      url: https://github.com/canlab-co/CLPE_G_NVP2650D_SDK.git
+      version: main
+    status: developed
   clpe_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clpe` to `0.1.0-2`:

- upstream repository: https://github.com/canlab-co/CLPE_G_NVP2650D_SDK.git
- release repository: https://github.com/canlab-co/CLPE_G_NVP2650D_SDK-ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## clpe

```
* Provides libclpe
* Contributors: Can-lab Corporation
```
