### PR TITLE
pose_cov_ops: 0.3.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2715,7 +2715,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pose_cov_ops-release.git
-      version: 0.3.3-1
+      version: 0.3.5-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pose_cov_ops` to `0.3.5-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
- release repository: https://github.com/ros2-gbp/pose_cov_ops-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.3.3-1`

## pose_cov_ops

```
* Remove find_package() calls due to wrong mrpt-ros2bridge-config.cmake in older mrpt2 versions
* Contributors: Jose Luis Blanco-Claraco
```
