### PR TITLE
diagnostics: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -726,10 +726,11 @@ repositories:
       packages:
       - diagnostic_aggregator
       - diagnostic_updater
+      - self_test
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 2.1.3-2
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `3.0.0-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.1.3-2`

## diagnostic_aggregator

```
* Use node clock for diagnostic_aggregator and diagnostic_updater (#210 <https://github.com/ros/diagnostics/issues/210>)
* Contributors: Kenji Miyake
```

## diagnostic_updater

```
* Merge pull request #217 <https://github.com/ros/diagnostics/issues/217> from boschresearch/ros-time-for-frequency-stat
* Allow clock instance to be set from outside in FrequencyStatus
* Use node clock for diagnostic_aggregator and diagnostic_updater (#210 <https://github.com/ros/diagnostics/issues/210>)
* Use DiagnosticStatus.msg values instead of creating bytes manually (#193 <https://github.com/ros/diagnostics/issues/193>)
* Contributors: Arne Nordmann, BasVolkers, Kenji Miyake, Marco Lampacrescia
```

## self_test

```
* Return the actual future from async_send_request (#209 <https://github.com/ros/diagnostics/issues/209>)
* Contributors: Chris Lalancette
```
