### PR TITLE
rm_controllers: 0.1.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7745,6 +7745,8 @@ repositories:
       version: master
     release:
       packages:
+      - gpio_controller
+      - mimic_joint_controller
       - rm_calibration_controllers
       - rm_chassis_controllers
       - rm_controllers
@@ -7756,7 +7758,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/rm-controls/rm_controllers-release.git
-      version: 0.1.4-1
+      version: 0.1.5-1
     source:
       type: git
       url: https://github.com/rm-controls/rm_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rm_controllers` to `0.1.5-1`:

- upstream repository: https://github.com/rm-controls/rm_controllers.git
- release repository: https://github.com/rm-controls/rm_controllers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.4-1`

## gpio_controller

```
* Merge remote-tracking branch 'origin/master'
* Merge pull request #70 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/70> from XYM-github/gpio_controller_2
  Update gpio_controller to version2.0.
* Optimize code structure.
* Modify gpio_controller configuration file format.
* Adaptation of gpio type moved from rm_hw to rm_common.
* Adaptation of gpio type to enum in gpio_interface.
* Update gpio_controller to version2.0.
* Contributors: QiayuanLiao, XYM-github, yezi
```

## mimic_joint_controller

```
* Merge remote-tracking branch 'origin/master'
* Merge pull request #67 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/67> from ljq-lv/joint_mime_controller
  Add Joint mime controller
* Modified name "mimic_joint" to "target_joint"
* Modified "joint_mime" to "mimic_joint"
* Modified the name from "mime" to "mimic"
* Contributors: QiayuanLiao, chenzheng, ljq-lv
```

## rm_calibration_controllers

```
* Merge remote-tracking branch 'origin/master'
* 0.1.4
* Merge branch 'master' into gimbal_track
* Merge pull request #45 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/45> from mlione/master
  Delete some config files in rm_controllers.
* Delete some config files in rm_controller.
* Merge pull request #46 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/46> from ye-luo-xi-tui/master
  Deprecated imu_filter_controller
* Contributors: QiayuanLiao, YuuinIH, mlione, qiayuan, yezi
```

## rm_chassis_controllers

```
* Update frames in update function.
* Add command_source_frame to follow mode.
* Merge remote-tracking branch 'origin/master'
* 0.1.4
* Add damping behavior to ReactionWheelController
* Add recover behavior to ReactionWheelController
* Add a low-pass filter to eliminate the constant pitch angle offset to ReactionWheelController
* Add a naive method for determining orientation of balance chassis
* Use new reaction wheel state space model
* Add setZero to Q and R
* Merge remote-tracking branch 'origin/master'
* Remove "convert model from continuous to discrete time" from ReactionWheel, the rm_common::Lqr accept continuous model.
* Merge pull request #57 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/57> from NaHCO3bc/master
  Update ReactionWheelController
* Change the number of joint name reads,change the QR matrix to an array and update the rm_chassis_controllers_plugins.xml.
* Merge branch 'chassis/reaction_wheel'
* Merge pull request #56 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/56> from NaHCO3bc/chassis/reaction_wheel
  Update ReactionWheelController
* Update reaction_wheel.cpp and add template_reaction_wheel.yaml
* Add some comments of ReactionWheelController
* Remove BalanceController
* Add ReactionWheelController
* Merge pull request #51 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/51> from Edwinlinks/sentry_catapult
  Complete sentry catapult and delete the redundant code
* Merge branch 'master' into gimbal_track
* Complete sentry catapult and delete the redundant code
* Merge pull request #45 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/45> from mlione/master
  Delete some config files in rm_controllers.
* Merge pull request #50 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/50> from ye-luo-xi-tui/ori
  Make rm_orientation_controller publish tf use imu data on the topic
* Delete some config files in rm_controller.
* Add a param publish_odom_tf, it decided whether tf would be published.
* Merge pull request #46 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/46> from ye-luo-xi-tui/master
  Deprecated imu_filter_controller
* Merge branch 'master' into gimbal_track
* Contributors: Edwinlinks, QiayuanLiao, YuuinIH, mlione, nahco3bc, qiayuan, yezi
```

## rm_controllers

```
* Merge remote-tracking branch 'origin/master'
* 0.1.4
* Merge remote-tracking branch 'origin/master'
* Merge pull request #60 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/60> from ye-luo-xi-tui/master
  Add subpackage to metapackage's package.xml
* Merge branch 'orientation_controller'
* Add all subpackages to metapackage.
* Merge branch 'master' into gimbal_track
* Merge pull request #46 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/46> from ye-luo-xi-tui/master
  Deprecated imu_filter_controller
* Contributors: QiayuanLiao, YuuinIH, qiayuan, yezi
```

## rm_gimbal_controllers

```
* Merge pull request #71 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/71> from ye-luo-xi-tui/gimbal/joint_velocity
  Set joint desired velocity according to the target velocity
* Fix a bug in setting joint desired velocity.
* Set joint desired velocity according to the target velocity.
* Merge pull request #69 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/69> from ChenZheng29/master
  Correct track topic message type:TrackData
* Merge remote-tracking branch 'origin/master'
* Merge pull request #66 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/66> from ye-luo-xi-tui/master
  Use motors' data in pid controller when imu_name isn't set
* Use motors' data in pid controller when imu_name isn't set.
* Correct the message type of gimbal subscription '/track' topic from 'rm_msgs::TrackCmd' to 'rm_msgs::TrackData'
* Modify the track topic name and message, and unify the track interface
* Merge remote-tracking branch 'origin/master'
* 0.1.4
* Move all computation in gimbal_controller i.r.t. "odom" instead of "map"
* Merge pull request #52 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/52> from ye-luo-xi-tui/gimbal_track
  Update gimbal_controller
* Modifier TrackCmd.msg format.
* Improve logic of function Controller::setDes().
* Fix a frame error in track mode.
* Merge branch 'master' into gimbal_track
* Merge pull request #45 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/45> from mlione/master
  Delete some config files in rm_controllers.
* Delete some config files in rm_controller.
* Merge pull request #46 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/46> from ye-luo-xi-tui/master
  Deprecated imu_filter_controller
* Merge branch 'master' into gimbal_track
* Rename a msg.
* Modifier track subscribe topic
* Contributors: QiayuanLiao, YuuinIH, chenzheng, mlione, qiayuan, yezi
```

## rm_orientation_controller

```
* Merge remote-tracking branch 'origin/master'
* Merge pull request #63 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/63> from ye-luo-xi-tui/master
  Publish tf from odom to base_link use imu data which is got from interface until getting imu data from topic
* 0.1.4
* Publish tf from odom to base_link use imu data which is got from interface until get imu data from topic.
* Merge pull request #53 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/53> from ye-luo-xi-tui/orientation_controller
  Fix a bug that time stamp error
* Fix a bug that time stamp error when it can't find transform from imu to odom.
* Merge branch 'master' into gimbal_track
* Merge pull request #45 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/45> from mlione/master
  Delete some config files in rm_controllers.
* Merge pull request #50 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/50> from ye-luo-xi-tui/ori
  Make rm_orientation_controller publish tf use imu data on the topic
* Delete some config files in rm_controller.
* Solve a problem that look up future transform.
* Delete publish_rate and relative codes.
* Publish tf use imu data on the topic.
* Merge pull request #46 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/46> from ye-luo-xi-tui/master
  Deprecated imu_filter_controller
* Contributors: QiayuanLiao, YuuinIH, mlione, qiayuan, yezi
```

## rm_shooter_controllers

```
* Add hz counting in trigger test mode.
* Merge remote-tracking branch 'origin/master'
* Add testing option to shooter for testing the trigger without friction wheel
* 0.1.4
* Merge branch 'master' into gimbal_track
* Merge pull request #45 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/45> from mlione/master
  Delete some config files in rm_controllers.
* Delete some config files in rm_controller.
* Merge pull request #46 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/46> from ye-luo-xi-tui/master
  Deprecated imu_filter_controller
* Contributors: BruceLannn, QiayuanLiao, YuuinIH, mlione, qiayuan, yezi
```

## robot_state_controller

```
* Merge remote-tracking branch 'origin/master'
* 0.1.4
* Merge branch 'master' into gimbal_track
* Merge pull request #46 <https://github.com/ye-luo-xi-tui/rm_controllers/issues/46> from ye-luo-xi-tui/master
  Deprecated imu_filter_controller
* Contributors: QiayuanLiao, YuuinIH, qiayuan, yezi
```
