### PR TITLE
maliput_drake: 0.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2295,6 +2295,22 @@ repositories:
       url: https://github.com/maliput/maliput.git
       version: main
     status: developed
+  maliput_drake:
+    doc:
+      type: git
+      url: https://github.com/maliput/maliput_drake.git
+      version: main
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/maliput_documentation-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/maliput/maliput_drake.git
+      version: main
+    status: developed
   map_transformer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_drake` to `0.1.0-1`:

- upstream repository: https://github.com/maliput/maliput_drake.git
- release repository: https://github.com/ros2-gbp/maliput_documentation-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## maliput_drake

```
* Moves package to root. (#22 <https://github.com/maliput/maliput_drake/issues/22>)
* Updates license. (#21 <https://github.com/maliput/maliput_drake/issues/21>)
* Uses ament_export_targets. (#20 <https://github.com/maliput/maliput_drake/issues/20>)
* Removes dashing support. (#19 <https://github.com/maliput/maliput_drake/issues/19>)
* Adds CI badges (#18 <https://github.com/maliput/maliput_drake/issues/18>)
* Removes spdlog dependency. (#17 <https://github.com/maliput/maliput_drake/issues/17>)
* Replaces push by workflow_dispatch event in gcc build. (#15 <https://github.com/maliput/maliput_drake/issues/15>)
* Adds to the supression list maliput_drake's header files. (#13 <https://github.com/maliput/maliput_drake/issues/13>)
* Remove autodiff and symbolic instantiations (#11 <https://github.com/maliput/maliput_drake/issues/11>)
* Remove gflags dependency (#10 <https://github.com/maliput/maliput_drake/issues/10>)
* Reduce dependencies of analysis (#9 <https://github.com/maliput/maliput_drake/issues/9>)
* Renames drake definitions (#8 <https://github.com/maliput/maliput_drake/issues/8>)
* Removes unused extern C method. (#7 <https://github.com/maliput/maliput_drake/issues/7>)
* Instructions to copy a drake release (#5 <https://github.com/maliput/maliput_drake/issues/5>)
* Namespace with maliput (#4 <https://github.com/maliput/maliput_drake/issues/4>)
* Create a proper readme (#3 <https://github.com/maliput/maliput_drake/issues/3>)
* Adds bionic support (#2 <https://github.com/maliput/maliput_drake/issues/2>)
* Initial repository structure (#1 <https://github.com/maliput/maliput_drake/issues/1>)
* Contributors: Agustin Alba Chicar, Franco Cipollone
```
