### PR TITLE
maliput_object: 0.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2311,6 +2311,22 @@ repositories:
       url: https://github.com/maliput/maliput_drake.git
       version: main
     status: developed
+  maliput_object:
+    doc:
+      type: git
+      url: https://github.com/maliput/maliput_object.git
+      version: main
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/maliput_object-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/maliput/maliput_object.git
+      version: main
+    status: developed
   map_transformer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_object` to `0.1.0-1`:

- upstream repository: https://github.com/maliput/maliput_object.git
- release repository: https://github.com/ros2-gbp/maliput_object-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## maliput_object

```
* Use <doc_depend> for ament_cmake_doxygen dependency. (#39 <https://github.com/maliput/maliput_object/issues/39>)
* Moves package to root. (#38 <https://github.com/maliput/maliput_object/issues/38>)
* Removes maliput_object_py from the repo (#37 <https://github.com/maliput/maliput_object/issues/37>)
* Updates license. (#35 <https://github.com/maliput/maliput_object/issues/35>)
* Uses ament_export_targets. (#34 <https://github.com/maliput/maliput_object/issues/34>)
* Adds testing support for LoadFile to parse objects from a YAML. (#33 <https://github.com/maliput/maliput_object/issues/33>)
* Creates bindings for the maliput::object::api namespace (#31 <https://github.com/maliput/maliput_object/issues/31>)
* Implements the loader for ObjectBook (#32 <https://github.com/maliput/maliput_object/issues/32>)
* Adds maliput_object_py to CI. (#30 <https://github.com/maliput/maliput_object/issues/30>)
* Creates the package for the python bindings (#29 <https://github.com/maliput/maliput_object/issues/29>)
* Adds documentation about the YAML specification for objects. (#24 <https://github.com/maliput/maliput_object/issues/24>)
* Adds missing BoundingBox::box_size() method defintion. (#28 <https://github.com/maliput/maliput_object/issues/28>)
* Adds ManualObjectBook. (#23 <https://github.com/maliput/maliput_object/issues/23>)
* Updates misleading OverlappingType's docstring. (#26 <https://github.com/maliput/maliput_object/issues/26>)
* Adds a SimpleObjectQuery implementation (#17 <https://github.com/maliput/maliput_object/issues/17>)
* Adds BoundingBox Implementation (#7 <https://github.com/maliput/maliput_object/issues/7>)
* Improves OverlappingTest definition. (#16 <https://github.com/maliput/maliput_object/issues/16>)
* Adds ObjectQuery class. (#13 <https://github.com/maliput/maliput_object/issues/13>)
* Creates ObjectBook API (#12 <https://github.com/maliput/maliput_object/issues/12>)
* Creates Object class (#8 <https://github.com/maliput/maliput_object/issues/8>)
* Adds BoundingRegion api class. (#6 <https://github.com/maliput/maliput_object/issues/6>)
* Setup maliput_object repository/package (#2 <https://github.com/maliput/maliput_object/issues/2>)
* Initial commit
  Create LICENSE file.
* Contributors: Agustin Alba Chicar, Franco Cipollone, Voldivh
```
