### PR TITLE
Revert mrpt msgs

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7245,7 +7245,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_msgs-release.git
-      version: 0.4.0-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7245,7 +7245,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_msgs-release.git
-      version: 0.4.3-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git


### PR DESCRIPTION
…3409)"

This reverts commit 10fdb1688002d081266ccbd51ea6efde1eab7938.

For reasons I don't completely understand (and probably don't have time to debug), the `mrpt_msgs` package later that 0.2.0 seems to install a file in `/opt/ros/melodic/.catkin`, which conflicts with other packages.  This causes all downstream packages that depend on `mrpt_msgs` to break (you can see the error in https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__mrpt_bridge__ubuntu_bionic_amd64__binary/71/console , for example).  Revert to the last known working version of `mrpt_msgs`.  @jlblancoc FYI.

