### PR TITLE
Revert pose_cov_ops to 0.2.1 in melodic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9125,7 +9125,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release.git
-      version: 0.3.1-1
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9125,7 +9125,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release.git
-      version: 0.3.3-1
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9125,7 +9125,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release.git
-      version: 0.3.2-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git


### PR DESCRIPTION
While it seems to work, it actually tries to install files to /opt/ros/melodic/.catkin, which then causes downstream packages to fail.  Revert back to 0.2.1, which is the last known working version.  @jlblancoc FYI