### PR TITLE
Back to the last known working version 2.4.3

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7215,7 +7215,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt2-release.git
-      version: 2.4.8-1
+      version: 2.4.5-1
     source:
       type: git
       url: https://github.com/mrpt/mrpt.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7215,7 +7215,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt2-release.git
-      version: 2.4.4-1
+      version: 2.4.3-1
     source:
       type: git
       url: https://github.com/mrpt/mrpt.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7215,7 +7215,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt2-release.git
-      version: 2.4.9-1
+      version: 2.4.8-1
     source:
       type: git
       url: https://github.com/mrpt/mrpt.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7215,7 +7215,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt2-release.git
-      version: 2.4.5-1
+      version: 2.4.4-1
     source:
       type: git
       url: https://github.com/mrpt/mrpt.git


### PR DESCRIPTION
The current version has conflicts with mrpt1, as seen in e.g. https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__mrpt_ekf_slam_2d__ubuntu_bionic_amd64__binary/94/console