### PR TITLE
Revert "clpe: 0.1.0-2 in 'foxy/distribution.yaml' [bloom] (#33519)"

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -596,21 +596,6 @@ repositories:
       url: https://github.com/CLOBOT-Co-Ltd/clober_msgs.git
       version: foxy-devel
     status: developed
-  clpe:
-    doc:
-      type: git
-      url: https://github.com/canlab-co/CLPE_G_NVP2650D_SDK.git
-      version: ros2-0.1.0
-    release:
-      tags:
-        release: release/foxy/{package}/{version}
-      url: https://github.com/canlab-co/CLPE_G_NVP2650D_SDK-ros2-release.git
-      version: 0.1.0-2
-    source:
-      type: git
-      url: https://github.com/canlab-co/CLPE_G_NVP2650D_SDK.git
-      version: main
-    status: developed
   clpe_ros:
     doc:
       type: git


### PR DESCRIPTION
This reverts commit 28562ef9c1e558dc71099055c0f16db6ec30cc24.

This change introduced a package name collision with the `clpe_sdk` repository.