### PR TITLE
fix rosdep broken issue

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -648,13 +648,6 @@ repositories:
       type: git
       url: https://github.com/canlab-co/CLPE_G_NVP2650D_SDK.git
       version: main
-    release:
-      packages:
-      - clpe
-      tags:
-        release: release/foxy/{package}/{version}
-      url: https://github.com/canlab-co/CLPE_G_NVP2650D_SDK-ros2-release.git
-      version: 0.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Fix for issue reported in https://github.com/ros-infrastructure/rosdep/issues/878 (I'm keeping the later code - not sure if that is entirely right, but right now rosdep is broken for ALL users who try to run rosdep update)