### PR TITLE
rm_control: 0.1.12-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7731,7 +7731,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/rm-controls/rm_control-release.git
-      version: 0.1.11-1
+      version: 0.1.12-3
     source:
       type: git
       url: https://github.com/rm-controls/rm_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rm_control` to `0.1.12-3`:

- upstream repository: https://github.com/rm-controls/rm_control.git
- release repository: https://github.com/rm-controls/rm_control-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.11-1`

## rm_common

```
* Update logic of changing enemy color.
* Merge pull request #59 <https://github.com/ye-luo-xi-tui/rm_control/issues/59> from ye-luo-xi-tui/master
  0.1.11
* Contributors: QiayuanLiao, yezi
```

## rm_control

```
* Merge pull request #59 <https://github.com/ye-luo-xi-tui/rm_control/issues/59> from ye-luo-xi-tui/master
  0.1.11
* Contributors: QiayuanLiao
```

## rm_dbus

```
* Merge pull request #59 <https://github.com/ye-luo-xi-tui/rm_control/issues/59> from ye-luo-xi-tui/master
  0.1.11
* Contributors: QiayuanLiao
```

## rm_gazebo

```
* Merge pull request #59 <https://github.com/ye-luo-xi-tui/rm_control/issues/59> from ye-luo-xi-tui/master
  0.1.11
* Contributors: QiayuanLiao
```

## rm_hw

```
* Merge pull request #59 <https://github.com/ye-luo-xi-tui/rm_control/issues/59> from ye-luo-xi-tui/master
  0.1.11
* Contributors: QiayuanLiao
```

## rm_msgs

```
* Merge pull request #59 <https://github.com/ye-luo-xi-tui/rm_control/issues/59> from ye-luo-xi-tui/master
  0.1.11
* Contributors: QiayuanLiao
```
