### PR TITLE
rt_manipulators_cpp: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5608,6 +5608,24 @@ repositories:
       url: https://github.com/ros-visualization/rqt_topic.git
       version: foxy-devel
     status: maintained
+  rt_manipulators_cpp:
+    doc:
+      type: git
+      url: https://github.com/rt-net/rt_manipulators_cpp.git
+      version: ros2
+    release:
+      packages:
+      - rt_manipulators_cpp
+      - rt_manipulators_examples
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/rt-net-gbp/rt_manipulators_cpp-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/rt-net/rt_manipulators_cpp.git
+      version: ros2
+    status: maintained
   rt_usb_9axisimu_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rt_manipulators_cpp` to `1.0.0-1`:

- upstream repository: https://github.com/rt-net/rt_manipulators_cpp.git
- release repository: https://github.com/rt-net-gbp/rt_manipulators_cpp-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## rt_manipulators_cpp

```
* ROS 2に対応 (#28 <https://github.com/rt-net/rt_manipulators_cpp/issues/28>)
```

## rt_manipulators_examples

```
* ROS 2に対応 (#28 <https://github.com/rt-net/rt_manipulators_cpp/issues/28>)
```
