### PR TITLE
rt_manipulators_cpp: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4663,6 +4663,24 @@ repositories:
       url: https://github.com/ros-visualization/rqt_topic.git
       version: humble
     status: maintained
+  rt_manipulators_cpp:
+    doc:
+      type: git
+      url: https://github.com/rt-net/rt_manipulators_cpp.git
+      version: ros2
+    release:
+      packages:
+      - rt_manipulators_cpp
+      - rt_manipulators_examples
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/rt-net-gbp/rt_manipulators_cpp-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/rt-net/rt_manipulators_cpp.git
+      version: ros2
+    status: maintained
   rtabmap:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rt_manipulators_cpp` to `1.0.0-1`:

- upstream repository: https://github.com/rt-net/rt_manipulators_cpp.git
- release repository: https://github.com/rt-net-gbp/rt_manipulators_cpp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## rt_manipulators_cpp

```
* ROS 2に対応 (#28 <https://github.com/rt-net/rt_manipulators_cpp/issues/28>)
```

## rt_manipulators_examples

```
* ROS 2に対応 (#28 <https://github.com/rt-net/rt_manipulators_cpp/issues/28>)
```
