### PR TITLE
fastrtps: 2.6.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -952,7 +952,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/fastrtps-release.git
-      version: 2.6.0-3
+      version: 2.6.1-1
     source:
       test_commits: true
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `fastrtps` to `2.6.1-1`:

- upstream repository: https://github.com/eProsima/Fast-DDS.git
- release repository: https://github.com/ros2-gbp/fastrtps-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.6.0-3`
