### PR TITLE
rosbridge_suite: 0.11.14-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11327,7 +11327,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.11.13-1
+      version: 0.11.14-1
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11331,7 +11331,7 @@ repositories:
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git
-      version: develop
+      version: ros1
     status: maintained
   roscompile:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11316,7 +11316,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git
-      version: master
+      version: ros1
     release:
       packages:
       - rosapi


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.11.14-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.11.13-1`

## rosapi

```
* Small fixes (#681 <https://github.com/RobotWebTools/rosbridge_suite/issues/681>)
* Contributors: Matthijs van der Burgh
```

## rosbridge_library

```
* Fix bson support for python3 (#545 <https://github.com/RobotWebTools/rosbridge_suite/issues/545>)
* Small fixes (#681 <https://github.com/RobotWebTools/rosbridge_suite/issues/681>)
* Check if key exists before accessing the dict in SubscriberManager::unsubscribe(), patches https://github.com/RobotWebTools/rosbridge_suite/issues/580 (#638 <https://github.com/RobotWebTools/rosbridge_suite/issues/638>)
* Contributors: Matthijs van der Burgh, Nick Paul, Steve Golton
```

## rosbridge_msgs

```
* Small fixes (#681 <https://github.com/RobotWebTools/rosbridge_suite/issues/681>)
* Contributors: Matthijs van der Burgh
```

## rosbridge_server

```
* Fix ROS 1 RosbridgeTcpSocket endless loop (#722 <https://github.com/RobotWebTools/rosbridge_suite/issues/722>)
* Fix bson support for python3 (#545 <https://github.com/RobotWebTools/rosbridge_suite/issues/545>)
* Small fixes (#681 <https://github.com/RobotWebTools/rosbridge_suite/issues/681>)
* Contributors: Matthijs van der Burgh, Nick Paul, curiosus42
```

## rosbridge_suite

```
* Small fixes (#681 <https://github.com/RobotWebTools/rosbridge_suite/issues/681>)
* Contributors: Matthijs van der Burgh
```
