### PR TITLE
maliput_malidrive: 0.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2318,6 +2318,22 @@ repositories:
       url: https://github.com/maliput/maliput_drake.git
       version: main
     status: developed
+  maliput_malidrive:
+    doc:
+      type: git
+      url: https://github.com/maliput/maliput_malidrive.git
+      version: main
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/maliput_malidrive-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/maliput/maliput_malidrive.git
+      version: main
+    status: developed
   maliput_object:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_malidrive` to `0.1.0-1`:

- upstream repository: https://github.com/maliput/maliput_malidrive.git
- release repository: https://github.com/ros2-gbp/maliput_malidrive-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## maliput_malidrive

```
* Use <doc_depend> for ament_cmake_doxygen dependency (#217 <https://github.com/maliput/maliput_malidrive/issues/217>)
* Uses ros-action-ci in build.yaml workflow. (#218 <https://github.com/maliput/maliput_malidrive/issues/218>)
* Moves package to root (#216 <https://github.com/maliput/maliput_malidrive/issues/216>)
* Updates license. (#215 <https://github.com/maliput/maliput_malidrive/issues/215>)
* Uses ament_export_targets. (#214 <https://github.com/maliput/maliput_malidrive/issues/214>)
* Removes dashing support. (#213 <https://github.com/maliput/maliput_malidrive/issues/213>)
* Adds the RoadGeometry to the IntersectionBook construction points. (#211 <https://github.com/maliput/maliput_malidrive/issues/211>)
* Modifies library dependancies from utilities to utility (#210 <https://github.com/maliput/maliput_malidrive/issues/210>)
* Renames PhaseBasedRightOfWayDiscreteValueRuleStateProvider class (#209 <https://github.com/maliput/maliput_malidrive/issues/209>)
* Merge pull request #208 <https://github.com/maliput/maliput_malidrive/issues/208> from maliput/voldivh/value_range_method_to_state
  Changed values() and ranges() method from Rules to states()
* [FEAT]: Changed values() and ranges() method from Rules to states()
* Adds LoopRoadPedestrianCrosswalk xodr and yaml. (#207 <https://github.com/maliput/maliput_malidrive/issues/207>)
* Fixes RoWR zone in SingleRoadPedestrianCrosswalk.yaml file. (#206 <https://github.com/maliput/maliput_malidrive/issues/206>)
* Adds missing SingleRoadPedestrianCrosswalk.yaml. (#205 <https://github.com/maliput/maliput_malidrive/issues/205>)
* Adds XODR and YAML to describe crosswalk intersection (#203 <https://github.com/maliput/maliput_malidrive/issues/203>)
* Creates PhaseProviderBuilder functor. (#202 <https://github.com/maliput/maliput_malidrive/issues/202>)
* Adds BUILD_DOCS flag as opt-in flag. (#204 <https://github.com/maliput/maliput_malidrive/issues/204>)
* Uses PhaseRingBook loader for new rule api. (#200 <https://github.com/maliput/maliput_malidrive/issues/200>)
* Supports loading rules via RuleRegistry + new RoadRulebook format. (#198 <https://github.com/maliput/maliput_malidrive/issues/198>)
* Fixes typo in README (#197 <https://github.com/maliput/maliput_malidrive/issues/197>)
* Adds workflow_dispatch option to scan_build and clan runs. (#196 <https://github.com/maliput/maliput_malidrive/issues/196>)
* Adds CI badges (#195 <https://github.com/maliput/maliput_malidrive/issues/195>)
* Improves the README adding info about OpenDRIVE specs coverage. (#194 <https://github.com/maliput/maliput_malidrive/issues/194>)
* Replaces push by workflow_dispatch event in gcc build. (#192 <https://github.com/maliput/maliput_malidrive/issues/192>)
* Improves standard_strictness_policy flag's documentation. (#189 <https://github.com/maliput/maliput_malidrive/issues/189>)
* Exposes RoadNetwork configuration builder keys. (#188 <https://github.com/maliput/maliput_malidrive/issues/188>)
* Pairs with maliput::plugin::RoadNetworkLoader functor change. (#186 <https://github.com/maliput/maliput_malidrive/issues/186>)
* Adds max_linear_tolerance parameter: linear tolerance as a range (#182 <https://github.com/maliput/maliput_malidrive/issues/182>)
* Improves use of maliput plugin architecture. (#181 <https://github.com/maliput/maliput_malidrive/issues/181>)
* Removes RoadNetworkConfiguration-based load method. (#177 <https://github.com/maliput/maliput_malidrive/issues/177>)
* Use maliput drake (#178 <https://github.com/maliput/maliput_malidrive/issues/178>)
* Fixes help message for the xodr apps. (#180 <https://github.com/maliput/maliput_malidrive/issues/180>)
* Adds ToRoadPosition query test. (#175 <https://github.com/maliput/maliput_malidrive/issues/175>)
* Fixes bug at ToRoadPosition query. (#174 <https://github.com/maliput/maliput_malidrive/issues/174>)
* Solves CMP0076 cmake warning related to log_level_flag target. (#167 <https://github.com/maliput/maliput_malidrive/issues/167>)
* Reduces integrator's maximum_step_size to half of scale_length. (#172 <https://github.com/maliput/maliput_malidrive/issues/172>)
* Documents maliput_malidrive xodr apps. (#170 <https://github.com/maliput/maliput_malidrive/issues/170>)
* Fixes doxygen format at docstring. (#171 <https://github.com/maliput/maliput_malidrive/issues/171>)
* Reduce epsilon value in lane's s_range_validation. (#169 <https://github.com/maliput/maliput_malidrive/issues/169>)
* Enable doxygen verification. (#168 <https://github.com/maliput/maliput_malidrive/issues/168>)
* Removes RoadGeometryBuilderBase in favor of less (unnecessary) abstraction. (#166 <https://github.com/maliput/maliput_malidrive/issues/166>)
* Improves ToRoadPosition query. (#165 <https://github.com/maliput/maliput_malidrive/issues/165>)
* Unify RoadNetworkBuilderBase with its implementation. (#164 <https://github.com/maliput/maliput_malidrive/issues/164>)
* Remove InertialToLaneMappingConfig. (#163 <https://github.com/maliput/maliput_malidrive/issues/163>)
* Removes from the installation files that (#162 <https://github.com/maliput/maliput_malidrive/issues/162>)
  should not be installed anymore.
  Installed header files for maliput_malidrive
  consumers, like malidrive was, are no longer needed.
* xodr_extract app: Generates XODR file from another XODR's roads. (#154 <https://github.com/maliput/maliput_malidrive/issues/154>)
* Improves throw message: Print range of tolerances evaluated (#157 <https://github.com/maliput/maliput_malidrive/issues/157>)
* Adjusts integrators accuracy. (#152 <https://github.com/maliput/maliput_malidrive/issues/152>)
* xodr_query app: Adds GetGeometries command. (#151 <https://github.com/maliput/maliput_malidrive/issues/151>)
* Relax G1 contiguity for non drivable lanes (#149 <https://github.com/maliput/maliput_malidrive/issues/149>)
* Includes Town01-07 maps. (#145 <https://github.com/maliput/maliput_malidrive/issues/145>)
* RoadNetwork configuration as string-to-string map (#143 <https://github.com/maliput/maliput_malidrive/issues/143>)
* Replaces AMENT_CURRENT_PREFIX by COLCON_PREFIX_PATH (#141 <https://github.com/maliput/maliput_malidrive/issues/141>)
* Supports lane-width description with negative value (#140 <https://github.com/maliput/maliput_malidrive/issues/140>)
* Tolerance selection: Improve logging and fix bug. (#138 <https://github.com/maliput/maliput_malidrive/issues/138>)
* Set up linker properly when using clang in CI. (#127 <https://github.com/maliput/maliput_malidrive/issues/127>)
* Disables extensive tests on tsan builds. (#134 <https://github.com/maliput/maliput_malidrive/issues/134>)
* Solves warnings while clang build. (#129 <https://github.com/maliput/maliput_malidrive/issues/129>)
* Improves cmake coding for testing. (#132 <https://github.com/maliput/maliput_malidrive/issues/132>)
* Removes repeated cmake flags settings (#131 <https://github.com/maliput/maliput_malidrive/issues/131>)
* Fixes throw when p value from integrator is negative (#124 <https://github.com/maliput/maliput_malidrive/issues/124>)
* Fix some warnings related to unnecessary std::move() calls. (#126 <https://github.com/maliput/maliput_malidrive/issues/126>)
* Increases kMaxToleranceSelectionRounds to 24. (#125 <https://github.com/maliput/maliput_malidrive/issues/125>)
  Updates kMaxToleranceSelectionRounds constant from 20 to 24 to guarantee
  a tolerance between 0.05 and 0.50 when automatic tolerance selection is enabled.
* Discards tiny geometries (#121 <https://github.com/maliput/maliput_malidrive/issues/121>)
* Discards function descriptions smaller than constants::kStrictTolerance. (#118 <https://github.com/maliput/maliput_malidrive/issues/118>)
* Removes ament_target_dependencies from libraries. (#122 <https://github.com/maliput/maliput_malidrive/issues/122>)
* Allows functions with NaN values only when they are discardable. (#116 <https://github.com/maliput/maliput_malidrive/issues/116>)
* Piecwise GroundCurve: Use epsilon instead of tolerance at range validation. (#119 <https://github.com/maliput/maliput_malidrive/issues/119>)
* Fixes bugs when creating LaneOffset and LaneWidth. (#115 <https://github.com/maliput/maliput_malidrive/issues/115>)
* Functions starting at the very end of the road are discarded. (#114 <https://github.com/maliput/maliput_malidrive/issues/114>)
* Enable foxy (#113 <https://github.com/maliput/maliput_malidrive/issues/113>)
* Relaxes epsilon when building piece-wise-defined functions. (#112 <https://github.com/maliput/maliput_malidrive/issues/112>)
* Parser: Allows function descriptions sharing same start point. (#111 <https://github.com/maliput/maliput_malidrive/issues/111>)
* Allows lane links inconsistency when semantic errors are allowed. (#102 <https://github.com/maliput/maliput_malidrive/issues/102>)
* Improves some throw messages. (#103 <https://github.com/maliput/maliput_malidrive/issues/103>)
* Avoids error when logging an XML node that has curly braces. (#101 <https://github.com/maliput/maliput_malidrive/issues/101>)
* Fixes body test style in road_geometry_builder_test (#99 <https://github.com/maliput/maliput_malidrive/issues/99>)
* non-drivable lanes are always built but hidden if needed(#97 <https://github.com/maliput/maliput_malidrive/issues/97>)
* Use --include-eol-distros with rosdep update (#98 <https://github.com/maliput/maliput_malidrive/issues/98>)
* OpenRangeValidator: relative epsilon. (#92 <https://github.com/maliput/maliput_malidrive/issues/92>)
* Improve some RoadGeometryBuilder log messages (#91 <https://github.com/maliput/maliput_malidrive/issues/91>)
* Fix include style part 3: reorder headers (#84 <https://github.com/maliput/maliput_malidrive/issues/84>)
* Fixes format.
* Require OpenDRIVE file in RoadGeometryConfiguration
* pybind11 is not needed in CI (#86 <https://github.com/maliput/maliput_malidrive/issues/86>)
* Use python3 for check_test_ran script (#85 <https://github.com/maliput/maliput_malidrive/issues/85>)
* Include XODR file name in error message (#87 <https://github.com/maliput/maliput_malidrive/issues/87>)
  Include the XODR file name, if possible, when no workable tolerance
  is found. Useful for debugging purposes.
* Omit non driveable lanes (#79 <https://github.com/maliput/maliput_malidrive/issues/79>)
* Improve the loader by opting for the automatic tolerance selection by default (#77 <https://github.com/maliput/maliput_malidrive/issues/77>)
* Fix include style part 2: <> for drake, add/remove newlines (#81 <https://github.com/maliput/maliput_malidrive/issues/81>)
* Fix include style part 1: use <> for maliput/ includes (#80 <https://github.com/maliput/maliput_malidrive/issues/80>)
* CI: Removes prereqs install for drake. (#76 <https://github.com/maliput/maliput_malidrive/issues/76>)
* Fixes segment bounds computation. (#73 <https://github.com/maliput/maliput_malidrive/issues/73>)
* Upgrade ros-tooling to v0.2.1 (#75 <https://github.com/maliput/maliput_malidrive/issues/75>)
* Use maliput_integration instead of maliput-integration. (#74 <https://github.com/maliput/maliput_malidrive/issues/74>)
* Uses maliput_documentation instead of maliput-documentation. (#72 <https://github.com/maliput/maliput_malidrive/issues/72>)
* Pairs hbound value with odrm implementation. (#71 <https://github.com/maliput/maliput_malidrive/issues/71>)
* Differentiate between schema and semantic errors when using strictness policy (#68 <https://github.com/maliput/maliput_malidrive/issues/68>)
* Improves the error message to explain which are the roads involved in… (#67 <https://github.com/maliput/maliput_malidrive/issues/67>)
* Adds verbose error exceptions  (#66 <https://github.com/maliput/maliput_malidrive/issues/66>)
* Lets disconnected Roads within a Junction to exist (#64 <https://github.com/maliput/maliput_malidrive/issues/64>)
* Allows selecting the flexibility of the xodr parser. (#62 <https://github.com/maliput/maliput_malidrive/issues/62>)
* Creates ParserConfiguration struct. (#61 <https://github.com/maliput/maliput_malidrive/issues/61>)
* Polish road_geometry_configuration.h (#63 <https://github.com/maliput/maliput_malidrive/issues/63>)
* Adds parameter to RoadGeometryConfiguration to set xodr parsing strictness (#59 <https://github.com/maliput/maliput_malidrive/issues/59>)
* Parser: Improves log message when missing 'connection' in a junction. (#60 <https://github.com/maliput/maliput_malidrive/issues/60>)
* Switch ament_cmake_doxygen to main. (#58 <https://github.com/maliput/maliput_malidrive/issues/58>)
* Optimizes scan-build run in CI. (#52 <https://github.com/maliput/maliput_malidrive/issues/52>)
* Add changelog template (#48 <https://github.com/maliput/maliput_malidrive/issues/48>)
* Point to maliput_infrastructure instead of dsim-repos-index (#47 <https://github.com/maliput/maliput_malidrive/issues/47>)
* Trigger PR clang builds on do-clang-test label (#46 <https://github.com/maliput/maliput_malidrive/issues/46>)
* Restores scan-build workflow on label (#45 <https://github.com/maliput/maliput_malidrive/issues/45>)
* Implements Inertial to Backend Frame translation (#44 <https://github.com/maliput/maliput_malidrive/issues/44>)
* Moves disabled workflows to a different folder. (#42 <https://github.com/maliput/maliput_malidrive/issues/42>)
* Adds tsan sanitizer workflow in CI (#39 <https://github.com/maliput/maliput_malidrive/issues/39>)
* Parallel build policy set in integration tests. (#40 <https://github.com/maliput/maliput_malidrive/issues/40>)
* Parallelizes the road geometry building process. (#37 <https://github.com/maliput/maliput_malidrive/issues/37>)
* Refer to a specific clang version and use lld linker. (#36 <https://github.com/maliput/maliput_malidrive/issues/36>)
* Matches with plugin extern c methods refactor. (#35 <https://github.com/maliput/maliput_malidrive/issues/35>)
* Update ros-tooling version in CI. (#34 <https://github.com/maliput/maliput_malidrive/issues/34>)
* Fixes ubsan behavior in CI. (#32 <https://github.com/maliput/maliput_malidrive/issues/32>)
* Fixes plugin test failure when running ubsan. (#33 <https://github.com/maliput/maliput_malidrive/issues/33>)
* Fix typo in GetRoadGeometryConfigurationFor() (#27 <https://github.com/maliput/maliput_malidrive/issues/27>)
* Fixes CI's wrong main branch. (#29 <https://github.com/maliput/maliput_malidrive/issues/29>)
* Removes Jenkins configuration. (#28 <https://github.com/maliput/maliput_malidrive/issues/28>)
* Append library dirs to plugin test. (#26 <https://github.com/maliput/maliput_malidrive/issues/26>)
* Restores integration tests and provides a dictionary with per xodr map configurations. (#23 <https://github.com/maliput/maliput_malidrive/issues/23>)
* Removes constraint of p being in range of lane_offset's domain. (#25 <https://github.com/maliput/maliput_malidrive/issues/25>)
* Builds non-driveable lanes. (#22 <https://github.com/maliput/maliput_malidrive/issues/22>)
* Adds tests for RoadNetworkLoader maliput_malidrive plugin. (#21 <https://github.com/maliput/maliput_malidrive/issues/21>)
* Implements a maliput RoadNetworkLoader plugin. (#19 <https://github.com/maliput/maliput_malidrive/issues/19>)
* Uses phase based discrete value rule provider (#20 <https://github.com/maliput/maliput_malidrive/issues/20>)
* Merge pull request #18 <https://github.com/maliput/maliput_malidrive/issues/18> from maliput/agalbachicar/`#361 <https://github.com/maliput/maliput_malidrive/issues/361>`__rename_to_geo_position
  Renames GeoPosition to InertialPosition.
* Merge branch 'main' into agalbachicar/`#361 <https://github.com/maliput/maliput_malidrive/issues/361>`__rename_to_geo_position
* Removes already completed TODO comment.. (#17 <https://github.com/maliput/maliput_malidrive/issues/17>)
* Renames GeoPosition to InertialPosition.
* Updates README file. (#3 <https://github.com/maliput/maliput_malidrive/issues/3>)
* Merge pull request #2 <https://github.com/maliput/maliput_malidrive/issues/2> from maliput/francocipollone/migrate_maliput_malidrive
  Migrates maliput_malidrive
* Adds GitHub Actions CI and Jenkins configs.
* Fixes header files in include folder for malidrive (#734 <https://github.com/maliput/maliput_malidrive/issues/734>)
* Fixes xodr_file path in yaml files in resources folder. (#733 <https://github.com/maliput/maliput_malidrive/issues/733>)
* Adds integration tests in maliput_malidrive package (#727 <https://github.com/maliput/maliput_malidrive/issues/727>)
* Move header files in maliput_malidrive (#730 <https://github.com/maliput/maliput_malidrive/issues/730>)
* Duplicates maps into malidrive (#729 <https://github.com/maliput/maliput_malidrive/issues/729>)
* Use maliput::test_utilities and try same branch name in actions (#728 <https://github.com/maliput/maliput_malidrive/issues/728>)
* Remove tests using Town0X maps in db_manager_test.cc (#726 <https://github.com/maliput/maliput_malidrive/issues/726>)
* Build shared libs in maliput_malidrive. (#725 <https://github.com/maliput/maliput_malidrive/issues/725>)
* Adds interface library.
* Moves xodr apps to maliput_malidrive package.
* Moves loader to maliput_malidrive package (#716 <https://github.com/maliput/maliput_malidrive/issues/716>)
* Removes proj4 (#715 <https://github.com/maliput/maliput_malidrive/issues/715>)
* Remove extra malidrive prefix in files and classes. (#714 <https://github.com/maliput/maliput_malidrive/issues/714>)
* Moves builder folder to maliput_malidrive package (#711 <https://github.com/maliput/maliput_malidrive/issues/711>)
* Moves base folder to maliput_malidrive (#710 <https://github.com/maliput/maliput_malidrive/issues/710>)
* Moves id_providers to maliput_malidrive package (#709 <https://github.com/maliput/maliput_malidrive/issues/709>)
* Moves xodr folder to maliput_malidrive package  (#707 <https://github.com/maliput/maliput_malidrive/issues/707>)
* Moves malidrive_road_curve.h/cc to road_curve.h/cc (#705 <https://github.com/maliput/maliput_malidrive/issues/705>)
* Moves utility folder to maliput_malidrive package. (#706 <https://github.com/maliput/maliput_malidrive/issues/706>)
* Adapts constants namespace (#702 <https://github.com/maliput/maliput_malidrive/issues/702>)
* Moves malidrive2 files of road_curve to maliput_malidrive (#697 <https://github.com/maliput/maliput_malidrive/issues/697>)
* Improve error logging when parsing. (#693 <https://github.com/maliput/maliput_malidrive/issues/693>)
* Splitts malidrive/constants.h (#684 <https://github.com/maliput/maliput_malidrive/issues/684>)
* Use ament_add_gtest_executable for xodr tests, remove libgtest (#689 <https://github.com/maliput/maliput_malidrive/issues/689>)
* Enable maliput_malidrive in Github Actions (#683 <https://github.com/maliput/maliput_malidrive/issues/683>)
* Moves macro_test.cc to maliput_malidrive package (#673 <https://github.com/maliput/maliput_malidrive/issues/673>)
* Improves logging (#675 <https://github.com/maliput/maliput_malidrive/issues/675>)
* Moves test_utilities folder to maliput_malidrive package (#674 <https://github.com/maliput/maliput_malidrive/issues/674>)
* Move macros.h folder to maliput_malidrive (#670 <https://github.com/maliput/maliput_malidrive/issues/670>)
* Renaming maliput-malidrive to maliput_malidrive (#672 <https://github.com/maliput/maliput_malidrive/issues/672>)
* first commit
* Contributors: Agustin Alba Chicar, Chien-Liang Fok, Franco Cipollone, Geoffrey Biggs, Liang Fok, Steve Peters, Voldivh
```
