### PR TITLE
maliput: 1.0.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2295,7 +2295,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput` to `1.0.4-1`:

- upstream repository: https://github.com/maliput/maliput.git
- release repository: https://github.com/ros2-gbp/maliput-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.0.3-1`

## maliput

```
* Fixes include folder installation. (#508 <https://github.com/maliput/maliput/issues/508>)
* Uses ros-action-ci in build.yaml workflow. (#505 <https://github.com/maliput/maliput/issues/505>)
* Contributors: Franco Cipollone
```
