### PR TITLE
maliput_drake: 0.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2311,7 +2311,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput_documentation-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_drake` to `0.1.1-1`:

- upstream repository: https://github.com/maliput/maliput_drake.git
- release repository: https://github.com/ros2-gbp/maliput_documentation-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.0-1`

## maliput_drake

```
* Fixes include folder installation. (#23 <https://github.com/maliput/maliput_drake/issues/23>)
* Contributors: Franco Cipollone
```
