### PR TITLE
gazebo_ros_pkgs: 3.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1065,7 +1065,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
-      version: 3.6.0-1
+      version: 3.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `3.7.0-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs
- release repository: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `3.6.0-1`

## gazebo_dev

- No changes

## gazebo_msgs

- No changes

## gazebo_plugins

```
* Add friction coefficient parameters (#1393 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1393>)
* GPS sensor plugin publishing velocity (#1371 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1371>) (#1387 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1387>)
* Contributors: Jacob Perron, Jenn Nguyen, Marcel Dudek
```

## gazebo_ros

```
* Fix gzserver launch file breaking when no ros args provided (#1395 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1395>)
* Multiple nodes with same name issue (#1394 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1394>)
* Expose launch parameter for ``params_file`` (#1391 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1391>)
* Contributors: Brian Chen, Deepanshu Bansal, Jacob Perron
```

## gazebo_ros_pkgs

- No changes
