### PR TITLE
Update maliput_drake release repository url.

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2310,7 +2310,7 @@ repositories:
     release:
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/ros2-gbp/maliput_documentation-release.git
+      url: https://github.com/ros2-gbp/maliput_drake-release.git
       version: 0.1.1-1
     source:
       test_pull_requests: true


### PR DESCRIPTION
This repository was renamed during the deployment of https://github.com/ros2-gbp/ros2-gbp-github-org/pull/69