### PR TITLE
foxglove_msgs: 1.2.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1129,7 +1129,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/ros_foxglove_msgs-release.git
-      version: 1.2.1-1
+      version: 1.2.2-1
     source:
       type: git
       url: https://github.com/foxglove/schemas.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_msgs` to `1.2.2-1`:

- upstream repository: https://github.com/foxglove/schemas.git
- release repository: https://github.com/ros2-gbp/ros_foxglove_msgs-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.2.1-1`

## foxglove_msgs

```
* Fix CMake build accessing parent directory
* Contributors: Jacob Bandes-Storch
```
