### PR TITLE
locator_ros_bridge: 2.1.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1762,7 +1762,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/locator_ros_bridge-release.git
-      version: 2.1.5-1
+      version: 2.1.6-1
     source:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `locator_ros_bridge` to `2.1.6-1`:

- upstream repository: https://github.com/boschglobal/locator_ros_bridge.git
- release repository: https://github.com/ros2-gbp/locator_ros_bridge-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.1.5-1`

## bosch_locator_bridge

```
* Change version numbers in server_bridge_node for compatibility with v1.4.0 (#13 <https://github.com/boschglobal/locator_ros_bridge/issues/13>)
* Make units of vehicleTransformLaser.yaw clear
* Set laser*_use_intensities to false by default
* Change version numbers for compatibility with v1.4.0
* Add parameters for using intensities
* Contributors: Fabian König, Stefan Laible
```
