### PR TITLE
locator_ros_bridge: 2.0.7-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2250,7 +2250,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/locator_ros_bridge-release.git
-      version: 2.0.6-1
+      version: 2.0.7-1
     source:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `locator_ros_bridge` to `2.0.7-1`:

- upstream repository: https://github.com/boschglobal/locator_ros_bridge.git
- release repository: https://github.com/ros2-gbp/locator_ros_bridge-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.0.6-1`

## bosch_locator_bridge

```
* Change version numbers in server_bridge_node for compatibility with v1.4.0 (#13 <https://github.com/boschglobal/locator_ros_bridge/issues/13>)
* Make units of vehicleTransformLaser.yaw clear (#11 <https://github.com/boschglobal/locator_ros_bridge/issues/11>)
* Set laser*_use_intensities to false by default
* Change version numbers for compatibility with v1.4.0
* Add parameters for using intensities
* Contributors: Stefan Laible
```
