### PR TITLE
soccer_interfaces: 0.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4824,7 +4824,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-sports/soccer_interfaces.git
-      version: rolling
+      version: humble
     release:
       packages:
       - soccer_interfaces
@@ -4838,7 +4838,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-sports/soccer_interfaces.git
-      version: rolling
+      version: humble
     status: developed
   soccer_object_msgs:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4827,13 +4827,14 @@ repositories:
       version: rolling
     release:
       packages:
+      - soccer_interfaces
       - soccer_vision_2d_msgs
       - soccer_vision_3d_msgs
       - soccer_vision_attribute_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/soccer_interfaces-release.git
-      version: 0.0.1-2
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/ros-sports/soccer_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `soccer_interfaces` to `0.1.0-1`:

- upstream repository: https://github.com/ros-sports/soccer_interfaces.git
- release repository: https://github.com/ros2-gbp/soccer_interfaces-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.0.1-2`

## soccer_interfaces

```
* add soccer_interfaces meta package
* Contributors: Kenji Brameld
```

## soccer_vision_2d_msgs

- No changes

## soccer_vision_3d_msgs

- No changes

## soccer_vision_attribute_msgs

- No changes
