### PR TITLE
soccer_interfaces: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4709,13 +4709,14 @@ repositories:
       version: rolling
     release:
       packages:
+      - soccer_interfaces
       - soccer_vision_2d_msgs
       - soccer_vision_3d_msgs
       - soccer_vision_attribute_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/soccer_interfaces-release.git
-      version: 0.0.1-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/ros-sports/soccer_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `soccer_interfaces` to `0.2.0-1`:

- upstream repository: https://github.com/ros-sports/soccer_interfaces.git
- release repository: https://github.com/ros2-gbp/soccer_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.0.1-1`

## soccer_interfaces

```
* add soccer_interfaces meta package
* Contributors: Kenji Brameld
```

## soccer_vision_2d_msgs

- No changes

## soccer_vision_3d_msgs

- No changes

## soccer_vision_attribute_msgs

- No changes
