### PR TITLE
ros_image_to_qimage: 0.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3981,7 +3981,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_image_to_qimage-release.git
-      version: 0.0.2-3
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/ros-sports/ros_image_to_qimage.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3976,7 +3976,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-sports/ros_image_to_qimage.git
-      version: rolling
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -3985,7 +3985,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-sports/ros_image_to_qimage.git
-      version: rolling
+      version: humble
     status: developed
   ros_testing:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_image_to_qimage` to `0.2.0-1`:

- upstream repository: https://github.com/ros-sports/ros_image_to_qimage.git
- release repository: https://github.com/ros2-gbp/ros_image_to_qimage-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.0.2-3`

## ros_image_to_qimage

```
* update readme
* update ci
* Contributors: Kenji Brameld
```
