### PR TITLE
ros_image_to_qimage: 0.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3875,7 +3875,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_image_to_qimage-release.git
-      version: 0.0.2-2
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/ros-sports/ros_image_to_qimage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_image_to_qimage` to `0.3.0-1`:

- upstream repository: https://github.com/ros-sports/ros_image_to_qimage.git
- release repository: https://github.com/ros2-gbp/ros_image_to_qimage-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.0.2-2`

## ros_image_to_qimage

```
* update readme
* update ci
* Contributors: Kenji Brameld
```
