### PR TITLE
rcss3d_agent: 0.1.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3342,7 +3342,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-sports/rcss3d_agent.git
-      version: rolling
+      version: galactic
     release:
       packages:
       - rcss3d_agent
@@ -3355,7 +3355,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-sports/rcss3d_agent.git
-      version: rolling
+      version: galactic
     status: developed
   rcutils:
     doc:

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3351,7 +3351,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rcss3d_agent-release.git
-      version: 0.0.7-1
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/ros-sports/rcss3d_agent.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcss3d_agent` to `0.1.0-1`:

- upstream repository: https://github.com/ros-sports/rcss3d_agent.git
- release repository: https://github.com/ros2-gbp/rcss3d_agent-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.0.7-1`

## rcss3d_agent

- No changes

## rcss3d_agent_basic

- No changes

## rcss3d_agent_msgs

- No changes
