### PR TITLE
rqt_image_overlay: 0.0.6-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4562,7 +4562,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_overlay-release.git
-      version: 0.0.5-1
+      version: 0.0.6-1
     source:
       type: git
       url: https://github.com/ros-sports/rqt_image_overlay.git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4554,7 +4554,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-sports/rqt_image_overlay.git
-      version: rolling
+      version: galactic
     release:
       packages:
       - rqt_image_overlay
@@ -4566,7 +4566,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-sports/rqt_image_overlay.git
-      version: rolling
+      version: galactic
     status: developed
   rqt_image_view:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_image_overlay` to `0.0.6-1`:

- upstream repository: https://github.com/ros-sports/rqt_image_overlay.git
- release repository: https://github.com/ros2-gbp/rqt_image_overlay-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.0.5-1`

## rqt_image_overlay

```
* fix up test
* change theora transport dependency to compressed transport
* Contributors: Kenji Brameld
```

## rqt_image_overlay_layer

- No changes
