### PR TITLE
rqt_image_overlay: 0.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4421,7 +4421,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-sports/rqt_image_overlay.git
-      version: rolling
+      version: humble
     release:
       packages:
       - rqt_image_overlay
@@ -4433,7 +4433,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-sports/rqt_image_overlay.git
-      version: rolling
+      version: humble
     status: developed
   rqt_image_view:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4429,7 +4429,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_overlay-release.git
-      version: 0.0.5-2
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/ros-sports/rqt_image_overlay.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_image_overlay` to `0.1.0-1`:

- upstream repository: https://github.com/ros-sports/rqt_image_overlay.git
- release repository: https://github.com/ros2-gbp/rqt_image_overlay-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.0.5-2`

## rqt_image_overlay

```
* fix up test
* change theora transport dependency to compressed transport
* Contributors: Kenji Brameld
```

## rqt_image_overlay_layer

- No changes
