### PR TITLE
gc_spl: 0.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1436,6 +1436,27 @@ repositories:
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
       version: foxy
     status: developed
+  gc_spl:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/gc_spl.git
+      version: foxy
+    release:
+      packages:
+      - gc_spl_2022
+      - rcgcd_spl_14
+      - rcgcd_spl_14_conversion
+      - rcgcrd_spl_4
+      - rcgcrd_spl_4_conversion
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/gc_spl-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-sports/gc_spl.git
+      version: foxy
+    status: developed
   geographic_info:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gc_spl` to `0.0.1-1`:

- upstream repository: https://github.com/ros-sports/gc_spl.git
- release repository: https://github.com/ros2-gbp/gc_spl-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## gc_spl_2022

```
* Initial commit
* Contributors: Kenji Brameld
```

## rcgcd_spl_14

```
* Initial commit
* Contributors: Kenji Brameld
```

## rcgcd_spl_14_conversion

```
* Initial commit
* Contributors: Kenji Brameld
```

## rcgcrd_spl_4

```
* Initial commit
* Contributors: Kenji Brameld
```

## rcgcrd_spl_4_conversion

```
* Initial commit
* Contributors: Kenji Brameld
```
