### PR TITLE
gc_spl: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1096,6 +1096,27 @@ repositories:
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
       version: ros2
     status: maintained
+  gc_spl:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/gc_spl.git
+      version: humble
+    release:
+      packages:
+      - gc_spl_2022
+      - rcgcd_spl_14
+      - rcgcd_spl_14_conversion
+      - rcgcrd_spl_4
+      - rcgcrd_spl_4_conversion
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/gc_spl-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-sports/gc_spl.git
+      version: humble
+    status: developed
   geographic_info:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gc_spl` to `2.0.0-1`:

- upstream repository: https://github.com/ros-sports/gc_spl.git
- release repository: https://github.com/ros2-gbp/gc_spl-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## gc_spl_2022

```
* Initial commit
* Contributors: Kenji Brameld
```

## rcgcd_spl_14

```
* Initial commit
* Contributors: Kenji Brameld
```

## rcgcd_spl_14_conversion

```
* Initial commit
* Contributors: Kenji Brameld
```

## rcgcrd_spl_4

```
* Initial commit
* Contributors: Kenji Brameld
```

## rcgcrd_spl_4_conversion

```
* Initial commit
* Contributors: Kenji Brameld
```
