### PR TITLE
gc_spl: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1072,6 +1072,27 @@ repositories:
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
       version: ros2
     status: maintained
+  gc_spl:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/gc_spl.git
+      version: rollin
+    release:
+      packages:
+      - gc_spl_2022
+      - rcgcd_spl_14
+      - rcgcd_spl_14_conversion
+      - rcgcrd_spl_4
+      - rcgcrd_spl_4_conversion
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gc_spl-release.git
+      version: 3.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-sports/gc_spl.git
+      version: rolling
+    status: developed
   geographic_info:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1076,7 +1076,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-sports/gc_spl.git
-      version: rollin
+      version: rolling
     release:
       packages:
       - gc_spl_2022


### PR DESCRIPTION
Increasing version of package(s) in repository `gc_spl` to `3.0.0-1`:

- upstream repository: https://github.com/ros-sports/gc_spl.git
- release repository: https://github.com/ros2-gbp/gc_spl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## gc_spl_2022

```
* Initial commit
* Contributors: Kenji Brameld
```

## rcgcd_spl_14

```
* Initial commit
* Contributors: Kenji Brameld
```

## rcgcd_spl_14_conversion

```
* Initial commit
* Contributors: Kenji Brameld
```

## rcgcrd_spl_4

```
* Initial commit
* Contributors: Kenji Brameld
```

## rcgcrd_spl_4_conversion

```
* Initial commit
* Contributors: Kenji Brameld
```
