### PR TITLE
Add `qemu-user-static` to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6767,6 +6767,10 @@ python-dev:
   ubuntu:
     '*': [python-dev]
     focal: [python2-dev]
+qemu-user-static:
+  debian: [qemu-user-static]
+  fedora: [qemu-user-static]
+  ubuntu: [qemu-user-static]
 qhull-bin:
   arch: [qhull]
   debian: [qhull-bin]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

qemu-user-static

## Package Upstream Source:

https://www.qemu.org/

## Purpose of using this:

I want to release the package that depends on this package.
I use this in cross compiling and building robot environment on arm architecture such as Raspberry pi.

Distro packaging links: https://github.com/jsk-ros-pkg/jsk_robot

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/qemu-user-static
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/jammy/qemu-user-static
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/qemu/qemu-user-static/
