### PR TITLE
gscam: 2.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1262,7 +1262,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gscam-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/ros-drivers/gscam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gscam` to `2.0.2-1`:

- upstream repository: https://github.com/ros-drivers/gscam.git
- release repository: https://github.com/ros2-gbp/gscam-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.0.1-1`

## gscam

```
* Update ROS2, Ubuntu and GStreamer versions (#85 <https://github.com/ros-drivers/gscam/issues/85>)
* fix: ros2 gstreamer timestamps (#83 <https://github.com/ros-drivers/gscam/issues/83>)
  * fix: correct gstreamer timestamp offset calculation for image header timestamp
  * docs: add use_gst_timestamps parameter to the readme file
* ci: update docker image for latest ros distribution (#81 <https://github.com/ros-drivers/gscam/issues/81>)
  * ci: update docker image of rolling
  * ci: add humble distribution
  * ci: add workaround for jammy
* Contributors: Clyde McQueen, Daisuke Nishimatsu, David Wong
```
