### PR TITLE
robot_calibration: 0.7.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10476,7 +10476,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/robot_calibration-release.git
-      version: 0.7.0-1
+      version: 0.7.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_calibration` to `0.7.1-1`:

- upstream repository: https://github.com/mikeferguson/robot_calibration.git
- release repository: https://github.com/ros-gbp/robot_calibration-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.7.0-1`

## robot_calibration

```
* enhance alignment (#130 <https://github.com/mikeferguson/robot_calibration/issues/130>)
  * handle NANs in laser data
  * add r2_tolerance
  * add spinOnce so that we can run single threaded
  * exit loop if shutting down
* fix regression in manual calibration (#129 <https://github.com/mikeferguson/robot_calibration/issues/129>)
* fix warnings reported on ros.org buildfarm (#128 <https://github.com/mikeferguson/robot_calibration/issues/128>)
* improve base calibration alignment (#127 <https://github.com/mikeferguson/robot_calibration/issues/127>)
  * add feature to align to arbitrary angle
  * parameterize things, including verbose
* refactor base_calibration into separate class (#126 <https://github.com/mikeferguson/robot_calibration/issues/126>)
* major refactor into re-usable components (#125 <https://github.com/mikeferguson/robot_calibration/issues/125>)
  * add getPosesFromBag function
  * add captureManager to clean up code and improve re-usability
  * split out exportResults as a function
  * for all models, renamed name() to getName(), added getType() function
  * add getCameraNames() function to optimizer, so that we can:
  * output camera calibrations for ALL cameras
* Contributors: Michael Ferguson
```

## robot_calibration_msgs

- No changes
