### PR TITLE
maliput_py: 0.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2366,6 +2366,22 @@ repositories:
       url: https://github.com/maliput/maliput_object.git
       version: main
     status: developed
+  maliput_py:
+    doc:
+      type: git
+      url: https://github.com/maliput/maliput_py.git
+      version: main
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/maliput_py-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/maliput/maliput_py.git
+      version: main
+    status: developed
   map_transformer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_py` to `0.1.0-1`:

- upstream repository: https://github.com/maliput/maliput_py.git
- release repository: https://github.com/ros2-gbp/maliput_py-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## maliput_py

```
* Updates package.xml
* Suppresses old-rule-api-related deprecation warnings. (#62 <https://github.com/maliput/maliput_py/issues/62>)
* Depends on pybind11 package via rosdep. (#61 <https://github.com/maliput/maliput_py/issues/61>)
* Uses ros-action-ci in build.yaml workflow. (#59 <https://github.com/maliput/maliput_py/issues/59>)
* Moves package to root (#60 <https://github.com/maliput/maliput_py/issues/60>)
* Updates license. (#58 <https://github.com/maliput/maliput_py/issues/58>)
* Removes dashing CI. (#57 <https://github.com/maliput/maliput_py/issues/57>)
* Added a binding in RoadPosition for ToInertialPosition method (#56 <https://github.com/maliput/maliput_py/issues/56>)
* Adds IntersectionBook::FindIntersection(inertial_pos) binding. (#55 <https://github.com/maliput/maliput_py/issues/55>)
* Merge pull request #54 <https://github.com/maliput/maliput_py/issues/54> from ToyotaResearchInstitute/voldivh/value_range_method_to_state
* [FEAT]: Changed values() and ranges() method from Rules to states()
* Adds bindings for new GetState method in the state providers. (#53 <https://github.com/maliput/maliput_py/issues/53>)
* Adds BUILD_DOCS flag as opt-in flag (#52 <https://github.com/maliput/maliput_py/issues/52>)
* Adds workflow_dispatch to other workflows. (#51 <https://github.com/maliput/maliput_py/issues/51>)
* Adds PhaseRingBook bindings (#48 <https://github.com/maliput/maliput_py/issues/48>)
* Tests maliput::api interfaces (#47 <https://github.com/maliput/maliput_py/issues/47>)
* Completes RoadNetwork bindings (#46 <https://github.com/maliput/maliput_py/issues/46>)
* Adds IntersectionBook (#45 <https://github.com/maliput/maliput_py/issues/45>)
* Adds CI badges (#50 <https://github.com/maliput/maliput_py/issues/50>)
* Adds Intersection bindings (#44 <https://github.com/maliput/maliput_py/issues/44>)
  Co-authored-by: Franco Cipollone <mailto:53065142+francocipollone@users.noreply.github.com>
* Adds PhaseProvider bindings (#43 <https://github.com/maliput/maliput_py/issues/43>)
* Adds PhaseRing bindings (#42 <https://github.com/maliput/maliput_py/issues/42>)
* Adds Phase bindings. (#41 <https://github.com/maliput/maliput_py/issues/41>)
* Adds bindings for UniqueBulbId, UniqueBulbGroupId and fixes hashing in other Ids (#40 <https://github.com/maliput/maliput_py/issues/40>)
* Adds TrafficLight bindings. (#39 <https://github.com/maliput/maliput_py/issues/39>)
* Adds BulbGroup bindings (#38 <https://github.com/maliput/maliput_py/issues/38>)
* Adds Bulb bindings. (#37 <https://github.com/maliput/maliput_py/issues/37>)
* Adds bindings for some Bulb related types (#36 <https://github.com/maliput/maliput_py/issues/36>)
* Adds bindings for RuleStateProviders. (#35 <https://github.com/maliput/maliput_py/issues/35>)
* Adds RoadRulebook bindings. (#34 <https://github.com/maliput/maliput_py/issues/34>)
* Adds bindings for RuleRegistry. (#33 <https://github.com/maliput/maliput_py/issues/33>)
* Adds DiscreteValueRule and RangeValueRule binding (#32 <https://github.com/maliput/maliput_py/issues/32>)
* Adds bindings for Rule, Rule::State and UniqueId (#30 <https://github.com/maliput/maliput_py/issues/30>)
* Replaces push by workflow_dispatch event in gcc build. (#29 <https://github.com/maliput/maliput_py/issues/29>)
* Completes Lane API bindinds and adds RBounds, HBounds and IsoLaneVelocity. (#28 <https://github.com/maliput/maliput_py/issues/28>)
* Adds LaneEndSet and BranchPoint (#27 <https://github.com/maliput/maliput_py/issues/27>)
* Adds LaneEnd binding. (#26 <https://github.com/maliput/maliput_py/issues/26>)
* Adds python bindings for SRange, LaneSRange and LaneSRoute. (#25 <https://github.com/maliput/maliput_py/issues/25>)
* Extends LanePosition and ***Id python interface (#24 <https://github.com/maliput/maliput_py/issues/24>)
* Extends python interface of some maliput.api entities. (#23 <https://github.com/maliput/maliput_py/issues/23>)
* Adds MaliputPluginManager::ListPlugins binding. (#22 <https://github.com/maliput/maliput_py/issues/22>)
* Documents maliput python interface. (#19 <https://github.com/maliput/maliput_py/issues/19>)
* Tests maliput::api bindings. (#17 <https://github.com/maliput/maliput_py/issues/17>)
* Fixes binding to CreateRoadNetworkFromPlugin method. (#15 <https://github.com/maliput/maliput_py/issues/15>)
* Set up linker properly when using clang. (#13 <https://github.com/maliput/maliput_py/issues/13>)
* Removes ament_target_dependencies  (#12 <https://github.com/maliput/maliput_py/issues/12>)
* Use drake branch of pybind11, use 20.04 in CI (#9 <https://github.com/maliput/maliput_py/issues/9>)
* Use newer revision of pybind11 (#10 <https://github.com/maliput/maliput_py/issues/10>)
* rosdep update --include-eol-distros (#11 <https://github.com/maliput/maliput_py/issues/11>)
* Fix include style part 2: rearrange headers (#8 <https://github.com/maliput/maliput_py/issues/8>)
* Fix include style part 1: use <> for maliput, pybind11 includes (#7 <https://github.com/maliput/maliput_py/issues/7>)
* Upgrade ros-tooling to v0.2.1 (#6 <https://github.com/maliput/maliput_py/issues/6>)
* Rename maliput documentation (#5 <https://github.com/maliput/maliput_py/issues/5>)
* Switch ament_cmake_doxygen to main. (#4 <https://github.com/maliput/maliput_py/issues/4>)
* Optimizes scan-build run in CI. (#3 <https://github.com/maliput/maliput_py/issues/3>)
* Add changelog template (#2 <https://github.com/maliput/maliput_py/issues/2>)
* Split maliput and maliput_py
* Installs git in workflows.
* Adds vcs checkout to matching branch.
* Adds various config and buid files that were not part of the migration.
* Adds CI configuration
* Moves maliput_py contents into maliput_py folder.
* Uses ament_cmake_flake8 package instead of pycodestyle. (#383 <https://github.com/maliput/maliput_py/issues/383>)
* Adds python3 dependency to maliput_py's package.xml. (#382 <https://github.com/maliput/maliput_py/issues/382>)
* Adds a python binding function to easily create a RoadNetwork (#380 <https://github.com/maliput/maliput_py/issues/380>)
* Implements a Plugin architecture (#377 <https://github.com/maliput/maliput_py/issues/377>)
* Rename ToGeoPosition and GeoPosition by ToInertialPosition and InertialPosition (#376 <https://github.com/maliput/maliput_py/issues/376>)
* Adds pylint to maliput_py package. (#375 <https://github.com/maliput/maliput_py/issues/375>)
* Move bindings to another package. (#374 <https://github.com/maliput/maliput_py/issues/374>)
* Initial commit
* Contributors: Agustin Alba Chicar, Chien-Liang Fok, Franco Cipollone, Geoffrey Biggs, Steve Peters, Voldivh
```
