### PR TITLE
maliput_py: 0.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2375,7 +2375,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput_py-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_py` to `0.1.1-1`:

- upstream repository: https://github.com/maliput/maliput_py.git
- release repository: https://github.com/ros2-gbp/maliput_py-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.0-1`

## maliput_py

```
* Removes pylint and pycodestyle explicit dependency. (#63 <https://github.com/maliput/maliput_py/issues/63>)
* Contributors: Franco Cipollone
```
