### PR TITLE
r2r_spl: 0.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3729,6 +3729,25 @@ repositories:
       url: https://github.com/OUXT-Polaris/quaternion_operation.git
       version: ros2
     status: maintained
+  r2r_spl:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/r2r_spl.git
+      version: foxy
+    release:
+      packages:
+      - r2r_spl_7
+      - splsm_7
+      - splsm_7_conversion
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/r2r_spl-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-sports/r2r_spl.git
+      version: foxy
+    status: developed
   radar_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `r2r_spl` to `0.0.1-1`:

- upstream repository: https://github.com/ros-sports/r2r_spl.git
- release repository: https://github.com/ros2-gbp/r2r_spl-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## r2r_spl_7

```
* Initial commit
* Contributors: Kenji Brameld
```

## splsm_7

```
* Initial commit
* Contributors: Kenji Brameld
```

## splsm_7_conversion

```
* Initial commit
* Contributors: Kenji Brameld
```
