### PR TITLE
r2r_spl: 1.0.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3076,6 +3076,25 @@ repositories:
       url: https://github.com/OUXT-Polaris/quaternion_operation.git
       version: ros2
     status: maintained
+  r2r_spl:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/r2r_spl.git
+      version: galactic
+    release:
+      packages:
+      - r2r_spl_7
+      - splsm_7
+      - splsm_7_conversion
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/r2r_spl-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-sports/r2r_spl.git
+      version: galactic
+    status: developed
   radar_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `r2r_spl` to `1.0.0-1`:

- upstream repository: https://github.com/ros-sports/r2r_spl.git
- release repository: https://github.com/ros2-gbp/r2r_spl-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## r2r_spl_7

```
* Initial commit
* Contributors: Kenji Brameld
```

## splsm_7

```
* Initial commit
* Contributors: Kenji Brameld
```

## splsm_7_conversion

```
* Initial commit
* Contributors: Kenji Brameld
```
