### PR TITLE
r2r_spl: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2946,6 +2946,25 @@ repositories:
       url: https://github.com/OUXT-Polaris/quaternion_operation.git
       version: ros2
     status: maintained
+  r2r_spl:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/r2r_spl.git
+      version: humble
+    release:
+      packages:
+      - r2r_spl_7
+      - splsm_7
+      - splsm_7_conversion
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/r2r_spl-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-sports/r2r_spl.git
+      version: humble
+    status: developed
   radar_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `r2r_spl` to `2.0.0-1`:

- upstream repository: https://github.com/ros-sports/r2r_spl.git
- release repository: https://github.com/ros2-gbp/r2r_spl-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## r2r_spl_7

```
* Initial commit
* Contributors: Kenji Brameld
```

## splsm_7

```
* Initial commit
* Contributors: Kenji Brameld
```

## splsm_7_conversion

```
* Initial commit
* Contributors: Kenji Brameld
```
