### PR TITLE
aws-robomaker-small-warehouse-world: 1.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -403,7 +403,8 @@ repositories:
       - aws_robomaker_small_warehouse_world
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/aws-gbp/aws_robomaker_small_warehouse_world-release.git
+      url: https://github.com/ros2-gbp/aws_robomaker_small_warehouse_world-release.git
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/aws-robotics/aws-robomaker-small-warehouse-world.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aws-robomaker-small-warehouse-world` to `1.0.5-1`:

- upstream repository: https://github.com/aws-robotics/aws-robomaker-small-warehouse-world.git
- release repository: https://github.com/ros2-gbp/aws_robomaker_small_warehouse_world-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`
