### PR TITLE
ros2_control: 2.10.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3748,7 +3748,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.9.0-1
+      version: 2.10.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.10.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.9.0-1`

## controller_interface

```
* CMakeLists cleanup (#733 <https://github.com/ros-controls/ros2_control/issues/733>)
* Update to clang format 12 (#731 <https://github.com/ros-controls/ros2_control/issues/731>)
* Make interface_list_contains_interface_type inline (#721 <https://github.com/ros-controls/ros2_control/issues/721>)
* Contributors: Andy Zelenak, Bence Magyar
```

## controller_manager

```
* Make RHEL CI happy! (#730 <https://github.com/ros-controls/ros2_control/issues/730>)
* CMakeLists cleanup (#733 <https://github.com/ros-controls/ros2_control/issues/733>)
* Update to clang format 12 (#731 <https://github.com/ros-controls/ros2_control/issues/731>)
* Contributors: Andy Zelenak, Bence Magyar, Márk Szitanics
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Make RHEL CI happy! (#730 <https://github.com/ros-controls/ros2_control/issues/730>)
* CMakeLists cleanup (#733 <https://github.com/ros-controls/ros2_control/issues/733>)
* Refactored error handling when hardware name is duplicated (#724 <https://github.com/ros-controls/ros2_control/issues/724>)
* Update to clang format 12 (#731 <https://github.com/ros-controls/ros2_control/issues/731>)
* Contributors: Andy Zelenak, Bence Magyar, Kvk Praneeth, Márk Szitanics
```

## ros2_control

- No changes

## ros2_control_test_assets

```
* Make RHEL CI happy! (#730 <https://github.com/ros-controls/ros2_control/issues/730>)
* CMakeLists cleanup (#733 <https://github.com/ros-controls/ros2_control/issues/733>)
* Contributors: Andy Zelenak, Márk Szitanics
```

## ros2controlcli

- No changes

## transmission_interface

```
* CMakeLists cleanup (#733 <https://github.com/ros-controls/ros2_control/issues/733>)
* Update to clang format 12 (#731 <https://github.com/ros-controls/ros2_control/issues/731>)
* Contributors: Andy Zelenak, Bence Magyar
```
