### PR TITLE
ros2_controllers: 2.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3670,7 +3670,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.5.0-1
+      version: 2.6.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.6.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.5.0-1`

## diff_drive_controller

```
* Disable failing workflows (#363 <https://github.com/ros-controls/ros2_controllers/issues/363>)
* CMakeLists cleanup (#362 <https://github.com/ros-controls/ros2_controllers/issues/362>)
* Fix exception about parameter already been declared & Change default c++ version to 17 (#360 <https://github.com/ros-controls/ros2_controllers/issues/360>)
  * Default C++ version to 17
  * Replace explicit use of declare_paremeter with auto_declare
* Contributors: Andy Zelenak, Jafar Abdi
```

## effort_controllers

```
* CMakeLists cleanup (#362 <https://github.com/ros-controls/ros2_controllers/issues/362>)
* Fix exception about parameter already been declared & Change default c++ version to 17 (#360 <https://github.com/ros-controls/ros2_controllers/issues/360>)
  * Default C++ version to 17
  * Replace explicit use of declare_paremeter with auto_declare
* Contributors: Andy Zelenak, Jafar Abdi
```

## force_torque_sensor_broadcaster

```
* Disable failing workflows (#363 <https://github.com/ros-controls/ros2_controllers/issues/363>)
* CMakeLists cleanup (#362 <https://github.com/ros-controls/ros2_controllers/issues/362>)
* Fix exception about parameter already been declared & Change default c++ version to 17 (#360 <https://github.com/ros-controls/ros2_controllers/issues/360>)
  * Default C++ version to 17
  * Replace explicit use of declare_paremeter with auto_declare
* Contributors: Andy Zelenak, Jafar Abdi
```

## forward_command_controller

```
* CMakeLists cleanup (#362 <https://github.com/ros-controls/ros2_controllers/issues/362>)
* Fix exception about parameter already been declared & Change default c++ version to 17 (#360 <https://github.com/ros-controls/ros2_controllers/issues/360>)
  * Default C++ version to 17
  * Replace explicit use of declare_paremeter with auto_declare
* Contributors: Andy Zelenak, Jafar Abdi
```

## gripper_controllers

```
* CMakeLists cleanup (#362 <https://github.com/ros-controls/ros2_controllers/issues/362>)
* Fix exception about parameter already been declared & Change default c++ version to 17 (#360 <https://github.com/ros-controls/ros2_controllers/issues/360>)
  * Default C++ version to 17
  * Replace explicit use of declare_paremeter with auto_declare
* Contributors: Andy Zelenak, Jafar Abdi
```

## imu_sensor_broadcaster

```
* CMakeLists cleanup (#362 <https://github.com/ros-controls/ros2_controllers/issues/362>)
* Fix exception about parameter already been declared & Change default c++ version to 17 (#360 <https://github.com/ros-controls/ros2_controllers/issues/360>)
  * Default C++ version to 17
  * Replace explicit use of declare_paremeter with auto_declare
* Contributors: Andy Zelenak, Jafar Abdi
```

## joint_state_broadcaster

```
* Fix exception about parameter already been declared & Change default c++ version to 17 (#360 <https://github.com/ros-controls/ros2_controllers/issues/360>)
  * Default C++ version to 17
  * Replace explicit use of declare_paremeter with auto_declare
* Contributors: Jafar Abdi
```

## joint_trajectory_controller

```
* Disable failing workflows (#363 <https://github.com/ros-controls/ros2_controllers/issues/363>)
* Fixed lof message in joint_trayectory_controller (#366 <https://github.com/ros-controls/ros2_controllers/issues/366>)
* CMakeLists cleanup (#362 <https://github.com/ros-controls/ros2_controllers/issues/362>)
* Fix exception about parameter already been declared & Change default c++ version to 17 (#360 <https://github.com/ros-controls/ros2_controllers/issues/360>)
  * Default C++ version to 17
  * Replace explicit use of declare_paremeter with auto_declare
* Member variable renaming in the Joint Traj Controller (#361 <https://github.com/ros-controls/ros2_controllers/issues/361>)
* Contributors: Alejandro Hernández Cordero, Andy Zelenak, Jafar Abdi
```

## position_controllers

```
* CMakeLists cleanup (#362 <https://github.com/ros-controls/ros2_controllers/issues/362>)
* Fix exception about parameter already been declared & Change default c++ version to 17 (#360 <https://github.com/ros-controls/ros2_controllers/issues/360>)
  * Default C++ version to 17
  * Replace explicit use of declare_paremeter with auto_declare
* Contributors: Andy Zelenak, Jafar Abdi
```

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## velocity_controllers

```
* CMakeLists cleanup (#362 <https://github.com/ros-controls/ros2_controllers/issues/362>)
* Fix exception about parameter already been declared & Change default c++ version to 17 (#360 <https://github.com/ros-controls/ros2_controllers/issues/360>)
  * Default C++ version to 17
  * Replace explicit use of declare_paremeter with auto_declare
* Contributors: AndyZe, Jafar
```
