### PR TITLE
Add wireguard rosdep key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7834,12 +7834,16 @@ wget:
       packages: [wget]
   ubuntu: [wget]
 wireguard:
-  debian: [wireguard]
+  debian: 
+    '*': [wireguard]
+    buster: null
   fedora: [wireguard-tools]
   gentoo: [net-vpn/wireguard-tools]
   nixos: [wireguard-tools]
   rhel: [wireguard-tools]
-  ubuntu: [wireguard]
+  ubuntu: 
+    '*': [wireguard]
+    bionic: null
 wireless-tools:
   debian: [wireless-tools]
   fedora: [wireless-tools]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7837,7 +7837,7 @@ wireguard:
   debian: [wireguard]
   fedora: [wireguard-tools]
   gentoo: [net-vpn/wireguard-tools]
-  nixos:  [wireguard-tools]
+  nixos: [wireguard-tools]
   rhel: [wireguard-tools]
   ubuntu: [wireguard]
 wireless-tools:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7834,14 +7834,14 @@ wget:
       packages: [wget]
   ubuntu: [wget]
 wireguard:
-  debian: 
+  debian:
     '*': [wireguard]
     buster: null
   fedora: [wireguard-tools]
   gentoo: [net-vpn/wireguard-tools]
   nixos: [wireguard-tools]
   rhel: [wireguard-tools]
-  ubuntu: 
+  ubuntu:
     '*': [wireguard]
     bionic: null
 wireless-tools:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7835,9 +7835,10 @@ wget:
   ubuntu: [wget]
 wireguard:
   debian: [wireguard]
-  fedora: [wireguard]
-  gentoo: [net-vpn/wireguard-modules]
-  nixos:  [wireguard]
+  fedora: [wireguard-tools]
+  gentoo: [net-vpn/wireguard-tools]
+  nixos:  [wireguard-tools]
+  rhel: [wireguard-tools]
   ubuntu: [wireguard]
 wireless-tools:
   debian: [wireless-tools]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7833,6 +7833,12 @@ wget:
     homebrew:
       packages: [wget]
   ubuntu: [wget]
+wireguard:
+  debian: [wireguard]
+  fedora: [wireguard]
+  gentoo: [net-vpn/wireguard-modules]
+  nixos:  [wireguard]
+  ubuntu: [wireguard]
 wireless-tools:
   debian: [wireless-tools]
   fedora: [wireless-tools]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

wireguard

## Package Upstream Source:

https://git.zx2c4.com/wireguard-tools/about/

## Purpose of using this:

Wireguard is used for creating a VPN tunnel, and FogROS 2 utilizes this to connect the robot edge's computer to an AWS VPC securely.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/sid/wireguard
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/jammy/wireguard
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/wireguard-tools/wireguard-tools/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/net-vpn/wireguard-tools
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=22.05&show=wireguard-tools&from=0&size=1&sort=relevance&type=packages&query=wireguard-tools