### PR TITLE
Add python3-wgconfig-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9038,6 +9038,13 @@ python3-west-pip:
   ubuntu:
     pip:
       packages: [west]
+python3-wgconfig-pip:
+  debian:
+    pip:
+      packages: [wgconfig]
+  ubuntu:
+    pip:
+      packages: [wgconfig]
 python3-whichcraft:
   arch: [python-whichcraft]
   debian: [python3-whichcraft]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-wgconfig-pip

## Package Upstream Source:

https://github.com/towalink/wgconfig

## Purpose of using this:

FogROS 2 uses wgconfig to deal with Wireguard configuration files more easily. 

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- pip: https://pypi.org/project/wgconfig/