### PR TITLE
Submit mvsim for indexing in rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2117,6 +2117,16 @@ repositories:
       url: https://github.com/KIT-MRT/mrt_cmake_modules.git
       version: master
     status: maintained
+  mvsim:
+    doc:
+      type: git
+      url: https://github.com/MRPT/mvsim.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/MRPT/mvsim.git
+      version: master
+    status: developed
   nao_button_sim:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

rolling

PS: It's already indexed in other ROS1 repos.

# The source is here: 

https://github.com/MRPT/mvsim

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro 
