### PR TITLE
boost_geometry_util: 0.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -457,6 +457,21 @@ repositories:
       url: https://github.com/ros/bond_core.git
       version: foxy-devel
     status: maintained
+  boost_geometry_util:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/boost_geometry_util.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/OUXT-Polaris/boost_geometry_util-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/boost_geometry_util.git
+      version: master
+    status: developed
   carla_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `boost_geometry_util` to `0.0.1-1`:

- upstream repository: https://github.com/OUXT-Polaris/boost_geometry_util.git
- release repository: https://github.com/OUXT-Polaris/boost_geometry_util-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## boost_geometry_util

```
* Merge pull request #1 <https://github.com/OUXT-Polaris/boost_geometry_util/issues/1> from OUXT-Polaris/workflow/sync
  [Bot] Update workflow
* Setup workflow
* add toPolygon function template
* add ToPolygon function
* add toPolygon function
* rename namespace
* rename header and source file
* add convex hull in test case
* add testcase for line string
* add test case
* add constructor
* add sample code
* add license file
* initial commit
* Contributors: Masaya Kataoka, wam-v-tan
```
