### PR TITLE
geomerty2_python3: 0.6.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2888,6 +2888,23 @@ repositories:
       url: https://github.com/ros-geographic-info/geographic_info.git
       version: master
     status: maintained
+  geomerty2_python3:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/geometry2_python3.git
+      version: melodic-devel
+    release:
+      packages:
+      - jsk_tf2_py_python3
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/tork-a/geometry2_python3-release.git
+      version: 0.6.9-1
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/geometry2_python3.git
+      version: melodic-devel
+    status: maintained
   geometric_shapes:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geomerty2_python3` to `0.6.9-1`:

- upstream repository: https://github.com/jsk-ros-pkg/geometry2_python3.git
- release repository: https://github.com/tork-a/geometry2_python3-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`
