### PR TITLE
orocos-kdl_python3: 1.4.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6266,6 +6266,23 @@ repositories:
       url: https://github.com/Jmeyer1292/opw_kinematics.git
       version: master
     status: developed
+  orocos-kdl_python3:
+    doc:
+      type: git
+      url: https://github.com/tork-a/orocos-kdl_python3-release.git
+      version: melodic
+    release:
+      packages:
+      - jsk_python_orocos_kdl_python3
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/tork-a/orocos-kdl_python3-release.git
+      version: 1.4.2-1
+    source:
+      type: git
+      url: https://github.com/tork-a/orocos-kdl_python3-release.git
+      version: melodic
+    status: maintained
   osqp_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos-kdl_python3` to `1.4.2-1`:

- upstream repository: https://github.com/jsk-ros-pkg/orocos_kinematics_dynamics_python3.git
- release repository: https://github.com/tork-a/orocos-kdl_python3-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`
