### PR TITLE
orocos-kdl_python3: 1.4.2-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8486,6 +8486,23 @@ repositories:
       url: https://github.com/appliedAI-Initiative/orb_slam_2_ros.git
       version: master
     status: maintained
+  orocos-kdl_python3:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/orocos_kinematics_dynamics_python3.git
+      version: melodic
+    release:
+      packages:
+      - jsk_python_orocos_kdl_python3
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/orocos-kdl_python3-release.git
+      version: 1.4.2-2
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/orocos_kinematics_dynamics_python3.git
+      version: melodic
+    status: maintained
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos-kdl_python3` to `1.4.2-2`:

- upstream repository: https://github.com/jsk-ros-pkg/orocos_kinematics_dynamics_python3.git
- release repository: https://github.com/tork-a/orocos-kdl_python3-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`
