### PR TITLE
geomerty2_python3: 0.6.9-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5263,6 +5263,23 @@ repositories:
       url: https://github.com/jsk-ros-pkg/jsk_control.git
       version: master
     status: developed
+  jsk_geometry2_python3:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/geometry2_python3.git
+      version: melodic-devel
+    release:
+      packages:
+      - jsk_tf2_py_python3
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/geometry2_python3-release.git
+      version: 0.6.9-2
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/geometry2_python3.git
+      version: melodic-devel
+    status: maintained
   jsk_model_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geomerty2_python3` to `0.6.9-2`:

- upstream repository: https://github.com/jsk-ros-pkg/geometry2_python3.git
- release repository: https://github.com/tork-a/geometry2_python3-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`
