### PR TITLE
navigation: 1.17.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5546,7 +5546,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.17.1-1
+      version: 1.17.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.17.2-1`:

- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.17.1-1`

## amcl

```
* Update pf.c (#1161 <https://github.com/ros-planning/navigation/issues/1161>)
  #1160 <https://github.com/ros-planning/navigation/issues/1160> AMCL miscalculates orientation covariance for clusters
* Improved Overall readablity (#1177 <https://github.com/ros-planning/navigation/issues/1177>)
* fix crashes in AMCL (#1152 <https://github.com/ros-planning/navigation/issues/1152>)
  * fix: catch runtime_error from roscore
  * ignore malformed message from laser, otherwise it will crash
* Fixes #1117 <https://github.com/ros-planning/navigation/issues/1117> (#1118 <https://github.com/ros-planning/navigation/issues/1118>)
* Fixed the risk of divide by zero. (#1099 <https://github.com/ros-planning/navigation/issues/1099>)
* (AMCL) add missing test dep on tf2_py (#1091 <https://github.com/ros-planning/navigation/issues/1091>)
* (AMCL)(Noetic) use robot pose in tests (#1087 <https://github.com/ros-planning/navigation/issues/1087>)
* (amcl) fix missing '#if NEW_UNIFORM_SAMPLING' (#1079 <https://github.com/ros-planning/navigation/issues/1079>)
* Contributors: David V. Lu!!, Matthijs van der Burgh, Noriaki Ando, Supernovae, christofschroeter, easylyou
```

## base_local_planner

```
* Commit 89a8593 removed footprint scaling. This brings it back. (#886 <https://github.com/ros-planning/navigation/issues/886>) (#1204 <https://github.com/ros-planning/navigation/issues/1204>)
  Co-authored-by: Frank Höller <mailto:frank.hoeller@fkie.fraunhofer.de>
* Contributors: Michael Ferguson
```

## carrot_planner

```
* Fix carrot planner (#1056 <https://github.com/ros-planning/navigation/issues/1056>)
  * fix memory leak of world_model_
  * fix uninitialized raw pointers
  * move the angles header into cpp
  * add missing angles dependency
  Co-authored-by: Dima Dorezyuk <mailto:dorezyuk@magazino.eu>
* Contributors: Dima Dorezyuk
```

## clear_costmap_recovery

```
* check if the layer is derived from costmap_2d::CostmapLayer (#1054 <https://github.com/ros-planning/navigation/issues/1054>)
  Co-authored-by: Dima Dorezyuk <mailto:dorezyuk@magazino.eu>
* Add invert_area_to_clear to clear costmap recovery behavior (#1030 <https://github.com/ros-planning/navigation/issues/1030>)
* Contributors: Dima Dorezyuk, G.Doisy
```

## costmap_2d

```
* Removed unused variables in costmap_2d_ros (#1126 <https://github.com/ros-planning/navigation/issues/1126>)
  remove unused robot_stopped_, old_pose_ and timer_
* Check if stamp of transformed pose is non-zero (#1200 <https://github.com/ros-planning/navigation/issues/1200>)
* fix crashes in AMCL (#1152 <https://github.com/ros-planning/navigation/issues/1152>)
  * fix: catch runtime_error from roscore
  * ignore malformed message from laser, otherwise it will crash
* The main function has to return an int value. (#1101 <https://github.com/ros-planning/navigation/issues/1101>)
* fix boundary point exclusion in convexFillCells (#1095 <https://github.com/ros-planning/navigation/issues/1095>)
* Fix deadlock when starting map with map-update-frequency set to zero (#1072 <https://github.com/ros-planning/navigation/issues/1072>)
  Co-authored-by: Dima Dorezyuk <mailto:dorezyuk@magazino.eu>
* Increase scope of costmap mutex in publishCostmap to cover costmap calls (#992 <https://github.com/ros-planning/navigation/issues/992>)
* costmap_2d: remove useless and buggy testing helper function (#1069 <https://github.com/ros-planning/navigation/issues/1069>) (#1070 <https://github.com/ros-planning/navigation/issues/1070>)
  Co-authored-by: JF Dalbosco <mailto:jean-francois.dalbosco@safrangroup.com>
* Fix future robot pose by Costmap2D (#1066 <https://github.com/ros-planning/navigation/issues/1066>)
  Co-authored-by: Pavlo Kolomiiets <mailto:pavlo@blindnology.com>
* use const-ref-getter for strings and vectors (#1035 <https://github.com/ros-planning/navigation/issues/1035>)
  Co-authored-by: Dima Dorezyuk <mailto:dorezyuk@magazino.eu>
* move enabled-logic to the LayeredCostmap (#1036 <https://github.com/ros-planning/navigation/issues/1036>)
  Co-authored-by: Dima Dorezyuk <mailto:dorezyuk@magazino.eu>
* cosmetic change (#1055 <https://github.com/ros-planning/navigation/issues/1055>)
* costmap_2d: Add missing package dependency to Eigen (#1033 <https://github.com/ros-planning/navigation/issues/1033>)
* Add invert_area_to_clear to clear costmap recovery behavior (#1030 <https://github.com/ros-planning/navigation/issues/1030>)
* Contributors: Atsushi Watanabe, ChristofDubs, Dhruv Maroo, Dima Dorezyuk, G.Doisy, Griswald Brooks, Noriaki Ando, Pavlo Kolomiiets, Yuki Furuta, Yukihiro Saito, easylyou, jdalbosc
```

## dwa_local_planner

- No changes

## fake_localization

- No changes

## global_planner

```
* Throttled failed to get plan error to 5 seconds (#1102 <https://github.com/ros-planning/navigation/issues/1102>)
* Fixed the risk of divide by zero. (#1099 <https://github.com/ros-planning/navigation/issues/1099>)
* No virtual destructor polyformic classes fixed.  (#1100 <https://github.com/ros-planning/navigation/issues/1100>)
* Fixes #1026 <https://github.com/ros-planning/navigation/issues/1026> (#1028 <https://github.com/ros-planning/navigation/issues/1028>)
* correctly delete previously allocated array (#1025 <https://github.com/ros-planning/navigation/issues/1025>)
  Co-authored-by: Fedor Vlasov <mailto:fedor.vlasov@de.kaercher.com>
* Contributors: David V. Lu!!, Noriaki Ando, Orhan G. Hafif, mechatheo
```

## map_server

```
* Change_map service to map_server [Rebase/Noetic] (#1029 <https://github.com/ros-planning/navigation/issues/1029>)
  * Refactored map loading from constructor to three methods
  * Added change_map service using LoadMap.srv
* map_server: Initialise a NodeHandle in main. (#1122 <https://github.com/ros-planning/navigation/issues/1122>)
* Add debug output regarding waiting for time (#1078 <https://github.com/ros-planning/navigation/issues/1078>)
  Added debug messages suggested in https://github.com/ros-planning/navigation/issues/1074#issuecomment-751557177. Makes it easier to discover if use_sim_time is true but no clock server is running
* crop_map: Fix extra pixel origin shift up every cropping (#1064 <https://github.com/ros-planning/navigation/issues/1064>) (#1067 <https://github.com/ros-planning/navigation/issues/1067>)
  Co-authored-by: Pavlo Kolomiiets <mailto:pavlo@blindnology.com>
* (map_server) add rtest dependency to tests (#1061 <https://github.com/ros-planning/navigation/issues/1061>)
* [noetic] MapServer variable cleanup: Precursor for #1029 <https://github.com/ros-planning/navigation/issues/1029> (#1043 <https://github.com/ros-planning/navigation/issues/1043>)
* Contributors: Christian Fritz, David V. Lu!!, Matthijs van der Burgh, Nikos Koukis, Pavlo Kolomiiets
```

## move_base

```
* Check if stamp of transformed pose is non-zero (#1200 <https://github.com/ros-planning/navigation/issues/1200>)
* Create move_base catkin library (#1116 <https://github.com/ros-planning/navigation/issues/1116>)
  Co-authored-by: vkotaru <mailto:prasant.kotaru@gmail.com>
* move_base crash when using default recovery behaviors (#1071 <https://github.com/ros-planning/navigation/issues/1071>)
* Publish recovery behavior melodic (#1051 <https://github.com/ros-planning/navigation/issues/1051>) (#1052 <https://github.com/ros-planning/navigation/issues/1052>)
  * First prototype of publishing recovery status
  custom message tells you where the behavior occured, the name, index,
  and total number of behaviors.
  * fix message field typos
  Co-authored-by: Peter Mitrano <mailto:mitranopeter@gmail.com>
  Co-authored-by: Peter Mitrano <mailto:mitranopeter@gmail.com>
* Contributors: David V. Lu!!, Prasanth Kotaru, Yuki Furuta, mattp256
```

## move_slow_and_clear

```
* [move_slow_and_clear] Add rosparam representing max vel rosparam name (#1039 <https://github.com/ros-planning/navigation/issues/1039>)
* Contributors: Naoya Yamaguchi
```

## nav_core

- No changes

## navfn

```
* navfn: stop installing test headers (#1085 <https://github.com/ros-planning/navigation/issues/1085>)
  The navtest executable is only built if FLTK is installed. However, the
  header it uses is installed regardless, and requires FLTK. Nothing else
  uses this header, and navfn doesn't depend upon FLTK, so stop installing
  the header. Also fix navtest to actually build when FLTK is installed.
* Contributors: Kyle Fazzari
```

## navigation

- No changes

## rotate_recovery

- No changes

## voxel_grid

- No changes
