### PR TITLE
ur_robot_driver: 2.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6507,6 +6507,28 @@ repositories:
       url: https://github.com/ros-industrial/ur_msgs.git
       version: foxy
     status: developed
+  ur_robot_driver:
+    doc:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
+      version: foxy
+    release:
+      packages:
+      - ur_bringup
+      - ur_controllers
+      - ur_dashboard_msgs
+      - ur_description
+      - ur_moveit_config
+      - ur_robot_driver
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
+      version: foxy
+    status: maintained
   urdf:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.0.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## ur_bringup

```
* Updated package dependencies (#399 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/399>)
* Foxy: Update dependencies and binary repos file (#373 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/373>)
* Foxy controller stopper (#324 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/324>)
* Fix ros2 control xacro (#213 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/213>)
* Add parameters for checking start state (#143 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/143>)
* Update for changes to ros2_control and ros2_controllers
  See: https://github.com/ros-controls/ros2_control/commit/156a3f6aaed319585a8a1fd445693e2e08c30ccd
  and: https://github.com/ros-controls/ros2_controllers/commit/612f610c24d026a41abd2dd026902c672cf778c9#diff-5d3e18800b3a217b37b91036031bdb170f5183970f54d1f951bb12f2e4847706
* Removed dashboard client from hardware interface
* README cleanup, make MoveIt installation optional (#86 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/86>)
* Using modern python
* Some intermediate commit
* Restore ur_control.launch.py
* Added view_ur for checking description
* Make an optional launch arg for RViz, document it in README (#82 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/82>)
* Review CI by correcting the configurations (#71 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/71>)
* Add support for gpios, update MoveIt and ros2_control launching (#66 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/66>)
* Delete controller_stopper and ur_bringup pkgs
* Add XML schema to all ``package.xml`` files
* Update packaging for ROS2
* Update package.xml files so ``ros2 pkg list`` shows all pkgs
* Delete all launch/config files with no UR5 relation
* Update CMakeLists and package.xml for:
* Change pkg versions to 0.0.0
* Add ur5_moveit_config, ur_bringup, ur_description pkgs
* Contributors: AndyZe, Denis Stogl, Denis Štogl, Felix Exner, Gaël Écorchard, John Morris, Kenneth Bogert, Marvin Große Besselmann, livanov93
```

## ur_controllers

```
* Updated package dependencies (#399 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/399>)
* Foxy controller stopper (#324 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/324>)
* Fixing foxy CI (#157 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/157>)
* Moved registering publisher and service to on_active (#151 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/151>)
* Correct formatting, include std::vector and update ros2_controller to master branch in repo file.
* Correct check for fixed has_trajectory_msg()
* Update for changes to ros2_control and ros2_controllers
* Fix gpio controller (#103 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/103>)
* Fixed speed slider service call (#100 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/100>)
* Reintegrating missing ur_client_library dependency since the break the building process (#97 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/97>)
* Setting speed slider with range of 0.0-1.0 and added warnings if range is exceeded (#88 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/88>)
* Fix move to home bug (#92 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/92>)
* Last fix-ups
* Some intermediate commit
* Last fix-ups
* Review CI by correcting the configurations (#71 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/71>)
* Add support for gpios, update MoveIt and ros2_control launching (#66 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/66>)
* Fix warning about deprecated controller_interface::return_type::SUCCESS (#68 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/68>)
* Use GitHub Actions, use pre-commit formatting (#56 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/56>)
* Scaled Joint Trajectory Controller (#43 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/43>)
* Code cleanup
* Only load speed scaling interface
* Removed controller from config file to realign with current branch
* Removed last remnants of joint_state_controller
* Added publisher rate
* Code formatting and cleanup
* Added publisher for speed scaling factor
* Initial version of the speed_scaling_state_controller
  Controller is base on the current joint_state_controller of ros2 control
* Update licence.
* Fix clang tidy in multiple pkgs.
* Update force torque state controller.
* Prepare for testing.
* Update ft state controller with ros2_control changes.
* Remove lifecycle node (update with ros2_control changes).
* Claim individual resources.
* Add force torque controller.
* Claim individual resources.
* Add force torque controller.
* Add XML schema to all ``package.xml`` files
  Better enable ``ament_xmllint`` to check validity.
* Silence ``ament_lint_cmake`` errors
* Update package.xml files so ``ros2 pkg list`` shows all pkgs
* Clean out ur_controllers, it needs a complete rewrite
* Update CMakeLists and package.xml for:
  - ur5_moveit_config
  - ur_bringup
  - ur_description
* Change pkg versions to 0.0.0
* Contributors: AndyZe, Denis Stogl, Denis Štogl, Felix Exner, John Morris, Kenneth Bogert, Lovro, Mads Holm Peters, Marvin Große Besselmann, livanov93
```

## ur_dashboard_msgs

```
* Review CI by correcting the configurations (#71 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/71>)
  * Update license.
  * Update CI configs.
  Co-authored-by: Lovro <mailto:lovro.ivanov@gmail.com>
  Co-authored-by: AndyZe <mailto:zelenak@picknik.ai>
* Use GitHub Actions, use pre-commit formatting (#56 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/56>)
* Add XML schema to all ``package.xml`` files
  Better enable ``ament_xmllint`` to check validity.
* Compile ur_dashboard_msgs for ROS2
* Contributors: AndyZe, Denis Štogl, John Morris, livanov93
```

## ur_description

```
* Migrated the description to ROS2
* Added support for Gazebo and Ignition
* Added ROS2_control definitions
* Contributors: AndyZe, Denis Stogl, Denis Štogl, Felix Exner, John Morris, Jorge Nicho, Lovro, Lukas Sackewitz, Marvin Große Besselmann, Robert Wilbrandt, Tirine, Vatan Aksoy Tezer, livanov93, urmahp
```

## ur_moveit_config

```
* Updated package dependencies (#399 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/399>)
* Remove obsolete and unused files and packages. (#80 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/80>)
* Review CI by correcting the configurations (#71 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/71>)
* Add support for gpios, update MoveIt and ros2_control launching (#66 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/66>)
* Contributors: Denis Štogl, Felix Exner
```

## ur_robot_driver

```
* Updated package dependencies (#399 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/399>)
* Foxy controller stopper (#324 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/324>)
* Backport: Change driver constructor and change calibration check (#282 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/282>) (#302 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/302>)
* Moved registering publisher and service to on_active (#151 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/151>)
* Converted io_test and switch_on_test to ROS2 (#124 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/124>)
* Added loghandler to handle log messages from the Client Library with … (#126 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/126>)
* Removed dashboard client from hardware interface
* [WIP] Updated feature list (#102 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/102>)
* Moved Async check out of script running check (#112 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/112>)
* Fix gpio controller (#103 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/103>)
* Fixed speed slider service call (#100 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/100>)
* Adding missing backslash and only setting workdir once (#108 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/108>)
* Added dockerfile for the driver (#105 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/105>)
* Using official Universal Robot Client Library (#101 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/101>)
* Reintegrating missing ur_client_library dependency since the break the building process (#97 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/97>)
* Fix readme hardware setup (#91 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/91>)
* Fix move to home bug (#92 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/92>)
* Using modern python
* Some intermediate commit
* Remove obsolete and unused files and packages. (#80 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/80>)
* Review CI by correcting the configurations (#71 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/71>)
* Add support for gpios, update MoveIt and ros2_control launching (#66 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/66>)
* Quickfix against move home bug
* Added missing initialization
* Use GitHub Actions, use pre-commit formatting (#56 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/56>)
* Put dashboard services into corresponding namespace
* Start dashboard client from within the hardware interface
* Added try catch blocks for service calls
* Removed repeated declaration of timeout parameter which lead to connection crash
* Removed static service name in which all auto generated services where mapped
* Removed unused variable
* Fixed clang-format issue
* Removed all robot status stuff
* Exchanged hardcoded value for RobotState msgs enum
* Removed currently unused controller state variables
* Added placeholder for industrial_robot_status_interface
* Fixed clang issues
* Added checks for internal robot state machine
* Only load speed scaling interface
* Changed state interface to combined speed scaling factor
* Added missing formatting in hardware interface
* Initial version of the speed_scaling_state_controller
  Controller is base on the current joint_state_controller of ros2 control
* Fix clang tidy in multiple pkgs.
* Clang tidy fix.
* Update force torque state controller.
* Prepare for testing.
* Fix decision breaker for position control. Make decision effect instantaneous.
* Use only position interface.
* Update hardware interface for ROS2 (#8 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/8>)
* Update the dashboard client for ROS2 (#5 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/5>)
* Hardware interface framework (#3 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/3>)
* Add XML schema to all ``package.xml`` files
  Better enable ``ament_xmllint`` to check validity.
* Silence ``ament_lint_cmake`` errors
* Update packaging for ROS2
* Update package.xml files so ``ros2 pkg list`` shows all pkgs
* Clean out ur_robot_driver for initial ROS2 compilation
* Compile ur_dashboard_msgs for ROS2
* Delete all launch/config files with no UR5 relation
* Initial work toward compiling ur_robot_driver
* Update CMakeLists and package.xml for:
  - ur5_moveit_config
  - ur_bringup
  - ur_description
* Change pkg versions to 0.0.0
* Contributors: AndyZe, Denis Stogl, Denis Štogl, Felix Exner, John Morris, Lovro, Mads Holm Peters, Marvin Große Besselmann, livanov93
```
