### PR TITLE
ur_robot_driver: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5322,6 +5322,29 @@ repositories:
       url: https://github.com/ros-industrial/ur_msgs.git
       version: foxy
     status: developed
+  ur_robot_driver:
+    doc:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
+      version: main
+    release:
+      packages:
+      - ur
+      - ur_bringup
+      - ur_calibration
+      - ur_controllers
+      - ur_dashboard_msgs
+      - ur_moveit_config
+      - ur_robot_driver
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
+      version: 2.2.0-1
+    source:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
+      version: main
+    status: developed
   urdf:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.2.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## ur

```
* wip
* Rework bringup (#403 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/403>)
  * Copy all bringup files to ur_robot_driver
  * Update documentation to use launchfiles from ur_robot_driver
  * Add deprecation warnings for ur_bringup
  * Add ``ur`` metapackage
  * Added deprecation warning to toplevel README
  * Added meta package to CI checks
* Contributors: Felix Exner
* Rework bringup (#403 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/403>)
* Contributors: Felix Exner
```

## ur_bringup

```
* Updated package maintainers
* Rework bringup (#403 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/403>)
* Fix force_torque_sensor_broadcaster config (#405 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/405>)
* Prepare for humble (#394 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/394>)
* Update dependencies on all packages (#391 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/391>)
* Add sphinx documentation (#340 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/340>)
* Use upstream fts_broadcaster (#304 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/304>)
* Update license to BSD-3-Clause (#277 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/277>)
* Only start controller_stopper when not using fake_hardware (#332 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/332>)
* Added controller stopper node (#309 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/309>)
* Fix package dependencies (#306 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/306>)
* Make documentation on how to use driver clearer. (#300 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/300>)
* Update MoveIt file for working with simulation. (#278 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/278>)
* Start the tool communication script if the flag is set (#267 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/267>)
* Used ``spawner`` instead of ``spanwer.py`` in launch files (#293 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/293>)
* Do not start dashboard client if FakeHardware simuation is used. (#286 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/286>)
* Use scaled trajectory controller per default. (#287 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/287>)
* Separate control node (#281 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/281>)
* Fix launch file arguments. (#243 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/243>)
* Move Servo launching into the main MoveIt launch file. Make it optional. (#239 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/239>)
* Tool communication (#218 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/218>)
* fix missing executable arg of joint_state_broadcaster (#248 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/248>)
* Remove obsolete comment 🐒 (#242 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/242>)
* Revert "Ignition Gazebo simulation for UR robots (#232 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/232>)" (#241 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/241>)
* Use 'spawner' instead of 'spawner.py' (#225 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/225>)
* Ignition Gazebo simulation for UR robots (#232 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/232>)
* Empirically set update rates. (#227 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/227>)
* Fix update rate configuration (#222 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/222>)
* Test execution tests (#216 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/216>)
* Integration tests improvement (#206 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/206>)
* Add resend program service and enable headless mode (#198 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/198>)
* Add default per joint constraints. (#203 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/203>)
* Do not customize the planning scene topics (#205 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/205>)
* Implement "choices" for robot_type param (#204 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/204>)
* Joint limits parameters for Moveit planning (#187 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/187>)
* Rename the joint controller that is launched by default (#185 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/185>)
* Enabling velocity mode (#146 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/146>)
* Add parameters for checking start state (#143 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/143>)
* Update for changes to ros2_control and ros2_controllers
  See: https://github.com/ros-controls/ros2_control/commit/156a3f6aaed319585a8a1fd445693e2e08c30ccd
  and: https://github.com/ros-controls/ros2_controllers/commit/612f610c24d026a41abd2dd026902c672cf778c9#diff-5d3e18800b3a217b37b91036031bdb170f5183970f54d1f951bb12f2e4847706
* Removed dashboard client from hardware interface
* README cleanup, make MoveIt installation optional (#86 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/86>)
* Using modern python
* Restore ur_control.launch.py
* Added view_ur for checking description
* Make an optional launch arg for RViz, document it in README (#82 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/82>)
* Review CI by correcting the configurations (#71 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/71>)
* Add support for gpios, update MoveIt and ros2_control launching (#66 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/66>)
* Delete controller_stopper and ur_bringup pkgs
* Add XML schema to all ``package.xml`` files
  Better enable ``ament_xmllint`` to check validity.
* Update packaging for ROS2
* Update package.xml files so ``ros2 pkg list`` shows all pkgs
* Delete all launch/config files with no UR5 relation
* Update CMakeLists and package.xml for:
  - ur5_moveit_config
  - ur_bringup
  - ur_description
* Change pkg versions to 0.0.0
* Add ur5_moveit_config, ur_bringup, ur_description pkgs
* Contributors: AndyZe, Denis Stogl, Denis Štogl, Felix Exner, John Morris, Kenneth Bogert, Mads Holm Peters, Marvin Große Besselmann, Thomas Barbier, Vatan Aksoy Tezer, livanov93, relffok, Robert Wilbrandt
```

## ur_calibration

```
* Updated package maintainers
* Update license to BSD-3-Clause (#277 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/277>)
* Add missing dependency on angles and update formatting for linters. (#283 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/283>)
* Calibration extraction package (#186 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/186>)
* Contributors: Denis Štogl, Felix Exner, livanov93
```

## ur_controllers

```
* Updated package maintainers
* Prepare for humble (#394 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/394>)
* Update dependencies on all packages (#391 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/391>)
* Update controllers' API (#351 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/351>)
* Update binary dependencies (#344 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/344>)
* Use upstream fts_broadcaster (#304 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/304>)
* Update license to BSD-3-Clause (#277 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/277>)
* Added controller stopper node (#309 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/309>)
* Add missing dependency on angles and update formatting for linters. (#283 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/283>)
* Payload service (#238 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/238>)
* Integration tests improvement (#206 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/206>)
* Add resend program service and enable headless mode (#198 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/198>)
* Update controllers adding dt in to update as in ros2_control (#171 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/171>)
* Update main branch with ros-controls changes (#160 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/160>)
* Update CI configuration to support galactic and rolling (#142 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/142>)
* Modify parameter declaration - approach equalization with ros-controls dependencies (#152 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/152>)
* Moved registering publisher and service to on_active (#151 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/151>)
* Correct formatting, include std::vector and update ros2_controller to master branch in repo file.
* Correct check for fixed has_trajectory_msg()
  See: https://github.com/ros-controls/ros2_controllers/commit/32f089b3f3b53a817412c6bbce9046028786431e
* Update for changes to ros2_control and ros2_controllers
  See: https://github.com/ros-controls/ros2_control/commit/156a3f6aaed319585a8a1fd445693e2e08c30ccd
  and: https://github.com/ros-controls/ros2_controllers/commit/612f610c24d026a41abd2dd026902c672cf778c9#diff-5d3e18800b3a217b37b91036031bdb170f5183970f54d1f951bb12f2e4847706
* Fix gpio controller (#103 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/103>)
* Fixed speed slider service call (#100 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/100>)
* Reintegrating missing ur_client_library dependency since the break the building process (#97 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/97>)
* Setting speed slider with range of 0.0-1.0 and added warnings if range is exceeded (#88 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/88>)
* Fix move to home bug (#92 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/92>)
* Review CI by correcting the configurations (#71 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/71>)
* Add support for gpios, update MoveIt and ros2_control launching (#66 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/66>)
* Fix warning about deprecated controller_interface::return_type::SUCCESS (#68 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/68>)
* Use GitHub Actions, use pre-commit formatting (#56 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/56>)
* Scaled Joint Trajectory Controller (#43 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/43>)
* Only load speed scaling interface
* Removed controller from config file to realign with current branch status
* Removed last remnants of joint_state_controller
* Added publisher rate
* Code formatting and cleanup
* Added publisher for speed scaling factor
* Initial version of the speed_scaling_state_controller
* Update licence.
* Fix clang tidy in multiple pkgs.
* Update force torque state controller.
* Prepare for testing.
* Update ft state controller with ros2_control changes.
* Remove lifecycle node (update with ros2_control changes).
* Claim individual resources.
* Add force torque controller.
* Claim individual resources.
* Add force torque controller.
* Add XML schema to all ``package.xml`` files
  Better enable ``ament_xmllint`` to check validity.
* Update package.xml files so ``ros2 pkg list`` shows all pkgs
* Clean out ur_controllers, it needs a complete rewrite
* Update CMakeLists and package.xml for:
  - ur5_moveit_config
  - ur_bringup
  - ur_description
* Change pkg versions to 0.0.0
* Contributors: AndyZe, Denis Stogl, Denis Štogl, Felix Exner, John Morris, Kenneth Bogert, Lovro, Mads Holm Peters, Marvin Große Besselmann, livanov93
```

## ur_dashboard_msgs

```
* Updated package maintainers
* Update license to BSD-3-Clause (#277 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/277>)
* Review CI by correcting the configurations (#71 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/71>)
* Use GitHub Actions, use pre-commit formatting (#56 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/56>)
* Add XML schema to all ``package.xml`` files
* Compile ur_dashboard_msgs for ROS2
* Contributors: AndyZe, Denis Štogl, Felix Exner, John Morris, livanov93
```

## ur_moveit_config

```
* Updated package maintainers
* Prepare for humble (#394 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/394>)
* Update dependencies on all packages (#391 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/391>)
* Replace warehouse_ros_mongo with warehouse_ros_sqlite (#362 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/362>)
* Add missing dep to warehouse_ros_mongo (#352 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/352>)
* Update license to BSD-3-Clause (#277 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/277>)
* Correct loading kinematics parameters from yaml (#308 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/308>)
* Update MoveIt file for working with simulation. (#278 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/278>)
* Changing default controller in MoveIt config. (#288 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/288>)
* Move Servo launching into the main MoveIt launch file. Make it optional. (#239 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/239>)
* Joint limits parameters for Moveit planning (#187 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/187>)
* Update Servo parameters, for smooth motion (#188 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/188>)
* Enabling velocity mode (#146 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/146>)
* Remove obsolete and unused files and packages. (#80 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/80>)
* Review CI by correcting the configurations (#71 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/71>)
* Add support for gpios, update MoveIt and ros2_control launching (#66 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/66>)
* Contributors: AndyZe, Denis Štogl, Felix Exner, livanov93, Robert Wilbrandt
```

## ur_robot_driver

```
* Updated package maintainers
* Rework bringup (#403 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/403>)
* Prepare for humble (#394 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/394>)
* Update dependencies on all packages (#391 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/391>)
* Update HW-interface API for humble. (#377 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/377>)
* Use types in hardware interface from ros2_control in local namespace (#339 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/339>)
* Update header extension to remove compile warning. (#285 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/285>)
* Add resource files from ROS World. (#226 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/226>)
* Add sphinx documentation (#340 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/340>)
* Update license to BSD-3-Clause (#277 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/277>)
* Update ROS_INTERFACE.md to current driver (#335 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/335>)
* Fix hardware interface names in error output (#329 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/329>)
* Added controller stopper node (#309 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/309>)
* Correct link to calibration extraction (#310 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/310>)
* Start the tool communication script if the flag is set (#267 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/267>)
* Change driver constructor and change calibration check (#282 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/282>)
* Use GPIO tag from URDF in driver. (#224 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/224>)
* Separate control node (#281 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/281>)
* Add missing dependency on angles and update formatting for linters. (#283 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/283>)
* Do not print an error output if writing is not possible (#266 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/266>)
* Update features.md (#250 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/250>)
* Tool communication (#218 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/218>)
* Payload service (#238 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/238>)
* Import transformation of force-torque into tcp frame from ROS1 driver (https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/blob/master/ur_robot_driver/src/hardware_interface.cpp). (#237 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/237>)
* Make reading and writing work when hardware is disconnected (#233 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/233>)
* Add missing command and state interfaces to get everything working with the fake hardware and add some comment into xacro file to be clearer. (#221 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/221>)
* Decrease the rate of async tasks. (#223 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/223>)
* Change robot type. (#220 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/220>)
* Driver to headless. (#217 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/217>)
* Test execution tests (#216 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/216>)
* Integration tests improvement (#206 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/206>)
* Set start modes to empty. Avoid position ctrl loop on start. (#211 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/211>)
* Add resend program service and enable headless mode (#198 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/198>)
* Implement "choices" for robot_type param (#204 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/204>)
* Calibration extraction package (#186 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/186>)
* Add breaking api changes from ros2_control to hardware_interface (#189 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/189>)
* Fix prepare and perform switch operation (#191 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/191>)
* Update CI configuration to support galactic and rolling (#142 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/142>)
* Dockerize ursim with driver in docker compose (#144 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/144>)
* Enabling velocity mode (#146 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/146>)
* Moved registering publisher and service to on_active (#151 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/151>)
* Converted io_test and switch_on_test to ROS2 (#124 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/124>)
* Added loghandler to handle log messages from the Client Library with … (#126 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/126>)
* Removed dashboard client from hardware interface
* [WIP] Updated feature list (#102 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/102>)
* Moved Async check out of script running check (#112 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/112>)
* Fix gpio controller (#103 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/103>)
* Fixed speed slider service call (#100 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/100>)
* Adding missing backslash and only setting workdir once (#108 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/108>)
* Added dockerfile for the driver (#105 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/105>)
* Using official Universal Robot Client Library (#101 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/101>)
* Reintegrating missing ur_client_library dependency since the break the building process (#97 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/97>)
* Fix readme hardware setup (#91 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/91>)
* Fix move to home bug (#92 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/92>)
* Using modern python
* Some intermediate commit
* Remove obsolete and unused files and packages. (#80 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/80>)
* Review CI by correcting the configurations (#71 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/71>)
* Add support for gpios, update MoveIt and ros2_control launching (#66 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/66>)
* Quickfix against move home bug
* Added missing initialization
* Use GitHub Actions, use pre-commit formatting (#56 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/56>)
* Put dashboard services into corresponding namespace
* Start dashboard client from within the hardware interface
* Added try catch blocks for service calls
* Removed repeated declaration of timeout parameter which lead to connection crash
* Removed static service name in which all auto generated services where mapped
* Removed unused variable
* Fixed clang-format issue
* Removed all robot status stuff
* Exchanged hardcoded value for RobotState msgs enum
* Removed currently unused controller state variables
* Added placeholder for industrial_robot_status_interface
* Fixed clang issues
* Added checks for internal robot state machine
* Only load speed scaling interface
* Changed state interface to combined speed scaling factor
* Added missing formatting in hardware interface
* Initial version of the speed_scaling_state_controller
* Fix clang tidy in multiple pkgs.
* Clang tidy fix.
* Update force torque state controller.
* Prepare for testing.
* Fix decision breaker for position control. Make decision effect instantaneous.
* Use only position interface.
* Update hardware interface for ROS2 (#8 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/8>)
* Update the dashboard client for ROS2 (#5 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/5>)
* Hardware interface framework (#3 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/3>)
* Add XML schema to all ``package.xml`` files
* Silence ``ament_lint_cmake`` errors
* Update packaging for ROS2
* Update package.xml files so ``ros2 pkg list`` shows all pkgs
* Clean out ur_robot_driver for initial ROS2 compilation
* Compile ur_dashboard_msgs for ROS2
* Delete all launch/config files with no UR5 relation
* Initial work toward compiling ur_robot_driver
* Update CMakeLists and package.xml for:
  - ur5_moveit_config
  - ur_bringup
  - ur_description
* Change pkg versions to 0.0.0
* Contributors: AndyZe, Denis Stogl, Denis Štogl, Felix Exner, John Morris, Lovro, Mads Holm Peters, Marvin Große Besselmann, Rune Søe-Knudsen, livanov93, Robert Wilbrandt
```
