### PR TITLE
maliput_object_py: 0.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2382,6 +2382,22 @@ repositories:
       url: https://github.com/maliput/maliput_object.git
       version: main
     status: developed
+  maliput_object_py:
+    doc:
+      type: git
+      url: https://github.com/maliput/maliput_object_py.git
+      version: main
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/maliput_object_py-release.git
+      version: 0.1.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/maliput/maliput_object_py.git
+      version: main
+    status: developed
   maliput_py:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_object_py` to `0.1.1-1`:

- upstream repository: https://github.com/maliput/maliput_object_py.git
- release repository: https://github.com/ros2-gbp/maliput_object_py-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## maliput_object_py

```
* Fixes package's license path.
* Contributors: Franco Cipollone
```
