### PR TITLE
maliput_dragway: 0.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2311,7 +2311,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput_dragway-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_dragway` to `0.1.1-1`:

- upstream repository: https://github.com/maliput/maliput_dragway.git
- release repository: https://github.com/ros2-gbp/maliput_dragway-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.0-1`

## maliput_dragway

```
* add missing dependency on python3-dev to get python.h (#72 <https://github.com/maliput/maliput_dragway/issues/72>)
  * add missing dependency on python3-dev to get python.h
  * Compiles test utilities when BUILD_TESTING flag is on, to match gtest dependency.
  Co-authored-by: Franco Cipollone <mailto:franco.c@ekumenlabs.com>
* Contributors: Tully Foote
```
