### PR TITLE
maliput_integration: 0.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2334,6 +2334,22 @@ repositories:
       url: https://github.com/maliput/maliput_drake.git
       version: main
     status: developed
+  maliput_integration:
+    doc:
+      type: git
+      url: https://github.com/maliput/maliput_integration.git
+      version: main
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/maliput_integration-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/maliput/maliput_integration.git
+      version: main
+    status: developed
   maliput_malidrive:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_integration` to `0.1.0-1`:

- upstream repository: https://github.com/maliput/maliput_integration.git
- release repository: https://github.com/ros2-gbp/maliput_integration-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## maliput_integration

```
* Updates package.xml file.
* Several changes for ros build farm compatibility (#118 <https://github.com/maliput/maliput_integration/issues/118>)
* Uses compile definitions for the tests. (#117 <https://github.com/maliput/maliput_integration/issues/117>)
* Updates license. (#116 <https://github.com/maliput/maliput_integration/issues/116>)
* Removes dashing support. (#115 <https://github.com/maliput/maliput_integration/issues/115>)
* Apps: Allows relative path to resource env var. (#114 <https://github.com/maliput/maliput_integration/issues/114>)
* Extends maliput_query app with maliput_object related queries (#112 <https://github.com/maliput/maliput_integration/issues/112>)
* Adds the RoadGeometry pointer when constructing IntersectionBooks. (#111 <https://github.com/maliput/maliput_integration/issues/111>)
* Modified library dependancies from utilities to utility (#110 <https://github.com/maliput/maliput_integration/issues/110>)
* Merge pull request #109 <https://github.com/maliput/maliput_integration/issues/109> from ToyotaResearchInstitute/voldivh/value_range_method_to_state
  Changed values() and ranges() method from Rules to states()
* [FEAT]: Changed values() and ranges() method from Rules to states()
* Adds example using dynamic rules (#107 <https://github.com/maliput/maliput_integration/issues/107>)
* Adds BUILD_DOCS flag as opt-in flag (#108 <https://github.com/maliput/maliput_integration/issues/108>)
* Matches with change in maliput's phase ring book loader. (#106 <https://github.com/maliput/maliput_integration/issues/106>)
* Adds gflag for loading a RuleRegistry yaml file. (#104 <https://github.com/maliput/maliput_integration/issues/104>)
* Adds workflow_dispatch to other workflows. (#103 <https://github.com/maliput/maliput_integration/issues/103>)
* Adds CI badges (#102 <https://github.com/maliput/maliput_integration/issues/102>)
* Replaces push by workflow_dispatch event in gcc build. (#100 <https://github.com/maliput/maliput_integration/issues/100>)
* Includes malidrive's new parameter: max_linear_tolerance (#99 <https://github.com/maliput/maliput_integration/issues/99>)
* Use maliput_drake instead of drake_vendor (#98 <https://github.com/maliput/maliput_integration/issues/98>)
* maliput_measure_load_time: Adds tutorial. (#97 <https://github.com/maliput/maliput_integration/issues/97>)
* Adds info about other maliput_to_string implemenatation apps. (#95 <https://github.com/maliput/maliput_integration/issues/95>)
* maliput_derive_lane_s_route: Improve app + tutorial (#94 <https://github.com/maliput/maliput_integration/issues/94>)
* Pairs with multilane::RoadGeometry going private. (#96 <https://github.com/maliput/maliput_integration/issues/96>)
* Extends maliput_to_obj app to also generate urdf file. (#93 <https://github.com/maliput/maliput_integration/issues/93>)
* Pairs with maliput_malidrive's load deprecation method. (#91 <https://github.com/maliput/maliput_integration/issues/91>)
* Adds maliput_to_obj tutorial. (#90 <https://github.com/maliput/maliput_integration/issues/90>)
* maliput_query: GetNumberOfLanes command. (#89 <https://github.com/maliput/maliput_integration/issues/89>)
* maliput_query: Adds elapsed time information. (#88 <https://github.com/maliput/maliput_integration/issues/88>)
* Updates maliput_query use using double dashes. (#87 <https://github.com/maliput/maliput_integration/issues/87>)
* Adds maliput query tutorial (#85 <https://github.com/maliput/maliput_integration/issues/85>)
* Adds maliput_to_string tutorial. (#84 <https://github.com/maliput/maliput_integration/issues/84>)
* Enable doxygen check. (#83 <https://github.com/maliput/maliput_integration/issues/83>)
* Removes references to InertialTolaneMappingConfig. (#82 <https://github.com/maliput/maliput_integration/issues/82>)
* maliput_to_string app: Adds check_invariants flag. (#81 <https://github.com/maliput/maliput_integration/issues/81>)
* Fixes maliput_to_string_with_plugin app. (#80 <https://github.com/maliput/maliput_integration/issues/80>)
* Adds GetLaneLength command to maliput_query app. (#79 <https://github.com/maliput/maliput_integration/issues/79>)
* maliput_query: Use the xodr file from gflag. (#77 <https://github.com/maliput/maliput_integration/issues/77>)
* Set up linker properly when using clang in CI. (#76 <https://github.com/maliput/maliput_integration/issues/76>)
* Enable foxy CI (#74 <https://github.com/maliput/maliput_integration/issues/74>)
* Prepare for foxy (#73 <https://github.com/maliput/maliput_integration/issues/73>)
* Info log road network loading status in apps. (#75 <https://github.com/maliput/maliput_integration/issues/75>)
* Fix include style part 1: use <> maliput_* includes (#72 <https://github.com/maliput/maliput_integration/issues/72>)
* Use newer revision of pybind11 (#71 <https://github.com/maliput/maliput_integration/issues/71>)
* rosdep update --include-eol-distros (#70 <https://github.com/maliput/maliput_integration/issues/70>)
* Require OpenDRIVE file in RoadGeometryConfiguration (#69 <https://github.com/maliput/maliput_integration/issues/69>)
* Pairs app with new flag in the malidrive::RoadGeometryConfiguration. (#68 <https://github.com/maliput/maliput_integration/issues/68>)
* CI: Removes prereqs install for drake. (#67 <https://github.com/maliput/maliput_integration/issues/67>)
* Upgrade ros-tooling to v0.2.1 (#66 <https://github.com/maliput/maliput_integration/issues/66>)
* Uses maliput_documentation instead of maliput-documentation. (#65 <https://github.com/maliput/maliput_integration/issues/65>)
* Use maliput_multilane instead of maliput-multilane. (#64 <https://github.com/maliput/maliput_integration/issues/64>)
* Use maliput_dragway instead of maliput-dragway. (#63 <https://github.com/maliput/maliput_integration/issues/63>)
* Updates standard_strictness_policy gflag. (#62 <https://github.com/maliput/maliput_integration/issues/62>)
* Apps: Improve configuration options when loading a malidrive backend. (#61 <https://github.com/maliput/maliput_integration/issues/61>)
* Switch ament_cmake_doxygen to main branch. (#60 <https://github.com/maliput/maliput_integration/issues/60>)
* Optimizes scan-build run in CI. (#59 <https://github.com/maliput/maliput_integration/issues/59>)
* Add changelog template (#56 <https://github.com/maliput/maliput_integration/issues/56>)
* Replaces occurrences of dsim-repos-index by maliput_infrastructure. (#58 <https://github.com/maliput/maliput_integration/issues/58>)
* Imports maliput_py to github actions. (#57 <https://github.com/maliput/maliput_integration/issues/57>)
* Points to maliput_infrastructure instead of dsim-repos-index (#55 <https://github.com/maliput/maliput_integration/issues/55>)
* Trigger PR clang builds on do-clang-test label (#54 <https://github.com/maliput/maliput_integration/issues/54>)
* Restores scan-build workflow on label (#53 <https://github.com/maliput/maliput_integration/issues/53>)
* Pairs with the change in RoadGeometry API (#52 <https://github.com/maliput/maliput_integration/issues/52>)
* Moves disabled workflows to a different folder. (#51 <https://github.com/maliput/maliput_integration/issues/51>)
* Adds app for measuring load time process (#50 <https://github.com/maliput/maliput_integration/issues/50>)
* Allows the apps to select build policy for malidrive backend. (#49 <https://github.com/maliput/maliput_integration/issues/49>)
* Refer to a specific clang version and use lld linker. (#48 <https://github.com/maliput/maliput_integration/issues/48>)
* Update ros-tooling version in CI. (#47 <https://github.com/maliput/maliput_integration/issues/47>)
* Fixes ubsan behavior in CI. (#46 <https://github.com/maliput/maliput_integration/issues/46>)
* Removes Jenkins configuration. (#45 <https://github.com/maliput/maliput_integration/issues/45>)
* Uses ament_cmake_flake8 package instead of pycodestyle. (#44 <https://github.com/maliput/maliput_integration/issues/44>)
* Adds applications in cpp and python that uses the maliput plugin architecture (#39 <https://github.com/maliput/maliput_integration/issues/39>)
* Improve application namespace consistency (#42 <https://github.com/maliput/maliput_integration/issues/42>)
* Replaces GeoPosition by InertialPosition (#38 <https://github.com/maliput/maliput_integration/issues/38>)
* Fixes clang Github CI workflow configuration. (#40 <https://github.com/maliput/maliput_integration/issues/40>)
* Adds maliput_malidrive dependency to CI and try to check out same branches (#36 <https://github.com/maliput/maliput_integration/issues/36>)
* Removes reference to maliput_malidrive/base/road_geometry.h because it is not installed anymore. (#34 <https://github.com/maliput/maliput_integration/issues/34>)
* Adds maliput_derive_lane_s_route_app. (#33 <https://github.com/maliput/maliput_integration/issues/33>)
* Unifies cmake install paths. (#32 <https://github.com/maliput/maliput_integration/issues/32>)
* Adds maliput_query app. (#30 <https://github.com/maliput/maliput_integration/issues/30>)
* Adds malidrive repository to scan_build workflow. (#31 <https://github.com/maliput/maliput_integration/issues/31>)
* Adds maliput_malidrive backend implementation to the apps. (#27 <https://github.com/maliput/maliput_integration/issues/27>)
* Adds scan_build job to Github Actions. (#26 <https://github.com/maliput/maliput_integration/issues/26>)
* Disables tsan because not all backends support that build configuration. (#29 <https://github.com/maliput/maliput_integration/issues/29>)
* Sets ACTIONS_ALLOW_UNSECURE_COMMANDS to true (#28 <https://github.com/maliput/maliput_integration/issues/28>)
* Adds clang8, asan, ubsan and tsan to Github Actions. (#25 <https://github.com/maliput/maliput_integration/issues/25>)
* Adds a template changelog. (#23 <https://github.com/maliput/maliput_integration/issues/23>)
* Updates package.xml (#22 <https://github.com/maliput/maliput_integration/issues/22>)
* Adds version number.
* Adds a template changelog.
* Fixes sanitizers variable. (#20 <https://github.com/maliput/maliput_integration/issues/20>)
* Use GitHub Actions CI to build and test with gcc (#19 <https://github.com/maliput/maliput_integration/issues/19>)
* Adds scan-build to jenkins configuration. (#18 <https://github.com/maliput/maliput_integration/issues/18>)
* Parallelizes CI.
* Adds Undefined Behavior Sanitizer.
* Adds Address Sanitizer.
* Adds application to serialize dragway and multilane. (#5 <https://github.com/maliput/maliput_integration/issues/5>)
* Generates URDF files for multilane and dragway implementation (#4 <https://github.com/maliput/maliput_integration/issues/4>) (#13 <https://github.com/maliput/maliput_integration/issues/13>)
* Pairs clang flags. (#12 <https://github.com/maliput/maliput_integration/issues/12>)
* Generates OBJ file either from multilane or dragway implementation. (#3 <https://github.com/maliput/maliput_integration/issues/3>)
* Changes namespace from utility to integration in yaml_to_obj.cc file. (#2 <https://github.com/maliput/maliput_integration/issues/2>)
* Modifies DefaultCFlags. (#9 <https://github.com/maliput/maliput_integration/issues/9>)
* Adapts files to multilane package's reorganization.
* Adapts files to dragway's reorganization. (#7 <https://github.com/maliput/maliput_integration/issues/7>)
* Merge pull request #1 <https://github.com/maliput/maliput_integration/issues/1> from ToyotaResearchInstitute/francocipollone/move_maliput_integration_to_a_repo
  Brings maliput-integration package from maliput repository.
* Changes package from maliput-integration to maliput_integration
* Adds license to the package.xml file.
* Adds missing files to the repository. Minor fixes.
* Move maliput-utilities to maliput core (#274 <https://github.com/maliput/maliput_integration/issues/274>)
* Move dragway_to_urdf to maliput-integration (#305 <https://github.com/maliput/maliput_integration/issues/305>)
* Move yaml_to_obj to maliput-integration, remove multilane dependency (#304 <https://github.com/maliput/maliput_integration/issues/304>)
* Adds maliput-integration package. (#299 <https://github.com/maliput/maliput_integration/issues/299>)
* Initial commit
* Contributors: Agustin Alba Chicar, Chien-Liang Fok, Daniel Stonier, Franco, Franco Cipollone, Geoffrey Biggs, Steve Peters, Steven Peters, Voldivh
```
