### PR TITLE
mvsim: 0.3.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5514,7 +5514,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/ual-arm-ros-pkg/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.3.2-1`:

- upstream repository: https://github.com/ual-arm-ros-pkg/mvsim.git
- release repository: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.3.1-1`

## mvsim

```
* Install models/ subdirectory too
* Changes towards building for both ros1 & ros2
* Copyright date bump
* Fix build and dependencies for ROS1.
* Fix build w/o python
* Fix consistent include path for installed targets
* BUGFIX: Fix random SIGSEGV due to unsafe shared global object for random number generation
* Fix no installation of mvsim_msgs python module
* Fix demo robot starts out of the map
* Contributors: Jose Luis Blanco-Claraco
```
