### PR TITLE
rosidl: 3.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4090,7 +4090,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 3.2.0-1
+      version: 3.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `3.2.1-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `3.2.0-1`

## rosidl_adapter

- No changes

## rosidl_cli

- No changes

## rosidl_cmake

```
* Fix comment in camel case conversion function (#683 <https://github.com/ros2/rosidl/issues/683>)
* Protect rosidl_target_interfaces from using NOTFOUND in include_directories (#679 <https://github.com/ros2/rosidl/issues/679>)
* Contributors: Jose Luis Rivero, Shane Loretz
```

## rosidl_generator_c

- No changes

## rosidl_generator_cpp

- No changes

## rosidl_parser

- No changes

## rosidl_runtime_c

- No changes

## rosidl_runtime_cpp

- No changes

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

- No changes

## rosidl_typesupport_introspection_cpp

- No changes
