### PR TITLE
robot_controllers: 0.9.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3746,7 +3746,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/robot_controllers-ros2-release.git
-      version: 0.9.1-1
+      version: 0.9.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_controllers` to `0.9.2-1`:

- upstream repository: https://github.com/fetchrobotics/robot_controllers.git
- release repository: https://github.com/fetchrobotics-gbp/robot_controllers-ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.9.1-1`

## robot_controllers

- No changes

## robot_controllers_interface

```
* fix a bug in the older constructor (#78 <https://github.com/mikeferguson/robot_controllers/issues/78>)
* Contributors: Michael Ferguson
```

## robot_controllers_msgs

- No changes
