### PR TITLE
sdformat_urdf: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4719,6 +4719,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sdformat_urdf-release.git
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sdformat_urdf` to `1.0.0-1`:

- upstream repository: https://github.com/ros/sdformat_urdf.git
- release repository: https://github.com/ros2-gbp/sdformat_urdf-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## sdformat_test_files

```
* Support for universal and ball joint as floating joints #13 <https://github.com/ros/sdformat_urdf/issues/13>
* Contributors: Dharini Dutia
```

## sdformat_urdf

```
* Support for universal and ball joint as floating joints #13 <https://github.com/ros/sdformat_urdf/issues/13>
* Support SDFormat 12 (#12 <https://github.com/ros/sdformat_urdf/issues/12>)
* Use urdfdom_headers::urdfdom_headers (#5 <https://github.com/ros/sdformat_urdf/issues/5>, #6 <https://github.com/ros/sdformat_urdf/issues/6>))
* Contributors: Dharini Dutia, Louise Poubel, Shane Loretz
```
