### PR TITLE
sdformat_urdf: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4830,7 +4830,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/sdformat_urdf-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sdformat_urdf` to `1.0.1-1`:

- upstream repository: https://github.com/ros/sdformat_urdf.git
- release repository: https://github.com/ros2-gbp/sdformat_urdf-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.0.0-1`

## sdformat_test_files

- No changes

## sdformat_urdf

```
* Remove version requirement on sdformat_test_files (#15 <https://github.com/ros/sdformat_urdf/issues/15>)
* Contributors: Shane Loretz
```
