### PR TITLE
ament_download: 0.0.5-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -155,6 +155,21 @@ repositories:
       url: https://github.com/ros2/ament_cmake_ros.git
       version: master
     status: maintained
+  ament_download:
+    doc:
+      type: git
+      url: https://github.com/samsung-ros/ament_download.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/samsung-ros/ament_download-release.git
+      version: 0.0.5-2
+    source:
+      type: git
+      url: https://github.com/samsung-ros/ament_download.git
+      version: ros2
+    status: developed
   ament_index:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_download` to `0.0.5-2`:

- upstream repository: https://github.com/samsung-ros/ament_download
- release repository: https://github.com/samsung-ros/ament_download-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`
