### PR TITLE
ament_download: 0.0.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -104,6 +104,21 @@ repositories:
       url: https://github.com/ros2/ament_cmake_ros.git
       version: foxy
     status: maintained
+  ament_download:
+    doc:
+      type: git
+      url: https://github.com/samsung-ros/ament_download.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/samsung-ros/ament_download-release.git
+      version: 0.0.5-1
+    source:
+      type: git
+      url: https://github.com/samsung-ros/ament_download.git
+      version: ros2
+    status: developed
   ament_index:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_download` to `0.0.5-1`:

- upstream repository: https://github.com/samsung-ros/ament_download
- release repository: https://github.com/samsung-ros/ament_download-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`
