### PR TITLE
boost_plugin_loader: 0.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -499,6 +499,17 @@ repositories:
       url: https://github.com/ros/bond_core.git
       version: kinetic-devel
     status: maintained
+  boost_plugin_loader:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/tesseract-robotics-release/boost_plugin_loader-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/tesseract-robotics/boost_plugin_loader.git
+      version: main
+    status: developed
   boost_sml:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `boost_plugin_loader` to `0.1.1-1`:

- upstream repository: git@github.com:tesseract-robotics/boost_plugin_loader.git
- release repository: https://github.com/tesseract-robotics-release/boost_plugin_loader-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## boost_plugin_loader

```
* Add cpack
* update windows ci
* update ubuntu focal CI build
* add std::enable_if to PluginLoader::getAvailablePlugins()
* update package.xml
* Update unit test to have full coverage
* Add PluginLoaderException class
* Update parseEnvironmentVariableList documentation
* Fixed search in system directories for plugins
* Switch got getSection method
* Rename getAllAvailablePlugins
* Port over @marip8 example
* Switch SECTION_NAME to section as member variable
* Add code coverage to ubunut CI build
* Rename to align with @marip8 refactor
* Remove ClassLoader class
* port macros.h
* Initial port from tesseract_common
* Initial commit
* Contributors: Levi Armstrong
```
