### PR TITLE
Remove obsolete mrpt_bridge package

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7221,21 +7221,6 @@ repositories:
       url: https://github.com/mrpt/mrpt.git
       version: develop
     status: maintained
-  mrpt_bridge:
-    doc:
-      type: git
-      url: https://github.com/mrpt-ros-pkg/mrpt_bridge.git
-      version: ros1
-    release:
-      tags:
-        release: release/melodic/{package}/{version}
-      url: https://github.com/mrpt-ros-pkg-release/mrpt_bridge-release.git
-      version: 1.0.1-1
-    source:
-      type: git
-      url: https://github.com/mrpt-ros-pkg/mrpt_bridge.git
-      version: ros1
-    status: maintained
   mrpt_msgs:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5394,21 +5394,6 @@ repositories:
       url: https://github.com/mrpt/mrpt.git
       version: develop
     status: developed
-  mrpt_bridge:
-    doc:
-      type: git
-      url: https://github.com/mrpt-ros-pkg/mrpt_bridge.git
-      version: master
-    release:
-      tags:
-        release: release/noetic/{package}/{version}
-      url: https://github.com/mrpt-ros-pkg-release/mrpt_bridge-release.git
-      version: 1.0.1-1
-    source:
-      type: git
-      url: https://github.com/mrpt-ros-pkg/mrpt_bridge.git
-      version: ros1
-    status: maintained
   mrpt_msgs:
     doc:
       type: git


### PR DESCRIPTION
The package has been deprecated, so as discussed in https://github.com/ros/rosdistro/pull/33016 it will be removed from all active ROS distributions.