### PR TITLE
crane_plus: 1.0.0-5 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -786,6 +786,29 @@ repositories:
       url: https://github.com/ros-controls/control_toolbox.git
       version: ros2-master
     status: maintained
+  crane_plus:
+    doc:
+      type: git
+      url: https://github.com/rt-net/crane_plus.git
+      version: foxy-devel
+    release:
+      packages:
+      - crane_plus
+      - crane_plus_control
+      - crane_plus_description
+      - crane_plus_examples
+      - crane_plus_gazebo
+      - crane_plus_ignition
+      - crane_plus_moveit_config
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/rt-net-gbp/crane_plus-release.git
+      version: 1.0.0-5
+    source:
+      type: git
+      url: https://github.com/rt-net/crane_plus.git
+      version: foxy-devel
+    status: maintained
   cyclonedds:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `crane_plus` to `1.0.0-5`:

- upstream repository: https://github.com/rt-net/crane_plus.git
- release repository: https://github.com/rt-net-gbp/crane_plus-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## crane_plus

```
* パッケージバージョン表記の更新 (#40 <https://github.com/rt-net/crane_plus/issues/40>)
* Contributors: Kuwamai
```

## crane_plus_control

```
* パッケージバージョン表記の更新 (#40 <https://github.com/rt-net/crane_plus/issues/40>)
* xacroファイルの読み込みを一元化するためのPythonスクリプトを追加 (#36 <https://github.com/rt-net/crane_plus/issues/36>)
* GripperActionControllerに関するコメントを削除 (#37 <https://github.com/rt-net/crane_plus/issues/37>)
* hardware_interfaceのパラメータをxacro引数から変更する (#35 <https://github.com/rt-net/crane_plus/issues/35>)
* Use new ros2 control interface (#27 <https://github.com/rt-net/crane_plus/issues/27>)
* Contributors: Kuwamai, Shota Aoki
```

## crane_plus_description

```
* パッケージバージョン表記の更新 (#40 <https://github.com/rt-net/crane_plus/issues/40>)
* crane_plus_ignition パッケージを追加し、Gazeboの使用を非推奨にする (#38 <https://github.com/rt-net/crane_plus/issues/38>)
* xacroファイルの読み込みを一元化するためのPythonスクリプトを追加 (#36 <https://github.com/rt-net/crane_plus/issues/36>)
* hardware_interfaceのパラメータをxacro引数から変更する (#35 <https://github.com/rt-net/crane_plus/issues/35>)
* Update crane_plus_gazebo (#30 <https://github.com/rt-net/crane_plus/issues/30>)
* Use new ros2 control interface (#27 <https://github.com/rt-net/crane_plus/issues/27>)
* Contributors: Kuwamai, Shota Aoki
```

## crane_plus_examples

```
* パッケージバージョン表記の更新 (#40 <https://github.com/rt-net/crane_plus/issues/40>)
* crane_plus_ignition パッケージを追加し、Gazeboの使用を非推奨にする (#38 <https://github.com/rt-net/crane_plus/issues/38>)
* xacroファイルの読み込みを一元化するためのPythonスクリプトを追加 (#36 <https://github.com/rt-net/crane_plus/issues/36>)
* GripperActionControllerに関するコメントを削除 (#37 <https://github.com/rt-net/crane_plus/issues/37>)
* hardware_interfaceのパラメータをxacro引数から変更する (#35 <https://github.com/rt-net/crane_plus/issues/35>)
* Update crane_plus_gazebo (#30 <https://github.com/rt-net/crane_plus/issues/30>)
* Contributors: Kuwamai, Shota Aoki
```

## crane_plus_gazebo

```
* パッケージバージョン表記の更新 (#40 <https://github.com/rt-net/crane_plus/issues/40>)
* crane_plus_ignition パッケージを追加し、Gazeboの使用を非推奨にする (#38 <https://github.com/rt-net/crane_plus/issues/38>)
* xacroファイルの読み込みを一元化するためのPythonスクリプトを追加 (#36 <https://github.com/rt-net/crane_plus/issues/36>)
* Update crane_plus_gazebo (#30 <https://github.com/rt-net/crane_plus/issues/30>)
* Contributors: Kuwamai, Shota Aoki
```

## crane_plus_ignition

```
* パッケージバージョン表記の更新 (#40 <https://github.com/rt-net/crane_plus/issues/40>)
* crane_plus_ignitionのpackage.xmlを修正 (#39 <https://github.com/rt-net/crane_plus/issues/39>)
* crane_plus_ignition パッケージを追加し、Gazeboの使用を非推奨にする (#38 <https://github.com/rt-net/crane_plus/issues/38>)
* Contributors: Kuwamai, Shota Aoki
```

## crane_plus_moveit_config

```
* パッケージバージョン表記の更新 (#40 <https://github.com/rt-net/crane_plus/issues/40>)
* xacroファイルの読み込みを一元化するためのPythonスクリプトを追加 (#36 <https://github.com/rt-net/crane_plus/issues/36>)
* Update crane_plus_gazebo (#30 <https://github.com/rt-net/crane_plus/issues/30>)
* Update installation for foxy release. (#29 <https://github.com/rt-net/crane_plus/issues/29>)
* Contributors: Kuwamai, Shota Aoki
```
