### PR TITLE
pr2_mechanism: 1.8.21-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6917,7 +6917,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_mechanism-release.git
-      version: 1.8.20-1
+      version: 1.8.21-1
     source:
       type: git
       url: https://github.com/pr2/pr2_mechanism.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_mechanism` to `1.8.21-1`:

- upstream repository: https://github.com/pr2/pr2_mechanism.git
- release repository: https://github.com/pr2-gbp/pr2_mechanism-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.8.20-1`

## pr2_controller_interface

- No changes

## pr2_controller_manager

```
* set catkin_add_gtest within CATKIN_ENABLE_TESTING (#346 <https://github.com/pr2/pr2_mechanism/issues/346>)
  fix with CATKIN_ENABLE_TESTING=OFF
* Contributors: Kei Okada
```

## pr2_hardware_interface

- No changes

## pr2_mechanism

- No changes

## pr2_mechanism_diagnostics

```
* set catkin_add_gtest within CATKIN_ENABLE_TESTING (#346 <https://github.com/pr2/pr2_mechanism/issues/346>)
  fix with CATKIN_ENABLE_TESTING=OFF
* Contributors: Kei Okada
```

## pr2_mechanism_model

```
* set catkin_add_gtest within CATKIN_ENABLE_TESTING (#346 <https://github.com/pr2/pr2_mechanism/issues/346>)
  fix with CATKIN_ENABLE_TESTING=OFF
* Parse old & new transmission style (#345 <https://github.com/pr2/pr2_mechanism/issues/345>)
  The transmission style changed in ros_control, to make them compatible
  we adjusted them in the pr2_description
  This came up when we integrated the shadow-hand- and the PR2-model
* Contributors: Kei Okada, Michael Görner
```
