### PR TITLE
fluent_rviz: 0.0.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1078,7 +1078,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/fluent_rviz-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/ForteFibre/FluentRviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fluent_rviz` to `0.0.3-1`:

- upstream repository: https://github.com/ForteFibre/FluentRviz.git
- release repository: https://github.com/ros2-gbp/fluent_rviz-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.0.2-1`

## fluent_rviz

```
* Add CONTRIBUTING.md
* Add LICENSE file
* Contributors: Kotaro Yoshimoto
```
