### PR TITLE
fluent_rviz: 0.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -998,11 +998,19 @@ repositories:
       version: ros2
     status: maintained
   fluent_rviz:
+    doc:
+      type: git
+      url: https://github.com/ForteFibre/FluentRviz.git
+      version: ros2
     release:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fluent_rviz-release.git
       version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/ForteFibre/FluentRviz.git
+      version: ros2
     status: developed
   fmi_adapter:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -997,6 +997,13 @@ repositories:
       url: https://github.com/ros/filters.git
       version: ros2
     status: maintained
+  fluent_rviz:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/fluent_rviz-release.git
+      version: 0.0.3-1
+    status: developed
   fmi_adapter:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fluent_rviz` to `0.0.3-1`:

- upstream repository: https://github.com/ForteFibre/FluentRviz.git
- release repository: https://github.com/ros2-gbp/fluent_rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## fluent_rviz

```
* Add CONTRIBUTING.md
* Add LICENSE file
* Contributors: Kotaro Yoshimoto
```
