### PR TITLE
ros_industrial_cmake_boilerplate: 0.2.16-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8299,7 +8299,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release.git
-      version: 0.2.15-1
+      version: 0.2.16-1
     source:
       type: git
       url: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_industrial_cmake_boilerplate` to `0.2.16-1`:

- upstream repository: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git
- release repository: https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.2.15-1`

## ros_industrial_cmake_boilerplate

```
* Always treat package description as a single string during extraction
* Fix cpack to generate correct names for nuget packages (#64 <https://github.com/ros-industrial/ros_industrial_cmake_boilerplate/issues/64>)
* Added CPack macro from tesseract (#62 <https://github.com/ros-industrial/ros_industrial_cmake_boilerplate/issues/62>)
* Contributors: Josh Langsfeld, Levi Armstrong, Michael Ripperger
```
