### PR TITLE
septentrio_gnss_driver: 1.2.2-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4750,7 +4750,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/septentrio-users/septentrio_gnss_driver_ros2-release.git
-      version: 1.2.1-1
+      version: 1.2.2-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `septentrio_gnss_driver` to `1.2.2-4`:

- upstream repository: https://github.com/septentrio-gnss/septentrio_gnss_driver
- release repository: https://github.com/septentrio-users/septentrio_gnss_driver_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.2.1-1`

## septentrio_gnss_driver

```
* Fixes
  
  Memory corruption under adverse conditions
* Commits
  
  Merge pull request #66 from thomasemter/dev/next2
  Fix memory corruption
  
  Fix parameter warnings
  
  Reset buffer size to 16384
  
  Update changelog
  
  Fix memory corruption
  
  Replace maps with unordered_maps
  
  Overload timestamp function
  
  Fix frame ids for INS msgs
  
  Add define to avoid usage of deprecated header
  
  Change readme on gps-msgs packet
  
  Add info on user credentials
  
  Fix spelling in readme
  
  Merge remote-tracking branch 'upstream/ros2' into dev/next2
  
  Add comment for heading from pose
  
  Contributors: Thomas Emter, Tibor Dome
```
