### PR TITLE
fluent_rviz: 0.0.3-3 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1379,6 +1379,18 @@ repositories:
       url: https://github.com/ros/filters.git
       version: ros2
     status: maintained
+  fluent_rviz:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/fluent_rviz-release.git
+      version: 0.0.3-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ForteFibre/FluentRviz.git
+      version: ros2
+    status: developed
   fmi_adapter:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fluent_rviz` to `0.0.3-3`:

- upstream repository: https://github.com/ForteFibre/FluentRviz.git
- release repository: https://github.com/ros2-gbp/fluent_rviz-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## fluent_rviz

```
* Add CONTRIBUTING.md
* Add LICENSE file
* Contributors: Kotaro Yoshimoto
```
