### PR TITLE
Adds maliput_integration_tests source to foxy.

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2436,6 +2436,13 @@ repositories:
       url: https://github.com/maliput/maliput_integration.git
       version: main
     status: developed
+  maliput_integration_tests:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/maliput/maliput_integration_tests.git
+      version: main
+    status: developed
   maliput_malidrive:
     doc:
       type: git


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

maliput_integration_tests

## Package Upstream Source:

https://github.com/maliput/maliput_integration_tests

## Purpose of using this:

Only source is being added for triggering CI for each pull request event.
No release is expected.
