### PR TITLE
Add and update Archlinux keys.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -511,6 +511,7 @@ clang:
   ubuntu: [clang]
 clang-format:
   alpine: [clang]
+  arch: [clang]
   debian:
     bullseye: [clang-format]
     buster: [clang-format]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -525,6 +525,7 @@ clang-format:
   ubuntu: [clang-format]
 clang-tidy:
   alpine: [clang-extra-tools]
+  arch: [clang]
   debian:
     bullseye: [clang-tidy]
     buster: [clang-tidy]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -994,6 +994,7 @@ ffmpeg2theora:
   gentoo: [media-video/ffmpeg2theora]
   ubuntu: [ffmpeg2theora]
 file:
+  arch: [file]
   debian: [file]
   fedora: [file]
   nixos: [file]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3178,6 +3178,7 @@ libfreenect-dev:
   ubuntu: [libfreenect-dev]
 libfreetype6:
   alpine: [freetype]
+  arch: [freetype2]
   debian: [libfreetype6]
   fedora: [freetype-devel]
   gentoo: [media-libs/freetype]
@@ -3187,6 +3188,7 @@ libfreetype6:
   ubuntu: [libfreetype6]
 libfreetype6-dev:
   alpine: [freetype-dev]
+  arch: [freetype2]
   debian: [libfreetype6-dev]
   fedora: [freetype-devel]
   gentoo: [media-libs/freetype]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -870,7 +870,7 @@ ed:
   ubuntu: [ed]
 eigen:
   alpine: [eigen-dev]
-  arch: [eigen3]
+  arch: [eigen]
   debian: [libeigen3-dev]
   fedora: [eigen3-devel]
   freebsd: [eigen]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -356,6 +356,7 @@ pydrive-pip:
       packages: [PyDrive]
 pyflakes3:
   alpine: [py3-pyflakes]
+  arch: [python-pyflakes]
   debian: [pyflakes3]
   fedora: [python3-pyflakes]
   gentoo: [dev-python/pyflakes]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7079,7 +7079,7 @@ python3-lark-parser:
     xenial: [python3-lark-parser]
 python3-lttng:
   alpine: [py3-lttng]
-  arch: [python-lttng-ust]
+  arch: [python-lttngust]
   debian: [python3-lttng]
   fedora: [python3-lttng]
   openembedded: [lttng-tools@openembedded-core]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7291,6 +7291,7 @@ python3-nlopt:
     bionic: null
     xenial: null
 python3-nose:
+  arch: [python-nose]
   debian: [python3-nose]
   fedora: [python3-nose]
   gentoo: [dev-python/nose]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7078,6 +7078,7 @@ python3-lark-parser:
     xenial: [python3-lark-parser]
 python3-lttng:
   alpine: [py3-lttng]
+  arch: [python-lttng-ust]
   debian: [python3-lttng]
   fedora: [python3-lttng]
   openembedded: [lttng-tools@openembedded-core]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7845,7 +7845,7 @@ python3-pygments:
   ubuntu: [python3-pygments]
 python3-pygraphviz:
   alpine: [py3-graphviz]
-  arch: [python2-pygraphviz]
+  arch: [python-graphviz]
   debian: [python3-pygraphviz]
   fedora: [python3-pygraphviz]
   freebsd: [py-pygraphviz]


### PR DESCRIPTION
It's been a couple years now since I've built ROS 2 on Arch instead of working in containers.

Some keys were missing Archlinux definitions and others needed updating for the current Arch repositories.

This isn't a comprehensive update but it's what I had bandwidth for while covering another project.

* clang-format, clang-tidy
  * [clang](https://archlinux.org/packages/extra/x86_64/clang/)
* eigen
  * [eigen](https://archlinux.org/packages/extra/any/eigen/)
* file
  * [file](https://archlinux.org/packages/core/x86_64/file/)
* libfreetype6, libfreetype6-dev
  * [freetype2](https://archlinux.org/packages/extra/x86_64/freetype2/)
* pyflakes3
  * [python-pyflakes](https://archlinux.org/packages/community/any/python-pyflakes/)
* python3-lttng
  * [python-lttngust](https://archlinux.org/packages/community/x86_64/python-lttngust/)
* python3-nose
  * [python-nose](https://archlinux.org/packages/extra/any/python-nose/)
* python3-pygraphviz
  * [python-graphviz](https://archlinux.org/packages/community/any/python-graphviz/)