### PR TITLE
Add robodk-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9182,6 +9182,13 @@ quadprog-pip:
     pip: [quadprog]
   ubuntu:
     pip: [quadprog]
+robodk-pip:
+  debian:
+    pip:
+      packages: [robodk]
+  ubuntu:
+    pip:
+      packages: [robodk]
 rosbag-metadata-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8255,6 +8255,13 @@ python3-retrying:
     pip:
       packages: [retrying]
   ubuntu: [python3-retrying]
+python3-robodk-pip:
+  debian:
+    pip:
+      packages: [robodk]
+  ubuntu:
+    pip:
+      packages: [robodk]
 python3-rocker:
   debian: [python3-rocker]
   ubuntu: [python3-rocker]
@@ -9182,13 +9189,6 @@ quadprog-pip:
     pip: [quadprog]
   ubuntu:
     pip: [quadprog]
-robodk-pip:
-  debian:
-    pip:
-      packages: [robodk]
-  ubuntu:
-    pip:
-      packages: [robodk]
 rosbag-metadata-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

robodk

## Package Upstream Source:

https://github.com/RoboDK/RoboDK-API
https://robodk.com/doc/en/PythonAPI/index.html

## Purpose of using this:

RoboDK is a software for controlling industrial robot arms. I am trying to write a ros node to interface with the robodk simulator.

https://robodk.com/index

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- pip: https://pypi.org/project/robodk/
