### PR TITLE
boost_plugin_loader: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -504,7 +504,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tesseract-robotics-release/boost_plugin_loader-release.git
-      version: 0.1.1-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/tesseract-robotics/boost_plugin_loader.git


### PR DESCRIPTION
Increasing version of package(s) in repository `boost_plugin_loader` to `0.2.0-1`:

- upstream repository: git@github.com:tesseract-robotics/boost_plugin_loader.git
- release repository: https://github.com/tesseract-robotics-release/boost_plugin_loader-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.1-1`

## boost_plugin_loader

```
* Update package CI
* Add cassert include to example
* Update package.xml
* Updates (#3 <https://github.com/tesseract-robotics/boost_plugin_loader/issues/3>)
  * Updated example and README
  * Replace pragma once with header guard
  * Remove include of implementation in header
  * Simplify test plugin getSection
* Contributors: Levi Armstrong, Michael Ripperger
```
