### PR TITLE
add: python-colorcet

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6184,6 +6184,9 @@ python3-colorama:
 python3-colorcet:
   debian:
     '*': [python3-colorcet]
+    buster:
+      pip:
+        packages: [colorcet]
   fedora: [python3-colorcet]
   ubuntu:
     '*': [python3-colorcet]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1180,6 +1180,16 @@ python-colorama:
     pip:
       packages: [colorama]
   ubuntu: [python-colorama]
+python-colorcet:
+  debian:
+    pip:
+      packages: [colorcet]
+  fedora:
+    pip:
+      packages: [colorcet]
+  ubuntu:
+    pip:
+      packages: [colorcet]
 python-concurrent.futures:
   debian: [python-concurrent.futures]
   gentoo: [virtual/python-futures]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1180,16 +1180,6 @@ python-colorama:
     pip:
       packages: [colorama]
   ubuntu: [python-colorama]
-python-colorcet:
-  debian:
-    pip:
-      packages: [colorcet]
-  fedora:
-    pip:
-      packages: [colorcet]
-  ubuntu:
-    pip:
-      packages: [colorcet]
 python-concurrent.futures:
   debian: [python-concurrent.futures]
   gentoo: [virtual/python-futures]
@@ -6191,6 +6181,15 @@ python3-colorama:
   openembedded: [python3-colorama@meta-python]
   rhel: ['python%{python3_pkgversion}-colorama']
   ubuntu: [python3-colorama]
+python3-colorcet:
+  debian:
+    bullseye: [python3-colorcet]
+  fedora: [python3-colorcet]
+  ubuntu:
+    '*': [python3-colorcet]
+    focal:
+      pip:
+        packages: [colorcet]
 python3-conan-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6183,10 +6183,13 @@ python3-colorama:
   ubuntu: [python3-colorama]
 python3-colorcet:
   debian:
-    bullseye: [python3-colorcet]
+    '*': [python3-colorcet]
   fedora: [python3-colorcet]
   ubuntu:
     '*': [python3-colorcet]
+    bionic:
+      pip:
+        packages: [colorcet]
     focal:
       pip:
         packages: [colorcet]


### PR DESCRIPTION
Signed-off-by: hsgwa <hasegawa.isp@gmail.com>

<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

colorcet

## Package Upstream Source:

https://github.com/holoviz/colorcet

## Purpose of using this:

colorcet is a package that provides easy-to-read color maps.
It is useful for visualization of continuous values and color categorization for each of several types.

official document
https://colorcet.holoviz.org/

Distro packaging links:

## Links to Distribution Packages

pip

https://github.com/holoviz/colorcet

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->


