### PR TITLE
mvsim: 0.3.2-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7375,7 +7375,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
-      version: 0.3.2-1
+      version: 0.3.2-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.3.2-2`:

- upstream repository: https://github.com/MRPT/mvsim.git
- release repository: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.3.2-1`

## mvsim

```
* Install models/ subdirectory too
* Changes towards building for both ros1 & ros2
* Copyright date bump
* Fix build and dependencies for ROS1.
* Fix build w/o python
* Fix consistent include path for installed targets
* BUGFIX: Fix random SIGSEGV due to unsafe shared global object for random number generation
* Fix no installation of mvsim_msgs python module
* Fix demo robot starts out of the map
* Contributors: Jose Luis Blanco-Claraco
```
