### PR TITLE
mrpt_navigation: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7246,6 +7246,7 @@ repositories:
       - mrpt_local_obstacles
       - mrpt_localization
       - mrpt_map
+      - mrpt_msgs_bridge
       - mrpt_navigation
       - mrpt_rawlog
       - mrpt_reactivenav2d
@@ -7253,7 +7254,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `1.0.1-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.0.0-1`

## mrpt_local_obstacles

```
* Ported to tf2 and mrpt::ros1bridge
* Contributors: Jose Luis Blanco Claraco
```

## mrpt_localization

```
* fix all build errors; removed now obsolete tf_prefix
* Ported to tf2 and mrpt::ros1bridge
* modernize cmake
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_map

```
* Fix build errors
* Removed now obsolete tf_prefix
* Ported to tf2 and mrpt::ros1bridge
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_msgs_bridge

```
* New package mrpt_msgs_bridge
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_navigation

- No changes

## mrpt_rawlog

```
* Correct demos
* Fix all build errors
* Removed now obsolete tf_prefix
* Ported to tf2 and mrpt::ros1bridge
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_reactivenav2d

```
* Correct demos
* Fix all build errors
* Removed now obsolete tf_prefix
* Ported to tf2 and mrpt::ros1bridge
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_tutorials

```
* Removed now obsolete tf_prefix
* Contributors: Jose Luis Blanco-Claraco
```
