### PR TITLE
mrpt_sensors: 0.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7264,6 +7264,15 @@ repositories:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
       version: ros1
+    release:
+      packages:
+      - mrpt_generic_sensor
+      - mrpt_sensorlib
+      - mrpt_sensors
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/mrpt-ros-pkg-release/mrpt_sensors-release.git
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_sensors` to `0.0.2-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_sensors-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## mrpt_generic_sensor

```
* New package
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensorlib

```
* New package
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensors

```
* New package
* Contributors: Jose Luis Blanco-Claraco
```
