### PR TITLE
ntpd_driver: 2.1.0-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2480,7 +2480,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ntpd_driver-release.git
-      version: 2.1.0-1
+      version: 2.1.0-2
     source:
       type: git
       url: https://github.com/vooon/ntpd_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ntpd_driver` to `2.1.0-2`:

- upstream repository: https://github.com/vooon/ntpd_driver.git
- release repository: https://github.com/ros2-gbp/ntpd_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.1.0-1`

## ntpd_driver

```
* make linker happy
* fix loading as a component
* Contributors: Vladimir Ermakov
```
