### PR TITLE
er_public_msgs: 1.4.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2918,7 +2918,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/enabled-robotics/er_public_msgs-release.git
-      version: 1.1.0-1
+      version: 1.4.0-1
     status: maintained
   ethercat_grant:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `er_public_msgs` to `1.4.0-1`:

- upstream repository: https://github.com/enabled-robotics/er_public_msgs.git
- release repository: https://github.com/enabled-robotics/er_public_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.1.0-1`

## er_public_msgs

```
* Added componentstatus msgs/srcs
* Contributors: Niels Hvid
```
