### PR TITLE
er_public_msgs: 1.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2183,6 +2183,12 @@ repositories:
       url: https://github.com/ensenso/ros_driver.git
       version: master
     status: developed
+  er_public_msgs:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/enabled-robotics/er_public_msgs-release.git
+      version: 1.4.0-1
   ergodic_exploration:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `er_public_msgs` to `1.4.0-1`:

- upstream repository: https://github.com/enabled-robotics/er_public_msgs.git
- release repository: https://github.com/enabled-robotics/er_public_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## er_public_msgs

```
* Added componentstatus msgs/srcs
* Contributors: Niels Hvid
```
