### PR TITLE
tensorrt_cmake_module: 0.0.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5425,7 +5425,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/tensorrt_cmake_module-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/tier4/tensorrt_cmake_module.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tensorrt_cmake_module` to `0.0.3-1`:

- upstream repository: https://github.com/tier4/tensorrt_cmake_module.git
- release repository: https://github.com/ros2-gbp/tensorrt_cmake_module-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.0.2-1`

## tensorrt_cmake_module

```
* chore: rename cmake file
* Contributors: Daisuke Nishimatsu
```
