### PR TITLE
mrpt_slam: 0.1.11-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7286,7 +7286,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_slam-release.git
-      version: 0.1.10-1
+      version: 0.1.11-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_slam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_slam` to `0.1.11-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_slam.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_slam-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.10-1`

## mrpt_ekf_slam_2d

```
* Ported to tf2 and mrpt::ros1bridge
* Fixed all 2D and 3D EKF wrappers to work with mrpt 2.x API
* Update build dep to mrpt2
* Merge pull request #63 <https://github.com/mrpt-ros-pkg/mrpt_slam/issues/63> from reinzor/patch-1
  fix(CMakeLists.txt): Install rviz and config dir
* fix(CMakeLists.txt): Install rviz and config dir
  Required for running the example launch files
* Contributors: Jose Luis Blanco-Claraco, Rein Appeldoorn
```

## mrpt_ekf_slam_3d

```
* Ported to tf2 and mrpt::ros1bridge
* Fixed all 2D and 3D EKF wrappers to work with mrpt 2.x API
* Update build dep to mrpt2
* Contributors: Jose Luis Blanco Claraco
```

## mrpt_graphslam_2d

```
* Ported to tf2 and mrpt::ros1bridge
* Fix build with mrpt2
* Update multimaster_msgs_fkie to fkie_ prefix
* Merge branch 'master' of ssh://github.com/mrpt-ros-pkg/mrpt_slam
* Update URLs to https
* Update build dep to mrpt2
* Merge pull request #65 <https://github.com/mrpt-ros-pkg/mrpt_slam/issues/65> from Pillowline/patch-1
  setting trajectory publishers to latched
* setting trajectory publishers to latched
  So you can obtain data when running mrpt_graphslam with a bagfile, even after the playback has finished.
* Contributors: Jose Luis Blanco-Claraco, Pillowline
```

## mrpt_icp_slam_2d

```
* Ported to tf2 and mrpt::ros1bridge
* Fix build with mrpt2
* Fixed all 2D and 3D EKF wrappers to work with mrpt 2.x API
* Update build dep to mrpt2
* Contributors: Jose Luis Blanco Claraco
```

## mrpt_rbpf_slam

```
* Ported to tf2 and mrpt::ros1bridge
* Coarser grid resolution
* fix build with mrpt2
* Fixed all 2D and 3D EKF wrappers to work with mrpt 2.x API
* Update URLs to https
* Update build dep to mrpt2
* Merge pull request #62 <https://github.com/mrpt-ros-pkg/mrpt_slam/issues/62> from mx-robotics/master
  Flag added to switch between a static and moving sensor
* Flag added to switch between a static and moving sensor
* Contributors: Jose Luis Blanco-Claraco, Markus Bader
```

## mrpt_slam

- No changes
