### PR TITLE
Add bullet-extras for nixos

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -404,6 +404,7 @@ bullet-extras:
   debian: [libbullet-extras-dev]
   fedora: [bullet-extras]
   gentoo: [sci-physics/bullet]
+  nixos: [bullet]
   ubuntu: [libbullet-extras-dev]
 bzip2:
   alpine: [bzip2-dev]


### PR DESCRIPTION
* NixOS/nixpkgs: https://search.nixos.org/packages
        bullet

I did a file compare on bullet built in in nixos and https://packages.debian.org/sid/amd64/libbullet-extras-dev/filelist and determines that the nixos build includes the files from the debian equivalent.
