### PR TITLE
moveit_resources: 2.0.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2103,7 +2103,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_resources-release.git
-      version: 2.0.4-2
+      version: 2.0.5-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_resources.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `2.0.5-1`:

- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros2-gbp/moveit_resources-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.0.4-2`

## moveit_resources

- No changes

## moveit_resources_fanuc_description

- No changes

## moveit_resources_fanuc_moveit_config

```
* Fix a typo in chomp_planning.yaml (#143 <https://github.com/ros-planning/moveit_resources/issues/143>)
* Update ros2_control launching (#140 <https://github.com/ros-planning/moveit_resources/issues/140>)
* Remove invalid sensor config (#141 <https://github.com/ros-planning/moveit_resources/issues/141>)
* Contributors: AndyZe, David V. Lu!!, Stephanie Eng
```

## moveit_resources_panda_description

- No changes

## moveit_resources_panda_moveit_config

```
* Fix a typo in chomp_planning.yaml (#143 <https://github.com/ros-planning/moveit_resources/issues/143>)
* Update ros2_control launching (#140 <https://github.com/ros-planning/moveit_resources/issues/140>)
* Proper scoping for controllers in Panda Config (#132 <https://github.com/ros-planning/moveit_resources/issues/132>)
* Contributors: AndyZe, David V. Lu!!, Stephanie Eng
```

## moveit_resources_pr2_description

- No changes
