### PR TITLE
mrpt_navigation: 1.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7271,7 +7271,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `1.0.2-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.0.1-1`

## mrpt_local_obstacles

- No changes

## mrpt_localization

- No changes

## mrpt_map

- No changes

## mrpt_msgs_bridge

```
* Fix wrong destination for mrpt_msgs_bridge headers
* Contributors: Jose Luis Blanco Claraco
```

## mrpt_navigation

- No changes

## mrpt_rawlog

- No changes

## mrpt_reactivenav2d

- No changes

## mrpt_tutorials

- No changes
