### PR TITLE
mrpt_slam: 0.1.12-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7305,14 +7305,13 @@ repositories:
       packages:
       - mrpt_ekf_slam_2d
       - mrpt_ekf_slam_3d
-      - mrpt_graphslam_2d
       - mrpt_icp_slam_2d
       - mrpt_rbpf_slam
       - mrpt_slam
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_slam-release.git
-      version: 0.1.11-1
+      version: 0.1.12-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_slam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_slam` to `0.1.12-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_slam.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_slam-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.11-1`

## mrpt_ekf_slam_2d

- No changes

## mrpt_ekf_slam_3d

- No changes

## mrpt_icp_slam_2d

- No changes

## mrpt_rbpf_slam

- No changes

## mrpt_slam

```
* Remove mrpt_graphslam_2d for melodic due to missing dependency
* Contributors: Jose Luis Blanco Claraco
```
