### PR TITLE
robot_calibration: 0.8.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3759,6 +3759,24 @@ repositories:
       url: https://github.com/ros2/rmw_implementation.git
       version: humble
     status: developed
+  robot_calibration:
+    doc:
+      type: git
+      url: https://github.com/mikeferguson/robot_calibration.git
+      version: ros2
+    release:
+      packages:
+      - robot_calibration
+      - robot_calibration_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/robot_calibration-release.git
+      version: 0.8.0-1
+    source:
+      type: git
+      url: https://github.com/mikeferguson/robot_calibration.git
+      version: ros2
+    status: developed
   robot_controllers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_calibration` to `0.8.0-1`:

- upstream repository: https://github.com/mikeferguson/robot_calibration.git
- release repository: https://github.com/ros2-gbp/robot_calibration-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## robot_calibration

```
* various fixes from on-robot testing (#136 <https://github.com/mikeferguson/robot_calibration/issues/136>)
  * fix topic names in load_bag
  * update DepthCameraInfoManager to read proper parameters from camera node
  * fix path/names for pluginlib portability
  * better debug messages when capturing
  * better debug messages from ChainManager
* add yaml option for storing capture poses (#135 <https://github.com/mikeferguson/robot_calibration/issues/135>)
  * load calibration poses from YAML
  * add test for YAML loading
  * add porting script to get ROS1 bagfiles converted to YAML file
* remove tinyxml from CMake (#134 <https://github.com/mikeferguson/robot_calibration/issues/134>)
  this is a left over from the XML RPC days
* initial ROS2 port of robot_calibration (#133 <https://github.com/mikeferguson/robot_calibration/issues/133>)
  * port finders to ROS2
  * port optimization to ROS2
  * port tests to ROS
  * reorganize file structure for better clarity around header file usage
  * update readme
  Major changes for ROS2:
  * In ROS1, many of the parameters were an array of complex structures - this does
  not work well with ROS2 and the declaration of parameters. Instead, we use an array
  of structure names, and then we can declare namespaced parameters for each of
  the structures.
  * chain model has been renamed to chain3d
* port robot_calibration_msgs to ROS2, update CI (#131 <https://github.com/mikeferguson/robot_calibration/issues/131>)
* enhance alignment (#130 <https://github.com/mikeferguson/robot_calibration/issues/130>)
  * handle NANs in laser data
  * add r2_tolerance
  * add spinOnce so that we can run single threaded
  * exit loop if shutting down
* fix regression in manual calibration (#129 <https://github.com/mikeferguson/robot_calibration/issues/129>)
* fix warnings reported on ros.org buildfarm (#128 <https://github.com/mikeferguson/robot_calibration/issues/128>)
* improve base calibration alignment (#127 <https://github.com/mikeferguson/robot_calibration/issues/127>)
  * add feature to align to arbitrary angle
  * parameterize things, including verbose
* refactor base_calibration into separate class (#126 <https://github.com/mikeferguson/robot_calibration/issues/126>)
* major refactor into re-usable components (#125 <https://github.com/mikeferguson/robot_calibration/issues/125>)
  * add getPosesFromBag function
  * add captureManager to clean up code and improve re-usability
  * split out exportResults as a function
  * for all models, renamed name() to getName(), added getType() function
  * add getCameraNames() function to optimizer, so that we can:
  * output camera calibrations for ALL cameras
* Contributors: Michael Ferguson
```

## robot_calibration_msgs

```
* port robot_calibration_msgs to ROS2, update CI (#131 <https://github.com/mikeferguson/robot_calibration/issues/131>)
* Contributors: Michael Ferguson
```
