### PR TITLE
Adding AWS IoT SDK v2

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5956,6 +5956,16 @@ python3-autobahn:
     '*': ['python%{python3_pkgversion}-autobahn']
     '7': null
   ubuntu: [python3-autobahn]
+python3-awsiotsdk-pip:
+  debian:
+    pip:
+      packages: [awsiotsdk]
+  fedora:
+    pip:
+      packages: [awsiotsdk]
+  ubuntu:
+    pip:
+      packages: [awsiotsdk]
 python3-babeltrace:
   alpine: [py3-babeltrace]
   debian: [python3-babeltrace]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

awsiotsdk - Unfortunately they didn't add a v2 or any indication of next version, just a new name.

## Package Upstream Source:

https://github.com/aws/aws-iot-device-sdk-python-v2

## Purpose of using this:

The [v1 version](https://github.com/ros/rosdistro/pull/17081) of this package is deprecated. AWS has published a v2 version of the library. We continue to use this to have robots communicate with AWS IoT services.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - [No results](https://packages.debian.org/search?searchon=contents&keywords=aws&mode=exactfilename&suite=stable&arch=any)
- Ubuntu: https://packages.ubuntu.com/
   - [No results](https://packages.ubuntu.com/search?suite=jammy&section=all&arch=any&keywords=aws&searchon=names)
- Fedora: https://packages.fedoraproject.org/
  - [No results](https://packages.fedoraproject.org/search?query=aws&start=0)
- Gentoo: https://packages.gentoo.org/
  - [No results](https://packages.gentoo.org/packages/search?q=aws)
- Pip:
  - [Package](https://pypi.org/project/awsiotsdk/)


# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
