### PR TITLE
Correct Melodic git branch for mrpt_slam

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7300,7 +7300,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_slam.git
-      version: ros1
+      version: melodic-devel
     release:
       packages:
       - mrpt_ekf_slam_2d
@@ -7315,7 +7315,7 @@ repositories:
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_slam.git
-      version: ros1
+      version: melodic-devel
     status: maintained
   mrt_cmake_modules:
     doc:


### PR DESCRIPTION
It has been forked recently into `melodic-devel`.
Updating it here will fix Travis `dev` jobs.
