### PR TITLE
add: python-multimethod

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2824,16 +2824,6 @@ python-multicast:
     pip: [py-multicast]
   ubuntu:
     pip: [py-multicast]
-python-multimethod:
-  debian:
-    pip:
-      packages: [multimethod]
-  fedora:
-    pip:
-      packages: [multimethod]
-  ubuntu:
-    pip:
-      packages: [multimethod]
 python-multiprocess-pip:
   arch:
     pip:
@@ -7206,6 +7196,16 @@ python3-msgpack:
   nixos: [python3Packages.msgpack]
   openembedded: [python3-msgpack@meta-python]
   ubuntu: [python3-msgpack]
+python3-multimethod-pip:
+  debian:
+    pip:
+      packages: [multimethod]
+  fedora:
+    pip:
+      packages: [multimethod]
+  ubuntu:
+    pip:
+      packages: [multimethod]
 python3-mypy:
   alpine: [py3-mypy]
   arch: [mypy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2824,6 +2824,16 @@ python-multicast:
     pip: [py-multicast]
   ubuntu:
     pip: [py-multicast]
+python-multimethod:
+  debian:
+    pip:
+      packages: [multimethod]
+  fedora:
+    pip:
+      packages: [multimethod]
+  ubuntu:
+    pip:
+      packages: [multimethod]
 python-multiprocess-pip:
   arch:
     pip:


### PR DESCRIPTION
Signed-off-by: hsgwa <hasegawa.isp@gmail.com>

<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

multimethod

## Package Upstream Source:

https://github.com/coady/multimethod

## Purpose of using this:

multimethod provides a decorator for adding multiple argument dispatches to functions in the same style as functools.singledispatsh.

## Links to Distribution Packages

pip

https://pypi.org/project/multimethod/

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->


