### PR TITLE
mavlink: 2022.6.27-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1972,7 +1972,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mavlink-gbp-release.git
-      version: 2022.2.2-3
+      version: 2022.6.27-1
     source:
       type: git
       url: https://github.com/mavlink/mavlink-gbp-release.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1966,8 +1966,8 @@ repositories:
   mavlink:
     doc:
       type: git
-      url: https://github.com/mavlink/mavlink-gbp-release.git
-      version: release/rolling/mavlink
+      url: https://github.com/ros2-gbp/mavlink-gbp-release.git
+      version: release/humble/mavlink
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -1975,8 +1975,8 @@ repositories:
       version: 2022.6.27-1
     source:
       type: git
-      url: https://github.com/mavlink/mavlink-gbp-release.git
-      version: release/rolling/mavlink
+      url: https://github.com/ros2-gbp/mavlink-gbp-release.git
+      version: release/humble/mavlink
     status: developed
   mavros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `mavlink` to `2022.6.27-1`:

- upstream repository: https://github.com/mavlink/mavlink.git
- release repository: https://github.com/ros2-gbp/mavlink-gbp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2022.2.2-3`
