### PR TITLE
mavros: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1919,7 +1919,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mavros-release.git
-      version: 2.1.0-2
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `2.2.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/ros2-gbp/mavros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.1.0-2`

## libmavconn

```
* Merge pull request #1720 <https://github.com/mavlink/mavros/issues/1720> from SylvainPastor/fix/libmavconn/udp/deadlocks
  libmavconn: fix UDP deadlocks
* libmavconn: fix UDP deadlock
  Same problems as for the TCP:
  - #1682 <https://github.com/mavlink/mavros/issues/1682>: fix std::system_error when tcp interface loses connection
  - #1679 <https://github.com/mavlink/mavros/issues/1679>: fix deadlock when call close()
* Contributors: Sylvain Pastor, Vladimir Ermakov
```

## mavros

```
* extras: fix build
* Merge branch 'master' into ros2
  * master:
  mount_control.cpp: detect MOUNT_ORIENTATION stale messages
  ESCTelemetryItem.msg: correct RPM units
  apm_config.yaml: add mount configuration
  sys_status.cpp fix free memory for values > 64KiB
  uncrustify cellular_status.cpp
  Add CellularStatus plugin and message
  *_config.yaml: document usage of multiple batteries diagnostics
  sys_status.cpp: fix compilation
  sys_status.cpp: support diagnostics on up-to 10 batteries
  sys_status.cpp: do not use harcoded constants
  sys_status.cpp: Timeout on MEMINFO and HWSTATUS mavlink messages and publish on the diagnostics
  sys_status.cpp: fix enabling of mem_diag and hwst_diag
  sys_status.cpp: Do not use battery1 voltage as voltage for all other batteries (bugfix).
  sys_status.cpp: ignore sys_status mavlink messages from gimbals
  mount_control.cpp: use mount_nh for params to keep similarities with other plugins set diag settings before add()
  sys_status.cpp: remove deprecated BATTERY2 mavlink message support
  Mount control plugin: add configurable diagnostics
  Bugfix: increment_f had no value asigned when input LaserScan was bigger than obstacle.distances.size()
  Bugfix: wrong interpolation when the reduction ratio (scale_factor) is not integer.
  Disable startup_px4_usb_quirk in px4_config.yaml
* cmake: style fix
* cmake: downgrade to C++17 as 20 breaks something in rclcpp
* pylib: fix flake8 for checkid
* cmake: hide -std=c++2a
* Merge pull request #1752 <https://github.com/mavlink/mavros/issues/1752> from alehed/fix/make_compatible_with_mavlink_pr_666
  Make compatible with pymavlink type annotations PR
* Make compatible with pymavlink type annotations PR
  In that PR, the attribute name is changed to msgname due to conflicts
  with message instance variables.
* Merge pull request #1744 <https://github.com/mavlink/mavros/issues/1744> from amilcarlucas/pr_gimbal_diagnostics_fixes
  mount_control.cpp: detect MOUNT_ORIENTATION stale messages
* mount_control.cpp: detect MOUNT_ORIENTATION stale messages
  correct MountConfigure response success
  correct constructor initialization order
  some gimbals send negated/inverted angle measurements, correct that to obey the MAVLink frame convention using run-time parameters
* Update global_position.py
* Merge pull request #1745 <https://github.com/mavlink/mavros/issues/1745> from antonyramsy/ros2
  fix subscribe_raw_salellites typo
* fix subscribe_raw_salellites typo
  subscribe_raw_salellites -> subscribe_raw_satellites
* Merge pull request #1743 <https://github.com/mavlink/mavros/issues/1743> from amilcarlucas/pr_apm_config
  apm_config.yaml: add mount configuration
* apm_config.yaml: add mount configuration
* Merge pull request #1732 <https://github.com/mavlink/mavros/issues/1732> from amilcarlucas/pr-meminfo-fix
  MEMINFO fixes
* sys_status.cpp fix free memory for values > 64KiB
* Merge pull request #1716 <https://github.com/mavlink/mavros/issues/1716> from amilcarlucas/avoid-harcoded-values
  sys_status.cpp: do not use harcoded constants
* Merge pull request #1711 <https://github.com/mavlink/mavros/issues/1711> from amilcarlucas/diagnose-up-to-n-batteries
  Diagnose up-to 10 batteries
* *_config.yaml: document usage of multiple batteries diagnostics
* sys_status.cpp: fix compilation
* sys_status.cpp: support diagnostics on up-to 10 batteries
  Uses as many battery monitors as the user specified in min_voltage parameter.
  Add myself as a contributor, this is not my first patch to this file
* Merge pull request #1712 <https://github.com/mavlink/mavros/issues/1712> from amilcarlucas/fix-disabled-diagnostics
  sys_status.cpp: fix enabling of mem_diag and hwst_diag
* sys_status.cpp: do not use harcoded constants
* sys_status.cpp: Timeout on MEMINFO and HWSTATUS mavlink messages and publish on the diagnostics
  Use atomic variable to prevent potential threading problems
* sys_status.cpp: fix enabling of mem_diag and hwst_diag
* Merge pull request #1704 <https://github.com/mavlink/mavros/issues/1704> from amilcarlucas/correct-bat-voltages
  sys_status.cpp: Do not use battery1 voltage for all batteries.
* sys_status.cpp: Do not use battery1 voltage as voltage for all other batteries (bugfix).
  Support both cell and total voltages above 65V
  Support up-to 14S batteries
  If available, add cell voltage information to the battery diagnostic
* Merge pull request #1707 <https://github.com/mavlink/mavros/issues/1707> from amilcarlucas/ignore-gimbal-sys-status
  sys_status.cpp: ignore sys_status mavlink messages from gimbals
* sys_status.cpp: ignore sys_status mavlink messages from gimbals
* Merge pull request #1703 <https://github.com/mavlink/mavros/issues/1703> from amilcarlucas/remove-deprecated-battery2
  sys_status.cpp: remove deprecated BATTERY2 mavlink message support
* sys_status.cpp: remove deprecated BATTERY2 mavlink message support
* Merge pull request #1696 <https://github.com/mavlink/mavros/issues/1696> from okalachev/patch-2
  Disable startup_px4_usb_quirk in px4_config.yaml
* Disable startup_px4_usb_quirk in px4_config.yaml
* Contributors: Alexander Hedges, Dr.-Ing. Amilcar do Carmo Lucas, Karthik Desai, Oleg Kalachev, Vladimir Ermakov, antonyramsy
```

## mavros_extras

```
* extras: fix build
* extras: fix build
* Merge branch 'master' into ros2
  * master:
  mount_control.cpp: detect MOUNT_ORIENTATION stale messages
  ESCTelemetryItem.msg: correct RPM units
  apm_config.yaml: add mount configuration
  sys_status.cpp fix free memory for values > 64KiB
  uncrustify cellular_status.cpp
  Add CellularStatus plugin and message
  *_config.yaml: document usage of multiple batteries diagnostics
  sys_status.cpp: fix compilation
  sys_status.cpp: support diagnostics on up-to 10 batteries
  sys_status.cpp: do not use harcoded constants
  sys_status.cpp: Timeout on MEMINFO and HWSTATUS mavlink messages and publish on the diagnostics
  sys_status.cpp: fix enabling of mem_diag and hwst_diag
  sys_status.cpp: Do not use battery1 voltage as voltage for all other batteries (bugfix).
  sys_status.cpp: ignore sys_status mavlink messages from gimbals
  mount_control.cpp: use mount_nh for params to keep similarities with other plugins set diag settings before add()
  sys_status.cpp: remove deprecated BATTERY2 mavlink message support
  Mount control plugin: add configurable diagnostics
  Bugfix: increment_f had no value asigned when input LaserScan was bigger than obstacle.distances.size()
  Bugfix: wrong interpolation when the reduction ratio (scale_factor) is not integer.
  Disable startup_px4_usb_quirk in px4_config.yaml
* cmake: style fix
* cmake: downgrade to C++17 as 20 breaks something in rclcpp
* cmake: hide -std=c++2a
* Merge pull request #1744 <https://github.com/mavlink/mavros/issues/1744> from amilcarlucas/pr_gimbal_diagnostics_fixes
  mount_control.cpp: detect MOUNT_ORIENTATION stale messages
* extras: fix cog re to extract plugin name
* mount_control.cpp: detect MOUNT_ORIENTATION stale messages
  correct MountConfigure response success
  correct constructor initialization order
  some gimbals send negated/inverted angle measurements, correct that to obey the MAVLink frame convention using run-time parameters
* Merge pull request #1735 <https://github.com/mavlink/mavros/issues/1735> from clydemcqueen/fix_1734
  Fix crash in vision_pose plugin
* Remove unrelated log message
* Initialize last_transform_stamp with RCL_ROS_TIME, fixes #1734 <https://github.com/mavlink/mavros/issues/1734>
* Merge pull request #1727 <https://github.com/mavlink/mavros/issues/1727> from BV-OpenSource/pr-cellular-status
  Pr cellular status
* uncrustify cellular_status.cpp
* Add CellularStatus plugin and message
* Merge pull request #1702 <https://github.com/mavlink/mavros/issues/1702> from amilcarlucas/mount_diagnostics
  Mount control plugin: add configurable diagnostics
* mount_control.cpp: use mount_nh for params to keep similarities with other plugins
  set diag settings before add()
* Mount control plugin: add configurable diagnostics
* Merge pull request #1700 <https://github.com/mavlink/mavros/issues/1700> from oroelipas/fix-obstacle-distance
  Fix obstacle distance
* Bugfix: increment_f had no value asigned when input LaserScan was bigger than obstacle.distances.size()
* Bugfix: wrong interpolation when the reduction ratio (scale_factor) is not integer.
* Contributors: Clyde McQueen, Dr.-Ing. Amilcar do Carmo Lucas, Rui Mendes, Vladimir Ermakov, oroel
```

## mavros_msgs

```
* Merge branch 'master' into ros2
  * master:
  mount_control.cpp: detect MOUNT_ORIENTATION stale messages
  ESCTelemetryItem.msg: correct RPM units
  apm_config.yaml: add mount configuration
  sys_status.cpp fix free memory for values > 64KiB
  uncrustify cellular_status.cpp
  Add CellularStatus plugin and message
  *_config.yaml: document usage of multiple batteries diagnostics
  sys_status.cpp: fix compilation
  sys_status.cpp: support diagnostics on up-to 10 batteries
  sys_status.cpp: do not use harcoded constants
  sys_status.cpp: Timeout on MEMINFO and HWSTATUS mavlink messages and publish on the diagnostics
  sys_status.cpp: fix enabling of mem_diag and hwst_diag
  sys_status.cpp: Do not use battery1 voltage as voltage for all other batteries (bugfix).
  sys_status.cpp: ignore sys_status mavlink messages from gimbals
  mount_control.cpp: use mount_nh for params to keep similarities with other plugins set diag settings before add()
  sys_status.cpp: remove deprecated BATTERY2 mavlink message support
  Mount control plugin: add configurable diagnostics
  Bugfix: increment_f had no value asigned when input LaserScan was bigger than obstacle.distances.size()
  Bugfix: wrong interpolation when the reduction ratio (scale_factor) is not integer.
  Disable startup_px4_usb_quirk in px4_config.yaml
* msgs: support humble
* Merge pull request #1742 <https://github.com/mavlink/mavros/issues/1742> from amilcarlucas/correct_rpm_units
  ESCTelemetryItem.msg: correct RPM units
* ESCTelemetryItem.msg: correct RPM units
* Merge pull request #1727 <https://github.com/mavlink/mavros/issues/1727> from BV-OpenSource/pr-cellular-status
  Pr cellular status
* Add CellularStatus plugin and message
* Contributors: Dr.-Ing. Amilcar do Carmo Lucas, Rui Mendes, Vladimir Ermakov
```
