### PR TITLE
Add aiortc

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5880,7 +5880,7 @@ python3-aiohttp-cors:
   fedora: [python-aiohttp-cors]
   gentoo: [dev-python/aiohttp-cors]
   ubuntu: [python3-aiohttp-cors]
-python3-aiortc-pip:
+python3-aiortc:
   debian:
     bookworm: [aiortc]
   osx:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5882,12 +5882,12 @@ python3-aiohttp-cors:
   ubuntu: [python3-aiohttp-cors]
 python3-aiortc:
   debian:
-    bookworm: [aiortc]
+    bookworm: [python3-aiortc]
   osx:
     pip:
       packages: [aiortc]
   ubuntu:
-    jammy: [aiortc]
+    jammy: [python3-aiortc]
 python3-albumentations-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5882,20 +5882,12 @@ python3-aiohttp-cors:
   ubuntu: [python3-aiohttp-cors]
 python3-aiortc-pip:
   debian:
-    pip:
-      packages: [aiortc]
-  fedora:
-    pip:
-      packages: [aiortc]
-  gentoo:
-    pip:
-      packages: [aiortc]
+    bookworm: [aiortc]
   osx:
     pip:
       packages: [aiortc]
   ubuntu:
-    pip:
-      packages: [aiortc]
+    jammy: [aiortc]
 python3-albumentations-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5880,6 +5880,22 @@ python3-aiohttp-cors:
   fedora: [python-aiohttp-cors]
   gentoo: [dev-python/aiohttp-cors]
   ubuntu: [python3-aiohttp-cors]
+python3-aiortc-pip:
+  debian:
+    pip:
+      packages: [aiortc]
+  fedora:
+    pip:
+      packages: [aiortc]
+  gentoo:
+    pip:
+      packages: [aiortc]
+  osx:
+    pip:
+      packages: [aiortc]
+  ubuntu:
+    pip:
+      packages: [aiortc]
 python3-albumentations-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`aiortc`

## Package Upstream Source:

<https://github.com/aiortc/aiortc>

## Purpose of using this:

`aiortc` is a Python implementation of the WebRTC protocol, including support for DataChannels. Notably, it doesn't depend on the Chromium WebRTC project, hence avoiding issues such as <https://github.com/RobotWebTools/webrtc_ros/issues/66>. WebRTC is not only useful for sending video data to a browser from a robot, but also low latency realtime data via datachannels. Hence, I think it is valuable to add this to the index.

Distro packaging links:

## Links to Distribution Packages

- Debian:
  - <https://pypi.org/project/aiortc/> or <https://packages.debian.org/bookworm/python3-aiortc>
- Ubuntu:
   - <https://pypi.org/project/aiortc/> or <https://packages.ubuntu.com/jammy/python3-aiortc>
- Fedora: https://packages.fedoraproject.org/
  - <https://pypi.org/project/aiortc/>
- Arch: https://www.archlinux.org/packages/
  - <https://pypi.org/project/aiortc/> or <https://aur.archlinux.org/packages/python-aiortc>
- Gentoo: https://packages.gentoo.org/
  - <https://pypi.org/project/aiortc/>
- macOS: https://formulae.brew.sh/
  - <https://pypi.org/project/aiortc/>
- Alpine:
  - <https://pypi.org/project/aiortc/>
- NixOS/nixpkgs:
  - <https://pypi.org/project/aiortc/>