### PR TITLE
hri_msgs: 0.7.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3366,7 +3366,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros4hri/hri_msgs-release.git
-      version: 0.5.2-1
+      version: 0.7.0-1
     source:
       type: git
       url: https://github.com/ros4hri/hri_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hri_msgs` to `0.7.0-1`:

- upstream repository: https://github.com/ros4hri/hri_msgs.git
- release repository: https://github.com/ros4hri/hri_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.5.2-1`

## hri_msgs

```
0.7.0 (2022-06-28)
------------------
* expressions: expand list + use string constants
  The list is based on Chambers' MSc thesis, Bristol Robotics lab 2020
* Contributors: Séverin Lemaignan

0.6.0 (2022-06-01)
------------------
* revise IdsMatch to enable associations between any 2 ids, incl ids of same type
  This is especially useful to be able to 'merge' 2 people (eg, alias one to the other)
  by publishing a 'match' between 2 person ids
* Contributors: Séverin Lemaignan
```
