### PR TITLE
Change most repos in ros2.repos to use rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -86,7 +86,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ament/ament_cmake.git
-      version: master
+      version: rolling
     release:
       packages:
       - ament_cmake
@@ -119,7 +119,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ament/ament_cmake.git
-      version: master
+      version: rolling
     status: developed
   ament_cmake_catch2:
     doc:
@@ -140,7 +140,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/ament_cmake_ros.git
-      version: master
+      version: rolling
     release:
       packages:
       - ament_cmake_ros
@@ -153,7 +153,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/ament_cmake_ros.git
-      version: master
+      version: rolling
     status: maintained
   ament_download:
     doc:
@@ -174,7 +174,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ament/ament_index.git
-      version: master
+      version: rolling
     release:
       packages:
       - ament_index_cpp
@@ -187,13 +187,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ament/ament_index.git
-      version: master
+      version: rolling
     status: maintained
   ament_lint:
     doc:
       type: git
       url: https://github.com/ament/ament_lint.git
-      version: master
+      version: rolling
     release:
       packages:
       - ament_clang_format
@@ -235,7 +235,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ament/ament_lint.git
-      version: master
+      version: rolling
     status: developed
   ament_nodl:
     release:
@@ -252,7 +252,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ament/ament_package.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -262,7 +262,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ament/ament_package.git
-      version: master
+      version: rolling
     status: developed
   ament_vitis:
     doc:
@@ -549,7 +549,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/class_loader.git
-      version: ros2
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -559,7 +559,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/class_loader.git
-      version: ros2
+      version: rolling
     status: maintained
   color_names:
     doc:
@@ -580,7 +580,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/common_interfaces.git
-      version: master
+      version: rolling
     release:
       packages:
       - actionlib_msgs
@@ -604,13 +604,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/common_interfaces.git
-      version: master
+      version: rolling
     status: maintained
   console_bridge_vendor:
     doc:
       type: git
       url: https://github.com/ros2/console_bridge_vendor.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -620,7 +620,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/console_bridge_vendor.git
-      version: master
+      version: rolling
     status: maintained
   control_box_rst:
     doc:
@@ -698,7 +698,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/demos.git
-      version: master
+      version: rolling
     release:
       packages:
       - action_tutorials_cpp
@@ -730,7 +730,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/demos.git
-      version: master
+      version: rolling
     status: developed
   depthimage_to_laserscan:
     doc:
@@ -873,7 +873,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/eigen3_cmake_module.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -882,7 +882,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/eigen3_cmake_module.git
-      version: master
+      version: rolling
     status: maintained
   eigen_stl_containers:
     doc:
@@ -904,7 +904,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/example_interfaces.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -914,13 +914,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/example_interfaces.git
-      version: master
+      version: rolling
     status: maintained
   examples:
     doc:
       type: git
       url: https://github.com/ros2/examples.git
-      version: master
+      version: rolling
     release:
       packages:
       - examples_rclcpp_async_client
@@ -953,7 +953,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/examples.git
-      version: master
+      version: rolling
     status: maintained
   fastcdr:
     release:
@@ -1178,7 +1178,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/geometry2.git
-      version: ros2
+      version: rolling
     release:
       packages:
       - examples_tf2_py
@@ -1203,7 +1203,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/geometry2.git
-      version: ros2
+      version: rolling
     status: maintained
   geometry_tutorials:
     doc:
@@ -1228,7 +1228,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ament/google_benchmark_vendor.git
-      version: 0.0.7
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1238,7 +1238,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ament/google_benchmark_vendor.git
-      version: main
+      version: rolling
     status: maintained
   googletest:
     release:
@@ -1252,7 +1252,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ament/googletest.git
-      version: ros2
+      version: rolling
     status: maintained
   gps_umd:
     doc:
@@ -1410,7 +1410,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ignition-release/ignition_cmake2_vendor.git
-      version: main
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1420,13 +1420,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ignition-release/ignition_cmake2_vendor.git
-      version: main
+      version: rolling
     status: maintained
   ignition_math6_vendor:
     doc:
       type: git
       url: https://github.com/ignition-release/ignition_math6_vendor.git
-      version: main
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1436,13 +1436,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ignition-release/ignition_math6_vendor.git
-      version: main
+      version: rolling
     status: maintained
   image_common:
     doc:
       type: git
       url: https://github.com/ros-perception/image_common.git
-      version: ros2
+      version: rolling
     release:
       packages:
       - camera_calibration_parsers
@@ -1457,7 +1457,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/image_common.git
-      version: ros2
+      version: rolling
     status: maintained
   image_pipeline:
     doc:
@@ -1531,7 +1531,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/interactive_markers.git
-      version: ros2
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1541,7 +1541,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/interactive_markers.git
-      version: ros2
+      version: rolling
     status: maintained
   joint_state_publisher:
     doc:
@@ -1589,7 +1589,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/kdl_parser.git
-      version: ros2
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1599,13 +1599,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/kdl_parser.git
-      version: ros2
+      version: rolling
     status: maintained
   keyboard_handler:
     doc:
       type: git
       url: https://github.com/ros-tooling/keyboard_handler.git
-      version: main
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1615,7 +1615,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-tooling/keyboard_handler.git
-      version: main
+      version: rolling
     status: developed
   lanelet2:
     doc:
@@ -1658,7 +1658,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/laser_geometry.git
-      version: ros2
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1668,7 +1668,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/laser_geometry.git
-      version: ros2
+      version: rolling
     status: maintained
   laser_proc:
     doc:
@@ -1690,7 +1690,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/launch.git
-      version: master
+      version: rolling
     release:
       packages:
       - launch
@@ -1707,7 +1707,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/launch.git
-      version: master
+      version: rolling
     status: developed
   launch_param_builder:
     doc:
@@ -1728,7 +1728,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/launch_ros.git
-      version: master
+      version: rolling
     release:
       packages:
       - launch_ros
@@ -1742,7 +1742,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/launch_ros.git
-      version: master
+      version: rolling
     status: maintained
   lgsvl_msgs:
     release:
@@ -1795,7 +1795,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1804,7 +1804,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git
-      version: master
+      version: rolling
     status: developed
   libyaml_vendor:
     release:
@@ -1816,7 +1816,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/libyaml_vendor.git
-      version: master
+      version: rolling
     status: maintained
   locator_ros_bridge:
     doc:
@@ -1944,7 +1944,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/message_filters.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1954,7 +1954,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/message_filters.git
-      version: master
+      version: rolling
     status: maintained
   micro_ros_diagnostics:
     doc:
@@ -2014,7 +2014,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/mimick_vendor.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2023,7 +2023,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/mimick_vendor.git
-      version: master
+      version: rolling
     status: maintained
   mir_robot:
     doc:
@@ -2246,7 +2246,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-planning/navigation_msgs.git
-      version: ros2
+      version: rolling
     release:
       packages:
       - map_msgs
@@ -2258,7 +2258,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-planning/navigation_msgs.git
-      version: ros2
+      version: rolling
     status: maintained
   neo_simulation2:
     doc:
@@ -2528,7 +2528,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/orocos_kdl_vendor.git
-      version: main
+      version: rolling
     status: developed
   osqp_vendor:
     doc:
@@ -2666,7 +2666,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/performance_test_fixture.git
-      version: main
+      version: rolling
     status: maintained
   phidgets_drivers:
     doc:
@@ -2755,7 +2755,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/pluginlib.git
-      version: ros2
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2765,7 +2765,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/pluginlib.git
-      version: ros2
+      version: rolling
     status: maintained
   point_cloud_msg_wrapper:
     doc:
@@ -2846,7 +2846,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/pybind11_vendor.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2856,13 +2856,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/pybind11_vendor.git
-      version: master
+      version: rolling
     status: maintained
   python_cmake_module:
     doc:
       type: git
       url: https://github.com/ros2/python_cmake_module.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2871,13 +2871,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/python_cmake_module.git
-      version: master
+      version: rolling
     status: developed
   python_qt_binding:
     doc:
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git
-      version: main
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2887,7 +2887,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git
-      version: main
+      version: rolling
     status: maintained
   qpoases_vendor:
     release:
@@ -2904,7 +2904,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/qt_gui_core.git
-      version: main
+      version: rolling
     release:
       packages:
       - qt_dotgraph
@@ -2921,7 +2921,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/qt_gui_core.git
-      version: main
+      version: rolling
     status: maintained
   quaternion_operation:
     doc:
@@ -3082,7 +3082,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rcl.git
-      version: master
+      version: rolling
     release:
       packages:
       - rcl
@@ -3097,13 +3097,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcl.git
-      version: master
+      version: rolling
     status: maintained
   rcl_interfaces:
     doc:
       type: git
       url: https://github.com/ros2/rcl_interfaces.git
-      version: master
+      version: rolling
     release:
       packages:
       - action_msgs
@@ -3122,13 +3122,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcl_interfaces.git
-      version: master
+      version: rolling
     status: maintained
   rcl_logging:
     doc:
       type: git
       url: https://github.com/ros2/rcl_logging.git
-      version: master
+      version: rolling
     release:
       packages:
       - rcl_logging_interface
@@ -3142,7 +3142,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcl_logging.git
-      version: master
+      version: rolling
     status: maintained
   rclc:
     doc:
@@ -3169,7 +3169,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rclcpp.git
-      version: master
+      version: rolling
     release:
       packages:
       - rclcpp
@@ -3184,13 +3184,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclcpp.git
-      version: master
+      version: rolling
     status: maintained
   rclpy:
     doc:
       type: git
       url: https://github.com/ros2/rclpy.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -3200,13 +3200,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclpy.git
-      version: master
+      version: rolling
     status: maintained
   rcpputils:
     doc:
       type: git
       url: https://github.com/ros2/rcpputils.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -3216,7 +3216,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcpputils.git
-      version: master
+      version: rolling
     status: developed
   rcss3d_agent:
     doc:
@@ -3241,7 +3241,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rcutils.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -3251,13 +3251,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcutils.git
-      version: master
+      version: rolling
     status: maintained
   realtime_support:
     doc:
       type: git
       url: https://github.com/ros2/realtime_support.git
-      version: master
+      version: rolling
     release:
       packages:
       - rttest
@@ -3270,7 +3270,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/realtime_support.git
-      version: master
+      version: rolling
     status: maintained
   realtime_tools:
     doc:
@@ -3291,7 +3291,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/resource_retriever.git
-      version: ros2
+      version: rolling
     release:
       packages:
       - libcurl_vendor
@@ -3304,7 +3304,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/resource_retriever.git
-      version: ros2
+      version: rolling
     status: maintained
   rmf_api_msgs:
     doc:
@@ -3569,7 +3569,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rmw.git
-      version: master
+      version: rolling
     release:
       packages:
       - rmw
@@ -3582,13 +3582,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw.git
-      version: master
+      version: rolling
     status: maintained
   rmw_connextdds:
     doc:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git
-      version: master
+      version: rolling
     release:
       packages:
       - rmw_connextdds
@@ -3601,13 +3601,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git
-      version: master
+      version: rolling
     status: developed
   rmw_cyclonedds:
     doc:
       type: git
       url: https://github.com/ros2/rmw_cyclonedds.git
-      version: master
+      version: rolling
     release:
       packages:
       - rmw_cyclonedds_cpp
@@ -3619,13 +3619,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_cyclonedds.git
-      version: master
+      version: rolling
     status: developed
   rmw_dds_common:
     doc:
       type: git
       url: https://github.com/ros2/rmw_dds_common.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -3635,13 +3635,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_dds_common.git
-      version: master
+      version: rolling
     status: maintained
   rmw_fastrtps:
     doc:
       type: git
       url: https://github.com/ros2/rmw_fastrtps.git
-      version: master
+      version: rolling
     release:
       packages:
       - rmw_fastrtps_cpp
@@ -3655,7 +3655,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_fastrtps.git
-      version: master
+      version: rolling
     status: developed
   rmw_gurumdds:
     doc:
@@ -3679,7 +3679,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rmw_implementation.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -3689,7 +3689,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_implementation.git
-      version: master
+      version: rolling
     status: developed
   robot_calibration:
     doc:
@@ -3724,7 +3724,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/robot_state_publisher.git
-      version: ros2
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -3734,7 +3734,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/robot_state_publisher.git
-      version: ros2
+      version: rolling
     status: maintained
   ros1_bridge:
     doc:
@@ -3879,7 +3879,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/ros2cli.git
-      version: master
+      version: rolling
     release:
       packages:
       - ros2action
@@ -3905,13 +3905,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/ros2cli.git
-      version: master
+      version: rolling
     status: maintained
   ros2cli_common_extensions:
     doc:
       type: git
       url: https://github.com/ros2/ros2cli_common_extensions.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -3920,7 +3920,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/ros2cli_common_extensions.git
-      version: master
+      version: rolling
     status: maintained
   ros2launch_security:
     doc:
@@ -4012,7 +4012,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/ros_testing.git
-      version: master
+      version: rolling
     release:
       packages:
       - ros2test
@@ -4025,7 +4025,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/ros_testing.git
-      version: master
+      version: rolling
     status: maintained
   ros_workspace:
     release:
@@ -4042,7 +4042,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rosbag2.git
-      version: master
+      version: rolling
     release:
       packages:
       - ros2bag
@@ -4069,7 +4069,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosbag2.git
-      version: master
+      version: rolling
     status: developed
   rosbag2_bag_v2:
     doc:
@@ -4134,7 +4134,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rosidl.git
-      version: master
+      version: rolling
     release:
       packages:
       - rosidl_adapter
@@ -4156,13 +4156,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl.git
-      version: master
+      version: rolling
     status: maintained
   rosidl_dds:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_dds.git
-      version: master
+      version: rolling
     release:
       packages:
       - rosidl_generator_dds_idl
@@ -4174,13 +4174,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_dds.git
-      version: master
+      version: rolling
     status: maintained
   rosidl_defaults:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_defaults.git
-      version: master
+      version: rolling
     release:
       packages:
       - rosidl_default_generators
@@ -4193,13 +4193,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_defaults.git
-      version: master
+      version: rolling
     status: maintained
   rosidl_python:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_python.git
-      version: master
+      version: rolling
     release:
       packages:
       - rosidl_generator_py
@@ -4211,13 +4211,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_python.git
-      version: master
+      version: rolling
     status: maintained
   rosidl_runtime_py:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_runtime_py.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -4227,13 +4227,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_runtime_py.git
-      version: master
+      version: rolling
     status: maintained
   rosidl_typesupport:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_typesupport.git
-      version: master
+      version: rolling
     release:
       packages:
       - rosidl_typesupport_c
@@ -4246,13 +4246,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_typesupport.git
-      version: master
+      version: rolling
     status: maintained
   rosidl_typesupport_fastrtps:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
-      version: master
+      version: rolling
     release:
       packages:
       - fastrtps_cmake_module
@@ -4266,7 +4266,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
-      version: master
+      version: rolling
     status: developed
   rosidl_typesupport_gurumdds:
     doc:
@@ -4325,7 +4325,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rpyutils.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -4335,13 +4335,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rpyutils.git
-      version: master
+      version: rolling
     status: developed
   rqt:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt.git
-      version: ros2
+      version: rolling
     release:
       packages:
       - rqt
@@ -4357,13 +4357,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt.git
-      version: ros2
+      version: rolling
     status: maintained
   rqt_action:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_action.git
-      version: ros2
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -4372,13 +4372,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_action.git
-      version: ros2
+      version: rolling
     status: maintained
   rqt_bag:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git
-      version: ros2
+      version: rolling
     release:
       packages:
       - rqt_bag
@@ -4390,7 +4390,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git
-      version: ros2
+      version: rolling
     status: maintained
   rqt_common_plugins:
     doc:
@@ -4411,7 +4411,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git
-      version: ros2
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -4420,13 +4420,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git
-      version: ros2
+      version: rolling
     status: maintained
   rqt_graph:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_graph.git
-      version: galactic-devel
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -4436,7 +4436,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_graph.git
-      version: galactic-devel
+      version: rolling
     status: maintained
   rqt_image_overlay:
     doc:
@@ -4491,7 +4491,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_msg.git
-      version: foxy-devel
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -4500,13 +4500,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_msg.git
-      version: foxy-devel
+      version: rolling
     status: maintained
   rqt_plot:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git
-      version: foxy-devel
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -4515,13 +4515,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git
-      version: foxy-devel
+      version: rolling
     status: maintained
   rqt_publisher:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git
-      version: foxy-devel
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -4530,13 +4530,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git
-      version: foxy-devel
+      version: rolling
     status: maintained
   rqt_py_console:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_py_console.git
-      version: crystal-devel
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -4545,13 +4545,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_py_console.git
-      version: crystal-devel
+      version: rolling
     status: maintained
   rqt_reconfigure:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_reconfigure.git
-      version: dashing
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -4561,7 +4561,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_reconfigure.git
-      version: dashing
+      version: rolling
     status: maintained
   rqt_robot_dashboard:
     doc:
@@ -4627,7 +4627,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_service_caller.git
-      version: crystal-devel
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -4636,13 +4636,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_service_caller.git
-      version: crystal-devel
+      version: rolling
     status: maintained
   rqt_shell:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_shell.git
-      version: crystal-devel
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -4651,13 +4651,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_shell.git
-      version: crystal-devel
+      version: rolling
     status: maintained
   rqt_srv:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_srv.git
-      version: crystal-devel
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -4666,13 +4666,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_srv.git
-      version: crystal-devel
+      version: rolling
     status: maintained
   rqt_topic:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_topic.git
-      version: foxy-devel
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -4682,7 +4682,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_topic.git
-      version: foxy-devel
+      version: rolling
     status: maintained
   rt_manipulators_cpp:
     doc:
@@ -4732,7 +4732,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rviz.git
-      version: ros2
+      version: rolling
     release:
       packages:
       - rviz2
@@ -4751,7 +4751,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rviz.git
-      version: ros2
+      version: rolling
     status: maintained
   rviz_visual_tools:
     doc:
@@ -4940,7 +4940,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/spdlog_vendor.git
-      version: master
+      version: rolling
     status: maintained
   srdfdom:
     doc:
@@ -4961,7 +4961,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/sros2.git
-      version: master
+      version: rolling
     release:
       packages:
       - sros2
@@ -4974,7 +4974,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/sros2.git
-      version: master
+      version: rolling
     status: developed
   stubborn_buddies:
     doc:
@@ -5020,7 +5020,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/system_tests.git
-      version: master
+      version: rolling
     status: developed
   tango_icons_vendor:
     release:
@@ -5031,7 +5031,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/tango_icons_vendor.git
-      version: master
+      version: rolling
     status: maintained
   teleop_tools:
     doc:
@@ -5105,7 +5105,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/test_interface_files.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -5115,7 +5115,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/test_interface_files.git
-      version: master
+      version: rolling
     status: maintained
   tf_transformations:
     doc:
@@ -5137,7 +5137,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/tinyxml2_vendor.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -5147,7 +5147,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/tinyxml2_vendor.git
-      version: master
+      version: rolling
     status: maintained
   tinyxml_vendor:
     release:
@@ -5159,13 +5159,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/tinyxml_vendor.git
-      version: master
+      version: rolling
     status: maintained
   tlsf:
     doc:
       type: git
       url: https://github.com/ros2/tlsf.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -5175,7 +5175,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/tlsf.git
-      version: master
+      version: rolling
     status: maintained
   topic_tools:
     doc:
@@ -5287,7 +5287,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/ros_tutorials.git
-      version: rolling-devel
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -5297,7 +5297,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/ros_tutorials.git
-      version: rolling-devel
+      version: rolling
     status: maintained
   tvm_vendor:
     doc:
@@ -5404,13 +5404,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ament/uncrustify_vendor.git
-      version: master
+      version: rolling
     status: maintained
   unique_identifier_msgs:
     doc:
       type: git
       url: https://github.com/ros2/unique_identifier_msgs.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -5420,7 +5420,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/unique_identifier_msgs.git
-      version: master
+      version: rolling
     status: maintained
   ur_client_library:
     doc:
@@ -5494,7 +5494,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/urdf.git
-      version: ros2
+      version: rolling
     release:
       packages:
       - urdf
@@ -5507,7 +5507,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/urdf.git
-      version: ros2
+      version: rolling
     status: maintained
   urdf_parser_py:
     doc:
@@ -5859,7 +5859,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/yaml_cpp_vendor.git
-      version: master
+      version: rolling
     status: maintained
   zbar_ros:
     doc:


### PR DESCRIPTION
This PR moves most of the repos in ros2.repos to the newly created rolling branches in each repository.