### PR TITLE
Fix python3-importlib-* rules for RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6912,8 +6912,9 @@ python3-importlib-metadata:
     pip:
       packages: [importlib_metadata]
   rhel:
-    '*': ['python%{python3_pkgversion}-importlib-metadata']
+    '*': [python3]
     '7': null
+    '8': [python3-importlib-metadata]
   ubuntu:
     '*': [python3-importlib-metadata]
     bionic:
@@ -6940,8 +6941,9 @@ python3-importlib-resources:
     pip:
       packages: [importlib-resources]
   rhel:
-    '*': ['python%{python3_pkgversion}-importlib-resources']
+    '*': [python3]
     '7': null
+    '8': [python3-importlib-resources]
   ubuntu:
     '*': [python3-minimal]
     bionic:


### PR DESCRIPTION
RHEL 7 does not package the Python importlib-* backport packages. RHEL 8 packages them as python3-importlib-{metadata,resources}. RHEL 9 packages Python 3.9, so the importlib backport packages are not necessary. Therefore, follow the same pattern as Fedora and other distributions and reference the core Python 3 package instead.

The `%{python3_pkgversion}` macro no longer serves any purpose when used in the rules for a single RHEL release, so I dropped it for clarity.