### PR TITLE
plotjuggler: 3.4.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3486,7 +3486,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.4.4-1
+      version: 3.4.5-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.4.5-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `3.4.4-1`

## plotjuggler

```
* fix compilation
* add QCodeEditor
* CI: cmake ubuntu/Windows
* Fix CSV generated time axis. (#666 <https://github.com/facontidavide/PlotJuggler/issues/666>)
  Previously the CSV dataload plugin was not saving the correct XML state
  when a generated time axis was used.
* Added support for converted int types (#673 <https://github.com/facontidavide/PlotJuggler/issues/673>)
  * Added support for converted int types
  * Added fallback for int32 and int64
  Co-authored-by: Rano Veder <mailto:r.veder@primevision.com>
* Add tooltip to the zoom out button (#670 <https://github.com/facontidavide/PlotJuggler/issues/670>)
* PlotJuggler will generate its own cmake target
* Parquet plugin (#664 <https://github.com/facontidavide/PlotJuggler/issues/664>)
* fix Cancel button in CSV loader (#659 <https://github.com/facontidavide/PlotJuggler/issues/659>)
* Make tutorial link open in browser when clicked (#660 <https://github.com/facontidavide/PlotJuggler/issues/660>)
  Similar to https://github.com/facontidavide/PlotJuggler/pull/658 but applied to the tutorial link in the reactive lua editor
* accept white lines in CSV
* Update README.md (#661 <https://github.com/facontidavide/PlotJuggler/issues/661>)
* Make link open in browser when clicked (#658 <https://github.com/facontidavide/PlotJuggler/issues/658>)
  Set openExternalLinks property of label_4 to true to allow the hyperlink to open in a web browser when clicked
* Fix  #655 <https://github.com/facontidavide/PlotJuggler/issues/655>. Add autoZoom to transform dialog
* Rememvber CSV time column. Cherry picking from #657 <https://github.com/facontidavide/PlotJuggler/issues/657>.
* fix #650 <https://github.com/facontidavide/PlotJuggler/issues/650>
* Contributors: Andrew Goessling, Bartimaeus-, Davide Faconti, Konstantinos Lyrakis, Rano Veder, Zach Davis
```
