### PR TITLE
geometry2: 0.26.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1198,7 +1198,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.26.0-1
+      version: 0.26.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.26.1-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.26.0-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

```
* Use orocos_kdl_vendor and orocos-kdl target (#534 <https://github.com/ros2/geometry2/issues/534>)
* Contributors: Scott K Logan
```

## tf2_geometry_msgs

```
* Use orocos_kdl_vendor and orocos-kdl target (#534 <https://github.com/ros2/geometry2/issues/534>)
* Contributors: Scott K Logan
```

## tf2_kdl

```
* Use orocos_kdl_vendor and orocos-kdl target (#534 <https://github.com/ros2/geometry2/issues/534>)
* Contributors: Scott K Logan
```

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

- No changes

## tf2_ros_py

- No changes

## tf2_sensor_msgs

```
* tf2_sensor_msgs find the right Python executable. (#525 <https://github.com/ros2/geometry2/issues/525>)
* Contributors: Jorge Perez
```

## tf2_tools

- No changes
