### PR TITLE
snmp_ros: 1.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9849,6 +9849,21 @@ repositories:
       url: https://github.com/oKermorgant/slider_publisher.git
       version: ros1
     status: maintained
+  snmp_ros:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/snmp_ros.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ctu-vras/snmp_ros-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/ctu-vras/snmp_ros.git
+      version: master
+    status: developed
   snowbot_operating_system:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `snmp_ros` to `1.0.2-1`:

- upstream repository: https://github.com/ctu-vras/snmp_ros
- release repository: https://github.com/ctu-vras/snmp_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## snmp_ros

```
* Fix dependencies.
* Contributors: Martin Pecka
```
