### PR TITLE
snmp_ros: 1.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13104,6 +13104,21 @@ repositories:
       url: https://github.com/SteveMacenski/slam_toolbox.git
       version: melodic-devel
     status: maintained
+  snmp_ros:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/snmp_ros.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ctu-vras/snmp_ros-release.git
+      version: 1.0.3-1
+    source:
+      type: git
+      url: https://github.com/ctu-vras/snmp_ros.git
+      version: master
+    status: developed
   snowbot_operating_system:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `snmp_ros` to `1.0.3-1`:

- upstream repository: https://github.com/ctu-vras/snmp_ros
- release repository: https://github.com/ctu-vras/snmp_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## snmp_ros

```
* Added URLs to package.xml
* Contributors: Martin Pecka
```
