### PR TITLE
mrpt_sensors: 0.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5449,6 +5449,25 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
       version: ros1
     status: developed
+  mrpt_sensors:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
+      version: ros1
+    release:
+      packages:
+      - mrpt_generic_sensor
+      - mrpt_sensorlib
+      - mrpt_sensors
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/mrpt-ros-pkg-release/mrpt_sensors-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
+      version: ros1
+    status: developed
   mrt_cmake_modules:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_sensors` to `0.0.2-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_sensors-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## mrpt_generic_sensor

```
* New package
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensorlib

```
* New package
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensors

```
* New package
* Contributors: Jose Luis Blanco-Claraco
```
