### PR TITLE
nerian_stereo_ros2: 1.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2992,7 +2992,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/nerian-vision/nerian_stereo_ros2-release.git
-      version: 1.0.3-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/nerian-vision/nerian_stereo_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nerian_stereo_ros2` to `1.1.0-1`:

- upstream repository: https://github.com/nerian-vision/nerian_stereo_ros2.git
- release repository: https://github.com/nerian-vision/nerian_stereo_ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.3-1`

## nerian_stereo

```
* Updated vision software relase to 10.0.0
* Fixed potential problem with time sources in logging code
* Support for Humble
* Initiate image transfer despite any failure to connect to parameter service.
  (Device-related parameters are unavailable then - a verbose error is logged.)
* Contributors: Konstantin Schauwecker, Ramin Yaghoubzadeh Torky
```
