### PR TITLE
control_toolbox: 2.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -680,7 +680,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 2.0.2-3
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `2.1.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.2-3`

## control_toolbox

```
* Fix parameter loading log levels
* Support pass in a precomputed derivative error
* Add getParametersCallbackHandle function
* Add topic_prefix_ to declareParam & setParameter
* Update include/control_toolbox/dither.hpp
* Correct contributing and license files for ament_copyright.
* Added license text file and contributing guidelines, corrected license short identifier.
* Remove build of downstream workspace.
* Update CI config and add pre-commit-config.
* Contributors: Bence Magyar, ChenJun, Denis Štogl, Timon Engelke
```
