### PR TITLE
rclpy: 1.9.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3370,7 +3370,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 1.9.1-1
+      version: 1.9.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `1.9.2-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.9.1-1`

## rclpy

```
* Bugfix/duration to msg precision (#876 <https://github.com/ros2/rclpy/issues/876>) (#916 <https://github.com/ros2/rclpy/issues/916>)
* Avoid exception in Node constructor when use override for 'use_sim_time' (#896 <https://github.com/ros2/rclpy/issues/896>) (#913 <https://github.com/ros2/rclpy/issues/913>)
* Contributors: mergify[bot]
```
