### PR TITLE
rcutils: 4.0.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3421,7 +3421,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 4.0.2-2
+      version: 4.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `4.0.3-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `4.0.2-2`

## rcutils

```
* Clarify duration arg description in logging macros (#359 <https://github.com/ros2/rcutils/issues/359>) (#361 <https://github.com/ros2/rcutils/issues/361>)
* Fix build on Android (#343 <https://github.com/ros2/rcutils/issues/343>)
* Contributors: Ivan Santiago Paunovic, mergify[bot]
```
