### PR TITLE
geometry2: 0.17.4-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1270,7 +1270,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.17.3-1
+      version: 0.17.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.17.4-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.17.3-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* [tf2_ros/tf2_monitor] Calculate hz for each tf (#526 <https://github.com/ros2/geometry2/issues/526>)
* Contributors: kminoda
```

## tf2_ros_py

- No changes

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
