### PR TITLE
performance_test: 1.2.1-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2644,13 +2644,10 @@ repositories:
       url: https://gitlab.com/ApexAI/performance_test.git
       version: 1.0.0
     release:
-      packages:
-      - performance_report
-      - performance_test
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/performance_test-release.git
-      version: 1.0.0-1
+      version: 1.2.1-2
     source:
       type: git
       url: https://gitlab.com/ApexAI/performance_test.git


### PR DESCRIPTION
Increasing version of package(s) in repository `performance_test` to `1.2.1-2`:

- upstream repository: https://gitlab.com/ApexAI/performance_test.git
- release repository: https://github.com/ros2-gbp/performance_test-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `1.0.0-1`
