### PR TITLE
performance_test: 1.2.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2730,13 +2730,10 @@ repositories:
       url: https://gitlab.com/ApexAI/performance_test.git
       version: 1.1.0
     release:
-      packages:
-      - performance_report
-      - performance_test
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/performance_test-release.git
-      version: 1.1.0-1
+      version: 1.2.1-1
     source:
       type: git
       url: https://gitlab.com/ApexAI/performance_test.git


### PR DESCRIPTION
Increasing version of package(s) in repository `performance_test` to `1.2.1-1`:

- upstream repository: https://gitlab.com/ApexAI/performance_test.git
- release repository: https://github.com/ros2-gbp/performance_test-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `1.1.0-1`
