### PR TITLE
rcss3d_agent: 0.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3228,10 +3228,11 @@ repositories:
       - rcss3d_agent
       - rcss3d_agent_basic
       - rcss3d_agent_msgs
+      - rcss3d_agent_msgs_to_soccer_interfaces
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcss3d_agent-release.git
-      version: 0.3.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/ros-sports/rcss3d_agent.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcss3d_agent` to `0.4.1-1`:

- upstream repository: https://github.com/ros-sports/rcss3d_agent.git
- release repository: https://github.com/ros2-gbp/rcss3d_agent-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.3.0-1`

## rcss3d_agent

- No changes

## rcss3d_agent_basic

- No changes

## rcss3d_agent_msgs

```
* Fix up comment in Player.msg
* Contributors: Kenji Brameld
```

## rcss3d_agent_msgs_to_soccer_interfaces

```
* Add player number and team conversion to getRobotArray
* Contributors: Kenji Brameld
```
