### PR TITLE
maliput_malidrive: 0.1.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2452,7 +2452,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput_malidrive-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_malidrive` to `0.1.2-1`:

- upstream repository: https://github.com/maliput/maliput_malidrive.git
- release repository: https://github.com/ros2-gbp/maliput_malidrive-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.1-1`

## maliput_malidrive

```
* Fixes environment hooks. (#223 <https://github.com/maliput/maliput_malidrive/issues/223>)
* Contributors: Franco Cipollone
```
