### PR TITLE
maliput_multilane: 0.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2468,7 +2468,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput_multilane-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_multilane` to `0.1.1-1`:

- upstream repository: https://github.com/maliput/maliput_multilane.git
- release repository: https://github.com/ros2-gbp/maliput_multilane-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.0-1`

## maliput_multilane

```
* Fixes environment hooks. (#90 <https://github.com/maliput/maliput_multilane/issues/90>)
* Fixes dependency on environment variables. (#89 <https://github.com/maliput/maliput_multilane/issues/89>)
* Contributors: Franco Cipollone
```
