### PR TITLE
ros2_controllers: 2.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3797,7 +3797,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.6.0-1
+      version: 2.7.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.7.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.6.0-1`

## diff_drive_controller

```
* Update controllers with new get_name hardware interfaces (#369 <https://github.com/ros-controls/ros2_controllers/issues/369>)
* Contributors: Lucas Schulze
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gripper_controllers

```
* Update controllers with new get_name hardware interfaces (#369 <https://github.com/ros-controls/ros2_controllers/issues/369>)
* Contributors: Lucas Schulze
```

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

```
* Update controllers with new get_name hardware interfaces (#369 <https://github.com/ros-controls/ros2_controllers/issues/369>)
* Contributors: Lucas Schulze
```

## joint_trajectory_controller

```
* Properly retrieve parameters in the Joint Trajectory Controller (#365 <https://github.com/ros-controls/ros2_controllers/issues/365>)
* Rename the "abort" variable in the joint traj controller (#367 <https://github.com/ros-controls/ros2_controllers/issues/367>)
* account for edge case in JTC (#350 <https://github.com/ros-controls/ros2_controllers/issues/350>)
* Contributors: Andy Zelenak, Michael Wiznitzer
```

## position_controllers

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## velocity_controllers

- No changes
