### PR TITLE
ros2_control: 2.11.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3863,7 +3863,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.10.0-1
+      version: 2.11.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.11.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.10.0-1`

## controller_interface

```
* [Interfaces] Improved ```get_name()``` method of hardware interfaces (soft) #api-breaking (#737 <https://github.com/ros-controls/ros2_control/issues/737>)
* Update maintainers of packages (#753 <https://github.com/ros-controls/ros2_control/issues/753>)
* Full functionality of chainable controllers in controller manager (#667 <https://github.com/ros-controls/ros2_control/issues/667>)
  * auto-switching of chained mode in controllers
  * interface-matching approach for managing chaining controllers
* Contributors: Bence Magyar, Denis Štogl, Lucas Schulze
```

## controller_manager

```
* Remove hybrid services in controller manager. (#761 <https://github.com/ros-controls/ros2_control/issues/761>)
* [Interfaces] Improved ```get_name()``` method of hardware interfaces #api-breaking (#737 <https://github.com/ros-controls/ros2_control/issues/737>)
* Update maintainers of packages (#753 <https://github.com/ros-controls/ros2_control/issues/753>)
* Fix test dependency for chainable test (#751 <https://github.com/ros-controls/ros2_control/issues/751>)
* Remove ament autolint (#749 <https://github.com/ros-controls/ros2_control/issues/749>)
* Full functionality of chainable controllers in controller manager (#667 <https://github.com/ros-controls/ros2_control/issues/667>)
  * auto-switching of chained mode in controllers
  * interface-matching approach for managing chaining controllers
* Fixup spanwer and unspawner tests. It changes spawner a bit to handle interupts internally. (#745 <https://github.com/ros-controls/ros2_control/issues/745>)
* Add missing field to initializer lists in tests (#746 <https://github.com/ros-controls/ros2_control/issues/746>)
* Small but useful output update on controller manager. (#741 <https://github.com/ros-controls/ros2_control/issues/741>)
* Fixed period passed to hardware components always 0 (#738 <https://github.com/ros-controls/ros2_control/issues/738>)
* Contributors: Bence Magyar, Denis Štogl, Maciej Bednarczyk, Lucas Schulze
```

## controller_manager_msgs

```
* Remove hybrid services in controller manager. They are just overhead. (#761 <https://github.com/ros-controls/ros2_control/issues/761>)
* Update and fix CI setup (#752 <https://github.com/ros-controls/ros2_control/issues/752>)
* Update maintainers of packages (#753 <https://github.com/ros-controls/ros2_control/issues/753>)
* Remove ament autolint (#749 <https://github.com/ros-controls/ros2_control/issues/749>)
* Contributors: Bence Magyar, Denis Štogl
```

## hardware_interface

```
* [Interfaces] Improved ```get_name()``` method of hardware interfaces #api-breaking (#737 <https://github.com/ros-controls/ros2_control/issues/737>)
* Update maintainers of packages (#753 <https://github.com/ros-controls/ros2_control/issues/753>)
* Remove ament autolint (#749 <https://github.com/ros-controls/ros2_control/issues/749>)
* Full functionality of chainable controllers in controller manager (#667 <https://github.com/ros-controls/ros2_control/issues/667>)
  * auto-switching of chained mode in controllers
  * interface-matching approach for managing chaining controllers
* Contributors: Bence Magyar, Denis Štogl, Lucas Schulze
```

## ros2_control

```
* Update maintainers of packages (#753 <https://github.com/ros-controls/ros2_control/issues/753>)
* Contributors: Bence Magyar
```

## ros2_control_test_assets

```
* Update maintainers of packages (#753 <https://github.com/ros-controls/ros2_control/issues/753>)
* Remove ament autolint (#749 <https://github.com/ros-controls/ros2_control/issues/749>)
* Contributors: Bence Magyar
```

## ros2controlcli

```
* Remove hybrid services in controller manager. They are just overhead. (#761 <https://github.com/ros-controls/ros2_control/issues/761>)
* Update maintainers of packages (#753 <https://github.com/ros-controls/ros2_control/issues/753>)
* Add available status and moved to fstrings when listing hardware interfaces (#739 <https://github.com/ros-controls/ros2_control/issues/739>)
* Contributors: Bence Magyar, Denis Štogl, Leander Stephen D'Souza
```

## transmission_interface

```
* [Interfaces] Improved ```get_name()``` method of hardware interfaces #api-breaking (#737 <https://github.com/ros-controls/ros2_control/issues/737>)
* Update maintainers of packages (#753 <https://github.com/ros-controls/ros2_control/issues/753>)
* Remove ament autolint (#749 <https://github.com/ros-controls/ros2_control/issues/749>)
* Fixup ament cpplint on 22.04 (#747 <https://github.com/ros-controls/ros2_control/issues/747>)
* Contributors: Bence Magyar, Denis Štogl, Lucas Schulze
```
