### PR TITLE
nerian_stereo_ros2: 1.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2992,7 +2992,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/nerian-vision/nerian_stereo_ros2-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/nerian-vision/nerian_stereo_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nerian_stereo_ros2` to `1.1.1-1`:

- upstream repository: https://github.com/nerian-vision/nerian_stereo_ros2.git
- release repository: https://github.com/nerian-vision/nerian_stereo_ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.0-1`
