### PR TITLE
vrpn: 7.35.0-8 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6974,6 +6974,21 @@ repositories:
       url: https://github.com/lagadic/visp.git
       version: master
     status: maintained
+  vrpn:
+    doc:
+      type: git
+      url: https://github.com/vrpn/vrpn.git
+      version: version_07.35
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: git@github.com:alvinsunyixiao/vrpn-release.git
+      version: 7.35.0-8
+    source:
+      type: git
+      url: https://github.com/vrpn/vrpn.git
+      version: master
+    status: maintained
   warehouse_ros:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6978,11 +6978,11 @@ repositories:
     doc:
       type: git
       url: https://github.com/vrpn/vrpn.git
-      version: version_07.35
+      version: master
     release:
       tags:
         release: release/foxy/{package}/{version}
-      url: git@github.com:alvinsunyixiao/vrpn-release.git
+      url: https://github.com/alvinsunyixiao/vrpn-release.git
       version: 7.35.0-8
     source:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6982,7 +6982,7 @@ repositories:
     release:
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/alvinsunyixiao/vrpn-release.git
+      url: https://github.com/ros2-gbp/vrpn-release.git
       version: 7.35.0-8
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn` to `7.35.0-8`:

- upstream repository: https://github.com/vrpn/vrpn.git
- release repository: git@github.com:alvinsunyixiao/vrpn-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`
