### PR TITLE
log_view: 0.2.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1892,6 +1892,21 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: galactic
     status: maintained
+  log_view:
+    doc:
+      type: git
+      url: https://github.com/hatchbed/log_view.git
+      version: ros2
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/hatchbed/log_view-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/hatchbed/log_view.git
+      version: ros2
+    status: developed
   lua_vendor:
     doc:
       type: git


### PR DESCRIPTION
Adding initial galactic version of package(s) in repository log_view to 0.2.0-1:

upstream repository: https://github.com/hatchbed/log_view.git
release repository: https://github.com/hatchbed/log_view-release.git
distro file: galactic/distribution.yaml
bloom version: 0.11.1
previous version for package: null