### PR TITLE
Add python3-river-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8296,6 +8296,13 @@ python3-retrying:
     pip:
       packages: [retrying]
   ubuntu: [python3-retrying]
+python3-river-pip:
+  debian:
+    pip:
+      packages: [river]
+  ubuntu:
+    pip:
+      packages: [river]
 python3-robodk-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8300,6 +8300,9 @@ python3-river-pip:
   debian:
     pip:
       packages: [river]
+  osx:
+    pip:
+      packages: [river]
   ubuntu:
     pip:
       packages: [river]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`River`

## Package Upstream Source:

[River](https://riverml.xyz/0.11.1/)

## Purpose of using this:

River is a library to build online machine learning models. Such models operate on data streams.

## Links to Distribution Packages

- Debian: https://pypi.org/project/river/
- Ubuntu: https://pypi.org/project/river/
- macOS: https://pypi.org/project/river/