### PR TITLE
gazebo_ros2_control: 0.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1090,7 +1090,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros2_control` to `0.3.1-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros2_control.git
- release repository: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.3.0-1`

```
* Added logic for activating hardware interfaces (#139 <https://github.com/ros-simulation/gazebo_ros2_control/issues/139>)
* Adjust repo URL (#134 <https://github.com/ros-simulation/gazebo_ros2_control/issues/134>)
* Contributors: Alejandro Hernández Cordero, Bence Magyar
```

```
* Fixed CMake source file extension (#140 <https://github.com/ros-simulation/gazebo_ros2_control/issues/140>)
* Adding simulation time parameter for the controller manager (#138 <https://github.com/ros-simulation/gazebo_ros2_control/issues/138>)
  Adding the simulation parameter so that the controller manager uses the simulation time instead of the ROS time.  The '/odom' and corresponding tf will only be published if this parameter is set to true.
* Adjust repo URL (#134 <https://github.com/ros-simulation/gazebo_ros2_control/issues/134>)
* Changed launch variable name (#130 <https://github.com/ros-simulation/gazebo_ros2_control/issues/130>)
* Contributors: Alejandro Hernández Cordero, Bence Magyar, Eslam Salah, Jakub "Deli" Delicat
```

Signed-off-by: ahcorde <ahcorde@gmail.com>