### PR TITLE
ros_industrial_cmake_boilerplate: 0.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8332,7 +8332,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release.git
-      version: 0.2.16-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_industrial_cmake_boilerplate` to `0.3.0-1`:

- upstream repository: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git
- release repository: https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.2.16-1`

## ros_industrial_cmake_boilerplate

```
* Fix target_code_coverage to support targets with plain visibility
* Update target_cxx_version to support windows
* Add missing include(GoogleTest) to find_gtest() macro
* Update package CI to use colcon
* Contributors: Levi Armstrong
```
