### PR TITLE
opw_kinematics: 0.5.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6304,7 +6304,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-industrial-release/opw_kinematics-release.git
-      version: 0.4.6-1
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/Jmeyer1292/opw_kinematics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `opw_kinematics` to `0.5.0-1`:

- upstream repository: https://github.com/Jmeyer1292/opw_kinematics.git
- release repository: https://github.com/ros-industrial-release/opw_kinematics-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.4.6-1`

## opw_kinematics

```
* remove xenial CI build
* Update to ros_industrial_cmake_boilerplate 0.3.0
* Contributors: Levi Armstrong
```
