### PR TITLE
twist_stamper: 0.0.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5805,6 +5805,11 @@ repositories:
       type: git
       url: https://github.com/joshnewans/twist_stamper.git
       version: main
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/joshnewans/twist_stamper-release.git
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/joshnewans/twist_stamper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `twist_stamper` to `0.0.2-1`:

- upstream repository: https://github.com/joshnewans/twist_stamper.git
- release repository: https://github.com/joshnewans/twist_stamper-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## twist_stamper

```
* Add unstamper
* Removed cache files from git
* Switched license to Apache 2.0 to match ROS2 standard
* Fixed unit test issues.
* Fixed license
* Added content
* Initial commit
* Contributors: Josh Newans
```
