### PR TITLE
Adds  liblmdb-dev and librtaudio-dev entries to rosdep

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3897,13 +3897,15 @@ liblinphone-dev:
   nixos: [liblinphone]
   ubuntu: [liblinphone-dev]
 liblmdb-dev:
-  arch: [lmdb]
   alpine: [lmdb-dev]
+  arch: [lmdb]
   debian: [liblmdb-dev]
   fedora: [lmdb-devel]
   gentoo: [dev-db/lmdb]
   macports: [lmdb]
   nixos: [lmdb]
+  opensuse: [lmdb-devel]
+  rhel: [lmdb-devel]
   ubuntu: [liblmdb-dev]
 liblttng-ust-dev:
   arch: [lttng-ust]
@@ -5010,6 +5012,7 @@ librtaudio-dev:
   gentoo: [media-libs/rtaudio]
   macports: [rtaudio]
   nixos: [rtaudio]
+  opensuse: [rtaudio-devel]
   ubuntu: [librtaudio-dev]
 libsecp256k1-dev:
   debian: [libsecp256k1-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3897,10 +3897,12 @@ liblinphone-dev:
   nixos: [liblinphone]
   ubuntu: [liblinphone-dev]
 liblmdb-dev:
+  arch: [lmdb]
   alpine: [lmdb-dev]
   debian: [liblmdb-dev]
   fedora: [lmdb-devel]
   gentoo: [dev-db/lmdb]
+  macports: [lmdb]
   nixos: [lmdb]
   ubuntu: [liblmdb-dev]
 liblttng-ust-dev:
@@ -5006,6 +5008,7 @@ librtaudio-dev:
   debian: [librtaudio-dev]
   fedora: [rtaudio-devel]
   gentoo: [media-libs/rtaudio]
+  macports: [rtaudio]
   nixos: [rtaudio]
   ubuntu: [librtaudio-dev]
 libsecp256k1-dev:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3896,6 +3896,13 @@ liblinphone-dev:
   gentoo: [net-voip/linphone]
   nixos: [liblinphone]
   ubuntu: [liblinphone-dev]
+liblmdb-dev:
+  alpine: [lmdb-dev]
+  debian: [liblmdb-dev]
+  fedora: [lmdb-devel]
+  gentoo: [dev-db/lmdb]
+  nixos: [lmdb]
+  ubuntu: [liblmdb-dev]
 liblttng-ust-dev:
   arch: [lttng-ust]
   debian: [liblttng-ust-dev]
@@ -4994,6 +5001,13 @@ libreadline-java:
   debian: [libreadline-java]
   gentoo: [dev-java/libreadline-java]
   ubuntu: [libreadline-java]
+librtaudio-dev:
+  arch: [rtaudio]
+  debian: [librtaudio-dev]
+  fedora: [rtaudio-devel]
+  gentoo: [media-libs/rtaudio]
+  nixos: [rtaudio]
+  ubuntu: [librtaudio-dev]
 libsecp256k1-dev:
   debian: [libsecp256k1-dev]
   fedora: [libsecp256k1-devel]

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -255,6 +255,10 @@ liblapack-dev:
   osx:
     homebrew:
       packages: []
+liblmdb-dev:
+  osx:
+    homebrew:
+      packages: [lmdb]
 libmsgsl-dev:
   osx:
     homebrew:
@@ -367,6 +371,10 @@ libreadline-dev:
   osx:
     homebrew:
       packages: [readline]
+librtaudio-dev:
+  osx:
+    homebrew:
+      packages: [rtaudio]
 libspnav-dev:
   osx:
     homebrew:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:
This PR adds two entries to rosdep:

- liblmdb-dev
- librtaudio-dev
## Package Upstream Source:

- __liblmdb-dev:__ 
   - homepage: https://www.symas.com/lmdb 
   - Upstream Source: https://github.com/openldap/openldap/tree/master/libraries/liblmdb
 
- __librtaudio-dev:__ 
   - homepage: https://www.music.mcgill.ca/~gary/rtaudio/
   - Upstream Source: https://github.com/thestk/rtaudio


## Purpose of using this:

- __liblmdb-dev:__ 

Lighting Memory-Mapped Database (LMDB) is an ultra-fast, ultra-compact key-value embedded data store developed for the OpenLDAP Project. It uses memory-mapped files, so it has the read performance of a pure in-memory database while still offering the persistence of standard disk-based databases, and is only limited to the size of the virtual address space, (it is not limited to the size of physical RAM). 
- __librtaudio-dev:__   

RtAudio is a set of C++ classes that provides a common API (Application Programming Interface) for realtime audio input/output across Linux (native ALSA, JACK, and OSS), Macintosh OS X, SGI, and Windows (DirectSound and ASIO) operating systems. RtAudio significantly simplifies the process of interacting with computer audio hardware.


Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- __liblmdb-dev:__ 
- Debian: https://packages.debian.org/stretch/liblmdb-dev
- Ubuntu: https://packages.ubuntu.com/bionic/liblmdb-dev
- Fedora:https://packages.fedoraproject.org/pkgs/lmdb/lmdb-devel/
- Arch: https://archlinux.org/packages/extra/x86_64/lmdb/
- Gentoo: https://packages.gentoo.org/packages/dev-db/lmdb
- macOS: https://formulae.brew.sh/formula/lmdb#default
- Alpine: https://pkgs.alpinelinux.org/package/edge/main/x86_64/lmdb-dev
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=22.05&from=0&size=50&sort=relevance&type=packages&query=lmdb

- __librtaudio-dev:__   
- Debian: https://packages.debian.org/sid/librtaudio-dev
- Ubuntu: https://packages.ubuntu.com/bionic/librtaudio-dev
- Fedora: https://packages.fedoraproject.org/pkgs/rtaudio/rtaudio-devel/
- Arch: https://archlinux.org/packages/community/x86_64/rtaudio/
- Gentoo: https://packages.gentoo.org/packages/media-libs/rtaudio
- macOS: https://formulae.brew.sh/formula/rtaudio#default
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=22.05&show=rtaudio&from=0&size=50&sort=relevance&type=packages&query=rtaudio
