### PR TITLE
fix python-dateutil for ubuntu jammy

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6314,6 +6314,7 @@ python3-dateutil:
   osx:
     pip:
       packages: [python-dateutil]
+  rhel: ['python%{python3_pkgversion}-dateutil']
   ubuntu: [python3-dateutil]
 python3-dbus:
   debian: [python3-dbus]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6309,7 +6309,7 @@ python3-dateutil:
   debian: [python3-dateutil]
   fedora: [python3-dateutil]
   gentoo: [dev-python/python-dateutil]
-  nixos: [python310Packages.python-dateutil]
+  nixos: [python3Packages.python-dateutil]
   opensuse: [python3-python-dateutil]
   osx:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6307,13 +6307,13 @@ python3-datadog-pip:
 python3-dateutil:
   arch: [python-dateutil]
   debian: [python3-dateutil]
-  opensuse: [python3-python-dateutil]
-  rhel: [python3-dateutil]
   gentoo: [dev-python/python-dateutil]
   nixos: [python310Packages.python-dateutil]
+  opensuse: [python3-python-dateutil]
   osx:
     pip:
       packages: [python-dateutil]
+  rhel: [python3-dateutil]
   ubuntu: [python3-dateutil]
 python3-dbus:
   debian: [python3-dbus]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6307,7 +6307,8 @@ python3-datadog-pip:
 python3-dateutil:
   arch: [python-dateutil]
   debian: [python3-dateutil]
-  fedora: [python38-dateutil]
+  opensuse: [python3-python-dateutil]
+  rhel: [python3-dateutil]
   gentoo: [dev-python/python-dateutil]
   nixos: [python310Packages.python-dateutil]
   osx:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6313,7 +6313,6 @@ python3-dateutil:
   osx:
     pip:
       packages: [python-dateutil]
-  rhel: [python3-dateutil]
   ubuntu: [python3-dateutil]
 python3-dbus:
   debian: [python3-dbus]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6307,6 +6307,7 @@ python3-datadog-pip:
 python3-dateutil:
   arch: [python-dateutil]
   debian: [python3-dateutil]
+  fedora: [python3-dateutil]
   gentoo: [dev-python/python-dateutil]
   nixos: [python310Packages.python-dateutil]
   opensuse: [python3-python-dateutil]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6304,6 +6304,16 @@ python3-datadog-pip:
   ubuntu:
     pip:
       packages: [datadog]
+python3-dateutil:
+  arch: [python-dateutil]
+  debian: [python3-dateutil]
+  fedora: [python38-dateutil]
+  gentoo: [dev-python/python-dateutil]
+  nixos: [python310Packages.python-dateutil]
+  osx:
+    pip:
+      packages: [python-dateutil]
+  ubuntu: [python3-dateutil]
 python3-dbus:
   debian: [python3-dbus]
   fedora: [python3-dbus]


### PR DESCRIPTION
Add a version for python-dateutil on ubuntu jammy