### PR TITLE
aruco_opencv: 0.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -176,6 +176,21 @@ repositories:
       url: https://github.com/vanadiumlabs/arbotix_ros.git
       version: noetic-devel
     status: maintained
+  aruco_opencv:
+    doc:
+      type: git
+      url: https://github.com/fictionlab/aruco_opencv.git
+      version: noetic
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/fictionlab-gbp/aruco_opencv-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/fictionlab/aruco_opencv.git
+      version: noetic
+    status: developed
   aruco_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_opencv` to `0.1.0-1`:

- upstream repository: https://github.com/fictionlab/aruco_opencv.git
- release repository: https://github.com/fictionlab-gbp/aruco_opencv-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## aruco_opencv

```
* Initial version of the package
* Contributors: Błażej Sowa
```
