### PR TITLE
bag2_to_image: 0.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -440,6 +440,21 @@ repositories:
       url: https://github.com/pal-robotics/backward_ros.git
       version: foxy-devel
     status: maintained
+  bag2_to_image:
+    doc:
+      type: git
+      url: https://github.com/wep21/bag2_to_image.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/bag2_to_image-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/wep21/bag2_to_image.git
+      version: main
+    status: maintained
   behaviortree_cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bag2_to_image` to `0.1.0-1`:

- upstream repository: https://github.com/wep21/bag2_to_image.git
- release repository: https://github.com/ros2-gbp/bag2_to_image-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## bag2_to_image

```
* docs: add status badge
* docs: fix usage
* docs: add license and contributing.md
* docs: fix readme
* chore: update CMakeLists.txt
* build(deps): Bump actions/upload-artifact from 1 to 3 (#1 <https://github.com/wep21/bag2_to_image/issues/1>)
  Bumps [actions/upload-artifact](https://github.com/actions/upload-artifact) from 1 to 3.
  - [Release notes](https://github.com/actions/upload-artifact/releases)
  - [Commits](https://github.com/actions/upload-artifact/compare/v1...v3)
  ---
  updated-dependencies:
  - dependency-name: actions/upload-artifact
  dependency-type: direct:production
  update-type: version-update:semver-major
  ...
  Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
* ci: add dependabot.yaml
* feat: initial commit
* Contributors: Daisuke Nishimatsu, dependabot[bot]
```
