### PR TITLE
soccer_vision_3d_rviz_markers: 0.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4897,6 +4897,21 @@ repositories:
       url: https://github.com/ijnek/soccer_object_msgs.git
       version: rolling
     status: developed
+  soccer_vision_3d_rviz_markers:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/soccer_vision_3d_rviz_markers.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/soccer_vision_3d_rviz_markers-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-sports/soccer_vision_3d_rviz_markers.git
+      version: rolling
+    status: developed
   soccer_visualization:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `soccer_vision_3d_rviz_markers` to `0.0.1-1`:

- upstream repository: https://github.com/ros-sports/soccer_vision_3d_rviz_markers.git
- release repository: https://github.com/ros2-gbp/soccer_vision_3d_rviz_markers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## soccer_vision_3d_rviz_markers

```
* Use a black and white ball mesh, so it looks better than a red sphere
* Simplify README by making it point to RTD.
* Add Ball, FieldBoundary, Goalpost, Marking, Obstacle, Robot conversions
* Update package description and license in setup.py
* Add rviz config for visualization demo
* Ensure DELETEALL marker is always included in the markerarray
* Removed foxy, galactic and humble ci
* Initial commit
* Contributors: Jan Gutsche, Kenji Brameld
```
