### PR TITLE
camera_aravis: 4.0.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -588,7 +588,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/FraunhoferIOSB/camera_aravis-release.git
-      version: 4.0.2-1
+      version: 4.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_aravis` to `4.0.3-1`:

- upstream repository: https://github.com/FraunhoferIOSB/camera_aravis.git
- release repository: https://github.com/FraunhoferIOSB/camera_aravis-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `4.0.2-1`

## camera_aravis

```
* Refactor image conversion (#20 <https://github.com/FraunhoferIOSB/camera_aravis/issues/20>)
* Use plain file names for includes (#17 <https://github.com/FraunhoferIOSB/camera_aravis/issues/17>)
* Add verbose flag for feature detection (default = false) (#19 <https://github.com/FraunhoferIOSB/camera_aravis/issues/19>)
* Assume num_streams_ = 1 if DeviceStreamChannelCount and GevStreamChannelCount unavailable (#18 <https://github.com/FraunhoferIOSB/camera_aravis/issues/18>)
* Add Line0 to Line5 to TriggerSource Enum
* Fix: nodelet namespace
* Fix: onInit deadlock
* Contributors: Dominik Kleiser, Boitumelo Ruf, Thomas Emter, Peter Mortimer, tas, Geoff McIver
```
