### PR TITLE
clpe_sdk: 0.1.0-6 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -669,7 +669,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/canlab-co/CLPE_G_NVP2650D_SDK-ros2-release.git
-      version: 0.1.0-5
+      version: 0.1.0-6
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clpe_sdk` to `0.1.0-6`:

- upstream repository: https://github.com/canlab-co/CLPE_G_NVP2650D_SDK.git
- release repository: https://github.com/canlab-co/CLPE_G_NVP2650D_SDK-ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.0-5`

## clpe

```
* Provides libclpe
* Contributors: Can-lab Corporation
```
