### PR TITLE
velodyne: 1.7.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10978,7 +10978,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/velodyne-release.git
-      version: 1.6.1-1
+      version: 1.7.0-1
     source:
       type: git
       url: https://github.com/ros-drivers/velodyne.git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne` to `1.7.0-1`:

- upstream repository: https://github.com/ros-drivers/velodyne.git
- release repository: https://github.com/ros-drivers-gbp/velodyne-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.6.1-1`

## velodyne

- No changes

## velodyne_driver

```
* Fix non-responsive node on packet timeout (#466 <https://github.com/ros-drivers/velodyne/issues/466>)
  * No abort on packet timeout
  Changed getPacket() to return 0 on timeout and 1 on success.
  * Removed trailing whitespace
* reuse Velodyne UDP port (#427 <https://github.com/ros-drivers/velodyne/issues/427>)
* add missing include to pcap.h that prevents tests from being built (#406 <https://github.com/ros-drivers/velodyne/issues/406>)
* PCAP timestamps & PCAP+GPS timestamps (#384 <https://github.com/ros-drivers/velodyne/issues/384>)
  * Add pcap_time param and implement gps_time with it
  * If gps_time == true, ignore pcap_time
* Add support for the velodyne Alpha Prime (#370 <https://github.com/ros-drivers/velodyne/issues/370>)
  * Add support for the velodyne Alpha Prime
  * Change packet rate for the VLS128 according to the times specified in the manual
  * Organize setup functions to avoid code duplication. Add a constant for the model ID of the VLS128.
  * Use the defined constants to calculate the time offset of the points for the VLS128
  Co-authored-by: jugo <mailto:juan.gonzalez@unibw.de>
* Contributors: HMellor, Institute for Autonomous Systems Technology, JKaniarz, Nagy Dániel Zoltán, Sebastian Scherer
```

## velodyne_laserscan

- No changes

## velodyne_msgs

- No changes

## velodyne_pcl

```
* Use std::uint16_t to reduce build warnings from PCL (#449 <https://github.com/ros-drivers/velodyne/issues/449>)
* Contributors: icolwell-as
```

## velodyne_pointcloud

```
* build timings in offline setup (#428 <https://github.com/ros-drivers/velodyne/issues/428>)
  Currently when using the offline setup, it does not build the per-point timing offsets which means when unpacking the packets in the offline mode, you cannot timestamp each point with its packet time.
  This commit does the following:
  - call buildTimings from setupOffline function
  - add model to setupOffline interface
  - set config model param which is needed by buildTimings
* vls128: add line only once all four banks are processed (#413 <https://github.com/ros-drivers/velodyne/issues/413>)
* PCAP timestamps & PCAP+GPS timestamps (#384 <https://github.com/ros-drivers/velodyne/issues/384>)
  * Add pcap_time param and implement gps_time with it
  * If gps_time == true, ignore pcap_time
* Fixed row_step=0 when init_width=0 (dense cloud) (#404 <https://github.com/ros-drivers/velodyne/issues/404>)
  The PointCloud2 msg will be then valid: http://docs.ros.org/en/melodic/api/sensor_msgs/html/msg/PointCloud2.html
  Referred issues:
  * https://answers.ros.org/question/377470/rtabmap-icp_odometrycpp453callbackcloud-fatal-error/
  * http://official-rtab-map-forum.67519.x6.nabble.com/Condition-scan3dMsg-data-size-scan3dMsg-row-step-scan3dMsg-height-not-met-td7852.html
* Fix accidental integer division (#391 <https://github.com/ros-drivers/velodyne/issues/391>)
  Intensity values for VLP-16 were being calculated incorrectly.
* Add VLS128 launch and calibration file (#382 <https://github.com/ros-drivers/velodyne/issues/382>)
* Fixing incorrect type in velodyne_pointcloud.
* Fixing typo.
* Add support for the velodyne Alpha Prime (#370 <https://github.com/ros-drivers/velodyne/issues/370>)
  * Add support for the velodyne Alpha Prime
  * Change packet rate for the VLS128 according to the times specified in the manual
  * Organize setup functions to avoid code duplication. Add a constant for the model ID of the VLS128.
  * Use the defined constants to calculate the time offset of the points for the VLS128
  Co-authored-by: jugo <mailto:juan.gonzalez@unibw.de>
* Contributors: Daisuke Nishimatsu, HMellor, Institute for Autonomous Systems Technology, Joshua Whitley, Martin Valgur, Nick Charron, Sebastian Scherer, matlabbe
```
