### PR TITLE
velodyne: 2.3.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -6171,7 +6171,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/velodyne-release.git
-      version: 2.2.0-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/ros-drivers/velodyne.git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -6160,7 +6160,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/velodyne.git
-      version: galactic-devel
+      version: ros2
     release:
       packages:
       - velodyne
@@ -6175,7 +6175,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/velodyne.git
-      version: galactic-devel
+      version: ros2
     status: developed
   velodyne_simulator:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne` to `2.3.0-1`:

- upstream repository: https://github.com/ros-drivers/velodyne.git
- release repository: https://github.com/ros2-gbp/velodyne-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.2.0-1`

## velodyne

```
* Updating maintainer email address. (#450 <https://github.com/ros-drivers/velodyne/issues/450>)
  * Updating maintainer email address.
  * chore: update maintainer email address
  Co-authored-by: Joshua Whitley <mailto:jwhitley@autonomoustuff.com>
* Replace deprecated argument names in launch (#430 <https://github.com/ros-drivers/velodyne/issues/430>)
* 2.1.1
* Updating for first Galactic release
* Contributors: Daisuke Nishimatsu, Joshua Whitley, Keane Quigley
```

## velodyne_driver

```
* Updating maintainer email address. (#450 <https://github.com/ros-drivers/velodyne/issues/450>)
  * Updating maintainer email address.
  * chore: update maintainer email address
  Co-authored-by: Joshua Whitley <mailto:jwhitley@autonomoustuff.com>
* fix: use rclcpp logger instead of perror
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* reuse Velodyne UDP port (#427 <https://github.com/ros-drivers/velodyne/issues/427>)
* Added config option to timestamp a full scan based on first velo packet instead of last packet (#436 <https://github.com/ros-drivers/velodyne/issues/436>)
  Co-authored-by: Shawn Hanna <mailto:shawn@kaarta.com>
* Replace deprecated argument names in launch (#430 <https://github.com/ros-drivers/velodyne/issues/430>)
* 2.1.1
* Updating for first Galactic release
* Minor fixes to string formatting. (#396 <https://github.com/ros-drivers/velodyne/issues/396>)
  These changes will allow velodyne to compile without warnings
  on Rolling (soon to be Galactic).  The changes are also backwards
  compatible to Foxy if we want to backport them.
* Contributors: Chris Lalancette, Daisuke Nishimatsu, Joshua Whitley, Keane Quigley, Nagy Dániel Zoltán
```

## velodyne_laserscan

```
* Updating maintainer email address. (#450 <https://github.com/ros-drivers/velodyne/issues/450>)
  * Updating maintainer email address.
  * chore: update maintainer email address
  Co-authored-by: Joshua Whitley <mailto:jwhitley@autonomoustuff.com>
* Fix small warnings from build and test.
* Add laserscan support for new PointXYZIR structure (#316 <https://github.com/ros-drivers/velodyne/issues/316>) (#439 <https://github.com/ros-drivers/velodyne/issues/439>)
  * Add laserscan support for new PointXYZIR structure
  * Support PointCloud2 offsets that are multiples of 4
  Co-authored-by: Kevin Hallenbeck <mailto:khallenbeck@dataspeedinc.com>
* Replace deprecated argument names in launch (#430 <https://github.com/ros-drivers/velodyne/issues/430>)
* 2.1.1
* Updating for first Galactic release
* Contributors: Chris Lalancette, Daisuke Nishimatsu, Joshua Whitley, Keane Quigley
```

## velodyne_msgs

```
* Updating maintainer email address. (#450 <https://github.com/ros-drivers/velodyne/issues/450>)
  * Updating maintainer email address.
  * chore: update maintainer email address
  Co-authored-by: Joshua Whitley <mailto:jwhitley@autonomoustuff.com>
* 2.1.1
* Updating for first Galactic release
* Contributors: Daisuke Nishimatsu, Joshua Whitley
```

## velodyne_pointcloud

```
* Passing fixed_frame and target_frame to Convert object. (#330 <https://github.com/ros-drivers/velodyne/issues/330>) (#451 <https://github.com/ros-drivers/velodyne/issues/451>)
  Co-authored-by: Joshua Whitley <mailto:jwhitley@autonomoustuff.com>
* Updating maintainer email address. (#450 <https://github.com/ros-drivers/velodyne/issues/450>)
  * Updating maintainer email address.
  * chore: update maintainer email address
  Co-authored-by: Joshua Whitley <mailto:jwhitley@autonomoustuff.com>
* Add per point time field (#440 <https://github.com/ros-drivers/velodyne/issues/440>)
  * Initial commit to timestamp each point using the timing spec in the manuals
  * Added model param to each of the cloud nodelet starters
  * Minor cleanup. added author tag to rawdata
  * Move timing offsets functionality into class private. Also fix linter errors
  * added #include <vector> for linter
  * fix: suppress compiler warning
  * feat: change XYZIR to XYZIRT
  Co-authored-by: Shawn Hanna <mailto:shawn@kaarta.com>
* Link against yaml-cpp (#443 <https://github.com/ros-drivers/velodyne/issues/443>)
* Increase the max_range of the 32C launch file (#323 <https://github.com/ros-drivers/velodyne/issues/323>) (#441 <https://github.com/ros-drivers/velodyne/issues/441>)
  Co-authored-by: Shawn Hanna <mailto:50845122+kaarta-SHanna@users.noreply.github.com>
* fix for #267 <https://github.com/ros-drivers/velodyne/issues/267>, transform each packet (#438 <https://github.com/ros-drivers/velodyne/issues/438>)
  * fix for #267 <https://github.com/ros-drivers/velodyne/issues/267>, transform each packet
  * fix: fix scope of access modifiers
  Co-authored-by: Sebastian <mailto:spuetz@uos.de>
* Replace deprecated argument names in launch (#430 <https://github.com/ros-drivers/velodyne/issues/430>)
* 2.1.1
* Updating for first Galactic release
* Contributors: Daisuke Nishimatsu, Joshua Whitley, Keane Quigley, Stephan Sundermann
```
