### PR TITLE
ros2_control: 2.12.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3885,6 +3885,7 @@ repositories:
       - controller_manager
       - controller_manager_msgs
       - hardware_interface
+      - joint_limits
       - ros2_control
       - ros2_control_test_assets
       - ros2controlcli
@@ -3892,7 +3893,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.11.0-1
+      version: 2.12.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.12.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.11.0-1`

## controller_interface

- No changes

## controller_manager

```
* Deprecate and rename start and stop nomenclature toward user to activate and deactivate #ABI-breaking (#755 <https://github.com/ros-controls/ros2_control/issues/755>)
  * Rename fields and deprecate old nomenclature.
  * Add new defines to SwitchController.srv
  * Deprecated start/stop nomenclature in all CLI commands.
  * Deprecate 'start_asap' too as other fields.
* [ros2_control_node] Automatically detect if RT kernel is used and opportunistically enable SCHED_FIFO (#748 <https://github.com/ros-controls/ros2_control/issues/748>)
* Contributors: Denis Štogl, Tyler Weaver
```

## controller_manager_msgs

```
* Deprecate and rename start and stop nomenclature toward user to activate and deactivate #ABI-breaking (#755 <https://github.com/ros-controls/ros2_control/issues/755>)
  * Rename fields and deprecate old nomenclature.
  * Add new defines to SwitchController.srv
  * Deprecated start/stop nomenclature in all CLI commands.
  * Deprecate 'start_asap' too as other fields.
* Contributors: Denis Štogl
```

## hardware_interface

```
* Hardware interface specific update rate and best practices about it (#716 <https://github.com/ros-controls/ros2_control/issues/716>)
* Deprecate fake components, long live mock components (#762 <https://github.com/ros-controls/ros2_control/issues/762>)
* Contributors: Bence Magyar, Lovro Ivanov
```

## joint_limits

```
* Move Joint Limits structures for use in controllers (#462 <https://github.com/ros-controls/ros2_control/issues/462>)
* Contributors: Denis Štogl, Andy Zelenak, Bence Magyar
```

## ros2_control

```
* Move Joint Limits structures for use in controllers (#462 <https://github.com/ros-controls/ros2_control/issues/462>)
* Contributors: Denis Štogl, Andy Zelenak, Bence Magyar
```

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Deprecate and rename start and stop nomenclature toward user to activate and deactivate #ABI-breaking (#755 <https://github.com/ros-controls/ros2_control/issues/755>)
  * Rename fields and deprecate old nomenclature.
  * Add new defines to SwitchController.srv
  * Deprecated start/stop nomenclature in all CLI commands.
  * Deprecate 'start_asap' too as other fields.
* Contributors: Denis Štogl
```

## transmission_interface

- No changes
