### PR TITLE
ros2_controllers: 2.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3811,7 +3811,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.7.0-1
+      version: 2.8.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.8.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.7.0-1`

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* Preallocate JTC variables to avoid resizing in realtime loops (#340 <https://github.com/ros-controls/ros2_controllers/issues/340>)
* Contributors: Andy Zelenak
```

## position_controllers

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

```
* Fix deprecation in setup.cfg on Jammy (Humble and Rolling). (#375 <https://github.com/ros-controls/ros2_controllers/issues/375>)
* Contributors: Denis Štogl
```

## velocity_controllers

- No changes
