### PR TITLE
add freetype-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3184,6 +3184,21 @@ libfreenect-dev:
     '*': [libfreenect-devel]
     '7': null
   ubuntu: [libfreenect-dev]
+libfreetype-dev:
+  alpine: [freetype-dev]
+  arch: [freetype2]
+  debian:
+    '*': [libfreetype-dev]
+    'buster': [libfreetype6-dev]
+  fedora: [freetype-devel]
+  gentoo: [media-libs/freetype]
+  nixos: [freetype]
+  openembedded: [freetype@openembedded-core]
+  opensuse: [freetype-devel]
+  rhel: [freetype-devel]
+  ubuntu:
+    '*': [libfreetype-dev]
+    'bionic': [libfreetype6-dev]
 libfreetype6:
   alpine: [freetype]
   arch: [freetype2]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

freetype-dev

## Package Upstream Source:

https://gitlab.freedesktop.org/freetype/freetype

## Purpose of using this:

The existing package libfreetype6-dev has been renamed to libfreetype-dev.

From libfreetype's [chagelog](https://changelogs.ubuntu.com/changelogs/binary/libf/libfreetype6-dev/2.10.1-2/changelog):

>   * libfreetype6-dev has been renamed to libfreetype-dev.
>     - libfreetype6-dev is now a transitional package.
>     - Please update your build dependencies accordingly.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/bullseye/libfreetype-dev
- Ubuntu: https://packages.ubuntu.com/jammy/libfreetype-dev
- Fedora: https://packages.fedoraproject.org/pkgs/freetype/freetype-devel/
- Arch: https://archlinux.org/packages/extra/x86_64/freetype2/
- Gentoo: https://packages.gentoo.org/packages/media-libs/freetype
- Alpine: https://pkgs.alpinelinux.org/package/edge/main/x86_64/freetype
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=22.05&show=freetype&from=0&size=50&sort=relevance&type=packages&query=freetype
- openSUSE: https://software.opensuse.org/package/freetype 