### PR TITLE
marvelmind_ros2_release: 1.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1978,6 +1978,14 @@ repositories:
       url: https://github.com/swri-robotics/marti_messages.git
       version: dashing-devel
     status: developed
+  marvelmind_ros2_release:
+    release:
+      packages:
+      - marvelmind_ros2
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/MarvelmindRobotics/marvelmind_ros2_release_repo.git
+      version: 1.0.2-1
   mavlink:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marvelmind_ros2_release` to `1.0.2-1`:

- upstream repository: https://github.com/MarvelmindRobotics/marvelmind_ros2_upstream.git
- release repository: https://github.com/MarvelmindRobotics/marvelmind_ros2_release_repo.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## marvelmind_ros2

```
* project files added
* first commit
* Contributors: Marvelmind Robotics, smoker771
```
