### PR TITLE
angles: 1.12.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -223,7 +223,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/angles-release.git
-      version: 1.12.3-1
+      version: 1.12.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `angles` to `1.12.5-1`:

- upstream repository: https://github.com/ros/angles.git
- release repository: https://github.com/ros2-gbp/angles-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.12.3-1`

## angles

```
* ROS 2 Python Port (#37 <https://github.com/ros/angles/issues/37>)
* Fix M_PI on Windows (#34 <https://github.com/ros/angles/issues/34>) (#35 <https://github.com/ros/angles/issues/35>)
* Contributors: David V. Lu!!, Akash
```
