### PR TITLE
affordance_primitives: 0.1.0-3 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -66,6 +66,16 @@ repositories:
       url: https://github.com/ros-acceleration/adaptive_component.git
       version: rolling
     status: developed
+  affordance_primitives:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/PickNikRobotics/affordance_primitives-release.git
+      version: 0.1.0-3
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/affordance_primitives.git
+      version: main
   ament_acceleration:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `affordance_primitives` to `0.1.0-3`:

- upstream repository: https://github.com/PickNikRobotics/affordance_primitives.git
- release repository: https://github.com/PickNikRobotics/affordance_primitives-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## affordance_primitives

```
* Add license and contributing files
* Use clang-format style file
* Add pre-commit config
* Use google style string for CI clang-format
* Add CI actions workflow
* Initial port of affordance_primitive libraries to open source
* Contributors: Joe Schornak
```
