### PR TITLE
fogros2: 0.1.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1070,7 +1070,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/fogros2-release.git
-      version: 0.1.6-3
+      version: 0.1.7-1
     source:
       type: git
       url: https://github.com/BerkeleyAutomation/FogROS2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fogros2` to `0.1.7-1`:

- upstream repository: https://github.com/BerkeleyAutomation/FogROS2.git
- release repository: https://github.com/ros2-gbp/fogros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.6-3`

## fogros2

```
* temporarily removing awscli as dependency due to regression
```
