### PR TITLE
raspimouse_description: 1.0.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3933,6 +3933,21 @@ repositories:
       url: https://github.com/rt-net/raspimouse2.git
       version: foxy-devel
     status: maintained
+  raspimouse_description:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspimouse_description.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/rt-net-gbp/raspimouse_description_ros2-release.git
+      version: 1.0.0-2
+    source:
+      type: git
+      url: https://github.com/rt-net/raspimouse_description.git
+      version: foxy-devel
+    status: maintained
   rc_common_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspimouse_description` to `1.0.0-2`:

- upstream repository: https://github.com/rt-net/raspimouse_description.git
- release repository: https://github.com/rt-net-gbp/raspimouse_description_ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## raspimouse_description

```
* LiDARの追加 (#38 <https://github.com/rt-net/raspimouse_description/issues/38>)
* Merge master branch (ROS1) into ros2 branch (#37 <https://github.com/rt-net/raspimouse_description/issues/37>)
* Update library to rviz2 (#36 <https://github.com/rt-net/raspimouse_description/issues/36>)
* Update tread (ROS 2) (#32 <https://github.com/rt-net/raspimouse_description/issues/32>)
* Update README for ROS 2 (#26 <https://github.com/rt-net/raspimouse_description/issues/26>)
* Support ROS 2 Foxy (#24 <https://github.com/rt-net/raspimouse_description/issues/24>)
* Contributors: Daisuke Sato, Shota Aoki, Shuhei Kozasa
```
