### PR TITLE
angles: 1.14.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -237,7 +237,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/angles-release.git
-      version: 1.12.4-2
+      version: 1.14.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `angles` to `1.14.0-1`:

- upstream repository: https://github.com/ros/angles.git
- release repository: https://github.com/ros2-gbp/angles-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.12.4-2`

## angles

```
* ROS 2 Python Port (#37 <https://github.com/ros/angles/issues/37>) (#38 <https://github.com/ros/angles/issues/38>)
* Fix M_PI on Windows (#34 <https://github.com/ros/angles/issues/34>) (#36 <https://github.com/ros/angles/issues/36>)
* Contributors: David V. Lu!!, Akash
```
