### PR TITLE
angles: 1.16.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -289,7 +289,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/angles-release.git
-      version: 1.13.0-2
+      version: 1.16.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `angles` to `1.16.0-1`:

- upstream repository: https://github.com/ros/angles.git
- release repository: https://github.com/ros2-gbp/angles-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.13.0-2`

## angles

```
* Correct versions for version bump
* ROS 2 Python Port (#37 <https://github.com/ros/angles/issues/37>)
* Fix M_PI on Windows (#34 <https://github.com/ros/angles/issues/34>)
* Contributors: Akash, David V. Lu!!, Geoffrey Biggs
```
