### PR TITLE
Update libjsoncpp version for Ubuntu Jammy in rosdep/base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3810,13 +3810,11 @@ libjsoncpp:
   opensuse: [libjsoncpp19]
   rhel: [jsoncpp]
   ubuntu:
-    '*': [libjsoncpp1]
-    precise: [libjsoncpp0]
-    saucy: [libjsoncpp0]
+    '*': [libjsoncpp25]
+    bionic: [libjsoncpp1]
+    focal: [libjsoncpp1]
     trusty: [libjsoncpp0]
-    utopic: [libjsoncpp0]
-    vivid: [libjsoncpp0]
-    wily: [libjsoncpp0v5]
+    xenial: [libjsoncpp1]
 libjsoncpp-dev:
   arch: [jsoncpp]
   debian: [libjsoncpp-dev]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please fix package version for Ubuntu Jammy. 

## Package name:

libjsoncpp

## Purpose of using this:

In Ubuntu Jammy libjsoncpp library package name was changed from libjsoncpp1 to libjsoncpp25. Incorrect package version affects ROS Humble.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Ubuntu: https://packages.ubuntu.com/jammy/libjsoncpp25
