### PR TITLE
plotjuggler: 3.5.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2918,7 +2918,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.4.5-1
+      version: 3.5.0-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.5.0-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `3.4.5-1`

## plotjuggler

```
* license changed to MPL 2.0
* Macos ci (#685 <https://github.com/facontidavide/PlotJuggler/issues/685>)
* Add CSV table preview and CSV highlighting (#680 <https://github.com/facontidavide/PlotJuggler/issues/680>)
  * Add CSV table preview and CSV highlighting
  * add toggles for enabling CSV table view and syntax highlighting
* Fix start/end time bug in CSV Exporter (#682 <https://github.com/facontidavide/PlotJuggler/issues/682>)
* Add tooltips to CSV publisher buttons (#683 <https://github.com/facontidavide/PlotJuggler/issues/683>)
  -Add tooltips to the buttons that set the start/end time based on vertical time tracker position
  -add missing space in text ("timerange" to "time range")
* Fix #415 <https://github.com/facontidavide/PlotJuggler/issues/415>
* add statistics
* Add background editor
* fix crash in Parquet plugin
* Add line numbers to csv loader (#679 <https://github.com/facontidavide/PlotJuggler/issues/679>)
* Fix type-o in reactive script editor (#678 <https://github.com/facontidavide/PlotJuggler/issues/678>)
  missing "r" in "ScatterXY"
* Contributors: Bartimaeus-, Davide Faconti
```
