### PR TITLE
plotjuggler: 3.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2727,7 +2727,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.4.4-2
+      version: 3.5.0-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.5.0-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/ros2-gbp/plotjuggler-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `3.4.4-2`

## plotjuggler

```
* license changed to MPL 2.0
* Macos ci (#685 <https://github.com/facontidavide/PlotJuggler/issues/685>)
* Add CSV table preview and CSV highlighting (#680 <https://github.com/facontidavide/PlotJuggler/issues/680>)
  * Add CSV table preview and CSV highlighting
  * add toggles for enabling CSV table view and syntax highlighting
* Fix start/end time bug in CSV Exporter (#682 <https://github.com/facontidavide/PlotJuggler/issues/682>)
* Add tooltips to CSV publisher buttons (#683 <https://github.com/facontidavide/PlotJuggler/issues/683>)
  -Add tooltips to the buttons that set the start/end time based on vertical time tracker position
  -add missing space in text ("timerange" to "time range")
* Fix #415 <https://github.com/facontidavide/PlotJuggler/issues/415>
* add statistics
* Add background editor
* fix crash in Parquet plugin
* Add line numbers to csv loader (#679 <https://github.com/facontidavide/PlotJuggler/issues/679>)
* Fix type-o in reactive script editor (#678 <https://github.com/facontidavide/PlotJuggler/issues/678>)
  missing "r" in "ScatterXY"
* Contributors: Bartimaeus-, Davide Faconti
```
