### PR TITLE
pyhri: 0.1.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7226,6 +7226,21 @@ repositories:
       url: https://github.com/wxmerkt/pybind11_catkin-release.git
       version: 2.5.0-1
     status: maintained
+  pyhri:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/pyhri.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros4hri/pyhri-release.git
+      version: 0.1.2-1
+    source:
+      type: git
+      url: https://github.com/ros4hri/pyhri.git
+      version: master
+    status: developed
   pyquaternion:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyhri` to `0.1.2-1`:

- upstream repository: https://github.com/ros4hri/pyhri.git
- release repository: https://github.com/ros4hri/pyhri-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## pyhri

```
* [cmake] add test only behing CATKIN_ENABLE_TESTING
* Contributors: Séverin Lemaignan
```
