### PR TITLE
hri_rviz: 0.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3387,6 +3387,21 @@ repositories:
       url: https://github.com/ros4hri/hri_msgs.git
       version: master
     status: developed
+  hri_rviz:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/hri_rviz.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros4hri/hri_rviz-release.git
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/ros4hri/hri_rviz.git
+      version: master
+    status: developed
   human_description:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hri_rviz` to `0.3.0-1`:

- upstream repository: https://github.com/ros4hri/hri_rviz.git
- release repository: https://github.com/ros4hri/hri_rviz-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## hri_rviz

```
* Added PAL Robotics copyright
* Refactored skeleton frames testing
  The new version takes a frame name, verifies if it has more than
  the minimum number of characters for a skeleton frame, checks
  if the name without the last 5 characters belongs to the skeleton
  ROS4HRI naming convention and if it belongs to a currently tracked
  body.
* bodies -> skeletons
  Bodies frames are now referenced as skeleton frame, for clarity.
* Redefined class name for the plugin
  To avoid confusion with the already existing TF plugin, the
  plugin will now be visualized as TF (HRI) in rviz
* First complete hri_tf version
* Fixed skeletons appearing when plugin was disabled
* Contributors: Séverin Lemaignan, lorenzoferrini
```
