### PR TITLE
depthai: 2.17.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -936,7 +936,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/luxonis/depthai-core-release.git
-      version: 2.15.5-1
+      version: 2.17.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai` to `2.17.0-1`:

- upstream repository: https://github.com/luxonis/depthai-core.git
- release repository: https://github.com/luxonis/depthai-core-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.15.5-1`

## depthai

```
* Support for new S2/Pro devices
* FW: support for OAK-D-S2 / OAK-D-Pro using the latest board DM9098 R6M2E6
* Handle new resolutions THE_720_P and THE_800_P for ColorCamera, applicable to OV9782 on RGB/center socket
* StereoDepth: Add option for disparity shift to reduce minimum depth
* StereoDepth: extended and subpixel mode can be enabled simultaneously
* YoloV6 support
* Refactor ImageManip node
* macOS / Linux shared library and CI improvements
* Bootloader improvements
* Flash boot improvements
* Bootloader improvements (capability to flash and boot from eMMC)
* Flashed application information
* Memory querying
* XLink device search race fix
* Capability to flash BoardConfig along with the Pipeline
* Added host monitor thread to disconnect offline PoE devices
* Contributors: Alex Bougdan, Szabolcs Gergely, Martin Peterlin, Sachin Guruswamy
```
