### PR TITLE
turtlebot4: 0.1.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5663,7 +5663,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot4.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4` to `0.1.1-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4.git
- release repository: https://github.com/ros2-gbp/turtlebot4-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.0-1`

## turtlebot4_description

- No changes

## turtlebot4_msgs

- No changes

## turtlebot4_navigation

```
* Install turtlebot4_navigation module
* Added turtlebot4 navigator
* Fixed AMCL robot_model_type parameter
* Contributors: Roni Kreinin, roni-kreinin
```

## turtlebot4_node

```
* Merge pull request #7 <https://github.com/turtlebot/turtlebot4/issues/7> from turtlebot/roni-kreinin/linters
  Fixed linter errors
* Fixed linter errors
* Contributors: Roni Kreinin, roni-kreinin
```
