### PR TITLE
marvelmind_ros2_msgs: 1.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1978,6 +1978,12 @@ repositories:
       url: https://github.com/swri-robotics/marti_messages.git
       version: dashing-devel
     status: developed
+  marvelmind_ros2_msgs:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/MarvelmindRobotics/marvelmind_ros2_msgs_release.git
+      version: 1.0.2-1
   mavlink:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marvelmind_ros2_msgs` to `1.0.2-1`:

- upstream repository: https://github.com/MarvelmindRobotics/marvelmind_ros2_msgs_upstream.git
- release repository: https://github.com/MarvelmindRobotics/marvelmind_ros2_msgs_release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## marvelmind_ros2_msgs

```
* first commit
* Contributors: smoker771
```
