### PR TITLE
image_common: 2.4.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1839,7 +1839,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 2.3.0-1
+      version: 2.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `2.4.0-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.0-1`

## camera_calibration_parsers

- No changes

## camera_info_manager

- No changes

## image_common

- No changes

## image_transport

```
* getNumSubscribers working method to foxy (#220 <https://github.com/ros-perception/image_common/issues/220>)
* Simple IT plugins shutdown (#225 <https://github.com/ros-perception/image_common/issues/225>) (#230 <https://github.com/ros-perception/image_common/issues/230>)
* Contributors: Michael Ferguson, Alejandro Hernández Cordero, vladimirilin, Matej Vargovcik, RoboTech Vision
```
