### PR TITLE
image_pipeline: 1.15.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4651,7 +4651,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/image_pipeline.git
-      version: indigo
+      version: melodic
     release:
       packages:
       - camera_calibration
@@ -4669,7 +4669,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-perception/image_pipeline.git
-      version: indigo
+      version: melodic
     status: developed
   image_transport_plugins:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4665,7 +4665,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/image_pipeline-release.git
-      version: 1.15.0-1
+      version: 1.15.2-1
     source:
       type: git
       url: https://github.com/ros-perception/image_pipeline.git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `1.15.2-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros-gbp/image_pipeline-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.15.0-1`

## camera_calibration

- No changes

## depth_image_proc

```
* Include vector
* support rgba8 and bgra8 encodings by skipping alpha channel
```

## image_pipeline

- No changes

## image_proc

- No changes

## image_publisher

- No changes

## image_rotate

- No changes

## image_view

- No changes

## stereo_image_proc

```
* support rgba8 and bgra8 encodings by skipping alpha channel
* build error fix
* feedback considered
* downsampling original img / upsampling disparity img
```
