### PR TITLE
Add gnuplot-iostream to rosdep base

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1418,6 +1418,9 @@ gnuplot:
   nixos: [gnuplot]
   openembedded: [gnuplot@meta-oe]
   ubuntu: [gnuplot]
+gnuplot-iostream:
+  debian: [libgnuplot-iostream-dev]
+  ubuntu: [libgnuplot-iostream-dev]
 gnuplot-x11:
   debian: [gnuplot-x11]
   ubuntu: [gnuplot-x11]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

gnuplot-iostream

## Package Upstream Source:

https://github.com/dstahlke/gnuplot-iostream

## Purpose of using this:

This adds a generic c++ interface for gnuplot which is already available via rosdep.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - [REQUIRED](https://packages.debian.org/source/sid/gnuplot-iostream)
- Ubuntu: https://packages.ubuntu.com/
   - [REQUIRED](https://packages.ubuntu.com/source/focal/gnuplot-iostream)
- Fedora: https://packages.fedoraproject.org/
  - not found
- Arch: https://www.archlinux.org/packages/
  - not found
- Gentoo: https://packages.gentoo.org/
  - not found
- macOS: https://formulae.brew.sh/
  - not found
- Alpine: https://pkgs.alpinelinux.org/packages
  - not found
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not checked
- openSUSE: https://software.opensuse.org/package/
  - not found