### PR TITLE
ros2_control: 2.12.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3784,7 +3784,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.12.0-1
+      version: 2.12.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.12.1-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.12.0-1`

## controller_interface

- No changes

## controller_manager

```
* Rename CM members from start/stop to activate/deactivate nomenclature. (#756 <https://github.com/ros-controls/ros2_control/issues/756>)
* Fix spelling in comment (#769 <https://github.com/ros-controls/ros2_control/issues/769>)
* Contributors: Denis Štogl, Tyler Weaver
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Fix fake components deprecation and add test for it (#771 <https://github.com/ros-controls/ros2_control/issues/771>)
* Contributors: Bence Magyar
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## transmission_interface

- No changes
