### PR TITLE
Unify key formatting in rosdep/base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1757,7 +1757,7 @@ hddtemp:
   rhel: [hddtemp]
   slackware: [hddtemp]
   ubuntu:
-    "*": null
+    '*': null
     bionic: [hddtemp]
     focal: [hddtemp]
     impish: [hddtemp]
@@ -3189,7 +3189,7 @@ libfreetype-dev:
   arch: [freetype2]
   debian:
     '*': [libfreetype-dev]
-    'buster': [libfreetype6-dev]
+    buster: [libfreetype6-dev]
   fedora: [freetype-devel]
   gentoo: [media-libs/freetype]
   nixos: [freetype]
@@ -3198,7 +3198,7 @@ libfreetype-dev:
   rhel: [freetype-devel]
   ubuntu:
     '*': [libfreetype-dev]
-    'bionic': [libfreetype6-dev]
+    bionic: [libfreetype6-dev]
 libfreetype6:
   alpine: [freetype]
   arch: [freetype2]


### PR DESCRIPTION


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

This MR unifies dictionary keys formatting in rosdep/base.yaml file. There were two places where single word keys were quoted and one place where double quotes were used.

## Package name:

hddtemp, libfreetype-dev

## Purpose of using this:

Unify yaml style in rosdep/base.yaml.
