### PR TITLE
maliput_full: 0.1.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2420,6 +2420,22 @@ repositories:
       url: https://github.com/maliput/maliput_drake.git
       version: main
     status: developed
+  maliput_full:
+    doc:
+      type: git
+      url: https://github.com/maliput/maliput_infrastructure.git
+      version: main
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/maliput_infrastructure-release.git
+      version: 0.1.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/maliput/maliput_infrastructure.git
+      version: main
+    status: developed
   maliput_integration:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_full` to `0.1.0-2`:

- upstream repository: https://github.com/maliput/maliput_infrastructure.git
- release repository: https://github.com/ros2-gbp/maliput_infrastructure-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## maliput_full

```
* Adds maliput_full meta package. (#280 <https://github.com/maliput/maliput_infrastructure/issues/280>)
* Contributors: Franco Cipollone
```
