### PR TITLE
rclpy: 3.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3208,7 +3208,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 3.5.0-1
+      version: 3.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `3.6.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.5.0-1`

## rclpy

```
* Add Parameter Client (#959 <https://github.com/ros2/rclpy/issues/959>)
* Change sphinx theme to readthedocs (#950 <https://github.com/ros2/rclpy/issues/950>)
* Name and type in descriptor(s) is ignored via declare_parameter(s). (#957 <https://github.com/ros2/rclpy/issues/957>)
* Typo fix (#951 <https://github.com/ros2/rclpy/issues/951>)
* Add py.typed to package (#946 <https://github.com/ros2/rclpy/issues/946>)
* Fix rclpy.shutdown() from hanging when triggered from callback (#947 <https://github.com/ros2/rclpy/pull/947>)
* Check if the context is already shutdown. (#939 <https://github.com/ros2/rclpy/issues/939>)
* Contributors: Brian Chen, Tomoya Fujita, Yuki Igarashi
```
