### PR TITLE
jsk_model_tools: 0.4.4-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4011,7 +4011,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tork-a/jsk_model_tools-release.git
-      version: 0.4.4-1
+      version: 0.4.4-2
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_model_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_model_tools` to `0.4.4-2`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_model_tools
- release repository: https://github.com/tork-a/jsk_model_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.4.4-1`

## eus_assimp

- No changes

## euscollada

```
* support use_simple_geometry, with bounding box (#244 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/244>)
* keep sensor_id correctly from collada (#236 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/236>)
* Noetic support (#238 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/238>)
  
    * fix for python3: use a in b, instead of b.has_key(a)
    * fix for python3 with 2to3 -w -f print
      add from __future__ import print_function
    * noetic does not have xacro.py, use xacro, skip teset if openhrp3 is not found
    * fix for python3 with 2to3 -w -f print
    * manually set collada_urdf_LIBRARIES due to https://github.com/ros/collada_urdf/issues/43
  
* add mimic joint support for collada2eus (#225 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/225>)
  
    * not sure why but we need double check 'strm' since  https://travis-ci.org/jsk-ros-pkg/jsk_model_tools/builds/632871892
    * suport calc-jacobian for mimnic joints, with tests
    * support mimic joints
    * introduce mimic-joint-parmas, rotational-mimic-joint, linear-mimic-joint class
  
* Contributors: Kei Okada, Naoki Hiraoka
```

## eusurdf

```
* add world-file-path on README (#230 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/230>)
* noetic support  (#238 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/238>)
  
    * use subprocess.getoutput if import commands fail
    * turn package format 3 and use python3-lxml for noetic
    * more fix on python3: fix str/byte problem : TypeError: a bytes-like object is required, not 'str' ,TypeError: write() argument must be str, not bytes
    * fix for python3 with 2to3 -w -f print
    * eusurdf.cmake : manually set collada_urdf_LIBRARIES due to https://github.com/ros/collada_urdf/issues/43
    * eusurdf.cmake : invoike python2/python3 using ROS_PYTHON=VERSION
  
* Contributors: Kei Okada, Yoshiki Obinata
```

## jsk_model_tools

- No changes
