### PR TITLE
Update the branches for image_pipeline.

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1850,7 +1850,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/image_pipeline.git
-      version: ros2
+      version: foxy
     release:
       packages:
       - camera_calibration
@@ -1869,7 +1869,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/image_pipeline.git
-      version: ros2
+      version: foxy
     status: maintained
   image_transport_plugins:
     doc:

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1518,7 +1518,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/image_pipeline.git
-      version: ros2
+      version: galactic
     release:
       packages:
       - camera_calibration
@@ -1537,7 +1537,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/image_pipeline.git
-      version: ros2
+      version: galactic
     status: maintained
   image_transport_plugins:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1513,7 +1513,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/image_pipeline.git
-      version: rolling
+      version: humble
     release:
       packages:
       - camera_calibration
@@ -1533,7 +1533,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/image_pipeline.git
-      version: rolling
+      version: humble
     status: maintained
   image_transport_plugins:
     doc:


### PR DESCRIPTION
This is to correspond to one branch per ROS distribution, which
just makes it easier to reason about.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>
