### PR TITLE
foxglove_msgs: 2.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3514,6 +3514,21 @@ repositories:
       url: https://github.com/ros-drivers/four_wheel_steering_msgs.git
       version: master
     status: maintained
+  foxglove_msgs:
+    doc:
+      type: git
+      url: https://github.com/foxglove/schemas.git
+      version: main
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/foxglove/ros_foxglove_msgs-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/foxglove/schemas.git
+      version: main
+    status: developed
   frame_editor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_msgs` to `2.0.0-1`:

- upstream repository: https://github.com/foxglove/schemas.git
- release repository: https://github.com/foxglove/ros_foxglove_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

Resolves https://github.com/foxglove/schemas/issues/44

## foxglove_msgs

```
* Consolidate Transform and FrameTransform
* Contributors: Adrian Macneil
```
