### PR TITLE
foxglove_msgs: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1087,7 +1087,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_foxglove_msgs-release.git
-      version: 1.2.2-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/foxglove/schemas.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_msgs` to `2.0.0-1`:

- upstream repository: https://github.com/foxglove/schemas.git
- release repository: https://github.com/ros2-gbp/ros_foxglove_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.2.2-1`

## foxglove_msgs

```
* Consolidate Transform and FrameTransform
* Contributors: Adrian Macneil
```
