### PR TITLE
fkie_multimaster: 1.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2550,7 +2550,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 1.3.0-2
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fkie_multimaster` to `1.3.1-1`:

- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.3.0-2`

## fkie_master_discovery

- No changes

## fkie_master_sync

- No changes

## fkie_multimaster

```
* fkie_multimaster_msgs: fix python3 dependency
* Contributors: Alexander Tiderko
```

## fkie_multimaster_msgs

```
* fkie_multimaster_msgs: fix python3 dependency
* Contributors: Alexander Tiderko
```

## fkie_node_manager

- No changes

## fkie_node_manager_daemon

- No changes
