### PR TITLE
rqt_console: 1.1.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5564,7 +5564,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_console-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_console` to `1.1.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_console.git
- release repository: https://github.com/ros2-gbp/rqt_console-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.1.1-1`

## rqt_console

```
* Merge pull request #37 <https://github.com/ros-visualization/rqt_console/issues/37> from coalman321/ros2
  Use a custom QoS profile based on the default rosout QoS profile
* added new maintainer
* Fix regression introduced in #21 <https://github.com/ros-visualization/rqt_console/issues/21> (#28 <https://github.com/ros-visualization/rqt_console/issues/28>)
* Changed the build type to ament_python and added setup.cfg (#21 <https://github.com/ros-visualization/rqt_console/issues/21>)
```
