### PR TITLE
disable devel build for vrpn package

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -7013,6 +7013,8 @@ repositories:
       url: https://github.com/ros2-gbp/vrpn-release.git
       version: 7.35.0-8
     source:
+      test_commits: false
+      test_pull_requests: false
       type: git
       url: https://github.com/vrpn/vrpn.git
       version: master


### PR DESCRIPTION
Disable devel build for the third party package [vrpn](https://github.com/vrpn/vrpn).