### PR TITLE
nixos: use pythonPackages.pybind11 instead of pybind11

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6755,7 +6755,7 @@ pybind11-dev:
   arch: [pybind11]
   debian: [pybind11-dev]
   fedora: [pybind11-devel]
-  nixos: [pybind11]
+  nixos: [pythonPackages.pybind11]
   rhel:
     '*': [pybind11-devel]
     '7': null


### PR DESCRIPTION
The top level `pybind11` package was removed from nixpkgs because the package needs to be built against a specific Python version.