### PR TITLE
eigenpy: 2.7.6-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -965,6 +965,21 @@ repositories:
       url: https://github.com/ros/eigen_stl_containers.git
       version: dashing
     status: maintained
+  eigenpy:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/eigenpy.git
+      version: master
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/eigenpy-release.git
+      version: 2.7.6-1
+    source:
+      type: git
+      url: https://github.com/stack-of-tasks/eigenpy.git
+      version: devel
+    status: maintained
   embree_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `eigenpy` to `2.7.6-1`:

- upstream repository: https://github.com/stack-of-tasks/eigenpy.git
- release repository: https://github.com/ros2-gbp/eigenpy-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`
