### PR TITLE
kdl_parser: 2.8.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1609,7 +1609,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/kdl_parser-release.git
-      version: 2.8.0-1
+      version: 2.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kdl_parser` to `2.8.1-1`:

- upstream repository: https://github.com/ros/kdl_parser.git
- release repository: https://github.com/ros2-gbp/kdl_parser-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.8.0-1`

## kdl_parser

```
* Add in a LICENSE file and fix up copyright headers (#66 <https://github.com/ros/kdl_parser/issues/66>)
* Use orocos_kdl_vendor and orocos-kdl target (#64 <https://github.com/ros/kdl_parser/issues/64>)
* Contributors: Chris Lalancette, Scott K Logan
```
