### PR TITLE
python3-typeguard

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8966,6 +8966,9 @@ python3-typeguard:
   arch: [python-typeguard]
   debian: [python3-typeguard]
   fedora: [python3-typeguard]
+  rhel:
+    '*': [python3-typeguard]
+    '7': null
   ubuntu:
     '*': [python3-typeguard]
     bionic:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8962,6 +8962,15 @@ python3-twisted:
     '*': ['python%{python3_pkgversion}-twisted']
     '7': null
   ubuntu: [python3-twisted]
+python3-typeguard:
+  arch: [python-typeguard]
+  debian: [python3-typeguard]
+  fedora: [python3-typeguard]
+  ubuntu:
+    '*': [python3-typeguard]
+    bionic:
+      pip:
+        packages: [typeguard]
 python3-tz:
   alpine: [py3-tz]
   arch: [python-pytz]


### PR DESCRIPTION
Signed-off-by: Tyler Weaver <tyler@picknik.ai>

## Package name:

python3-typeguard

## Package Upstream Source:

https://github.com/agronholm/typeguard

## Purpose of using this:

We would like to depend on this python package. It provides run-time type checking for functions.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/python3-typeguard
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/jammy/python3-typeguard
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-typeguard/python3-typeguard/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/community/any/python-typeguard/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/typeguard
- macOS: https://formulae.brew.sh/
  - NOT FOUND
- Alpine: https://pkgs.alpinelinux.org/packages
  - NOT FOUND
- NixOS/nixpkgs: https://search.nixos.org/packages
  - NOT FOUND
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python3-typeguard
- pip
  - https://pypi.org/project/typeguard/

## Notes

This is my first time submitting a PR like this. Please let me know if/what I missed so I can update this.
