### PR TITLE
Adding ess_imu_ros1_uart_driver to documentation index for noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2227,7 +2227,7 @@ repositories:
     release:
       tags:
         release: release/noetic/{package}/{version}
-      url: https://github.com/cubicleguy/ess_imu_ros1_uart_driver.git
+      url: https://github.com/cubicleguy/ess_imu_ros1_uart_driver-release.git
       version: 1.3.0
     source:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2219,6 +2219,21 @@ repositories:
       url: https://github.com/bostoncleek/ergodic_exploration.git
       version: noetic-devel
     status: developed
+  ess_imu_ros1_uart_driver:
+    doc:
+      type: git
+      url: https://github.com/cubicleguy/ess_imu_ros1_uart_driver.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/cubicleguy/ess_imu_ros1_uart_driver.git
+      version: 1.3.0
+    source:
+      type: git
+      url: https://github.com/cubicleguy/ess_imu_ros1_uart_driver.git
+      version: noetic-devel
+    status: maintained
   ethercat_grant:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

ess_imu_ros1_uart_driver

# The source is here:

https://github.com/cubicleguy/ess_imu_ros1_uart_driver.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
