### PR TITLE
sick_safetyscanners_base: 1.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5026,7 +5026,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/SICKAG/sick_safetyscanners_base-release.git
-      version: 1.0.1-3
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_safetyscanners_base.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safetyscanners_base` to `1.0.2-1`:

- upstream repository: https://github.com/SICKAG/sick_safetyscanners_base.git
- release repository: https://github.com/SICKAG/sick_safetyscanners_base-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.0.1-3`

## sick_safetyscanners_base

```
* Added missing 'using' statement to UDPClient.cpp
* Contributors: Lennart Puck, crown-bdee
```
