### PR TITLE
ur_robot_driver: 2.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5529,7 +5529,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.2.1-1
+      version: 2.2.2-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.2.2-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.1-1`

## ur

- No changes

## ur_bringup

```
* Made sure all past maintainers are listed as authors (#429 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/429>)
* Contributors: Felix Exner
```

## ur_calibration

```
* Made sure all past maintainers are listed as authors (#429 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/429>)
* Contributors: Felix Exner
```

## ur_controllers

```
* Adapted to JTC interpolation method feature (#439 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/439>)
* Made sure all past maintainers are listed as authors (#429 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/429>)
* Contributors: Felix Exner
```

## ur_dashboard_msgs

```
* Made sure all past maintainers are listed as authors (#429 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/429>)
* Contributors: Felix Exner
```

## ur_moveit_config

```
* Made sure all past maintainers are listed as authors (#429 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/429>)
* Contributors: Felix Exner
```

## ur_robot_driver

```
* Made sure all past maintainers are listed as authors (#429 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/429>)
* Silence a compilation warning (#425 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/425>)
  Since setting the receive timeout takes the time_buffer as an argument
  this raises a "may be used uninitialized" warning. Setting this to 0
  explicitly should prevent that.
* Doc: Fix IP address in usage->ursim section (#422 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/422>)
* Contributors: Felix Exner
```
