### PR TITLE
moveit_resources: 2.0.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2148,7 +2148,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_resources-release.git
-      version: 2.0.5-1
+      version: 2.0.6-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_resources.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `2.0.6-1`:

- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros2-gbp/moveit_resources-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.0.5-1`

## moveit_resources

- No changes

## moveit_resources_fanuc_description

- No changes

## moveit_resources_fanuc_moveit_config

```
* fake_components -> mock_components (#147 <https://github.com/ros-planning/moveit_resources/issues/147>)
* Rename cartesian_limits.yaml (#146 <https://github.com/ros-planning/moveit_resources/issues/146>)
* Contributors: AndyZe, Tyler Weaver
```

## moveit_resources_panda_description

- No changes

## moveit_resources_panda_moveit_config

```
* fake_components -> mock_components (#147 <https://github.com/ros-planning/moveit_resources/issues/147>)
* Rename cartesian_limits.yaml (#146 <https://github.com/ros-planning/moveit_resources/issues/146>)
* Contributors: AndyZe, Tyler Weaver
```

## moveit_resources_pr2_description

- No changes
