### PR TITLE
rviz_visual_tools: 4.1.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4946,7 +4946,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz_visual_tools-release.git
-      version: 4.1.2-3
+      version: 4.1.3-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/rviz_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `4.1.3-1`:

- upstream repository: https://github.com/PickNikRobotics/rviz_visual_tools.git
- release repository: https://github.com/ros2-gbp/rviz_visual_tools-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.1.2-3`

## rviz_visual_tools

```
* Humble CI and formatting updates (#220 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/220>)
* Minor typo fix (#222 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/222>)
* Add a method to publish a plane using the normal and distance (#221 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/221>)
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
* Fix description of plane functions (#219 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/219>)
* Update black version (#218 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/218>)
* Add option to never wait for subscriber (#217 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/217>)
* Contributors: Marq Rasmussen, Stephanie Eng, Vatan Aksoy Tezer
```
