### PR TITLE
hri_msgs: 0.7.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4469,7 +4469,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros4hri/hri_msgs-release.git
-      version: 0.7.0-1
+      version: 0.7.1-1
     source:
       type: git
       url: https://github.com/ros4hri/hri_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hri_msgs` to `0.7.1-1`:

- upstream repository: https://github.com/ros4hri/hri_msgs.git
- release repository: https://github.com/ros4hri/hri_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.7.0-1`

## hri_msgs

```
* add missing 'AudioFeatures.msg' and 'LiveSpeech.msg' to CMakeLists
* [IdsMatch] clarify semantic of confidence level for anonymous persons
* Contributors: Séverin Lemaignan, saracooper
```
