### PR TITLE
marvelmind_ros2_release: 1.0.2-3 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2009,6 +2009,18 @@ repositories:
         release: release/humble/{package}/{version}
       url: https://github.com/MarvelmindRobotics/marvelmind_ros2_msgs_release.git
       version: 1.0.2-1
+  marvelmind_ros2_release:
+    release:
+      packages:
+      - marvelmind_ros2
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/MarvelmindRobotics/marvelmind_ros2_release_repo.git
+      version: 1.0.2-3
+    source:
+      type: git
+      url: https://github.com/MarvelmindRobotics/marvelmind_ros2_upstream.git
+      version: main
   mavlink:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marvelmind_ros2_release` to `1.0.2-3`:

- upstream repository: https://github.com/MarvelmindRobotics/marvelmind_ros2_upstream.git
- release repository: https://github.com/MarvelmindRobotics/marvelmind_ros2_release_repo.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## marvelmind_ros2

```
* project files added
* first commit
* Contributors: Marvelmind Robotics, smoker771
```
