### PR TITLE
rclc: 4.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3304,7 +3304,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
-      version: 4.0.0-1
+      version: 4.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclc` to `4.0.1-1`:

- upstream repository: https://github.com/ros2/rclc.git
- release repository: https://github.com/ros2-gbp/rclc-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `4.0.0-1`

## rclc

```
* updated documentation bloom build status table (#291) (#292)
* updated os-version to ubuntu-22.04 (#295)
* [rolling] updated ros-tooling versions (backport #289) (#297)
* improved doxygen-generated API documentation (#301) (#302)
```

## rclc_examples

```
* no changes
```

## rclc_lifecycle

```
* improved doxygen-generated API documentation (#301) (#302)
```

## rclc_parameter

```
* improved doxygen-generated API documentation (#301) (#302)
```
