### PR TITLE
Add Arch support to rosdep_repo_check

### DIFF
--- a/test/rosdep_repo_check/__init__.py
+++ b/test/rosdep_repo_check/__init__.py
@@ -41,6 +41,10 @@ except ImportError:
     from urllib2 import urlopen
 
 
+def fmt_os(os_name, os_code_name):
+    return (os_name + ' ' + os_code_name) if os_code_name else os_name
+
+
 def is_probably_gzip(response):
     """
     Determine if a urllib response is likely gzip'd.
@@ -196,7 +200,7 @@ def summarize_broken_packages(broken):
     grouped = {}
 
     for os_name, os_ver, os_arch, key, package, _ in broken:
-        platform = '%s %s on %s' % (os_name, os_ver, os_arch)
+        platform = '%s on %s' % (fmt_os(os_name, os_ver), os_arch)
         if platform not in grouped:
             grouped[platform] = set()
         grouped[platform].add('- Package %s for rosdep key %s' % (package, key))
@@ -228,7 +232,9 @@ def find_package(config, pkg_name, os_name, os_code_name, os_arch):
         else:
             sources = [os_sources]
         if not sources:
-            print('WARNING: No sources for %s %s' % (os_name, os_code_name), file=sys.stderr)
+            print(
+                'WARNING: No sources for %s' % (fmt_os(os_name, os_code_name)),
+                 file=sys.stderr)
         for source in sources:
             for p in source.enumerate_packages(os_name, os_code_name, os_arch):
                 if p == pkg_name:

--- a/test/rosdep_repo_check/config.py
+++ b/test/rosdep_repo_check/config.py
@@ -31,6 +31,7 @@ import yaml
 
 from .apk import apk_base_url
 from .deb import deb_base_url
+from .pacman import pacman_base_url
 from .rpm import rpm_base_url
 
 
@@ -48,6 +49,11 @@ def load_deb_base_url(loader, node):
     return deb_base_url(base_url, comp)
 
 
+def load_pacman_base_url(loader, node):
+    base_url, repo_name = node.value.rsplit(' ', 1)
+    return pacman_base_url(base_url, repo_name)
+
+
 def load_rpm_base_url(loader, node):
     return rpm_base_url(node.value)
 
@@ -60,6 +66,8 @@ yaml.add_constructor(
     u'!apk_base_url', load_apk_base_url, Loader=yaml.SafeLoader)
 yaml.add_constructor(
     u'!deb_base_url', load_deb_base_url, Loader=yaml.SafeLoader)
+yaml.add_constructor(
+    u'!pacman_base_url', load_pacman_base_url, Loader=yaml.SafeLoader)
 yaml.add_constructor(
     u'!rpm_base_url', load_rpm_base_url, Loader=yaml.SafeLoader)
 yaml.add_constructor(

--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -4,6 +4,10 @@ package_sources:
   - !apk_base_url https://dl-cdn.alpinelinux.org/alpine/$releasever/main
   - !apk_base_url https://dl-cdn.alpinelinux.org/alpine/$releasever/community
   - !apk_base_url https://dl-cdn.alpinelinux.org/alpine/$releasever/testing
+  arch:
+  - !pacman_base_url https://archive.archlinux.org/repos/last/$repo/os/$arch/ core
+  - !pacman_base_url https://archive.archlinux.org/repos/last/$repo/os/$arch/ extra
+  - !pacman_base_url https://archive.archlinux.org/repos/last/$repo/os/$arch/ community
   debian:
   - !deb_base_url http://deb.debian.org/debian main
   - !deb_base_url http://deb.debian.org/debian contrib
@@ -39,6 +43,8 @@ package_sources:
   - !deb_base_url http://repos.ros.org/repos/ros_bootstrap main
 
 package_dashboards:
+- pattern: !regular_expression .*//archive.archlinux.org/repos/last/([^/]+)/os/.*
+  url: https://archlinux.org/packages/\1/{os_arch}/{source_name}/
 - pattern: !regular_expression .*//deb.debian.org/debian/.*
   url: https://packages.debian.org/{os_code_name}/{binary_name}
 - pattern: !regular_expression .*//dl.fedoraproject.org/pub/.*
@@ -53,6 +59,8 @@ package_dashboards:
 supported_versions:
   alpine:
   - edge
+  arch:
+  - ''
   debian:
   - buster
   - bullseye
@@ -71,6 +79,8 @@ supported_versions:
 
 supported_arches:
   alpine:
+  - x86_64
+  arch:
   - x86_64
   debian:
   - amd64

--- a/test/rosdep_repo_check/pacman.py
+++ b/test/rosdep_repo_check/pacman.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2022, Open Source Robotics Foundation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Willow Garage, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import tarfile
+
+from . import open_gz_url
+from . import PackageEntry
+from . import RepositoryCacheCollection
+
+
+def replace_tokens(string, repo_name, os_arch):
+    """Replace pacman-specific tokens in the repository base URL."""
+    for key, value in {
+        '$arch': os_arch,
+        '$repo': repo_name,
+    }.items():
+        string = string.replace(key, value)
+    return string
+
+
+def enumerate_descs(url):
+    """
+    Enumerate desc files from a pacman db.
+
+    :param url: the URL of the pacman db.
+
+    :returns: an enumeration of desc file contents.
+    """
+    with open_gz_url(url) as f:
+        with tarfile.open(mode='r|', fileobj=f) as tf:
+            for ti in tf:
+                if ti.name.endswith('/desc'):
+                    yield tf.extractfile(ti)
+
+
+def enumerate_blocks(url):
+    """
+    Enumerate blocks of mapped data from a pacman db.
+
+    :param url: the URL of the pacman db.
+
+    :returns: an enumeration of mappings.
+    """
+    for desc in enumerate_descs(url):
+        block = {}
+        while True:
+            k = desc.readline()
+            if not k:
+                break
+            k = k.strip().decode()
+            if not k:
+                continue
+
+            v = []
+            while True:
+                line = desc.readline().strip().decode()
+                if not line:
+                    break
+                v.append(line)
+
+            block[k] = v
+
+        if block: 
+            yield block
+
+
+def enumerate_pacman_packages(base_url, repo_name, os_arch):
+    """
+    Enumerate pacman packages in a repository.
+
+    :param base_url: the pacman repository base URL.
+    :param repo_name: the name of the repository to enumerate.
+    :param os_arch: the system architecture associated with the repository.
+
+    :returns: an enumeration of package entries.
+    """
+    base_url = replace_tokens(base_url, repo_name, os_arch)
+    db_url = os.path.join(base_url, repo_name + '.db.tar.gz')
+    print('Reading pacman package metadata from ' + db_url)
+    for block in enumerate_blocks(db_url):
+        pkg_url = os.path.join(base_url, block['%FILENAME%'][0])
+        pkg_name = block['%NAME%'][0]
+        pkg_ver = block['%VERSION%'][0]
+        yield PackageEntry(pkg_name, pkg_ver, pkg_url)
+        for pkg_prov in block.get('%PROVIDES%', ()):
+            yield PackageEntry(pkg_prov, pkg_ver, pkg_url, pkg_name, pkg_name)
+
+
+def pacman_base_url(base_url, repo_name):
+    """
+    Create an enumerable cache for a pacman repository.
+
+    :param base_url: the URL of the pacman repository.
+    :param repo_name: the name of the repository to enumerate.
+
+    :returns: an enumerable repository cache instance.
+    """
+    return RepositoryCacheCollection(
+        lambda os_name, os_code_name, os_arch:
+            enumerate_pacman_packages(base_url, repo_name, os_arch))


### PR DESCRIPTION
This change adds support for Arch Linux to `rosdep_repo_check`. It largely follows the patterns laid out for the other platforms, the most notable exception being the lack of a platform version for Arch. Since the framework requires one, I set it to an empty string, and improved some of the console output to look better in that case.