### PR TITLE
Add rosdep rule for python3-pytest-benchmark

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8145,7 +8145,9 @@ python3-pytest-benchmark:
   debian: [python3-pytest-benchmark]
   fedora: [python3-pytest-benchmark]
   opensuse: [python3-pytest-benchmark]
-  rhel: [python3-pytest-benchmark]
+  rhel:
+    '*': [python3-pytest-benchmark]
+    '7': null
   ubuntu: [python3-pytest-benchmark]
 python3-pytest-cov:
   alpine: [py3-pytest-cov]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8141,6 +8141,12 @@ python3-pytest-asyncio:
   ubuntu:
     '*': [python3-pytest-asyncio]
     bionic: null
+python3-pytest-benchmark:
+  debian: [python3-pytest-benchmark]
+  fedora: [python3-pytest-benchmark]
+  opensuse: [python3-pytest-benchmark]
+  rhel: [python3-pytest-benchmark]
+  ubuntu: [python3-pytest-benchmark]
 python3-pytest-cov:
   alpine: [py3-pytest-cov]
   arch: [python-pytest-cov]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-pytest-benchmark

## Package Upstream Source:

https://github.com/ionelmc/pytest-benchmark

## Purpose of using this:

Add benchmark tests in rclpy
https://github.com/ros2/rclpy/pull/973

## Links to Distribution Packages

* debian
  * [bullseye](http://deb.debian.org/debian/pool/main/p/python-pytest-benchmark/python3-pytest-benchmark_3.2.2-2_all.deb)
  * [buster](http://deb.debian.org/debian/pool/main/p/python-pytest-benchmark/python3-pytest-benchmark_3.2.2-1_all.deb)
* fedora
  * [35](https://dl.fedoraproject.org/pub/fedora/linux/releases/35/Everything/x86_64/os/Packages/p/python3-pytest-benchmark-3.4.1-3.fc35.noarch.rpm)
  * [36](https://dl.fedoraproject.org/pub/fedora/linux/releases/36/Everything/x86_64/os/Packages/p/python3-pytest-benchmark-3.4.1-4.fc36.noarch.rpm)
* opensuse
  * [15.2](http://download.opensuse.org/distribution/leap/15.2/repo/oss/noarch/python3-pytest-benchmark-3.2.3-lp152.2.1.noarch.rpm)
* rhel
  * [8](https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/p/python3-pytest-benchmark-3.1.1-8.el8.noarch.rpm)
* ubuntu
  * [bionic](http://archive.ubuntu.com/ubuntu/pool/universe/p/python-pytest-benchmark/python3-pytest-benchmark_3.0.0-1_all.deb)
  * [focal](http://archive.ubuntu.com/ubuntu/pool/universe/p/python-pytest-benchmark/python3-pytest-benchmark_3.2.2-2_all.deb)
  * [jammy](http://archive.ubuntu.com/ubuntu/pool/universe/p/python-pytest-benchmark/python3-pytest-benchmark_3.2.2-2_all.deb)
