### PR TITLE
Remove RHEL 7 from list of supported versions

### DIFF
--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -62,7 +62,6 @@ supported_versions:
   opensuse:
   - '15.2'
   rhel:
-  - '7'
   - '8'
   ubuntu:
   - bionic
@@ -90,9 +89,6 @@ name_replacements:
     '36':
       '%{__isa_name}': 'x86'
   rhel:
-    '7':
-      '%{__isa_name}': 'x86'
-      '%{python3_pkgversion}': '36'
     '8':
       '%{__isa_name}': 'x86'
       '%{python3_pkgversion}': '3'


### PR DESCRIPTION
There doesn't appear to be an active distro with it as a release platform.