### PR TITLE
nao_lola: 0.0.5-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2354,7 +2354,7 @@ repositories:
   nao_lola:
     doc:
       type: git
-      url: https://github.com/ijnek/nao_lola.git
+      url: https://github.com/ros-sports/nao_lola.git
       version: rolling
     release:
       tags:
@@ -2363,7 +2363,7 @@ repositories:
       version: 0.0.5-1
     source:
       type: git
-      url: https://github.com/ijnek/nao_lola.git
+      url: https://github.com/ros-sports/nao_lola.git
       version: rolling
     status: developed
   navigation2:

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2355,7 +2355,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-sports/nao_lola.git
-      version: rolling
+      version: galactic
     release:
       tags:
         release: release/galactic/{package}/{version}
@@ -2364,7 +2364,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-sports/nao_lola.git
-      version: rolling
+      version: galactic
     status: developed
   navigation2:
     doc:

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2359,8 +2359,8 @@ repositories:
     release:
       tags:
         release: release/galactic/{package}/{version}
-      url: https://github.com/ijnek/nao_lola-release.git
-      version: 0.0.4-1
+      url: https://github.com/ros2-gbp/nao_lola-release.git
+      version: 0.0.5-1
     source:
       type: git
       url: https://github.com/ijnek/nao_lola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_lola` to `0.0.5-1`:

- upstream repository: https://github.com/ros-sports/nao_lola.git
- release repository: https://github.com/ros2-gbp/nao_lola-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.0.4-1`

## nao_lola

```
* Split off galactic and humble branches
* Fix status test to use int rather than float
* Contributors: Kenji Brameld
```
