### PR TITLE
nao_lola: 0.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2352,7 +2352,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-sports/nao_lola.git
-      version: rolling
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -2361,7 +2361,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-sports/nao_lola.git
-      version: rolling
+      version: humble
     status: developed
   navigation2:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2351,7 +2351,7 @@ repositories:
   nao_lola:
     doc:
       type: git
-      url: https://github.com/ijnek/nao_lola.git
+      url: https://github.com/ros-sports/nao_lola.git
       version: rolling
     release:
       tags:
@@ -2360,7 +2360,7 @@ repositories:
       version: 0.1.0-1
     source:
       type: git
-      url: https://github.com/ijnek/nao_lola.git
+      url: https://github.com/ros-sports/nao_lola.git
       version: rolling
     status: developed
   navigation2:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2357,7 +2357,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/nao_lola-release.git
-      version: 0.0.4-4
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/ijnek/nao_lola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_lola` to `0.1.0-1`:

- upstream repository: https://github.com/ros-sports/nao_lola.git
- release repository: https://github.com/ros2-gbp/nao_lola-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.0.4-4`

## nao_lola

```
* Split off galactic and humble branches
* Fix status test to use int rather than float
* Contributors: Kenji Brameld
```
