### PR TITLE
nao_lola: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2266,7 +2266,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nao_lola-release.git
-      version: 0.0.4-3
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/ijnek/nao_lola.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2260,7 +2260,7 @@ repositories:
   nao_lola:
     doc:
       type: git
-      url: https://github.com/ijnek/nao_lola.git
+      url: https://github.com/ros-sports/nao_lola.git
       version: rolling
     release:
       tags:
@@ -2269,7 +2269,7 @@ repositories:
       version: 0.2.0-1
     source:
       type: git
-      url: https://github.com/ijnek/nao_lola.git
+      url: https://github.com/ros-sports/nao_lola.git
       version: rolling
     status: developed
   navigation_msgs:


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_lola` to `0.2.0-1`:

- upstream repository: https://github.com/ros-sports/nao_lola.git
- release repository: https://github.com/ros2-gbp/nao_lola-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.0.4-3`

## nao_lola

```
* Split off galactic and humble branches
* Fix status test to use int rather than float
* Contributors: Kenji Brameld
```
