### PR TITLE
rcss3d_nao: 0.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3266,6 +3266,21 @@ repositories:
       url: https://github.com/ros-sports/rcss3d_agent.git
       version: rolling
     status: developed
+  rcss3d_nao:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/rcss3d_nao.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rcss3d_nao-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros-sports/rcss3d_nao.git
+      version: rolling
+    status: developed
   rcutils:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcss3d_nao` to `0.1.0-1`:

- upstream repository: https://github.com/ros-sports/rcss3d_nao.git
- release repository: https://github.com/ros2-gbp/rcss3d_nao-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## rcss3d_nao

```
* Implemented basic functionality
* Contributors: Kenji Brameld, ijnek
```
