### PR TITLE
ros_image_to_qimage: 0.1.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4225,7 +4225,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/ros_image_to_qimage-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/ros-sports/ros_image_to_qimage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_image_to_qimage` to `0.1.1-1`:

- upstream repository: https://github.com/ros-sports/ros_image_to_qimage.git
- release repository: https://github.com/ros2-gbp/ros_image_to_qimage-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.0-1`

## ros_image_to_qimage

```
* Fix readme
* Contributors: Kenji Brameld
```
