### PR TITLE
lsc_ros_driver: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6190,6 +6190,21 @@ repositories:
       url: https://github.com/hatchbed/log_view.git
       version: devel
     status: developed
+  lsc_ros_driver:
+    doc:
+      type: git
+      url: https://github.com/AutonicsLiDAR/lsc_ros_driver.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/AutonicsLiDAR-release/lsc_ros_driver-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/AutonicsLiDAR/lsc_ros_driver.git
+      version: master
+    status: maintained
   lsm_localization:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lsc_ros_driver` to `1.0.1-1`:

- upstream repository: https://github.com/AutonicsLiDAR/lsc_ros_driver.git
- release repository: https://github.com/AutonicsLiDAR-release/lsc_ros_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## lsc_ros_driver

```
* Initical release
```
