### PR TITLE
class_loader: 2.0.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -579,7 +579,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/class_loader-release.git
-      version: 2.0.2-1
+      version: 2.0.3-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `2.0.3-1`:

- upstream repository: https://github.com/ros/class_loader.git
- release repository: https://github.com/ros2-gbp/class_loader-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.2-1`

## class_loader

```
* Fix spelling mistake (#183 <https://github.com/ros/class_loader/issues/183>) (#185 <https://github.com/ros/class_loader/issues/185>)
* Contributors: David V. Lu!!
```
