### PR TITLE
executive_smach_visualization: 4.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2993,7 +2993,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/jbohren/executive_smach_visualization-release.git
-      version: 3.0.0-1
+      version: 4.0.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/executive_smach_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `executive_smach_visualization` to `4.0.0-1`:

- upstream repository: https://github.com/ros-visualization/executive_smach_visualization.git
- release repository: https://github.com/jbohren/executive_smach_visualization-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `3.0.0-1`

## executive_smach_visualization

- No changes

## smach_viewer

```
* publish smach viewer image (#37 <https://github.com/ros-visualization/executive_smach_visualization/issues/37>)
* use custom TextWrapper to wrap a sentence of multibyte languages into several lines (#40 <https://github.com/ros-visualization/executive_smach_visualization/issues/40>)
  
    * use TextWrapper for multibyte launguages
    * the TextWrapper is copied from sphinx
  
* Melodic/Noetic support (#42 <https://github.com/ros-visualization/executive_smach_visualization/issues/42>)
  
    * use MyXDotParser in python3
    * check subgraph_shapes hasattr
    * Merge branch 'melodic-devel' into image-publish
    * apply 2to3 -w -f import *
    * Use GetPosition istead of GetPositionTuple
    * noetic support, based on InigoMoreno's work. see #39 <https://github.com/ros-visualization/executive_smach_visualization/issues/39>
  
* fix unpacking the user data (#38 <https://github.com/ros-visualization/executive_smach_visualization/issues/38>)
* Fix CI #41 <https://github.com/ros-visualization/executive_smach_visualization/issues/41> from k-okada/fix_ci
  
    * update .travis.yml
    * apply 2to3 -w -f import *
    * apply 2to3 -w -f dict *
    * apply 2to3 -w -f zip *
    * add try except and trying line width one by one
      
        * publish smach viewer image
      
  
* [FIX] 'Jump' object has no attribute 'url' (#31 <https://github.com/ros-visualization/executive_smach_visualization/issues/31>)
  Fix for AttributeError: 'Jump' object has no attribute 'url'
  To reproduce:
  - roscore
  - rosrun smach_viewer smach_viewer.py
  - Press "+" button to increase depth and hover over/click text "Path not available"
  - Error prints in terminal
* Contributors: Gintaras, Kei Okada, Kousuke Takeuchi, Shingo Kitagawa
```
