### PR TITLE
neonavigation_rviz_plugins: 0.11.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7705,12 +7705,13 @@ repositories:
       version: master
     release:
       packages:
+      - costmap_cspace_rviz_plugins
       - neonavigation_rviz_plugins
       - trajectory_tracker_rviz_plugins
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/at-wat/neonavigation_rviz_plugins-release.git
-      version: 0.3.1-1
+      version: 0.11.6-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation_rviz_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation_rviz_plugins` to `0.11.6-1`:

- upstream repository: https://github.com/at-wat/neonavigation_rviz_plugins.git
- release repository: https://github.com/at-wat/neonavigation_rviz_plugins-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.1-1`

## costmap_cspace_rviz_plugins

```
* Add rviz plugin for costmap_cspace_msgs::CSpace3D (#34 <https://github.com/at-wat/neonavigation_rviz_plugins/issues/34>)
* Contributors: Naotaka Hatao
```

## neonavigation_rviz_plugins

- No changes

## trajectory_tracker_rviz_plugins

- No changes
