### PR TITLE
plotjuggler: 3.5.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9070,7 +9070,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.5.0-1
+      version: 3.5.1-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.5.1-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `3.5.0-1`

## plotjuggler

```
* Dev/ros1 ros2 snap (#698 <https://github.com/facontidavide/PlotJuggler/issues/698>)
* update nlohmann json to fix #640 <https://github.com/facontidavide/PlotJuggler/issues/640>
* should prevent error #696 <https://github.com/facontidavide/PlotJuggler/issues/696>
* Merge branch 'improved_zoomout' into main
* cleanup after #702 <https://github.com/facontidavide/PlotJuggler/issues/702>
* Statistics dialog improvements and bug fixes (#702 <https://github.com/facontidavide/PlotJuggler/issues/702>)
* Include std::thread instead of QThread, since it is being utilized in the mqtt plugin instead of QThread. (#700 <https://github.com/facontidavide/PlotJuggler/issues/700>)
* fix zmq compilation
* cherry picking from #698 <https://github.com/facontidavide/PlotJuggler/issues/698>
* increase playback step precision (#692 <https://github.com/facontidavide/PlotJuggler/issues/692>)
* Fix typo in ColorMap warning (#693 <https://github.com/facontidavide/PlotJuggler/issues/693>)
* Set buttonBackground icon in .ui file (#694 <https://github.com/facontidavide/PlotJuggler/issues/694>)
* Update README.md
* Fix #697 <https://github.com/facontidavide/PlotJuggler/issues/697>
* update sol2 and fix #687 <https://github.com/facontidavide/PlotJuggler/issues/687>
* try to improve the linked zoomout
* Contributors: Bartimaeus-, Davide Faconti, Guillaume Beuzeboc, Hugal31, ozzdemir
```
