### PR TITLE
ess_imu_ros1_uart_driver: 1.3.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2920,6 +2920,21 @@ repositories:
       url: https://github.com/enabled-robotics/er_public_msgs-release.git
       version: 1.4.0-1
     status: maintained
+  ess_imu_ros1_uart_driver:
+    doc:
+      type: git
+      url: https://github.com/cubicleguy/ess_imu_ros1_uart_driver.git
+      version: main
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/cubicleguy/ess_imu_ros1_uart_driver-release.git
+      version: 1.3.1-1
+    source:
+      type: git
+      url: https://github.com/cubicleguy/ess_imu_ros1_uart_driver.git
+      version: main
+    status: maintained
   ethercat_grant:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ess_imu_ros1_uart_driver` to `1.3.1-1`:

- upstream repository: https://github.com/cubicleguy/ess_imu_ros1_uart_driver.git
- release repository: https://github.com/cubicleguy/ess_imu_ros1_uart_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## ess_imu_ros1_uart_driver

- No changes
