### PR TITLE
Update Foxy source branch for mimick_vendor

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2756,7 +2756,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/mimick_vendor.git
-      version: master
+      version: foxy
     release:
       tags:
         release: release/foxy/{package}/{version}
@@ -2765,7 +2765,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/mimick_vendor.git
-      version: master
+      version: foxy
     status: maintained
   mir_robot:
     doc:


### PR DESCRIPTION
We're no longer tracking the master branch.

https://github.com/ros2/mimick_vendor/tree/foxy