### PR TITLE
orocos_kinematics_dynamics: 3.4.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2709,7 +2709,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/orocos_kinematics_dynamics-release.git
-      version: 3.3.3-2
+      version: 3.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_kinematics_dynamics` to `3.4.0-1`:

- upstream repository: https://github.com/ros2/orocos_kinematics_dynamics.git
- release repository: https://github.com/ros2-gbp/orocos_kinematics_dynamics-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.3.3-2`
