### PR TITLE
performance_test_fixture: 0.0.9-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2879,7 +2879,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/performance_test_fixture-release.git
-      version: 0.0.8-1
+      version: 0.0.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `performance_test_fixture` to `0.0.9-1`:

- upstream repository: https://github.com/ros2/performance_test_fixture.git
- release repository: https://github.com/ros2-gbp/performance_test_fixture-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.8-1`

## performance_test_fixture

```
* Mirror rolling to main
* Add "cstring" to the list of includes (#19 <https://github.com/ros2/performance_test_fixture/issues/19>)
* Contributors: Audrow Nash, Chris Lalancette
```
