### PR TITLE
rclcpp: 2.4.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4197,7 +4197,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 2.4.1-1
+      version: 2.4.2-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `2.4.2-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.4.1-1`

## rclcpp

```
* Add statistics for handle_loaned_message (#1927 <https://github.com/ros2/rclcpp/issues/1927>) (#1934 <https://github.com/ros2/rclcpp/issues/1934>)
* Add test-dep ament_cmake_google_benchmark (#1904 <https://github.com/ros2/rclcpp/issues/1904>) (#1910 <https://github.com/ros2/rclcpp/issues/1910>)
* Use parantheses around logging macro parameter (#1820 <https://github.com/ros2/rclcpp/issues/1820>) (#1823 <https://github.com/ros2/rclcpp/issues/1823>)
* Contributors: Abrar Rahman Protyasha, Barry Xu, Gaël Écorchard
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
