### PR TITLE
rmw_cyclonedds: 0.7.9-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4631,7 +4631,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 0.7.8-1
+      version: 0.7.9-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `0.7.9-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.8-1`

## rmw_cyclonedds_cpp

```
* Fix the history depth for KEEP_ALL (#305 <https://github.com/ros2/rmw_cyclonedds/issues/305>) (#394 <https://github.com/ros2/rmw_cyclonedds/issues/394>)
* Contributors: Chris Lalancette
```
