### PR TITLE
rmw_fastrtps: 1.3.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4669,7 +4669,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `1.3.1-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.3.0-1`

## rmw_fastrtps_cpp

```
* Handle exception on deserializing ROS message (#603 <https://github.com/ros2/rmw_fastrtps/issues/603>)
* Contributors: Erki Suurjaak, Miguel Company
```

## rmw_fastrtps_dynamic_cpp

```
* Handle exception on deserializing ROS message (#603 <https://github.com/ros2/rmw_fastrtps/issues/603>)
* Contributors: Erki Suurjaak, Miguel Company
```

## rmw_fastrtps_shared_cpp

```
* Handle exception on deserializing ROS message (#603 <https://github.com/ros2/rmw_fastrtps/issues/603>)
* Contributors: Erki Suurjaak, Miguel Company
```
