### PR TITLE
rosidl_python: 0.9.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5323,7 +5323,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.9.5-1
+      version: 0.9.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_python` to `0.9.6-1`:

- upstream repository: https://github.com/ros2/rosidl_python.git
- release repository: https://github.com/ros2-gbp/rosidl_python-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.9.5-1`

## rosidl_generator_py

```
* Removes erroneous unmatched closing parenthesis (#125 <https://github.com/ros2/rosidl_python/issues/125>) (#158 <https://github.com/ros2/rosidl_python/issues/158>)
* Contributors: Charles Cross, Chris Lalancette
```
