### PR TITLE
lsc_ros_driver: 1.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6199,7 +6199,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/AutonicsLiDAR-release/lsc_ros_driver-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/AutonicsLiDAR/lsc_ros_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lsc_ros_driver` to `1.0.2-1`:

- upstream repository: https://github.com/AutonicsLiDAR/lsc_ros_driver.git
- release repository: https://github.com/AutonicsLiDAR-release/lsc_ros_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.1-1`

## lsc_ros_driver

```
* Change pacakge info
```
