### PR TITLE
maliput: 1.0.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2381,7 +2381,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput-release.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput` to `1.0.5-1`:

- upstream repository: https://github.com/maliput/maliput.git
- release repository: https://github.com/ros2-gbp/maliput-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.0.4-1`

## maliput

```
* Provides convenient method for loading a RN via plugins. (#512 <https://github.com/maliput/maliput/issues/512>)
* Adds triage workflow. (#513 <https://github.com/maliput/maliput/issues/513>)
* Improves README. (#511 <https://github.com/maliput/maliput/issues/511>)
* Update README.md with new github.com/maliput URLs (#510 <https://github.com/maliput/maliput/issues/510>)
  Needed due to the transition to the "maliput" organization.
  Also refer developers to new documentation website.
* Contributors: Chien-Liang Fok, Franco Cipollone
```
