### PR TITLE
qt_advanced_docking_system: 3.8.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3828,6 +3828,15 @@ repositories:
       url: https://github.com/Autoware-AI/qpoases_vendor.git
       version: ros2
     status: maintained
+  qt_advanced_docking_system:
+    release:
+      packages:
+      - qt_advanced_docking
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/tesseract-robotics-release/qt_advanced_docking_system-release.git
+      version: 3.8.2-1
+    status: developed
   qt_gui_core:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3829,6 +3829,10 @@ repositories:
       version: ros2
     status: maintained
   qt_advanced_docking_system:
+    doc:
+      type: git
+      url: https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System.git
+      version: master
     release:
       packages:
       - qt_advanced_docking
@@ -3836,6 +3840,10 @@ repositories:
         release: release/foxy/{package}/{version}
       url: https://github.com/tesseract-robotics-release/qt_advanced_docking_system-release.git
       version: 3.8.2-1
+    source:
+      type: git
+      url: https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System.git
+      version: master
     status: developed
   qt_gui_core:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_advanced_docking_system` to `3.8.2-1`:

- upstream repository: https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System
- release repository: https://github.com/tesseract-robotics-release/qt_advanced_docking_system-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
