### PR TITLE
robot_localization: 2.7.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7990,7 +7990,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/cra-ros-pkg/robot_localization-release.git
-      version: 2.7.3-1
+      version: 2.7.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `2.7.4-1`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/cra-ros-pkg/robot_localization-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.7.3-1`

## robot_localization

```
* Fix odometry and acceleration processing pipeline (#753 <https://github.com/cra-ros-pkg/robot_localization/issues/753>)
* Use default CXX, need to specify boost::placeholders::_1 instead of just _1 (#750 <https://github.com/cra-ros-pkg/robot_localization/issues/750>)
* Fix odometry msgs with child frame other than baseLink (#728 <https://github.com/cra-ros-pkg/robot_localization/issues/728>)
* update documentation (#723 <https://github.com/cra-ros-pkg/robot_localization/issues/723>)
* Fix unused-parameter warning (#721 <https://github.com/cra-ros-pkg/robot_localization/issues/721>)
* Fix tf lookup timestamp during map->odom publication (#719 <https://github.com/cra-ros-pkg/robot_localization/issues/719>)
* UKF cleanup (#671 <https://github.com/cra-ros-pkg/robot_localization/issues/671>)
* Added geographiclib to catkin exported depends (#709 <https://github.com/cra-ros-pkg/robot_localization/issues/709>)
* Make the navsat tf frame name parametric (#699 <https://github.com/cra-ros-pkg/robot_localization/issues/699>)
* Propagate the suppression of tf warnings (#705 <https://github.com/cra-ros-pkg/robot_localization/issues/705>)
* Fix typo in base_link_frame_output name. (#701 <https://github.com/cra-ros-pkg/robot_localization/issues/701>)
* Contributors: AR Dabbour, Carlos Agüero, Haoguang Yang, J.P.S, Joshua Owen, Leonardo Hemerly, Lucas Walter, Marcus Scheunemann, Stephen Williams, Tom Moore
```
