### PR TITLE
Adding python3 can-j1939 library

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6113,6 +6113,16 @@ python3-can:
   ubuntu:
     '*': [python3-can]
     xenial: null
+python3-can-j1939-pip:
+  debian:
+    pip:
+      packages: [can-j1939]
+  fedora:
+    pip:
+      packages: [can-j1939]
+  ubuntu:
+    pip:
+      packages: [can-j1939]
 python3-cantools-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

can-j1939

## Package Upstream Source:

https://github.com/juergenH87/python-can-j1939

## Purpose of using this:

This python module is being used to interface with ECU devices via J1939 bus with python. I had a similar library that [worked with J1939](https://github.com/ros/rosdistro/pull/30763) but it looks to have been abandoned, but not officially.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - [No results](https://packages.debian.org/search?mode=exactfilename&suite=bullseye&section=all&arch=any&searchon=contents&keywords=can-j1939)
- Ubuntu: https://packages.ubuntu.com/
   - [No results](https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=can-j1939&searchon=names)
- Fedora: https://packages.fedoraproject.org/
  - [No results](https://packages.fedoraproject.org/search?query=can-j1939)
- Pip
  -  [Package](https://pypi.org/project/can-j1939/) 

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro