### PR TITLE
Adding python3 bitstring

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6013,7 +6013,9 @@ python3-bitstring:
   fedora: [python3-bitstring]
   gentoo: [dev-python/bitstring]
   opensuse: [python3-bitstring]
-  rhel: [python3-bitstring]
+  rhel:
+    '*': [python3-bitstring]
+    '7': [python36-bitstring]
   ubuntu: [python3-bitstring]
 python3-bluerobotics-ping-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6008,6 +6008,13 @@ python3-bitarray:
   gentoo: [dev-python/bitarray]
   nixos: [python3Packages.bitarray]
   ubuntu: [python3-bitarray]
+python3-bitstring:
+  debian: [python3-bitstring]
+  fedora: [python3-bitstring]
+  gentoo: [dev-python/bitstring]
+  opensuse: [python3-bitstring]
+  rhel: [python3-bitstring]
+  ubuntu: [python3-bitstring]
 python3-bluerobotics-ping-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

bitstring

## Package Upstream Source:

https://github.com/scott-griffiths/bitstring

## Purpose of using this:

Python3 version of bitstring. Used to read and write bitstrings.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - [Package](https://packages.debian.org/search?keywords=python3-bitstring&searchon=names&suite=all&section=all)
- Ubuntu: https://packages.ubuntu.com/
   - [Package](https://packages.ubuntu.com/search?keywords=bitstring&searchon=names&suite=all&section=all)
- Fedora: https://packages.fedoraproject.org/
  - [Package](https://packages.fedoraproject.org/pkgs/python-bitstring/python3-bitstring/)
- Gentoo: https://packages.gentoo.org/
  - [Package](https://packages.gentoo.org/packages/dev-python/bitstring)
- NixOS/nixpkgs: https://search.nixos.org/packages
  - [Package](https://search.nixos.org/packages?channel=22.05&show=python39Packages.bitstring&from=0&size=50&sort=relevance&type=packages&query=bitstring) (Only 3.9 or 3.10, opted for 3.9)
- openSUSE: https://software.opensuse.org/package/
  - [Package](https://software.opensuse.org/package/python3-bitstring?search_term=python3-bitstring)
 


# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
