### PR TITLE
maliput_py: 0.1.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2532,7 +2532,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput_py-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_py` to `0.1.2-1`:

- upstream repository: https://github.com/maliput/maliput_py.git
- release repository: https://github.com/ros2-gbp/maliput_py-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.1-1`

## maliput_py

```
* Use maliput's method for creating road network via plugin api. (#68 <https://github.com/maliput/maliput_py/issues/68>)
* Fixes IntersectionBook's bug. (#69 <https://github.com/maliput/maliput_py/issues/69>)
* Adds triage workflow. (#66 <https://github.com/maliput/maliput_py/issues/66>)
* Adds TrafficLightBook bindings. (#65 <https://github.com/maliput/maliput_py/issues/65>)
* Improves README. (#64 <https://github.com/maliput/maliput_py/issues/64>)
* Contributors: Franco Cipollone
```
