### PR TITLE
maliput_integration: 0.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2445,7 +2445,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput_integration-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_integration` to `0.1.1-1`:

- upstream repository: https://github.com/maliput/maliput_integration.git
- release repository: https://github.com/ros2-gbp/maliput_integration-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.0-1`

## maliput_integration

```
* Matches change in create_road_network binding. (#120 <https://github.com/maliput/maliput_integration/issues/120>)
* Adds triage workflow. (#121 <https://github.com/maliput/maliput_integration/issues/121>)
* Improves README. (#119 <https://github.com/maliput/maliput_integration/issues/119>)
* Contributors: Franco Cipollone
```
