### PR TITLE
raspimouse2: 1.1.0-4 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3941,8 +3941,8 @@ repositories:
       - raspimouse_msgs
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/rt-net/raspimouse2-release.git
-      version: 1.0.2-1
+      url: https://github.com/ros2-gbp/raspimouse2-release.git
+      version: 1.1.0-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspimouse2` to `1.1.0-4`:

- upstream repository: https://github.com/rt-net/raspimouse2.git
- release repository: https://github.com/ros2-gbp/raspimouse2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.2-1`

## raspimouse

```
* Add authors to package.xml
* トピックpublish周波数とフレームIDを変更するパラメータを追加 (#42 <https://github.com/rt-net/raspimouse2/issues/42>)
* ノードの実行を簡単にするためlaunchファイルとconfigファイルを追加 #41 <https://github.com/rt-net/raspimouse2/issues/41>
* Add initial_motor_power param (#39 <https://github.com/rt-net/raspimouse2/issues/39>)
* パラメータの追加（#35 <https://github.com/rt-net/raspimouse2/issues/35>） (#38 <https://github.com/rt-net/raspimouse2/issues/38>)
* パラメータの追加 （#34 <https://github.com/rt-net/raspimouse2/issues/34>） (#36 <https://github.com/rt-net/raspimouse2/issues/36>)
* Contributors: Shota Aoki, Shuhei Kozasa
```

## raspimouse_msgs

```
* Add authors to package.xml
```
