### PR TITLE
mocap_nokov: 0.0.1-2 in 'noetic/distribution.yaml'

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5148,7 +5148,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/NOKOV-MOCAP/mocap_nokov_release.git
-      version: 0.0.1-1
+      version: 0.0.1-2
     source:
       type: git
       url: https://github.com/NOKOV-MOCAP/mocap_nokov.git


### PR DESCRIPTION
Increasing version of package(s) in repository moveit to 0.0.1-2:
    upstream repository: https://github.com/NOKOV-MOCAP/mocap_nokov.git
    release repository: https://github.com/NOKOV-MOCAP/mocap_nokov_release.git
    rosdistro version: 0.0.1-1
    old version: 0.0.1-1
    new version: 0.0.1-2