### PR TITLE
cob_environments: 0.6.13-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1036,7 +1036,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_environments-release.git
-      version: 0.6.12-1
+      version: 0.6.13-1
     source:
       type: git
       url: https://github.com/ipa320/cob_environments.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_environments` to `0.6.13-1`:

- upstream repository: https://github.com/ipa320/cob_environments.git
- release repository: https://github.com/ipa320/cob_environments-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.12-1`

## cob_default_env_config

- No changes

## cob_environments

- No changes
