### PR TITLE
cob_supported_robots: 0.6.16-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1246,7 +1246,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_supported_robots-release.git
-      version: 0.6.15-1
+      version: 0.6.16-1
     source:
       type: git
       url: https://github.com/ipa320/cob_supported_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_supported_robots` to `0.6.16-1`:

- upstream repository: https://github.com/ipa320/cob_supported_robots.git
- release repository: https://github.com/ipa320/cob_supported_robots-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.15-1`

## cob_supported_robots

```
* Merge pull request #29 <https://github.com/ipa320/cob_supported_robots/issues/29> from pgehring/add_license
  add LICENSE
* add LICENSE
* update travis config
* Contributors: Felix Messmer, pgehring
```
