### PR TITLE
cob_robots: 0.7.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1188,7 +1188,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_robots-release.git
-      version: 0.7.6-4
+      version: 0.7.7-1
     source:
       type: git
       url: https://github.com/ipa320/cob_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_robots` to `0.7.7-1`:

- upstream repository: https://github.com/ipa320/cob_robots.git
- release repository: https://github.com/ipa320/cob_robots-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.6-4`

## cob_bringup

- No changes

## cob_default_robot_behavior

- No changes

## cob_default_robot_config

- No changes

## cob_hardware_config

- No changes

## cob_moveit_config

- No changes

## cob_robots

- No changes
