### PR TITLE
cob_simulation: 0.7.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1210,7 +1210,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_simulation-release.git
-      version: 0.7.5-2
+      version: 0.7.6-1
     source:
       type: git
       url: https://github.com/ipa320/cob_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_simulation` to `0.7.6-1`:

- upstream repository: https://github.com/ipa320/cob_simulation.git
- release repository: https://github.com/ipa320/cob_simulation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.5-2`

## cob_bringup_sim

- No changes

## cob_gazebo

- No changes

## cob_gazebo_objects

- No changes

## cob_gazebo_tools

- No changes

## cob_gazebo_worlds

```
* Merge pull request #184 <https://github.com/ipa320/cob_simulation/issues/184> from fmessmer/fix/TF_REPEATED_DATA
  replace world_tf_publisher
* replace world_tf_publisher
* Contributors: Felix Messmer, fmessmer
```

## cob_simulation

- No changes
