### PR TITLE
cob_common: 0.7.8-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -949,7 +949,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_common-release.git
-      version: 0.7.7-1
+      version: 0.7.8-1
     source:
       type: git
       url: https://github.com/ipa320/cob_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `0.7.8-1`:

- upstream repository: https://github.com/ipa320/cob_common.git
- release repository: https://github.com/ipa320/cob_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.7-1`

## cob_actions

- No changes

## cob_common

- No changes

## cob_description

- No changes

## cob_msgs

```
* Merge pull request #297 <https://github.com/ipa320/cob_common/issues/297> from floweisshardt/feature/power_state_connected
  add explicit power_state.connected
* add explicit power_state.connected
* Contributors: Felix Messmer, floweisshardt
```

## cob_srvs

- No changes

## raw_description

- No changes
