### PR TITLE
cob_driver: 0.7.13-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1018,7 +1018,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_driver-release.git
-      version: 0.7.12-1
+      version: 0.7.13-1
     source:
       type: git
       url: https://github.com/ipa320/cob_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_driver` to `0.7.13-1`:

- upstream repository: https://github.com/ipa320/cob_driver.git
- release repository: https://github.com/ipa320/cob_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.12-1`

## cob_base_drive_chain

- No changes

## cob_bms_driver

```
* Merge pull request #434 <https://github.com/ipa320/cob_driver/issues/434> from floweisshardt/feature/power_state_connected
  add explicit power_state.connected
* remove unused subscriber
* add explicit power_state.connected
* Merge pull request #432 <https://github.com/ipa320/cob_driver/issues/432> from fmessmer/feature/publish_battery_state
  power_state_aggregator now also publishes sensor_msgs.BatteryState
* fix percentage value range
  Co-authored-by: Benjamin Maidel <mailto:benjamin.maidel@mojin-robotics.de>
* update current_buffer_size
* power_state_aggregator now also publishes sensor_msgs.BatteryState
* Contributors: Felix Messmer, floweisshardt, fmessmer
```

## cob_canopen_motor

- No changes

## cob_driver

- No changes

## cob_elmo_homing

- No changes

## cob_generic_can

- No changes

## cob_light

```
* Merge pull request #433 <https://github.com/ipa320/cob_driver/issues/433> from fmessmer/cob_light/num_led_info
  [cob_light] more info in error case
* more info in error case
* Contributors: Felix Messmer, fmessmer
```

## cob_mimic

- No changes

## cob_phidget_em_state

- No changes

## cob_phidget_power_state

- No changes

## cob_phidgets

- No changes

## cob_relayboard

- No changes

## cob_scan_unifier

- No changes

## cob_sick_lms1xx

- No changes

## cob_sick_s300

- No changes

## cob_sound

- No changes

## cob_undercarriage_ctrl

- No changes

## cob_utilities

- No changes

## cob_voltage_control

- No changes

## laser_scan_densifier

- No changes
