### PR TITLE
log_view: 0.2.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1931,7 +1931,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/hatchbed/log_view-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/hatchbed/log_view.git


### PR DESCRIPTION
Increasing version of package(s) in repository `log_view` to `0.2.2-1`:

- upstream repository: https://github.com/hatchbed/log_view.git
- release repository: https://github.com/hatchbed/log_view-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.1-1`

## log_view

```
* Improve message handling so that log messages are not dropped. (#8 <https://github.com/hatchbed/log_view/issues/8>)
* Contributors: Marc Alban
```
