### PR TITLE
control_msgs: 4.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -690,7 +690,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/control_msgs-release.git
-      version: 3.0.0-1
+      version: 4.0.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `4.0.0-1`:

- upstream repository: https://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros2-gbp/control_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.0.0-1`

## control_msgs

```
* Added controller states for multi dof joints (#64 <https://github.com/ros-controls/control_msgs/issues/64>)
* Add initial configurations for multiple distros. (#59 <https://github.com/ros-controls/control_msgs/issues/59>)
  * Add CI configuration with multiple ROS distributions and use pre-commit in the repository.
  * Add badges
* Contributors: Denis Štogl, George Stavrinos
```
