### PR TITLE
ur_robot_driver: 2.2.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5580,7 +5580,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.2.2-1
+      version: 2.2.3-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.2.3-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.2-1`

## ur

- No changes

## ur_bringup

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* Adapt ros control api (#448 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/448>)
  * scaled jtc: Use get_interface_name instead of get_name
  * Migrate from stopped controllers to inactive controllers
  stopped controllers has been depreated upstream
* Contributors: Felix Exner
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

- No changes

## ur_robot_driver

```
* Adapt ros control api (#448 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/448>)
  * scaled jtc: Use get_interface_name instead of get_name
  * Migrate from stopped controllers to inactive controllers
  stopped controllers has been depreated upstream
* Contributors: Felix Exner
```
