### PR TITLE
ur_robot_driver: 2.1.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5996,7 +5996,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.1.1-1
+      version: 2.1.2-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.1.2-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.1-1`

## ur_bringup

```
* Fix force_torque_sensor_broadcaster config (#406 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/406>)
* Fix dependencies for galactic (#392 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/392>)
* Contributors: Felix Exner, Robert Wilbrandt
```

## ur_calibration

- No changes

## ur_controllers

```
* Fix dependencies for galactic (#392 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/392>)
* Contributors: Felix Exner, Robert Wilbrandt
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* Fix dependencies for galactic (#392 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/392>)
* Contributors: Felix Exner, Robert Wilbrandt
```

## ur_robot_driver

```
* Silence a compilation warning (#425 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/425>) (#427 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/427>)
* Fix dependencies for galactic (#392 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/392>)
* Contributors: Felix Exner, Robert Wilbrandt
```
