### PR TITLE
ur_robot_driver: 2.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6713,7 +6713,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.0.1-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-1`

## ur_bringup

- No changes

## ur_controllers

- No changes

## ur_dashboard_msgs

- No changes

## ur_description

- No changes

## ur_moveit_config

- No changes

## ur_robot_driver

```
* added ur_bringup to test_depend of ur_robot_driver (#454 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/454>)
* Contributors: Felix Exner
```
