### PR TITLE
rviz: 1.13.26-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12664,7 +12664,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.13.25-1
+      version: 1.13.26-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.13.26-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.13.25-1`

## rviz

```
* Improve SplitterHandle of PropertyTreeWidgets (#1760 <https://github.com/ros-visualization/rviz/issues/1760>)
  
    * Suppress horizontal scrolling and auto-resizing of columns
    * Double click auto-adjusts to content
  
* Fix segfault occuring for direct dock panel deletion (#1759 <https://github.com/ros-visualization/rviz/issues/1759>)
* Fix race conditions in PointCloud displays (#1754 <https://github.com/ros-visualization/rviz/issues/1754>)
* Acquire mutexes before destroying PointCloudCommon
* PointCloud displays: unsubscribe before destroying PointCloudCommon
* Fix segfault in ``TimePanel::onTimeSignal()`` (#1753 <https://github.com/ros-visualization/rviz/issues/1753>): Drop source Display* argument, which is a dangling pointer if the Display was deleted meanwhile
* Drop OGRE/ from #include directives
* Contributors: Robert Haschke
```
