### PR TITLE
hpp-fcl: 2.1.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4454,7 +4454,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/humanoid-path-planner/hpp-fcl-ros-release.git
-      version: 1.8.1-1
+      version: 2.1.2-1
     source:
       type: git
       url: https://github.com/humanoid-path-planner/hpp-fcl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hpp-fcl` to `2.1.2-1`:

- upstream repository: https://github.com/humanoid-path-planner/hpp-fcl.git
- release repository: https://github.com/humanoid-path-planner/hpp-fcl-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.8.1-1`
