### PR TITLE
hpp-fcl: 2.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1404,7 +1404,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/hpp_fcl-release.git
-      version: 2.1.1-1
+      version: 2.1.2-1
     source:
       type: git
       url: https://github.com/humanoid-path-planner/hpp-fcl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hpp-fcl` to `2.1.2-1`:

- upstream repository: https://github.com/humanoid-path-planner/hpp-fcl.git
- release repository: https://github.com/ros2-gbp/hpp_fcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.1-1`
