### PR TITLE
executive_smach_visualization: 4.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2993,7 +2993,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/jbohren/executive_smach_visualization-release.git
-      version: 4.0.0-1
+      version: 4.0.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/executive_smach_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `executive_smach_visualization` to `4.0.1-1`:

- upstream repository: https://github.com/ros-visualization/executive_smach_visualization.git
- release repository: https://github.com/jbohren/executive_smach_visualization-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `4.0.0-1`

## executive_smach_visualization

- No changes

## smach_viewer

```
* Fix 4.0.0, which does not work on both Melodic/Noetic (#43 <https://github.com/ros-visualization/executive_smach_visualization/issues/43>)
  
    * use LooseVersion(wx.__version__) to support old Melodic (wxPython 3.0)
    * typos
    * more deprecated functions to test on melodic
    * why wouldn't this work with python3 ?
    * add missing dependency on cv_bridge
    * update use of deprecated functions
    * update pckage.xml based on https://github.com/ros-visualization/executive_smach_visualization/pull/39
    * use catkin_install_python to automatically set /usr/bin/env python3 for noetic, but need to remove smach_viewer/lib/smach_viewer from sys.path
    * xdot/wxxdot.py: intentionally uses from xdot, instead of from .xdot, because we want to use local xdot for Pytohn2 and sytem xdot for Python3
    * Revert "apply 2to3 -w -f import *" This reverts commit 4cbd2ab0d16d4123e9227bf6b9e627bd4bd8ea7f.
  
* Contributors: Kei Okada, Mikael Arguedas
```
