### PR TITLE
ros2_control: 1.6.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3998,7 +3998,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 1.5.1-1
+      version: 1.6.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `1.6.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.5.1-1`

## controller_interface

- No changes

## controller_manager

```
* Fixes of issue with seg-fault when checking interfaces on unconfigured controllers. (#580 <https://github.com/ros-controls/ros2_control/issues/580>) (#795 <https://github.com/ros-controls/ros2_control/issues/795>)
* [ros2_control_node] Automatically detect if RT kernel is used and opportunistically enable SCHED_FIFO (#748 <https://github.com/ros-controls/ros2_control/issues/748>) (#768 <https://github.com/ros-controls/ros2_control/issues/768>)
* Contributors: Denis Štogl, Tyler Weaver
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## transmission_interface

- No changes
