### PR TITLE
ros2_control: 2.13.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3956,7 +3956,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.12.1-1
+      version: 2.13.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.13.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.12.1-1`

## controller_interface

- No changes

## controller_manager

```
* Clang tidy: delete a redundant return (#790 <https://github.com/ros-controls/ros2_control/issues/790>)
* Add chained controllers information in list controllers service #abi-braking (#758 <https://github.com/ros-controls/ros2_control/issues/758>)
  * add chained controllers in ros2controlcli
  * remove controller_group from service
  * added comments to ControllerState message
  * added comments to ChainedConnection message
* spawner.py: Fix python logging on deprecation warning (#787 <https://github.com/ros-controls/ros2_control/issues/787>)
* Add documentation for realtime permission (#781 <https://github.com/ros-controls/ros2_control/issues/781>)
* Fix bug in spawner with getter for node's logger (#776 <https://github.com/ros-controls/ros2_control/issues/776>)
* Contributors: Andy Zelenak, Felix Exner, Paul Gesel, Bijou Abraham
```

## controller_manager_msgs

```
* Add chained controllers information in list controllers service #abi-braking (#758 <https://github.com/ros-controls/ros2_control/issues/758>)
  * add chained controllers in ros2controlcli
  * remove controller_group from service
  * added comments to ControllerState message
  * added comments to ChainedConnection message
* Contributors: Paul Gesel
```

## hardware_interface

- No changes

## joint_limits

```
* Make output of joint limits nicer. (#788 <https://github.com/ros-controls/ros2_control/issues/788>)
* Contributors: Denis Štogl
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Add chained controllers information in list controllers service #abi-braking (#758 <https://github.com/ros-controls/ros2_control/issues/758>)
  * add chained controllers in ros2controlcli
  * remove controller_group from service
  * added comments to ControllerState message
  * added comments to ChainedConnection message
* Added spawner colors to command interfaces based on availablity and claimed status (#754 <https://github.com/ros-controls/ros2_control/issues/754>)
* Contributors: Leander Stephen D'Souza, Paul Gesel
```

## transmission_interface

- No changes
