### PR TITLE
rqt_publisher: 1.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4608,7 +4608,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_publisher-release.git
-      version: 1.2.0-1
+      version: 1.6.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_publisher` to `1.6.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_publisher.git
- release repository: https://github.com/ros2-gbp/rqt_publisher-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.0-1`

## rqt_publisher

```
* Delete sync to foxy-devel workflow
* Merge pull request #33 <https://github.com/ros-visualization/rqt_publisher/issues/33> from NBadyal/improve-evaluation-of-types
* Use regex matching to strip errors from input
* Change slot_type verification strategy
* Mirror rolling to foxy-devel
* Contributors: Audrow Nash, Geoffrey Biggs, Nicholas Badyal
```
