### PR TITLE
ess_imu_ros1_uart_driver: 1.3.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2234,7 +2234,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/cubicleguy/ess_imu_ros1_uart_driver-release.git
-      version: 1.3.1-1
+      version: 1.3.2-1
     source:
       type: git
       url: https://github.com/cubicleguy/ess_imu_ros1_uart_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ess_imu_ros1_uart_driver` to `1.3.2-1`:

- upstream repository: https://github.com/cubicleguy/ess_imu_ros1_uart_driver.git
- release repository: https://github.com/cubicleguy/ess_imu_ros1_uart_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.1-1`

## ess_imu_ros1_uart_driver

```
* update cmake_minimum_required to avoid unstable build on buildfarm due to CMP0048 warning
* update README.md for name change in package.xml, CMakeLists.txt
* add dependency geometry_msgs and tf2
* fix for name change in package.xml, CMakeLists.txt, launch files
* Cleanup description of applicable licensing for files BSD-3 and Public Domain
```
