### PR TITLE
generate_parameter_library: 0.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1169,6 +1169,27 @@ repositories:
       url: https://github.com/ros-sports/gc_spl.git
       version: rolling
     status: developed
+  generate_parameter_library:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/generate_parameter_library.git
+      version: main
+    release:
+      packages:
+      - generate_parameter_library
+      - generate_parameter_library_example
+      - generate_parameter_library_py
+      - parameter_traits
+      - tcb_span
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/PickNikRobotics/generate_parameter_library-release.git
+      version: 0.2.2-1
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/generate_parameter_library.git
+      version: main
+    status: developed
   geographic_info:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `generate_parameter_library` to `0.2.2-1`:

- upstream repository: https://github.com/PickNikRobotics/generate_parameter_library.git
- release repository: https://github.com/PickNikRobotics/generate_parameter_library-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## generate_parameter_library

- No changes

## generate_parameter_library_example

- No changes

## generate_parameter_library_py

```
* Add better error messages (#48 <https://github.com/PickNikRobotics/generate_parameter_library/issues/48>)
* Lock mutex around modifying internal state of ParamListener (#47 <https://github.com/PickNikRobotics/generate_parameter_library/issues/47>)
* Contributors: Paul Gesel, Tyler Weaver
```

## parameter_traits

- No changes

## tcb_span

- No changes
