### PR TITLE
ros2_controllers: 2.11.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3981,11 +3981,12 @@ repositories:
       - ros2_controllers
       - ros2_controllers_test_nodes
       - rqt_joint_trajectory_controller
+      - tricycle_controller
       - velocity_controllers
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.10.0-1
+      version: 2.11.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.11.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.10.0-1`

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

```
* Use explicit type in joint_state_broadcaster test (#403 <https://github.com/ros-controls/ros2_controllers/issues/403>)
  This use of auto is causing a static assert on RHEL. Explicitly
  specifying the type seems to resolve the failure and allow the test to
  be compiled.
* Contributors: Scott K Logan
```

## joint_trajectory_controller

- No changes

## position_controllers

- No changes

## ros2_controllers

```
* Tricycle controller (#345 <https://github.com/ros-controls/ros2_controllers/issues/345>)
* Contributors: Tony Najjar
```

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## tricycle_controller

```
* Tricycle controller (#345 <https://github.com/ros-controls/ros2_controllers/issues/345>)
* Contributors: Bence Magyar, Tony Najjar
```

## velocity_controllers

- No changes
