### PR TITLE
ign_ros_control: 0.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3492,6 +3492,24 @@ repositories:
       url: https://github.com/ethz-adrl/ifopt.git
       version: master
     status: maintained
+  ign_ros_control:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/ign_ros_control.git
+      version: master
+    release:
+      packages:
+      - ign_ros_control
+      - ign_ros_control_demos
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/ign_ros_control-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/ign_ros_control.git
+      version: master
+    status: maintained
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ign_ros_control` to `0.0.1-1`:

- upstream repository: https://github.com/ros-controls/ign_ros_control
- release repository: https://github.com/ros-gbp/ign_ros_control-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ign_ros_control

```
* Default ignition version cmake should be the same as in package.xml
* Fix dependencies in package.xml files
* Set up ros_control for Ignition
* Contributors: Bence Magyar, Gennaro Raiola, Ryan Sinnet
```

## ign_ros_control_demos

```
* Fix dependencies in package.xml files
* Set up basic set of demos for ign_ros_control
* Contributors: Gennaro Raiola, Ryan Sinnet
```
