### PR TITLE
neonavigation: 0.11.7-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7701,7 +7701,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.11.6-1
+      version: 0.11.7-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.11.7-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.11.6-1`

## costmap_cspace

- No changes

## joystick_interrupt

```
* joystick_interrupt: enable omni-directional movement (#645 <https://github.com/at-wat/neonavigation/issues/645>)
* Contributors: Naotaka Hatao
```

## map_organizer

- No changes

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

- No changes

## obj_to_pointcloud

- No changes

## planner_cspace

```
* planner_cspace: fix pose duplication on path interpolation (#648 <https://github.com/at-wat/neonavigation/issues/648>)
* Contributors: Atsushi Watanabe
```

## safety_limiter

```
* safety_limiter: enable omni-directional safety brake (#646 <https://github.com/at-wat/neonavigation/issues/646>)
* Contributors: Naotaka Hatao
```

## track_odometry

- No changes

## trajectory_tracker

```
* trajectory_tracker: fix prediction_offset of trajectory_tracker (#644 <https://github.com/at-wat/neonavigation/issues/644>)
* Contributors: Naotaka Hatao
```
