### PR TITLE
plotjuggler: 3.5.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3499,7 +3499,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.5.1-1
+      version: 3.5.2-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.5.2-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.5.1-1`

## plotjuggler

```
* fix issue #642 <https://github.com/facontidavide/PlotJuggler/issues/642>
* fix FFT toolbox
* Add options for enabling/disabling autozoom in preferences (#704 <https://github.com/facontidavide/PlotJuggler/issues/704>)
* add support for custom window titles (#715 <https://github.com/facontidavide/PlotJuggler/issues/715>)
* Fix/snap rosbag (#714 <https://github.com/facontidavide/PlotJuggler/issues/714>)
* fix mosquitto build in linux
* Better cmake (#710 <https://github.com/facontidavide/PlotJuggler/issues/710>)
* fix #707 <https://github.com/facontidavide/PlotJuggler/issues/707>
* better installation instructions
* fix(snap): reapply changes remove by the merge of main (#703 <https://github.com/facontidavide/PlotJuggler/issues/703>)
* save ColorMaps in layout
* Contributors: Bartimaeus-, Davide Faconti, Guillaume Beuzeboc, grekiki
```
