### PR TITLE
orocos_kdl_vendor: 0.2.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2725,7 +2725,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
-      version: 0.2.3-1
+      version: 0.2.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_kdl_vendor` to `0.2.4-1`:

- upstream repository: https://github.com/ros2/orocos_kdl_vendor.git
- release repository: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.3-1`

## orocos_kdl_vendor

```
* Make sure to quote orocos variables when setting targets. (#14 <https://github.com/ros2/orocos_kdl_vendor/issues/14>)
* Ensure orocos-kdl is available as a target (#13 <https://github.com/ros2/orocos_kdl_vendor/issues/13>)
* Contributors: Chris Lalancette, Scott K Logan
```

## python_orocos_kdl_vendor

- No changes
