### PR TITLE
simple_actions: 0.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6046,6 +6046,22 @@ repositories:
       url: https://github.com/SICKAG/sick_scan2.git
       version: master
     status: developed
+  simple_actions:
+    doc:
+      type: git
+      url: https://github.com/DLu/simple_actions.git
+      version: main
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/DLu/simple_actions-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/DLu/simple_actions.git
+      version: main
+    status: developed
   simple_launch:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_actions` to `0.1.0-1`:

- upstream repository: https://github.com/DLu/simple_actions.git
- release repository: https://github.com/DLu/simple_actions-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
