### PR TITLE
Added statistics and sbp modules

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4481,6 +4481,13 @@ python-rx-pip:
   ubuntu:
     pip:
       packages: [rx]
+python-sbp-pip:
+  debian:
+    pip:
+      packages: [sbp]
+  ubuntu:
+    pip:
+      packages: [sbp]
 python-scapy:
   debian: [python-scapy]
   fedora: [scapy]
@@ -4909,6 +4916,13 @@ python-sqlalchemy:
 python-sqlite:
   debian: [python-sqlite]
   ubuntu: [python-sqlite]
+python-statistics-pip:
+  debian:
+    pip:
+      packages: [statistics]
+  ubuntu:
+    pip:
+      packages: [statistics]
 python-statsd:
   debian: [python-statsd]
   fedora: [python-statsd]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4481,7 +4481,7 @@ python-rx-pip:
   ubuntu:
     pip:
       packages: [rx]
-python-sbp-pip:
+python-sbp-pip: &migrate_eol_2027_04_30_python3_sbp_pip
   debian:
     pip:
       packages: [sbp]
@@ -8453,6 +8453,7 @@ python3-ruamel.yaml:
   nixos: [python3Packages.ruamel_yaml]
   openembedded: [python3-ruamel-yaml@meta-python]
   ubuntu: [python3-ruamel.yaml]
+python3-sbp-pip: *migrate_eol_2027_04_30_python3_sbp_pip
 python3-schedule:
   debian: [python3-schedule]
   nixos: [python3Packages.schedule]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

sbp
statistics

## Package Upstream Source:

sbp: https://github.com/swift-nav/libsbp
statistics: https://github.com/digitalemagine/py-statistics

## Purpose of using this:

sbp is used to integrate with the swift binary protocol. This is necessary to integrate with Swift GPS units for navigation/autonomy.
statistics is a python2 port of the extremely useful python3 statistics module

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - Not Available
- Ubuntu: https://packages.ubuntu.com/
   - Not Available
- Pip:
  - https://pypi.org/project/sbp/
  - https://pypi.org/project/statistics/