### PR TITLE
r2r_spl: 3.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3035,7 +3035,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/r2r_spl-release.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/ros-sports/r2r_spl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `r2r_spl` to `3.0.1-1`:

- upstream repository: https://github.com/ros-sports/r2r_spl.git
- release repository: https://github.com/ros2-gbp/r2r_spl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.0-1`

## r2r_spl_7

- No changes

## splsm_7

```
* Adapt to modified SPLSM msg
* Deduce num_of_data_bytes from data bounded array size
* Contributors: Kenji Brameld
```

## splsm_7_conversion

```
* Change SPLSM msg data field to bounded array
* Remove SPLSM msg num_of_data_bytes field
* Contributors: Kenji Brameld
```
