### PR TITLE
r2r_spl: 1.0.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3184,7 +3184,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/r2r_spl-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ros-sports/r2r_spl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `r2r_spl` to `1.0.1-1`:

- upstream repository: https://github.com/ros-sports/r2r_spl.git
- release repository: https://github.com/ros2-gbp/r2r_spl-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-1`

## r2r_spl_7

- No changes

## splsm_7

```
* Change SPLSM msg data field to bounded array
* Remove SPLSM msg num_of_data_bytes field
* Contributors: Kenji Brameld
```

## splsm_7_conversion

```
* Adapt to modified SPLSM msg
* Deduce num_of_data_bytes from data bounded array size
* Contributors: Kenji Brameld
```
