### PR TITLE
r2r_spl: 0.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3880,7 +3880,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/r2r_spl-release.git
-      version: 0.0.1-1
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/ros-sports/r2r_spl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `r2r_spl` to `0.0.2-1`:

- upstream repository: https://github.com/ros-sports/r2r_spl.git
- release repository: https://github.com/ros2-gbp/r2r_spl-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.1-1`

## r2r_spl_7

- No changes

## splsm_7

```
* Change SPLSM msg data field to bounded array
* Remove SPLSM msg num_of_data_bytes field
* Contributors: Kenji Brameld
```

## splsm_7_conversion

```
* Adapt to modified SPLSM msg
* Deduce num_of_data_bytes from data bounded array size
* Contributors: Kenji Brameld
```
