### PR TITLE
gazebo_ros2_control: 0.4.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1150,7 +1150,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.3.0-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros2_control` to `0.4.0-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros2_control.git
- release repository: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.0-1`

## gazebo_ros2_control

```
* Implemented perform_command_mode_switch override in GazeboSystem (#136 <https://github.com/ros-simulation/gazebo_ros2_control/issues/136>)
* added namespace to controller manager (#147 <https://github.com/ros-simulation/gazebo_ros2_control/issues/147>)
* Activate all hardware in URDF (#144 <https://github.com/ros-simulation/gazebo_ros2_control/issues/144>)
* activated all hardware by default (#143 <https://github.com/ros-simulation/gazebo_ros2_control/issues/143>)
* Fix setting initial values if command interfaces are not defined. (#110 <https://github.com/ros-simulation/gazebo_ros2_control/issues/110>)
* changed name to GazeboSystem (#142 <https://github.com/ros-simulation/gazebo_ros2_control/issues/142>)
* Contributors: Denis Štogl, Keegan Sotebeer, Maciej Bednarczyk
```

## gazebo_ros2_control_demos

```
* fix demo launch
* Fix setting initial values if command interfaces are not defined. (#110 <https://github.com/ros-simulation/gazebo_ros2_control/issues/110>)
* Contributors: Bence Magyar, Denis Štogl, Maciej Bednarczyk
```
