### PR TITLE
ign_ros2_control: 0.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1453,6 +1453,24 @@ repositories:
       url: https://github.com/ros2-gbp/ifm3d-release.git
       version: 0.18.0-6
     status: developed
+  ign_ros2_control:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/gz_ros2_control.git
+      version: master
+    release:
+      packages:
+      - ign_ros2_control
+      - ign_ros2_control_demos
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ign_ros2_control-release.git
+      version: 0.5.0-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/gz_ros2_control.git
+      version: master
+    status: maintained
   ign_rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ign_ros2_control` to `0.5.0-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## ign_ros2_control

```
* Fix setting initial values if command interfaces are not defined. (#73 <https://github.com/ros-controls/gz_ros2_control/issues/73>)
* activated all hardware by default and improved variable naming (#74 <https://github.com/ros-controls/gz_ros2_control/issues/74>)
* Implemented perform_command_mode_switch override in GazeboSystem (#76 <https://github.com/ros-controls/gz_ros2_control/issues/76>)
* Remove warnings (#72 <https://github.com/ros-controls/gz_ros2_control/issues/72>)
* change component name for ignition (#69 <https://github.com/ros-controls/gz_ros2_control/issues/69>)
* Added logic for activating hardware interfaces (#68 <https://github.com/ros-controls/gz_ros2_control/issues/68>)
* Merge branch 'foxy' into ahcorde/foxy_to_galactic_27_05_2022
* Remove URDF dependency (#56 <https://github.com/ros-controls/gz_ros2_control/issues/56>)
* Adapt to ROS 2 Humble
* typo in citadel name (#54 <https://github.com/ros-controls/gz_ros2_control/issues/54>)
* typo in citadel name (#51 <https://github.com/ros-controls/gz_ros2_control/issues/51>)
* ros2_control is now having usings under its namespace. (#43 <https://github.com/ros-controls/gz_ros2_control/issues/43>)
* Fix default ign gazebo version Rolling (#45 <https://github.com/ros-controls/gz_ros2_control/issues/45>)
* Fix ignition version in package.xml - Rolling (#41 <https://github.com/ros-controls/gz_ros2_control/issues/41>)
* Fixed position control (#29 <https://github.com/ros-controls/gz_ros2_control/issues/29>)
* Add support for initial_values for hardware interfaces when starting simulation. (#27 <https://github.com/ros-controls/gz_ros2_control/issues/27>)
* Contributors: Alejandro Hernández Cordero, Denis Štogl, Guillaume Beuzeboc, Tianyu Li
```

## ign_ros2_control_demos

```
* Fix setting initial values if command interfaces are not defined. (#73 <https://github.com/ros-controls/gz_ros2_control/issues/73>)
* fix demo launch (#75 <https://github.com/ros-controls/gz_ros2_control/issues/75>)
* Adjust URLs (#65 <https://github.com/ros-controls/gz_ros2_control/issues/65>)
* ign_ros2_control_demos: Install urdf dir (#61 <https://github.com/ros-controls/gz_ros2_control/issues/61>)
* Remove URDF dependency (#56 <https://github.com/ros-controls/gz_ros2_control/issues/56>)
* Use Ubuntu Jammy in CI (#47 <https://github.com/ros-controls/gz_ros2_control/issues/47>)
* Add support for initial_values for hardware interfaces when starting simulation. (#27 <https://github.com/ros-controls/gz_ros2_control/issues/27>)
* Contributors: Alejandro Hernández Cordero, Andrej Orsula, Bence Magyar, Denis Štogl, Maciej Bednarczyk, ahcorde
```
