### PR TITLE
Update Humble development branch for image_transport_plugins

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1600,7 +1600,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/image_transport_plugins.git
-      version: ros2
+      version: humble
     release:
       packages:
       - compressed_depth_image_transport
@@ -1615,7 +1615,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/image_transport_plugins.git
-      version: ros2
+      version: humble
     status: maintained
   imu_tools:
     doc:


### PR DESCRIPTION
Related to breaking change being introduced in https://github.com/ros-perception/image_transport_plugins/pull/106