### PR TITLE
leo_robot: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1893,6 +1893,24 @@ repositories:
       url: https://github.com/LeoRover/leo_desktop-ros2.git
       version: humble
     status: maintained
+  leo_robot:
+    doc:
+      type: git
+      url: https://github.com/LeoRover/leo_robot-ros2.git
+      version: humble
+    release:
+      packages:
+      - leo_bringup
+      - leo_fw
+      - leo_robot
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/fictionlab-gbp/leo_robot-ros2-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/LeoRover/leo_robot-ros2.git
+      version: humble
   lgsvl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_robot` to `1.0.0-1`:

- upstream repository: https://github.com/LeoRover/leo_robot-ros2.git
- release repository: https://github.com/fictionlab-gbp/leo_robot-ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## leo_bringup

```
* Initial ROS2 port
* Contributors: Błażej Sowa, Aleksander Szymański
```

## leo_fw

```
* Initial ROS2 port
* Contributors: Błażej Sowa
```

## leo_robot

```
* Initial ROS2 port
* Contributors: Błażej Sowa
```
