### PR TITLE
Revert "plotjuggler_ros: 1.7.1-3 in 'humble/distribution.yaml' [bloom]"

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2944,7 +2944,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-ros-plugins-release.git
-      version: 1.7.1-3
+      version: 1.5.1-3
     source:
       type: git
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git


### PR DESCRIPTION
Reverts ros/rosdistro#33890 because of a regression, see https://build.ros2.org/job/Hbin_uJ64__plotjuggler_ros__ubuntu_jammy_amd64__binary/.