### PR TITLE
Add asyncapi_gencpp, log_view, rpad, rpad_ros, and param_util source to rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1929,7 +1929,7 @@ repositories:
       url: https://github.com/boschglobal/locator_ros_bridge.git
       version: main
     status: maintained
-  log_vew:
+  log_view:
     doc:
       type: git
       url: https://github.com/hatchbed/log_view.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -359,6 +359,16 @@ repositories:
       url: https://github.com/fkie/async_web_server_cpp.git
       version: ros2-develop
     status: maintained
+  asyncapi_gencpp:
+    doc:
+      type: git
+      url: https://github.com/hatchbed/asyncapi_gencpp.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/hatchbed/asyncapi_gencpp.git
+      version: main
+    status: developed
   automotive_autonomy_msgs:
     doc:
       type: git
@@ -1919,6 +1929,16 @@ repositories:
       url: https://github.com/boschglobal/locator_ros_bridge.git
       version: main
     status: maintained
+  log_vew:
+    doc:
+      type: git
+      url: https://github.com/hatchbed/log_view.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/hatchbed/log_view.git
+      version: ros2
+    status: developed
   marti_common:
     doc:
       type: git
@@ -2682,6 +2702,16 @@ repositories:
       type: git
       url: https://github.com/OUXT-Polaris/ouxt_common.git
       version: master
+    status: developed
+  param_util:
+    doc:
+      type: git
+      url: https://github.com/hatchbed/param_util.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/hatchbed/param_util.git
+      version: main
     status: developed
   pcl_msgs:
     release:
@@ -4431,6 +4461,26 @@ repositories:
       url: https://github.com/AIS-Bonn/rot_conv_lib.git
       version: master
     status: maintained
+  rpad:
+    doc:
+      type: git
+      url: https://github.com/hatchbed/rpad.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/hatchbed/rpad.git
+      version: main
+    status: developed
+  rpad_ros:
+    doc:
+      type: git
+      url: https://github.com/hatchbed/rpad_ros.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/hatchbed/rpad_ros.git
+      version: ros2
+    status: developed
   rplidar_ros:
     release:
       tags:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2634,6 +2634,26 @@ repositories:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
       version: 1.5.2-2
+  opensw:
+    doc:
+      type: git
+      url: https://github.com/hatchbed/opensw.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/hatchbed/opensw.git
+      version: main
+    status: developed
+  opensw_ros:
+    doc:
+      type: git
+      url: https://github.com/hatchbed/opensw_ros.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/hatchbed/opensw_ros.git
+      version: ros2
+    status: developed
   orocos_kdl_vendor:
     release:
       packages:
@@ -4461,26 +4481,6 @@ repositories:
       url: https://github.com/AIS-Bonn/rot_conv_lib.git
       version: master
     status: maintained
-  rpad:
-    doc:
-      type: git
-      url: https://github.com/hatchbed/rpad.git
-      version: main
-    source:
-      type: git
-      url: https://github.com/hatchbed/rpad.git
-      version: main
-    status: developed
-  rpad_ros:
-    doc:
-      type: git
-      url: https://github.com/hatchbed/rpad_ros.git
-      version: ros2
-    source:
-      type: git
-      url: https://github.com/hatchbed/rpad_ros.git
-      version: ros2
-    status: developed
   rplidar_ros:
     release:
       tags:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1411,6 +1411,16 @@ repositories:
       url: https://github.com/tier4/hash_library_vendor.git
       version: main
     status: maintained
+  hatchbed_common:
+    doc:
+      type: git
+      url: https://github.com/hatchbed/hatchbed_common.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/hatchbed/hatchbed_common.git
+      version: main
+    status: developed
   hls_lfcd_lds_driver:
     doc:
       type: git
@@ -2702,16 +2712,6 @@ repositories:
       type: git
       url: https://github.com/OUXT-Polaris/ouxt_common.git
       version: master
-    status: developed
-  param_util:
-    doc:
-      type: git
-      url: https://github.com/hatchbed/param_util.git
-      version: main
-    source:
-      type: git
-      url: https://github.com/hatchbed/param_util.git
-      version: main
     status: developed
   pcl_msgs:
     release:


### PR DESCRIPTION
References https://github.com/ros2-gbp/ros2-gbp-github-org/issues/88

# Please Add This Package to be indexed in the rosdistro.

rolling

# The source is here:
  * [hatchbed_common](https://github.com/hatchbed/hatchbed_common)
  * [log_view](https://github.com/hatchbed/log_view)
  * [asyncapi_gencpp](https://github.com/hatchbed/asyncapi_gencpp) 
  * [opensw](https://github.com/hatchbed/opensw)
  * [opensw_ros](https://github.com/hatchbed/opensw_ros)



# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
