### PR TITLE
Add python3-polling2-pip to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7678,6 +7678,9 @@ python3-polling2-pip:
   fedora:
     pip:
       packages: [polling2]
+  osx:
+    pip:
+      packages: [polling2]
   ubuntu:
     pip:
       packages: [polling2]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7671,6 +7671,16 @@ python3-ply:
     '*': [python3-ply]
     '7': null
   ubuntu: [python3-ply]
+python3-polling2-pip:
+  debian:
+    pip:
+      packages: [polling2]
+  fedora:
+    pip:
+      packages: [polling2]
+  ubuntu:
+    pip:
+      packages: [polling2]
 python3-pqdict-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-polling2-pip

## Package Upstream Source:

Source: https://github.com/ddmee/polling2
Docs: https://polling2.readthedocs.io/

## Purpose of using this:

Polling2 is a utility library with functions to wait for specified conditions.

## Links to Distribution Packages

This package is only distributed via PyPI.