### PR TITLE
Add python3-stonesoup-pip to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8811,6 +8811,19 @@ python3-staticmap-pip:
   ubuntu:
     pip:
       packages: [staticmap]
+python3-stonesoup-pip:
+  debian:
+    pip:
+      packages: [stonesoup]
+  fedora:
+    pip:
+      packages: [stonesoup]
+  osx:
+    pip:
+      packages: [stonesoup]
+  ubuntu:
+    pip:
+      packages: [stonesoup]
 python3-suas-interop-clients-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-stonesoup-pip

## Package Upstream Source:

Source: https://github.com/dstl/Stone-Soup
Docs: https://stonesoup.readthedocs.io/

## Purpose of using this:

Stone Soup is a framework for the development and testing of tracking and state estimation algorithms. It is developed by the Defence Science and Technology Laboratory. [This article](https://www.gov.uk/government/news/dstl-shares-new-open-source-framework-initiative) gives more background information.

## Links to Distribution Packages

This package is only available via PyPI.