### PR TITLE
ntrip_client: 1.2.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2598,7 +2598,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/ntrip_client-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ntrip_client` to `1.2.0-1`:

- upstream repository: https://github.com/LORD-MicroStrain/ntrip_client.git
- release repository: https://github.com/ros2-gbp/ntrip_client-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.0-1`

## ntrip_client

```
* Adds the ability to configure the NTRIP client to connect using SSL (#23 <https://github.com/LORD-MicroStrain/ntrip_client/issues/23>)
* ROS automatic reconnect (#18 <https://github.com/LORD-MicroStrain/ntrip_client/issues/18>)
  * Adds ability to reconnect to ROS
  * Allows the timeouts and other parameters to be modified via the launch file
  * Moves optional config out of constructor, and declares constnats in class definition
* Contributors: Rob
```
