### PR TITLE
depthai-ros: 2.5.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -751,7 +751,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/luxonis/depthai-ros-release.git
-      version: 2.5.2-1
+      version: 2.5.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai-ros` to `2.5.3-1`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: https://github.com/luxonis/depthai-ros-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.5.2-1`

## depthai-ros

```
* Updated release version
* Contributors: Sachin
```

## depthai_bridge

```
* Updated release version
* Merge remote-tracking branch 'origin/main' into ros-release
* Timestamp update (#129 <https://github.com/luxonis/depthai-ros/issues/129>)
  * Updated timestamp style
  * Changed Loglevel Namesapce
* Fixed seg fault in yolo detections
* Updated mobilenet center position
* Fix for spatial detection for noetic (#120 <https://github.com/luxonis/depthai-ros/issues/120>)
  * moved the depthai bridge position of find package
  * Updated condition for spatial detection for ros1
  "
* moved the depthai bridge position of find package (#115 <https://github.com/luxonis/depthai-ros/issues/115>)
* Contributors: Sachin, Sachin Guruswamy
```

## depthai_examples

```
* Updated release version
* Added upgrades to stereo node and fixed the nodelet issue (#130 <https://github.com/luxonis/depthai-ros/issues/130>)
* Contributors: Sachin, Sachin Guruswamy
```

## depthai_ros_msgs

```
* Updated release version
* moved the depthai bridge position of find package (#115 <https://github.com/luxonis/depthai-ros/issues/115>)
* Contributors: Sachin, Sachin Guruswamy
```
