### PR TITLE
rviz: 1.13.29-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12680,7 +12680,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.13.27-1
+      version: 1.13.29-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.13.29-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.13.27-1`

## rviz

```
* Fixup to #1760 <https://github.com/ros-visualization/rviz/issues/1760>, SplitterHandle (#1766 <https://github.com/ros-visualization/rviz/issues/1766>)
* Contributors: Robert Haschke
```
