### PR TITLE
rviz: 1.14.18-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9642,7 +9642,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.14.16-1
+      version: 1.14.18-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.14.18-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.14.16-1`

## rviz

```
* Fixup to #1760 <https://github.com/ros-visualization/rviz/issues/1760>, SplitterHandle (#1766 <https://github.com/ros-visualization/rviz/issues/1766>)
* Contributors: Robert Haschke
```
