### PR TITLE
Added python3-pytest-timeout dependency for nixos

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8272,6 +8272,7 @@ python3-pytest-timeout:
   debian: [python3-pytest-timeout]
   fedora: [python3-pytest-timeout]
   gentoo: [dev-python/pytest-timeout]
+  nixos: [python3Packages.pytest-timeout]
   opensuse: [python3-pytest-timeout]
   rhel: ['python%{python3_pkgversion}-pytest-timeout']
   ubuntu: [python3-pytest-timeout]


### PR DESCRIPTION
Please update the following dependency to the rosdep database.

## Package name:

python3-pytest-timeout

## Package Upstream Source:

https://github.com/pytest-dev/pytest-timeout

## Purpose of using this:

Some ros cli utils (`ros2run`, for example) in humble release requires this python package but this dependency link is missed for nixos.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- NixOS/nixpkgs: https://search.nixos.org/packages?channel=unstable&show=python39Packages.pytest-timeout&from=0&size=50&sort=relevance&type=packages&query=pytest-timeout
