### PR TITLE
hpp-fcl: 2.1.2-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1470,7 +1470,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/hpp_fcl-release.git
-      version: 2.1.2-1
+      version: 2.1.2-2
     source:
       type: git
       url: https://github.com/humanoid-path-planner/hpp-fcl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hpp-fcl` to `2.1.2-2`:

- upstream repository: https://github.com/humanoid-path-planner/hpp-fcl.git
- release repository: https://github.com/ros2-gbp/hpp_fcl-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.2-1`
