### PR TITLE
[dep] Adding yarn

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8143,6 +8143,17 @@ yamllint:
       packages: [yamllint]
   rhel: [yamllint]
   ubuntu: [yamllint]
+yarn:
+  alpine: [yarn]
+  arch: [yarn]
+  debian: [yarnpkg]
+  fedora: [yarnpkg]
+  gentoo: [sys-apps/yarn]
+  macports: [yarn]
+  nixos: [yarn]
+  ubuntu:
+    '*': [yarnpkg]
+    bionic: null
 yasm:
   arch: [yasm]
   debian: [yasm]


### PR DESCRIPTION
## Package name:

`yarn`

## Package Upstream Source:

https://yarnpkg.com/

## Purpose of using this:

- One popular usecase: Installing `.js` packages.
   - Some say it's arguably a better alternative to `npm`.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=yarn
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/search?suite=focal&arch=any&searchon=names&keywords=yarnpkg
- Fedora: https://packages.fedoraproject.org/
  - https://src.fedoraproject.org/rpms/yarnpkg
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/community/any/yarn/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/sys-apps/yarn
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/yarn#default
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/community/x86_64/yarn
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=22.05&show=yarn&from=0&size=50&sort=relevance&type=packages&query=yarn
- openSUSE: https://software.opensuse.org/package/
  - <s>https://software.opensuse.org/package/yarn</s> -> [CI failed](https://github.com/ros/rosdistro/actions/runs/2863014358) and I'm not sure how to fix this so removed opensuse for now.
