### PR TITLE
Add RHEL 9+ rule for python3-mypy

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7370,6 +7370,10 @@ python3-mypy:
   osx:
     pip:
       packages: [mypy]
+  rhel:
+    '*': [python3-mypy]
+    '7': null
+    '8': null
   ubuntu: [python3-mypy]
 python3-nclib-pip:
   arch:


### PR DESCRIPTION
This package is still not available for RHEL 7 or RHEL 8, but is already available for RHEL 9. Even though RHEL 9 is not yet targeted by rosdep_repo_check, it's helpful to add rules early to make triaging easier.

https://packages.fedoraproject.org/pkgs/python3-mypy/python3-mypy/