### PR TITLE
rosbag2_storage_mcap: 0.1.7-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5207,7 +5207,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2_storage_mcap-release.git
-      version: 0.1.6-1
+      version: 0.1.7-1
     source:
       type: git
       url: https://github.com/ros-tooling/rosbag2_storage_mcap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2_storage_mcap` to `0.1.7-1`:

- upstream repository: https://github.com/ros-tooling/rosbag2_storage_mcap.git
- release repository: https://github.com/ros2-gbp/rosbag2_storage_mcap-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.6-1`

## mcap_vendor

```
* Add all lz4 sources to fix undefined symbols at runtime (#46 <https://github.com/ros-tooling/rosbag2_storage_mcap/issues/46>)
* Contributors: Emerson Knapp
```

## rosbag2_storage_mcap

```
* Add all lz4 sources to fix undefined symbols at runtime (#46 <https://github.com/ros-tooling/rosbag2_storage_mcap/issues/46>)
* Contributors: Emerson Knapp
```
