### PR TITLE
simple_actions: 0.2.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5180,6 +5180,22 @@ repositories:
       url: https://github.com/SICKAG/sick_safetyscanners_base.git
       version: ros2
     status: developed
+  simple_actions:
+    doc:
+      type: git
+      url: https://github.com/DLu/simple_actions.git
+      version: main
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/DLu/simple_actions-release.git
+      version: 0.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/DLu/simple_actions.git
+      version: main
+    status: developed
   simple_launch:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_actions` to `0.2.1-1`:

- upstream repository: https://github.com/DLu/simple_actions.git
- release repository: https://github.com/DLu/simple_actions-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
