### PR TITLE
raspimouse_ros2_examples: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3979,6 +3979,21 @@ repositories:
       url: https://github.com/rt-net/raspimouse_description.git
       version: foxy-devel
     status: maintained
+  raspimouse_ros2_examples:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspimouse_ros2_examples.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/raspimouse_ros2_examples-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/rt-net/raspimouse_ros2_examples.git
+      version: foxy-devel
+    status: maintained
   rc_common_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspimouse_ros2_examples` to `1.0.0-1`:

- upstream repository: https://github.com/rt-net/raspimouse_ros2_examples.git
- release repository: https://github.com/ros2-gbp/raspimouse_ros2_examples-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## raspimouse_ros2_examples

```
* Update map command (#38 <https://github.com/rt-net/raspimouse_ros2_examples/issues/38>)
* Adds config file for DUALSHOCK4 (#36 <https://github.com/rt-net/raspimouse_ros2_examples/issues/36>)
* Update README for foxy-devel (#34 <https://github.com/rt-net/raspimouse_ros2_examples/issues/34>)
* Remove node_ prefix from launch files (#33 <https://github.com/rt-net/raspimouse_ros2_examples/issues/33>)
* Use ament_export_targets instead of ament_export_interfaces. (#31 <https://github.com/rt-net/raspimouse_ros2_examples/issues/31>)
* Remove dashing check from CI (#32 <https://github.com/rt-net/raspimouse_ros2_examples/issues/32>)
* Update rviz config to show scan and graph topics (#29 <https://github.com/rt-net/raspimouse_ros2_examples/issues/29>)
* Add descriptions to READMEs for use_pulse_counters param settings (#28 <https://github.com/rt-net/raspimouse_ros2_examples/issues/28>)
* Use joy_linux instead of joy (#27 <https://github.com/rt-net/raspimouse_ros2_examples/issues/27>)
* Update CI to support ROS Foxy (#26 <https://github.com/rt-net/raspimouse_ros2_examples/issues/26>)
* Update package.xml (#25 <https://github.com/rt-net/raspimouse_ros2_examples/issues/25>)
* Install raspimouse2 and imu packages via rosdep command (#22 <https://github.com/rt-net/raspimouse_ros2_examples/issues/22>)
* Add rt_usb_9axisimu_driver dependency to package.xml (#21 <https://github.com/rt-net/raspimouse_ros2_examples/issues/21>)
* Add direction control example (#18 <https://github.com/rt-net/raspimouse_ros2_examples/issues/18>)
* Use images of rt-net/images repo. (#17 <https://github.com/rt-net/raspimouse_ros2_examples/issues/17>)
* Add lidar example (#14 <https://github.com/rt-net/raspimouse_ros2_examples/issues/14>)
* Turn on/off leds with joy inputs (#15 <https://github.com/rt-net/raspimouse_ros2_examples/issues/15>)
* Update Gamepad F710 usage in README (#13 <https://github.com/rt-net/raspimouse_ros2_examples/issues/13>)
* Use multi threads in the object tracking example to stabilize the tracking (#11 <https://github.com/rt-net/raspimouse_ros2_examples/issues/11>)
* update video link (#12 <https://github.com/rt-net/raspimouse_ros2_examples/issues/12>)
* Merge teleop_joy launch files into one file. (#10 <https://github.com/rt-net/raspimouse_ros2_examples/issues/10>)
* Add line follower examples (#9 <https://github.com/rt-net/raspimouse_ros2_examples/issues/9>)
* Add object tracking sample (#8 <https://github.com/rt-net/raspimouse_ros2_examples/issues/8>)
* Rename launch files (#7 <https://github.com/rt-net/raspimouse_ros2_examples/issues/7>)
* Refactoring (#6 <https://github.com/rt-net/raspimouse_ros2_examples/issues/6>)
* Support remote control (#5 <https://github.com/rt-net/raspimouse_ros2_examples/issues/5>)
* Add Joystic example (#4 <https://github.com/rt-net/raspimouse_ros2_examples/issues/4>)
* Add industrial_ci test settings (#3 <https://github.com/rt-net/raspimouse_ros2_examples/issues/3>)
* Fix teleop.launch for flake8 check (#2 <https://github.com/rt-net/raspimouse_ros2_examples/issues/2>)
* Add github workflow (#1 <https://github.com/rt-net/raspimouse_ros2_examples/issues/1>)
* Contributors: Daisuke Sato, Shota Aoki, Shuhei Kozasa
```
