### PR TITLE
image_transport_plugins: 2.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1583,7 +1583,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 2.5.0-1
+      version: 2.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `2.6.0-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.5.0-1`

## compressed_depth_image_transport

```
* Fix advertiseImpl() in compressed_depth_publisher and subscribeImpl() in compressed_depth_subscriber. (#106 <https://github.com/ros-perception/image_transport_plugins/issues/106>)
* Contributors: Ivan Santiago Paunovic
```

## compressed_image_transport

```
* Fix advertiseImpl() in compressed_publisher and subscribeImpl() in compressed_subscriber. (#106 <https://github.com/ros-perception/image_transport_plugins/issues/106>)
* Contributors: Ivan Santiago Paunovic
```

## image_transport_plugins

- No changes

## theora_image_transport

```
* Fix advertiseImpl() in theora_publisher and subscribeImpl() in theora_subscriber. (#106 <https://github.com/ros-perception/image_transport_plugins/issues/106>)
* Contributors: Ivan Santiago Paunovic
```
