### PR TITLE
plotjuggler: 3.6.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6788,7 +6788,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.5.2-1
+      version: 3.6.0-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.6.0-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.5.2-1`

## plotjuggler

```
* More memes
* Refactoring of the MessageParser plugins
* Mcap support (#722 <https://github.com/facontidavide/PlotJuggler/issues/722>)
* Improve CSV loader error handling (#721 <https://github.com/facontidavide/PlotJuggler/issues/721>)
* Fix plotwidget drag and drop bug (Issue #716 <https://github.com/facontidavide/PlotJuggler/issues/716>) (#717 <https://github.com/facontidavide/PlotJuggler/issues/717>)
* fix(snap): remove yaml grade (#718 <https://github.com/facontidavide/PlotJuggler/issues/718>)
  grade is set from the part
  YAML grade has priority over the programmed one so we remove it
* Contributors: Bartimaeus-, Davide Faconti, Guillaume Beuzeboc
```
