### PR TITLE
maliput: 1.0.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2396,7 +2396,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput-release.git
-      version: 1.0.5-1
+      version: 1.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput` to `1.0.6-1`:

- upstream repository: https://github.com/maliput/maliput.git
- release repository: https://github.com/ros2-gbp/maliput-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.5-1`

## maliput

```
* Implements KDTree::RangeSearch method. (#520 <https://github.com/maliput/maliput/issues/520>)
* Adds AxisAlignedBox. (#519 <https://github.com/maliput/maliput/issues/519>)
* Brings BoundingRegion's related stuff from maliput_object. (#518 <https://github.com/maliput/maliput/issues/518>)
* Adds KDTree to maliput::math. (#515 <https://github.com/maliput/maliput/issues/515>)
* Contributors: Franco Cipollone
```
