### PR TITLE
Added K4A mapping for Azure Kinect SDK debian packages

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2184,6 +2184,9 @@ jython:
   gentoo: [dev-java/jython]
   nixos: [jython]
   ubuntu: [jython]
+K4A:
+  arch: [azure-kinect-sensor-sdk-git]
+  ubuntu: [k4a-tools, libk4a1.4, libk4a1.4-dev]
 kakasi:
   arch: [kakasi]
   debian: [kakasi]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

K4A (Azure Kinect SDK)

## Package Upstream Source:

https://github.com/microsoft/Azure-Kinect-Sensor-SDK

## Purpose of using this:

This addresses this ros1/ros2 package

https://github.com/microsoft/Azure_Kinect_ROS_Driver

as is discussed here
https://github.com/microsoft/Azure_Kinect_ROS_Driver/pull/248

## Links to Distribution Packages

This is not packaged by Debian or Ubuntu. 
The debian packages are available at the Microsoft repositories here:
https://packages.microsoft.com/ubuntu/18.04/prod/pool/main/

I know that Microsoft is only providing packages for 18.04, and that this is a big problem. However, if someones wants to install the packages provided by Microsoft, they do so at their own risk, and (at least) this will make rosdep work in workspaces where the azure kinect driver is included.