### PR TITLE
rosbridge_suite: 1.3.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4378,7 +4378,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 1.2.0-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `1.3.0-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.0-1`

## rosapi

```
* Fixed /get_param service for arrays (#776 <https://github.com/RobotWebTools/rosbridge_suite/issues/776>)
* Contributors: p0rys
```

## rosapi_msgs

- No changes

## rosbridge_library

```
* Allow integers in conversion to float array messages (#777 <https://github.com/RobotWebTools/rosbridge_suite/issues/777>)
* Non standard msg modules (#735 <https://github.com/RobotWebTools/rosbridge_suite/issues/735>)
* Contributors: Jacob Bandes-Storch, Will
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* Add url_path config option (#709 <https://github.com/RobotWebTools/rosbridge_suite/issues/709>)
* Contributors: Matthijs van der Burgh, Sirawat S
```

## rosbridge_suite

- No changes

## rosbridge_test_msgs

- No changes
