### PR TITLE
maliput_object: 0.1.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2515,7 +2515,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput_object-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_object` to `0.1.2-1`:

- upstream repository: https://github.com/maliput/maliput_object.git
- release repository: https://github.com/ros2-gbp/maliput_object-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.1-1`

## maliput_object

```
* Moves BoundingRegion, BoundingBox and OverlappingType to maliput (#44 <https://github.com/maliput/maliput_object/issues/44>)
* Adds triage workflow. (#43 <https://github.com/maliput/maliput_object/issues/43>)
* Improves README. (#42 <https://github.com/maliput/maliput_object/issues/42>)
* Contributors: Franco Cipollone
```
