### PR TITLE
Add gz keys for Gazebo Citadel and Fortress

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1743,6 +1743,115 @@ gv:
   gentoo: [app-text/gv]
   nixos: [gv]
   ubuntu: [gv]
+gz-citadel:
+  ubuntu:
+    focal: [gz-citadel]
+gz-cmake2:
+  ubuntu:
+    focal: [libgz-cmake2-dev]
+    jammy: [libgz-cmake2-dev]
+gz-common3:
+  ubuntu:
+    focal: [libgz-common3-dev]
+gz-common4:
+  ubuntu:
+    focal: [libgz-common4-dev]
+    jammy: [libgz-common4-dev]
+gz-fortress:
+  ubuntu:
+    focal: [gz-fortress]
+    jammy: [gz-fortress]
+gz-fuel-tools4:
+  ubuntu:
+    focal: [libgz-fuel-tools4-dev]
+gz-fuel-tools7:
+  ubuntu:
+    focal: [libgz-fuel-tools7-dev]
+    jammy: [libgz-fuel-tools7-dev]
+gz-gui3:
+  ubuntu:
+    focal: [libgz-gui3-dev]
+gz-gui6:
+  ubuntu:
+    focal: [libgz-gui6-dev]
+    jammy: [libgz-gui6-dev]
+gz-launch2:
+  ubuntu:
+    focal: [libgz-launch2-dev]
+gz-launch5:
+  ubuntu:
+    focal: [libgz-launch5-dev]
+    jammy: [libgz-launch5-dev]
+gz-math6:
+  ubuntu:
+    focal: [libgz-math6-dev]
+    jammy: [libgz-math6-dev]
+gz-math6-eigen3:
+  ubuntu:
+    focal: [libgz-math6-eigen3-dev]
+    jammy: [libgz-math6-eigen3-dev]
+gz-msgs5:
+  ubuntu:
+    focal: [libgz-msgs5-dev]
+gz-msgs8:
+  ubuntu:
+    focal: [libgz-msgs8-dev]
+    jammy: [libgz-msgs8-dev]
+gz-physics2:
+  ubuntu:
+    focal: [libgz-physics2-dev]
+gz-physics5:
+  ubuntu:
+    focal: [libgz-physics5-dev]
+    jammy: [libgz-physics5-dev]
+gz-plugin:
+  ubuntu:
+    focal: [libgz-plugin-dev]
+    jammy: [libgz-plugin-dev]
+gz-rendering3:
+  ubuntu:
+    focal: [libgz-rendering3-dev]
+gz-rendering6:
+  ubuntu:
+    focal: [libgz-rendering6-dev]
+    jammy: [libgz-rendering6-dev]
+gz-sensors3:
+  ubuntu:
+    focal: [libgz-sensors3-dev]
+gz-sensors6:
+  ubuntu:
+    focal: [libgz-sensors6-dev]
+    jammy: [libgz-sensors6-dev]
+gz-sim3:
+  ubuntu:
+    focal: [libgz-sim3-dev]
+gz-sim6:
+  ubuntu:
+    focal: [libgz-sim6-dev]
+    jammy: [libgz-sim6-dev]
+gz-sim6-plugins:
+  ubuntu:
+    focal: [libgz-sim6-plugins]
+    jammy: [libgz-sim6-plugins]
+gz-tools:
+  ubuntu:
+    focal: [libgz-tools-dev]
+    jammy: [libgz-tools-dev]
+gz-transport11:
+  ubuntu:
+    focal: [libgz-transport11-dev]
+    jammy: [libgz-transport11-dev]
+gz-transport8:
+  ubuntu:
+    focal: [libgz-transport8-dev]
+gz-utils1:
+  ubuntu:
+    focal: [libgz-utils1-dev]
+    jammy: [libgz-utils1-dev]
+gz-utils1-cli:
+  ubuntu:
+    focal: [libgz-utils1-cli-dev]
+    jammy: [libgz-utils1-cli-dev]
 haproxy:
   debian: [haproxy]
   fedora: [haproxy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6981,6 +6981,14 @@ python3-grpcio:
     bionic: null
     xenial: null
 python3-gurobipy-pip: *migrate_eol_2025_04_30_python3_gurobipy_pip
+python3-gz-math6:
+  ubuntu:
+    focal: [python3-gz-math6]
+    jammy: [python3-gz-math6]
+python3-gz-sim6:
+  ubuntu:
+    focal: [python3-gz-sim6]
+    jammy: [python3-gz-sim6]
 python3-h5py:
   debian: [python3-h5py]
   fedora: [python3-h5py]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

* Part of https://github.com/gazebo-tooling/release-tools/issues/698
* Depends on 
    * https://github.com/ros-infrastructure/reprepro-updater/pull/168
    * https://github.com/ros-infrastructure/reprepro-updater/pull/169

## Package name:

[Gazebo](https://gazebosim.org/)

## Package Upstream Source:

All packages are on this org: https://github.com/gazebosim/

## Purpose of using this:

Gazebo is being renamed from [Ignition back to Gazebo](https://community.gazebosim.org/t/a-new-era-for-gazebo/1356). The Gazebo team will keep supporting the `ignition` name for Citadel and Fortress until they reach end of life, but we're providing `gz` aliases so the community can start using the new name and future-proof their packages.

Once the rosdep keys are available, we'll update packages like `ros_gz` and `gz_ros2_control` to use the new keys, and we encourage the community to do the same.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Ubuntu: https://packages.ubuntu.com/
   - http://packages.osrfoundation.org/gazebo/ubuntu-stable/
- macOS: https://formulae.brew.sh/
  - https://github.com/osrf/homebrew-simulation/
