### PR TITLE
raspimouse_slam_navigation_ros2: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4009,6 +4009,26 @@ repositories:
       url: https://github.com/rt-net/raspimouse_ros2_examples.git
       version: foxy-devel
     status: maintained
+  raspimouse_slam_navigation_ros2:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspimouse_slam_navigation_ros2.git
+      version: foxy-devel
+    release:
+      packages:
+      - raspimouse_navigation
+      - raspimouse_slam
+      - raspimouse_slam_navigation
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rt-net/raspimouse_slam_navigation_ros2.git
+      version: foxy-devel
+    status: maintained
   rc_common_msgs:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4024,7 +4024,6 @@ repositories:
       url: https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release.git
       version: 1.0.0-1
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/rt-net/raspimouse_slam_navigation_ros2.git
       version: foxy-devel


### PR DESCRIPTION
Increasing version of package(s) in repository `raspimouse_slam_navigation_ros2` to `1.0.0-1`:

- upstream repository: https://github.com/rt-net/raspimouse_slam_navigation_ros2.git
- release repository: https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## raspimouse_navigation

```
* DWB:Criticsのパラメータを調整
* AMCL:回転のノイズを調整
* DWB: 走行速度を小さくした
* AMCL: 回転のノイズパラメータを小さくした
* DWBにゴール判定のプラグインを追加
* DWBの走行速度パラメータをラズパイマウスに合わせて調整
* AMCLのパラメータに仮の初期位置・姿勢を設定
* コストマップのパラメータを調整
* 1m四方のフィールドで自己位置推定ができるように、AMCLのパラメータを調整した
* footprintをラズパイマウスとケーブルの形状に合わせて長方形に変更
* Change the raspimouse node activation method
* Save the map file to the home directory and use the absolute path to the map file
* Adds raspimouse_description as a dependent pacakgae
* Update launch file so that it brings up the node for RPLIDAR
* Removes arguments and replaces with LaunchConfigurationEquals
* Adds lifecycle sequence
* Adds joint_state_publisher node
* Add navigation launch file for Robot
* Add navigation launch file for PC
* Adds README for navigation package
* Creates raspimouse_navigation package
* Contributors: Shota Aoki, Shuhei Kozasa
```

## raspimouse_slam

```
* 1m四方のフィールドでSLAMが実施できるようにパラメータ調整
* 使用していないパラメータファイルを削除
* Save the map file to the home directory and use the absolute path to the map file
* Adds raspimouse_description as a dependent pacakgae
* Update launch file to use rplidar
* Adds new param file. Updates launch file to use it as default
* Adds description to launch teleop launch file
* Adds launch file to publish the robot_description
* Update launch file so that it brings up the node for RPLIDAR
* Change tag to exec_depend. The sllidar package is not included in the rosdep list
* Removes static tf node. raspimouse_description has that covered
* Update launch files. Use LaunchConfigurationEquals instead.
* Adds rplidar related arguments and definitions
* Updates joystick controller file name sequence
* Adds lds and urg options
* Adds necessary arguments for lds and urg
* Adds urg_node package as a dependent package
* Adds config file for SLAM
* Creates raspimouse_slam package
* Contributors: Shota Aoki, Shuhei Kozasa
```

## raspimouse_slam_navigation

```
* Adds version
* Creates metapackage
* Contributors: Shuhei Kozasa
```
