### PR TITLE
Add python3 lockfile

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7200,6 +7200,15 @@ python3-lark-parser:
     '*': [python3-lark]
     bionic: [python3-lark-parser]
     xenial: [python3-lark-parser]
+python3-lockfile:
+  arch: [python-lockfile]
+  debian: [python3-lockfile]
+  fedora: [python3-lockfile]
+  gentoo: [dev-python/lockfile]
+  nixos: [python310Packages.lockfile]
+  opensuse: [python-lockfile]
+  rhel: [python3-lockfile]
+  ubuntu: [python3-lockfile]
 python3-lttng:
   alpine: [py3-lttng]
   arch: [python-lttngust]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7201,11 +7201,12 @@ python3-lark-parser:
     bionic: [python3-lark-parser]
     xenial: [python3-lark-parser]
 python3-lockfile:
+  alpine: [py3-lockfile]
   arch: [python-lockfile]
   debian: [python3-lockfile]
   fedora: [python3-lockfile]
   gentoo: [dev-python/lockfile]
-  nixos: [python310Packages.lockfile]
+  nixos: [python39Packages.lockfile]
   opensuse: [python-lockfile]
   rhel: [python3-lockfile]
   ubuntu: [python3-lockfile]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-lockfile

## Package Upstream Source:

https://opendev.org/openstack/pylockfile/

## Purpose of using this:

[Used in for example Balena deployments to lock a device from automatically updating](https://www.balena.io/docs/learn/deploy/release-strategy/update-locking/)

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/buster/python3-lockfile
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/focal/python/python-lockfile
- Fedora: https://packages.fedoraproject.org/
  - https://src.fedoraproject.org/rpms/python-lockfile
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/community/any/python-lockfile/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/lockfile
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/community/x86/py3-lockfile
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://mynixos.com/nixpkgs/package/python39Packages.lockfile
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python-lockfile
