### PR TITLE
panda_moveit_config: 0.7.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8714,7 +8714,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/panda_moveit_config-release.git
-      version: 0.7.4-1
+      version: 0.7.6-1
     source:
       type: git
       url: https://github.com/ros-planning/panda_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `panda_moveit_config` to `0.7.6-1`:

- upstream repository: https://github.com/ros-planning/panda_moveit_config.git
- release repository: https://github.com/ros-gbp/panda_moveit_config-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.4-1`

## panda_moveit_config

```
* Update to franka_description 0.9 (#83 <https://github.com/ros-planning/panda_moveit_config/issues/83>)
* Add 'demo_stomp' launch file (#82 <https://github.com/ros-planning/panda_moveit_config/issues/82>)
* Contributors: Gauthier Hentz, Michel Breyer, Rick Staa, Robert Haschke
```
