### PR TITLE
twist_mux: 3.1.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10721,7 +10721,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/twist_mux-release.git
-      version: 3.1.1-1
+      version: 3.1.2-1
     source:
       type: git
       url: https://github.com/ros-teleop/twist_mux.git


### PR DESCRIPTION
Increasing version of package(s) in repository `twist_mux` to `3.1.2-1`:

- upstream repository: https://github.com/ros-teleop/twist_mux.git
- release repository: https://github.com/ros-gbp/twist_mux-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.1.1-1`

## twist_mux

```
* Install joystick_relay.py with catkin_install_python (#37 <https://github.com/ros-teleop/twist_mux/issues/37>)
* Some more logical operator fixes
* Use standard logical or operator
* Contributors: Bence Magyar, Tobias Fischer, Wolfgang Merkt
```
