### PR TITLE
generate_parameter_library: 0.2.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1214,7 +1214,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/PickNikRobotics/generate_parameter_library-release.git
-      version: 0.2.3-1
+      version: 0.2.4-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `generate_parameter_library` to `0.2.4-1`:

- upstream repository: https://github.com/PickNikRobotics/generate_parameter_library.git
- release repository: https://github.com/PickNikRobotics/generate_parameter_library-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.3-1`

## generate_parameter_library

```
* 0.2.3
* Contributors: Tyler Weaver
```

## generate_parameter_library_example

```
* INTEGER type (#53 <https://github.com/PickNikRobotics/generate_parameter_library/issues/53>)
* 0.2.3
* Contributors: Tyler Weaver
```

## generate_parameter_library_py

```
* INTEGER type (#53 <https://github.com/PickNikRobotics/generate_parameter_library/issues/53>)
* 0.2.3
* Contributors: Tyler Weaver
```

## parameter_traits

```
* 0.2.3
* Contributors: Tyler Weaver
```

## tcb_span

```
* 0.2.3
* Add test dependency (#49 <https://github.com/PickNikRobotics/generate_parameter_library/issues/49>)
* Contributors: Tyler Weaver
```
