### PR TITLE
Update src and doc versions of v4l2-camera galactic humble & rolling

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -6183,7 +6183,7 @@ repositories:
     doc:
       type: git
       url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
-      version: foxy
+      version: galactic
     release:
       tags:
         release: release/galactic/{package}/{version}
@@ -6192,7 +6192,7 @@ repositories:
     source:
       type: git
       url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
-      version: foxy
+      version: galactic
     status: developed
   variants:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5963,7 +5963,7 @@ repositories:
     doc:
       type: git
       url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
-      version: foxy
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -5972,7 +5972,7 @@ repositories:
     source:
       type: git
       url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
-      version: foxy
+      version: humble
     status: developed
   variants:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5793,7 +5793,7 @@ repositories:
     doc:
       type: git
       url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
-      version: foxy
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -5802,7 +5802,7 @@ repositories:
     source:
       type: git
       url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
-      version: foxy
+      version: rolling
     status: developed
   variants:
     doc:


### PR DESCRIPTION
This fixes source versions for the v4l2-package that never got updated after bringing the package from foxy to galactic, humble and rolling, which causes breakage of the builds for those distros on the build farm, e.g. [here for rolling](https://build.ros2.org/job/Rdev__v4l2_camera__ubuntu_jammy_amd64/4/).