### PR TITLE
robot_controllers: 0.9.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3921,7 +3921,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/robot_controllers-ros2-release.git
-      version: 0.9.2-1
+      version: 0.9.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_controllers` to `0.9.3-1`:

- upstream repository: https://github.com/fetchrobotics/robot_controllers.git
- release repository: https://github.com/fetchrobotics-gbp/robot_controllers-ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.9.2-1`

## robot_controllers

- No changes

## robot_controllers_interface

```
* Fix tf node spam (#80 <https://github.com/mikeferguson/robot_controllers/issues/80>)
  Stop the tf listener from creating its own node by passing a reference to the parent node.
  The parallelism is untouched as tf uses a callback group for the tf topics that is spon its own executor instance.
  This lowers the overhead from too many nodes and reduces spam in visualizations such as the rqt node graph.
* Contributors: Florian Vahl
```

## robot_controllers_msgs

- No changes
