### PR TITLE
mocap_nokov: 0.0.2-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6802,6 +6802,22 @@ repositories:
       url: https://github.com/nobleo/mobile_robot_simulator.git
       version: master
     status: maintained
+  mocap_nokov:
+    doc:
+      type: git
+      url: https://github.com/NOKOV-MOCAP/mocap_nokov.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/NOKOV-MOCAP/mocap_nokov_release.git
+      version: 0.0.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/NOKOV-MOCAP/mocap_nokov.git
+      version: master
+    status: maintained
   mocap_optitrack:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mocap_nokov` to `0.0.2-2`:

- upstream repository: https://github.com/NOKOV-MOCAP/mocap_nokov
- release repository: https://github.com/NOKOV-MOCAP/mocap_nokov_release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## mocap_nokov

```
* Upload project
* Initial commit
* Contributors: duguguang
```
