### PR TITLE
crane_plus: 1.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -817,8 +817,8 @@ repositories:
       - crane_plus_moveit_config
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/rt-net-gbp/crane_plus-release.git
-      version: 1.0.0-5
+      url: https://github.com/ros2-gbp/crane_plus-release.git
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/rt-net/crane_plus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `crane_plus` to `1.1.0-1`:

- upstream repository: https://github.com/rt-net/crane_plus.git
- release repository: https://github.com/ros2-gbp/crane_plus-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-5`

## crane_plus

```
* Update author tags (#49 <https://github.com/rt-net/crane_plus/issues/49>)
* Add crane_plus_ignition dependency (#48 <https://github.com/rt-net/crane_plus/issues/48>)
* Rename CRANE+V2 to CRANE+ V2 (#44 <https://github.com/rt-net/crane_plus/issues/44>)
* Contributors: Shota Aoki
```

## crane_plus_control

```
* Update author tags (#49 <https://github.com/rt-net/crane_plus/issues/49>)
* Rename CRANE+V2 to CRANE+ V2 (#44 <https://github.com/rt-net/crane_plus/issues/44>)
* Contributors: Shota Aoki
```

## crane_plus_description

```
* Update author tags (#49 <https://github.com/rt-net/crane_plus/issues/49>)
* effort limitをサーボのカタログ値に変更 (#46 <https://github.com/rt-net/crane_plus/issues/46>)
* Rename CRANE+V2 to CRANE+ V2 (#44 <https://github.com/rt-net/crane_plus/issues/44>)
* Contributors: Atsushi Kuwagata, Shota Aoki
```

## crane_plus_examples

```
* Update author tags (#49 <https://github.com/rt-net/crane_plus/issues/49>)
* Rename CRANE+V2 to CRANE+ V2 (#44 <https://github.com/rt-net/crane_plus/issues/44>)
* Contributors: Shota Aoki
```

## crane_plus_gazebo

```
* Update author tags (#49 <https://github.com/rt-net/crane_plus/issues/49>)
* Rename CRANE+V2 to CRANE+ V2 (#44 <https://github.com/rt-net/crane_plus/issues/44>)
* Contributors: Shota Aoki
```

## crane_plus_ignition

```
* Update author tags (#49 <https://github.com/rt-net/crane_plus/issues/49>)
* gui.config追加 (#45 <https://github.com/rt-net/crane_plus/issues/45>)
* Rename CRANE+V2 to CRANE+ V2 (#44 <https://github.com/rt-net/crane_plus/issues/44>)
* fix typo
* Contributors: Atsushi Kuwagata, Shota Aoki
```

## crane_plus_moveit_config

```
* Update author tags (#49 <https://github.com/rt-net/crane_plus/issues/49>)
* Rename CRANE+V2 to CRANE+ V2 (#44 <https://github.com/rt-net/crane_plus/issues/44>)
* Contributors: Shota Aoki
```
