### PR TITLE
imu_tools: 1.2.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3636,7 +3636,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/uos-gbp/imu_tools-release.git
-      version: 1.2.4-1
+      version: 1.2.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `1.2.5-1`:

- upstream repository: https://github.com/ccny-ros-pkg/imu_tools.git
- release repository: https://github.com/uos-gbp/imu_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.4-1`

## imu_complementary_filter

```
* Added ability to reset IMU filters when ROS time jumps back. (#165 <https://github.com/CCNYRoboticsLab/imu_tools/issues/165>)
* Contributors: Martin Pecka
```

## imu_filter_madgwick

```
* Added ability to reset IMU filters when ROS time jumps back. (#165 <https://github.com/CCNYRoboticsLab/imu_tools/issues/165>)
* Contributors: Martin Pecka
```

## imu_tools

- No changes

## rviz_imu_plugin

- No changes
