### PR TITLE
Add sparkfun_ublox_gps

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8835,6 +8835,19 @@ python3-sounddevice-pip:
   ubuntu:
     pip:
       packages: [sounddevice]
+python3-sparkfun-ublox-gps-pip:
+  debian:
+    pip:
+      packages: [sparkfun-ublox-gps]
+  fedora:
+    pip:
+      packages: [sparkfun-ublox-gps]
+  osx:
+    pip:
+      packages: [sparkfun-ublox-gps]
+  ubuntu:
+    pip:
+      packages: [sparkfun-ublox-gps]
 python3-sphinx:
   debian: [python3-sphinx]
   fedora: [python3-sphinx]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

sparkfun-ublox-gps

## Package Upstream Source:

https://pypi.org/project/sparkfun-ublox-gps/

## Purpose of using this:

Useful for interacting with GPS products based on u-blox GPS modules. See https://github.com/sparkfun/Qwiic_Ublox_Gps_Py

## Links to Distribution Packages

python3 pip installable https://pypi.org/project/sparkfun-ublox-gps/

