### PR TITLE
maliput_object_py: 0.1.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2531,7 +2531,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput_object_py-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_object_py` to `0.1.2-1`:

- upstream repository: https://github.com/maliput/maliput_object_py.git
- release repository: https://github.com/ros2-gbp/maliput_object_py-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.1-1`

## maliput_object_py

```
* Pairs with BoundingRegion being moved to maliput. (#8 <https://github.com/maliput/maliput_object_py/issues/8>)
* Adds triage workflow. (#6 <https://github.com/maliput/maliput_object_py/issues/6>)
* Improves README. (#5 <https://github.com/maliput/maliput_object_py/issues/5>)
* Contributors: Franco Cipollone
```
