### PR TITLE
add python3-breathe dep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -840,10 +840,6 @@ python-breathe:
   debian: [python-breathe]
   fedora: [python-breathe]
   ubuntu: [python-breathe]
-python3-breathe:
-  debian: [python3-breathe]
-  fedora: [python3-breathe]
-  ubuntu: [python3-breathe]
 python-bs4:
   debian: [python-bs4]
   fedora: [python-beautifulsoup4]
@@ -6108,6 +6104,10 @@ python3-boto3:
     '*': ['python%{python3_pkgversion}-boto3']
     '7': null
   ubuntu: [python3-boto3]
+python3-breathe:
+  debian: [python3-breathe]
+  fedora: [python3-breathe]
+  ubuntu: [python3-breathe]
 python3-bs4:
   arch: [python-beautifulsoup4]
   debian: [python3-bs4]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6108,7 +6108,9 @@ python3-breathe:
   debian: [python3-breathe]
   fedora: [python3-breathe]
   opensuse: [python3-breathe]
-  rhel: [python3-breathe]
+  rhel:
+    '*': ['python%{python3_pkgversion}-breathe']
+    '7': null
   ubuntu: [python3-breathe]
 python3-bs4:
   arch: [python-beautifulsoup4]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6107,6 +6107,8 @@ python3-boto3:
 python3-breathe:
   debian: [python3-breathe]
   fedora: [python3-breathe]
+  opensuse: [python3-breathe]
+  rhel: [python3-breathe]
   ubuntu: [python3-breathe]
 python3-bs4:
   arch: [python-beautifulsoup4]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -840,6 +840,10 @@ python-breathe:
   debian: [python-breathe]
   fedora: [python-breathe]
   ubuntu: [python-breathe]
+python3-breathe:
+  debian: [python3-breathe]
+  fedora: [python3-breathe]
+  ubuntu: [python3-breathe]
 python-bs4:
   debian: [python-bs4]
   fedora: [python-beautifulsoup4]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-breathe

## Package Upstream Source:

[Github Link](https://github.com/michaeljones/breathe)

## Purpose of using this:

Breathe is an extension to reStructuredText and Sphinx to be able to read and
render [Doxygen](http://www.doxygen.org/) xml output. Currently used by ROS2 packages, such as [cyclonedds](https://github.com/eclipse-cyclonedds/cyclonedds). 

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/stretch/python3-breathe
- Ubuntu: https://packages.ubuntu.com/bionic/python3-breathe
- Fedora: https://packages.fedoraproject.org/pkgs/python-breathe/python3-breathe/

