### PR TITLE
navigation_experimental: 0.4.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5730,7 +5730,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/navigation_experimental-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_experimental` to `0.4.1-1`:

- upstream repository: https://github.com/ros-planning/navigation_experimental.git
- release repository: https://github.com/ros-gbp/navigation_experimental-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.0-1`

## assisted_teleop

- No changes

## goal_passer

- No changes

## navigation_experimental

- No changes

## pose_base_controller

- No changes

## pose_follower

- No changes

## sbpl_lattice_planner

```
* Implement allow_unknown feature (#60 <https://github.com/ros-planning/navigation_experimental/issues/60>)
* debug move_base launch files: Fix warnings, track unknown space
* Contributors: Martin Günther, Martin Peris
```

## sbpl_recovery

- No changes

## twist_recovery

- No changes
