### PR TITLE
leo_common: 2.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4392,7 +4392,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_common-release.git
-      version: 2.1.0-1
+      version: 2.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_common` to `2.2.0-1`:

- upstream repository: https://github.com/LeoRover/leo_common.git
- release repository: https://github.com/fictionlab-gbp/leo_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.0-1`

## leo

- No changes

## leo_description

- No changes

## leo_msgs

```
* Add service definition for setting IMU calibration (#2 <https://github.com/LeoRover/leo_common/issues/2>)
* Fix description of wheel states units
* Contributors: Aleksander Szymański, Błażej Sowa
```

## leo_teleop

- No changes
