### PR TITLE
leo_robot: 2.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4451,7 +4451,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_robot-release.git
-      version: 2.2.0-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_robot` to `2.3.0-1`:

- upstream repository: https://github.com/LeoRover/leo_robot.git
- release repository: https://github.com/fictionlab-gbp/leo_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.0-1`

## leo_bringup

- No changes

## leo_fw

```
* Add IMU gyro calibration (#9 <https://github.com/LeoRover/leo_robot/issues/9>)
* Contributors: Aleksander Szymański
```

## leo_robot

- No changes
