### PR TITLE
graceful_controller: 0.4.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3108,7 +3108,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mikeferguson/graceful_controller-gbp.git
-      version: 0.4.3-1
+      version: 0.4.4-1
     source:
       type: git
       url: https://github.com/mikeferguson/graceful_controller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `graceful_controller` to `0.4.4-1`:

- upstream repository: https://github.com/mikeferguson/graceful_controller.git
- release repository: https://github.com/mikeferguson/graceful_controller-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.3-1`

## graceful_controller

- No changes

## graceful_controller_ros

```
* always rotate to match desired heading (#54 <https://github.com/mikeferguson/graceful_controller/issues/54>)
  If the goal tolerances are large (greater than 0.5m) the
  robot might end up trying to point at the goal rather than
  aligning with the goal heading
* Contributors: Michael Ferguson
```
