### PR TITLE
Add key for fmt on rhel

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1088,6 +1088,7 @@ fmt:
   fedora: [fmt-devel]
   gentoo: [dev-libs/libfmt]
   nixos: [fmt]
+  rhel: [fmt-devel]
   ubuntu: [libfmt-dev]
 fonts-noto:
   alpine: [font-noto]


### PR DESCRIPTION
Signed-off-by: Tyler Weaver <tyler@picknik.ai>

## Package name:

fmt

## Purpose of using this:

Add fmt key for rhel

My motivation for adding this is our `genereate_parameter_library` depends on fmt and I realized that fmt key was missing from rhel and ros2_control is would like to use  `generate_parameter_library` and they test and target rhel.

## Links to Distribution Packages

- RHEL: https://rpmfind.net/linux/rpm2html/search.php?query=fmt-devel
