### PR TITLE
eigenpy: 2.7.12-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -924,7 +924,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/eigenpy-release.git
-      version: 2.7.11-1
+      version: 2.7.12-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/eigenpy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `eigenpy` to `2.7.12-1`:

- upstream repository: https://github.com/stack-of-tasks/eigenpy.git
- release repository: https://github.com/ros2-gbp/eigenpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.7.11-1`
