### PR TITLE
fastrtps: 2.1.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1355,7 +1355,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/fastrtps-release.git
-      version: 2.1.1-1
+      version: 2.1.2-1
     source:
       test_commits: true
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `fastrtps` to `2.1.2-1`:

- upstream repository: https://github.com/eProsima/Fast-DDS.git
- release repository: https://github.com/ros2-gbp/fastrtps-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `2.1.1-1`
