### PR TITLE
navigation2: 1.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2439,6 +2439,7 @@ repositories:
       - nav2_behaviors
       - nav2_bringup
       - nav2_bt_navigator
+      - nav2_collision_monitor
       - nav2_common
       - nav2_constrained_smoother
       - nav2_controller
@@ -2459,6 +2460,7 @@ repositories:
       - nav2_system_tests
       - nav2_theta_star_planner
       - nav2_util
+      - nav2_velocity_smoother
       - nav2_voxel_grid
       - nav2_waypoint_follower
       - nav_2d_msgs
@@ -2467,7 +2469,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/SteveMacenski/navigation2-release.git
-      version: 1.1.0-2
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/ros-planning/navigation2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation2` to `1.1.2-1`:

- upstream repository: https://github.com/ros-planning/navigation2.git
- release repository: https://github.com/SteveMacenski/navigation2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-2`
