### PR TITLE
tesseract: 0.13.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10447,7 +10447,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-industrial-release/tesseract-release.git
-      version: 0.10.0-1
+      version: 0.13.1-1
     source:
       type: git
       url: https://github.com/ros-industrial-consortium/tesseract.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tesseract` to `0.13.1-1`:

- upstream repository: https://github.com/tesseract-robotics/tesseract.git
- release repository: https://github.com/ros-industrial-release/tesseract-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.10.0-1`

## tesseract_collision

```
* Move most SWIG commands to tesseract_python package (#809 <https://github.com/tesseract-robotics/tesseract/issues/809>)
* Add find_bullet macro which creates a target to link against (#803 <https://github.com/tesseract-robotics/tesseract/issues/803>)
* Contributors: John Wason, Levi Armstrong
```

## tesseract_common

```
* Add tesseract extension macro
* Move most SWIG commands to tesseract_python package (#809 <https://github.com/tesseract-robotics/tesseract/issues/809>)
* Add isNull method to TypeErasureBase
* Fix TypeErasure to fully support being null
* Add find_bullet macro which creates a target to link against (#803 <https://github.com/tesseract-robotics/tesseract/issues/803>)
* Update almostEqualRelativeAndAbs to support vector of max_diff and max_rel_diff (#802 <https://github.com/tesseract-robotics/tesseract/issues/802>)
* Contributors: John Wason, Levi Armstrong
```

## tesseract_environment

```
* Move most SWIG commands to tesseract_python package (#809 <https://github.com/tesseract-robotics/tesseract/issues/809>)
* Contributors: John Wason
```

## tesseract_geometry

```
* Move most SWIG commands to tesseract_python package (#809 <https://github.com/tesseract-robotics/tesseract/issues/809>)
* Contributors: John Wason
```

## tesseract_kinematics

```
* Move most SWIG commands to tesseract_python package (#809 <https://github.com/tesseract-robotics/tesseract/issues/809>)
* Contributors: John Wason
```

## tesseract_scene_graph

```
* Move most SWIG commands to tesseract_python package (#809 <https://github.com/tesseract-robotics/tesseract/issues/809>)
* Contributors: John Wason
```

## tesseract_srdf

```
* Move boost serialization export outside tesseract_common namespace in srdf_model.cpp
* Move most SWIG commands to tesseract_python package (#809 <https://github.com/tesseract-robotics/tesseract/issues/809>)
* Contributors: John Wason, Levi Armstrong
```

## tesseract_state_solver

```
* Move most SWIG commands to tesseract_python package (#809 <https://github.com/tesseract-robotics/tesseract/issues/809>)
* Contributors: John Wason
```

## tesseract_support

```
* Fix the Windows 2019 github action (#805 <https://github.com/tesseract-robotics/tesseract/issues/805>)
* Contributors: John Wason
```

## tesseract_urdf

- No changes

## tesseract_visualization

```
* Move most SWIG commands to tesseract_python package (#809 <https://github.com/tesseract-robotics/tesseract/issues/809>)
* Contributors: John Wason
```
