### PR TITLE
ros_inorbit_samples: 0.2.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11149,7 +11149,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/inorbit-ai/ros_inorbit_samples-release.git
-      version: 0.2.4-1
+      version: 0.2.5-1
     source:
       type: git
       url: https://github.com/inorbit-ai/ros_inorbit_samples.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_inorbit_samples` to `0.2.5-1`:

- upstream repository: https://github.com/inorbit-ai/ros_inorbit_samples.git
- release repository: https://github.com/inorbit-ai/ros_inorbit_samples-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.4-1`

## inorbit_republisher

```
* Add filtering in JSON mappings (#14 <https://github.com/inorbit-ai/ros_inorbit_samples/pull/14>)
* Contributors: Elvio_Aruta
```
