### PR TITLE
rqt_tf_tree: 1.0.4-1 in 'rolling/distribution.yaml'

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4790,6 +4790,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_srv.git
       version: rolling
     status: maintained
+  rqt_tf_tree:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_tf_tree.git
+      version: humble
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_tf_tree-release.git
+      version: 1.0.4-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_tf_tree.git
+      version: humble
+    status: maintained
   rqt_topic:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_tf_tree` to `1.0.4-1`:

* upstream repository: https://github.com/ros-visualization/rqt_tf_tree
* release repository: https://github.com/ros2-gbp/rqt_tf_tree-release
* distro file: `rolling/distribution.yaml`
* bloom version: `0.11.2`
* previous version for package: `none`