### PR TITLE
simple_launch: 1.5.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5205,7 +5205,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/oKermorgant/simple_launch-release.git
-      version: 1.4.1-1
+      version: 1.5.0-1
     source:
       type: git
       url: https://github.com/oKermorgant/simple_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_launch` to `1.5.0-1`:

- upstream repository: https://github.com/oKermorgant/simple_launch.git
- release repository: https://github.com/oKermorgant/simple_launch-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.4.1-1`

## simple_launch

```
* allow spawning a Gz model from file
* parameters are list of dict
* allow substitution for topics in ros_ign_image bridge
* Gazebo bridge handles invalid ROS topics through yaml config file. Image bridges are automatically run through ros_ign_image
* better handling of gazebo spawn pose
* Contributors: Olivier Kermorgant
```
