### PR TITLE
libfranka: 0.9.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4513,7 +4513,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/frankaemika/libfranka-release.git
-      version: 0.9.0-2
+      version: 0.9.1-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libfranka` to `0.9.1-1`:

- upstream repository: https://github.com/frankaemika/libfranka.git
- release repository: https://github.com/frankaemika/libfranka-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.9.0-2`
