### PR TITLE
linux_peripheral_interfaces: 0.2.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4617,6 +4617,25 @@ repositories:
       url: https://github.com/ros-drivers/libuvc_ros.git
       version: master
     status: unmaintained
+  linux_peripheral_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/linux_peripheral_interfaces.git
+      version: kinetic
+    release:
+      packages:
+      - laptop_battery_monitor
+      - libsensors_monitor
+      - linux_peripheral_interfaces
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/linux_peripheral_interfaces-release.git
+      version: 0.2.2-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/linux_peripheral_interfaces.git
+      version: kinetic
+    status: unmaintained
   lms1xx:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `linux_peripheral_interfaces` to `0.2.2-1`:

- upstream repository: https://github.com/ros-drivers/linux_peripheral_interfaces.git
- release repository: https://github.com/ros-gbp/linux_peripheral_interfaces-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## laptop_battery_monitor

```
* Support Python3 for noetic (#19)
  
  These changes allow the node to work with noetic, ubuntu 20.04, with python3
* Contributors: Jeremy Fix, Kei Okada
```

## libsensors_monitor

- No changes

## linux_peripheral_interfaces

- No changes
