### PR TITLE
audio_common: 0.3.15-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -693,7 +693,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/audio_common-release.git
-      version: 0.3.14-1
+      version: 0.3.15-1
     source:
       type: git
       url: https://github.com/ros-drivers/audio_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common` to `0.3.15-1`:

- upstream repository: https://github.com/ros-drivers/audio_common.git
- release repository: https://github.com/ros-gbp/audio_common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.3.14-1`

## audio_capture

- No changes

## audio_common

- No changes

## audio_common_msgs

- No changes

## audio_play

- No changes

## sound_play

```
* Merge pull request #200 <https://github.com/ros-drivers/audio_common/issues/200> from knorth55/yaml-missing
* show error and skip loading when plugin yaml is missing
* Merge pull request #199 <https://github.com/ros-drivers/audio_common/issues/199> from knorth55/install-plugin-yaml
* fix missing install in CMakeLists.txt
* Contributors: Shingo Kitagawa
```
