### PR TITLE
Add python3 pyside2 key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8186,10 +8186,13 @@ python3-pyrr-pip:
     pip:
       packages: [pyrr]
 python3-pyside2:
-  debian: [libpyside2-dev, libshiboken2-dev, python3-pyside2.qtcore, python3-pyside2.qtgui, python3-pyside2.qthelp, python3-pyside2.qtnetwork, python3-pyside2.qtprintsupport, python3-pyside2.qttest, python3-pyside2.qtwidgets, python3-pyside2.qtxml, shiboken2]
+  arch: [pyside2, python-shiboken2, shiboken2]
+  debian: [libpyside2-dev, libshiboken2-dev, python3-pyside2.qtcore, python3-pyside2.qtgui, python3-pyside2.qthelp, python3-pyside2.qtnetwork, python3-pyside2.qtprintsupport, python3-pyside2.qttest, python3-pyside2.qtsvg, python3-pyside2.qtwidgets, python3-pyside2.qtxml, shiboken2]
   fedora: [python3-pyside2, pyside2-tools, python3-pyside2-devel, python3-shiboken2, python3-shiboken2-devel, shiboken2]
+  gentoo: [dev-python/pyside2, dev/python/shiboken2]
   ubuntu:
-    "*": [libpyside2-dev, libshiboken2-dev, python3-pyside2.qtcore, python3-pyside2.qtgui, python3-pyside2.qthelp, python3-pyside2.qtnetwork, python3-pyside2.qtprintsupport, python3-pyside2.qttest, python3-pyside2.qtwidgets, python3-pyside2.qtxml, shiboken2]
+    "*": [libpyside2-dev, libshiboken2-dev, python3-pyside2.qtcore, python3-pyside2.qtgui, python3-pyside2.qthelp, python3-pyside2.qtnetwork, python3-pyside2.qtprintsupport, python3-pyside2.qtsvg, python3-pyside2.qttest, python3-pyside2.qtwidgets, python3-pyside2.qtxml, shiboken2]
+    bionic: null
 python3-pyside2.qtopengl:
   arch: [pyside2]
   debian: [python3-pyside2.qtopengl]
@@ -8208,10 +8211,6 @@ python3-pyside2.qtquick:
     '*': [python3-pyside2.qtquick]
     bionic: null
     xenial: null
-python3-pyside2.qtsvg:
-  debian: [python3-pyside2.qtsvg]
-  ubuntu:
-    "*": [python3-pyside2.qtsvg]
 python3-pyside2.qtuitools:
   debian: [python3-pyside2.qtuitools]
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8187,6 +8187,7 @@ python3-pyrr-pip:
       packages: [pyrr]
 python3-pyside2:
   debian: [libpyside2-dev, libshiboken2-dev, python3-pyside2.qtcore, python3-pyside2.qtgui, python3-pyside2.qthelp, python3-pyside2.qtnetwork, python3-pyside2.qtprintsupport, python3-pyside2.qttest, python3-pyside2.qtwidgets, python3-pyside2.qtxml, shiboken2]
+  fedora: [python3-pyside2, pyside2-tools, python3-pyside2-devel, python3-shiboken2, python3-shiboken2-devel, shiboken2]
   ubuntu:
     "*": [libpyside2-dev, libshiboken2-dev, python3-pyside2.qtcore, python3-pyside2.qtgui, python3-pyside2.qthelp, python3-pyside2.qtnetwork, python3-pyside2.qtprintsupport, python3-pyside2.qttest, python3-pyside2.qtwidgets, python3-pyside2.qtxml, shiboken2]
 python3-pyside2.qtopengl:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8185,6 +8185,9 @@ python3-pyrr-pip:
   ubuntu:
     pip:
       packages: [pyrr]
+python3-pyside2:
+  ubuntu:
+    "*": [libpyside2-dev, libshiboken2-dev, python3-pyside2.qtcore, python3-pyside2.qtdbus, python3-pyside2.qtdesigner, python3-pyside2.qtgui, python3-pyside2.qthelp, python3-pyside2.qtnetwork, python3-pyside2.qtprintsupport, python3-pyside2.qttest, python3-pyside2.qtwidgets, python3-pyside2.qtxml, shiboken2]
 python3-pyside2.qtopengl:
   arch: [pyside2]
   debian: [python3-pyside2.qtopengl]
@@ -8203,6 +8206,9 @@ python3-pyside2.qtquick:
     '*': [python3-pyside2.qtquick]
     bionic: null
     xenial: null
+python3-pyside2.qtsvg:
+  ubuntu:
+    "*": [python3-pyside2.qtsvg]
 python3-pyside2.qtuitools:
   debian: [python3-pyside2.qtuitools]
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8186,8 +8186,9 @@ python3-pyrr-pip:
     pip:
       packages: [pyrr]
 python3-pyside2:
+  debian: [libpyside2-dev, libshiboken2-dev, python3-pyside2.qtcore, python3-pyside2.qtgui, python3-pyside2.qthelp, python3-pyside2.qtnetwork, python3-pyside2.qtprintsupport, python3-pyside2.qttest, python3-pyside2.qtwidgets, python3-pyside2.qtxml, shiboken2]
   ubuntu:
-    "*": [libpyside2-dev, libshiboken2-dev, python3-pyside2.qtcore, python3-pyside2.qtdbus, python3-pyside2.qtdesigner, python3-pyside2.qtgui, python3-pyside2.qthelp, python3-pyside2.qtnetwork, python3-pyside2.qtprintsupport, python3-pyside2.qttest, python3-pyside2.qtwidgets, python3-pyside2.qtxml, shiboken2]
+    "*": [libpyside2-dev, libshiboken2-dev, python3-pyside2.qtcore, python3-pyside2.qtgui, python3-pyside2.qthelp, python3-pyside2.qtnetwork, python3-pyside2.qtprintsupport, python3-pyside2.qttest, python3-pyside2.qtwidgets, python3-pyside2.qtxml, shiboken2]
 python3-pyside2.qtopengl:
   arch: [pyside2]
   debian: [python3-pyside2.qtopengl]
@@ -8207,6 +8208,7 @@ python3-pyside2.qtquick:
     bionic: null
     xenial: null
 python3-pyside2.qtsvg:
+  debian: [python3-pyside2.qtsvg]
   ubuntu:
     "*": [python3-pyside2.qtsvg]
 python3-pyside2.qtuitools:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-pyside2

## Package Upstream Source:

https://code.qt.io/cgit/pyside/pyside-setup.git/
https://code.qt.io/cgit/pyside/pyside.git/
https://code.qt.io/cgit/pyside/shiboken.git/

## Purpose of using this:

The goal of this key is to eventually replace the pyside2 specific portion of python3-qt5-bindings.
This key will install qt python libraries wrapped with PySide2. The key installs the same libraries as python3-pyqt5 see #34246. This is thought to simplify switching between pyqt and pyside2 as python wrapper providers (see https://github.com/ros-visualization/python_qt_binding/issues/114)

It will at least install wrappers for the following qt libraries:
* qtcore
* qtgui
* qthelp 
* qtnetwork
* qtprintsupport
* qtsvg
* qttest
* qtwidgets
* qtxml

In addition it will install:
* shiboken2 and libraries (generator for pyside2 wrappers)

On Fedora the pyside package is not split so this will install all libraries.


Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?searchon=names&keywords=python3-pyside2
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/search?keywords=python3-pyside2&searchon=names
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-pyside2/python3-pyside2/fedora-rawhide.html
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/pyside2/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/pyside2


