### PR TITLE
marti_common: 2.15.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4815,6 +4815,7 @@ repositories:
     release:
       packages:
       - marti_data_structures
+      - rosman
       - swri_console_util
       - swri_dbw_interface
       - swri_geometry_util
@@ -4834,7 +4835,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 2.14.2-1
+      version: 2.15.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `2.15.1-2`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.14.2-1`

## rosman

```
* Merge branch 'master' into PR644
* Merge pull request #643 <https://github.com/swri-robotics/marti_common/issues/643> from rookie80/rosman_check_improvement
  added xlmrpc support for rosman check, changed output for rosman check
* removed dead code
* added xlmrpc support for rosman check, changed output for rosman check
* Merge branch 'master' into setParam_getParam_support
* Contributors: David Anthony, Justus
```
