### PR TITLE
Add python3 pyqt5 package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *~
 .DS_STORE
 *.pyc
-.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 .DS_STORE
 *.pyc
+.vscode/

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8159,6 +8159,11 @@ python3-pyqrcode:
   gentoo: [dev-python/pyqrcode]
   nixos: [python3Packages.pyqrcode]
   ubuntu: [python3-pyqrcode]
+python3-pyqt5:
+  ubuntu:
+    '*': [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
+    artful: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
+    bionic: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
 python3-pyqt5.qtquick:
   debian: [python3-pyqt5.qtquick]
   ubuntu: [python3-pyqt5.qtquick]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8164,8 +8164,6 @@ python3-pyqt5:
   arch: [python-pyqt5]
   debian:
     '*': [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
-    jessie: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
-    stretch: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
   fedora: [python3-qt5-devel, python3-sip-devel, libXext-devel]
   gentoo: [dev-python/PyQt5]
   nixos: [python3Packages.pyqt5]
@@ -8175,8 +8173,6 @@ python3-pyqt5:
   slackware: [python3-PyQt5]
   ubuntu:
     '*': [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
-    artful: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
-    bionic: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
 python3-pyqt5.qtquick:
   debian: [python3-pyqt5.qtquick]
   ubuntu: [python3-pyqt5.qtquick]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8162,8 +8162,7 @@ python3-pyqrcode:
 python3-pyqt5:
   alpine: [py3-qt5]
   arch: [python-pyqt5]
-  debian:
-    '*': [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
+  debian: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
   fedora: [python3-qt5-devel, python3-sip-devel, libXext-devel]
   gentoo: [dev-python/PyQt5]
   nixos: [python3Packages.pyqt5]
@@ -8171,8 +8170,7 @@ python3-pyqt5:
   opensuse: [python3-qt5]
   rhel: ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
   slackware: [python3-PyQt5]
-  ubuntu:
-    '*': [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
+  ubuntu: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
 python3-pyqt5.qtquick:
   debian: [python3-pyqt5.qtquick]
   ubuntu: [python3-pyqt5.qtquick]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8160,6 +8160,19 @@ python3-pyqrcode:
   nixos: [python3Packages.pyqrcode]
   ubuntu: [python3-pyqrcode]
 python3-pyqt5:
+  alpine: [py3-qt5]
+  arch: [python-pyqt5]
+  debian:
+    '*': [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
+    jessie: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
+    stretch: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
+  fedora: [python3-qt5-devel, python3-sip-devel, libXext-devel]
+  gentoo: [dev-python/PyQt5]
+  nixos: [python3Packages.pyqt5]
+  openembedded: [python3-pyqt5@meta-qt5]
+  opensuse: [python3-qt5]
+  rhel: ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
+  slackware: [python3-PyQt5]
   ubuntu:
     '*': [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
     artful: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-pyqt5

## Package Upstream Source:

https://riverbankcomputing.com/software/pyqt/download

## Purpose of using this:

The goal of this key is to eventually replace python3-qt5-bindings.
This key will install qt python libraries wrapped with PyQt (SIP). The key installs the same libraries as python3-pyside2 see #34243. This is thought to simplify switching between pyqt and pyside2 as python wrapper providers (see https://github.com/ros-visualization/python_qt_binding/issues/114)

It will at least install wrappers for the following qt libraries:

* qtcore
* qtgui
* qthelp
* qtnetwork
* qtprintsupport
* qtsvg
* qttest
* qtwidgets
* qtxml

In addition it will install:

* sip (generator for pyside2 wrappers)
* development libraries

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=python3-pyqt5
  - https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=python3-sip
  - https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=pyqt5-dev
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/search?keywords=python3-pyqt5&searchon=names
   - https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=python3-sip&searchon=names
   - https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=pyqt5-dev&searchon=names

Keys for other distributions are copied over from python3-qt5-bindings.
