### PR TITLE
Add qtpy for rhel

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8380,7 +8380,8 @@ python3-qtpy:
   debian: [python3-qtpy]
   gentoo: [dev-python/QtPy]
   nixos: [python3Packages.qtpy]
-  rhel: [python3-qtpy]
+  rhel:
+    '8': [python3-qtpy]
   ubuntu: [python3-qtpy]
 python3-qwt:
   debian: [python3-qwt]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8380,6 +8380,7 @@ python3-qtpy:
   debian: [python3-qtpy]
   gentoo: [dev-python/QtPy]
   nixos: [python3Packages.qtpy]
+  rhel: [python3-qtpy]
   ubuntu: [python3-qtpy]
 python3-qwt:
   debian: [python3-qwt]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8378,6 +8378,7 @@ python3-qt5-bindings-webkit:
 python3-qtpy:
   arch: [python-qtpy]
   debian: [python3-qtpy]
+  fedora: [python3-QtPy]
   gentoo: [dev-python/QtPy]
   nixos: [python3Packages.qtpy]
   rhel:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8381,7 +8381,7 @@ python3-qtpy:
   gentoo: [dev-python/QtPy]
   nixos: [python3Packages.qtpy]
   rhel:
-    '8': [python3-qtpy]
+    '8': [python3-QtPy]
   ubuntu: [python3-qtpy]
 python3-qwt:
   debian: [python3-qwt]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-qtpy

## Package Upstream Source:

https://github.com/spyder-ide/qtpy

## Purpose of using this:

Add support for RHEL. See https://github.com/ros-visualization/python_qt_binding/issues/114

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- EPEL 8: 
  - https://packages.fedoraproject.org/pkgs/python-QtPy/python3-QtPy/

