### PR TITLE
cras_ros_utils: 2.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2062,10 +2062,12 @@ repositories:
     release:
       packages:
       - cras_cpp_common
+      - cras_py_common
+      - cras_topic_tools
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/ctu-vras/ros-utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_ros_utils` to `2.0.2-1`:

- upstream repository: https://github.com/ctu-vras/ros-utils
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.1-1`

## cras_cpp_common

```
* De-flake throttle test and enable catkin_lint when it has chance to run correctly.
* Add linters and licenses.
* Set up roslaunch-check for test files.
* added catkin_lint
* added roslint, fixed issues.
* catkin_lint, moved external folder inside include/project to avoid collisions with other projects.
* Avoid threading errors when stopping nodes created by node_from_nodelet.
* time_utils: Fix build on 32bit armhf.
* Contributors: Martin Pecka
```

## cras_py_common

```
* De-flake throttle test and enable catkin_lint when it has chance to run correctly.
* Added website links.
* Add linters and licenses.
* Contributors: Martin Pecka
```

## cras_topic_tools

```
* Added option to change_header to apply current ROS time to stamp.
* De-flake throttle test and enable catkin_lint when it has chance to run correctly.
* Satisfy more pedantic Noetic linter.
* Added website links.
* Add linters and licenses.
* Fixed dependency.
* Added linters.
* Fix catkin_lint, re-enable testing.
* Improved comments in nodelet.xml.
* De-flake and speed up throttle test.
* De-flake and speed up repeater test.
* De-flake and speed up relay test.
* De-flake and speed up filter test.
* De-flake and speed up change_header test.
* Avoid threading errors when stopping nodes created by node_from_nodelet.
* Fix compilation on GCC 7.
* Contributors: Martin Pecka
```
