### PR TITLE
vrpn_mocap: 1.0.0-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5966,6 +5966,21 @@ repositories:
       url: https://github.com/vrpn/vrpn.git
       version: master
     status: maintained
+  vrpn_mocap:
+    doc:
+      type: git
+      url: https://github.com/alvinsunyixiao/vrpn_mocap.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/vrpn_mocap-release.git
+      version: 1.0.0-3
+    source:
+      type: git
+      url: https://github.com/alvinsunyixiao/vrpn_mocap.git
+      version: main
+    status: developed
   warehouse_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn_mocap` to `1.0.0-3`:

- upstream repository: https://github.com/alvinsunyixiao/vrpn_mocap.git
- release repository: https://github.com/ros2-gbp/vrpn_mocap-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## vrpn_mocap

```
* Initial public release of vrpn_mocap
* Contributors: Alvin Sun
```
