### PR TITLE
vrpn: 7.35.0-11 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6156,6 +6156,21 @@ repositories:
       url: https://github.com/ros-acceleration/vitis_common.git
       version: rolling
     status: developed
+  vrpn:
+    doc:
+      type: git
+      url: https://github.com/vrpn/vrpn.git
+      version: master
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/vrpn-release.git
+      version: 7.35.0-11
+    source:
+      type: git
+      url: https://github.com/vrpn/vrpn.git
+      version: master
+    status: maintained
   warehouse_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn` to `7.35.0-11`:

- upstream repository: https://github.com/vrpn/vrpn.git
- release repository: https://github.com/ros2-gbp/vrpn-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
