### PR TITLE
realtime_tools: 2.3.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3550,7 +3550,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros-gbp/realtime_tools-release.git
-      version: 2.2.0-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `2.3.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros-gbp/realtime_tools-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.2.0-1`

## realtime_tools

```
* Fix source-based branch names (#90 <https://github.com/ros-controls/realtime_tools/issues/90>)
* Fix formatting (#89 <https://github.com/ros-controls/realtime_tools/issues/89>)
* fix cpplint errors
* Add a library to set thread priority
* Add CI setup as for ros2_control repository.
* Contributors: Andy Zelenak, Bence Magyar, Denis Štogl
```
