### PR TITLE
mrpt2: 2.5.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2909,7 +2909,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt2-release.git
-      version: 2.5.1-1
+      version: 2.5.2-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt2` to `2.5.2-1`:

- upstream repository: https://github.com/MRPT/mrpt.git
- release repository: https://github.com/ros2-gbp/mrpt2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.5.1-1`
