### PR TITLE
industrial_core: 0.7.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3680,7 +3680,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-industrial-release/industrial_core-release.git
-      version: 0.7.2-1
+      version: 0.7.3-1
     source:
       type: git
       url: https://github.com/ros-industrial/industrial_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `industrial_core` to `0.7.3-1`:

- upstream repository: https://github.com/ros-industrial/industrial_core.git
- release repository: https://github.com/ros-industrial-release/industrial_core-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.2-1`

## industrial_core

```
* No changes
```

## industrial_deprecated

```
* No changes
```

## industrial_msgs

```
* No changes
```

## industrial_robot_client

```
* No changes
```

## industrial_robot_simulator

```
* No changes
```

## industrial_trajectory_filters

```
* No changes
```

## industrial_utils

```
* No changes
```

## simple_message

```
* accept old defines as well for now, bw-compatibility for (#262 <https://github.com/ros-industrial/industrial_core/issues/262>) (#275 <https://github.com/ros-industrial/industrial_core/issues/275>)
* for a complete list of changes see the commit log for 0.7.3 <https://github.com/ros-industrial/industrial_core/compare/0.7.2...0.7.3>.
* contributors: gavanderhoorn
```
