### PR TITLE
gps_umd: 1.0.5-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1351,7 +1351,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/gps_umd-release.git
-      version: 1.0.4-2
+      version: 1.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_umd` to `1.0.5-1`:

- upstream repository: https://github.com/swri-robotics/gps_umd.git
- release repository: https://github.com/ros2-gbp/gps_umd-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.4-2`

## gps_msgs

- No changes

## gps_tools

```
* Fix truncation warning for UTM zone snprintf() (#45 <https://github.com/swri-robotics/gps_umd/issues/45>)
* Contributors: Kevin Hallenbeck
```

## gps_umd

- No changes

## gpsd_client

```
* Cleaner shutdown after unload
* Fix build issues with gpsd 3.21 and 3.23
* Fixing build warnings about deprecated API. DISTRIBUTION A. Approved for public release; distribution unlimited. OPSEC #4584 <https://github.com/swri-robotics/gps_umd/issues/4584> (#61 <https://github.com/swri-robotics/gps_umd/issues/61>)
* Adding debug message to help diagnose failures (#60 <https://github.com/swri-robotics/gps_umd/issues/60>)
* User configurable publish rate (#58 <https://github.com/swri-robotics/gps_umd/issues/58>)
* Fix ros2 component topics (#46 <https://github.com/swri-robotics/gps_umd/issues/46>)
* Contributors: Dave Mohamad, David Anthony, Philip Cheney
```
