### PR TITLE
adding xsimd to rosdistro

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8066,6 +8066,10 @@ xtensor:
   ubuntu:
     bionic: [xtensor-dev]
     jammy: [libxtensor-dev]
+xsimd:
+  fedora: [xsimd-devel]
+  ubuntu:
+    jammy: [libxsimd-dev]
 xterm:
   arch: [xterm]
   debian: [xterm]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8060,12 +8060,6 @@ xsltproc:
   gentoo: [dev-libs/libxslt]
   nixos: [libxslt]
   ubuntu: [xsltproc]
-xtensor:
-  arch: [xtensor]
-  fedora: [xtensor]
-  ubuntu:
-    bionic: [xtensor-dev]
-    jammy: [libxtensor-dev]
 xsimd:
   alpine: [xsimd]
   debian:
@@ -8080,6 +8074,12 @@ xsimd:
     '*': [libxsimd-dev]
     bionic: null
     focal: null
+xtensor:
+  arch: [xtensor]
+  fedora: [xtensor]
+  ubuntu:
+    bionic: [xtensor-dev]
+    jammy: [libxtensor-dev]
 xterm:
   arch: [xterm]
   debian: [xterm]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8053,13 +8053,6 @@ xpath-perl:
   gentoo: [dev-perl/XML-XPath]
   macports: [p5-xml-xpath]
   ubuntu: [libxml-xpath-perl]
-xsltproc:
-  arch: [libxslt]
-  debian: [xsltproc]
-  fedora: [libxslt]
-  gentoo: [dev-libs/libxslt]
-  nixos: [libxslt]
-  ubuntu: [xsltproc]
 xsimd:
   alpine: [xsimd]
   debian:
@@ -8074,6 +8067,13 @@ xsimd:
     '*': [libxsimd-dev]
     bionic: null
     focal: null
+xsltproc:
+  arch: [libxslt]
+  debian: [xsltproc]
+  fedora: [libxslt]
+  gentoo: [dev-libs/libxslt]
+  nixos: [libxslt]
+  ubuntu: [xsltproc]
 xtensor:
   arch: [xtensor]
   fedora: [xtensor]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8067,10 +8067,15 @@ xtensor:
     bionic: [xtensor-dev]
     jammy: [libxtensor-dev]
 xsimd:
-  debian: [libxsimd-dev]
+  alpine: [xsimd]
+  debian:
+    "*": [libxsimd-dev]
+    bullseye: null
+    buster: null
   fedora: [xsimd-devel]
   ubuntu:
-    jammy: [libxsimd-dev]
+    "*": [libxsimd-dev]
+    focal: null
 xterm:
   arch: [xterm]
   debian: [xterm]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8067,6 +8067,7 @@ xtensor:
     bionic: [xtensor-dev]
     jammy: [libxtensor-dev]
 xsimd:
+  debian: [libxsimd-dev]
   fedora: [xsimd-devel]
   ubuntu:
     jammy: [libxsimd-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8073,8 +8073,10 @@ xsimd:
     bullseye: null
     buster: null
   fedora: [xsimd-devel]
+  rhel: [xsimd-devel]
   ubuntu:
     "*": [libxsimd-dev]
+    bionic: null
     focal: null
 xterm:
   arch: [xterm]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8069,13 +8069,15 @@ xtensor:
 xsimd:
   alpine: [xsimd]
   debian:
-    "*": [libxsimd-dev]
+    '*': [libxsimd-dev]
     bullseye: null
     buster: null
   fedora: [xsimd-devel]
-  rhel: [xsimd-devel]
+  rhel:
+    '*': [xsimd-devel]
+    '7': null
   ubuntu:
-    "*": [libxsimd-dev]
+    '*': [libxsimd-dev]
     bionic: null
     focal: null
 xterm:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`xsimd`

## Package Upstream Source:

https://github.com/xtensor-stack/xsimd

## Purpose of using this:

Optimizing use of xtensor for MPPI and other tensor applications in C++

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/sid/libxsimd-dev
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/jammy/libxsimd-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/xsimd/xsimd-devel/
- Arch: https://www.archlinux.org/packages/
  - N/A
- Gentoo: https://packages.gentoo.org/
  - N/A
- macOS: https://formulae.brew.sh/
  - N/A
- Alpine: https://pkgs.alpinelinux.org/packages
  - N/A
- NixOS/nixpkgs: https://search.nixos.org/packages
  - N/A
- openSUSE: https://software.opensuse.org/package/
  - N/A