### PR TITLE
vrpn_mocap: 1.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5975,7 +5975,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/vrpn_mocap-release.git
-      version: 1.0.0-3
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/alvinsunyixiao/vrpn_mocap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn_mocap` to `1.0.3-1`:

- upstream repository: https://github.com/alvinsunyixiao/vrpn_mocap.git
- release repository: https://github.com/ros2-gbp/vrpn_mocap-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-3`

## vrpn_mocap

```
* fix header typo
* Contributors: Alvin Sun
```
