### PR TITLE
leo_common: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1869,7 +1869,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/leo_common-release.git
-      version: 1.0.3-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_common-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_common` to `1.1.0-1`:

- upstream repository: https://github.com/LeoRover/leo_common-ros2.git
- release repository: https://github.com/ros2-gbp/leo_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.3-1`

## leo

- No changes

## leo_description

- No changes

## leo_msgs

```
* Add service definition for setting IMU calibration (#2 <https://github.com/LeoRover/leo_common-ros2/issues/2>)
* Contributors: Aleksander Szymański
```

## leo_teleop

- No changes
