### PR TITLE
abb_driver: 1.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8,6 +8,21 @@ release_platforms:
   ubuntu:
   - focal
 repositories:
+  abb_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/abb_driver.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-industrial-release/abb_driver-release.git
+      version: 1.4.0-1
+    source:
+      type: git
+      url: https://github.com/ros-industrial/abb_driver.git
+      version: kinetic-devel
+    status: maintained
   abb_robot_driver_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `abb_driver` to `1.4.0-1`:

- upstream repository: https://github.com/ros-industrial/abb_driver.git
- release repository: https://github.com/ros-industrial-release/abb_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## abb_driver

```
* First release of stand-alone ``abb_driver`` from new repository.
* Contributors: gavanderhoorn
```
