### PR TITLE
Disable Humble devel build for VRPN package

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -7013,6 +7013,8 @@ repositories:
       url: https://github.com/ros2-gbp/vrpn-release.git
       version: 7.35.0-8
     source:
+      test_commits: false
+      test_pull_requests: false
       type: git
       url: https://github.com/vrpn/vrpn.git
       version: master

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6167,6 +6167,8 @@ repositories:
       url: https://github.com/ros2-gbp/vrpn-release.git
       version: 7.35.0-11
     source:
+      test_commits: false
+      test_pull_requests: false
       type: git
       url: https://github.com/vrpn/vrpn.git
       version: master


### PR DESCRIPTION
VRPN is a third-party package that has compilation warnings on the devel branch. Similar to #33876.