### PR TITLE
Revert eigenpy in Melodic to 2.7.8

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2861,7 +2861,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/stack-of-tasks/eigenpy-ros-release.git
-      version: 2.7.12-1
+      version: 2.7.11-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/eigenpy.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2861,7 +2861,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/stack-of-tasks/eigenpy-ros-release.git
-      version: 2.7.11-1
+      version: 2.7.10-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/eigenpy.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2861,7 +2861,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/stack-of-tasks/eigenpy-ros-release.git
-      version: 2.7.10-1
+      version: 2.7.8-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/eigenpy.git


### PR DESCRIPTION
Despite the recent fixes, we still have packages failing to compile against the newer versions, like: https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__dynamic-graph-python__ubuntu_bionic_amd64__binary/ .  Let's revert it for now and see if that helps.

@wxmerkt FYI