### PR TITLE
Revert "qb_device: 3.0.4-3 in 'melodic/distribution.yaml' [bloom] (#3…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9795,7 +9795,6 @@ repositories:
       - qb_device_control
       - qb_device_description
       - qb_device_driver
-      - qb_device_gazebo
       - qb_device_hardware_interface
       - qb_device_msgs
       - qb_device_srvs
@@ -9803,7 +9802,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
-      version: 3.0.4-3
+      version: 2.0.1-0
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbdevice-ros.git


### PR DESCRIPTION
…3887)"

This reverts commit 04a5dace39651931af56e564b2a8d107d1458f83.

This hasn't compiled since it was updated in July: https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__qb_device_hardware_interface__ubuntu_bionic_amd64__binary/

@umbertofontana93 FYI
