### PR TITLE
Revert "hpp-fcl: 2.1.2-1 in 'melodic/distribution.yaml' [bloom] (#340…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4488,7 +4488,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/humanoid-path-planner/hpp-fcl-ros-release.git
-      version: 2.1.2-1
+      version: 1.8.1-1
     source:
       type: git
       url: https://github.com/humanoid-path-planner/hpp-fcl.git


### PR DESCRIPTION
…31)"

This reverts commit 9b0b3b7b24c05671234d4ea5936dbab1b004bee4.

With the reverted version of eigenpy from https://github.com/ros/rosdistro/pull/34283 , this version no longer builds.

@wxmerkt FYI