### PR TITLE
Revert "pinocchio: 2.6.9-1 in 'melodic/distribution.yaml' [bloom] (#3…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9084,7 +9084,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/stack-of-tasks/pinocchio-ros-release.git
-      version: 2.6.9-1
+      version: 2.6.8-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/pinocchio.git


### PR DESCRIPTION
…4131)"

This reverts commit c34f8d940ce4721a82941fbf6e20eaf942329ae0.

Necessary because of the revert of eigenpy in https://github.com/ros/rosdistro/pull/34283 .

@wxmerkt FYI