### PR TITLE
Revert "libfranka: 0.9.2-1 in 'melodic/distribution.yaml' [bloom] (#3…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6028,7 +6028,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/frankaemika/libfranka-release.git
-      version: 0.9.2-1
+      version: 0.9.1-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
…4280)"

This reverts commit 816bdf4417f6a0e8937e88d343cf14bdde93aab3.

When trying to build downstream packages with it, we get errors like:

```
CMake Error in CMakeLists.txt:
  Imported target "Franka::Franka" includes non-existent path

    "/opt/ros/melodic/include/libfranka"

  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:

  * The path was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and references files it does not
  provide.
```

See https://build.ros.org/job/Mbin_uB64__franka_visualization__ubuntu_bionic_amd64__binary/54/ for more information.

@marcbone FYI