### PR TITLE
Revert "libfranka: 0.9.1-1 in 'melodic/distribution.yaml' [bloom] (#3…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6028,7 +6028,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/frankaemika/libfranka-release.git
-      version: 0.9.1-1
+      version: 0.9.0-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
…4235)"

This reverts commit bbb175797999fdc57755849a32d2de256da90501.