### PR TITLE
panda_moveit_config: 0.8.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6548,7 +6548,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/panda_moveit_config-release.git
-      version: 0.7.5-1
+      version: 0.8.0-1
     source:
       type: git
       url: https://github.com/ros-planning/panda_moveit_config.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6543,7 +6543,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-planning/panda_moveit_config.git
-      version: melodic-devel
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -6552,7 +6552,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-planning/panda_moveit_config.git
-      version: melodic-devel
+      version: noetic-devel
     status: maintained
   parameter_pa:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `panda_moveit_config` to `0.8.0-1`:

- upstream repository: https://github.com/ros-planning/panda_moveit_config.git
- release repository: https://github.com/ros-gbp/panda_moveit_config-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.5-1`

## panda_moveit_config

```
* Thorough rework based on franka_description 0.9.1 (using fine and coarse collision models)
  The internal robot controller uses coarse collision models for self-collision checking.
  In MoveIt, these coarse models should be used for self-collision checking only as well.
  Particularly, these coarse models should not be used for collision checking with the environment.
```
