### PR TITLE
Add postfix to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6698,6 +6698,10 @@ portaudio19-dev:
   nixos: [portaudio]
   openembedded: [portaudio-v19@meta-oe]
   ubuntu: [portaudio19-dev]
+postfix:
+  debian: [postfix]
+  fedora: [postfix]
+  ubuntu: [postfix]
 postgresql:
   debian: [postgresql, postgresql-contrib]
   fedora: [postgresql-server, postgresql-contrib]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6699,8 +6699,11 @@ portaudio19-dev:
   openembedded: [portaudio-v19@meta-oe]
   ubuntu: [portaudio19-dev]
 postfix:
+  alpine: [postfix]
+  arch: [postfix]
   debian: [postfix]
   fedora: [postfix]
+  rhel: [postfix]
   ubuntu: [postfix]
 postgresql:
   debian: [postgresql, postgresql-contrib]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6703,6 +6703,7 @@ postfix:
   arch: [postfix]
   debian: [postfix]
   fedora: [postfix]
+  opensuse: [postfix]
   rhel: [postfix]
   ubuntu: [postfix]
 postgresql:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

postfix

## Package Upstream Source:

https://www.postfix.org/

## Purpose of using this:

I want to release the package that depends on this package.
I use this package and send email from robot.

Distro packaging links: https://github.com/jsk-ros-pkg/jsk_robot

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/postfix
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/jammy/postfix
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/postfix/postfix/
- Arch
  - https://archlinux.org/packages/extra/x86_64/postfix/
- alpine
  - https://pkgs.alpinelinux.org/package/edge/main/x86_64/postfix  