### PR TITLE
Add typeguard-pip to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9140,6 +9140,16 @@ python3-typeguard:
     bionic:
       pip:
         packages: [typeguard]
+python3-typeguard-pip:
+  debian:
+    pip:
+      packages: [typeguard]
+  fedora:
+    pip:
+      packages: [typeguard]
+  ubuntu:
+    pip:
+      packages: [typeguard]
 python3-tz:
   alpine: [py3-tz]
   arch: [python-pytz]
@@ -9473,16 +9483,6 @@ tilestache:
   debian: [tilestache]
   fedora: [python-tilestache]
   ubuntu: [tilestache]
-typeguard-pip:
-  debian:
-    pip:
-      packages: [typeguard]
-  fedora:
-    pip:
-      packages: [typeguard]
-  ubuntu:
-    pip:
-      packages: [typeguard]
 uavcan-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9473,6 +9473,16 @@ tilestache:
   debian: [tilestache]
   fedora: [python-tilestache]
   ubuntu: [tilestache]
+typeguard-pip:
+  debian:
+    pip:
+      packages: [typeguard]
+  fedora:
+    pip:
+      packages: [typeguard]
+  ubuntu:
+    pip:
+      packages: [typeguard]
 uavcan-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

typeguard-pip

## Package Upstream Source:
[link to github repository](https://github.com/agronholm/typeguard)
[link to github repository](https://pypi.org/project/typeguard/)

## Purpose of using this:

There is a python3-typeguard, which points to the apt version of the package. However, those binaries are still on version 2.2.2 of typeguard (which was released on 2018-08-13). I suggest adding this typeguard-pip to be able to use the more recent versions available on pip.
