### PR TITLE
ros2_controllers: 2.12.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4042,7 +4042,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.11.0-1
+      version: 2.12.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.12.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.11.0-1`

## diff_drive_controller

```
* Fix formatting CI job (#418 <https://github.com/ros-controls/ros2_controllers/issues/418>)
* Contributors: Tyler Weaver
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

```
* Generate params for ForceTorqueSensorBroadcaster (#395 <https://github.com/ros-controls/ros2_controllers/issues/395>)
* Contributors: Tyler Weaver
```

## forward_command_controller

- No changes

## gripper_controllers

```
* Add an initialization of the gripper action command for safe startup. (#425 <https://github.com/ros-controls/ros2_controllers/issues/425>)
* Fix formatting CI job (#418 <https://github.com/ros-controls/ros2_controllers/issues/418>)
* Contributors: Shota Aoki, Tyler Weaver
```

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

```
* Fix formatting CI job (#418 <https://github.com/ros-controls/ros2_controllers/issues/418>)
* Contributors: Tyler Weaver
```

## joint_trajectory_controller

```
* Use a "steady clock" when measuring time differences (#427 <https://github.com/ros-controls/ros2_controllers/issues/427>)
* [JTC] Add additional parameter to enable configuration of interfaces for following controllers in a chain. (#380 <https://github.com/ros-controls/ros2_controllers/issues/380>)
* test: :white_check_mark: fix and add back joint_trajectory_controller state_topic_consistency (#415 <https://github.com/ros-controls/ros2_controllers/issues/415>)
* Reinstate JTC tests (#391 <https://github.com/ros-controls/ros2_controllers/issues/391>)
* [JTC] Hold position if tolerance is violated even during non-active goal (#368 <https://github.com/ros-controls/ros2_controllers/issues/368>)
* Small fixes for JTC. (#390 <https://github.com/ros-controls/ros2_controllers/issues/390>)
  variables in JTC to not clutter other PR with them.
  fixes of updating parameters on renewed configuration of JTC that were missed
* Contributors: Andy Zelenak, Bence Magyar, Denis Štogl, Jaron Lundwall, Michael Wiznitzer
```

## position_controllers

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

```
* fix: :bug: make bare exceptions more narrow (#422 <https://github.com/ros-controls/ros2_controllers/issues/422>)
* Fix formatting because pre-commit was not running on CI for some time. (#409 <https://github.com/ros-controls/ros2_controllers/issues/409>)
* Contributors: Denis Štogl, Jaron Lundwall
```

## tricycle_controller

```
* Fix formatting CI job (#418 <https://github.com/ros-controls/ros2_controllers/issues/418>)
* Fix formatting because pre-commit was not running on CI for some time. (#409 <https://github.com/ros-controls/ros2_controllers/issues/409>)
* Contributors: Denis Štogl, Tyler Weaver
```

## velocity_controllers

- No changes
