### PR TITLE
iris_lama: 1.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3815,7 +3815,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/eupedrosa/iris_lama-release.git
-      version: 1.2.0-1
+      version: 1.3.0-1
     status: developed
   iris_lama_ros:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `iris_lama` to `1.3.0-1`:

- upstream repository: https://github.com/iris-ua/iris_lama.git
- release repository: https://github.com/eupedrosa/iris_lama-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.0-1`

## iris_lama

```
* Switch to plain cmake instead of a catkin based
* Several performance improvements
* Add a 2D slam solution based on pose graph optimization
* Add read support for more image types thanks to stb_image.h
* Add IO to the map data structure
* Introduce transient mapping to slam2d
* Reduce memory usage of the dynamic distance map by ~30%
* Fix a bug where some cells in the dynamic distance map were not update correctly
```
