### PR TITLE
panda_moveit_config: 0.7.7-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8749,7 +8749,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/panda_moveit_config-release.git
-      version: 0.7.6-1
+      version: 0.7.7-1
     source:
       type: git
       url: https://github.com/ros-planning/panda_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `panda_moveit_config` to `0.7.7-1`:

- upstream repository: https://github.com/ros-planning/panda_moveit_config.git
- release repository: https://github.com/ros-gbp/panda_moveit_config-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.6-1`

## panda_moveit_config

```
* Thorough rework based on franka_description 0.9.1 (using fine and coarse collision models)
  The internal robot controller uses coarse collision models for self-collision checking.
  In MoveIt, these coarse models should be used for self-collision checking only as well.
  Particularly, these coarse models should not be used for collision checking with the environment.
* Adapt ACM configuration to Melodic
  Melodic's srdfdom/MoveIt don't support tags <disable_default_collisions> and <enable_collisions>.
* Remove adapter ResolveConstraintFrames
  as it's not implemented in Melodic
```
