### PR TITLE
rplidar_ros: 2.0.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4555,7 +4555,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/allenh1/rplidar_ros-release.git
-      version: 2.0.2-1
+      version: 2.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rplidar_ros` to `2.0.3-1`:

- upstream repository: https://github.com/allenh1/rplidar_ros
- release repository: https://github.com/allenh1/rplidar_ros-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.2-1`

## rplidar_ros

```
* Fix build with later versions of GCC
* Contributors: Hunter L. Allen
```
