### PR TITLE
bond_core: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -502,7 +502,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/bond_core-release.git
-      version: 3.0.2-1
+      version: 4.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `4.0.0-1`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros2-gbp/bond_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.2-1`

## bond

- No changes

## bond_core

- No changes

## bondcpp

```
* Bond cleanups (#87 <https://github.com/ros/bond_core/issues/87>)
* Contributors: Michael Carroll
```

## smclib

```
* Drop unused access specifiers (#86 <https://github.com/ros/bond_core/issues/86>)
* Contributors: Michael Carroll
```

## test_bond

```
* Bond cleanups (#87 <https://github.com/ros/bond_core/issues/87>)
* Modernize rosidl_get_typesupport for Humble+ (#85 <https://github.com/ros/bond_core/issues/85>)
* Contributors: Michael Carroll
```
