### PR TITLE
bond_core: 3.0.2-3 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -508,11 +508,10 @@ repositories:
       - bond_core
       - bondcpp
       - smclib
-      - test_bond
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/bond_core-release.git
-      version: 3.0.2-2
+      version: 3.0.2-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `3.0.2-3`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros2-gbp/bond_core-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.2-2`

## bond

- No changes

## bond_core

```
* Remove test_bond dependency from bond_core (#79 <https://github.com/ros/bond_core/issues/79>)
* Contributors: Michael Carroll
```

## bondcpp

- No changes

## smclib

- No changes
