### PR TITLE
rclpy: 1.0.9-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4295,7 +4295,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 1.0.8-1
+      version: 1.0.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `1.0.9-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.8-1`

## rclpy

```
* Add __enter__ and __exit__ to Waitable (#761 <https://github.com/ros2/rclpy/issues/761>) (#998 <https://github.com/ros2/rclpy/issues/998>)
* Remove feedback callback when the goal has been completed (#927 <https://github.com/ros2/rclpy/issues/927>) (#933 <https://github.com/ros2/rclpy/issues/933>)
* Fix memory leak for get_(publishers|subscriptions)_info_by_topic (#955 <https://github.com/ros2/rclpy/issues/955>)
* Fix type annotation for get_parameters_by_prefix (#964 <https://github.com/ros2/rclpy/issues/964>)
* Fix rclpy.duration.Duration.to_msg() losing precision (#876 <https://github.com/ros2/rclpy/issues/876>) (#917 <https://github.com/ros2/rclpy/issues/917>)
* Fix inverted error code for action client take (#949 <https://github.com/ros2/rclpy/issues/949>)
* Fix memory leak for serialization (#898 <https://github.com/ros2/rclpy/issues/898>)
* Fix crash on spinning raw subscription when publishes closes (#827 <https://github.com/ros2/rclpy/issues/827>). (#903 <https://github.com/ros2/rclpy/issues/903>)
* Contributors: Chen Lihui, Chris Lalancette, Erki Suurjaak, HyunSeok Kil, Jonathan Chapple, Shane Loretz, Tully Foote, Tomoya Fujita
```
