### PR TITLE
menge_vendor: 1.0.0-4 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2119,7 +2119,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/menge_vendor-release.git
-      version: 1.0.0-3
+      version: 1.0.0-4
     source:
       type: git
       url: https://github.com/open-rmf/menge_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `menge_vendor` to `1.0.0-4`:

- upstream repository: https://github.com/open-rmf/menge_vendor.git
- release repository: https://github.com/ros2-gbp/menge_vendor-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-3`

## menge_vendor

```
* fix find_package problem when installed (#1 <https://github.com/osrf/menge_core/issues/1>)
* menge core
* Contributors: Marco A. Gutiérrez, Shao Guoliang, flooshao
```
