### PR TITLE
clpe_ros: 0.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -635,7 +635,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/canlab-co/clpe_ros-ros2-release.git
-      version: 0.1.0-2
+      version: 0.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clpe_ros` to `0.1.1-1`:

- upstream repository: https://github.com/canlab-co/clpe_ros.git
- release repository: https://github.com/canlab-co/clpe_ros-ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.0-2`

## clpe_ros

```
* remove EEPROM
```
