### PR TITLE
rm_control: 0.1.15-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7960,7 +7960,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/rm-controls/rm_control-release.git
-      version: 0.1.13-1
+      version: 0.1.15-1
     source:
       type: git
       url: https://github.com/rm-controls/rm_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rm_control` to `0.1.15-1`:

- upstream repository: https://github.com/rm-controls/rm_control.git
- release repository: https://github.com/rm-controls/rm_control-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.13-1`

## rm_common

- No changes

## rm_control

- No changes

## rm_dbus

- No changes

## rm_gazebo

- No changes

## rm_hw

```
* Add namespace.
* Fix realtime loop.
* Contributors: yezi
```

## rm_msgs

- No changes
