### PR TITLE
Revert eigenpy in Melodic to 2.7.5

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2861,7 +2861,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/stack-of-tasks/eigenpy-ros-release.git
-      version: 2.7.7-1
+      version: 2.7.6-3
     source:
       type: git
       url: https://github.com/stack-of-tasks/eigenpy.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2861,7 +2861,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/stack-of-tasks/eigenpy-ros-release.git
-      version: 2.7.8-1
+      version: 2.7.7-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/eigenpy.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2861,7 +2861,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/stack-of-tasks/eigenpy-ros-release.git
-      version: 2.7.6-3
+      version: 2.7.5-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/eigenpy.git


### PR DESCRIPTION
As requested in https://discourse.ros.org/t/preparing-for-melodic-sync-2022-09-01/27180/2 and https://github.com/ros/rosdistro/pull/34283#issuecomment-1234806721 .

@wxmerkt FYI