### PR TITLE
Split off humble branch for vision_opencv

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -7068,7 +7068,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/vision_opencv.git
-      version: ros2
+      version: foxy
     release:
       packages:
       - cv_bridge
@@ -7082,7 +7082,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/vision_opencv.git
-      version: ros2
+      version: foxy
     status: maintained
   visp:
     doc:

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -6274,7 +6274,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/vision_opencv.git
-      version: ros2
+      version: galactic
     release:
       packages:
       - cv_bridge
@@ -6288,7 +6288,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/vision_opencv.git
-      version: ros2
+      version: galactic
     status: maintained
   visp:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6108,7 +6108,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/vision_opencv.git
-      version: ros2
+      version: humble
     release:
       packages:
       - cv_bridge
@@ -6122,7 +6122,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/vision_opencv.git
-      version: ros2
+      version: humble
     status: maintained
   visp:
     doc:


### PR DESCRIPTION
A foxy, galactic and humble branch was split off in vision_opencv, and so the dev and doc references should be updated to the new branch.