### PR TITLE
v4l2_camera: 0.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5813,7 +5813,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_v4l2_camera-release.git
-      version: 0.4.0-2
+      version: 0.6.0-1
     source:
       type: git
       url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `v4l2_camera` to `0.6.0-1`:

- upstream repository: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
- release repository: https://github.com/ros2-gbp/ros2_v4l2_camera-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.0-2`

## v4l2_camera

```
* Use cv_bridge to perform conversions
* Fix: Image topic should be image_raw, not raw_image, in README.md
* Fix: Properly declare camera_info_url parameter
* Contributors: Marcus M. Scheunemann, Sander G. van Dijk, ijnek
```
