### PR TITLE
pal_statistics: 2.1.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2837,7 +2837,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/pal-gbp/pal_statistics-release.git
-      version: 2.1.1-1
+      version: 2.1.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_statistics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_statistics` to `2.1.2-1`:

- upstream repository: https://github.com/pal-robotics/pal_statistics.git
- release repository: https://github.com/pal-gbp/pal_statistics-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.1-1`

## pal_statistics

- No changes

## pal_statistics_msgs

```
* Merge branch 'ament_cmake_dependency' into 'galactic-devel'
  Add missing dependency ament_cmake
  See merge request qa/pal_statistics!25
* add missing dependency ament_cmake
* Merge pull request #11 from v-lopez/galactic-devel
  Fix missing ament_lint_common dependency
* Fix missing ament_lint_common dependency
* Contributors: Jordan Palacios, Noel Jimenez, Victor Lopez
```
