### PR TITLE
pal_statistics: 1.5.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2815,6 +2815,16 @@ repositories:
       url: https://github.com/OUXT-Polaris/ouxt_common.git
       version: master
     status: developed
+  pal_statistics:
+    release:
+      packages:
+      - pal_carbon_collector
+      - pal_statistics
+      - pal_statistics_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/pal_statistics-release.git
+      version: 1.5.0-1
   pcl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_statistics` to `1.5.0-1`:

- upstream repository: https://github.com/pal-robotics/pal_statistics.git
- release repository: https://github.com/pal-gbp/pal_statistics-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## pal_carbon_collector

- No changes

## pal_statistics

```
* Merge branch 'python3' into 'erbium-devel'
  Make python code compatible with python2/3
  See merge request qa/pal_statistics!23
* futurize'd python code
* Contributors: Jordan Palacios
```

## pal_statistics_msgs

- No changes
