### PR TITLE
pal_statistics: 2.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2815,6 +2815,16 @@ repositories:
       url: https://github.com/OUXT-Polaris/ouxt_common.git
       version: master
     status: developed
+  pal_statistics:
+    release:
+      packages:
+      - pal_statistics
+      - pal_statistics_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/pal_statistics-release.git
+      version: 2.1.2-1
+    status: maintained
   pcl_msgs:
     release:
       tags:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2816,6 +2816,10 @@ repositories:
       version: master
     status: developed
   pal_statistics:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pal_statistics.git
+      version: galactic-devel
     release:
       packages:
       - pal_statistics
@@ -2824,6 +2828,10 @@ repositories:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_statistics-release.git
       version: 2.1.2-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pal_statistics.git
+      version: galactic-devel
     status: maintained
   pcl_msgs:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_statistics` to `2.1.2-1`:

- upstream repository: https://github.com/pal-robotics/pal_statistics.git
- release repository: https://github.com/pal-gbp/pal_statistics-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## pal_statistics

- No changes

## pal_statistics_msgs

```
* Merge branch 'ament_cmake_dependency' into 'galactic-devel'
  Add missing dependency ament_cmake
  See merge request qa/pal_statistics!25
* add missing dependency ament_cmake
* Merge pull request #11 from v-lopez/galactic-devel
  Fix missing ament_lint_common dependency
* Fix missing ament_lint_common dependency
* Contributors: Jordan Palacios, Noel Jimenez, Victor Lopez
```
