### PR TITLE
pal_statistics: 2.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3403,7 +3403,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/pal-gbp/pal_statistics-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_statistics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_statistics` to `2.0.2-1`:

- upstream repository: https://github.com/pal-robotics/pal_statistics.git
- release repository: https://github.com/pal-gbp/pal_statistics-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.1-1`

## pal_statistics

- No changes

## pal_statistics_msgs

```
* Merge branch 'cherry-pick-92889b69' into 'foxy-devel'
  Merge branch 'ament_cmake_dependency' into 'foxy-devel'
  See merge request qa/pal_statistics!26
* Merge branch 'ament_cmake_dependency' into 'galactic-devel'
  Add missing dependency ament_cmake
  See merge request qa/pal_statistics!25
  (cherry picked from commit 92889b69d3146b64f859770e03cda1b576a644d8)
  1225c140 add missing dependency ament_cmake
* Merge pull request #12 <https://github.com/pal-robotics/pal_statistics/issues/12> from v-lopez/foxy-devel
  Fix missing ament_lint_common dependency
* Fix missing ament_lint_common dependency
* Contributors: Jordan Palacios, Victor Lopez
```
