### PR TITLE
depthai: 2.17.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -936,7 +936,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/luxonis/depthai-core-release.git
-      version: 2.17.0-1
+      version: 2.17.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai` to `2.17.3-1`:

- upstream repository: https://github.com/luxonis/depthai-core.git
- release repository: https://github.com/luxonis/depthai-core-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.17.0-1`

## depthai

```
* Updated FW - BMI270 IMU improvements
* Added seq & timestamps for more messages
* New boards support
* Windows DLL improvements (install libusb dll alongside libdepthai-core.dll)
* XLink - improved connecting directly to given IP
* StereoDepth ImgFrame metadata w/h when decimation filter is enabled
* Intrinsic read fix #379
* Contributors: Alex Bougdan, Szabolcs Gergely, Martin Peterlin, Sachin Guruswamy
```
