### PR TITLE
Add awscli from rhel

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -282,6 +282,7 @@ awscli:
   fedora: [awscli]
   gentoo: [dev-python/awscli]
   nixos: [awscli]
+  rhel: [awscli]
   ubuntu: [awscli]
 babeltrace:
   debian: [babeltrace]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

awscli

## Package Upstream Source:

https://github.com/aws/aws-cli

## Purpose of using this:

awscli is useful for configuring credentials and regions for AWS. Currently, there is no rosdep key for rhel. 

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- EPEL 8: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/awscli/awscli/
