### PR TITLE
mocap_nokov: 0.0.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5221,7 +5221,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/NOKOV-MOCAP/mocap_nokov_release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/NOKOV-MOCAP/mocap_nokov.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mocap_nokov` to `0.0.3-1`:

- upstream repository: https://github.com/NOKOV-MOCAP/mocap_nokov
- release repository: https://github.com/NOKOV-MOCAP/mocap_nokov_release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.2-1`

## mocap_nokov

```
* Solve lib dependency
```
