### PR TITLE
vision_opencv: 1.16.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11247,7 +11247,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/vision_opencv-release.git
-      version: 1.16.0-1
+      version: 1.16.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `1.16.1-1`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros-gbp/vision_opencv-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.16.0-1`

## cv_bridge

```
* Fix 16U encoding type (#445 <https://github.com/ros-perception/vision_opencv/issues/445>)
* Add header arg to cv2_to_imgmsg (#326 <https://github.com/ros-perception/vision_opencv/issues/326>)
* Contributors: Ibrahim Essam, Kenji Brameld, Naoya Yamaguchi
```

## image_geometry

- No changes

## vision_opencv

- No changes
