### PR TITLE
rplidar_ros: 2.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4605,7 +4605,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rplidar_ros-release.git
-      version: 2.0.3-1
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rplidar_ros` to `2.1.0-1`:

- upstream repository: https://github.com/allenh1/rplidar_ros
- release repository: https://github.com/ros2-gbp/rplidar_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.3-1`

## rplidar_ros

```
* Add auto standby mode (#29 <https://github.com/allenh1/rplidar_ros/issues/29>)
  * Add auto standby mode
  Turn on/off motor based on topic subsribers
  * Set auto_standby off by default
* Fix building on Apple machines (#30 <https://github.com/allenh1/rplidar_ros/issues/30>)
* Update README & fix launch files for Foxy and up (#26 <https://github.com/allenh1/rplidar_ros/issues/26>)
  * Update README.md
  based on modifications from youngday
  * Update launch files for Foxy or later
* Contributors: Jesse Zhang, Vasily Kiniv
```
