### PR TITLE
pr2_common: 1.13.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6998,7 +6998,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_common-release.git
-      version: 1.13.0-1
+      version: 1.13.1-1
     source:
       type: git
       url: https://github.com/pr2/pr2_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_common` to `1.13.1-1`:

- upstream repository: https://github.com/pr2/pr2_common.git
- release repository: https://github.com/pr2-gbp/pr2_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.13.0-1`

## pr2_common

- No changes

## pr2_dashboard_aggregator

```
* fix typo pr2_etherCAT -> pr2_ethercat (#288 <https://github.com/PR2/pr2_common/issues/288>)
* Contributors: Shingo Kitagawa
```

## pr2_description

```
* allow pr2.urdf.xacro to accept customized calibration values (#285 <https://github.com/PR2/pr2_common/issues/285>)
  If 0.0, use the default values. (This retains backward compatibility)
  If not 0.0, use the passed values. (Enable custom calibration values for all macro instantiations
  Using 0.0 to trigger the old defaults is necessary because some default values need to be computed from other parameters.
* Contributors: Shuang Li
```

## pr2_machine

- No changes

## pr2_msgs

- No changes
