### PR TITLE
pal_statistics: 2.1.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2819,7 +2819,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/pal-robotics/pal_statistics.git
-      version: galactic-devel
+      version: humble-devel
     release:
       packages:
       - pal_statistics
@@ -2831,7 +2831,7 @@ repositories:
     source:
       type: git
       url: https://github.com/pal-robotics/pal_statistics.git
-      version: galactic-devel
+      version: humble-devel
     status: maintained
   pcl_msgs:
     release:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2827,7 +2827,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_statistics-release.git
-      version: 2.1.2-1
+      version: 2.1.3-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_statistics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_statistics` to `2.1.3-1`:

- upstream repository: https://github.com/pal-robotics/pal_statistics.git
- release repository: https://github.com/pal-gbp/pal_statistics-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.2-1`

## pal_statistics

```
* Merge branch 'fix_linter' into 'humble-devel'
  fix linter
  See merge request qa/pal_statistics!27
* fix linter
* Contributors: Jordan Palacios, Noel Jimenez
```

## pal_statistics_msgs

- No changes
