### PR TITLE
dynamic-graph: 4.4.3-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2549,7 +2549,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/stack-of-tasks/dynamic-graph-ros-release.git
-      version: 4.4.0-1
+      version: 4.4.3-2
     source:
       type: git
       url: https://github.com/stack-of-tasks/dynamic-graph.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic-graph` to `4.4.3-2`:

- upstream repository: https://github.com/stack-of-tasks/dynamic-graph.git
- release repository: https://github.com/stack-of-tasks/dynamic-graph-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.4.0-1`
