### PR TITLE
dynamic-graph-python: 4.0.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1936,7 +1936,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/stack-of-tasks/dynamic-graph-python-ros-release.git
-      version: 4.0.4-1
+      version: 4.0.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic-graph-python` to `4.0.9-1`:

- upstream repository: https://github.com/stack-of-tasks/dynamic-graph-python.git
- release repository: https://github.com/stack-of-tasks/dynamic-graph-python-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.4-1`
