### PR TITLE
dynamic-graph-tutorial: 1.3.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2580,7 +2580,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/stack-of-tasks/dynamic-graph-tutorial-ros-release.git
-      version: 1.2.2-1
+      version: 1.3.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic-graph-tutorial` to `1.3.5-1`:

- upstream repository: https://github.com/stack-of-tasks/dynamic-graph-tutorial.git
- release repository: https://github.com/stack-of-tasks/dynamic-graph-tutorial-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.2-1`
