### PR TITLE
naoqi_libqi: 2.9.7-0 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5708,6 +5708,13 @@ repositories:
       url: https://github.com/ual-arm-ros-pkg/mvsim.git
       version: master
     status: developed
+  naoqi_libqi:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-naoqi/libqi-release.git
+      version: 2.9.7-0
+    status: maintained
   navigation:
     doc:
       type: git


### PR DESCRIPTION
Release naoqi_libqi for noetic, in version `2.9.7-0`:

upstream repository: https://github.com/ros-naoqi/libqi.git
release repository: https://github.com/ros-naoqi/libqi-release.git
distro file: `noetic/distribution.yaml`
bloom version: `0.11.2`
previous version for package: `null`