### PR TITLE
aruco_opencv: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -197,10 +197,13 @@ repositories:
       url: https://github.com/fictionlab/aruco_opencv.git
       version: noetic
     release:
+      packages:
+      - aruco_opencv
+      - aruco_opencv_msgs
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fictionlab-gbp/aruco_opencv-release.git
-      version: 0.1.0-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/fictionlab/aruco_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_opencv` to `0.2.0-1`:

- upstream repository: https://github.com/fictionlab/aruco_opencv.git
- release repository: https://github.com/fictionlab-gbp/aruco_opencv-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.0-1`

## aruco_opencv

```
* Move message definitions to aruco_opencv_msgs package (#2 <https://github.com/fictionlab/aruco_opencv/issues/2>)
* Fix build for Debian Buster
* Publish transforms from output_frame to markers on tf2
* Transform marker poses to specified output frame
* Allow changing camera info without restarting the tracker
* Add dynamically reconfigurable parameters for corner refinement
* Contributors: Błażej Sowa
```

## aruco_opencv_msgs

```
* Move message definitions to aruco_opencv_msgs package (#2 <https://github.com/fictionlab/aruco_opencv/issues/2>)
* Contributors: Błażej Sowa
```
