### PR TITLE
naoqi_bridge_msgs: 0.0.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5717,6 +5717,20 @@ repositories:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-naoqi/nao_meshes-release.git
       version: 0.1.13-0
+  naoqi_bridge_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_bridge_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-naoqi/naoqi_bridge_msgs-release.git
+      version: 0.0.9-1
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_bridge_msgs.git
+      version: master
     status: maintained
   navigation:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_bridge_msgs` to `0.0.9-1`:

- upstream repository: https://github.com/ros-naoqi/naoqi_bridge_msgs.git
- release repository: https://github.com/ros-naoqi/naoqi_bridge_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
