### PR TITLE
qb_device: 3.0.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9796,6 +9796,7 @@ repositories:
       - qb_device_control
       - qb_device_description
       - qb_device_driver
+      - qb_device_gazebo
       - qb_device_hardware_interface
       - qb_device_msgs
       - qb_device_srvs
@@ -9803,7 +9804,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
-      version: 2.0.1-0
+      version: 3.0.5-1
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbdevice-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_device` to `3.0.5-1`:

- upstream repository: https://bitbucket.org/qbrobotics/qbdevice-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.1-0`

## qb_device

- No changes

## qb_device_bringup

```
* MINOR FIX: Changed cmake version required in all packages (current version 3.0.2).
* Bug fixed when executing the waypoint movement and different controller with different number of controller joints are loaded.
* Changed device controller bringup to load properly the device controller.
```

## qb_device_control

```
* MINOR FIX: Changed cmake version required in all packages (current version 3.0.2).
* Bug fixed when executing the waypoint movement and different controller with different number of controller joints are loaded.
```

## qb_device_description

```
* MINOR FIX: Changed cmake version required in all packages (current version 3.0.2).
```

## qb_device_driver

```
* MINOR FIX: Changed cmake version required in all packages (current version 3.0.2).
```

## qb_device_gazebo

```
* MINOR FIX: Changed cmake version required in all packages (current version 3.0.2).
```

## qb_device_hardware_interface

```
* MINOR FIX: Changed cmake version required in all packages (current version 3.0.2).
* FIX: Added control_msgs dependecy in qb_device_hardware_interface pkg. This cause error during release phase.
* Bug fixed when executing the waypoint movement and different controller with different number of controller joints are loaded.
```

## qb_device_msgs

```
* MINOR FIX: Changed cmake version required in all packages (current version 3.0.2).
```

## qb_device_srvs

```
* MINOR FIX: Changed cmake version required in all packages (current version 3.0.2).
```

## qb_device_utils

```
* MINOR FIX: Changed cmake version required in all packages (current version 3.0.2).
```
