### PR TITLE
melodic: Re-release eigenpy 2.7.12 and hpp-fcl 2.1.2

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2861,7 +2861,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/stack-of-tasks/eigenpy-ros-release.git
-      version: 2.7.5-1
+      version: 2.7.12-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/eigenpy.git
@@ -4488,7 +4488,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/humanoid-path-planner/hpp-fcl-ros-release.git
-      version: 1.8.1-1
+      version: 2.1.2-1
     source:
       type: git
       url: https://github.com/humanoid-path-planner/hpp-fcl.git


### PR DESCRIPTION
The other downstream packages are being fixed this sync cycle and require the newer versions of eigenpy and hpp-fcl respectively to build
