### PR TITLE
naoqi_driver: 0.5.12-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7528,7 +7528,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_driver-release.git
-      version: 0.5.11-0
+      version: 0.5.12-1
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_driver` to `0.5.12-1`:

- upstream repository: https://github.com/ros-naoqi/alrosbridge.git
- release repository: https://github.com/ros-naoqi/naoqi_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.5.11-0`

## naoqi_driver

```
* Fix typo in README, remove old rst README
* Merge pull request #153 <https://github.com/ros-naoqi/naoqi_driver/issues/153> from mbusy/ci
  CI migration to github actions
* Migrate CI from TravisCI to Github actions, update the README accordingly (switching to markdown)
* Merge pull request #152 <https://github.com/ros-naoqi/naoqi_driver/issues/152> from mbusy/naoqi-2.9
  Naoqi 2.9 compatibility
* Refactor the converters for compatibility
* Refactor the audio event for compatibility
* Add the getNaoqiVersion and isNaoqiVersionLesser to the driver helpers
* Add the NaoqiVersion struct
* Handle libqi 2.9 for the external registration, and update the launchfile accordingly
* Add the driver authenticator class
* Merge pull request #132 <https://github.com/ros-naoqi/naoqi_driver/issues/132> from mbusy/robust_movebase
  Robustify moveTo
* Safer moveTo: only odom and base_footprint are accepted as references, and check if yaw is nan
* Merge pull request #131 <https://github.com/ros-naoqi/naoqi_driver/issues/131> from ros-naoqi/testing_repo
  Update CI for melodic
* melodic not allowed to fail anymore, indigo allowed
* use testing repo
* Contributors: Maxime Busy, Mikael Arguedas, Pandhariix, mbusy
```
