### PR TITLE
pepper_meshes: 0.2.5-0 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6630,6 +6630,13 @@ repositories:
       url: https://github.com/wg-perception/people.git
       version: noetic
     status: maintained
+  pepper_meshes:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-naoqi/pepper_meshes-release.git
+      version: 0.2.5-0
+    status: maintained
   perception_pcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_meshes` to `0.2.5-0`:

- upstream repository: https://github.com/ros-naoqi/pepper_meshes.git
- release repository: https://github.com/ros-naoqi/pepper_meshes-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## pepper_meshes

```
* Update ERROR_FILE to ERROR_FILE_CMD in CMakeLists to avoid build crash
* Contributors: mbusy
```
