### PR TITLE
naoqi_libqi: 2.9.7-0 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5711,6 +5711,7 @@ repositories:
       url: https://github.com/ual-arm-ros-pkg/mvsim.git
       version: master
     status: developed
+<<<<<<< HEAD
   nao_meshes:
     release:
       tags:
@@ -5731,6 +5732,14 @@ repositories:
       type: git
       url: https://github.com/ros-naoqi/naoqi_bridge_msgs.git
       version: master
+=======
+  naoqi_libqi:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-naoqi/libqi-release.git
+      version: 2.9.7-0
+>>>>>>> 8fd9bd51b... naoqi_libqi: 2.9.7-0 in 'noetic/distribution.yaml' [bloom]
     status: maintained
   navigation:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5711,13 +5711,13 @@ repositories:
       url: https://github.com/ual-arm-ros-pkg/mvsim.git
       version: master
     status: developed
-<<<<<<< HEAD
   nao_meshes:
     release:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-naoqi/nao_meshes-release.git
       version: 0.1.13-0
+    status: maintained
   naoqi_bridge_msgs:
     doc:
       type: git
@@ -5732,14 +5732,21 @@ repositories:
       type: git
       url: https://github.com/ros-naoqi/naoqi_bridge_msgs.git
       version: master
-=======
+    status: maintained
   naoqi_libqi:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/libqi.git
+      version: master
     release:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-naoqi/libqi-release.git
       version: 2.9.7-0
->>>>>>> 8fd9bd51b... naoqi_libqi: 2.9.7-0 in 'noetic/distribution.yaml' [bloom]
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/libqi.git
+      version: master
     status: maintained
   navigation:
     doc:


### PR DESCRIPTION
Release naoqi_libqi for noetic, in version `2.9.7-0`:

upstream repository: https://github.com/ros-naoqi/libqi.git
release repository: https://github.com/ros-naoqi/libqi-release.git
distro file: `noetic/distribution.yaml`
bloom version: `0.11.2`
previous version for package: `null`

Fixing previous conflicts with other packages from the ros-naoqi stack