### PR TITLE
locator_ros_bridge: 2.0.8-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2351,7 +2351,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/locator_ros_bridge-release.git
-      version: 2.0.7-1
+      version: 2.0.8-1
     source:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `locator_ros_bridge` to `2.0.8-1`:

- upstream repository: https://github.com/boschglobal/locator_ros_bridge.git
- release repository: https://github.com/ros2-gbp/locator_ros_bridge-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.7-1`

## bosch_locator_bridge

```
* Fixed a bug that could cause latency in localization poses
* Remove tf broadcaster
* Check if laser scan message is valid
* Add refresh timer to service callback group to avoid overlapping json rpc calls
* Update to ROKIT Locator version 1.5
* Contributors: Fabian König, Stefan Laible
```
