### PR TITLE
Update the geometry_tutorials release repository.

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1599,7 +1599,7 @@ repositories:
       - turtle_tf2_py
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/ros-gbp/geometry_tutorials-release.git
+      url: https://github.com/ros2-gbp/geometry_tutorials-release.git
       version: 0.3.4-1
     source:
       type: git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1304,7 +1304,7 @@ repositories:
       - turtle_tf2_py
       tags:
         release: release/galactic/{package}/{version}
-      url: https://github.com/ros-gbp/geometry_tutorials-release.git
+      url: https://github.com/ros2-gbp/geometry_tutorials-release.git
       version: 0.3.4-1
     source:
       type: git


### PR DESCRIPTION
It should be ros2-gbp, not ros-gbp.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>
