### PR TITLE
geometry_tutorials: 0.3.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1600,7 +1600,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/geometry_tutorials-release.git
-      version: 0.3.4-1
+      version: 0.3.5-1
     source:
       type: git
       url: https://github.com/ros/geometry_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_tutorials` to `0.3.5-1`:

- upstream repository: https://github.com/ros/geometry_tutorials
- release repository: https://github.com/ros2-gbp/geometry_tutorials-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.4-1`

## geometry_tutorials

- No changes

## turtle_tf2_cpp

```
* Cleanup CI (#70 <https://github.com/ros/geometry_tutorials/issues/70>)
* Contributors: Chris Lalancette
```

## turtle_tf2_py

```
* Remove the dependency on tf_transformations. (#69 <https://github.com/ros/geometry_tutorials/issues/69>)
* Contributors: Chris Lalancette
```
