### PR TITLE
rosidl_core: 0.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4280,6 +4280,25 @@ repositories:
       url: https://github.com/ros2/rosidl.git
       version: rolling
     status: maintained
+  rosidl_core:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_core.git
+      version: rolling
+    release:
+      packages:
+      - rosidl_core_generators
+      - rosidl_core_runtime
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_core-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_core.git
+      version: rolling
+    status: maintained
   rosidl_dds:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_core` to `0.1.0-1`:

- upstream repository: https://github.com/ros2/rosidl_core.git
- release repository: https://github.com/ros2-gbp/rosidl_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## rosidl_core_generators

```
* Add generators and runtime configuration packages (#1 <https://github.com/ros2/rosidl_core/issues/1>)
  Moved (and renamed) from rosidl_defaults.
  Related PR: https://github.com/ros2/rosidl_defaults/pull/22
* Contributors: Jacob Perron
```

## rosidl_core_runtime

```
* Add generators and runtime configuration packages (#1 <https://github.com/ros2/rosidl_core/issues/1>)
  Moved (and renamed) from rosidl_defaults.
  Related PR: https://github.com/ros2/rosidl_defaults/pull/22
* Contributors: Jacob Perron
```
