### PR TITLE
mocap_nokov: 0.0.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6831,7 +6831,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/NOKOV-MOCAP/mocap_nokov_release.git
-      version: 0.0.3-1
+      version: 0.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mocap_nokov` to `0.0.4-1`:

- upstream repository: https://github.com/NOKOV-MOCAP/mocap_nokov
- release repository: https://github.com/NOKOV-MOCAP/mocap_nokov_release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.3-1`

## mocap_nokov

```
* Exclude other arch lib
* Update CHANGELOG.rst
  0.0.3
* 0.0.3
* Contributors: duguguang
```
