### PR TITLE
iris_lama_ros: 1.3.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3825,7 +3825,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/eupedrosa/iris_lama_ros-release.git
-      version: 1.3.1-1
+      version: 1.3.3-1
     status: developed
   ivcon:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `iris_lama_ros` to `1.3.3-1`:

- upstream repository: https://github.com/iris-ua/iris_lama_ros.git
- release repository: https://github.com/eupedrosa/iris_lama_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.1-1`

## iris_lama_ros

```
* Trigger graph optimization when map is requested
* Add graph slam to install list
```
