### PR TITLE
Removed ros_ign - it should be rename to ros_gz

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4261,29 +4261,6 @@ repositories:
       url: https://github.com/ros/ros_environment.git
       version: humble
     status: maintained
-  ros_ign:
-    doc:
-      type: git
-      url: https://github.com/ignitionrobotics/ros_ign.git
-      version: ros2
-    release:
-      packages:
-      - ros_ign
-      - ros_ign_bridge
-      - ros_ign_gazebo
-      - ros_ign_gazebo_demos
-      - ros_ign_image
-      - ros_ign_interfaces
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 0.244.3-1
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/ignitionrobotics/ros_ign.git
-      version: ros2
-    status: developed
   ros_image_to_qimage:
     doc:
       type: git


### PR DESCRIPTION
Ignition Gazebo was renamed to Gazebo. From `ign` to `gz`. I removed this entry to release the new packages.