### PR TITLE
system_fingerprint: 0.5.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6375,6 +6375,22 @@ repositories:
       url: https://github.com/swri-robotics/swri_console.git
       version: ros2-devel
     status: developed
+  system_fingerprint:
+    doc:
+      type: git
+      url: https://github.com/MetroRobots/ros_system_fingerprint.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/MetroRobots/ros_system_fingerprint-release.git
+      version: 0.5.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/MetroRobots/ros_system_fingerprint-release.git
+      version: ros2
+    status: developed
   system_metrics_collector:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6388,7 +6388,7 @@ repositories:
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/MetroRobots/ros_system_fingerprint-release.git
+      url: https://github.com/MetroRobots/ros_system_fingerprint.git
       version: ros2
     status: developed
   system_metrics_collector:


### PR DESCRIPTION
Increasing version of package(s) in repository `system_fingerprint` to `0.5.0-1`:

- upstream repository: https://github.com/MetroRobots/ros_system_fingerprint.git
- release repository: https://github.com/MetroRobots/ros_system_fingerprint-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
