### PR TITLE
unique_identifier_msgs: 2.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5603,7 +5603,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/unique_identifier_msgs-release.git
-      version: 2.3.0-1
+      version: 2.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `unique_identifier_msgs` to `2.3.1-1`:

- upstream repository: https://github.com/ros2/unique_identifier_msgs.git
- release repository: https://github.com/ros2-gbp/unique_identifier_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.0-1`

## unique_identifier_msgs

```
* Depend on rosidl_core instead of rosidl_defaults (#24 <https://github.com/ros2/unique_identifier_msgs/issues/24>)
* Mirror rolling to master
* Update maintainers (#22 <https://github.com/ros2/unique_identifier_msgs/issues/22>)
* Contributors: Audrow Nash, Jacob Perron, methylDragon
```
