### PR TITLE
rcl_interfaces: 1.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3219,7 +3219,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_interfaces-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_interfaces` to `1.3.1-1`:

- upstream repository: https://github.com/ros2/rcl_interfaces.git
- release repository: https://github.com/ros2-gbp/rcl_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.0-1`

## action_msgs

```
* Depend on rosidl_core_generators for packages required by actions (#144 <https://github.com/ros2/rcl_interfaces/issues/144>)
* Contributors: Jacob Perron
```

## builtin_interfaces

```
* Depend on rosidl_core_generators for packages required by actions (#144 <https://github.com/ros2/rcl_interfaces/issues/144>)
* Fix documented range (#139 <https://github.com/ros2/rcl_interfaces/issues/139>)
* Contributors: Jacob Perron, Tully Foote
```

## composition_interfaces

- No changes

## lifecycle_msgs

- No changes

## rcl_interfaces

- No changes

## rosgraph_msgs

- No changes

## statistics_msgs

- No changes

## test_msgs

```
* Depend on rosidl_core_generators for packages required by actions (#144 <https://github.com/ros2/rcl_interfaces/issues/144>)
* Make the functions in the header static inline (#140 <https://github.com/ros2/rcl_interfaces/issues/140>)
* Contributors: Chris Lalancette, Jacob Perron
```
