### PR TITLE
naoqi_libqicore: 2.9.7-0 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5748,6 +5748,21 @@ repositories:
       url: https://github.com/ros-naoqi/libqi.git
       version: master
     status: maintained
+  naoqi_libqicore:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/libqicore.git
+      version: ros
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-naoqi/libqicore-release.git
+      version: 2.9.7-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/libqicore.git
+      version: ros
+    status: maintained
   navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_libqicore` to `2.9.7-0`:

- upstream repository: https://github.com/ros-naoqi/libqicore.git
- release repository: https://github.com/ros-naoqi/libqicore-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
