### PR TITLE
naoqi_libqicore: 2.9.7-0 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2960,6 +2960,21 @@ repositories:
       url: https://github.com/ros-naoqi/libqi.git
       version: ros2
     status: maintained
+  naoqi_libqicore:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/libqicore.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros-naoqi/libqicore-release.git
+      version: 2.9.7-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/libqicore.git
+      version: ros2
+    status: maintained
   navigation2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_libqicore` to `2.9.7-0`:

- upstream repository: https://github.com/ros-naoqi/libqicore.git
- release repository: https://github.com/ros-naoqi/libqicore-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
