### PR TITLE
naoqi_libqi: 2.9.7-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2954,7 +2954,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros-naoqi/libqi-release.git
-      version: 2.9.7-1
+      version: 2.9.7-2
     source:
       type: git
       url: https://github.com/ros-naoqi/libqi.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_libqi` to `2.9.7-2`:

- upstream repository: https://github.com/ros-naoqi/libqi.git
- release repository: https://github.com/ros-naoqi/libqi-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.9.7-1`
