### PR TITLE
naoqi_libqi: 2.9.7-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2390,7 +2390,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros-naoqi/libqi-release.git
-      version: 2.9.7-0
+      version: 2.9.7-1
     source:
       type: git
       url: https://github.com/ros-naoqi/libqi.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_libqi` to `2.9.7-1`:

- upstream repository: https://github.com/ros-naoqi/libqi.git
- release repository: https://github.com/ros-naoqi/libqi-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.9.7-0`
