### PR TITLE
pepper_meshes: 2.0.0-0 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3435,6 +3435,13 @@ repositories:
       url: https://github.com/ros-perception/pcl_msgs.git
       version: ros2
     status: maintained
+  pepper_meshes:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros-naoqi/pepper_meshes2-release.git
+      version: 2.0.0-0
+    status: maintained
   perception_pcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_meshes` to `2.0.0-0`:

- upstream repository: https://github.com/ros-naoqi/pepper_meshes2.git
- release repository: https://github.com/ros-naoqi/pepper_meshes2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## pepper_meshes

```
* Fix typo in CMakeLists.txt
* Add pepper_meshes package files for ROS2, refactoring the package.xml and the CMakeLists.txt
* Contributors: mbusy
```
