### PR TITLE
linear_sum_assignment: 1.9.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1902,6 +1902,21 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: rolling
     status: maintained
+  linear_sum_assignment:
+    doc:
+      type: git
+      url: https://github.com/wep21/linear_sum_assignment.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/linear_sum_assignment-release.git
+      version: 1.9.2-1
+    source:
+      type: git
+      url: https://github.com/wep21/linear_sum_assignment.git
+      version: main
+    status: maintained
   locator_ros_bridge:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `linear_sum_assignment` to `1.9.2-1`:

- upstream repository: https://github.com/wep21/linear_sum_assignment.git
- release repository: https://github.com/ros2-gbp/linear_sum_assignment-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## linear_sum_assignment

```
* docs: add license and CONTRIBUTING.md
* docs: add readme
* feat: initial commit
* Contributors: Daisuke Nishimatsu
```
