### PR TITLE
add overlay_rviz_plugins repository to rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2683,6 +2683,12 @@ repositories:
       url: https://github.com/OUXT-Polaris/ouxt_common.git
       version: master
     status: developed
+  overlay_rviz_plugins:
+    source:
+      type: git
+      url: https://github.com/teamspatzenhirn/overlay_rviz_plugins.git
+      version: main
+    status: maintained
   pcl_msgs:
     release:
       tags:


### PR DESCRIPTION
Adding new repository https://github.com/teamspatzenhirn/overlay_rviz_plugins to `rolling` as requested in https://github.com/ros2-gbp/ros2-gbp-github-org/issues/112#issuecomment-1242351309,
for the purpose of releasing the packages
* [overlay_rviz_msgs](https://github.com/teamspatzenhirn/overlay_rviz_plugins/tree/main/overlay_rviz_msgs)
* [overlay_rviz_plugins](https://github.com/teamspatzenhirn/overlay_rviz_plugins/tree/main/overlay_rviz_plugins)

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
