### PR TITLE
rtcm_msgs: 1.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6004,6 +6004,21 @@ repositories:
       url: https://github.com/introlab/rtabmap_ros.git
       version: foxy-devel
     status: developed
+  rtcm_msgs:
+    doc:
+      type: git
+      url: https://github.com/tilk/rtcm_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/nobleo/rtcm_msgs-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/tilk/rtcm_msgs.git
+      version: master
+    status: maintained
   ruckig:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtcm_msgs` to `1.1.0-1`:

- upstream repository: https://github.com/tilk/rtcm_msgs.git
- release repository: https://github.com/nobleo/rtcm_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
