### PR TITLE
Update cookiecutter for jammy and bionic python3

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1228,10 +1228,7 @@ python-cookiecutter:
   osx:
     pip:
       packages: [cookiecutter]
-  ubuntu:
-    bionic: [python-cookiecutter]
-    bionic_python3: [python3-cookiecutter]
-    jammy: [python3-cookiecutter]
+  ubuntu: [python-cookiecutter]
 python-cookiecutter-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1216,14 +1216,6 @@ python-control-pip:
   ubuntu:
     pip:
       packages: [control]
-python3-cookiecutter:
-  debian:
-    buster: [python3-cookiecutter]
-    stretch: [python3-cookiecutter]
-  fedora: [python3-cookiecutter]
-  ubuntu:
-    '*': [python3-cookiecutter]
-    focal: null
 python-cookiecutter:
   debian:
     buster: [python-cookiecutter]
@@ -6329,6 +6321,14 @@ python3-construct:
   gentoo: [dev-python/construct]
   nixos: [python3Packages.construct]
   ubuntu: [python3-construct]
+python3-cookiecutter:
+  debian:
+    buster: [python3-cookiecutter]
+    stretch: [python3-cookiecutter]
+  fedora: [python3-cookiecutter]
+  ubuntu:
+    '*': [python3-cookiecutter]
+    focal: null
 python3-coverage:
   debian: [python3-coverage]
   fedora: [python3-coverage]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1216,6 +1216,11 @@ python-control-pip:
   ubuntu:
     pip:
       packages: [control]
+python3-cookiecutter:
+  debian:
+    buster: [python3-cookiecutter]
+    stretch: [python3-cookiecutter]
+  ubuntu: [python3-cookiecutter]
 python-cookiecutter:
   debian:
     buster: [python-cookiecutter]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1228,7 +1228,10 @@ python-cookiecutter:
   osx:
     pip:
       packages: [cookiecutter]
-  ubuntu: [python-cookiecutter]
+  ubuntu:
+    bionic: [python-cookiecutter]
+    bionic_python3: [python3-cookiecutter]
+    jammy: [python3-cookiecutter]
 python-cookiecutter-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1220,7 +1220,10 @@ python3-cookiecutter:
   debian:
     buster: [python3-cookiecutter]
     stretch: [python3-cookiecutter]
-  ubuntu: [python3-cookiecutter]
+  fedora: [python3-cookiecutter]
+  ubuntu:
+    '*': [python3-cookiecutter]
+    focal: null
 python-cookiecutter:
   debian:
     buster: [python-cookiecutter]


### PR DESCRIPTION
Update cookiecutter package name for jammy and add bionic_python3

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/search?keywords=cookiecutter&searchon=names
