### PR TITLE
rospy_message_converter: 0.5.9-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11745,7 +11745,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uos-gbp/rospy_message_converter-release.git
-      version: 0.5.7-1
+      version: 0.5.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospy_message_converter` to `0.5.9-1`:

- upstream repository: https://github.com/uos/rospy_message_converter.git
- release repository: https://github.com/uos-gbp/rospy_message_converter-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.5.7-1`

## rospy_message_converter

```
* Fix flake8 errors
* Re-format code using black
* package.xml: Add missing build_export_depend
* Fix EOF and trailing whitespace
* Add pre-commit config
* README: Add note about branches
* pass down log_level to helper functions (#60 <https://github.com/uos/rospy_message_converter/issues/60>)
* Declare file encoding
  This is necessary on ROS Melodic (Python2), because I have added a
  non-ASCII character (u umlaut) in my last commit.
* Add LICENSE file and license headers
* Contributors: Martin Günther, Yuri Rocha
```
