### PR TITLE
Add python3-git for rhel

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6855,7 +6855,9 @@ python3-git:
   fedora: [python3-GitPython]
   gentoo: [dev-python/git-python]
   nixos: [python3Packages.GitPython]
-  rhel: [python3-GitPython]
+  rhel:
+    '*': [python3-GitPython]
+    '7': null
   ubuntu: [python3-git]
 python3-github:
   debian: [python3-github]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6854,6 +6854,7 @@ python3-git:
   debian: [python3-git]
   fedora: [python3-GitPython]
   gentoo: [dev-python/git-python]
+  rhel: [python3-GitPython]
   nixos: [python3Packages.GitPython]
   ubuntu: [python3-git]
 python3-github:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6854,8 +6854,8 @@ python3-git:
   debian: [python3-git]
   fedora: [python3-GitPython]
   gentoo: [dev-python/git-python]
-  rhel: [python3-GitPython]
   nixos: [python3Packages.GitPython]
+  rhel: [python3-GitPython]
   ubuntu: [python3-git]
 python3-github:
   debian: [python3-github]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`python3-git`

## Package Upstream Source:

[`python3-GitPython (fedora)`](https://packages.fedoraproject.org/pkgs/GitPython/python3-GitPython/)

## Purpose of using this:

Package exists for other distros, just not RHEL. Blocking the Galactic blooming of [`system_fingerprint`](https://github.com/MetroRobots/ros_system_fingerprint)

- Fedora: https://packages.fedoraproject.org/
  - [`python3-GitPython (fedora)`](https://packages.fedoraproject.org/pkgs/GitPython/python3-GitPython/)
