### PR TITLE
Closes #34332

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4418,6 +4418,7 @@ libopenni2-dev:
   fedora: [openni-devel]
   gentoo: [dev-libs/OpenNI2]
   nixos: [openni2]
+  rhel: [libfreenect-openni]
   ubuntu: [libopenni2-dev]
 libopenscenegraph:
   arch: [openscenegraph]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4418,7 +4418,9 @@ libopenni2-dev:
   fedora: [openni-devel]
   gentoo: [dev-libs/OpenNI2]
   nixos: [openni2]
-  rhel: [libfreenect-openni]
+  rhel:
+    '*': [libfreenect-openni]
+    '7': null
   ubuntu: [libopenni2-dev]
 libopenscenegraph:
   arch: [openscenegraph]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`libopenni2-dev`

## Package Upstream Source:

[`libfreenect-openni/ (fedora)`](https://packages.fedoraproject.org/pkgs/libfreenect/libfreenect-openni/)

## Purpose of using this:

Package exists for other distros, just not RHEL. 

- Fedora: https://packages.fedoraproject.org/
  - [`libfreenect-openni/ (fedora)`](https://packages.fedoraproject.org/pkgs/libfreenect/libfreenect-openni/)
