### PR TITLE
rclpy: 1.0.10-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4332,7 +4332,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 1.0.9-1
+      version: 1.0.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `1.0.10-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.9-1`

## rclpy

```
* Raise user handler exception in MultiThreadedExecutor (#984 <https://github.com/ros2/rclpy/issues/984>) (#992 <https://github.com/ros2/rclpy/issues/992>)
* Contributors: Tomoya Fujita
```
