### PR TITLE
launch_ros: 0.11.7-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2188,7 +2188,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.11.6-1
+      version: 0.11.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.11.7-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.11.6-1`

## launch_ros

```
* Handle empty strings when evaluating parameters (#300 <https://github.com/ros2/launch_ros/issues/300>) (#302 <https://github.com/ros2/launch_ros/issues/302>)
* Fix TypeError accessing name and value of SetParameter (#298 <https://github.com/ros2/launch_ros/issues/298>)
* Contributors: Jacob Perron
```

## launch_testing_ros

- No changes

## ros2launch

- No changes
