### PR TITLE
launch: 0.10.9-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2138,7 +2138,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.10.8-2
+      version: 0.10.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.10.9-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.10.8-2`

## launch

```
* Support scoping environment variables (#601 <https://github.com/ros2/launch/issues/601>) (#630 <https://github.com/ros2/launch/issues/630>)
* Contributors: Jacob Perron
```

## launch_testing

```
* Fix Typo (#641 <https://github.com/ros2/launch/issues/641>) (#642 <https://github.com/ros2/launch/issues/642>)
* Add compatitibility with pytest 7 (#592 <https://github.com/ros2/launch/issues/592>) (#628 <https://github.com/ros2/launch/issues/628>)
* Mention that ready_fn in generate_test_description is deprecated (#623 <https://github.com/ros2/launch/issues/623>) (#624 <https://github.com/ros2/launch/issues/624>)
* Switch to using a comprehension for process_names (#614 <https://github.com/ros2/launch/issues/614>) (#617 <https://github.com/ros2/launch/issues/617>)
* Contributors: Bi0T1N, Chris Lalancette, Kenji Brameld, Shane Loretz
```

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* Support scoping environment variables (#601 <https://github.com/ros2/launch/issues/601>) (#630 <https://github.com/ros2/launch/issues/630>)
* Contributors: Jacob Perron
```

## launch_yaml

```
* Support scoping environment variables (#601 <https://github.com/ros2/launch/issues/601>) (#630 <https://github.com/ros2/launch/issues/630>)
* Contributors: Jacob Perron
```
