### PR TITLE
rviz: 8.2.7-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6078,7 +6078,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 8.2.6-1
+      version: 8.2.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `8.2.7-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `8.2.6-1`

## rviz2

- No changes

## rviz_assimp_vendor

```
* Fix support for assimp 5.1.0 (#826 <https://github.com/ros2/rviz/issues/826>)
* Contributors: Akash
```

## rviz_common

- No changes

## rviz_default_plugins

```
* Make Axes display use latest transform (#892 <https://github.com/ros2/rviz/issues/892>) (#904 <https://github.com/ros2/rviz/issues/904>)
* Set error status when duplicate markers are in the same MarkerArray (#891 <https://github.com/ros2/rviz/issues/891>) (#901 <https://github.com/ros2/rviz/issues/901>)
* Contributors: Shane Loretz
```

## rviz_ogre_vendor

```
* Fix interface link libraries in ogre vendor (#761 <https://github.com/ros2/rviz/issues/761>) (#880 <https://github.com/ros2/rviz/issues/880>)
* Contributors: Jacob Perron, Laszlo Turanyi
```

## rviz_rendering

```
* Fix support for assimp 5.1.0 (#826 <https://github.com/ros2/rviz/issues/826>)
* Contributors: Akash
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
