### PR TITLE
Update source branches for rqt_console

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5685,7 +5685,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git
-      version: dashing-devel
+      version: foxy-devel
     release:
       tags:
         release: release/foxy/{package}/{version}
@@ -5694,7 +5694,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git
-      version: dashing-devel
+      version: foxy-devel
     status: maintained
   rqt_graph:
     doc:

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4689,7 +4689,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git
-      version: ros2
+      version: galactic
     release:
       tags:
         release: release/galactic/{package}/{version}
@@ -4698,7 +4698,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git
-      version: ros2
+      version: galactic
     status: maintained
   rqt_graph:
     doc:


### PR DESCRIPTION
I noticed these were incorrect.

Related release repository change: https://github.com/ros2-gbp/rqt_console-release/pull/4