### PR TITLE
pepper_meshes: 2.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3455,7 +3455,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros-naoqi/pepper_meshes2-release.git
-      version: 2.0.0-0
+      version: 2.0.1-1
     status: maintained
   perception_pcl:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_meshes` to `2.0.1-1`:

- upstream repository: https://github.com/ros-naoqi/pepper_meshes2.git
- release repository: https://github.com/ros-naoqi/pepper_meshes2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-0`

## pepper_meshes

```
* Merge branch 'fix_binaries' into main
* Update CMakeLists.txt, attempting to fix the binaries for ROS2
* Fix badge links in README
* Contributors: mbusy
```
