### PR TITLE
naoqi_bridge_msgs: 2.0.0-0 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2381,6 +2381,21 @@ repositories:
       url: https://github.com/ros-sports/nao_lola.git
       version: galactic
     status: developed
+  naoqi_bridge_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_bridge_msgs2.git
+      version: main
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros-naoqi/naoqi_bridge_msgs2-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_bridge_msgs2.git
+      version: main
+    status: maintained
   naoqi_libqi:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_bridge_msgs` to `2.0.0-0`:

- upstream repository: https://github.com/ros-naoqi/naoqi_bridge_msgs2.git
- release repository: https://github.com/ros-naoqi/naoqi_bridge_msgs2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## naoqi_bridge_msgs

```
* Update README, add buildfarm status badges
* Merge branch 'ros2_integration' into main
* ROS2 integration from https://github.com/mbusy/naoqi_bridge_msgs/tree/ros2
* Contributors: mbusy
```
