### PR TITLE
grid_map: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1415,6 +1415,37 @@ repositories:
       url: https://github.com/flynneva/grbl_ros.git
       version: devel
     status: maintained
+  grid_map:
+    doc:
+      type: git
+      url: https://github.com/ANYbotics/grid_map.git
+      version: humble
+    release:
+      packages:
+      - grid_map
+      - grid_map_cmake_helpers
+      - grid_map_core
+      - grid_map_costmap_2d
+      - grid_map_cv
+      - grid_map_demos
+      - grid_map_filters
+      - grid_map_loader
+      - grid_map_msgs
+      - grid_map_octomap
+      - grid_map_pcl
+      - grid_map_ros
+      - grid_map_rviz_plugin
+      - grid_map_sdf
+      - grid_map_visualization
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/grid_map-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ANYbotics/grid_map.git
+      version: humble
+    status: developed
   gscam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grid_map` to `2.0.0-1`:

- upstream repository: https://github.com/ANYbotics/grid_map.git
- release repository: https://github.com/ros2-gbp/grid_map-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## grid_map

```
* fix: build error on jammy
* Initial ROS2 port
* Contributors: Maximilian Wulf, Steve Macenski
```

## grid_map_cmake_helpers

```
* Initial ROS2 port
* Contributors: Steve Macenski
* Update for rolliing (#296 <https://github.com/ANYbotics/grid_map/issues/296>)
  Co-authored-by: Francisco Martin Rico <mailto:fmrico@gmail.com>
* Initial ROS2 port
* added grid_map_cmake_helpers maintainers
* changed grid_map_common to grid_map_cmake_helpers
* Contributors: Daisuke Nishimatsu, Marwan Taher, Steve Macenski
```

## grid_map_core

```
* Initial ROS2 port
* Contributors: Maximilian Wulf, Steve Macenski
```

## grid_map_costmap_2d

```
* fix: mark Eigen library as SYSTEM
* Initial ROS2 port
* Contributors: Maximilian Wulf, Steve Macenski
```

## grid_map_cv

```
* fix: mark Eigen library as SYSTEM
* fix: build error on jammy
* Initial ROS2 port
* Contributors: Maximilian Wulf, Steve Macenski
```

## grid_map_demos

```
* fix: mark Eigen library as SYSTEM
* fix: build error on jammy
* Initial ROS2 port
* Contributors: Maximilian Wulf, Steve Macenski
```

## grid_map_filters

```
* fix: mark Eigen library as SYSTEM
* fix: build error on jammy
* Initial ROS2 port
* Contributors: Maximilian Wulf, Steve Macenski
```

## grid_map_loader

```
* fix: mark Eigen library as SYSTEM
* fix: build error on jammy
* Initial ROS2 port
* Contributors: Maximilian Wulf, Steve Macenski
```

## grid_map_msgs

```
* Initial ROS2 port
* Contributors: Steve Macenski
```

## grid_map_octomap

```
* fix: mark Eigen library as SYSTEM
* fix: build error on jammy
* Initial ROS2 port
* Contributors: Maximilian Wulf, Steve Macenski
```

## grid_map_pcl

```
* ci: fix tests in grid map pcl
* fix: mark Eigen library as SYSTEM
* fix: build error on jammy
* Add height of cluster with the most points method
* Initial ROS2 port
* Contributors: Maximilian Wulf, Steve Macenski
```

## grid_map_ros

```
* fix: mark Eigen library as SYSTEM
* fix: build error on jammy
* Initial ROS2 port
* Contributors: Maximilian Wulf, Steve Macenski
```

## grid_map_rviz_plugin

```
* fix: mark Eigen library as SYSTEM
* fix: build error on jammy
* Initial ROS2 port
* Contributors: Maximilian Wulf, Steve Macenski
```

## grid_map_sdf

```
* fix: mark Eigen library as SYSTEM
* fix: build error on jammy
* Initial ROS2 port
* Contributors: Maximilian Wulf, Steve Macenski
```

## grid_map_visualization

```
* fix: mark Eigen library as SYSTEM
* fix: build error on jammy
* Initial ROS2 port
* Contributors: Maximilian Wulf, Steve Macenski
```
