### PR TITLE
moveit_msgs: 0.11.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5390,7 +5390,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit_msgs-release.git
-      version: 0.11.2-1
+      version: 0.11.3-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_msgs` to `0.11.3-1`:

- upstream repository: https://github.com/ros-planning/moveit_msgs.git
- release repository: https://github.com/ros-gbp/moveit_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.11.2-1`

## moveit_msgs

```
* Rename: cartesian_speed_end_effector_link -> cartesian_speed_limited_link (#130 <https://github.com/ros-planning/moveit_msgs/issues/130>)
* Clean all trailing whitespace in definitions (#134 <https://github.com/ros-planning/moveit_msgs/issues/134>)
* Remove disclaimer from ``CollisionObject/pose`` (#126 <https://github.com/ros-planning/moveit_msgs/issues/126>)
* Improve comments (#123 <https://github.com/ros-planning/moveit_msgs/issues/123>)
* ``GetCartesianPath.srv``: added fields to set for the maximum cartesian end effector (#113 <https://github.com/ros-planning/moveit_msgs/issues/113>)
* Remove erroneous comment from Pickup/Place action files (#112 <https://github.com/ros-planning/moveit_msgs/issues/112>)
* Add ``LICENSE.txt`` (#107 <https://github.com/ros-planning/moveit_msgs/issues/107>)
* Contributors: Felix von Drigalski, Jorge Santos Simón, Michael Görner, Peter Mitrano, Thies Oelerich, Tyler Weaver, Vatan Aksoy Tezer
```
