### PR TITLE
moveit: 1.1.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5355,7 +5355,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 1.1.9-1
+      version: 1.1.10-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `1.1.10-1`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.9-1`

## chomp_motion_planner

```
* Fix segfaults in CHOMP (#3204 <https://github.com/ros-planning/moveit/issues/3204>)
* Contributors: Robert Haschke
```

## moveit

- No changes

## moveit_chomp_optimizer_adapter

- No changes

## moveit_commander

```
* Limit Cartesian speed for link(s) (#2856 <https://github.com/ros-planning/moveit/issues/2856>)
* Validate JointState argument to moveit_commander.set_joint_value_target (#3187 <https://github.com/ros-planning/moveit/issues/3187>)
* Adjust python PSI to new CollisionObject.pose interface (#3176 <https://github.com/ros-planning/moveit/issues/3176>)
* moveit_commander: make current joint state copy-paste-able (#3133 <https://github.com/ros-planning/moveit/issues/3133>)
* Replace obsolete distutils.core with setuptools (#3103 <https://github.com/ros-planning/moveit/issues/3103>)
* Contributors: Filip Sund, Michael Görner, Stephanie Eng
```

## moveit_core

```
* Limit Cartesian speed for link(s) (#2856 <https://github.com/ros-planning/moveit/issues/2856>)
* Generalize computeCartesianPath() to consider a link_offset (#3197 <https://github.com/ros-planning/moveit/issues/3197>)
* Generate version.h with git branch and commit hash (#2793 <https://github.com/ros-planning/moveit/issues/2793>)
* robot_model_test_utils: Add loadIKPluginForGroup()
* Remove ConstraintSampler::project() (#3170 <https://github.com/ros-planning/moveit/issues/3170>)
* Add dual arm test (#3119 <https://github.com/ros-planning/moveit/issues/3119>)
* Fix PlanarJointModel::satisfiesPositionBounds (#3160 <https://github.com/ros-planning/moveit/issues/3160>)
* Switch to hpp headers of pluginlib
* Fix bug in applying planning scene diffs that have attached collision objects (#3124 <https://github.com/ros-planning/moveit/issues/3124>)
* Fix flaky constraint sampler test (#3135 <https://github.com/ros-planning/moveit/issues/3135>)
* Constraint samplers with seed (#3112 <https://github.com/ros-planning/moveit/issues/3112>)
* Replace bind() with lambdas (#3106 <https://github.com/ros-planning/moveit/issues/3106>)
* Fix null pointer access to CollisionEnvObject in PlanningScene (#3104 <https://github.com/ros-planning/moveit/issues/3104>)
* ACM: Consider default entries when packing a ROS message (#3096 <https://github.com/ros-planning/moveit/issues/3096>)
* Contributors: Captain Yoshi, Jafar, Jochen Sprickerhof, Michael Görner, Robert Haschke, Rufus Wong, Tahsincan Köse, cambel
```

## moveit_fake_controller_manager

```
* Replace bind() with lambdas (#3106 <https://github.com/ros-planning/moveit/issues/3106>)
* Contributors: Michael Görner
```

## moveit_kinematics

```
* Merge PR #3172 <https://github.com/ros-planning/moveit/issues/3172>: Fix CI
* Fix test_ikfast_plugins.sh
* auto_create_ikfast_moveit_plugin.sh: allow xacro input
* Switch to hpp headers of pluginlib
* Replace bind() with lambdas (#3106 <https://github.com/ros-planning/moveit/issues/3106>)
* Contributors: Jochen Sprickerhof, Michael Görner, Robert Haschke
```

## moveit_planners

- No changes

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

```
* Remove ConstraintSampler::project() (#3170 <https://github.com/ros-planning/moveit/issues/3170>)
* Replace bind() with lambdas (#3106 <https://github.com/ros-planning/moveit/issues/3106>)
* Cleanup OMPL's PlanningContextManager's protected API
* planning_context_manager: rename protected methods
* Contributors: Michael Görner, Robert Haschke
```

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

```
* Fix namespace of planning plugin for benchmarks examples (#3128 <https://github.com/ros-planning/moveit/issues/3128>)
* Replace bind() with lambdas (#3106 <https://github.com/ros-planning/moveit/issues/3106>)
* Filter more invalid values in moveit_benchmark_statistics.py (#3084 <https://github.com/ros-planning/moveit/issues/3084>)
* Contributors: Hugal31, Michael Görner, Robert Haschke
```

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

```
* Replace bind() with lambdas (#3106 <https://github.com/ros-planning/moveit/issues/3106>)
* Contributors: Michael Görner
```

## moveit_ros_move_group

```
* Limit Cartesian speed for link(s) (#2856 <https://github.com/ros-planning/moveit/issues/2856>)
* Optionally enable dynamics monitoring in move_group node (#3137 <https://github.com/ros-planning/moveit/issues/3137>)
* Replace bind() with lambdas (#3106 <https://github.com/ros-planning/moveit/issues/3106>)
* Contributors: Michael Görner
```

## moveit_ros_occupancy_map_monitor

```
* Replace bind() with lambdas (#3106 <https://github.com/ros-planning/moveit/issues/3106>)
* Contributors: Michael Görner
```

## moveit_ros_perception

```
* Replace bind() with lambdas (#3106 <https://github.com/ros-planning/moveit/issues/3106>)
* Contributors: Michael Görner, Robert Haschke
```

## moveit_ros_planning

```
* Limit Cartesian speed for link(s) (#2856 <https://github.com/ros-planning/moveit/issues/2856>)
* trajectory execution manager: reactivate tests (#3177 <https://github.com/ros-planning/moveit/issues/3177>)
* Clean up TrajectoryExecutionManager API (#3178 <https://github.com/ros-planning/moveit/issues/3178>)
* MoveItCpp: Allow multiple pipelines (#3131 <https://github.com/ros-planning/moveit/issues/3131>)
* Replace bind() with lambdas (#3106 <https://github.com/ros-planning/moveit/issues/3106>)
* Contributors: Jochen Sprickerhof, Michael Görner, Robert Haschke, cambel, v4hn
```

## moveit_ros_planning_interface

```
* Limit Cartesian speed for link(s) (#2856 <https://github.com/ros-planning/moveit/issues/2856>)
* Generalize computeCartesianPath() to consider a link_offset (#3197 <https://github.com/ros-planning/moveit/issues/3197>)
* Validate JointState argument to moveit_commander.set_joint_value_target (#3187 <https://github.com/ros-planning/moveit/issues/3187>)
* Add dual arm test (#3119 <https://github.com/ros-planning/moveit/issues/3119>)
* Replace bind() with lambdas (#3106 <https://github.com/ros-planning/moveit/issues/3106>)
* Replace obsolete distutils.core with setuptools (#3103 <https://github.com/ros-planning/moveit/issues/3103>)
* Contributors: Filip Sund, Michael Görner, Robert Haschke, Stephanie Eng, cambel, v4hn
```

## moveit_ros_robot_interaction

```
* Find end-effectors for empty parent_group (#3108 <https://github.com/ros-planning/moveit/issues/3108>)
* Replace bind() with lambdas (#3106 <https://github.com/ros-planning/moveit/issues/3106>)
* Consider eef's parent group when creating eef markers (#3095 <https://github.com/ros-planning/moveit/issues/3095>)
* Contributors: Michael Görner, Robert Haschke
```

## moveit_ros_visualization

```
* Fix rviz segfault when changing move group during execution (#3123 <https://github.com/ros-planning/moveit/issues/3123>)
* Replace bind() with lambdas (#3106 <https://github.com/ros-planning/moveit/issues/3106>)
* Replace obsolete distutils.core with setuptools (#3103 <https://github.com/ros-planning/moveit/issues/3103>)
* Contributors: Michael Görner, Robert Haschke, bsygo
```

## moveit_ros_warehouse

```
* Replace bind() with lambdas (#3106 <https://github.com/ros-planning/moveit/issues/3106>)
* Contributors: Michael Görner, Robert Haschke
```

## moveit_runtime

- No changes

## moveit_servo

- No changes

## moveit_setup_assistant

```
* Limit Cartesian speed for link(s) (#2856 <https://github.com/ros-planning/moveit/issues/2856>)
* MSA templates: replace hard-coded package name
* Extended ACM editing in MSA (#3093 <https://github.com/ros-planning/moveit/issues/3093>)
  
    * Allow disabling/enabling links by default
    * Use matrix view by default
  
* Optionally enable dynamics monitoring in move_group node (#3137 <https://github.com/ros-planning/moveit/issues/3137>)
* Replace bind() with lambdas (#3106 <https://github.com/ros-planning/moveit/issues/3106>)
* Improve Gazebo-compatible URDF generation in MSA (#3081 <https://github.com/ros-planning/moveit/issues/3081>)
* Contributors: AM4283, Michael Görner, Robert Haschke, rickstaa
```

## moveit_simple_controller_manager

```
* Replace bind() with lambdas (#3106 <https://github.com/ros-planning/moveit/issues/3106>)
* Contributors: Michael Görner
```

## pilz_industrial_motion_planner

```
* Add missing header for std::unique_ptr (#3180 <https://github.com/ros-planning/moveit/issues/3180>)
* Switch to hpp headers of pluginlib
* Replace bind() with lambdas (#3106 <https://github.com/ros-planning/moveit/issues/3106>)
* Contributors: Jochen Sprickerhof, Michael Görner
```

## pilz_industrial_motion_planner_testutils

```
* Replace bind() with lambdas (#3106 <https://github.com/ros-planning/moveit/issues/3106>)
* Contributors: Michael Görner
```
