### PR TITLE
add python-flask-sqlalchemy key to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6784,6 +6784,17 @@ python3-flask-restplus-pip:
 python3-flask-socketio:
   debian: [python3-flask-socketio]
   ubuntu: [python3-flask-socketio]
+python3-flask-sqlalchemy:
+  arch: [python-flask-sqlalchemy]
+  debian: [python3-flask-sqlalchemy]
+  fedora: [python3-flask-sqlalchemy]
+  gentoo: [dev-python/flask-sqlalchemy]
+  nixos: [python39Packages.flask_sqlalchemy]
+  opensuse: [python-Flask-SQLAlchemy]
+  rhel:
+    '*': [python3-flask-sqlalchemy]
+    '7': null
+  ubuntu: [python3-flask-sqlalchemy]
 python3-funcsigs:
   debian: [python3-funcsigs]
   fedora: [python3-funcsigs]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-flask-sqlalchemy

## Package Upstream Source:

https://github.com/pallets-eco/flask-sqlalchemy

## Purpose of using this:

Flask-SQLAlchemy is an extension for Flask that adds support for SQLAlchemy

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/python3-flask-sqlalchemy
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/focal/python3-flask-sqlalchemy
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-flask-sqlalchemy/python3-flask-sqlalchemy/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/community/any/python-flask-sqlalchemy/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/flask-sqlalchemy
- macOS: https://formulae.brew.sh/
  - Not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - Not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=22.05&show=python39Packages.flask_sqlalchemy&from=0&size=50&sort=relevance&type=packages&query=flask-sqlalchemy
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python-Flask-SQLAlchemy
