### PR TITLE
vision_opencv rename ros2 branch to rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5937,7 +5937,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/vision_opencv.git
-      version: ros2
+      version: rolling
     release:
       packages:
       - cv_bridge
@@ -5951,7 +5951,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/vision_opencv.git
-      version: ros2
+      version: rolling
     status: maintained
   visp:
     doc:


### PR DESCRIPTION
Renamed ``ros2`` branch to ``rolling``in vision_opencv. ([ros2 branch](https://github.com/ros-perception/vision_opencv/tree/rolling))