### PR TITLE
realsense2_camera: 4.51.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3552,7 +3552,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
-      version: 4.0.4-1
+      version: 4.51.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `4.51.1-1`:

- upstream repository: https://github.com/IntelRealSense/realsense-ros.git
- release repository: https://github.com/IntelRealSense/realsense-ros-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.4-1`

## realsense2_camera

```
* Fix crash when activating IMU & aligned depth together
* Fix rosbag device loading by preventing set_option to HDR/Gain/Exposure
* Support ROS2 Humble
* Publish real frame rate of realsense camera node topics/publishers
* No need to start/stop sensors for align depth changes
* Fix colorizer filter which returns null reference ptr
* Fix align_depth enable/disable
* Add colorizer.enable to rs_launch.py
* Add copyright and license to all ROS2-beta source files
* Fix CUDA suffix for pointcloud and align_depth topics
* Add ROS build farm pre-release to ci
* Contributors: Eran, NirAz, SamerKhshiboun
```

## realsense2_camera_msgs

```
* Add copyright and license to all ROS2-beta source files
* Contributors: SamerKhshiboun
```

## realsense2_description

```
* Add copyright and license to all ROS2-beta source files
* Contributors: SamerKhshiboun
```
