### PR TITLE
Add python3-timm-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9036,6 +9036,13 @@ python3-tilestache-pip:
   ubuntu:
     pip:
       packages: [tilestache]
+python3-timm-pip:
+  debian:
+    pip:
+      packages: [timm]
+  ubuntu:
+    pip:
+      packages: [timm]
 python3-tk:
   debian: [python3-tk]
   fedora: [python3-tkinter]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`Timm`

## Package Upstream Source:

[Timm](https://github.com/rwightman/pytorch-image-models)

## Purpose of using this:

Timm, also known as [pytorch-image-models](https://github.com/rwightman/pytorch-image-models), is an open-source collection of state-of-the-art PyTorch image models, pretrained weights, and utility scripts for training, inference, and validation.

## Links to Distribution Packages

- Debian: (https://pypi.org/project/timm/)
- Ubuntu: (https://pypi.org/project/timm/)
