### PR TITLE
yaml_cpp_vendor: 8.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6118,7 +6118,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
-      version: 8.0.1-1
+      version: 8.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `yaml_cpp_vendor` to `8.1.0-1`:

- upstream repository: https://github.com/ros2/yaml_cpp_vendor.git
- release repository: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `8.0.1-1`

## yaml_cpp_vendor

```
* Sets CMP0135 policy behavior to NEW (#36 <https://github.com/ros2/yaml_cpp_vendor/issues/36>)
* Fixes policy CMP0135 warning for CMake >= 3.24 (#35 <https://github.com/ros2/yaml_cpp_vendor/issues/35>)
* build shared lib only if BUILD_SHARED_LIBS is set (#34 <https://github.com/ros2/yaml_cpp_vendor/issues/34>)
* Mirror rolling to master
* Contributors: Audrow Nash, Cristóbal Arroyo, hannes09
```
