### PR TITLE
spdlog_vendor: 1.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5146,7 +5146,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/spdlog_vendor-release.git
-      version: 1.4.0-1
+      version: 1.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `spdlog_vendor` to `1.4.1-1`:

- upstream repository: https://github.com/ros2/spdlog_vendor.git
- release repository: https://github.com/ros2-gbp/spdlog_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.4.0-1`

## spdlog_vendor

```
* Fixes policy CMP0135 warning for CMake >= 3.24 (#30 <https://github.com/ros2/spdlog_vendor/issues/30>)
* build shared lib only if BUILD_SHARED_LIBS is set (#29 <https://github.com/ros2/spdlog_vendor/issues/29>)
* Mirror rolling to master
* xml tag order
* updating maintainer
* Contributors: Audrow Nash, Cristóbal Arroyo, Dharini Dutia, hannes09
```
