### PR TITLE
rqt_topic: 1.3.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5979,7 +5979,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_topic-release.git
-      version: 1.2.2-1
+      version: 1.3.0-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_topic.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_topic` to `1.3.0-2`:

- upstream repository: https://github.com/ros-visualization/rqt_topic.git
- release repository: https://github.com/ros2-gbp/rqt_topic-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.2-1`

## rqt_topic

```
* Fix the display of array type elements. (#41 <https://github.com/ros-visualization/rqt_topic/issues/41>)
* Fix removal of topics while they are being monitored. (#39 <https://github.com/ros-visualization/rqt_topic/issues/39>)
* Contributors: Chris Lalancette
```
