### PR TITLE
rviz: 12.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4926,7 +4926,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 11.3.0-1
+      version: 12.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `12.0.0-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `11.3.0-1`

## rviz2

```
* Add rviz1_to_rviz2.py conversion script (#882 <https://github.com/ros2/rviz/issues/882>)
* Contributors: Shane Loretz
```

## rviz_assimp_vendor

```
* Fixes policy CMP0135 warning for CMake >= 3.24 (#898 <https://github.com/ros2/rviz/issues/898>)
* Contributors: Cristóbal Arroyo
```

## rviz_common

```
* Document getTransform() time behavior (#893 <https://github.com/ros2/rviz/issues/893>)
* Ogre 1.12.10 upgrade (#878 <https://github.com/ros2/rviz/issues/878>)
* Add RVIZ_COMMON_PUBLIC macro (#865 <https://github.com/ros2/rviz/issues/865>)
* Contributors: Kenji Brameld, Shane Loretz, juchajam
```

## rviz_default_plugins

```
* Set error status when duplicate markers are in the same MarkerArray (#891 <https://github.com/ros2/rviz/issues/891>)
* Make Axes display use latest transform (#892 <https://github.com/ros2/rviz/issues/892>)
* Show link names in inertia error message (#874 <https://github.com/ros2/rviz/issues/874>)
* Ogre 1.12.10 upgrade (#878 <https://github.com/ros2/rviz/issues/878>)
* Use make_shared to construct PointCloud2 (#869 <https://github.com/ros2/rviz/issues/869>)
* Fix include order (#858 <https://github.com/ros2/rviz/issues/858>)
* Contributors: Hunter L. Allen, Jacob Perron, Kenji Brameld, Shane Loretz, Timon Engelke
```

## rviz_ogre_vendor

```
* Fixes policy CMP0135 warning for CMake >= 3.24 (#898 <https://github.com/ros2/rviz/issues/898>)
* Ogre 1.12.10 upgrade (#878 <https://github.com/ros2/rviz/issues/878>)
* Make resource file paths relative (#862 <https://github.com/ros2/rviz/issues/862>)
* Use CMAKE_STAGING_PREFIX for staging OGRE installation (#861 <https://github.com/ros2/rviz/issues/861>)
* Contributors: Cristóbal Arroyo, Kenji Brameld, Scott K Logan
```

## rviz_rendering

```
* Ogre 1.12.10 upgrade (#878 <https://github.com/ros2/rviz/issues/878>)
* Contributors: Kenji Brameld
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

```
* Ogre 1.12.10 upgrade (#878 <https://github.com/ros2/rviz/issues/878>)
* Contributors: Kenji Brameld
```
