### PR TITLE
rosidl_typesupport: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4383,7 +4383,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-      version: 2.1.0-1
+      version: 2.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport` to `2.2.0-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.0-1`

## rosidl_typesupport_c

```
* Replace rosidl_cmake imports with rosidl_pycommon (#126 <https://github.com/ros2/rosidl_typesupport/issues/126>)
* [service introspection] Use stddef.h instead of cstddef (#125 <https://github.com/ros2/rosidl_typesupport/issues/125>)
* Contributors: Brian, Jacob Perron
```

## rosidl_typesupport_cpp

```
* Replace rosidl_cmake imports with rosidl_pycommon (#126 <https://github.com/ros2/rosidl_typesupport/issues/126>)
* Contributors: Jacob Perron
```
