### PR TITLE
rosidl_python: 0.16.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4348,7 +4348,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.15.0-1
+      version: 0.16.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_python` to `0.16.0-1`:

- upstream repository: https://github.com/ros2/rosidl_python.git
- release repository: https://github.com/ros2-gbp/rosidl_python-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.15.0-1`

## rosidl_generator_py

```
* man_farmer
  
  Fix NaN values bound numpy windows version (#182)
* Allow NaN values to pass floating point bounds check. (#167 <https://github.com/ros2/rosidl_python/issues/167>)
* Replace rosidl_cmake imports with rosidl_pycommon (#177 <https://github.com/ros2/rosidl_python/issues/177>)
* Change decode error mode to replace (#176 <https://github.com/ros2/rosidl_python/issues/176>)
* Merge pull request #173 <https://github.com/ros2/rosidl_python/issues/173> from ros2/quarkytale/fix_import_order
* fix flake
* sorting after conversion
* Revert "Use modern cmake targets to avoid absolute paths to appear in binary archives (#160 <https://github.com/ros2/rosidl_python/issues/160>)" (#166 <https://github.com/ros2/rosidl_python/issues/166>)
* Use modern cmake targets to avoid absolute paths to appear in binary archives (#160 <https://github.com/ros2/rosidl_python/issues/160>)
* michel as author
* adding maintainer
* Contributors: Cristóbal Arroyo, Dharini Dutia, Ivan Santiago Paunovic, Jacob Perron, Tomoya Fujita, quarkytale, Øystein Sture
```
