### PR TITLE
ros2cli_common_extensions: 0.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4038,7 +4038,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli_common_extensions-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/ros2/ros2cli_common_extensions.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli_common_extensions` to `0.2.1-1`:

- upstream repository: https://github.com/ros2/ros2cli_common_extensions.git
- release repository: https://github.com/ros2-gbp/ros2cli_common_extensions-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.0-1`

## ros2cli_common_extensions

```
* Update maintainers (#6 <https://github.com/ros2/ros2cli_common_extensions/issues/6>)
* Contributors: methylDragon
```
