### PR TITLE
rmw_fastrtps: 6.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3768,7 +3768,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 6.3.0-1
+      version: 6.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `6.4.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `6.3.0-1`

## rmw_fastrtps_cpp

```
* Use Fast-DDS Waitsets instead of listeners (#619 <https://github.com/ros2/rmw_fastrtps/issues/619>)
* Remove rosidl_cmake dependency (#629 <https://github.com/ros2/rmw_fastrtps/issues/629>)
* Revert "add line feed for RCUTILS_SAFE_FWRITE_TO_STDERR (#608 <https://github.com/ros2/rmw_fastrtps/issues/608>)" (#612 <https://github.com/ros2/rmw_fastrtps/issues/612>)
* add line feed for RCUTILS_SAFE_FWRITE_TO_STDERR (#608 <https://github.com/ros2/rmw_fastrtps/issues/608>)
* Allow null arguments in the EventsExecutor parameters (#602 <https://github.com/ros2/rmw_fastrtps/issues/602>)
* Add RMW_CHECKS to rmw_fastrtps_cpp EventsExecutor implementation
* Contributors: Jacob Perron, Jose Luis Rivero, Ricardo González, Tomoya Fujita
```

## rmw_fastrtps_dynamic_cpp

```
* Use Fast-DDS Waitsets instead of listeners (#619 <https://github.com/ros2/rmw_fastrtps/issues/619>)
* Revert "add line feed for RCUTILS_SAFE_FWRITE_TO_STDERR (#608 <https://github.com/ros2/rmw_fastrtps/issues/608>)" (#612 <https://github.com/ros2/rmw_fastrtps/issues/612>)
* add line feed for RCUTILS_SAFE_FWRITE_TO_STDERR (#608 <https://github.com/ros2/rmw_fastrtps/issues/608>)
* Allow null arguments in the EventsExecutor parameters (#602 <https://github.com/ros2/rmw_fastrtps/issues/602>)
* Add EventExecutor to rmw_fastrtps_dynamic_cpp
* Fix cpplint error (#601 <https://github.com/ros2/rmw_fastrtps/issues/601>)
* Contributors: Jose Luis Rivero, Ricardo González, Tomoya Fujita
```

## rmw_fastrtps_shared_cpp

```
* Use Fast-DDS Waitsets instead of listeners (#619 <https://github.com/ros2/rmw_fastrtps/issues/619>)
* Take all available samples on service/client on_data_available. (#616 <https://github.com/ros2/rmw_fastrtps/issues/616>)
* Revert "add line feed for RCUTILS_SAFE_FWRITE_TO_STDERR (#608 <https://github.com/ros2/rmw_fastrtps/issues/608>)" (#612 <https://github.com/ros2/rmw_fastrtps/issues/612>)
* add line feed for RCUTILS_SAFE_FWRITE_TO_STDERR (#608 <https://github.com/ros2/rmw_fastrtps/issues/608>)
* Contributors: Miguel Company, Ricardo González, Tomoya Fujita
```
