### PR TITLE
rmw_dds_common: 1.7.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3748,7 +3748,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_dds_common-release.git
-      version: 1.7.0-1
+      version: 1.7.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_dds_common` to `1.7.1-1`:

- upstream repository: https://github.com/ros2/rmw_dds_common.git
- release repository: https://github.com/ros2-gbp/rmw_dds_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.7.0-1`

## rmw_dds_common

```
* build shared lib only if BUILD_SHARED_LIBS is set (#62 <https://github.com/ros2/rmw_dds_common/issues/62>)
* Update maintainers (#61 <https://github.com/ros2/rmw_dds_common/issues/61>)
* Contributors: hannes09, methylDragon
```
