### PR TITLE
rcutils: 6.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3364,7 +3364,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 5.2.0-1
+      version: 6.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `6.0.0-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `5.2.0-1`

## rcutils

```
* Optimize rcutils_logging_get_logger_effective_level() (#381 <https://github.com/ros2/rcutils/issues/381>)
* Change syntax __VAR_ARGS__ to __VA_ARGS__ (#376 <https://github.com/ros2/rcutils/issues/376>)
* Fix a bug in hash_map_get_next_key_and_data. (#375 <https://github.com/ros2/rcutils/issues/375>)
* More fixes from review.
* Fixes from review.
* Make g_rcutils_logging_output_handler static.
* Make g_rcutils_logging_default_logger_level static.
* Optimize rcutils_find_lastn where possible.
* Don't bother computing the hash_map key if the hash map is empty.
* Make sure to expand char_array by at least 1.5x.
* Optimize index computation in hash_map_find.
* Improve the performance of rcutils_logging_format_message. (#372 <https://github.com/ros2/rcutils/issues/372>)
* Get rid of unnecessary ret variable.
* Get rid of unnecessary ifdef cplusplus checks in the C file.
* Get rid of unnecessary rcutils_custom_add_{gtest,gmock}
* Get rid of unnecessary and unused RMW switching for logging tests.
* Remove unnecessary IS_OUTPUT_COLORIZED macro.
* Rename logging internal structures to use our new convention.
* Make all of the logging 'expand' methods static.
* Fix up error checking for RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED.
* Cleanup error handling for the RCUTILS_CONSOLE_OUTPUT_FORMAT checks.
* Revamp error handling in rcutils_logging_initialize_with_allocator.
* Revamp rcutils_logging_initialize_with_allocator.
* Make a few logging global variables static.
* Optimize calls via the RCUTILS_LOG macros. (#369 <https://github.com/ros2/rcutils/issues/369>)
* time_unix: add zephyr posix time (#368 <https://github.com/ros2/rcutils/issues/368>)
* Optimize the implementation of rcutils_char_array_strncpy. (#367 <https://github.com/ros2/rcutils/issues/367>)
* strdup.c: fix arbitrary length overread (#366 <https://github.com/ros2/rcutils/issues/366>)
* Mirror rolling to master
* strdup.c: fix 1 byte buffer overread (#363 <https://github.com/ros2/rcutils/issues/363>)
* Clarify duration arg description in logging macros (#359 <https://github.com/ros2/rcutils/issues/359>)
* Contributors: Abrar Rahman Protyasha, Audrow Nash, Chris Lalancette, Felipe Neves, Yakumoo, guijan
```
