### PR TITLE
rclpy: 3.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3297,7 +3297,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 3.6.0-1
+      version: 3.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `3.7.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.6.0-1`

## rclpy

```
* support wildcard matching for params file (#987 <https://github.com/ros2/rclpy/issues/987>)
* Raise user handler exception in MultiThreadedExecutor. (#984 <https://github.com/ros2/rclpy/issues/984>)
* Add wait_for_node method (#930 <https://github.com/ros2/rclpy/issues/930>)
* Create sublogger for action server and action client (#982 <https://github.com/ros2/rclpy/issues/982>)
* Support for pre-set and post-set parameter callback. (#966 <https://github.com/ros2/rclpy/issues/966>)
* fix gcc 7.5 build errors (#977 <https://github.com/ros2/rclpy/issues/977>)
* make _on_parameter_event return result correctly (#817 <https://github.com/ros2/rclpy/issues/817>)
* Fix a small typo in documentation. (#967 <https://github.com/ros2/rclpy/issues/967>)
* Contributors: Chen Lihui, Chris Lalancette, Deepanshu Bansal, Gonzo, Seulbae Kim, Steve Nogar, Tomoya Fujita, Tony Najjar
```
