### PR TITLE
rclcpp: 17.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3281,7 +3281,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 16.2.0-1
+      version: 17.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `17.0.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `16.2.0-1`

## rclcpp

```
* Make ParameterService and Sync/AsyncParameterClient accept rclcpp::QoS (#1978 <https://github.com/ros2/rclcpp/issues/1978>)
* support regex match for parameter client (#1992 <https://github.com/ros2/rclcpp/issues/1992>)
* operator+= and operator-= for Duration (#1988 <https://github.com/ros2/rclcpp/issues/1988>)
* Revert "Revert "Add a create_timer method to Node and LifecycleNode classes (#1975 <https://github.com/ros2/rclcpp/issues/1975>)" (#2009 <https://github.com/ros2/rclcpp/issues/2009>) (#2010 <https://github.com/ros2/rclcpp/issues/2010>)
* force compiler warning if callback handles not captured (#2000 <https://github.com/ros2/rclcpp/issues/2000>)
* Revert "Add a create_timer method to Node and LifecycleNode classes (#1975 <https://github.com/ros2/rclcpp/issues/1975>)" (#2009 <https://github.com/ros2/rclcpp/issues/2009>)
* Add a create_timer method to Node and LifecycleNode classes (#1975 <https://github.com/ros2/rclcpp/issues/1975>)
* [docs] add note about callback lifetime for {on, post}_set_parameter_callback (#1981 <https://github.com/ros2/rclcpp/issues/1981>)
* fix memory leak (#1994 <https://github.com/ros2/rclcpp/issues/1994>)
* Support pre-set and post-set parameter callbacks in addition to on-set-parameter-callback. (#1947 <https://github.com/ros2/rclcpp/issues/1947>)
* Make create_service accept rclcpp::QoS (#1969 <https://github.com/ros2/rclcpp/issues/1969>)
* Make create_client accept rclcpp::QoS (#1964 <https://github.com/ros2/rclcpp/issues/1964>)
* Fix the documentation for rclcpp::ok to be accurate. (#1965 <https://github.com/ros2/rclcpp/issues/1965>)
* use regex for wildcard matching (#1839 <https://github.com/ros2/rclcpp/issues/1839>)
* Revert "Introduce executors new spin_for method, replace spin_until_future_complete with spin_until_complete. (#1821 <https://github.com/ros2/rclcpp/issues/1821>) (#1874 <https://github.com/ros2/rclcpp/issues/1874>)" (#1956 <https://github.com/ros2/rclcpp/issues/1956>)
* Introduce executors new spin_for method, replace spin_until_future_complete with spin_until_complete. (#1821 <https://github.com/ros2/rclcpp/issues/1821>) (#1874 <https://github.com/ros2/rclcpp/issues/1874>)
* test adjustment for LoanedMessage. (#1951 <https://github.com/ros2/rclcpp/issues/1951>)
* fix virtual dispatch issues identified by clang-tidy (#1816 <https://github.com/ros2/rclcpp/issues/1816>)
* Remove unused on_parameters_set_callback_ (#1945 <https://github.com/ros2/rclcpp/issues/1945>)
* Fix subscription.is_serialized() for callbacks with message info (#1950 <https://github.com/ros2/rclcpp/issues/1950>)
* wait for subscriptions on another thread. (#1940 <https://github.com/ros2/rclcpp/issues/1940>)
* Fix documentation of RCLCPP_[INFO,WARN,...] (#1943 <https://github.com/ros2/rclcpp/issues/1943>)
* Always trigger guard condition waitset (#1923 <https://github.com/ros2/rclcpp/issues/1923>)
* Add statistics for handle_loaned_message (#1927 <https://github.com/ros2/rclcpp/issues/1927>)
* Drop wrong template specialization (#1926 <https://github.com/ros2/rclcpp/issues/1926>)
* Contributors: Alberto Soragna, Andrew Symington, Barry Xu, Brian, Chen Lihui, Chris Lalancette, Daniel Reuter, Deepanshu Bansal, Hubert Liberacki, Ivan Santiago Paunovic, Jochen Sprickerhof, Nikolai Morin, Shane Loretz, Tomoya Fujita, Tyler Weaver, William Woodall, schrodinbug
```

## rclcpp_action

```
* Revert "Introduce executors new spin_for method, replace spin_until_future_complete with spin_until_complete. (#1821 <https://github.com/ros2/rclcpp/issues/1821>) (#1874 <https://github.com/ros2/rclcpp/issues/1874>)" (#1956 <https://github.com/ros2/rclcpp/issues/1956>)
* Introduce executors new spin_for method, replace spin_until_future_complete with spin_until_complete. (#1821 <https://github.com/ros2/rclcpp/issues/1821>) (#1874 <https://github.com/ros2/rclcpp/issues/1874>)
* Contributors: Hubert Liberacki, William Woodall
```

## rclcpp_components

```
* Revert "Introduce executors new spin_for method, replace spin_until_future_complete with spin_until_complete. (#1821 <https://github.com/ros2/rclcpp/issues/1821>) (#1874 <https://github.com/ros2/rclcpp/issues/1874>)" (#1956 <https://github.com/ros2/rclcpp/issues/1956>)
* Introduce executors new spin_for method, replace spin_until_future_complete with spin_until_complete. (#1821 <https://github.com/ros2/rclcpp/issues/1821>) (#1874 <https://github.com/ros2/rclcpp/issues/1874>)
* Contributors: Hubert Liberacki, William Woodall
```

## rclcpp_lifecycle

```
* Revert "Revert "Add a create_timer method to Node and LifecycleNode classes (#1975 <https://github.com/ros2/rclcpp/issues/1975>)" (#2009 <https://github.com/ros2/rclcpp/issues/2009>) (#2010 <https://github.com/ros2/rclcpp/issues/2010>)
* Revert "Add a create_timer method to Node and LifecycleNode classes (#1975 <https://github.com/ros2/rclcpp/issues/1975>)" (#2009 <https://github.com/ros2/rclcpp/issues/2009>)
* Add a create_timer method to Node and LifecycleNode classes (#1975 <https://github.com/ros2/rclcpp/issues/1975>)
* Support pre-set and post-set parameter callbacks in addition to on-set-parameter-callback. (#1947 <https://github.com/ros2/rclcpp/issues/1947>)
* Make create_service accept rclcpp::QoS (#1969 <https://github.com/ros2/rclcpp/issues/1969>)
* Make create_client accept rclcpp::QoS (#1964 <https://github.com/ros2/rclcpp/issues/1964>)
* Contributors: Andrew Symington, Deepanshu Bansal, Ivan Santiago Paunovic, Shane Loretz
```
