### PR TITLE
pybind11_vendor: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2953,7 +2953,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pybind11_vendor-release.git
-      version: 2.4.0-1
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pybind11_vendor` to `3.0.0-1`:

- upstream repository: https://github.com/ros2/pybind11_vendor.git
- release repository: https://github.com/ros2-gbp/pybind11_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.4.0-1`

## pybind11_vendor

```
* Mirror rolling to master
* Update maintainers (#14 <https://github.com/ros2/pybind11_vendor/issues/14>)
* Update to pybind11 2.9.1.
* Rename patch file for history continuity.
* Contributors: Audrow Nash, Steven! Ragnarök, methylDragon
```
