### PR TITLE
orocos_kdl_vendor: 0.3.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2612,7 +2612,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
-      version: 0.3.3-1
+      version: 0.3.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_kdl_vendor` to `0.3.4-1`:

- upstream repository: https://github.com/ros2/orocos_kdl_vendor.git
- release repository: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.3-1`

## orocos_kdl_vendor

- No changes

## python_orocos_kdl_vendor

```
* Fixes policy CMP0135 warning for CMake >= 3.24 (#16 <https://github.com/ros2/orocos_kdl_vendor/issues/16>)
* Workaround pybind11 CMake error (#9 <https://github.com/ros2/orocos_kdl_vendor/issues/9>)
* Contributors: Cristóbal Arroyo, Jacob Perron
```
