### PR TITLE
message_filters: 4.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2033,7 +2033,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_message_filters-release.git
-      version: 4.4.1-1
+      version: 4.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_filters` to `4.5.0-1`:

- upstream repository: https://github.com/ros2/message_filters.git
- release repository: https://github.com/ros2-gbp/ros2_message_filters-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.4.1-1`

## message_filters

```
* Add latest time zero-order-hold sync policy (#73 <https://github.com/ros2/message_filters/issues/73>)
* Fix python examples and add a new example in documentation (#79 <https://github.com/ros2/message_filters/issues/79>)
* Mirror rolling to master
* Contributors: Audrow Nash, Carlos Andrés Álvarez Restrepo, andermi
```
