### PR TITLE
launch: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1786,7 +1786,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `1.2.0-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-1`

## launch

```
* Update launch/test/launch/test_execute_local.py
* Added unit test ensuring that output dictionary works with ExecuteLocal
* Addresses issue #588 <https://github.com/ros2/launch/issues/588>, allowing dict for 'output'
* Contributors: Matthew Elwin, Michael Jeronimo
```

## launch_pytest

- No changes

## launch_testing

```
* Fix Typo (#641 <https://github.com/ros2/launch/issues/641>)
* ReadyToTest action timeout using decorator (#625 <https://github.com/ros2/launch/issues/625>)
* Switch to using a comprehension for process_names. (#614 <https://github.com/ros2/launch/issues/614>)
* Contributors: Chris Lalancette, Deepanshu Bansal, Kenji Brameld
```

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
