### PR TITLE
common_interfaces: 4.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -614,7 +614,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 4.5.0-1
+      version: 4.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_interfaces` to `4.6.0-1`:

- upstream repository: https://github.com/ros2/common_interfaces.git
- release repository: https://github.com/ros2-gbp/common_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.5.0-1`

## actionlib_msgs

- No changes

## common_interfaces

- No changes

## diagnostic_msgs

- No changes

## geometry_msgs

- No changes

## nav_msgs

- No changes

## sensor_msgs

```
* use regex for matching cv types (#202 <https://github.com/ros2/common_interfaces/issues/202>)
* Fix outdated file path for image_encodings (#200 <https://github.com/ros2/common_interfaces/issues/200>)
* Use uint32_t for pointcloud2 resize method (#195 <https://github.com/ros2/common_interfaces/issues/195>)
* Retain width and height after resize for master (#193 <https://github.com/ros2/common_interfaces/issues/193>)
* Contributors: Kenji Brameld, Tianyu Li
```

## sensor_msgs_py

```
* Add support for non standard point step sizes (#199 <https://github.com/ros2/common_interfaces/issues/199>)
* Remove reference to old implementation (#198 <https://github.com/ros2/common_interfaces/issues/198>)
* Contributors: Florian Vahl
```

## shape_msgs

- No changes

## std_msgs

- No changes

## std_srvs

- No changes

## stereo_msgs

- No changes

## trajectory_msgs

- No changes

## visualization_msgs

- No changes
