### PR TITLE
turtlesim: 1.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5503,7 +5503,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_tutorials-release.git
-      version: 1.4.1-2
+      version: 1.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlesim` to `1.5.0-1`:

- upstream repository: https://github.com/ros/ros_tutorials.git
- release repository: https://github.com/ros2-gbp/ros_tutorials-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.4.1-2`

## turtlesim

```
* Add parameter to enable holonomic motion (#131 <https://github.com/ros/ros_tutorials/issues/131>)
* Add humble turtle (#140 <https://github.com/ros/ros_tutorials/issues/140>)
* Contributors: Audrow Nash, Daisuke Sato
```
