### PR TITLE
resource_retriever: 3.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3417,7 +3417,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 3.2.0-1
+      version: 3.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `3.2.1-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros2-gbp/resource_retriever-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.2.0-1`

## libcurl_vendor

```
* Sets CMP0135 policy behavior to NEW (#79 <https://github.com/ros/resource_retriever/issues/79>)
* Fixes policy CMP0135 warning for CMake >= 3.24
* Contributors: Cristóbal Arroyo, Crola1702
```

## resource_retriever

- No changes
