### PR TITLE
tango_icons_vendor: 0.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5238,7 +5238,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tango_icons_vendor-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/tango_icons_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tango_icons_vendor` to `0.2.1-1`:

- upstream repository: https://github.com/ros-visualization/tango_icons_vendor.git
- release repository: https://github.com/ros2-gbp/tango_icons_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.0-1`

## tango_icons_vendor

```
* Mirror rolling to master
* Contributors: Audrow Nash
```
