### PR TITLE
rqt_reconfigure: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4706,7 +4706,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_reconfigure-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_reconfigure` to `1.2.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_reconfigure.git
- release repository: https://github.com/ros2-gbp/rqt_reconfigure-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-1`

## rqt_reconfigure

```
* Fix float slider step size (#117 <https://github.com/ros-visualization/rqt_reconfigure/issues/117>)
* update maintainer
* Contributors: Audrow Nash, Dharini Dutia, Florian Vahl, Jacob Perron, quarkytale
```
