### PR TITLE
rqt_bag: 1.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4536,7 +4536,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
-      version: 1.2.0-1
+      version: 1.2.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `1.2.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros2-gbp/rqt_bag-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.0-1`

## rqt_bag

```
* Increase publishing checkbox size (#122 <https://github.com/ros-visualization/rqt_bag/issues/122>)
* Fix toggle thumbnails button (#117 <https://github.com/ros-visualization/rqt_bag/issues/117>)
* ensure data types match what PyQt expects (#118 <https://github.com/ros-visualization/rqt_bag/issues/118>)
* Visualize topics being published and highlight topic being selected (#116 <https://github.com/ros-visualization/rqt_bag/issues/116>)
* Be able to scroll up and down, not only zoom-in and out the timeline (#114 <https://github.com/ros-visualization/rqt_bag/issues/114>)
* [Fixes] Fix crash when no qos metadata, make scroll bar appear if needed, add gitignore (#113 <https://github.com/ros-visualization/rqt_bag/issues/113>)
* Contributors: Ivan Santiago Paunovic, Kenji Brameld
```

## rqt_bag_plugins

- No changes
