### PR TITLE
rqt_graph: 1.2.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4732,7 +4732,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_graph-release.git
-      version: 1.2.1-1
+      version: 1.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_graph` to `1.2.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_graph.git
- release repository: https://github.com/ros2-gbp/rqt_graph-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.1-1`

## rqt_graph

```
* Minor cleanup (#80 <https://github.com/ros-visualization/rqt_graph/issues/80>)
* Mirror rolling to galactic-devel
* graph load/save into DOT file corrections for py3 (#78 <https://github.com/ros-visualization/rqt_graph/issues/78>)
* Contributors: Audrow Nash, David V. Lu!!, mergify[bot]
```
