### PR TITLE
naoqi_driver: 0.5.13-0 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5733,6 +5733,21 @@ repositories:
       url: https://github.com/ros-naoqi/naoqi_bridge_msgs.git
       version: master
     status: maintained
+  naoqi_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_driver.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-naoqi/naoqi_driver-release.git
+      version: 0.5.13-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_driver.git
+      version: master
+    status: maintained
   naoqi_libqi:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_driver` to `0.5.13-0`:

- upstream repository: https://github.com/ros-naoqi/naoqi_driver.git
- release repository: https://github.com/ros-naoqi/naoqi_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## naoqi_driver

```
* Merge branch 'noetic_update'
* Update package.xml for noetic compatibility
* Update README, remove CI stretch tests
* Contributors: mbusy
```
