### PR TITLE
webots_ros: 2022.1.0-1 in 'noetic/distribution.yaml' [bloom] 

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11623,7 +11623,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/cyberbotics/webots_ros-release.git
-      version: 5.0.1-2
+      version: 2022.1.0-1
     source:
       type: git
       url: https://github.com/cyberbotics/webots_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `webots_ros` to `2022.1.0-1`:
* upstream repository: https://github.com/cyberbotics/webots_ros.git
* release repository: https://github.com/cyberbotics/webots_ros-release.git
* distro file: `noetic/distribution.yaml`
* bloom version: `0.11.2`
* previous version for package: `5.0.1-2`

