### PR TITLE
vision_opencv: 3.1.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -6358,7 +6358,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 2.2.1-2
+      version: 3.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `3.1.0-1`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros2-gbp/vision_opencv-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.1-2`

## cv_bridge

```
* Add apache license and bsd license, because both are used. (#482 <https://github.com/ros-perception/vision_opencv/issues/482>)
* Fix 16U encoding type (#462 <https://github.com/ros-perception/vision_opencv/issues/462>)
* Reorganize author tag (#468 <https://github.com/ros-perception/vision_opencv/issues/468>)
* Update maintainers (#451 <https://github.com/ros-perception/vision_opencv/issues/451>)
* Fix ModuleNotFoundError: No module named 'cv_bridge' error (#444 <https://github.com/ros-perception/vision_opencv/issues/444>)
* Update README.md (#252 <https://github.com/ros-perception/vision_opencv/issues/252>)
* Make python3-opencv from test_depend to depend tag in package.xml (#439 <https://github.com/ros-perception/vision_opencv/issues/439>)
* Contributors: Daisuke Nishimatsu, Kenji Brameld, RachelRen05
```

## image_geometry

```
* Add apache license and bsd license, because both are used. (#482 <https://github.com/ros-perception/vision_opencv/issues/482>)
* Reorganize author tag (#468 <https://github.com/ros-perception/vision_opencv/issues/468>)
* Add description of MISSING_Z (#465 <https://github.com/ros-perception/vision_opencv/issues/465>)
* Update maintainers (#451 <https://github.com/ros-perception/vision_opencv/issues/451>)
* Contributors: Kenji Brameld
```

## vision_opencv

```
* Add apache license and bsd license, because both are used. (#482 <https://github.com/ros-perception/vision_opencv/issues/482>)
* Reorganize author tag (#468 <https://github.com/ros-perception/vision_opencv/issues/468>)
* Update maintainers (#451 <https://github.com/ros-perception/vision_opencv/issues/451>)
* Contributors: Kenji Brameld
```
