### PR TITLE
vision_opencv: 3.0.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -7168,7 +7168,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 2.2.1-1
+      version: 3.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `3.0.4-1`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros2-gbp/vision_opencv-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.1-1`

## cv_bridge

```
* Add apache license and bsd license, because both are used. (#481 <https://github.com/ros-perception/vision_opencv/issues/481>)
* Fix 16U encoding type (#461 <https://github.com/ros-perception/vision_opencv/issues/461>)
* Reorganize author tag (#467 <https://github.com/ros-perception/vision_opencv/issues/467>)
* Update maintainers (#451 <https://github.com/ros-perception/vision_opencv/issues/451>)
* Fix ModuleNotFoundError: No module named 'cv_bridge' error (#444 <https://github.com/ros-perception/vision_opencv/issues/444>)
* Make python3-opencv from test_depend to depend tag in package.xml (#439 <https://github.com/ros-perception/vision_opencv/issues/439>)
* Contributors: Daisuke Nishimatsu, Kenji Brameld, RachelRen05
```

## image_geometry

```
* Add apache license and bsd license, because both are used. (#481 <https://github.com/ros-perception/vision_opencv/issues/481>)
* Reorganize author tag (#467 <https://github.com/ros-perception/vision_opencv/issues/467>)
* Add description of MISSING_Z (#464 <https://github.com/ros-perception/vision_opencv/issues/464>)
* Update maintainers (#451 <https://github.com/ros-perception/vision_opencv/issues/451>)
* Contributors: Kenji Brameld
```

## vision_opencv

```
* Add apache license and bsd license, because both are used. (#481 <https://github.com/ros-perception/vision_opencv/issues/481>)
* Reorganize author tag (#467 <https://github.com/ros-perception/vision_opencv/issues/467>)
* Update maintainers (#451 <https://github.com/ros-perception/vision_opencv/issues/451>)
* Contributors: Kenji Brameld
```
