### PR TITLE
ros_gz: 0.244.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4307,6 +4307,34 @@ repositories:
       url: https://github.com/ros/ros_environment.git
       version: humble
     status: maintained
+  ros_gz:
+    doc:
+      type: git
+      url: https://github.com/gazebosim/ros_gz
+      version: humble
+    release:
+      packages:
+      - ros_gz
+      - ros_gz_bridge
+      - ros_gz_image
+      - ros_gz_interfaces
+      - ros_gz_sim
+      - ros_gz_sim_demos
+      - ros_ign
+      - ros_ign_bridge
+      - ros_ign_gazebo
+      - ros_ign_gazebo_demos
+      - ros_ign_image
+      - ros_ign_interfaces
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_ign-release.git
+      version: 0.244.6-1
+    source:
+      type: git
+      url: https://github.com/gazebosim/ros_gz
+      version: humble
+    status: maintained
   ros_image_to_qimage:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4310,7 +4310,7 @@ repositories:
   ros_gz:
     doc:
       type: git
-      url: https://github.com/gazebosim/ros_gz
+      url: https://github.com/gazebosim/ros_gz.git
       version: humble
     release:
       packages:
@@ -4332,7 +4332,7 @@ repositories:
       version: 0.244.6-1
     source:
       type: git
-      url: https://github.com/gazebosim/ros_gz
+      url: https://github.com/gazebosim/ros_gz.git
       version: humble
     status: maintained
   ros_image_to_qimage:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `0.244.6-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## ros_gz

- No changes

## ros_gz_bridge

- No changes

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

- No changes

## ros_gz_sim_demos

- No changes

## ros_ign

```
* Restructured directories (#296 <https://github.com/gazebosim/ros_gz/issues/296>)
* Contributors: Alejandro Hernández Cordero
```

## ros_ign_bridge

```
* Restructured directories (#296 <https://github.com/gazebosim/ros_gz/issues/296>)
* Contributors: Alejandro Hernández Cordero
```

## ros_ign_gazebo

```
* Restructured directories (#296 <https://github.com/gazebosim/ros_gz/issues/296>)
* Contributors: Alejandro Hernández Cordero
```

## ros_ign_gazebo_demos

```
* Restructured directories (#296 <https://github.com/gazebosim/ros_gz/issues/296>)
* Contributors: Alejandro Hernández Cordero
```

## ros_ign_image

```
* Restructured directories (#296 <https://github.com/gazebosim/ros_gz/issues/296>)
* Contributors: Alejandro Hernández Cordero
```

## ros_ign_interfaces

```
* Restructured directories (#296 <https://github.com/gazebosim/ros_gz/issues/296>)
* Contributors: Alejandro Hernández Cordero
```
