### PR TITLE
Add jax and jaxlib mapping

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7122,6 +7122,14 @@ python3-interpreter:
   rhel: [python3]
   slackware: [python3]
   ubuntu: [python3-minimal]
+python3-jax:
+  ubuntu:
+    pip:
+      packages: [jax]
+python3-jaxlib:
+  ubuntu:
+    pip:
+      packages: [jaxlib]
 python3-j1939-pip: *migrate_eol_2025_04_30_python3_j1939_pip
 python3-jinja2:
   alpine: [py3-jinja2]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Jax and JaxLib:

`jax`
`jaxlib`

## Package Upstream Source:

[jax](https://github.com/google/jax)


## Purpose of using this:

What’s new is that JAX uses [XLA](https://www.tensorflow.org/xla) to compile and run your NumPy programs on GPUs and TPUs.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian:
  https://pypi.org/project/jax/
  https://pypi.org/project/jaxlib/
- Ubuntu: 
  https://pypi.org/project/jax/
  https://pypi.org/project/jaxlib/




