### PR TITLE
maliput_py: 0.1.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2547,7 +2547,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput_py-release.git
-      version: 0.1.2-1
+      version: 0.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_py` to `0.1.3-1`:

- upstream repository: https://github.com/maliput/maliput_py.git
- release repository: https://github.com/ros2-gbp/maliput_py-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.2-1`

## maliput_py

```
* Adds binding for ToSegmentPosition. (#70 <https://github.com/maliput/maliput_py/issues/70>)
* Contributors: Franco Cipollone
```
