### PR TITLE
maliput_dragway: 0.1.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2412,7 +2412,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput_dragway-release.git
-      version: 0.1.2-1
+      version: 0.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_dragway` to `0.1.3-1`:

- upstream repository: https://github.com/maliput/maliput_dragway.git
- release repository: https://github.com/ros2-gbp/maliput_dragway-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.2-1`

## maliput_dragway

```
* Matches with changes in Maliput: Lane::ToLanePosition. (#76 <https://github.com/maliput/maliput_dragway/issues/76>)
* Adds triage workflow. (#75 <https://github.com/maliput/maliput_dragway/issues/75>)
* Improves README. (#74 <https://github.com/maliput/maliput_dragway/issues/74>)
* Contributors: Franco Cipollone
```
