### PR TITLE
maliput_integration: 0.1.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2460,7 +2460,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput_integration-release.git
-      version: 0.1.2-1
+      version: 0.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_integration` to `0.1.3-1`:

- upstream repository: https://github.com/maliput/maliput_integration.git
- release repository: https://github.com/ros2-gbp/maliput_integration-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.2-1`

## maliput_integration

```
* Adds Lane::ToSegmentPosition query. (#123 <https://github.com/maliput/maliput_integration/issues/123>)
* Contributors: Franco Cipollone
```
