### PR TITLE
Add mongodb_store to Noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5245,6 +5245,12 @@ repositories:
       url: https://github.com/ros-drivers/mocap_optitrack.git
       version: master
     status: maintained
+  mongodb_store:
+    source:
+      type: git
+      url: https://github.com/strands-project/mongodb_store.git
+      version: noetic-devel
+    status: developed
   monkeywrench:
     doc:
       type: git


### PR DESCRIPTION
Adding the [mongodb_store](https://github.com/strands-project/mongodb_store) repository to Noetic for the purpose of running pre-release tests, as specified by the [release guide](http://wiki.ros.org/ROS/ReleasingAPackage).  
The package is already released for older ROS1 distributions.

 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro