### PR TITLE
irobot_create_msgs: 2.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1684,6 +1684,16 @@ repositories:
       url: https://github.com/ros-visualization/interactive_markers.git
       version: humble
     status: maintained
+  irobot_create_msgs:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/irobot_create_msgs-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/iRobotEducation/irobot_create_msgs.git
+      version: main
   joint_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `irobot_create_msgs` to `2.1.0-1`:

- upstream repository: https://github.com/iRobotEducation/irobot_create_msgs.git
- release repository: https://github.com/ros2-gbp/irobot_create_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## irobot_create_msgs

```
* rename DockServo action into Dock and Dock msg into DockStatus
* Contributors: Alberto Soragna
```
