### PR TITLE
turtlebot4: 0.1.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5814,7 +5814,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot4.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4` to `0.1.2-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4.git
- release repository: https://github.com/ros2-gbp/turtlebot4-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.1-1`

## turtlebot4_description

- No changes

## turtlebot4_msgs

- No changes

## turtlebot4_navigation

```
* ci: Fixed flake8 lint
* Contributors: Daisuke Nishimatsu, Roni Kreinin
```

## turtlebot4_node

```
* Added support for Empty service
* Added RPLIDAR motor stop service as a function option
* Added timeouts to services (defaults to 30s)
* Updated rclcpp action api
* Contributors: Daisuke Nishimatsu, Roni Kreinin
```
