### PR TITLE
turtlebot4_robot: 0.1.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5872,7 +5872,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4_robot-release.git
-      version: 0.1.2-1
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot4_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4_robot` to `0.1.3-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4_robot.git
- release repository: https://github.com/ros2-gbp/turtlebot4_robot-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.2-1`

## turtlebot4_base

- No changes

## turtlebot4_bringup

```
* Added RPLIDAR Motor function to config
* Contributors: Roni Kreinin
```

## turtlebot4_diagnostics

- No changes

## turtlebot4_robot

- No changes

## turtlebot4_tests

- No changes
