### PR TITLE
twist_stamper: 0.0.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5971,8 +5971,8 @@ repositories:
     release:
       tags:
         release: release/galactic/{package}/{version}
-      url: https://github.com/joshnewans/twist_stamper-release.git
-      version: 0.0.2-1
+      url: https://github.com/ros2-gbp/twist_stamper-release.git
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/joshnewans/twist_stamper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `twist_stamper` to `0.0.3-1`:

- upstream repository: https://github.com/joshnewans/twist_stamper.git
- release repository: https://github.com/ros2-gbp/twist_stamper-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.2-1`

## twist_stamper

```
* fix python setuptools install error (#1 <https://github.com/joshnewans/twist_stamper/issues/1>)
  Co-authored-by: Sönke Niemann <mailto:soenke.niemann@ipk.fraunhofer.de>
* Contributors: niemsoen
```
