### PR TITLE
twist_stamper: 0.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5545,6 +5545,11 @@ repositories:
       type: git
       url: https://github.com/joshnewans/twist_stamper.git
       version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/twist_stamper-release.git
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/joshnewans/twist_stamper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `twist_stamper` to `0.0.3-1`:

- upstream repository: https://github.com/joshnewans/twist_stamper.git
- release repository: https://github.com/ros2-gbp/twist_stamper-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## twist_stamper

```
* fix python setuptools install error (#1 <https://github.com/joshnewans/twist_stamper/issues/1>)
  Co-authored-by: Sönke Niemann <mailto:soenke.niemann@ipk.fraunhofer.de>
* Contributors: niemsoen
```
