### PR TITLE
CHANGE: Update franka_ros 0.10.1

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3597,7 +3597,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/frankaemika/franka_ros-release.git
-      version: 0.10.0-1
+      version: 0.10.1-1
     source:
       type: git
       url: https://github.com/frankaemika/franka_ros.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2766,7 +2766,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/frankaemika/franka_ros-release.git
-      version: 0.10.0-1
+      version: 0.10.1-1
     source:
       type: git
       url: https://github.com/frankaemika/franka_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `franka_ros` to 0.10.1-1:

* upstream repository: https://github.com/frankaemika/franka_ros.git
* release repository: https://github.com/frankaemika/franka_ros-release.git
* distro file: {melodic,noetic}/distribution.yaml
* bloom version: 0.11.2
* previous version for package: 0.10.0-1

## Changes according to CHANGELOG

Requires `libfranka` >= 0.8.0

  * `franka_example_controllers`: Fix examples not working on melodic due to non-ascii symbols in comments of `franka_example_controllers.yaml`.
  * `franka_example_controllers`: The `link_name` in  `cartesian_impedance_example_controller.launch` is now determined over the `arm_id`.
  * `franka_description`: Fix catkin warning about `catkin_add_nosetests`

