### PR TITLE
Revert the latest updates to Foxy and Galactic vision_opencv

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -7183,7 +7183,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 3.0.4-1
+      version: 2.2.1-1
     source:
       test_pull_requests: true
       type: git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -6373,7 +6373,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 3.1.0-1
+      version: 2.2.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
While that package itself succeeds, it seems to be causing problems in downstream packages:

https://build.ros2.org/job/Fbin_uF64__rqt_image_view__ubuntu_focal_amd64__binary/87/console
https://build.ros2.org/job/Gbin_uF64__rqt_image_view__ubuntu_focal_amd64__binary/43/console

@ijnek FYI.