### PR TITLE
vision_opencv: 3.0.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -7183,7 +7183,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 2.2.1-1
+      version: 3.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
**A release that reverts commits that broke API in https://github.com/ros/rosdistro/pull/34582 (which caused downstream packages to break). It would be great if @clalancette could review this one please. Thanks!**

---

Increasing version of package(s) in repository `vision_opencv` to `3.0.5-1`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros2-gbp/vision_opencv-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.1-1`

## cv_bridge

```
* Revert API breakages
* Contributors: Kenji Brameld
```

## image_geometry

```
* Revert API breakages
* Contributors: Kenji Brameld
```

## vision_opencv

- No changes
