### PR TITLE
ros2_control: 2.15.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3888,7 +3888,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.13.0-1
+      version: 2.15.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.15.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.13.0-1`

## controller_interface

```
* Remove autodeclare of parameters for controllers. (#757 <https://github.com/ros-controls/ros2_control/issues/757>)
* Contributors: Denis Štogl
```

## controller_manager

- No changes

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* migrate from graphviz python to pygraphviz (#812 <https://github.com/ros-controls/ros2_control/issues/812>)
* Contributors: Sachin Kumar
```

## transmission_interface

- No changes
