### PR TITLE
mongodb_store: 0.6.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5246,6 +5246,19 @@ repositories:
       version: master
     status: maintained
   mongodb_store:
+    doc:
+      type: git
+      url: https://github.com/strands-project/mongodb_store.git
+      version: noetic-devel
+    release:
+      packages:
+      - mongodb_log
+      - mongodb_store
+      - mongodb_store_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/strands-project-releases/mongodb_store.git
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.6.0-1`:

- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## mongodb_log

```
* Ensure Python 3 compatibility in mongodb log (#277 <https://github.com/strands-project/mongodb_store/issues/277>)
* update package.xml to format=3 (#269 <https://github.com/strands-project/mongodb_store/issues/269>)
* Contributors: Gal Gorjup, Kei Okada, Nick Hawes
```

## mongodb_store

```
* Avoid deadlock on server shutdown (#279 <https://github.com/strands-project/mongodb_store/issues/279>)
* Fix Python 3 bugs in mongodb_store (#272 <https://github.com/strands-project/mongodb_store/issues/272>, #274 <https://github.com/strands-project/mongodb_store/issues/274>, #275 <https://github.com/strands-project/mongodb_store/issues/275>)
* handling of host binding (#270 <https://github.com/strands-project/mongodb_store/issues/270>)
* update package.xml to format=3 (#269 <https://github.com/strands-project/mongodb_store/issues/269>)
* fix connection_string arg default value (#266 <https://github.com/strands-project/mongodb_store/issues/266>)
* fixed bug in where the replicator node did not recognize the db_host (#261 <https://github.com/strands-project/mongodb_store/issues/261>)
* Added .launch to the roslaunch command that was written in the readme file (#262 <https://github.com/strands-project/mongodb_store/issues/262>)
* fixed a formatting issue
* fixed bug in where the replicator node did not recognize the db_host
* remembering namespace in rosparam
* Provide options to prevent unnecessary nodes launching
* added ability for message store to use a full connection string
* Removed --smallfiles arg no longer supported by MongoDB (#257 <https://github.com/strands-project/mongodb_store/issues/257>)
* Contributors: Adrian Dole, Gal Gorjup, Kei Okada, Marc Hanheide, Nick Hawes, Shingo Kitagawa, Vittoria Santoro
```

## mongodb_store_msgs

- No changes
