### PR TITLE
rviz_visual_tools: 3.9.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9826,7 +9826,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/PickNikRobotics/rviz_visual_tools-release.git
-      version: 3.9.1-1
+      version: 3.9.2-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/rviz_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `3.9.2-1`:

- upstream repository: https://github.com/PickNikRobotics/rviz_visual_tools.git
- release repository: https://github.com/PickNikRobotics/rviz_visual_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.9.1-1`

## rviz_visual_tools

```
* Cleanup for new Ubuntu versions (#215 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/215>)
* spin independent thread for RemoteControl (#224 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/224>)
  Avoid deadlocks and cross-thread effects with other callbacks.
* Migrate CI to Github Actions (#197 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/197>)
* migrate to <random> (#195 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/195>)
* Fix bugtracker typo (#186 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/186>)
* Contributors: Jochen Sprickerhof, Michael Görner, Nathan Brooks, Vatan Aksoy Tezer
```
