### PR TITLE
vision_opencv: 3.0.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -7183,7 +7183,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 2.2.1-1
+      version: 3.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
#34556 accidentally broke api.
#34582 reverted the release, without running bloom.
#34583 fixed the broken api, but broke build on windows (this wasn't merged into rosdistro)
This release (#34596) fixes the broken windows build.

Increasing version of package(s) in repository `vision_opencv` to `3.0.6-1`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros2-gbp/vision_opencv-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.1-1`

## cv_bridge

```
* Fix windows build when Boost 1.67 or newer (#488 <https://github.com/ros-perception/vision_opencv/issues/488>)
* Contributors: Kenji Brameld
```

## image_geometry

- No changes

## vision_opencv

- No changes
