### PR TITLE
vision_opencv: 3.1.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -6373,7 +6373,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 2.2.1-2
+      version: 3.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
#34555 accidentally broke api.
#34582 reverted the release, without running bloom.
#34584 fixed the broken api, but broke build on windows (this wasn't merged into rosdistro)
This release (#34597) fixes the broken windows build.

Increasing version of package(s) in repository `vision_opencv` to `3.1.2-1`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros2-gbp/vision_opencv-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.1-2`

## cv_bridge

```
* Fix windows build when Boost 1.67 or newer (#489 <https://github.com/ros-perception/vision_opencv/issues/489>)
* Contributors: Kenji Brameld
```

## image_geometry

- No changes

## vision_opencv

- No changes
