### PR TITLE
vision_opencv: 3.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5959,7 +5959,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 3.3.0-1
+      version: 3.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `3.3.1-1`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros2-gbp/vision_opencv-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.3.0-1`

## cv_bridge

```
* export rclcpp as dependency (#491 <https://github.com/ros-perception/vision_opencv/issues/491>)
* silence dperecation warnings using boost macros (#478 <https://github.com/ros-perception/vision_opencv/issues/478>)
* Contributors: Kenji Brameld
```

## image_geometry

- No changes

## vision_opencv

- No changes
