### PR TITLE
vision_opencv: 3.2.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6224,7 +6224,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 3.2.0-1
+      version: 3.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `3.2.1-1`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros2-gbp/vision_opencv-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.2.0-1`

## cv_bridge

```
* silence dperecation warnings using boost macros (#492 <https://github.com/ros-perception/vision_opencv/issues/492>)
* Contributors: Kenji Brameld
```

## image_geometry

- No changes

## vision_opencv

- No changes
