### PR TITLE
Set Fast-DDS devel branch to 2.7.x in Rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1009,7 +1009,7 @@ repositories:
       test_pull_requests: false
       type: git
       url: https://github.com/eProsima/Fast-DDS.git
-      version: master
+      version: 2.7.x
     status: maintained
   filters:
     doc:


### PR DESCRIPTION
The master branch references an as-yet-unreleased 2.8.0 and Rolling is currently tracking the 2.7.x branch[1] in the meantime.

[1]: https://github.com/eprosima/fast-dds/tree/2.7.x
