### PR TITLE
slider_publisher: 2.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6273,7 +6273,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/oKermorgant/slider_publisher-release.git
-      version: 2.1.1-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/oKermorgant/slider_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `slider_publisher` to `2.2.0-1`:

- upstream repository: https://github.com/oKermorgant/slider_publisher.git
- release repository: https://github.com/oKermorgant/slider_publisher-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.1-1`

## slider_publisher

```
* add python3-scipy and numpy dependencies
* rate and config parameters
* Contributors: Olivier Kermorgant
```
