### PR TITLE
leo_robot: 1.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1946,11 +1946,12 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/leo_robot-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_robot-ros2.git
       version: humble
+    status: maintained
   lgsvl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_robot` to `1.2.0-1`:

- upstream repository: https://github.com/LeoRover/leo_robot-ros2.git
- release repository: https://github.com/ros2-gbp/leo_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-1`

## leo_bringup

```
* Add image_proc to dependencies
* Run v4l2_camera node in container together with image_proc nodes
* Add camera calibration file
* Contributors: Błażej Sowa
```

## leo_fw

```
* Fix test_hw script
* Update leocore firmware to version 1.0.1
* Contributors: Błażej Sowa
```

## leo_robot

- No changes
