### PR TITLE
leo_desktop: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1927,7 +1927,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/leo_desktop-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_desktop-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_desktop` to `1.1.0-1`:

- upstream repository: https://github.com/LeoRover/leo_desktop-ros2.git
- release repository: https://github.com/ros2-gbp/leo_desktop-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-1`

## leo_desktop

- No changes

## leo_viz

```
* Use compressed image topic for camera images in rviz config
* Contributors: Błażej Sowa
```
