### PR TITLE
system_fingerprint: 0.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5205,6 +5205,22 @@ repositories:
       url: https://github.com/open-rmf/stubborn_buddies.git
       version: main
     status: developed
+  system_fingerprint:
+    doc:
+      type: git
+      url: https://github.com/MetroRobots/ros_system_fingerprint.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/MetroRobots/ros_system_fingerprint-release.git
+      version: 0.5.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/MetroRobots/ros_system_fingerprint.git
+      version: ros2
+    status: developed
   system_modes:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `system_fingerprint` to `0.5.0-1`:

- upstream repository: https://github.com/MetroRobots/ros_system_fingerprint.git
- release repository: https://github.com/MetroRobots/ros_system_fingerprint-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
