### PR TITLE
rtcm_msgs: 1.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6073,7 +6073,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/nobleo/rtcm_msgs-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/tilk/rtcm_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtcm_msgs` to `1.1.1-1`:

- upstream repository: https://github.com/tilk/rtcm_msgs.git
- release repository: https://github.com/nobleo/rtcm_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-1`
