### PR TITLE
add rviz_2d_overlay_plugins repo to rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4933,6 +4933,12 @@ repositories:
       url: https://github.com/ros2/rviz.git
       version: rolling
     status: maintained
+  rviz_2d_overlay_plugins:
+    source:
+      type: git
+      url: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git
+      version: main
+    status: maintained
   rviz_visual_tools:
     doc:
       type: git


### PR DESCRIPTION
Adding new repository https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins to `rolling` as requested in https://github.com/ros2-gbp/ros2-gbp-github-org/issues/112#issuecomment-1242351309,
for the purpose of releasing the packages
* [rviz_2d_overlay_msgs](https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins/tree/main/rviz_2d_overlay_msgs)
* [rviz_2d_overlay_plugins](https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins/tree/main/rviz_2d_overlay_plugins)

(follow up from #34422)

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
