### PR TITLE
qb_hand: 3.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9820,11 +9820,12 @@ repositories:
       - qb_hand
       - qb_hand_control
       - qb_hand_description
+      - qb_hand_gazebo
       - qb_hand_hardware_interface
       tags:
         release: release/melodic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbhand-ros-release.git
-      version: 2.0.0-1
+      version: 3.0.2-1
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbhand-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_hand` to `3.0.2-1`:

- upstream repository: https://bitbucket.org/qbrobotics/qbhand-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbhand-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-1`

## qb_hand

- No changes

## qb_hand_control

- No changes

## qb_hand_description

```
* FEAT: Added end effector link.
* FEAT: Added xacro macro to build qb SoftHand Research with 90 deg flange
```

## qb_hand_hardware_interface

- No changes
