### PR TITLE
qb_hand: 3.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7560,7 +7560,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbhand-ros-release.git
-      version: 2.2.2-1
+      version: 3.0.2-1
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbhand-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_hand` to `3.0.2-1`:

- upstream repository: https://bitbucket.org/qbrobotics/qbhand-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbhand-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.2.2-1`

## qb_hand

- No changes

## qb_hand_control

- No changes

## qb_hand_description

```
* FEAT: Added end effector link.
* FEAT: Added xacro macro to build qb SoftHand Research with 90 deg flange
```

## qb_hand_hardware_interface

- No changes
