### PR TITLE
Add python3-mako rule

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2564,9 +2564,7 @@ python-mako:
   debian: [python-mako]
   fedora: [python-mako]
   gentoo: [dev-python/mako]
-  ubuntu:
-    '*': [python3-mako]
-    bionic: [python-mako]
+  ubuntu: [python-mako]
 python-mapnik:
   debian: [python-mapnik]
   fedora: [mapnik-python]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2564,7 +2564,9 @@ python-mako:
   debian: [python-mako]
   fedora: [python-mako]
   gentoo: [dev-python/mako]
-  ubuntu: [python-mako]
+  ubuntu:
+    '*': [python3-mako]
+    bionic: [python-mako]
 python-mapnik:
   debian: [python-mapnik]
   fedora: [mapnik-python]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6716,6 +6716,12 @@ python3-lxml:
       packages: [lxml]
   rhel: ['python%{python3_pkgversion}-lxml']
   ubuntu: [python3-lxml]
+python3-mako:
+  debian: [python3-mako]
+  fedora: [python-mako]
+  gentoo: [dev-python/mako]
+  opensuse: [python3-Mako]
+  ubuntu: [python3-mako]
 python3-mapbox-earcut-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6721,6 +6721,9 @@ python3-mako:
   fedora: [python-mako]
   gentoo: [dev-python/mako]
   opensuse: [python3-Mako]
+  rhel:
+    '*': ['python%{python3_pkgversion}-mako']
+    '7': null
   ubuntu: [python3-mako]
 python3-mapbox-earcut-pip:
   debian:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please update the following dependency to the rosdep database. The `python-mako` package is not available for Ubuntu after focal. This change allows for the `python3-mako` package to be installed for newer versions of Ubuntu. 

## Package name:

python3-mako

## Package Upstream Source:

https://www.makotemplates.org/

## Purpose of using this:

This is an existing package already in the rosdep index.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - REQUIRED
  - https://packages.debian.org/buster/python-mako
  - https://packages.debian.org/buster/python3-mako
- Ubuntu: https://packages.ubuntu.com/
   - REQUIRED
   - https://packages.ubuntu.com/focal/python-mako
   - https://packages.ubuntu.com/focal/python3-mako
- Fedora: https://packages.fedoraproject.org/
  - IF AVAILABLE
  - https://packages.fedoraproject.org/pkgs/python-mako/python3-mako/
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
  - https://packages.gentoo.org/packages/dev-python/mako
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/
  - IF AVAILABLE
