### PR TITLE
Rename ros_system_fingerprint + version increase

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8702,22 +8702,6 @@ repositories:
       url: https://github.com/ros/ros_realtime.git
       version: noetic-devel
     status: maintained
-  ros_system_fingerprint:
-    doc:
-      type: git
-      url: https://github.com/MetroRobots/ros_system_fingerprint.git
-      version: noetic
-    release:
-      tags:
-        release: release/noetic/{package}/{version}
-      url: https://github.com/MetroRobots/ros_system_fingerprint-release.git
-      version: 0.3.0-1
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/MetroRobots/ros_system_fingerprint.git
-      version: noetic
-    status: developed
   ros_tutorials:
     doc:
       type: git
@@ -10472,6 +10456,22 @@ repositories:
       type: git
       url: https://github.com/swri-robotics/swri_profiler.git
       version: master
+    status: developed
+  system_fingerprint:
+    doc:
+      type: git
+      url: https://github.com/MetroRobots/ros_system_fingerprint.git
+      version: noetic
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/MetroRobots/ros_system_fingerprint-release.git
+      version: 0.6.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/MetroRobots/ros_system_fingerprint.git
+      version: noetic
     status: developed
   taskflow:
     release:


### PR DESCRIPTION
I ran bloom to bump the version up to 0.6.0, but since I'm trying to rename the key, I'm making the PR manually. 

The differences between this and the bloom-suggested PR include
 * Change name of key `ros_system_fingerprint` to `system_fingerprint`
 * The yaml is reordered to put the entry in the right place alphabetically. 
 * The `packages` section is left off because **I'm guessing** that the name of the package is not needed when it matches the key. 


---



Increasing version of package(s) in repository `ros_system_fingerprint` to `0.6.0-1`:

- upstream repository: https://github.com/MetroRobots/ros_system_fingerprint.git
- release repository: https://github.com/MetroRobots/ros_system_fingerprint-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.0-1`
