### PR TITLE
depthai: 2.17.4-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -730,7 +730,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/luxonis/depthai-core-release.git
-      version: 2.17.3-1
+      version: 2.17.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai` to `2.17.4-1`:

- upstream repository: https://github.com/luxonis/depthai-core.git
- release repository: https://github.com/luxonis/depthai-core-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.17.3-1`

## depthai

```
* DEPTHAI_WATCHDOG=0 bugfix (245fb57)
* V5 Calibration flashing fix
* FW log level bugfix (#587)
* Updated DeviceBootloader::Config to retain existing values
* PoE watchdog issues addressed (74b699c)
* XLink - kernel driver detach (fixes some USB connectivity issues) (ba9bd8b)
* Added EEPROM clear capability
* Added missing installation of DLL files (#550)
* Asset RPC refactor
* Exposed Device::getAllConnectedDevices()
* Exposed FW & BL versions
* Contributors: Alex Bougdan, Szabolcs Gergely, Martin Peterlin
```
