### PR TITLE
Add python3-scipy rule for RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8608,6 +8608,7 @@ python3-scipy:
     pip:
       depends: [gfortran]
       packages: [scipy]
+  rhel: ['python%{python3_pkgversion}-scipy']
   ubuntu: [python3-scipy]
 python3-scp:
   debian: [python3-scp]


### PR DESCRIPTION
In RHEL 7, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/python3-scipy/python36-scipy/
In RHEL 8, this package is provided by AppStream: https://repo.almalinux.org/almalinux/8/AppStream/x86_64/os/Packages/python3-scipy-1.0.0-21.module_el8.5.0+2569+5c5719bc.x86_64.rpm