### PR TITLE
webots_ros2: 2022.1.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -6479,7 +6479,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/webots_ros2-release.git
-      version: 1.2.3-1
+      version: 2022.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `webots_ros2` to `2022.1.0-1`:

- upstream repository: https://github.com/cyberbotics/webots_ros2.git
- release repository: https://github.com/ros2-gbp/webots_ros2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.3-1`

## webots_ros2

```
* Adapted controllers to communicate with Webots R2022b.
* Added feature to import URDF on the fly.
* Add PointCloud2 support for RangeFinder.
```

## webots_ros2_driver

```
* Added an URDF importer feature to spawn robots from URDF files.
```

## webots_ros2_importer

```
* Upgraded to urdf2webots 2.0.0
```

## webots_ros2_msgs

```
* Added URDF robot messages
```

## webots_ros2_universal_robot

```
* The 'robot' and 'moveit_demo' scenarios now show a use case of the new URDF importer.
```
