### PR TITLE
gps_umd: 1.0.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1636,7 +1636,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/swri-robotics/gps_umd.git
-      version: dashing-devel
+      version: foxy-devel
     release:
       packages:
       - gps_msgs
@@ -1651,7 +1651,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/swri-robotics/gps_umd.git
-      version: dashing-devel
+      version: foxy-devel
     status: developed
   graph_msgs:
     doc:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1646,7 +1646,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/swri-robotics-gbp/gps_umd-release.git
-      version: 1.0.5-2
+      version: 1.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_umd` to `1.0.6-1`:

- upstream repository: https://github.com/swri-robotics/gps_umd.git
- release repository: https://github.com/swri-robotics-gbp/gps_umd-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.5-2`

## gps_msgs

- No changes

## gps_tools

- No changes

## gps_umd

- No changes

## gpsd_client

```
* Fixing Foxy regression (#67 <https://github.com/swri-robotics/gps_umd/issues/67>)
  Addresses https://github.com/swri-robotics/gps_umd/issues/66
* Contributors: David Anthony
```
