### PR TITLE
microstrain_inertial: 2.7.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6707,7 +6707,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/LORD-MicroStrain/microstrain_inertial-release.git
-      version: 2.6.0-1
+      version: 2.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `2.7.0-1`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/LORD-MicroStrain/microstrain_inertial-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.6.0-1`

## microstrain_inertial_driver

```
* ROS serial improvements (#177 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/177>)
  * Adds logging loop every second that will print the number of bytes read and written
  * Adds ability to configure the baudrate on the device using set_baud
  * Changes *_data_rate fields to floating point numbers to allow users to configure data rates at non whole numbers
  * Fixes bug where a quaternion would be indexed into before it was populated
* ROS Updates params file to note required changes for devices, and corrects incorrect documentation (#170 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/170>)
* Contributors: Rob
```

## microstrain_inertial_examples

- No changes

## microstrain_inertial_msgs

- No changes

## microstrain_inertial_rqt

- No changes
