### PR TITLE
microstrain_inertial: 2.7.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2257,7 +2257,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/microstrain_inertial-release.git
-      version: 2.6.0-1
+      version: 2.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `2.7.0-1`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/ros2-gbp/microstrain_inertial-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.6.0-1`

## microstrain_inertial_driver

```
* ROS2 serial improvements (#177 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/178>)
  * Adds logging loop every second that will print the number of bytes read and written
  * Adds ability to configure the baudrate on the device using set_baud
  * Changes *_data_rate fields to floating point numbers to allow users to configure data rates at non whole numbers
  * Fixes bug where a quaternion would be indexed into before it was populated
* ROS2 Updates params file to note required changes for devices, and corrects incorrect documentation (#170 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/169>)
* Contributors: Rob
```

## microstrain_inertial_examples

- No changes

## microstrain_inertial_msgs

- No changes

## microstrain_inertial_rqt

- No changes
