### PR TITLE
Add python3-dbus rule for RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6382,6 +6382,7 @@ python3-dbus:
   debian: [python3-dbus]
   fedora: [python3-dbus]
   nixos: [python3Packages.dbus-python]
+  rhel: [python3-dbus]
   ubuntu: [python3-dbus]
 python3-decorator:
   debian: [python3-decorator]


### PR DESCRIPTION
In RHEL 7, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/python3-dbus/python36-dbus/
In RHEL 8, this package is part of BaseOS: https://repo.almalinux.org/almalinux/8/BaseOS/x86_64/os/Packages/python3-dbus-1.2.4-15.el8.x86_64.rpm