### PR TITLE
Add python3-whichcraft rule for RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9366,6 +9366,9 @@ python3-whichcraft:
   fedora: [python3-whichcraft]
   gentoo: [dev-python/whichcraft]
   nixos: [python3Packages.whichcraft]
+  rhel:
+    '*': [python3-whichcraft]
+    '7': null
   ubuntu: [python3-whichcraft]
 python3-wrapt:
   arch: [python-wrapt]


### PR DESCRIPTION
This package is not available for RHEL 7, but is part of EPEL in RHEL 8: https://packages.fedoraproject.org/pkgs/python-whichcraft/python3-whichcraft/