### PR TITLE
mavros: 1.14.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4945,7 +4945,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 1.13.0-1
+      version: 1.14.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `1.14.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.13.0-1`

## libmavconn

```
* libmavconn: fix MAVLink v1.0 output selection
  Fix #1787 <https://github.com/mavlink/mavros/issues/1787>
* Merge pull request #1775 <https://github.com/mavlink/mavros/issues/1775> from acxz/find-geographiclib
  use already installed FindGeographicLib.cmake
* use already installed FindGeographicLib.cmake
* Contributors: Vladimir Ermakov, acxz
```

## mavros

```
* scripts: waypoint and param files are text, not binary
  Fix #1784 <https://github.com/mavlink/mavros/issues/1784>
* Merge pull request #1780 <https://github.com/mavlink/mavros/issues/1780> from snktshrma/master
  guided_target: accept position-target-global-int messages
* plugins: add guided_target to accept offboard position targets
  Update guided_target.cpp
  Update guided_target.cpp
  Update mavros_plugins.xml
  Update CMakeLists.txt
  Added offboard_position.cpp
  Update apm_config.yaml
  Update offboard_position.cpp
  Update offboard_position.cpp
  Rename offboard_position.cpp to guided_target.cpp
  Update CMakeLists.txt
  Update mavros_plugins.xml
  Update apm_config.yaml
  Update guided_target.cpp
* Merge pull request #1775 <https://github.com/mavlink/mavros/issues/1775> from acxz/find-geographiclib
  use already installed FindGeographicLib.cmake
* add cmake module path for geographiclib on debian based systems
* Merge pull request #1744 <https://github.com/mavlink/mavros/issues/1744> from amilcarlucas/pr_gimbal_diagnostics_fixes
  mount_control.cpp: detect MOUNT_ORIENTATION stale messages
* mount_control.cpp: detect MOUNT_ORIENTATION stale messages
  correct MountConfigure response success
  correct constructor initialization order
  some gimbals send negated/inverted angle measurements, correct that to obey the MAVLink frame convention using run-time parameters
* Merge pull request #1743 <https://github.com/mavlink/mavros/issues/1743> from amilcarlucas/pr_apm_config
  apm_config.yaml: add mount configuration
* apm_config.yaml: add mount configuration
* Merge pull request #1732 <https://github.com/mavlink/mavros/issues/1732> from amilcarlucas/pr-meminfo-fix
  MEMINFO fixes
* sys_status.cpp fix free memory for values > 64KiB
* Merge pull request #1716 <https://github.com/mavlink/mavros/issues/1716> from amilcarlucas/avoid-harcoded-values
  sys_status.cpp: do not use harcoded constants
* Merge pull request #1711 <https://github.com/mavlink/mavros/issues/1711> from amilcarlucas/diagnose-up-to-n-batteries
  Diagnose up-to 10 batteries
* *_config.yaml: document usage of multiple batteries diagnostics
* sys_status.cpp: fix compilation
* sys_status.cpp: support diagnostics on up-to 10 batteries
  Uses as many battery monitors as the user specified in min_voltage parameter.
  Add myself as a contributor, this is not my first patch to this file
* Merge pull request #1712 <https://github.com/mavlink/mavros/issues/1712> from amilcarlucas/fix-disabled-diagnostics
  sys_status.cpp: fix enabling of mem_diag and hwst_diag
* sys_status.cpp: do not use harcoded constants
* sys_status.cpp: Timeout on MEMINFO and HWSTATUS mavlink messages and publish on the diagnostics
  Use atomic variable to prevent potential threading problems
* sys_status.cpp: fix enabling of mem_diag and hwst_diag
* Merge pull request #1704 <https://github.com/mavlink/mavros/issues/1704> from amilcarlucas/correct-bat-voltages
  sys_status.cpp: Do not use battery1 voltage for all batteries.
* sys_status.cpp: Do not use battery1 voltage as voltage for all other batteries (bugfix).
  Support both cell and total voltages above 65V
  Support up-to 14S batteries
  If available, add cell voltage information to the battery diagnostic
* Merge pull request #1707 <https://github.com/mavlink/mavros/issues/1707> from amilcarlucas/ignore-gimbal-sys-status
  sys_status.cpp: ignore sys_status mavlink messages from gimbals
* sys_status.cpp: ignore sys_status mavlink messages from gimbals
* Merge pull request #1703 <https://github.com/mavlink/mavros/issues/1703> from amilcarlucas/remove-deprecated-battery2
  sys_status.cpp: remove deprecated BATTERY2 mavlink message support
* sys_status.cpp: remove deprecated BATTERY2 mavlink message support
* Merge pull request #1696 <https://github.com/mavlink/mavros/issues/1696> from okalachev/patch-2
  Disable startup_px4_usb_quirk in px4_config.yaml
* Disable startup_px4_usb_quirk in px4_config.yaml
* Contributors: Dr.-Ing. Amilcar do Carmo Lucas, Karthik Desai, Oleg Kalachev, Sanket Sharma, Vladimir Ermakov, acxz
```

## mavros_extras

```
* Merge pull request #1780 <https://github.com/mavlink/mavros/issues/1780> from snktshrma/master
  guided_target: accept position-target-global-int messages
* plugins: add guided_target to accept offboard position targets
  Update guided_target.cpp
  Update guided_target.cpp
  Update mavros_plugins.xml
  Update CMakeLists.txt
  Added offboard_position.cpp
  Update apm_config.yaml
  Update offboard_position.cpp
  Update offboard_position.cpp
  Rename offboard_position.cpp to guided_target.cpp
  Update CMakeLists.txt
  Update mavros_plugins.xml
  Update apm_config.yaml
  Update guided_target.cpp
* Merge pull request #1744 <https://github.com/mavlink/mavros/issues/1744> from amilcarlucas/pr_gimbal_diagnostics_fixes
  mount_control.cpp: detect MOUNT_ORIENTATION stale messages
* mount_control.cpp: detect MOUNT_ORIENTATION stale messages
  correct MountConfigure response success
  correct constructor initialization order
  some gimbals send negated/inverted angle measurements, correct that to obey the MAVLink frame convention using run-time parameters
* Merge pull request #1727 <https://github.com/mavlink/mavros/issues/1727> from BV-OpenSource/pr-cellular-status
  Pr cellular status
* uncrustify cellular_status.cpp
* Add CellularStatus plugin and message
* Merge pull request #1702 <https://github.com/mavlink/mavros/issues/1702> from amilcarlucas/mount_diagnostics
  Mount control plugin: add configurable diagnostics
* mount_control.cpp: use mount_nh for params to keep similarities with other plugins
  set diag settings before add()
* Mount control plugin: add configurable diagnostics
* Merge pull request #1700 <https://github.com/mavlink/mavros/issues/1700> from oroelipas/fix-obstacle-distance
  Fix obstacle distance
* Bugfix: increment_f had no value asigned when input LaserScan was bigger than obstacle.distances.size()
* Bugfix: wrong interpolation when the reduction ratio (scale_factor) is not integer.
* Contributors: Dr.-Ing. Amilcar do Carmo Lucas, Rui Mendes, Sanket Sharma, Vladimir Ermakov, oroel
```

## mavros_msgs

```
* Merge pull request #1742 <https://github.com/mavlink/mavros/issues/1742> from amilcarlucas/correct_rpm_units
  ESCTelemetryItem.msg: correct RPM units
* ESCTelemetryItem.msg: correct RPM units
* Merge pull request #1727 <https://github.com/mavlink/mavros/issues/1727> from BV-OpenSource/pr-cellular-status
  Pr cellular status
* Add CellularStatus plugin and message
* Contributors: Dr.-Ing. Amilcar do Carmo Lucas, Rui Mendes, Vladimir Ermakov
```

## test_mavros

- No changes
