### PR TITLE
slider_publisher: 2.2.1-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6272,8 +6272,8 @@ repositories:
     release:
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/oKermorgant/slider_publisher-release.git
-      version: 2.2.0-1
+      url: https://github.com/ros2-gbp/slider_publisher-release
+      version: 2.2.1-2
     source:
       type: git
       url: https://github.com/oKermorgant/slider_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `slider_publisher` to `2.2.1-2`:

- upstream repository: https://github.com/oKermorgant/slider_publisher.git
- release repository: https://github.com/ros2-gbp/slider_publisher-release
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.0-1`

## slider_publisher

```
* remove py extension, fix rate default value
* switch to CMake to avoid deprecation messages
* Contributors: Olivier Kermorgant
```
