### PR TITLE
genmsg: 0.5.16-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3781,7 +3781,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/genmsg-release.git
-      version: 0.5.16-1
+      version: 0.5.16-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genmsg` to `0.5.16-2`:

- upstream repository: git@github.com:ros/genmsg.git
- release repository: https://github.com/ros-gbp/genmsg-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.5.16-1`

## genmsg

```
* fix comment handling in service spec string constants (#92 <https://github.com/ros/genmsg/issues/92>)
```
