### PR TITLE
ros_image_to_qimage: 0.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4137,7 +4137,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_image_to_qimage-release.git
-      version: 0.3.0-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/ros-sports/ros_image_to_qimage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_image_to_qimage` to `0.4.0-1`:

- upstream repository: https://github.com/ros-sports/ros_image_to_qimage.git
- release repository: https://github.com/ros2-gbp/ros_image_to_qimage-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.0-1`

## ros_image_to_qimage

```
* Ensure bgr8 gets converted to rgb8 (#21 <https://github.com/ros-sports/ros_image_to_qimage/issues/21>)
* Add functionality to convert mono colors too (#18 <https://github.com/ros-sports/ros_image_to_qimage/issues/18>)
* Add tests for cpp (#13 <https://github.com/ros-sports/ros_image_to_qimage/issues/13>)
* Add python API (#5 <https://github.com/ros-sports/ros_image_to_qimage/issues/5>)
* Fix README.md (#4 <https://github.com/ros-sports/ros_image_to_qimage/issues/4>)
* Contributors: Kenji Brameld
```
