### PR TITLE
rqt_image_overlay: 0.0.8-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4766,7 +4766,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_overlay-release.git
-      version: 0.0.7-1
+      version: 0.0.8-1
     source:
       type: git
       url: https://github.com/ros-sports/rqt_image_overlay.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_image_overlay` to `0.0.8-1`:

- upstream repository: https://github.com/ros-sports/rqt_image_overlay.git
- release repository: https://github.com/ros2-gbp/rqt_image_overlay-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.7-1`

## rqt_image_overlay

```
* Correctly map ImageManager list model index to topic vector (#47 <https://github.com/ros-sports/rqt_image_overlay/issues/47>)
* Contributors: Kenji Brameld, Marcel Zeilinger
```

## rqt_image_overlay_layer

- No changes
