### PR TITLE
gencpp: 0.6.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3725,7 +3725,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/gencpp-release.git
-      version: 0.6.5-1
+      version: 0.6.6-1
     source:
       type: git
       url: https://github.com/ros/gencpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gencpp` to `0.6.6-1`:

- upstream repository: git@github.com:ros/gencpp.git
- release repository: https://github.com/ros-gbp/gencpp-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.5-1`

## gencpp

```
* Fix usage of deprecated std::allocator::rebind (#51 <https://github.com/ros/gencpp/issues/51>)
* Remove unnecessary map include (#48 <https://github.com/ros/gencpp/issues/48>)
* Contributors: Markus Vieth, poggenhans
```
