### PR TITLE
Add python3-formant-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6795,6 +6795,13 @@ python3-flask-sqlalchemy:
     '*': [python3-flask-sqlalchemy]
     '7': null
   ubuntu: [python3-flask-sqlalchemy]
+python3-formant-pip:
+  debian:
+    pip:
+      packages: [formant]
+  ubuntu:
+    pip:
+      packages: [formant]
 python3-funcsigs:
   debian: [python3-funcsigs]
   fedora: [python3-funcsigs]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`python3-formant-pip`

## Package Upstream Source:

https://pypi.org/project/formant/

## Purpose of using this:

"[Formant](https://formant.io/) is a cloud platform built for modern robotics companies."

They support ROS1 and [ROS2 integrations](https://github.com/FormantIO/ros2-adapter), and this Python package is the SDK used to talk to their cloud platform.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - not available
- Ubuntu: https://packages.ubuntu.com/
   - not available
- Fedora: https://packages.fedoraproject.org/
  - not available
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available
- openSUSE: https://software.opensuse.org/package/
  - not available
