### PR TITLE
rosbag2: 0.9.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4384,7 +4384,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.9.1-3
+      version: 0.9.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Closes https://github.com/ros2/rosbag2/issues/1100

Increasing version of package(s) in repository `rosbag2` to `0.9.2-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.9.1-3`

## ros2bag

- No changes

## rosbag2

- No changes

## rosbag2_compression

- No changes

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Enable sanitizers only if code actually can run (#572 <https://github.com/ros2/rosbag2/issues/572>) (#952 <https://github.com/ros2/rosbag2/issues/952>)
* Add API samples for writing to bags programmatically (#869 <https://github.com/ros2/rosbag2/issues/869>)
* Fix discovery silently stops after unknown msg type is found. (#848 <https://github.com/ros2/rosbag2/issues/848>) (#858 <https://github.com/ros2/rosbag2/issues/858>)
* Contributors: Emerson Knapp, Geoffrey Biggs, Jacob Perron
```

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

```
* [backport galactic] Fix build of benchmarking package (#881 <https://github.com/ros2/rosbag2/issues/881>, #882 <https://github.com/ros2/rosbag2/issues/882>) (#883 <https://github.com/ros2/rosbag2/issues/883>)
* Contributors: Adam Dąbrowski
```

## rosbag2_py

```
* Add stopRecording into rosbag2_py (#854 <https://github.com/ros2/rosbag2/issues/854>) (#995 <https://github.com/ros2/rosbag2/issues/995>)
* [backport galactic] Fix ros2 bag record race at startup (#911 <https://github.com/ros2/rosbag2/issues/911>)
* Contributors: Afonso da Fonseca Braga, Ivan Santiago Paunovic
```

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

```
* allow for implementation of composable recorder via inheritance (#892 <https://github.com/ros2/rosbag2/issues/892>)
* Fix discovery silently stops after unknown msg type is found. (#848 <https://github.com/ros2/rosbag2/issues/848>) (#858 <https://github.com/ros2/rosbag2/issues/858>)
* [backport galactic] recording with --all and --exclude fix (#765 <https://github.com/ros2/rosbag2/issues/765>) (#825 <https://github.com/ros2/rosbag2/issues/825>)
* Contributors: Bernd Pfrommer, Cameron Miller, Emerson Knapp
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
