### PR TITLE
ecl_lite: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -871,7 +871,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_lite-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_lite` to `1.2.0-1`:

- upstream repository: https://github.com/stonier/ecl_lite.git
- release repository: https://github.com/yujinrobot-release/ecl_lite-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-1`

## ecl_sigslots_lite

```
* [sigslots_lite] new c++14 insists on const expr init in the same translation unit, #38 <https://github.com/stonier/ecl_lite/pull/38>
```
