### PR TITLE
sophus: 1.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5154,7 +5154,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/yujinrobot-release/sophus-release.git
-      version: 1.2.1-1
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/stonier/sophus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sophus` to `1.3.1-1`:

- upstream repository: https://github.com/stonier/sophus.git
- release repository: https://github.com/yujinrobot-release/sophus-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.1-1`
