### PR TITLE
sophus: 1.3.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5415,6 +5415,21 @@ repositories:
       url: https://github.com/OUXT-Polaris/sol_vendor.git
       version: main
     status: developed
+  sophus:
+    doc:
+      type: git
+      url: https://github.com/stonier/sophus.git
+      version: release/1.3.x
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/yujinrobot-release/sophus-release.git
+      version: 1.3.1-1
+    source:
+      type: git
+      url: https://github.com/stonier/sophus.git
+      version: release/1.3.x
+    status: maintained
   spdlog_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sophus` to `1.3.1-1`:

- upstream repository: https://github.com/stonier/sophus.git
- release repository: https://github.com/yujinrobot-release/sophus-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
