### PR TITLE
rmf_internal_msgs: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3534,6 +3534,8 @@ repositories:
       - rmf_fleet_msgs
       - rmf_ingestor_msgs
       - rmf_lift_msgs
+      - rmf_obstacle_msgs
+      - rmf_scheduler_msgs
       - rmf_site_map_msgs
       - rmf_task_msgs
       - rmf_traffic_msgs
@@ -3541,7 +3543,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
-      version: 2.0.0-1
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_internal_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_internal_msgs` to `3.0.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_internal_msgs.git
- release repository: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-1`
