### PR TITLE
rmf_internal_msgs: 3.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3728,6 +3728,8 @@ repositories:
       - rmf_fleet_msgs
       - rmf_ingestor_msgs
       - rmf_lift_msgs
+      - rmf_obstacle_msgs
+      - rmf_scheduler_msgs
       - rmf_site_map_msgs
       - rmf_task_msgs
       - rmf_traffic_msgs
@@ -3735,7 +3737,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
-      version: 2.0.0-2
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_internal_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_internal_msgs` to `3.0.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_internal_msgs.git
- release repository: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-2`
