### PR TITLE
rviz_2d_overlay_plugins: 1.2.0-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5176,6 +5176,21 @@ repositories:
       url: https://github.com/ros2/rviz.git
       version: humble
     status: maintained
+  rviz_2d_overlay_plugins:
+    release:
+      packages:
+      - rviz_2d_overlay_msgs
+      - rviz_2d_overlay_plugins
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/rviz_2d_overlay_plugins-release.git
+      version: 1.2.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git
+      version: main
+    status: developed
   rviz_visual_tools:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5177,6 +5177,10 @@ repositories:
       version: humble
     status: maintained
   rviz_2d_overlay_plugins:
+    doc:
+      type: git
+      url: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git
+      version: main
     release:
       packages:
       - rviz_2d_overlay_msgs


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_2d_overlay_plugins` to `1.2.0-2`:

- upstream repository: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git
- release repository: https://github.com/ros2-gbp/rviz_2d_overlay_plugins-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## rviz_2d_overlay_msgs

```
* Rename package from overlay_rviz_msgs to rviz_2d_overlay_msgs
* Contributors: Jonas Otto
```

## rviz_2d_overlay_plugins

```
* Add missing dependencies to package.xml
* Fix various compiler-warnings (NFC)
* Rename package from overlay_rviz_plugins to rviz_2d_overlay_plugins
* Contributors: Jonas Otto
```
