### PR TITLE
Revert "webots_ros2: 2022.1.0-1 in 'foxy/distribution.yaml' [bloom] (#34627)"

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -7305,7 +7305,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/webots_ros2-release.git
-      version: 2022.1.0-1
+      version: 1.2.3-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
This reverts commit 2aa28ccae78543621feeec434d95c48a66bfc156.

Hopefully, this will fix the regression before we sync Foxy.

FYI @ad-daniel 