### PR TITLE
jackal: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1959,6 +1959,26 @@ repositories:
       url: https://github.com/ros-visualization/interactive_markers.git
       version: foxy
     status: maintained
+  jackal:
+    doc:
+      type: git
+      url: https://github.com/jackal/jackal.git
+      version: foxy-devel
+    release:
+      packages:
+      - jackal_control
+      - jackal_description
+      - jackal_msgs
+      - jackal_navigation
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/clearpath-gbp/jackal-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/jackal/jackal.git
+      version: foxy-devel
+    status: developed
   jlb_pid:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `1.0.0-1`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## jackal_control

```
* Updated all packages to 0.8.5.
* Added sim support
* Use Substitions for launch files
  Added back CHANGELOG.rst
* Fixed imu filter node name
  Updated scan topic to use /front/scan by default
* Control fixes
* Use IMU filter
* Minor cleanup
* 50Hz controller
* ROS2 jackal_control
* ROS 2 Port
* Contributors: David V. Lu, Roni Kreinin, Tony Baltovski
```

## jackal_description

```
* Updated all packages to 0.8.5.
* Added sim support
* Added Nav2 and slam_toolbox to jackal_navigation
* Control fixes
* Minor cleanup
* Added ros2_control to description
* Remove RViz Dependency
* Hack until lms1xx and pointgrey_camera_description are available
* ROS 2 Port
* Contributors: David V. Lu, Roni Kreinin, Tony Baltovski
```

## jackal_msgs

```
* Updated all packages to 0.8.5.
* Moved MCU messages to jackal_msgs
* Fixed header message
  Removed COLCON_IGNORE
* Version number and description
* Set feedback frequency back to 50hz
* Foxy updates
* ROS 2 Port
* Contributors: David V. Lu, Roni Kreinin, Tony Baltovski
```

## jackal_navigation

```
* Use Substitions for launch files
  Added back CHANGELOG.rst
* Linter fixes
* Fixed imu filter node name
  Updated scan topic to use /front/scan by default
* Added Nav2 and slam_toolbox to jackal_navigation
* ROS 2 Port
* Contributors: David V. Lu, Roni Kreinin
```
