### PR TITLE
rmf_traffic: 2.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3810,7 +3810,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic-release.git
-      version: 2.0.0-2
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_traffic` to `2.0.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_traffic.git
- release repository: https://github.com/ros2-gbp/rmf_traffic-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-2`
