### PR TITLE
Add wall_follower_ros2 repo to humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6328,6 +6328,12 @@ repositories:
       url: https://github.com/vrpn/vrpn.git
       version: master
     status: maintained
+  wall_follower_ros2:
+    source:
+      type: git
+      url: https://github.com/rfzeg/wall_follower_ros2.git
+      version: master
+    status: maintained
   warehouse_ros:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6332,7 +6332,7 @@ repositories:
     source:
       type: git
       url: https://github.com/rfzeg/wall_follower_ros2.git
-      version: master
+      version: main
     status: maintained
   warehouse_ros:
     doc:


### PR DESCRIPTION
Adding new repository:
https://github.com/rfzeg/wall_follower_ros2.git
to humble as requested in
https://github.com/ros2-gbp/ros2-gbp-github-org/issues/99
for the purpose of releasing the package wall_follower_ros2

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
