### PR TITLE
add waymo-open-dataset-tf-2-6-0

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9301,6 +9301,13 @@ python3-watchdog:
   gentoo: [dev-python/watchdog]
   nixos: [python3Packages.watchdog]
   ubuntu: [python3-watchdog]
+python3-waymo-open-dataset-tf-2-6-0-pip:
+  debian:
+    pip:
+      packages: [waymo-open-dataset-tf-2-6-0]
+  ubuntu:
+    pip:
+      packages: [waymo-open-dataset-tf-2-6-0]
 python3-weasyprint-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`python3-waymo-open-dataset-tf-2-6-0-pip`
## Package Upstream Source:

[https://github.com/waymo-research/waymo-open-dataset/](https://github.com/waymo-research/waymo-open-dataset/) 

## Purpose of using this:

Interacting with the Waymo open dataset. The Waymo dataset provides rich sensor data for autonomous vehicle applications.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- PIP: https://pypi.org/project/waymo-open-dataset-tf-2-6-0/