### PR TITLE
generate_parameter_library: 0.2.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1239,7 +1239,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/PickNikRobotics/generate_parameter_library-release.git
-      version: 0.2.5-2
+      version: 0.2.6-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `generate_parameter_library` to `0.2.6-1`:

- upstream repository: https://github.com/PickNikRobotics/generate_parameter_library.git
- release repository: https://github.com/PickNikRobotics/generate_parameter_library-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.5-2`

## generate_parameter_library

```
* Depend on python package (#75 <https://github.com/PickNikRobotics/generate_parameter_library/issues/75>)
* Drop requirement for CMake to 3.16 (#73 <https://github.com/PickNikRobotics/generate_parameter_library/issues/73>)
* Added -- for ros-args to find (#71 <https://github.com/PickNikRobotics/generate_parameter_library/issues/71>)
* Contributors: Michael Wrock, Tyler Weaver
```

## generate_parameter_library_example

- No changes

## generate_parameter_library_py

```
* Depend on python dependencies in package.xml (#74 <https://github.com/PickNikRobotics/generate_parameter_library/issues/74>)
* Contributors: Tyler Weaver
```

## parameter_traits

```
* Remove unused member variable (#77 <https://github.com/PickNikRobotics/generate_parameter_library/issues/77>)
* Depend on tcb_span (#76 <https://github.com/PickNikRobotics/generate_parameter_library/issues/76>)
* Drop requirement for CMake to 3.16 (#73 <https://github.com/PickNikRobotics/generate_parameter_library/issues/73>)
* Contributors: Tyler Weaver
```
