### PR TITLE
ros_image_to_qimage: 0.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4181,7 +4181,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_image_to_qimage-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/ros-sports/ros_image_to_qimage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_image_to_qimage` to `0.4.1-1`:

- upstream repository: https://github.com/ros-sports/ros_image_to_qimage.git
- release repository: https://github.com/ros2-gbp/ros_image_to_qimage-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.0-1`

## ros_image_to_qimage

```
* Change #include cv_bridge.h to cv_bridge.hpp in ros_image_to_qimage.hpp (#27 <https://github.com/ros-sports/ros_image_to_qimage/issues/27>, #28 <https://github.com/ros-sports/ros_image_to_qimage/issues/28>)
* Change python_qt_binding from exec_depend to depend, because it is being used in CMakeLists.txt. (#25 <https://github.com/ros-sports/ros_image_to_qimage/issues/25>)
* Contributors: Kenji Brameld
```
