### PR TITLE
rmf_internal_msgs: 3.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3585,7 +3585,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_internal_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_internal_msgs` to `3.0.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_internal_msgs.git
- release repository: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.0-1`
