### PR TITLE
radar_msgs: 0.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3119,7 +3119,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/radar_msgs-release.git
-      version: 0.2.1-2
+      version: 0.2.2-1
     status: maintained
   random_numbers:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `radar_msgs` to `0.2.2-1`:

- upstream repository: https://github.com/ros-perception/radar_msgs.git
- release repository: https://github.com/ros2-gbp/radar_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.1-2`
