### PR TITLE
Update domain_bridge source branch for Humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -886,7 +886,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/domain_bridge.git
-      version: main
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -896,7 +896,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/domain_bridge.git
-      version: main
+      version: humble
     status: developed
   dynamixel_sdk:
     doc:


### PR DESCRIPTION
New branch can be found here: https://github.com/ros2/domain_bridge/tree/humble