### PR TITLE
nlohmann_json_schema_validator_vendor: 0.1.0-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2433,7 +2433,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nlohmann_json_schema_validator_vendor-release.git
-      version: 0.1.0-3
+      version: 0.1.0-4
     source:
       type: git
       url: https://github.com/open-rmf/nlohmann_json_schema_validator_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nlohmann_json_schema_validator_vendor` to `0.1.0-4`:

- upstream repository: https://github.com/open-rmf/nlohmann_json_schema_validator_vendor
- release repository: https://github.com/ros2-gbp/nlohmann_json_schema_validator_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.0-3`
