### PR TITLE
rviz_2d_overlay_plugins: 1.2.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5176,6 +5176,25 @@ repositories:
       url: https://github.com/ros2/rviz.git
       version: humble
     status: maintained
+  rviz_2d_overlay_plugins:
+    doc:
+      type: git
+      url: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git
+      version: main
+    release:
+      packages:
+      - rviz_2d_overlay_msgs
+      - rviz_2d_overlay_plugins
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/rviz_2d_overlay_plugins-release.git
+      version: 1.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git
+      version: main
+    status: developed
   rviz_visual_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_2d_overlay_plugins` to `1.2.1-1`:

- upstream repository: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git
- release repository: https://github.com/ros2-gbp/rviz_2d_overlay_plugins-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## rviz_2d_overlay_msgs

- No changes

## rviz_2d_overlay_plugins

```
* Add package documentation using doxygen
* add rosdoc2 config
* add readme at package level
* Contributors: Jonas Otto, Dominik Authaler
```
