### PR TITLE
mvsim: 0.4.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2983,6 +2983,21 @@ repositories:
       url: https://github.com/KIT-MRT/mrt_cmake_modules.git
       version: master
     status: maintained
+  mvsim:
+    doc:
+      type: git
+      url: https://github.com/MRPT/mvsim.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/mvsim-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/MRPT/mvsim.git
+      version: master
+    status: developed
   naoqi_bridge_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.4.0-1`:

- upstream repository: https://github.com/MRPT/mvsim.git
- release repository: https://github.com/ros2-gbp/mvsim-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## mvsim

```
* Major new release with tons of new features.
* New sensors: RGB, depth, RGB+D cameras
* Support for ROS1 and ROS2.
* Sensors now can have 3D models.
* New GUI controls to customize visualization.
* New 3 and 4 wheels differential kinematic models.
* Allow "include"s in XML files.
* Add 3D Jackal robot model.
* ROS nodes: publishers in parallel thread
* mvsim-cli new flag to enable full profiling
* Use new nanogui feature to limit GUI refresh rate
* Fix running faster than real-time
* More consistent timestamping of simulated sensors
* mvsim now shows program version info
* get_pose() service now also gets twist
* Fix elevation maps
* pybind11 per-version directory
* Remove trailing '/' in tf frame names for consistency with modern conventions.
* Rename COPYING -> LICENSE
* Contributors: Jose Luis Blanco-Claraco
```
