### PR TITLE
kobuki_velocity_smoother: 0.15.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1760,6 +1760,22 @@ repositories:
       url: https://github.com/ros-tooling/keyboard_handler.git
       version: rolling
     status: developed
+  kobuki_velocity_smoother:
+    doc:
+      type: git
+      url: https://github.com/kobuki-base/kobuki_velocity_smoother.git
+      version: release/0.15.x
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/kobuki_velocity_smoother-release.git
+      version: 0.15.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/kobuki-base/kobuki_velocity_smoother.git
+      version: release/0.15.x
+    status: maintained
   lanelet2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_velocity_smoother` to `0.15.0-1`:

- upstream repository: https://github.com/kobuki-base/kobuki_velocity_smoother.git
- release repository: https://github.com/ros2-gbp/kobuki_velocity_smoother-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## kobuki_velocity_smoother

```
* Rename the package to kobuki_velocity_smoother. (#20 <https://github.com/kobuki-base/kobuki_velocity_smoother/issues/20>)
* Make a few more style fixes for older cpplint. (#18 <https://github.com/kobuki-base/kobuki_velocity_smoother/issues/18>)
* Update the README.md (#17 <https://github.com/kobuki-base/kobuki_velocity_smoother/issues/17>)
* Don't install test artifacts. (#16 <https://github.com/kobuki-base/kobuki_velocity_smoother/issues/16>)
* Minor cleanup of the includes.
* Remove the internal accel_lim_w variable.
* Remove internal accel_lim_v.
* Remove decel_factor internal variable.
* Remove internal decel_lim_w variable.
* Remove internal decel_lim_v variable.
* Remove speed_lim_w internal variable.
* Remove speed_lim_v internal variable.
* Remove the quiet internal variable.
* Make sure to allow other parameters in the list.
* Enable the style checkers, and fix the style to conform. (#14 <https://github.com/kobuki-base/kobuki_velocity_smoother/issues/14>)
* Fix the tests to work with modern ROS 2. (#13 <https://github.com/kobuki-base/kobuki_velocity_smoother/issues/13>)
* Small fix to the velocity smoother. (#12 <https://github.com/kobuki-base/kobuki_velocity_smoother/issues/12>)
* Fix the test so it works with 'colcon test' (#11 <https://github.com/kobuki-base/kobuki_velocity_smoother/issues/11>)
```
