### PR TITLE
Add crete_robot and libcreate repos to foxy

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -824,6 +824,12 @@ repositories:
       url: https://github.com/rt-net/crane_plus.git
       version: foxy-devel
     status: maintained
+  create_robot:
+    source:
+      type: git
+      url: https://github.com/MADdantas/create_robot.git
+      version: foxy
+    status: maintained
   cyclonedds:
     release:
       tags:
@@ -2298,6 +2304,12 @@ repositories:
       url: https://github.com/lgsvl/lgsvl_msgs.git
       version: foxy-devel
     status: developed
+  libcreate:
+    source:
+      type: git
+      url: https://github.com/MADdantas/libcreate.git
+      version: master
+    status: mainteined
   libfranka:
     doc:
       type: git


### PR DESCRIPTION
Adding new repositories:
https://github.com/MADdantas/libcreate.git
https://github.com/MADdantas/create_robot.git
to foxy as requested in
https://github.com/ros2-gbp/ros2-gbp-github-org/issues/130
for the purpose of releasing the packages create_robot and libcreate

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
