### PR TITLE
Add psutil-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7888,6 +7888,16 @@ python3-psutil:
   rhel: ['python%{python3_pkgversion}-psutil']
   slackware: [psutil]
   ubuntu: [python3-psutil]
+python3-psutil-pip:
+  debian:
+    pip:
+      packages: [psutil]
+  fedora:
+    pip:
+      packages: [psutil]
+  ubuntu:
+    pip:
+      packages: [psutil]
 python3-py3exiv2-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

pip/pip3 psutil

## Package Upstream Source:

https://github.com/giampaolo/psutil

## Purpose of using this:

Similar to #34293, the `python3-psutil` version is outdated via apt, so this simply adds the pip definition to be able to use the latest `psutil` library.

### Tags for anyone searching for a solution to this kind of issue in the future:
apt outdated old version pip new

## Links to Distribution Packages

- Pip: https://pypi.org/project/psutil/


