### PR TITLE
slider_publisher: 2.2.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5346,8 +5346,8 @@ repositories:
     release:
       tags:
         release: release/galactic/{package}/{version}
-      url: https://github.com/oKermorgant/slider_publisher-release.git
-      version: 2.2.0-1
+      url: https://github.com/ros2-gbp/slider_publisher-release.git
+      version: 2.2.1-1
     source:
       type: git
       url: https://github.com/oKermorgant/slider_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `slider_publisher` to `2.2.1-1`:

- upstream repository: https://github.com/oKermorgant/slider_publisher.git
- release repository: https://github.com/ros2-gbp/slider_publisher-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.0-1`

## slider_publisher

```
* remove py extension, fix rate default value
* switch to CMake to avoid deprecation messages
* Contributors: Olivier Kermorgant
```
