### PR TITLE
vision_opencv: 1.13.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -14876,7 +14876,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/vision_opencv-release.git
-      version: 1.13.0-0
+      version: 1.13.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `1.13.1-1`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros-gbp/vision_opencv-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.13.0-0`

## cv_bridge

```
* Fix endian mismatch issue per boostorg/python PR #218 <https://github.com/ros-perception/vision_opencv/issues/218>
* Update CMakeLists.txt for Windows build environment (#265 <https://github.com/ros-perception/vision_opencv/issues/265>)
* Remove path splash separator from 'package_dir' (#267 <https://github.com/ros-perception/vision_opencv/issues/267>)
* Fix travis. (#269 <https://github.com/ros-perception/vision_opencv/issues/269>)
* Contributors: Duan Yutong, James Xu, Kenji Brameld, Sean Yen
```

## image_geometry

```
* Update CMakeLists.txt for Windows build environment (#265 <https://github.com/ros-perception/vision_opencv/issues/265>)
* Windows bringup
* Correct binary locations for shared libraries.
* Fix build break.
* Fix cv_bridge_boost.pyd.
* remove hard-coded STATIC (#3 <https://github.com/ros-perception/vision_opencv/issues/3>)
* remove WINDOWS_EXPORT_ALL_SYMBOLS property (#4 <https://github.com/ros-perception/vision_opencv/issues/4>)
* add DLL import/export macros (#266 <https://github.com/ros-perception/vision_opencv/issues/266>)
* update macro names (#2 <https://github.com/ros-perception/vision_opencv/issues/2>)
* add exports.h and dll import/export macros
* Contributors: James Xu
```

## vision_opencv

- No changes
