### PR TITLE
rqt_image_overlay: 0.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4686,7 +4686,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_overlay-release.git
-      version: 0.2.1-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/ros-sports/rqt_image_overlay.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_image_overlay` to `0.3.0-1`:

- upstream repository: https://github.com/ros-sports/rqt_image_overlay.git
- release repository: https://github.com/ros2-gbp/rqt_image_overlay-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.1-1`

## rqt_image_overlay

```
* Change #include of cv_bridge.h to cv_bridge.hpp (#51 <https://github.com/ros-sports/rqt_image_overlay/issues/51>)
* Correctly map ImageManager list model index to topic vector (#46 <https://github.com/ros-sports/rqt_image_overlay/issues/46>)
* Allow depth images to be displayed too (#42 <https://github.com/ros-sports/rqt_image_overlay/issues/42>)
* Add configuration dialog and wait window setting (#41 <https://github.com/ros-sports/rqt_image_overlay/issues/41>)
* Contributors: Kenji Brameld, Marcel Zeilinger
```

## rqt_image_overlay_layer

- No changes
