### PR TITLE
rmf_visualization: 2.0.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3748,7 +3748,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_visualization-release.git
-      version: 2.0.0-1
+      version: 2.0.0-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_visualization` to `2.0.0-2`:

- upstream repository: https://github.com/open-rmf/rmf_visualization.git
- release repository: https://github.com/ros2-gbp/rmf_visualization-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-1`
