### PR TITLE
rmf_visualization: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3923,12 +3923,15 @@ repositories:
       - rmf_visualization
       - rmf_visualization_building_systems
       - rmf_visualization_fleet_states
+      - rmf_visualization_floorplans
+      - rmf_visualization_navgraphs
+      - rmf_visualization_obstacles
       - rmf_visualization_rviz2_plugins
       - rmf_visualization_schedule
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_visualization-release.git
-      version: 1.2.1-3
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_visualization` to `2.0.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_visualization.git
- release repository: https://github.com/ros2-gbp/rmf_visualization-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.1-3`
