### PR TITLE
Add ack rules for Fedora and RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6,7 +6,9 @@ ace:
   ubuntu: [libace-dev]
 ack:
   debian: [ack]
+  fedora: [ack]
   nixos: [ack]
+  rhel: [ack]
   ubuntu:
     '*': [ack]
     xenial: null


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/ack/ack/

In both RHEL 7 and RHEL 8, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/ack/ack/