### PR TITLE
Add fswebcam rules for Fedora and RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1126,7 +1126,11 @@ fsharp:
   nixos: [fsharp]
   ubuntu: [fsharp]
 fswebcam:
+  fedora: [fswebcam]
   nixos: [fswebcam]
+  rhel:
+    '*': [fswebcam]
+    '7': null
   ubuntu: [fswebcam]
 ftdi-eeprom:
   arch: [libftdi]


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/fswebcam/fswebcam/

This package is not available for RHEL 7.
In RHEL 8, this package is provieded by EPEL: https://packages.fedoraproject.org/pkgs/fswebcam/fswebcam/