### PR TITLE
Add libcap-ng-dev rules for Fedora and RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2907,7 +2907,9 @@ libcap-dev:
   ubuntu: [libcap-dev]
 libcap-ng-dev:
   debian: [libcap-ng-dev]
+  fedora: [libcap-ng-devel]
   nixos: [libcap_ng]
+  rhel: [libcap-ng-devel]
   ubuntu: [libcap-ng-dev]
 libcap-ng0:
   debian: [libcap-ng0]


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/libcap-ng/libcap-ng-devel/

In RHEL 7, this package is provided by `os`: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/libcap-ng-devel-0.7.5-4.el7.i686.rpm
In RHEL 8, this package is provided by `BaseOS`: https://repo.almalinux.org/almalinux/8/BaseOS/x86_64/os/Packages/libcap-ng-devel-0.7.11-1.el8.i686.rpm