### PR TITLE
Add libconfig++-dev rules for Fedora and RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2993,8 +2993,10 @@ libcoin80-dev:
     xenial: [libcoin80-dev]
 libconfig++-dev:
   debian: [libconfig++-dev]
+  fedora: [libconfig-devel]
   gentoo: ['dev-libs/libconfig[cxx]']
   nixos: [libconfig]
+  rhel: [libconfig-devel]
   ubuntu: [libconfig++-dev]
 libconfig-dev:
   debian: [libconfig-dev]


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/libconfig/libconfig-devel/

In RHEL 7, this package is provided by `os`: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/libconfig-devel-1.4.9-5.el7.i686.rpm
In RHEL 8, this package is provided by `PowerTools`: https://repo.almalinux.org/almalinux/8/PowerTools/x86_64/os/Packages/libconfig-devel-1.5-9.el8.i686.rpm