### PR TITLE
Add libdpkg-dev rules for Fedora and RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3098,7 +3098,9 @@ libdmtx-dev:
   ubuntu: [libdmtx-dev]
 libdpkg-dev:
   debian: [libdpkg-dev]
+  fedora: [dpkg-devel]
   nixos: [dpkg]
+  rhel: [dpkg-devel]
   ubuntu: [libdpkg-dev]
 libdrm-dev:
   arch: [libdrm]


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/dpkg/dpkg-devel/

In both RHEL 7 and RHEL 8, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/dpkg/dpkg-devel/