### PR TITLE
Add libgdal-dev rules for Fedora and RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3433,8 +3433,10 @@ libgconf2:
   ubuntu: [libgconf-2-4]
 libgdal-dev:
   debian: [libgdal-dev]
+  fedora: [gdal-devel]
   nixos: [gdal]
   opensuse: [gdal-devel]
+  rhel: [gdal-devel]
   ubuntu: [libgdal-dev]
 libgeographiclib-dev:
   debian:


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/gdal/gdal-devel/

In both RHEL 7 and RHEL 8, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/gdal/gdal-devel/