### PR TITLE
Add libjack-dev rules for Fedora and RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3888,6 +3888,8 @@ libiw-dev:
   ubuntu: [libiw-dev]
 libjack-dev:
   debian: [libjack-dev]
+  fedora: [jack-audio-connection-kit-devel]
+  rhel: [jack-audio-connection-kit-devel]
   ubuntu: [libjack-dev]
 libjackson-json-java:
   debian: [libjackson-json-java]


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/jack-audio-connection-kit/jack-audio-connection-kit-devel/

In both RHEL 7 and RHEL 8, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/jack-audio-connection-kit/jack-audio-connection-kit-devel/