### PR TITLE
Add python3-gitlab rules for Fedora and RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6912,7 +6912,11 @@ python3-gitlab:
     stretch:
       pip:
         packages: [python-gitlab]
+  fedora: [python3-gitlab]
   gentoo: [dev-vcs/python-gitlab]
+  rhel:
+    '*': [python3-gitlab]
+    '7': null
   ubuntu:
     '*': [python3-gitlab]
     artful:


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/python-gitlab/python3-gitlab/

This package is not available for RHEL 7.
In RHEL 8, this package is provieded by EPEL: https://packages.fedoraproject.org/pkgs/python-gitlab/python3-gitlab/