### PR TITLE
Add python3-msgpack rules for Fedora and RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7431,8 +7431,10 @@ python3-msgpack:
   debian:
     '*': [python3-msgpack]
     stretch: null
+  fedora: [python3-msgpack]
   nixos: [python3Packages.msgpack]
   openembedded: [python3-msgpack@meta-python]
+  rhel: ['python%{python3_pkgversion}-msgpack']
   ubuntu: [python3-msgpack]
 python3-msk-pip:
   debian:


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/python-msgpack/python3-msgpack/

In RHEL 7, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/python-msgpack/python36-msgpack/
In RHEL 8, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/python-msgpack/python3-msgpack/