### PR TITLE
Add python3-paho-mqtt rules for Fedora and RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7728,6 +7728,10 @@ python3-padatious-pip:
       packages: [padatious]
 python3-paho-mqtt:
   debian: [python3-paho-mqtt]
+  fedora: [python3-paho-mqtt]
+  rhel:
+    '*': [python3-paho-mqtt]
+    '7': null
   ubuntu:
     '*': [python3-paho-mqtt]
     xenial: null


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/python-paho-mqtt/python3-paho-mqtt/

This package is not available for RHEL 7.
In RHEL 8, this package is provieded by EPEL: https://packages.fedoraproject.org/pkgs/python-paho-mqtt/python3-paho-mqtt/