### PR TITLE
Add python3-pexpect rules for Fedora and RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7798,7 +7798,9 @@ python3-petact-pip:
       packages: [petact]
 python3-pexpect:
   debian: [python3-pexpect]
+  fedora: [python3-pexpect]
   opensuse: [python3-pexpect]
+  rhel: ['python%{python3_pkgversion}-pexpect']
   ubuntu: [python3-pexpect]
 python3-pickleDB-pip:
   debian:


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/python-pexpect/python3-pexpect/

In RHEL 7, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/python-pexpect/python36-pexpect/
In RHEL 8, this package is provided by `AppStream`: https://repo.almalinux.org/almalinux/8/AppStream/x86_64/os/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm