### PR TITLE
Add python3-pika rules for Fedora and RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7812,6 +7812,8 @@ python3-pickleDB-pip:
       packages: [pickleDB]
 python3-pika:
   debian: [python3-pika]
+  fedora: [python3-pika]
+  rhel: ['python%{python3_pkgversion}-pika']
   ubuntu: [python3-pika]
 python3-pil:
   alpine: [py3-pillow]


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/python-pika/python3-pika/

In RHEL 7, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/python-pika/python36-pika/
In RHEL 8, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/python-pika/python3-pika/