### PR TITLE
Add python3-pystemd rules for Fedora and RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8372,7 +8372,11 @@ python3-pysnmp:
 python3-pystemd:
   debian:
     bullseye: [python3-pystemd]
+  fedora: [python3-pystemd]
   nixos: [python3Packages.pystemd]
+  rhel:
+    '*': [python3-pystemd]
+    '7': null
   ubuntu:
     '*': [python3-pystemd]
     bionic:


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/python-pystemd/python3-pystemd/

This package is not available for RHEL 7.
In RHEL 8, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/python-pystemd/python3-pystemd/