### PR TITLE
Add python3-systemd rules for Fedora and RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9125,7 +9125,11 @@ python3-sympy:
   ubuntu: [python3-sympy]
 python3-systemd:
   debian: [python3-systemd]
+  fedora: [python3-systemd]
   nixos: [python3Packages.systemd]
+  rhel:
+    '*': [python3-systemd]
+    '7': null
   ubuntu: [python3-systemd]
 python3-sysv-ipc:
   debian: [python3-sysv-ipc]


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/python-systemd/python3-systemd/

This package is not available for RHEL 7.
In RHEL 8, this package is provided by `BaseOS`: https://repo.almalinux.org/almalinux/8/BaseOS/x86_64/os/Packages/python3-systemd-234-8.el8.x86_64.rpm