### PR TITLE
Make rosdep suggestions based on python?dist(foo)

### DIFF
--- a/test/rosdep_repo_check/suggest.py
+++ b/test/rosdep_repo_check/suggest.py
@@ -25,7 +25,12 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import re
+
 from . import find_package
+
+
+_PYTHON_PATTERN = re.compile(r'^python(\d)-(.*)')
 
 
 def make_suggestion(config, key, os_name):
@@ -67,3 +72,15 @@ def make_suggestion(config, key, os_name):
         suggestion = make_suggestion(config, 'pkgconfig(' + key[:-6] + ')', os_name)
         if suggestion:
             return suggestion
+    # 5) Try python?dist(foo)
+    py_match = _PYTHON_PATTERN.match(key)
+    if py_match:
+        suggestion = make_suggestion(
+            config, 'python%sdist(%s)' % (py_match.group(1), py_match.group(2)), os_name)
+        if suggestion:
+            return suggestion
+        if '-' in py_match.group(2):
+            suggestion = make_suggestion(
+                config, 'python%sdist(%s)' % (py_match.group(1), py_match.group(2).replace('-', '_')), os_name)
+            if suggestion:
+                return suggestion


### PR DESCRIPTION
In Debian/Ubuntu, the recommended naming practice for Python packages is to prefix with `python`, then the major Python version and a hyphen, and then the module name (as permitted by other naming policies).

Fedora/EPEL plays more loosely with the package names, but provides a virtual package `python?dist(foo)` for each Python module provided by a package. We can use this virtual package to make rule suggestions for the more uniquely named Python packages.

When run across the current database, this results in 10 new suggestions for RHEL and 7 new suggestions for Fedora for the following keys:
- python3-catkin-lint
- python3-djangorestframework
- python3-geographiclib
- python3-prometheus-client
- python3-pyee
- python3-requests-futures
- python3-rosinstall-generator
- python3-ruamel.yaml
- python3-sysv-ipc