### PR TITLE
dynamic-graph-tutorial: 1.3.5-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1955,7 +1955,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/stack-of-tasks/dynamic-graph-tutorial-ros-release.git
-      version: 1.3.5-2
+      version: 1.3.5-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic-graph-tutorial` to `1.3.5-3`:

- upstream repository: https://github.com/stack-of-tasks/dynamic-graph-tutorial.git
- release repository: https://github.com/stack-of-tasks/dynamic-graph-tutorial-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.5-2`
