### PR TITLE
rmf_demos: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3760,16 +3760,18 @@ repositories:
       packages:
       - rmf_demos
       - rmf_demos_assets
+      - rmf_demos_bridges
       - rmf_demos_dashboard_resources
+      - rmf_demos_fleet_adapter
       - rmf_demos_gz
-      - rmf_demos_ign
+      - rmf_demos_gz_classic
       - rmf_demos_maps
       - rmf_demos_panel
       - rmf_demos_tasks
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_demos-release.git
-      version: 1.3.1-3
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_demos.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_demos` to `2.0.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_demos.git
- release repository: https://github.com/ros2-gbp/rmf_demos-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.1-3`
