### PR TITLE
rmf_simulation: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3831,15 +3831,15 @@ repositories:
     release:
       packages:
       - rmf_building_sim_common
-      - rmf_building_sim_gazebo_plugins
-      - rmf_building_sim_ignition_plugins
+      - rmf_building_sim_gz_classic_plugins
+      - rmf_building_sim_gz_plugins
       - rmf_robot_sim_common
-      - rmf_robot_sim_gazebo_plugins
-      - rmf_robot_sim_ignition_plugins
+      - rmf_robot_sim_gz_classic_plugins
+      - rmf_robot_sim_gz_plugins
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_simulation-release.git
-      version: 1.2.0-4
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_simulation` to `2.0.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_simulation.git
- release repository: https://github.com/ros2-gbp/rmf_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.0-4`
