### PR TITLE
Add python3 ujson to ubuntu focal

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5465,18 +5465,6 @@ python-ujson:
     vivid:
       pip:
         packages: [ujson]
-python3-ujson:
-  debian: [python3-ujson]
-  fedora: [python3-ujson]
-  gentoo: [dev-python/ujson]
-  nixos: [python3Packages.ujson]
-  osx:
-    pip:
-      packages: [ujson]
-  rhel:
-    '*': [python3-ujson]
-    '7': null
-  ubuntu: [python3-ujson]
 python-unittest2:
   debian: [python-unittest2]
   nixos: [pythonPackages.unittest2]
@@ -9354,6 +9342,18 @@ python3-ubjson:
   ubuntu:
     '*': [python3-ubjson]
     xenial: null
+python3-ujson:
+  debian: [python3-ujson]
+  fedora: [python3-ujson]
+  gentoo: [dev-python/ujson]
+  nixos: [python3Packages.ujson]
+  osx:
+    pip:
+      packages: [ujson]
+  rhel:
+    '*': [python3-ujson]
+    '7': null
+  ubuntu: [python3-ujson]
 python3-unidiff:
   arch: [python-unidiff]
   debian: [python3-unidiff]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5466,6 +5466,9 @@ python-ujson:
       pip:
         packages: [ujson]
 python3-ujson:
+  debian:
+    '*': [python3-ujson]
+  fedora: [python3-ujson]
   ubuntu:
     '*': [python3-ujson]
 python-unittest2:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5467,7 +5467,7 @@ python-ujson:
         packages: [ujson]
 python3-ujson:
   ubuntu:
-    focal: [python3-ujson]
+    '*': [python3-ujson]
 python-unittest2:
   debian: [python-unittest2]
   nixos: [pythonPackages.unittest2]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5465,6 +5465,9 @@ python-ujson:
     vivid:
       pip:
         packages: [ujson]
+python3-ujson:
+  ubuntu:
+    focal: [python3-ujson]
 python-unittest2:
   debian: [python-unittest2]
   nixos: [pythonPackages.unittest2]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5466,8 +5466,7 @@ python-ujson:
       pip:
         packages: [ujson]
 python3-ujson:
-  debian:
-    '*': [python3-ujson]
+  debian: [python3-ujson]
   fedora: [python3-ujson]
   gentoo: [dev-python/ujson]
   nixos: [pythonPackages.ujson]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5469,7 +5469,7 @@ python3-ujson:
   debian: [python3-ujson]
   fedora: [python3-ujson]
   gentoo: [dev-python/ujson]
-  nixos: [pythonPackages.ujson]
+  nixos: [python3Packages.ujson]
   osx:
     pip:
       packages: [ujson]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5476,8 +5476,7 @@ python3-ujson:
   rhel:
     '*': [python3-ujson]
     '7': null
-  ubuntu:
-    '*': [python3-ujson]
+  ubuntu: [python3-ujson]
 python-unittest2:
   debian: [python-unittest2]
   nixos: [pythonPackages.unittest2]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5473,6 +5473,9 @@ python3-ujson:
   osx:
     pip:
       packages: [ujson]
+  rhel:
+    '*': [python3-ujson]
+    '7': null
   ubuntu:
     '*': [python3-ujson]
 python-unittest2:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5469,6 +5469,11 @@ python3-ujson:
   debian:
     '*': [python3-ujson]
   fedora: [python3-ujson]
+  gentoo: [dev-python/ujson]
+  nixos: [pythonPackages.ujson]
+  osx:
+    pip:
+      packages: [ujson]
   ubuntu:
     '*': [python3-ujson]
 python-unittest2:


### PR DESCRIPTION
I would like to add a new third party system package, it is just the python3 version of the already included ujson package.