### PR TITLE
ur_client_library: 1.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6948,7 +6948,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `1.2.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-1`

## ur_client_library

```
* Initialized receive timeout and changed exception to warning (#118 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/118>)
* Added tests for the control interface classes (#112 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/112>)
* Added note about Polyscope version requirement
* Added tcp_offset
* Added interface for forwarding script commands to the robot, that is … (#111 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/111>)
* Fixed parsing of incomming packages when using rtde protocol v1 (#114 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/114>)
  The received rtde packages should be parsed slightly different whether we use protocol v1 or v2.
* Add codecov step (#116 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/116>)
* Added humble build
* Fixed downstream test instructions
* Update atomicops.h (#117 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/117>)
  Fix the url in the comment regarding POSIX semaphores to fix error in the CI
* Make the read during boot depend on the frequency of the robot controller (#102 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/102>)
* Ignore debian folder in check_links (#100 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/100>)
  Otherwise this job raises an error in the release repository.
* Contributors: Felix Exner, Mads Holm Peters, Rune Søe-Knudsen, urmahp, urmarp
```
