### PR TITLE
Add create_robot and libcreate to Foxy index

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -824,6 +824,16 @@ repositories:
       url: https://github.com/rt-net/crane_plus.git
       version: foxy-devel
     status: maintained
+  create_robot:
+    doc:
+      type: git
+      url: https://github.com/AutonomyLab/create_robot.git
+      version: foxy
+    source:
+      type: git
+      url: https://github.com/AutonomyLab/create_robot.git
+      version: foxy
+    status: developed
   cyclonedds:
     release:
       tags:
@@ -2297,6 +2307,16 @@ repositories:
       type: git
       url: https://github.com/lgsvl/lgsvl_msgs.git
       version: foxy-devel
+    status: developed
+  libcreate:
+    doc:
+      type: git
+      url: https://github.com/AutonomyLab/libcreate.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/AutonomyLab/libcreate.git
+      version: master
     status: developed
   libfranka:
     doc:


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add create_robot and libcreate to be indexed in the rosdistro.

Foxy

# The source is here:

https://github.com/autonomylab/create_robot/tree/foxy
https://github.com/autonomylab/libcreate


# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
