### PR TITLE
Add create_robot to Noetic index

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1502,6 +1502,16 @@ repositories:
       url: https://github.com/ctu-vras/ros-utils.git
       version: master
     status: developed
+  create_robot:
+    doc:
+      type: git
+      url: https://github.com/AutonomyLab/create_robot.git
+      version: melodic
+    source:
+      type: git
+      url: https://github.com/AutonomyLab/create_robot.git
+      version: melodic
+    status: developed
   criutils:
     doc:
       type: git


### PR DESCRIPTION
# Please Add create_robot to be indexed in the rosdistro.

Noetic

# The source is here:

https://github.com/autonomylab/create_robot/tree/melodic

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
