### PR TITLE
Add create_robot to Melodic index

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2078,6 +2078,16 @@ repositories:
       type: git
       url: https://github.com/whoenig/crazyflie_ros.git
       version: master
+  create_robot:
+    doc:
+      type: git
+      url: https://github.com/AutonomyLab/create_robot.git
+      version: melodic
+    source:
+      type: git
+      url: https://github.com/AutonomyLab/create_robot.git
+      version: melodic
+    status: developed
   criutils:
     doc:
       type: git


### PR DESCRIPTION
# Please Add create_robot to be indexed in the rosdistro.

Melodic

# The source is here:

https://github.com/autonomylab/create_robot/tree/melodic

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
