### PR TITLE
rsl: 0.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5179,6 +5179,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_topic.git
       version: humble
     status: maintained
+  rsl:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/RSL.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/PickNikRobotics/RSL-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/RSL.git
+      version: main
+    status: developed
   rt_manipulators_cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rsl` to `0.1.0-1`:

- upstream repository: https://github.com/PickNikRobotics/RSL.git
- release repository: https://github.com/PickNikRobotics/RSL-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## rsl

```
* monad.hpp - Functions and operators for monadic expressions
* no_discard.hpp - [[nodiscard]] for lambdas
* overload.hpp - Class template for easily visiting variants
* queue.hpp - Thread-safe queue
* random.hpp - Modern C++ randomness made easy
* try.hpp - Macro to emulatate absl::CONFIRM or operator? from Rust
* Contributors: Chris Thrasher, Tyler Weaver
```
