### PR TITLE
range-v3 for rhel

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7159,6 +7159,9 @@ range-v3:
     stretch: null
   fedora: [range-v3-devel]
   gentoo: [dev-cpp/range-v3]
+  rhel:
+    '*': [range-v3-devel]
+    '7': null
   ubuntu:
     '*': [librange-v3-dev]
     xenial: null


### PR DESCRIPTION
As far as I can tell this package exists in rhel just as it exists in fedora. I got an error when blooming rsl about this not existing in rhel.