### PR TITLE
ros2_control: 3.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3976,7 +3976,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.0.0-1
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.1.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.0.0-1`

## controller_interface

```
* Add docs in export interface configurations for controllers. (#804 <https://github.com/ros-controls/ros2_control/issues/804>)
* Contributors: Denis Štogl
```

## controller_manager

```
* Don't ask to export reference interface if controller not 'inactive' or 'active' (#824 <https://github.com/ros-controls/ros2_control/issues/824>)
* Add diagnostics for controllers activity (#820 <https://github.com/ros-controls/ros2_control/issues/820>)
* Search for controller manager in the same namespace as spawner (#810 <https://github.com/ros-controls/ros2_control/issues/810>)
* Handle HW errors on read and write in CM by stopping controllers (#742 <https://github.com/ros-controls/ros2_control/issues/742>)
  Add code for deactivating controller when hardware gets an error on read and write.
  Fix misleading variable name in the tests.
  Remove all interface from available list for hardware when an error happens.
  Do some more variable renaming to the new nomenclature.
* Contributors: Denis Štogl, Tony Najjar
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Cleanup Resource Manager a bit to increase clarity. (#816 <https://github.com/ros-controls/ros2_control/issues/816>)
* Handle hardware errors in Resource Manager (#805 <https://github.com/ros-controls/ros2_control/issues/805>)
  * Add code for deactivating controller when hardware gets an error on read and write.
* Contributors: Denis Štogl
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## transmission_interface

- No changes
