### PR TITLE
paho-mqtt-c: 1.3.11-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3519,7 +3519,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/nobleo/paho.mqtt.c-release.git
-      version: 1.3.9-4
+      version: 1.3.11-1
     source:
       type: git
       url: https://github.com/eclipse/paho.mqtt.c.git


### PR DESCRIPTION
Increasing version of package(s) in repository `paho-mqtt-c` to `1.3.11-1`:

- upstream repository: https://github.com/eclipse/paho.mqtt.c.git
- release repository: https://github.com/nobleo/paho.mqtt.c-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.9-4`
