### PR TITLE
paho-mqtt-c: 1.3.11-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2880,7 +2880,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/nobleo/paho.mqtt.c-release.git
-      version: 1.3.10-1
+      version: 1.3.11-1
     source:
       type: git
       url: https://github.com/eclipse/paho.mqtt.c.git


### PR DESCRIPTION
Increasing version of package(s) in repository `paho-mqtt-c` to `1.3.11-1`:

- upstream repository: https://github.com/eclipse/paho.mqtt.c.git
- release repository: https://github.com/nobleo/paho.mqtt.c-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.10-1`
