### PR TITLE
paho-mqtt-c: 1.3.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6621,7 +6621,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/nobleo/paho.mqtt.c-release.git
-      version: 1.3.10-1
+      version: 1.3.11-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `paho-mqtt-c` to `1.3.11-1`:

- upstream repository: https://github.com/eclipse/paho.mqtt.c.git
- release repository: https://github.com/nobleo/paho.mqtt.c-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.10-1`
