### PR TITLE
ros2_controllers: 2.13.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4006,7 +4006,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.12.0-1
+      version: 2.13.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.13.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.12.0-1`

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

```
* Fix undeclared and wrong parameters in controllers. (#438 <https://github.com/ros-controls/ros2_controllers/issues/438>)
  * Add missing parameter declaration in the joint state broadcaster.
  * Fix unsensible test in IMU Sensor Broadcaster.
* Contributors: Denis Štogl
```

## joint_state_broadcaster

```
* Generate parameters for Joint State Broadcaster (#401 <https://github.com/ros-controls/ros2_controllers/issues/401>)
* Fix undeclared and wrong parameters in controllers. (#438 <https://github.com/ros-controls/ros2_controllers/issues/438>)
  * Add missing parameter declaration in the joint state broadcaster.
  * Fix unsensible test in IMU Sensor Broadcaster.
* [JointStateBroadcaster] Reset internal variables to avoid duplication of joints (#431 <https://github.com/ros-controls/ros2_controllers/issues/431>)
* Contributors: Denis Štogl, Gilmar Correia, Tyler Weaver, Bence Magyar
```

## joint_trajectory_controller

```
* Generate Parameter Library for Joint Trajectory Controller (#384 <https://github.com/ros-controls/ros2_controllers/issues/384>)
* Fix rates in JTC userdoc.rst (#433 <https://github.com/ros-controls/ros2_controllers/issues/433>)
* Fix for high CPU usage by JTC in gzserver (#428 <https://github.com/ros-controls/ros2_controllers/issues/428>)
  * Change type cast wall timer period from second to nanoseconds.
  create_wall_timer() expects delay in nanoseconds (duration object) however the type cast to seconds will result in 0 (if duration is less than 1s) and thus causing timer to be fired non stop resulting in very high CPU usage.
  * Reset smartpointer so that create_wall_timer() call can destroy previous trajectory timer.
  node->create_wall_timer() first removes timers associated with expired smartpointers before servicing current request.  The JTC timer pointer gets overwrite only after the create_wall_timer() returns and thus not able to remove previous trajectory timer resulting in upto two timers running for JTC during trajectory execution.  Althougth the previous timer does nothing but still get fired.
* Contributors: Arshad Mehmood, Borong Yuan, Tyler Weaver, Andy Zelenak, Bence Magyar, Denis Štogl
```

## position_controllers

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

```
* Enable definition of all fields in JointTrajectory message when using test node. (#389 <https://github.com/ros-controls/ros2_controllers/issues/389>)
* Contributors: Denis Štogl
```

## rqt_joint_trajectory_controller

- No changes

## tricycle_controller

- No changes

## velocity_controllers

- No changes
