### PR TITLE
Add python3-catkin-lint rule for RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6188,6 +6188,7 @@ python3-catkin-lint:
     stretch: null
   fedora: [python3-catkin_lint]
   openembedded: [python3-catkin-lint@meta-ros-common]
+  rhel: [python3-catkin_lint]
   ubuntu:
     '*': [python3-catkin-lint]
     bionic: null


### PR DESCRIPTION
In RHEL 7, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/python-catkin_lint/python36-catkin_lint/
In RHEL 8, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/python-catkin_lint/python3-catkin_lint/