### PR TITLE
Add python3-djangorestframework rules for Fedora and RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6476,7 +6476,11 @@ python3-django-extra-views:
   ubuntu: [python3-django-extra-views]
 python3-djangorestframework:
   debian: [python3-djangorestframework]
+  fedora: [python3-django-rest-framework]
   opensuse: [python3-djangorestframework]
+  rhel:
+    '*': [python3-django-rest-framework]
+    '7': null
   ubuntu: [python3-djangorestframework]
 python3-dlib-pip:
   debian:


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/python-django-rest-framework/python3-django-rest-framework/

This package is not available for RHEL 7.
In RHEL 8, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/python-django-rest-framework/python3-django-rest-framework/