### PR TITLE
Add python3-geographiclib rule for RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6854,6 +6854,9 @@ python3-geographiclib:
   gentoo: [sci-geosciences/GeographicLib]
   nixos: [python3Packages.geographiclib]
   opensuse: [python3-geographiclib]
+  rhel:
+    '*': [python3-GeographicLib]
+    '7': null
   ubuntu: [python3-geographiclib]
 python3-geomag-pip:
   debian:


### PR DESCRIPTION
This package is not available for RHEL 7.
In RHEL 8, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/GeographicLib/python3-GeographicLib/