### PR TITLE
Add python3-prometheus-client rules for Fedora and RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7960,6 +7960,10 @@ python3-progressbar:
   ubuntu: [python3-progressbar]
 python3-prometheus-client:
   debian: [python3-prometheus-client]
+  fedora: [python3-prometheus_client]
+  rhel:
+    '*': [python3-prometheus_client]
+    '7': null
   ubuntu: [python3-prometheus-client]
 python3-prompt-toolkit:
   arch: [python-prompt_toolkit]


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/python-prometheus_client/python3-prometheus_client/

This package is not available for RHEL 7.
In RHEL 8, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/python-prometheus_client/python3-prometheus_client/