### PR TITLE
Add python3-rosinstall-generator rules for Fedora and RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8677,6 +8677,8 @@ python3-rosdistro-modules:
   rhel: ['python%{python3_pkgversion}-rosdistro']
   ubuntu: [python3-rosdistro-modules]
 python3-rosinstall-generator:
+  fedora: [python3-rosinstall_generator]
+  rhel: [python3-rosinstall_generator]
   ubuntu: [python3-rosinstall-generator]
 python3-rospkg:
   alpine: [py3-rospkg]


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/python-rosinstall_generator/python3-rosinstall_generator/

In both RHEL 7 and 8, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/python-rosinstall_generator/python3-rosinstall_generator/