### PR TITLE
Add python3-ruamel.yaml rules for Fedora and RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8731,8 +8731,10 @@ python3-ruamel.yaml:
     buster: [python3-ruamel.yaml]
     jessie: [python3-ruamel.yaml]
     stretch: [python3-ruamel.yaml]
+  fedora: [python3-ruamel-yaml]
   nixos: [python3Packages.ruamel_yaml]
   openembedded: [python3-ruamel-yaml@meta-python]
+  rhel: ['python%{python3_pkgversion}-ruamel-yaml']
   ubuntu: [python3-ruamel.yaml]
 python3-sbp-pip: *migrate_eol_2027_04_30_python3_sbp_pip
 python3-schedule:


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/python-ruamel-yaml/python3-ruamel-yaml/

In RHEL 7, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/python-ruamel-yaml/python36-ruamel-yaml/
In RHEL 8, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/python-ruamel-yaml/python3-ruamel-yaml/