### PR TITLE
Add python3-sysv-ipc rules for Fedora and RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9154,6 +9154,10 @@ python3-systemd:
   ubuntu: [python3-systemd]
 python3-sysv-ipc:
   debian: [python3-sysv-ipc]
+  fedora: [python3-sysv_ipc]
+  rhel:
+    '*': [python3-sysv_ipc]
+    '7': null
   ubuntu: [python3-sysv-ipc]
 python3-tables:
   debian: [python3-tables]


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/python-sysv_ipc/python3-sysv_ipc/

This package is not available for RHEL 7.
In RHEL 8, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/python-sysv_ipc/python3-sysv_ipc/