### PR TITLE
Add ipython3 rule for RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -251,6 +251,9 @@ ipython3:
   fedora: [ipython3]
   nixos: [python3Packages.ipython]
   openembedded: [python3-ipython@meta-python]
+  rhel:
+    '*': [python3-ipython]
+    '7': null
   ubuntu: [ipython3]
 jupyter-nbconvert:
   arch: [jupyter-nbconvert]


### PR DESCRIPTION
This package is not available for RHEL 7.
In RHEL 8, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/ipython/python3-ipython/