### PR TITLE
Add python3-vcstool rule for RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9414,6 +9414,7 @@ python3-vcstool:
   osx:
     pip:
       packages: [vcstool]
+  rhel: [python3-vcstool]
   ubuntu: [python3-vcstool]
 python3-vedo-pip:
   debian:


### PR DESCRIPTION
In RHEL 7, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/python-vcstool/python36-vcstool/
In RHEL 8, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/python-vcstool/python3-vcstool/