### PR TITLE
Add alsa-utils rule for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -59,6 +59,7 @@ alsa-utils:
   gentoo: [media-sound/alsa-utils]
   nixos: [alsaUtils]
   opensuse: [alsa-utils]
+  rhel: [alsa-utils]
   ubuntu: [alsa-utils]
 ant:
   arch: [apache-ant]


### PR DESCRIPTION
In RHEL 7, this package is part of `os`: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/alsa-utils-1.1.8-2.el7.x86_64.rpm
In RHEL 8, this package is part of `AppStream`: https://repo.almalinux.org/almalinux/8/AppStream/x86_64/os/Packages/alsa-utils-1.2.6-1.el8.x86_64.rpm