### PR TITLE
Add ant rule for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -66,6 +66,7 @@ ant:
   fedora: [ant]
   gentoo: [dev-java/ant]
   nixos: [ant]
+  rhel: [ant]
   ubuntu: [ant]
 antlr:
   arch: [antlr]


### PR DESCRIPTION
In RHEL 7, this package is part of `os`: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/ant-1.9.4-2.el7.noarch.rpm
In RHEL 8, this package is part of `AppStream`: https://repo.almalinux.org/almalinux/8/AppStream/x86_64/os/Packages/ant-1.10.5-1.module_el8.0.0+6031+d80e135e.noarch.rpm