### PR TITLE
Add at-spi2-core rule for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -202,6 +202,7 @@ at-spi2-core:
   fedora: [at-spi2-core]
   gentoo: [at-spi2-core]
   nixos: [at-spi2-core]
+  rhel: [at-spi2-core]
   ubuntu: [at-spi2-core]
 atlas:
   arch: [atlas-lapack]


### PR DESCRIPTION
In RHEL 7, this package is provided by `os`: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/at-spi2-core-2.28.0-1.el7.i686.rpm
In RHEL 8, this package is provided by `AppStream`: https://repo.almalinux.org/almalinux/8/AppStream/x86_64/os/Packages/at-spi2-core-2.28.0-1.el8.i686.rpm