### PR TITLE
Add atlas rule for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -209,6 +209,7 @@ atlas:
   fedora: [atlas-devel]
   gentoo: [sci-libs/atlas]
   macports: [atlas]
+  rhel: [atlas-devel]
   ubuntu: [libatlas-base-dev]
 autoconf:
   arch: [autoconf]


### PR DESCRIPTION
In RHEL 7, this package is provided by `os`: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/atlas-devel-3.10.1-12.el7.i686.rpm
In RHEL 8, this package is provided by `BaseOS`: https://repo.almalinux.org/almalinux/8/BaseOS/x86_64/os/Packages/atlas-devel-3.10.3-8.el8.i686.rpm