### PR TITLE
Add bullet-extras rule for RHEL, fix Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -406,9 +406,10 @@ bullet:
 bullet-extras:
   arch: [bullet]
   debian: [libbullet-extras-dev]
-  fedora: [bullet-extras]
+  fedora: [bullet-extras-devel]
   gentoo: [sci-physics/bullet]
   nixos: [bullet]
+  rhel: [bullet-extras-devel]
   ubuntu: [libbullet-extras-dev]
 bzip2:
   alpine: [bzip2-dev]


### PR DESCRIPTION
The other rules for this key specify development packages, so should Fedora and RHEL.

Fedora: https://packages.fedoraproject.org/pkgs/bullet/bullet-extras-devel/

In both RHEL 7 and 8, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/bullet/bullet-extras-devel/