### PR TITLE
Add ca-certificates rule for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -436,6 +436,7 @@ ca-certificates:
   nixos: [cacert]
   openembedded: [ca-certificates@openembedded-core]
   opensuse: [ca-certificates]
+  rhel: [ca-certificates]
   ubuntu: [ca-certificates]
 can-utils:
   debian: [can-utils]


### PR DESCRIPTION
In RHEL 7, this package is part of `os`: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/ca-certificates-2020.2.41-70.0.el7_8.noarch.rpm
In RHEL 8, this package is part of `BaseOS`: https://repo.almalinux.org/almalinux/8/BaseOS/x86_64/os/Packages/ca-certificates-2021.2.50-80.0.el8_4.noarch.rpm