### PR TITLE
Add i2c-tools rule for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1931,6 +1931,7 @@ i2c-tools:
   gentoo: [sys-apps/i2c-tools]
   nixos: [i2c-tools]
   opensuse: [i2c-tools]
+  rhel: [i2c-tools]
   ubuntu: [i2c-tools]
 ifstat:
   debian: [ifstat]


### PR DESCRIPTION
In RHEL 7, this package is provided by `os`: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/i2c-tools-3.1.0-13.el7.x86_64.rpm
In RHEL 8, this package is provided by `AppStream`: https://repo.almalinux.org/almalinux/8/AppStream/x86_64/os/Packages/i2c-tools-4.0-12.el8.x86_64.rpm