### PR TITLE
Add jansson-devel rules for Fedora and RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3915,8 +3915,10 @@ libjackson-json-java:
   ubuntu: [libjackson-json-java]
 libjansson-dev:
   debian: [libjansson-dev]
+  fedora: [jansson-devel]
   gentoo: [dev-libs/jansson]
   nixos: [jansson]
+  rhel: [jansson-devel]
   ubuntu: [libjansson-dev]
 libjaxp1.3-java:
   debian: [libjaxp1.3-java]


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/jansson/jansson-devel/

In RHEL 7, this package is part of `os`: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/jansson-devel-2.10-1.el7.i686.rpm
In RHEL 8, this package is part of `AppStream`: https://repo.almalinux.org/almalinux/8/AppStream/x86_64/os/Packages/jansson-devel-2.14-1.el8.i686.rpm