### PR TITLE
Add libkml-dev rules for Fedora and RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4007,7 +4007,11 @@ libkdtree++-dev:
 libkml-dev:
   arch: [libkml]
   debian: [libkml-dev]
+  fedora: [libkml-devel]
   nixos: [libkml]
+  rhel:
+    '*': [libkml-devel]
+    '7': null
   ubuntu: [libkml-dev]
 liblapack-dev:
   arch: [lapack]


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/libkml/libkml-devel/

This package is not available for RHEL 7.
In RHEL 8, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/libkml/libkml-devel/