### PR TITLE
Add python-dev rules for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6982,6 +6982,9 @@ python-dev:
   debian: [python-dev]
   fedora: [python2-devel]
   nixos: [pythonPackages.python]
+  rhel:
+    '7': [python2-devel]
+    '8': [python2-devel]
   ubuntu:
     '*': [python-dev]
     focal: [python2-dev]


### PR DESCRIPTION
In RHEL 7, this package is provided by `os`: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/python-devel-2.7.5-89.el7.x86_64.rpm
In RHEL 8, this package is provided by `AppStream`: https://repo.almalinux.org/almalinux/8/AppStream/x86_64/os/Packages/python2-devel-2.7.18-10.module_el8.6.0+2781+fed64c13.alma.x86_64.rpm

This package is not available in RHEL 9. In anticipation of targeting RHEL 9 in the near future, I'm explicitly adding RHEL 7 and 8 rules as this package will not be available moving forward.