### PR TITLE
Add source and doc entries for mrpt_{navigation,sensors} [rolling]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2333,6 +2333,26 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
       version: master
     status: maintained
+  mrpt_navigation:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
+      version: ros2
+    status: developed
+  mrpt_sensors:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
+      version: ros2
+    status: developed
   mrt_cmake_modules:
     doc:
       type: git


### PR DESCRIPTION
Add basic information for these two repositories to  ROS2 rolling.
Both are already in ROS1 distributions.

# The source is here:

  - https://github.com/mrpt-ros-pkg/mrpt_navigation/tree/ros2
  - https://github.com/mrpt-ros-pkg/mrpt_sensors/tree/ros2

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro  (**WORK IN PROGRESS FOR ROS2**)
