### PR TITLE
rmf_demos: 2.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3775,7 +3775,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_demos.git
-      version: main
+      version: humble
     release:
       packages:
       - rmf_demos
@@ -3791,11 +3791,11 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_demos-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_demos.git
-      version: main
+      version: humble
     status: developed
   rmf_internal_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_demos` to `2.0.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_demos.git
- release repository: https://github.com/ros2-gbp/rmf_demos-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-1`
