### PR TITLE
rmf_task: 2.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3871,16 +3871,19 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_task.git
-      version: main
+      version: humble
     release:
+      packages:
+      - rmf_task
+      - rmf_task_sequence
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
-      version: 1.0.0-3
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_task.git
-      version: main
+      version: humble
     status: developed
   rmf_traffic:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_task` to `2.1.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_task.git
- release repository: https://github.com/ros2-gbp/rmf_task-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-3`
