### PR TITLE
dynamixel_workbench_msgs: 2.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -853,6 +853,21 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
       version: ros2
     status: maintained
+  dynamixel_workbench_msgs:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/robotis-ros2-release/dynamixel-workbench-msgs-release.git
+      version: 2.0.3-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
+      version: ros2
+    status: maintained
   ecl_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_workbench_msgs` to `2.0.3-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
- release repository: https://github.com/robotis-ros2-release/dynamixel-workbench-msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## dynamixel_workbench_msgs

```
* release for ROS2
* Contributors: Will Son
```
