### PR TITLE
nlohmann_json_schema_validator_vendor: 0.1.3-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2653,7 +2653,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/nlohmann_json_schema_validator_vendor-release.git
-      version: 0.1.1-1
+      version: 0.1.3-2
     source:
       type: git
       url: https://github.com/open-rmf/nlohmann_json_schema_validator_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nlohmann_json_schema_validator_vendor` to `0.1.3-2`:

- upstream repository: https://github.com/open-rmf/nlohmann_json_schema_validator_vendor
- release repository: https://github.com/ros2-gbp/nlohmann_json_schema_validator_vendor-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.1-1`
