### PR TITLE
simple_launch: 1.5.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6330,7 +6330,7 @@ repositories:
     release:
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/oKermorgant/simple_launch-release.git
+      url: https://github.com/ros2-gbp/simple_launch-release.git
       version: 1.5.0-1
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_launch` to `1.5.0-1`:

- upstream repository: https://github.com/oKermorgant/simple_launch.git
- release repository: https://github.com/ros2-gbp/simple_launch-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.5.0-1`

## simple_launch

```
* allow spawning a Gz model from file
* parameters are list of dict
* allow substitution for topics in ros_ign_image bridge
* Gazebo bridge handles invalid ROS topics through yaml config file. Image bridges are automatically run through ros_ign_image
* better handling of gazebo spawn pose
* Contributors: Olivier Kermorgant
```
