### PR TITLE
simple_launch: 1.6.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5310,8 +5310,8 @@ repositories:
     release:
       tags:
         release: release/galactic/{package}/{version}
-      url: https://github.com/oKermorgant/simple_launch-release.git
-      version: 1.5.0-1
+      url: https://github.com/ros2-gbp/simple_launch-release.git
+      version: 1.6.0-1
     source:
       type: git
       url: https://github.com/oKermorgant/simple_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_launch` to `1.6.0-1`:

- upstream repository: https://github.com/oKermorgant/simple_launch.git
- release repository: https://github.com/ros2-gbp/simple_launch-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.5.0-1`

## simple_launch

```
* check use_sim_time versus a parameter file
* resolve any builtin type as Substitution, not only text
* improve documentation
* Gazebo + humble compat
* OpaqueFunction wrapper and SimpleSubstitution
* switch to CMake to avoid deprecation messages
* more spawn_gz
* Contributors: Olivier Kermorgant
```
