### PR TITLE
Add apt pkg libespeak-ng1

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3166,6 +3166,10 @@ libespeak-dev:
   gentoo: [app-accessibility/espeak]
   nixos: [espeak]
   ubuntu: [libespeak-dev]
+libespeak-ng1:
+  debian: [libespeak-ng1]
+  opensuse: [libespeak-ng1]
+  ubuntu: [libespeak-ng1]
 libestools-dev:
   debian:
     buster: [libestools-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3168,7 +3168,11 @@ libespeak-dev:
   ubuntu: [libespeak-dev]
 libespeak-ng1:
   debian: [libespeak-ng1]
+  fedora: [espeak-ng]
   opensuse: [libespeak-ng1]
+  rhel:
+    '*': [espeak-ng]
+    '7': null
   ubuntu: [libespeak-ng1]
 libestools-dev:
   debian:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

libespeak-ng1

## Package Upstream Source:

https://github.com/espeak-ng/espeak-ng

## Purpose of using this:

eSpeak NG is a software speech synthesizer for English, and some other languages.
This package contains the espeak NG program in a shared library.

Distro packaging links:

## Links to Distribution Packages
- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/libespeak-ng1
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/focal/libespeak-ng1
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/espeak-ng/espeak-ng/
- RHEL:
  - https://repo.almalinux.org/almalinux/8/AppStream/x86_64/os/Packages/espeak-ng-1.49.2-4.el8.i686.rpm
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/libespeak-ng1
