### PR TITLE
rosbridge_suite: 0.11.15-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8822,7 +8822,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.11.14-1
+      version: 0.11.15-1
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.11.15-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.11.14-1`

## rosapi

- No changes

## rosbridge_library

```
* Remove unnecessary checking of topic globs. (#793 <https://github.com/RobotWebTools/rosbridge_suite/issues/793>)
  We do not have to check the topic globs on each incoming ros message. It is enough to check if the topic is allowed to be subscribed in the actual subscribe call as the message callback method (publish) is only called when the topic is subscribed to.
* Skip unnecessary conversion for cbor/cbor-raw compression (#792 <https://github.com/RobotWebTools/rosbridge_suite/issues/792>)
  * Skip unnecessary conversion for cbor compression.
  This change avoids some unnecessary conversions when using cbor/cbor-raw compression, leading to a significantly perfomance boost.
  * Add caching for subscriptions with cbor compression.
* Contributors: Hans-Joachim Krauch
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* Skip unnecessary conversion for cbor/cbor-raw compression (#792 <https://github.com/RobotWebTools/rosbridge_suite/issues/792>)
  * Skip unnecessary conversion for cbor compression.
  This change avoids some unnecessary conversions when using cbor/cbor-raw compression, leading to a significantly perfomance boost.
  * Add caching for subscriptions with cbor compression.
* Contributors: Hans-Joachim Krauch
```

## rosbridge_suite

- No changes
