### PR TITLE
rosbag2_storage_mcap: 0.4.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4570,10 +4570,11 @@ repositories:
       packages:
       - mcap_vendor
       - rosbag2_storage_mcap
+      - rosbag2_storage_mcap_test_fixture_interfaces
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2_storage_mcap-release.git
-      version: 0.1.7-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/ros-tooling/rosbag2_storage_mcap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2_storage_mcap` to `0.4.0-1`:

- upstream repository: https://github.com/ros-tooling/rosbag2_storage_mcap.git
- release repository: https://github.com/ros2-gbp/rosbag2_storage_mcap-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.7-1`

## mcap_vendor

- No changes

## rosbag2_storage_mcap

```
* Some minor improvements in rosbag2_storage_mcap after review (#58 <https://github.com/ros-tooling/rosbag2_storage_mcap/issues/58>)
  1. Fixed some findings from Clang-Tidy
  1. Some renames according to the ROS2 coding style
  1. Add default initializations for member variables
  1. Moved code responsible for adding schema and channel from write(msg)
  to create_topic(topic) method to reduce performance burden on first
  message write and in lieu to preparation for moving schema collection
  process to upper SequentialWriter layer.
* Revert "rosbag2_storage_mcap: add storage preset profiles"
  This reverts commit 38830add3935b978968fe2703d3180b413ccc8c2.
* rosbag2_storage_mcap: add storage preset profiles
* Contributors: James Smith, Michael Orlov
```

## rosbag2_storage_mcap_test_fixture_interfaces

- No changes
