### PR TITLE
dynamixel_workbench: 2.2.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -917,6 +917,24 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
       version: ros2
     status: maintained
+  dynamixel_workbench:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
+      version: humble-devel
+    release:
+      packages:
+      - dynamixel_workbench
+      - dynamixel_workbench_toolbox
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/robotis-ros2-release/dynamixel-workbench-release.git
+      version: 2.2.3-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
+      version: humble-devel
+    status: maintained
   ecl_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_workbench` to `2.2.3-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
- release repository: https://github.com/robotis-ros2-release/dynamixel-workbench-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## dynamixel_workbench

```
* ROS2 release (Foxy, Galactic, Humble)
* fix variable length warning (#364)
* Contributoers: Kenji Brameld, Will Son
```

## dynamixel_workbench_toolbox

```
* ROS2 release (Foxy, Galactic, Humble)
* fix variable length warning (#364)
* Contributoers: Kenji Brameld, Will Son
```
