### PR TITLE
ur_robot_driver: 2.2.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5858,7 +5858,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.2.3-1
+      version: 2.2.4-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.2.4-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.3-1`

## ur

- No changes

## ur_bringup

```
* Remove duplicated update_rate parameter (#479 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/479>)
* Contributors: Felix Exner
```

## ur_calibration

- No changes

## ur_controllers

```
* Adapt jtc controller params to new param api
* Contributors: Felix Exner
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* Fix selecting the right controller given fake_hw
  This was falsely introduced earlier. This is a working version.
* add ur_moveit.launch.py parameter to use working controller when using fake hardware (#464 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/464>)
  add script parameter to use correct controller when using fake hardware
* Contributors: Felix Exner, adverley
```

## ur_robot_driver

```
* Remove the custom ursim docker files (#478 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/478>)
  This has been migrated inside the docs and is not needed anymore.
* Remove duplicated update_rate parameter (#479 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/479>)
* Contributors: Felix Exner
```
