### PR TITLE
Add doc and source entries for Fuse to ROS Rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1168,6 +1168,17 @@ repositories:
       url: https://github.com/foxglove/schemas.git
       version: main
     status: maintained
+  fuse:
+    doc:
+      type: git
+      url: https://github.com/locusrobotics/fuse.git
+      version: rolling
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/locusrobotics/fuse.git
+      version: rolling
+    status: maintained
   gazebo_ros2_control:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.
rolling

# The source is here:

https://github.com/locusrobotics/fuse

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro - **no, adding source entry to get a PR job while porting** (see https://github.com/locusrobotics/fuse/issues/276 for more info)
