### PR TITLE
v4l2_camera: 0.6.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6019,7 +6019,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_v4l2_camera-release.git
-      version: 0.6.0-1
+      version: 0.6.1-1
     source:
       type: git
       url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `v4l2_camera` to `0.6.1-1`:

- upstream repository: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
- release repository: https://github.com/ros2-gbp/ros2_v4l2_camera-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.0-1`

## v4l2_camera

```
* Rename include to resolve deprecation warning.
* Contributors: Sander G. van Dijk, Steven! Ragnarök
```
