### PR TITLE
leo_simulator: 1.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4518,7 +4518,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_simulator-release.git
-      version: 1.0.1-1
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_simulator` to `1.1.0-1`:

- upstream repository: https://github.com/LeoRover/leo_simulator.git
- release repository: https://github.com/fictionlab-gbp/leo_simulator-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.1-1`

## leo_gazebo

```
* Add launch file for marsyard2022 world
* Contributors: Błażej Sowa
```

## leo_gazebo_plugins

```
* Add gazebo_ros to dependencies to prevent ROS buildfarm from building this package for unsupported platforms
* Contributors: Błażej Sowa
```

## leo_gazebo_worlds

```
* Add marsyard2022 world
* Change marsyard2020_terrain model name
* Contributors: Błażej Sowa
```

## leo_simulator

- No changes
