### PR TITLE
ur_client_library: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11043,7 +11043,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
-      version: 0.3.2-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `0.4.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.2-1`

## ur_client_library

```
* Initialized receive timeout and changed exception to warning (#118 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/118>)
* Added tests for the control interface classes (#112 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/112>)
* Added note about Polyscope version requirement
* Added tcp_offset
* Added interface for forwarding script commands to the robot, that is … (#111 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/111>)
* Fixed parsing of incomming packages when using rtde protocol v1 (#114 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/114>)
  The received rtde packages should be parsed slightly different whether we use protocol v1 or v2.
* Add codecov step (#116 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/116>)
* Added humble build
* Fixed downstream test instructions
* Update atomicops.h (#117 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/117>)
  Fix the url in the comment regarding POSIX semaphores to fix error in the CI
* Make the read during boot depend on the frequency of the robot controller (#102 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/102>)
* Ignore debian folder in check_links (#100 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/100>)
  Otherwise this job raises an error in the release repository.
* Support starting the driver, before the robot is booted (#98 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/98>)
* Clear the queue when consumer reads from it (#96 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/96>)
* Fix build with newer glibc
* Doxygen check (#77 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/77>)
* Added target_frequency to RTDEClient (#85 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/85>)
* Removed console_bridge dependency (#74 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/74>)
* Added "On behalf of Universal Robots A/S" notice (#81 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/81>)
  to all files that have been created by FZI
* Always install package.xml file (#78 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/78>)
* register package with ament index
* Corrected smaller doxygen errors
* Added rosdoc_lite check
* Contributors: Cory Crean, Felix Exner, Jørn Bersvendsen, Mads Holm Peters, Martin Jansa, Stefan Scherzinger, Rune Søe-Knudsen, urmahp, urmarp
```
