### PR TITLE
rmf_ros2: 2.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3829,21 +3829,22 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git
-      version: main
+      version: humble
     release:
       packages:
       - rmf_fleet_adapter
       - rmf_fleet_adapter_python
       - rmf_task_ros2
       - rmf_traffic_ros2
+      - rmf_websocket
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 1.4.0-3
+      version: 2.1.2-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git
-      version: main
+      version: humble
     status: developed
   rmf_simulation:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_ros2` to `2.1.2-1`:

- upstream repository: https://github.com/open-rmf/rmf_ros2.git
- release repository: https://github.com/ros2-gbp/rmf_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.4.0-3`
