### PR TITLE
Don't use hdf5 virtual package use native one.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1894,12 +1894,12 @@ hddtemp:
     impish: [hddtemp]
 hdf5:
   arch: [hdf5-cpp-fortran]
-  debian: [libhdf5-serial-dev]
+  debian: [libhdf5-dev]
   fedora: [hdf5-devel]
   gentoo: [sci-libs/hdf5]
   macports: [hdf5]
   nixos: [hdf5]
-  ubuntu: [libhdf5-serial-dev]
+  ubuntu: [libhdf5-dev]
 hdf5-tools:
   debian: [hdf5-tools]
   ubuntu: [hdf5-tools]


### PR DESCRIPTION
Removing declarations of transitional dummy packages and using actual implementation package

https://packages.debian.org/buster/libhdf5-serial-dev

https://packages.ubuntu.com/bionic/libhdf5-serial-dev

We don't have good support for virtual packages and this is clearer and more consistent.