### PR TITLE
Add libfreetype6 for ubuntu and debian

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1128,10 +1128,12 @@ freeimage:
   ubuntu: [libfreeimage-dev]
 freetype:
   alpine: [freetype]
+  debian: [libfreetype6]
   fedora: [freetype]
   gentoo: [media-libs/freetype]
   macports: [freetype]
   nixos: [freetype]
+  ubuntu: [libfreetype6]
 fsharp:
   debian: [fsharp]
   gentoo: [dev-lang/fsharp]


### PR DESCRIPTION
https://packages.ubuntu.com/bionic/libfreetype6
https://packages.debian.org/buster/libfreetype6

Adding in these missing packages for ubuntu and debian