### PR TITLE
libtiff-dev exists in the generic on all supported platforms

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5373,11 +5373,7 @@ libtheora:
   ubuntu: [libtheora-dev]
 libtiff-dev:
   arch: [libtiff]
-  debian:
-    buster: [libtiff5-dev]
-    jessie: [libtiff5-dev]
-    stretch: [libtiff5-dev]
-    wheezy: [libtiff5-alt-dev]
+  debian: [libtiff-dev]
   fedora: [libtiff]
   freebsd: [tiff]
   gentoo: [media-libs/tiff]
@@ -5387,26 +5383,7 @@ libtiff-dev:
   slackware:
     slackpkg:
       packages: [libtiff]
-  ubuntu:
-    artful: [libtiff5-dev]
-    bionic: [libtiff5-dev]
-    focal: [libtiff-dev]
-    lucid: [libtiff4-dev]
-    maverick: [libtiff4-dev]
-    natty: [libtiff4-dev]
-    oneiric: [libtiff4-dev]
-    precise: [libtiff4-dev]
-    quantal: [libtiff5-dev]
-    raring: [libtiff5-dev]
-    saucy: [libtiff5-dev]
-    trusty: [libtiff5-dev]
-    trusty_python3: [libtiff5-dev]
-    utopic: [libtiff5-dev]
-    vivid: [libtiff5-dev]
-    wily: [libtiff5-dev]
-    xenial: [libtiff5-dev]
-    yakkety: [libtiff5-dev]
-    zesty: [libtiff5-dev]
+  ubuntu: [libtiff-dev]
 libtiff4-dev:
   arch: [libtiff]
   debian: [libtiff4-dev]


### PR DESCRIPTION
We don't need the specific version numbers, they're aliased by the versionless one.

Ubuntu: https://packages.ubuntu.com/bionic/libtiff-dev

Debian: https://packages.debian.org/buster/libtiff-dev

I needed this to be able to use it on Jammy and newer platforms. I cleaned it up instead of just extending.
