### PR TITLE
clpe_ros: 0.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -814,6 +814,11 @@ repositories:
       type: git
       url: https://github.com/canlab-co/clpe_ros.git
       version: noetic
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/canlab-co/clpe_ros-ros-release.git
+      version: 0.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clpe_ros` to `0.1.1-1`:

- upstream repository: https://github.com/canlab-co/clpe_ros.git
- release repository: https://github.com/canlab-co/clpe_ros-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## clpe_ros

```
* remove eeprom
```
