### PR TITLE
clpe_ros_msgs: 0.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -825,6 +825,11 @@ repositories:
       type: git
       url: https://github.com/canlab-co/clpe_ros_msgs.git
       version: noetic
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/canlab-co/clpe_ros_msgs-ros-release.git
+      version: 0.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clpe_ros_msgs` to `0.1.0-1`:

- upstream repository: https://github.com/canlab-co/clpe_ros_msgs.git
- release repository: https://github.com/canlab-co/clpe_ros_msgs-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## clpe_ros_msgs

```
* Provides ClpeCameraInfo message
* Contributors: Teo Koon Peng, Yadunund Vijay
```
