### PR TITLE
clpe_sdk: 0.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -836,6 +836,13 @@ repositories:
       type: git
       url: https://github.com/canlab-co/CLPE_G_NVP2650D_SDK.git
       version: noetic
+    release:
+      packages:
+      - clpe
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/canlab-co/CLPE_G_NVP2650D_SDK-ros-release.git
+      version: 0.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clpe_sdk` to `0.1.1-1`:

- upstream repository: https://github.com/canlab-co/CLPE_G_NVP2650D_SDK.git
- release repository: https://github.com/canlab-co/CLPE_G_NVP2650D_SDK-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## clpe

```
* remove eeprom
* Contributors: Can-lab Corporation
```
