### PR TITLE
geometry2: 0.7.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3046,7 +3046,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/geometry2-release.git
-      version: 0.7.5-1
+      version: 0.7.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.7.6-1`:

- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry2-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.5-1`

## geometry2

- No changes

## tf2

```
* Fix dead loop in message filter (#532 <https://github.com/ros/geometry2/issues/532>)
* Restore time difference order so future extrapolation exceptions don't show non-sensical negative seconds into the future (#522 <https://github.com/ros/geometry2/issues/522>)
* Contributors: Feng Zhaolin, Lucas Walter
```

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_geometry_msgs

```
* remove method with misleading doc (#534 <https://github.com/ros/geometry2/issues/534>)
* Contributors: Wellington Castro
```

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* tf2_ros polling interval proportional to timeout (#492 <https://github.com/ros/geometry2/issues/492>)
  * polling interval proportional to timeout
  * CAN_TRANSFORM_POLLING_SCALE as global
  * add DEFAULT_CAN_TRANSFORM_POLLING_SCALE
* Removed print statements from buffer interface (#530 <https://github.com/ros/geometry2/issues/530>)
* Switch to new boost/bind/bind.hpp (#528 <https://github.com/ros/geometry2/issues/528>)
* Updating the documentation to reflect current constructor for a MessageFilter (#527 <https://github.com/ros/geometry2/issues/527>)
* (tf2_ros) Docs working on python 3 (#521 <https://github.com/ros/geometry2/issues/521>)
* Mitigate flakey test in tf2_ros (#490 <https://github.com/ros/geometry2/issues/490>)
* Contributors: Atsushi Watanabe, Janno Lunenburg, Jochen Sprickerhof, Matthijs van der Burgh, Shih-Wei Guo, Tassos Natsakis
```

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
