### PR TITLE
Add python3-fabric-pip to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6637,6 +6637,19 @@ python3-ezdxf:
     focal:
       pip:
         packages: [ezdxf]
+python3-fabric-pip:
+  debian:
+    pip:
+      packages: [fabric]
+  fedora:
+    pip:
+      packages: [fabric]
+  osx:
+    pip:
+      packages: [fabric]
+  ubuntu:
+    pip:
+      packages: [fabric]
 python3-falcon:
   arch: [python-falcon]
   debian: [python3-falcon]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-fabric-pip

## Package Upstream Source:

Source: https://github.com/fabric/fabric
Docs: https://www.fabfile.org/

## Purpose of using this:

Fabric is a Python3 utility library for remote execution of processes using SSH with first-class citizens for ssh-connection, processes, etc.

## Links to Distribution Packages
This package is only distributed via PyPi: https://pypi.org/project/fabric/