### PR TITLE
kinematics_interface: 0.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1771,6 +1771,24 @@ repositories:
       url: https://github.com/ros-tooling/keyboard_handler.git
       version: rolling
     status: developed
+  kinematics_interface:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/kinematics_interface.git
+      version: master
+    release:
+      packages:
+      - kinematics_interface
+      - kinematics_interface_kdl
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros-controls/kinematics_interface-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/kinematics_interface.git
+      version: master
+    status: developed
   kobuki_velocity_smoother:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematics_interface` to `0.0.1-1`:

- upstream repository: https://github.com/ros-controls/kinematics_interface.git
- release repository: https://github.com/ros-controls/kinematics_interface-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## kinematics_interface

```
* Make formatting of comments unified and nice. (#11 <https://github.com/ros-controls/kinematics_interface/issues/11>)
* Enable interface to use Eigen per default (#6 <https://github.com/ros-controls/kinematics_interface/issues/6>)
* Add CI setup to the repository. (#8 <https://github.com/ros-controls/kinematics_interface/issues/8>)
* Update CMakeFiles, correct deps and formatting. (#10 <https://github.com/ros-controls/kinematics_interface/issues/10>)
* add pre-commit to repo (#7 <https://github.com/ros-controls/kinematics_interface/issues/7>)
* Fix more indentations and alphabetize
* Update dependencies and maintainers
* Kinematics interface with KDL implementation
* change directory name and use header only interface
* changed plugin name to kinematics_interface_kdl/KDLKinematics
* add calculate_jacobian as new interface method
* added argument to specify which link the Jacobian is calculated with respect to
* made interface stateless, changed method name, fixed small bugs
* updated README and cleaned up code
* added KDL plugin for kinematics interface
* Contributors: Paul Gesel, Andy Zelenak, Bence Magyar, Denis Štogl
```

## kinematics_interface_kdl

```
* Enable interface to use Eigen per default (#6 <https://github.com/ros-controls/kinematics_interface/issues/6>)
* Add CI setup to the repository. (#8 <https://github.com/ros-controls/kinematics_interface/issues/8>)
* Remove duplicate of Eigen dependency.
* Update CMakeFiles, correct deps and formatting. (#10 <https://github.com/ros-controls/kinematics_interface/issues/10>)
* add pre-commit to repo (#7 <https://github.com/ros-controls/kinematics_interface/issues/7>)
  add pre-commit
* Fix failing KDL test (#5 <https://github.com/ros-controls/kinematics_interface/issues/5>)
  * add verification for all inputs
  * add underscore to end_effector
  * add test to ensure inverse then forward calculation is approximately unit
* Fix more indentations and alphabetize
* Update dependencies and maintainers
* Kinematics interface with KDL implementation
* change directory name and use header only interface
* Contributors: Paul Gesel, Andy Zelenak, Bence Magyar, Denis Štogl
```
