### PR TITLE
pinocchio: 2.6.10-3 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3086,7 +3086,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pinocchio-release.git
-      version: 2.6.10-2
+      version: 2.6.10-3
     source:
       type: git
       url: https://github.com/stack-of-tasks/pinocchio.git


### PR DESCRIPTION
**This PR reduces the debug information level to try to address the out-of-memory during linking**

Increasing version of package(s) in repository `pinocchio` to `2.6.10-3`:

- upstream repository: https://github.com/stack-of-tasks/pinocchio.git
- release repository: https://github.com/ros2-gbp/pinocchio-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.6.10-2`
