### PR TITLE
ros_gz: 0.244.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4463,7 +4463,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 0.244.6-1
+      version: 0.244.7-1
     source:
       type: git
       url: https://github.com/gazebosim/ros_gz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `0.244.7-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.244.6-1`

## ros_gz

```
* Merge branch 'ros2' into ports/galactic_to_ros2
* Contributors: Michael Carroll
```

## ros_gz_bridge

```
* Make sure that ign_* yaml configs work as well (#310 <https://github.com/gazebosim/ros_gz/issues/310>)
* Bridge between msgs::Float_V and ros_gz_interfaces/Float32Array msg types (#306 <https://github.com/gazebosim/ros_gz/issues/306>)
  * bridge float_v and float32_multi_array msg type
  Co-authored-by: Ian Chen <mailto:ichen@openrobotics.org>
* Bridge between msgs::Pose_V and geometry_msgs/PoseArray msg types (#305 <https://github.com/gazebosim/ros_gz/issues/305>)
* replace ign with gz in ros_gz_bridge README (#303 <https://github.com/gazebosim/ros_gz/issues/303>)
* Merge pull request #275 <https://github.com/gazebosim/ros_gz/issues/275> (Galactic to Humble)
  Galactic to Humble
* Fix merge
* Merge branch 'ros2' into ports/galactic_to_ros2
* Contributors: Ian Chen, Michael Carroll, Olivier Kermorgant
```

## ros_gz_image

```
* Merge branch 'ros2' into ports/galactic_to_ros2
* Contributors: Michael Carroll
```

## ros_gz_interfaces

```
* Bridge between msgs::Float_V and ros_gz_interfaces/Float32Array msg types (#306 <https://github.com/gazebosim/ros_gz/issues/306>)
  * bridge float_v and float32_multi_array msg type
  Co-authored-by: Ian Chen <mailto:ichen@openrobotics.org>
* Merge pull request #275 <https://github.com/gazebosim/ros_gz/issues/275> (Galactic to Humble)
  Galactic to Humble
* Merge branch 'ros2' into ports/galactic_to_ros2
* Contributors: Ian Chen, Michael Carroll
```

## ros_gz_sim

```
* Fix launch substitutions for ign_args (#309 <https://github.com/gazebosim/ros_gz/issues/309>)
  * Fix launch substitutions for ign_args
* Merge pull request #275 <https://github.com/gazebosim/ros_gz/issues/275> (Galactic to Humble)
  Galactic to Humble
* Merge branch 'ros2' into ports/galactic_to_ros2
* Contributors: Michael Carroll
```

## ros_gz_sim_demos

```
* Merge pull request #275 <https://github.com/gazebosim/ros_gz/issues/275> (Galactic to Humble)
  Galactic to Humble
* Merge branch 'ros2' into ports/galactic_to_ros2
* Contributors: Michael Carroll
```

## ros_ign

- No changes

## ros_ign_bridge

```
* Merge branch 'ros2' into ports/galactic_to_ros2
* Merge branch 'galactic' into ports/galactic_to_ros2
* Make tests faster and more robust (#272 <https://github.com/gazebosim/ros_gz/issues/272>)
* Improve documentation around yaml configuration (#271 <https://github.com/gazebosim/ros_gz/issues/271>)
* Fix small typo in bridge README (#270 <https://github.com/gazebosim/ros_gz/issues/270>)
* Port NavSat (#224 <https://github.com/gazebosim/ros_gz/issues/224>) from ROS 1 to ROS 2 (#268 <https://github.com/gazebosim/ros_gz/issues/268>)
  Co-authored-by: Tyler Howell <mailto:76003804+TyHowellWork@users.noreply.github.com>
* Add ParamVec and bridge from Ignition (#261 <https://github.com/gazebosim/ros_gz/issues/261>)
  * Introduces ros_ign_interfaces::msg::ParamVec for storing a list of Parameters that are int, bool, double, or string.
  * Introduces bridge for ignition::msgs::param to ros_ign_interfaces::msg::ParamVec
  * Introduces bridge for ignition::msgs::param_v to ros_ign_interfaces::msg::ParamVec
* Add support for converting Any <-> ParamValue (#260 <https://github.com/gazebosim/ros_gz/issues/260>)
  * Add support for converting Any <-> ParamValue
* Feature: set QoS options to override durability (#250 <https://github.com/gazebosim/ros_gz/issues/250>) (#259 <https://github.com/gazebosim/ros_gz/issues/259>)
  Co-authored-by: Louise Poubel <mailto:louise@openrobotics.org>
  Co-authored-by: Daisuke Nishimatsu <mailto:42202095+wep21@users.noreply.github.com>
* Add node component and yaml-configured bridge node (#238 <https://github.com/gazebosim/ros_gz/issues/238>)
  * Refactor in support of adding yaml-configured node
* Add rssi to Dataframe.msg (#249 <https://github.com/gazebosim/ros_gz/issues/249>)
  * Adding rssi field to ros_ign_interfaces/Dataframe.msg
* Use the python generator for tests as well (#234 <https://github.com/gazebosim/ros_gz/issues/234>)
  * Use the python generator for tests as well
* Generate boilerplate files from Python scripts (#233 <https://github.com/gazebosim/ros_gz/issues/233>)
  The way that we add factories can be a bit error-prone, as there are a lot of strings that cannot be checked at compilation time. This changes several of the boilerplate files to be generated automatically by python scripts, in line with how ros1_bridge does it.
* [galactic] Backport GuiCamera, StringVec, TrackVisual, VideoRecord (#241 <https://github.com/gazebosim/ros_gz/issues/241>)
  * [ros_ign_interfaces] Add more interface definitions.
  * Add converion functions for the added messages
  * Update the factory factory function with the new messages
  * Add new messages to docs
  * Add test cases for the new messages conversions
  Co-authored-by: Ivan Santiago Paunovic <mailto:ivanpauno@ekumenlabs.com>
* Add Dataframe message and bridging (#239 <https://github.com/gazebosim/ros_gz/issues/239>)
* Factory interface needs virtual destructor (#232 <https://github.com/gazebosim/ros_gz/issues/232>)
* Optional "lazy" bridge subscribers (#225 <https://github.com/gazebosim/ros_gz/issues/225>)
  This allows for the bridge to be created in such a way that it is "lazy". In this case "lazy" means:
  * The publication (output) side of the bridge is always on and actively looking for subscriptions.
  * The subscription (input) side of the bridge is only turned on in the case that there are subscriptions on the output side.
* Contributors: Carlos Agüero, Louise Poubel, Michael Carroll
```

## ros_ign_gazebo

```
* Fix launch substitutions for ign_args (#309 <https://github.com/gazebosim/ros_gz/issues/309>)
  * Fix launch substitutions for ign_args
* Merge branch 'ros2' into ports/galactic_to_ros2
* Merge branch 'galactic' into ports/galactic_to_ros2
* Add ROS2 version of Stopwatch (#287 <https://github.com/gazebosim/ros_gz/issues/287>)
* Add debugger option in launch (#286 <https://github.com/gazebosim/ros_gz/issues/286>)
  * add debugger option in launch
  * remove xterm dependency; rely on x-terminal-emulator from update-alternatives
* [galactic] Backport: Add std_msgs as dependency of ros_ign_gazebo (#264 <https://github.com/gazebosim/ros_gz/issues/264>)
  Co-authored-by: Kenji Brameld <mailto:kenjibrameld@gmail.com>
* Contributors: Michael Carroll, andermi
```

## ros_ign_gazebo_demos

```
* Merge branch 'galactic' into ports/galactic_to_ros2
* Port NavSat (#224 <https://github.com/gazebosim/ros_gz/issues/224>) from ROS 1 to ROS 2 (#268 <https://github.com/gazebosim/ros_gz/issues/268>)
  Co-authored-by: Tyler Howell <mailto:76003804+TyHowellWork@users.noreply.github.com>
* Contributors: Michael Carroll
```

## ros_ign_image

```
* Merge branch 'ros2' into ports/galactic_to_ros2
* Contributors: Michael Carroll
```

## ros_ign_interfaces

```
* Merge branch 'ros2' into ports/galactic_to_ros2
* Merge branch 'galactic' into ports/galactic_to_ros2
* Add ParamVec and bridge from Ignition (#261 <https://github.com/gazebosim/ros_gz/issues/261>)
  * Introduces ros_ign_interfaces::msg::ParamVec for storing a list of Parameters that are int, bool, double, or string.
  * Introduces bridge for ignition::msgs::param to ros_ign_interfaces::msg::ParamVec
  * Introduces bridge for ignition::msgs::param_v to ros_ign_interfaces::msg::ParamVec
* Add rssi to Dataframe.msg (#249 <https://github.com/gazebosim/ros_gz/issues/249>)
  * Adding rssi field to ros_ign_interfaces/Dataframe.msg
* [galactic] Backport GuiCamera, StringVec, TrackVisual, VideoRecord (#241 <https://github.com/gazebosim/ros_gz/issues/241>)
  * [ros_ign_interfaces] Add more interface definitions.
  * Add converion functions for the added messages
  * Update the factory factory function with the new messages
  * Add new messages to docs
  * Add test cases for the new messages conversions
  Co-authored-by: Ivan Santiago Paunovic <mailto:ivanpauno@ekumenlabs.com>
* Add Dataframe message and bridging (#239 <https://github.com/gazebosim/ros_gz/issues/239>)
* Contributors: Carlos Agüero, Michael Carroll
```
