### PR TITLE
Revert "realtime_tools: 2.3.0-1 in 'galactic/distribution.yaml' [bloom]"

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3633,7 +3633,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros-gbp/realtime_tools-release.git
-      version: 2.3.0-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
I believe that this update was released into Galactic by mistake. In any case, the update is broken and has regressed several downstream packages. Until the maintainer can resolve the problem, it should be reverted to a working version.

This reverts #34258.