### PR TITLE
ros_gz: 0.245.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4211,6 +4211,28 @@ repositories:
       url: https://github.com/ros/ros_environment.git
       version: rolling
     status: maintained
+  ros_gz:
+    doc:
+      type: git
+      url: https://github.com/gazebosim/ros_gz.git
+      version: ros2
+    release:
+      packages:
+      - ros_gz
+      - ros_gz_bridge
+      - ros_gz_image
+      - ros_gz_interfaces
+      - ros_gz_sim
+      - ros_gz_sim_demos
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_ign-release.git
+      version: 0.245.0-1
+    source:
+      type: git
+      url: https://github.com/gazebosim/ros_gz.git
+      version: ros2
+    status: maintained
   ros_ign:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `0.245.0-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## ros_gz

```
* humble to ros2 (#311 <https://github.com/gazebosim/ros_gz/issues/311>)
  Co-authored-by: Michael Carroll <mailto:michael@openrobotics.org>
* Merge remote-tracking branch 'origin/humble' into ahcorde/humble_to_ros2
* Contributors: Alejandro Hernández Cordero, ahcorde
```

## ros_gz_bridge

```
* humble to ros2 (#311 <https://github.com/gazebosim/ros_gz/issues/311>)
  Co-authored-by: Michael Carroll <mailto:michael@openrobotics.org>
* Remove Humble+ deprecations (#312 <https://github.com/gazebosim/ros_gz/issues/312>)
  * Remove Humble+ deprecations
* Merge remote-tracking branch 'origin/humble' into ahcorde/humble_to_ros2
* Remove all ignition references on ROS 2 branch (#302 <https://github.com/gazebosim/ros_gz/issues/302>)
  * Remove all shims
  * Update CMakeLists and package.xml for garden
  * Complete garden gz renaming
  * Drop fortress CI
* Contributors: Alejandro Hernández Cordero, Michael Carroll, ahcorde
```

## ros_gz_image

```
* humble to ros2 (#311 <https://github.com/gazebosim/ros_gz/issues/311>)
  Co-authored-by: Michael Carroll <mailto:michael@openrobotics.org>
* Merge remote-tracking branch 'origin/humble' into ahcorde/humble_to_ros2
* Remove all ignition references on ROS 2 branch (#302 <https://github.com/gazebosim/ros_gz/issues/302>)
  * Remove all shims
  * Update CMakeLists and package.xml for garden
  * Complete garden gz renaming
  * Drop fortress CI
* Contributors: Alejandro Hernández Cordero, Michael Carroll, ahcorde
```

## ros_gz_interfaces

```
* humble to ros2 (#311 <https://github.com/gazebosim/ros_gz/issues/311>)
  Co-authored-by: Michael Carroll <mailto:michael@openrobotics.org>
* Merge remote-tracking branch 'origin/humble' into ahcorde/humble_to_ros2
* Contributors: Alejandro Hernández Cordero, ahcorde
```

## ros_gz_sim

```
* humble to ros2 (#311 <https://github.com/gazebosim/ros_gz/issues/311>)
  Co-authored-by: Michael Carroll <mailto:michael@openrobotics.org>
* Merge remote-tracking branch 'origin/humble' into ahcorde/humble_to_ros2
* Remove all ignition references on ROS 2 branch (#302 <https://github.com/gazebosim/ros_gz/issues/302>)
  * Remove all shims
  * Update CMakeLists and package.xml for garden
  * Complete garden gz renaming
  * Drop fortress CI
* Contributors: Alejandro Hernández Cordero, Michael Carroll, ahcorde
```

## ros_gz_sim_demos

```
* humble to ros2 (#311 <https://github.com/gazebosim/ros_gz/issues/311>)
  Co-authored-by: Michael Carroll <mailto:michael@openrobotics.org>
* Merge remote-tracking branch 'origin/humble' into ahcorde/humble_to_ros2
* Remove all ignition references on ROS 2 branch (#302 <https://github.com/gazebosim/ros_gz/issues/302>)
  * Remove all shims
  * Update CMakeLists and package.xml for garden
  * Complete garden gz renaming
  * Drop fortress CI
* Contributors: Alejandro Hernández Cordero, Michael Carroll, ahcorde
```
