### PR TITLE
launch: 0.10.10-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2202,7 +2202,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.10.9-1
+      version: 0.10.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.10.10-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.10.9-1`

## launch

```
* Fix bug in test_push_and_pop_environment.py
  Sandbox the environment so the tests do not affect other tests.
  This is a partial backport of (#652 <https://github.com/ros2/launch/issues/652>)
* Sandbox environment in tests to fix repeated job failures (#609 <https://github.com/ros2/launch/issues/609>)
* Fix the restoring of os.environ to maintain its type. (#656 <https://github.com/ros2/launch/issues/656>)
* Contributors: Chris Lalancette, Shane Loretz
```

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
