### PR TITLE
Revert vision_opencv

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -6406,7 +6406,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 2.2.1-1
+      version: 2.2.1-2
     source:
       test_pull_requests: true
       type: git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -6406,7 +6406,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 3.1.2-1
+      version: 2.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
@cottsay
Reverting vision_opencv to address the broken vision_opencv galactic build on Galactic for RHEL.