### PR TITLE
Add librapidxml-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5150,7 +5150,6 @@ librabbitmq-dev:
 librapidxml-dev:
   debian: [librapidxml-dev]
   fedora: [rapidxml-devel]
-  rhel: [rapidxml-devel]
   ubuntu: [librapidxml-dev]
 libraw1394:
   arch:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5147,6 +5147,11 @@ librabbitmq-dev:
   fedora: [librabbitmq-devel]
   rhel: [librabbitmq-devel]
   ubuntu: [librabbitmq-dev]
+librapidxml-dev:
+  debian: [librapidxml-dev]
+  fedora: [rapidxml-devel]
+  rhel: [rapidxml-devel]
+  ubuntu: [librapidxml-dev]
 libraw1394:
   arch:
     pacman:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

librapidxml-dev

## Package Upstream Source:

https://rapidxml.sourceforge.net/
https://github.com/viriuwu/rapidxml  (mirror)

## Purpose of using this:

I want to add it as a system dependency to replace a source copy shipped by one of the packages I maintain.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/sid/librapidxml-dev
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/kinetic/librapidxml-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/rapidxml/rapidxml-devel/

