### PR TITLE
mvsim: 0.4.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5734,7 +5734,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/ual-arm-ros-pkg/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.4.1-1`:

- upstream repository: https://github.com/ual-arm-ros-pkg/mvsim.git
- release repository: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.0-1`

## mvsim

```
* Add more documentation, demo files, and screenshots
* Support animations from keyframe list for blocks and vehicles
* Refactor common xml params in Simulable interface
* Support PARENT_NAME usage in sensor definition files; add "<publish>" tags to tutorial sensors
* 2D lidar sensor: new XML parameter maxRange
* change threshold to decimate sensors preview subwindows
* BUGFIX: Uninitialized quaternion in rviz marker (Closes #14 <https://github.com/MRPT/mvsim/issues/14>)
* Allow expressions in include tags
* Expose more lidar params in its XML
* Contributors: Jose Luis Blanco-Claraco
```
