### PR TITLE
Revert "ros_gz: 0.245.0-1 in 'rolling/distribution.yaml' [bloom]"

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4195,28 +4195,6 @@ repositories:
       url: https://github.com/ros/ros_environment.git
       version: rolling
     status: maintained
-  ros_gz:
-    doc:
-      type: git
-      url: https://github.com/gazebosim/ros_gz.git
-      version: ros2
-    release:
-      packages:
-      - ros_gz
-      - ros_gz_bridge
-      - ros_gz_image
-      - ros_gz_interfaces
-      - ros_gz_sim
-      - ros_gz_sim_demos
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 0.245.0-1
-    source:
-      type: git
-      url: https://github.com/gazebosim/ros_gz.git
-      version: ros2
-    status: maintained
   ros_ign:
     doc:
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#34914

This release is failing on the buildfarm because no release artifacts were generated for Ubuntu Jammy due to the dependency bumps.

```
Could not resolve rosdep key 'gz-math7'
Failed to resolve gz-math7 on ubuntu:jammy with: Error running generator: Failed to resolve rosdep key 'gz-math7', aborting.
gz-math7 is depended on by these packages: ['ros_gz_sim']
<== Failed
Could not resolve rosdep key 'gz-msgs9'
Failed to resolve gz-msgs9 on ubuntu:jammy with: Error running generator: Failed to resolve rosdep key 'gz-msgs9', aborting.
gz-msgs9 is depended on by these packages: ['ros_gz_bridge', 'ros_gz_image']
<== Failed
Could not resolve rosdep key 'gz-sim7'
Failed to resolve gz-sim7 on ubuntu:jammy with: Error running generator: Failed to resolve rosdep key 'gz-sim7', aborting.
gz-sim7 is depended on by these packages: ['ros_gz_sim_demos', 'ros_gz_sim']
<== Failed
Could not resolve rosdep key 'gz-transport12'
Failed to resolve gz-transport12 on ubuntu:jammy with: Error running generator: Failed to resolve rosdep key 'gz-transport12', aborting.
gz-transport12 is depended on by these packages: ['ros_gz_bridge', 'ros_gz_image']
<== Failed
```