### PR TITLE
system_fingerprint: 0.7.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5530,7 +5530,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/MetroRobots/ros_system_fingerprint-release.git
-      version: 0.5.0-1
+      version: 0.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `system_fingerprint` to `0.7.0-1`:

- upstream repository: https://github.com/MetroRobots/ros_system_fingerprint.git
- release repository: https://github.com/MetroRobots/ros_system_fingerprint-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.5.0-1`
