### PR TITLE
Add apt-transport-https rule for Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -111,6 +111,7 @@ apr:
   ubuntu: [libapr1-dev, libaprutil1-dev]
 apt-transport-https:
   debian: [apt-transport-https]
+  fedora: [apt]
   ubuntu: [apt-transport-https]
 aravis:
   debian: [libaravis-0.6-0, aravis-tools]


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/apt/apt/

The [documentation for apt-transport-https](https://packages.debian.org/buster/apt-transport-https) states that apt >= 1.5 contains this functionality built-in.