### PR TITLE
Add libdlib-dev rule for Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3106,6 +3106,7 @@ libdevil-dev:
   ubuntu: [libdevil-dev]
 libdlib-dev:
   debian: [libdlib-dev]
+  fedora: [dlib-devel]
   gentoo:
     portage:
       packages: [sci-libs/dlib]


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/dlib/dlib-devel/