### PR TITLE
Add libgazebo-dev rule for Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3419,6 +3419,7 @@ libgazebo-dev:
   debian:
     bullseye: [libgazebo-dev]
     buster: [libgazebo11-dev]
+  fedora: [gazebo-devel]
   gentoo: [=sci-electronics/gazebo-11*]
   ubuntu:
     focal: [libgazebo11-dev]


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/gazebo/gazebo-devel/