### PR TITLE
mqtt_client: 1.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5566,7 +5566,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ika-rwth-aachen/mqtt_client-release.git
-      version: 1.0.2-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ika-rwth-aachen/mqtt_client.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mqtt_client` to `1.1.0-1`:

- upstream repository: https://github.com/ika-rwth-aachen/mqtt_client.git
- release repository: https://github.com/ika-rwth-aachen/mqtt_client-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.2-1`

## mqtt_client

```
* Merge pull request #6 from ika-rwth-aachen/feature/primitive-msgs
  Support exchange of primitive messages with other MQTT clients
* Contributors: Lennart Reiher
```
