### PR TITLE
Add libi2c-dev rule for Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3775,6 +3775,7 @@ libhidapi-dev:
 libi2c-dev:
   arch: [linux-api-headers]
   debian: [libi2c-dev]
+  fedora: [libi2c-devel]
   gentoo: [sys-apps/i2c-tools]
   nixos: [i2c-tools]
   ubuntu: [libi2c-dev]


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/i2c-tools/libi2c-devel/