### PR TITLE
Add libxcursor-dev rule for Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5852,6 +5852,7 @@ libxaw:
   ubuntu: [libxaw7-dev]
 libxcursor-dev:
   debian: [libxcursor-dev]
+  fedora: [libXcursor-devel]
   nixos: [xorg.libXcursor]
   ubuntu: [libxcursor-dev]
 libxenomai-dev:


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/libXcursor/libXcursor-devel/