### PR TITLE
Add python3-django-extensions rule for Fedora

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6483,6 +6483,7 @@ python3-django-cors-headers:
   ubuntu: [python3-django-cors-headers]
 python3-django-extensions:
   debian: [python3-django-extensions]
+  fedora: [python3-django-extensions]
   ubuntu: [python3-django-extensions]
 python3-django-extra-views:
   debian: [python3-django-extra-views]


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/python-django-extensions/python3-django-extensions/