### PR TITLE
Add python3-imageio rule for Fedora

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7094,6 +7094,7 @@ python3-ignition-math6:
     jammy: [python3-ignition-math6]
 python3-imageio:
   debian: [python3-imageio]
+  fedora: [python3-imageio]
   gentoo: [dev-python/imageio]
   nixos: [python3Packages.imageio]
   openembedded: [python3-imageio@meta-python]


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/python-imageio/python3-imageio/