### PR TITLE
Added python3-munkres

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7489,9 +7489,7 @@ python3-multimethod-pip:
     pip:
       packages: [multimethod]
 python3-munkres:
-  debian:
-    bullseye: [python3-munkres]
-    buster: [python3-munkres]
+  debian: [python3-munkres]
   fedora: [python3-munkres]
   nixos: [python3Packages.munkre]
   opensuse: [python3-munkres]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7493,6 +7493,7 @@ python3-munkres:
     bullseye: [python3-munkres]
     buster: [python3-munkres]
   fedora: [python3-munkres]
+  nixos: [python3Packages.munkre]
   opensuse: [python3-munkres]
   rhel:
     '*': [python3-munkres]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7496,10 +7496,7 @@ python3-munkres:
   rhel:
     '*': [python3-munkres]
     '7': null
-  ubuntu:
-    bionic: [python3-munkres]
-    focal: [python3-munkres]
-    jammy: [python3-munkres]
+  ubuntu: [python3-munkres]
 python3-mycroft-messagebus-client-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7494,6 +7494,9 @@ python3-munkres:
     buster: [python3-munkres]
   fedora: [python3-munkres]
   opensuse: [python3-munkres]
+  rhel:
+    '*': [python3-munkres]
+    '7': null
   ubuntu:
     bionic: [python3-munkres]
     focal: [python3-munkres]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7488,6 +7488,16 @@ python3-multimethod-pip:
   ubuntu:
     pip:
       packages: [multimethod]
+python3-munkres:
+  debian: 
+    bullseye: [python3-munkres]
+    buster: [python3-munkres]
+  fedora: [python3-munkres]
+  opensuse: [python3-munkres]
+  ubuntu:
+    bionic: [python3-munkres]
+    focal: [python3-munkres]
+    jammy: [python3-munkres]
 python3-mycroft-messagebus-client-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7489,7 +7489,7 @@ python3-multimethod-pip:
     pip:
       packages: [multimethod]
 python3-munkres:
-  debian: 
+  debian:
     bullseye: [python3-munkres]
     buster: [python3-munkres]
   fedora: [python3-munkres]


### PR DESCRIPTION
Added python3-munkres package.

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-munkres

## Package Upstream Source:

[link to source repository](https://github.com/bmc/munkres)

## Purpose of using this:

Use munkres algorithm.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian:https://packages.debian.org/bullseye/python3-munkres
  - [REQUIRED](https://packages.debian.org/bullseye/python3-munkres)
- Ubuntu: https://packages.ubuntu.com/jammy/python3-munkres
   - [REQUIRED](https://packages.ubuntu.com/jammy/python3-munkres)
- Fedora: https://packages.fedoraproject.org/
  - IF AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/
  - IF AVAILABLE
