### PR TITLE
pr2_gripper_sensor: 1.0.12-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7178,6 +7178,26 @@ repositories:
       url: https://github.com/pr2/pr2_ethercat_drivers.git
       version: kinetic-devel
     status: unmaintained
+  pr2_gripper_sensor:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_gripper_sensor.git
+      version: hydro-devel
+    release:
+      packages:
+      - pr2_gripper_sensor
+      - pr2_gripper_sensor_action
+      - pr2_gripper_sensor_controller
+      - pr2_gripper_sensor_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_gripper_sensor-release.git
+      version: 1.0.12-1
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_gripper_sensor.git
+      version: hydro-devel
+    status: unmaintained
   pr2_kinematics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_gripper_sensor` to `1.0.12-1`:

- upstream repository: https://github.com/PR2/pr2_gripper_sensor.git
- release repository: https://github.com/pr2-gbp/pr2_gripper_sensor-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## pr2_gripper_sensor

- No changes

## pr2_gripper_sensor_action

- No changes

## pr2_gripper_sensor_controller

```
* fix error reported by clang 13
* Contributors: v4hn
```

## pr2_gripper_sensor_msgs

- No changes
