### PR TITLE
vision_opencv: 3.1.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -6406,7 +6406,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 2.2.1-2
+      version: 3.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `3.1.3-1`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros2-gbp/vision_opencv-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.1-2`

## cv_bridge

```
* Add message to print out Boost_VERSION_STRING, and apply with CMP0093
* Fix RHEL buildfailure with Boost 1.66.0
* Contributors: Kenji Brameld
```

## image_geometry

- No changes

## vision_opencv

- No changes
