### PR TITLE
vision_opencv: 3.0.7-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -7273,7 +7273,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 3.0.6-1
+      version: 3.0.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `3.0.7-1`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros2-gbp/vision_opencv-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.6-1`

## cv_bridge

```
* Add message to print out Boost_VERSION_STRING, and apply with CMP0093
* Address RHEL buildfailure with Boost 1.66.0
* Contributors: Kenji Brameld
```

## image_geometry

- No changes

## vision_opencv

- No changes
