### PR TITLE
wireless: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -7402,6 +7402,24 @@ repositories:
       url: https://github.com/cyberbotics/webots_ros2.git
       version: master
     status: maintained
+  wireless:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/wireless.git
+      version: foxy-devel
+    release:
+      packages:
+      - wireless_msgs
+      - wireless_watcher
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/clearpath-gbp/wireless-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/wireless.git
+      version: foxy-devel
+    status: maintained
   xacro:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wireless` to `1.0.0-1`:

- upstream repository: https://github.com/clearpathrobotics/wireless.git
- release repository: https://github.com/clearpath-gbp/wireless-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## wireless_msgs

```
* Minor fixes
* Updated wireless_msgs for ROS2.
  Updated wireless_watcher for ROS2.
* Contributors: Roni Kreinin
```

## wireless_watcher

```
* Minor fixes
* Added previous changelogs
* Updated wireless_msgs for ROS2.
  Updated wireless_watcher for ROS2.
* Contributors: Roni Kreinin
```
