### PR TITLE
kobuki_ros_interfaces: 1.0.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1702,6 +1702,22 @@ repositories:
       url: https://github.com/ros/kdl_parser.git
       version: galactic
     status: maintained
+  kobuki_ros_interfaces:
+    doc:
+      type: git
+      url: https://github.com/kobuki-base/kobuki_ros_interfaces.git
+      version: release/1.0.x
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/kobuki_ros_interfaces-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/kobuki-base/kobuki_ros_interfaces.git
+      version: release/1.0.x
+    status: maintained
   kobuki_velocity_smoother:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_ros_interfaces` to `1.0.0-1`:

- upstream repository: https://github.com/kobuki-base/kobuki_ros_interfaces.git
- release repository: https://github.com/ros2-gbp/kobuki_ros_interfaces-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## kobuki_ros_interfaces

```
* Rename from kobuki_msgs -> kobuki_ros_interfaces, #1 <https://github.com/kobuki-base/kobuki_ros_interfaces/pull/1>
* ROS2 eloquent upgrade, #11 <https://github.com/yujinrobot/kobuki_msgs/issues/11>
```
