### PR TITLE
update Libdc1394-dev for newer Ubuntu releases

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3101,8 +3101,8 @@ libdc1394-dev:
       packages: [libdc1394]
   ubuntu:
     '*': [libdc1394-dev]
-    focal: [libdc1394-22-dev]
     bionic: [libdc1394-22-dev]
+    focal: [libdc1394-22-dev]
 libdevil-dev:
   arch: [devil]
   debian: [libdevil-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3090,8 +3090,8 @@ libdc1394-dev:
       packages: [libdc1394]
   debian:
     '*': [libdc1394-dev]
-    'buster': [libdc1394-22-dev]
-    'stretch': [libdc1394-22-dev]
+    buster: [libdc1394-22-dev]
+    stretch: [libdc1394-22-dev]
   fedora: [libdc1394-devel]
   gentoo: [media-libs/libdc1394]
   nixos: [libdc1394]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3103,6 +3103,7 @@ libdc1394-dev:
     'impish': [libdc1394-22-dev]
     'focal': [libdc1394-22-dev]
     'bionic': [libdc1394-22-dev]
+    'artful': [libdc1394-22-dev]
 libdevil-dev:
   arch: [devil]
   debian: [libdevil-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3098,12 +3098,8 @@ libdc1394-dev:
       packages: [libdc1394]
   ubuntu:
     '*': [libdc1394-dev]
-    'artful': [libdc1394-22-dev]
-    'bionic': [libdc1394-22-dev]
     'focal': [libdc1394-22-dev]
-    'impish': [libdc1394-22-dev]
-    'trusty': [libdc1394-22-dev]
-    'xenial': [libdc1394-22-dev]
+    'bionic': [libdc1394-22-dev]
 libdevil-dev:
   arch: [devil]
   debian: [libdevil-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3096,7 +3096,13 @@ libdc1394-dev:
   osx:
     macports:
       packages: [libdc1394]
-  ubuntu: [libdc1394-22-dev]
+  ubuntu:
+    '*': [libdc1394-dev]
+    'trusty': [libdc1394-22-dev]
+    'xenial': [libdc1394-22-dev]
+    'impish': [libdc1394-22-dev]
+    'focal': [libdc1394-22-dev]
+    'bionic': [libdc1394-22-dev]
 libdevil-dev:
   arch: [devil]
   debian: [libdevil-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3101,8 +3101,8 @@ libdc1394-dev:
       packages: [libdc1394]
   ubuntu:
     '*': [libdc1394-dev]
-    'focal': [libdc1394-22-dev]
-    'bionic': [libdc1394-22-dev]
+    focal: [libdc1394-22-dev]
+    bionic: [libdc1394-22-dev]
 libdevil-dev:
   arch: [devil]
   debian: [libdevil-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3098,12 +3098,12 @@ libdc1394-dev:
       packages: [libdc1394]
   ubuntu:
     '*': [libdc1394-dev]
+    'artful': [libdc1394-22-dev]
+    'bionic': [libdc1394-22-dev]
+    'focal': [libdc1394-22-dev]
+    'impish': [libdc1394-22-dev]
     'trusty': [libdc1394-22-dev]
     'xenial': [libdc1394-22-dev]
-    'impish': [libdc1394-22-dev]
-    'focal': [libdc1394-22-dev]
-    'bionic': [libdc1394-22-dev]
-    'artful': [libdc1394-22-dev]
 libdevil-dev:
   arch: [devil]
   debian: [libdevil-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3088,7 +3088,10 @@ libdc1394-dev:
   arch:
     pacman:
       packages: [libdc1394]
-  debian: [libdc1394-22-dev]
+  debian:
+    '*': [libdc1394-dev]
+    'buster': [libdc1394-22-dev]
+    'stretch': [libdc1394-22-dev]
   fedora: [libdc1394-devel]
   gentoo: [media-libs/libdc1394]
   nixos: [libdc1394]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

libdc1394-dev

## Purpose of using this:
Since Ubuntu kinetic the package `libdc1394-22-dev` is replaced by `libdc1394-dev`. 
Therefore I set `libdc1394-dev` as the new standard package for Ubuntu and added rules for the older Ubuntu releases.
See:
- https://askubuntu.com/questions/1407580/unable-to-locate-package-libdc1394-22-dev
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=963924


closes [#34921](https://github.com/ros/rosdistro/issues/34921)

## Links to Distribution Packages
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/jammy/libdc1394-dev
   - https://packages.ubuntu.com/kinetic/libdc1394-dev
