### PR TITLE
image_pipeline: 1.17.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3614,7 +3614,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/image_pipeline-release.git
-      version: 1.16.0-1
+      version: 1.17.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `1.17.0-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros-gbp/image_pipeline-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.16.0-1`

## camera_calibration

- No changes

## depth_image_proc

```
* Switch to hpp headers of pluginlib
* Drop old C++ standard compiler flag
* Switch to new boost/bind/bind.hpp
* Add missing CATKIN_DEPENDS
* Update frame id to match depth_front, rgb_front
* Create point_cloud_xyzrgb.launch
  Created launch file for point_cloud_xyzrgb
* Delete depth_image_proc/script directory
* Delete depth_image_proc/launch directory
* Contributors: Anirban Dam, Jochen Sprickerhof
```

## image_pipeline

- No changes

## image_proc

```
* Switch to hpp headers of pluginlib
* Drop old C++ standard compiler flag
* Switch to new boost/bind/bind.hpp
* Update ROI parameters on resize
* Contributors: Jochen Sprickerhof, Yuki Furuta
```

## image_publisher

```
* Switch to hpp headers of pluginlib
* Switch to new boost/bind/bind.hpp
* Contributors: Jochen Sprickerhof
```

## image_rotate

```
* Switch to hpp headers of pluginlib
* Fix tf2 dependency for image_rotate
* Switch to new boost/bind/bind.hpp
* Contributors: Jochen Sprickerhof, Timo Röhling
```

## image_view

```
* Switch to hpp headers of pluginlib
* Switch to new boost/bind/bind.hpp
* Add support for floating point fps
* Contributors: Jochen Sprickerhof, Júnio Eduardo de Morais Aquino
```

## stereo_image_proc

```
* Switch to hpp headers of pluginlib
* Drop old C++ standard compiler flag
* Switch to new boost/bind/bind.hpp
* Contributors: Jochen Sprickerhof
```
