### PR TITLE
pyhri: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7508,7 +7508,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros4hri/pyhri-release.git
-      version: 0.1.2-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/ros4hri/pyhri.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyhri` to `0.2.0-1`:

- upstream repository: https://github.com/ros4hri/pyhri.git
- release repository: https://github.com/ros4hri/pyhri-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.2-1`

## pyhri

```
* autogenerate docs with rosdoc (for display on ROS wiki) and SPHINX
* More api documentation
* adjust code base for ReadTheDocs doc generation
  In particular:
  - add a requirements.txt file for catkin
  - allows importing pyhri without rospy
* Face.transform|Face.gaze_transform can change their reference frame
* removed dep on numpy.typing as it is not widely available yet
* mark features as invalid once they disappear
* returns copy of persons to avoid modifying dictionary while iterating
  While here, add infrastrcutre to check whether a face/body/voice/person is still valid
* expose the tf transform of the face and gaze
* add BSD license file
* [test] further tuning of tests' waiting behaviours for #1
* Contributors: Séverin Lemaignan
```
