### PR TITLE
ros2_control: 2.16.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4209,7 +4209,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.15.0-1
+      version: 2.16.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.16.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.15.0-1`

## controller_interface

```
* Add docs in export interface configurations for controllers. (#804 <https://github.com/ros-controls/ros2_control/issues/804>) (#842 <https://github.com/ros-controls/ros2_control/issues/842>)
* Contributors: Denis Štogl
```

## controller_manager

```
* Search for controller manager in the same namespace as spawner (#810 <https://github.com/ros-controls/ros2_control/issues/810>) (#839 <https://github.com/ros-controls/ros2_control/issues/839>)
* Don't ask to export reference interface if controller not 'inactive' or 'active' (#824 <https://github.com/ros-controls/ros2_control/issues/824>) (#843 <https://github.com/ros-controls/ros2_control/issues/843>)
* Contributors: Denis Štogl, Tony Najjar
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* fix broken links (issue #831 <https://github.com/ros-controls/ros2_control/issues/831>) (#833 <https://github.com/ros-controls/ros2_control/issues/833>) (#845 <https://github.com/ros-controls/ros2_control/issues/845>)
* Contributors: Manuel Muth
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## transmission_interface

- No changes
