### PR TITLE
launch: 1.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1917,7 +1917,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `1.0.3-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.2-1`

## launch

```
* Fix bug in test_push_and_pop_environment.py
* Fix the restoring of os.environ to maintain type. (#656 <https://github.com/ros2/launch/issues/656>)
* Addresses issue #588 <https://github.com/ros2/launch/issues/588>, allowing dict for 'output' (backport #640 <https://github.com/ros2/launch/issues/640>) (#647 <https://github.com/ros2/launch/issues/647>)
* Contributors: Chris Lalancette, mergify[bot]
```

## launch_pytest

- No changes

## launch_testing

```
* Fix Typo (#641 <https://github.com/ros2/launch/issues/641>) (#644 <https://github.com/ros2/launch/issues/644>)
* Switch to using a comprehension for process_names. (#614 <https://github.com/ros2/launch/issues/614>) (#615 <https://github.com/ros2/launch/issues/615>)
* Contributors: mergify[bot]
```

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
