### PR TITLE
rosbridge_suite: 0.11.16-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11450,7 +11450,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.11.15-1
+      version: 0.11.16-2
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.11.16-2`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.11.15-1`

## rosapi

```
* Bump minimum required cmake version. (#814 <https://github.com/RobotWebTools/rosbridge_suite/issues/814>)
* Contributors: Hans-Joachim Krauch
```

## rosbridge_library

```
* Bump minimum required cmake version. (#814 <https://github.com/RobotWebTools/rosbridge_suite/issues/814>)
* Fix send_message being called with wrong arguments. (#812 <https://github.com/RobotWebTools/rosbridge_suite/issues/812>)
* Contributors: Hans-Joachim Krauch
```

## rosbridge_msgs

```
* Bump minimum required cmake version. (#814 <https://github.com/RobotWebTools/rosbridge_suite/issues/814>)
* Contributors: Hans-Joachim Krauch
```

## rosbridge_server

```
* Bump minimum required cmake version. (#814 <https://github.com/RobotWebTools/rosbridge_suite/issues/814>)
* Fix send_message being called with wrong arguments. (#812 <https://github.com/RobotWebTools/rosbridge_suite/issues/812>)
* Contributors: Hans-Joachim Krauch
```

## rosbridge_suite

```
* Bump minimum required cmake version. (#814 <https://github.com/RobotWebTools/rosbridge_suite/issues/814>)
* Contributors: Hans-Joachim Krauch
```
