### PR TITLE
Add dynamixel_control to Rolling index

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -844,6 +844,16 @@ repositories:
       url: https://github.com/ros2/domain_bridge.git
       version: main
     status: developed
+  dynamixel_control:
+    doc:
+      type: git
+      url: https://github.com/youtalk/dynamixel_control.git
+      version: rolling
+    source:
+      type: git
+      url: https://github.com/youtalk/dynamixel_control.git
+      version: rolling
+    status: developed
   dynamixel_sdk:
     doc:
       type: git
@@ -863,16 +873,6 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
       version: ros2
     status: maintained
-  dynamixel_control:
-    doc:
-      type: git
-      url: https://github.com/youtalk/dynamixel_control.git
-      version: rolling
-    source:
-      type: git
-      url: https://github.com/youtalk/dynamixel_control.git
-      version: rolling
-    status: developed
   dynamixel_workbench:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -863,6 +863,16 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
       version: ros2
     status: maintained
+  dynamixel_control:
+    doc:
+      type: git
+      url: https://github.com/youtalk/dynamixel_control.git
+      version: rolling
+    source:
+      type: git
+      url: https://github.com/youtalk/dynamixel_control.git
+      version: rolling
+    status: developed
   ecl_core:
     doc:
       type: git


### PR DESCRIPTION
Signed-off-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>

# Please Add This Package to be indexed in the rosdistro.

Rolling

# The source is here:

https://github.com/youtalk/dynamixel_control/tree/rolling

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
