### PR TITLE
Add dynamixel_control to Humble index

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -917,6 +917,16 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
       version: ros2
     status: maintained
+  dynamixel_control:
+    doc:
+      type: git
+      url: https://github.com/youtalk/dynamixel_control.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/youtalk/dynamixel_control.git
+      version: humble
+    status: developed
   ecl_tools:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -898,6 +898,16 @@ repositories:
       url: https://github.com/ros2/domain_bridge.git
       version: humble
     status: developed
+  dynamixel_control:
+    doc:
+      type: git
+      url: https://github.com/youtalk/dynamixel_control.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/youtalk/dynamixel_control.git
+      version: humble
+    status: developed
   dynamixel_sdk:
     doc:
       type: git
@@ -917,16 +927,6 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
       version: ros2
     status: maintained
-  dynamixel_control:
-    doc:
-      type: git
-      url: https://github.com/youtalk/dynamixel_control.git
-      version: humble
-    source:
-      type: git
-      url: https://github.com/youtalk/dynamixel_control.git
-      version: humble
-    status: developed
   dynamixel_workbench:
     doc:
       type: git


### PR DESCRIPTION
Signed-off-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>

# Please Add This Package to be indexed in the rosdistro.

Humble

# The source is here:

https://github.com/youtalk/dynamixel_control/tree/humble

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
