### PR TITLE
Add dynamixel_control to Foxy index

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1069,6 +1069,16 @@ repositories:
       url: https://github.com/stack-of-tasks/dynamic-graph.git
       version: devel
     status: maintained
+  dynamixel_control:
+    doc:
+      type: git
+      url: https://github.com/youtalk/dynamixel_control.git
+      version: foxy
+    source:
+      type: git
+      url: https://github.com/youtalk/dynamixel_control.git
+      version: foxy
+    status: developed
   dynamixel_hardware_interface:
     doc:
       type: git


### PR DESCRIPTION
Signed-off-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>

# Please Add This Package to be indexed in the rosdistro.

Foxy

# The source is here:

https://github.com/youtalk/dynamixel_control/tree/foxy

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
