### PR TITLE
mvsim: 0.4.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7493,7 +7493,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
-      version: 0.4.1-1
+      version: 0.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.4.2-1`:

- upstream repository: https://github.com/MRPT/mvsim.git
- release repository: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.1-1`

## mvsim

```
* Disable Python wrappers for python <3.8
* Honor DESTDIR when building and installing
* Honor cli-provided PYTHON_INSTALL_DIRECTORY via cmake flags
* Fix protobuf-generated broken Python3 imports (using protoletariat)
* Add new WorldElement type: pointcloud
* Add Python3 example for teleop twist
* Contributors: Jose Luis Blanco-Claraco
```
