### PR TITLE
launch_pal: 0.0.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1924,6 +1924,21 @@ repositories:
       url: https://github.com/ros2/launch.git
       version: humble
     status: developed
+  launch_pal:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/launch_pal.git
+      version: master
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/launch_pal-release.git
+      version: 0.0.6-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/launch_pal.git
+      version: master
+    status: maintained
   launch_param_builder:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_pal` to `0.0.6-1`:

- upstream repository: https://github.com/pal-robotics/launch_pal.git
- release repository: https://github.com/pal-gbp/launch_pal-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## launch_pal

```
* Merge branch 'update_copyright' into 'master'
  Update copyright
  See merge request common/launch_pal!6
* update copyright
* Merge branch 'update_maintainers' into 'master'
  Update maintainers
  See merge request common/launch_pal!5
* update maintainers
* Merge branch 'arg_robot_name' into 'master'
  Add get_robot_name argument to choose default value
  See merge request common/launch_pal!4
* add get_robot_name arg to choose default value
* Merge branch 'robot_utils' into 'master'
  Robot utils
  See merge request common/launch_pal!3
* pal-gripper as default end_effector
* launch methods for tiago
* linters
* rm unused import
* robot utils for pmb2
* Merge branch 'fix_slash_warns' into 'master'
  Fix slash warns
  See merge request common/launch_pal!2
* fix slash warns
* Contributors: Jordan Palacios, Noel Jimenez
```
