### PR TITLE
pal_gazebo_worlds: 3.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2981,6 +2981,21 @@ repositories:
       url: https://github.com/OUXT-Polaris/ouxt_common.git
       version: master
     status: developed
+  pal_gazebo_worlds:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pal_gazebo_worlds.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/pal_gazebo_worlds-ros2-release.git
+      version: 3.0.3-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pal_gazebo_worlds.git
+      version: humble-devel
+    status: maintained
   pal_statistics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_gazebo_worlds` to `3.0.3-1`:

- upstream repository: https://github.com/pal-robotics/pal_gazebo_worlds.git
- release repository: https://github.com/pal-gbp/pal_gazebo_worlds-ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## pal_gazebo_worlds

```
* Merge branch 'cleanup' into 'humble-devel'
  Cleanup
  See merge request common/pal_gazebo_worlds!55
* cleanup
* Merge branch 'linters' into 'humble-devel'
  Linters
  See merge request common/pal_gazebo_worlds!54
* linters
* CONTRIBUTING.md
* add linters
* Merge branch 'update_copyright' into 'humble-devel'
  Update copyright
  See merge request common/pal_gazebo_worlds!51
* restore original LICENSE
* update copyright and license
* Merge branch 'cleanup' into 'humble-devel'
  Cleanup
  See merge request common/pal_gazebo_worlds!53
* rm ros1 launcher and test
* Merge branch 'refactor_ld' into 'humble-devel'
  Refactor LaunchDescription population
  See merge request common/pal_gazebo_worlds!52
* refactor LaunchDescription population
* Merge branch 'update_maintainers' into 'humble-devel'
  update maintainers
  See merge request common/pal_gazebo_worlds!50
* update maintainers
* Merge branch 'humble_fixes' into 'humble-devel'
  update way of launching gazebo
  See merge request common/pal_gazebo_worlds!48
* update way to launch gazebo
* Merge branch 'foxy_obstacle_avoidance' into 'foxy-devel'
  Foxy obstacle avoidance
  See merge request common/pal_gazebo_worlds!43
* add gazebo_ros_state plugin
* Merge branch 'foxy_obstacle_avoidance' into 'foxy-devel'
  Foxy obstacle avoidance
  See merge request common/pal_gazebo_worlds!41
* move corridor worlds to origin
* empty room world
* small cylinder model
* corridor_85cm world
* Contributors: Jordan Palacios, Noel Jimenez, Noel Jimenez Garcia, victor
```
