### PR TITLE
urdf_test: 2.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6228,6 +6228,21 @@ repositories:
       url: https://github.com/ros/urdf_parser_py.git
       version: ros2
     status: maintained
+  urdf_test:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/urdf_test.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/urdf_test-ros2-gbp.git
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/urdf_test.git
+      version: humble-devel
+    status: maintained
   urdf_tutorial:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_test` to `2.0.1-1`:

- upstream repository: https://github.com/pal-robotics/urdf_test.git
- release repository: https://github.com/pal-gbp/urdf_test-ros2-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## urdf_test

```
* Merge branch 'cleanup' into 'humble-devel'
  Cleanup
  See merge request qa/urdf_test!7
* clean ros1 files
* Merge branch 'update_copyright' into 'humble-devel'
  Update copyright
  See merge request qa/urdf_test!6
* update copyright
* Merge branch 'update_maintainers' into 'humble-devel'
  update maintainers
  See merge request qa/urdf_test!5
* update maintainers
* Merge branch 'tests' into 'humble-devel'
  fix linter errors
  See merge request qa/urdf_test!4
* linters
* Contributors: Jordan Palacios, Noel Jimenez
```
