### PR TITLE
ros_control: 0.19.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8511,7 +8511,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.19.5-1
+      version: 0.19.6-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.19.6-1`:

- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.19.5-1`

## combined_robot_hw

- No changes

## combined_robot_hw_tests

- No changes

## controller_interface

- No changes

## controller_manager

```
* SPAWNER: Wait for the clock to be available before proceeding (#432 <https://github.com/ros-controls/ros_control/issues/432>)
  This patch is to resolve an issue when the simulated clock is not published right away (coming from a remote gazebo instance for example).
  If the clock is not published right away, the rosservice wait_for_service times out prematurely and the controllers fail to be loaded since the system is not yet ready (no Gazebo clock).
  With no, gazebo system, the clock will be ready immediately and the spawner will proceed.
  Issue: #431 <https://github.com/ros-controls/ros_control/issues/431>
* Contributors: Guillaume Autran
```

## controller_manager_msgs

- No changes

## controller_manager_tests

- No changes

## hardware_interface

```
* Update mainpage.dox (#496 <https://github.com/ros-controls/ros_control/issues/496>)
* Contributors: PaddyCube
```

## joint_limits_interface

- No changes

## ros_control

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
