### PR TITLE
ros_controllers: 0.21.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8556,7 +8556,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.20.0-1
+      version: 0.21.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.21.0-1`:

- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.20.0-1`

## ackermann_steering_controller

```
* Switch to hpp headers of pluginlib
* std::bind and placeholders instead of boost
* use boost::placeholders::_1/_2 in remaining instances, include boost/bind/bind.hpp instead of boost/bind.hpp, eliminated unnecessary bind.hpp include
* Contributors: Jochen Sprickerhof, Lucas Walter
```

## diff_drive_controller

```
* std::bind and placeholders instead of boost
* use boost::placeholders::_1/_2 in remaining instances, include boost/bind/bind.hpp instead of boost/bind.hpp, eliminated unnecessary bind.hpp include
* Contributors: Lucas Walter
```

## effort_controllers

- No changes

## force_torque_sensor_controller

- No changes

## forward_command_controller

- No changes

## four_wheel_steering_controller

```
* use boost::placeholders::_1/_2 in remaining instances, include boost/bind/bind.hpp instead of boost/bind.hpp, eliminated unnecessary bind.hpp include
* Contributors: Lucas Walter
```

## gripper_action_controller

```
* std::bind and placeholders instead of boost
* Contributors: Lucas Walter
```

## imu_sensor_controller

- No changes

## joint_state_controller

- No changes

## joint_trajectory_controller

```
* std::bind and placeholders instead of boost
* Contributors: Lucas Walter
```

## position_controllers

- No changes

## ros_controllers

- No changes

## rqt_joint_trajectory_controller

```
* [rqt_joint_trajectory_controller] Added Timestamp to the outgoing command message
* Contributors: Bence Magyar, Caedael
```

## velocity_controllers

- No changes
