### PR TITLE
Revert "ur_robot_driver: 2.2.4-1 in 'humble/distribution.yaml' [bloom]"

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6220,7 +6220,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.2.4-1
+      version: 2.2.3-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Reverts ros/rosdistro#34868

It seems that this release has been creating failing builds on CI: https://build.ros2.org/view/Hbin_uJ64/job/Hbin_uJ64__ur_controllers__ubuntu_jammy_amd64__binary/21/console