### PR TITLE
Adding new repository for indexing: rviz_ground_image

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6221,6 +6221,11 @@ repositories:
       url: https://github.com/ros2/rviz.git
       version: foxy
     status: maintained
+  rviz_static_ground_image:
+    doc:
+      type: git
+      url: https://github.com/Plaba/rviz-ground-image.git
+      version: v0.0.1
   rviz_visual_tools:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6221,11 +6221,11 @@ repositories:
       url: https://github.com/ros2/rviz.git
       version: foxy
     status: maintained
-  rviz_static_ground_image:
+  rviz_ground_image:
     doc:
       type: git
-      url: https://github.com/Plaba/rviz-ground-image.git
-      version: v0.0.1
+      url: https://github.com/Plaba/rviz_ground_image.git
+      version: foxy-devel
   rviz_visual_tools:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add rviz_static_ground_image to be indexed in the rosdistro.

FOXY

# The source is here:

https://github.com/Plaba/rviz_ground_image.git



# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
