### PR TITLE
rosbridge_suite: 1.3.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5469,7 +5469,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `1.3.1-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.3.0-1`

## rosapi

```
* Add graceful shutdown (#794 <https://github.com/RobotWebTools/rosbridge_suite/issues/794>)
* Contributors: Hans-Joachim Krauch
```

## rosapi_msgs

- No changes

## rosbridge_library

```
* Optimized large binary array publishing (#819 <https://github.com/RobotWebTools/rosbridge_suite/issues/819>)
* Skip unnecessary conversion for cbor/cbor-raw compression (#792 <https://github.com/RobotWebTools/rosbridge_suite/issues/792>) (#800 <https://github.com/RobotWebTools/rosbridge_suite/issues/800>)
* Improve robustness for multiple client connections (#803 <https://github.com/RobotWebTools/rosbridge_suite/issues/803>)
* Minor performance improvements (#809 <https://github.com/RobotWebTools/rosbridge_suite/issues/809>)
* Remove unnecessary checking of topic globs. (#793 <https://github.com/RobotWebTools/rosbridge_suite/issues/793>) (#799 <https://github.com/RobotWebTools/rosbridge_suite/issues/799>)
* Fix duplicate subscription created with wrong 'raw' attribute. (#798 <https://github.com/RobotWebTools/rosbridge_suite/issues/798>)
* Contributors: Hans-Joachim Krauch, Steffen Nattke, Ted Sender
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* Fix exceptions not being handled correctly. (#817 <https://github.com/RobotWebTools/rosbridge_suite/issues/817>)
* Skip unnecessary conversion for cbor/cbor-raw compression (#792 <https://github.com/RobotWebTools/rosbridge_suite/issues/792>) (#800 <https://github.com/RobotWebTools/rosbridge_suite/issues/800>)
* Improve robustness for multiple client connections (#803 <https://github.com/RobotWebTools/rosbridge_suite/issues/803>)
* Minor performance improvements (#809 <https://github.com/RobotWebTools/rosbridge_suite/issues/809>)
* Fix hostname parameter is no longer converted as an int value (#780 <https://github.com/RobotWebTools/rosbridge_suite/issues/780>)
* Fix duplicate subscription created with wrong 'raw' attribute. (#798 <https://github.com/RobotWebTools/rosbridge_suite/issues/798>)
* Add graceful shutdown (#794 <https://github.com/RobotWebTools/rosbridge_suite/issues/794>)
* Contributors: Hans-Joachim Krauch, Hugo Perier, Steffen Nattke
```

## rosbridge_suite

- No changes

## rosbridge_test_msgs

- No changes
