### PR TITLE
novatel_gps_driver: 4.1.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2766,7 +2766,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/novatel_gps_driver-release.git
-      version: 4.1.0-3
+      version: 4.1.1-2
     source:
       type: git
       url: https://github.com/swri-robotics/novatel_gps_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `4.1.1-2`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/ros2-gbp/novatel_gps_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.1.0-3`

## novatel_gps_driver

```
* Merge pull request #116 <https://github.com/swri-robotics/novatel_gps_driver/issues/116> from devrite/115-fix-humble-build-errors-tf2-and-rclcpp-components
  Fix humble build errors tf2 and rclcpp_components
* Include tf2 to geometry_msgs header
  Fixes #115 <https://github.com/swri-robotics/novatel_gps_driver/issues/115>
* cmake: add rclcpp_components to deps
* Merge pull request #109 <https://github.com/swri-robotics/novatel_gps_driver/issues/109> from Smiffe/dashing-devel
  expected_rate based on polling_period parameter
* Merge pull request #113 <https://github.com/swri-robotics/novatel_gps_driver/issues/113> from ksuszka/galactic-launch-fix
  Fix example launch files to work under Galactic
* expected_rate based on polling_period parameter
* Merge pull request #108 <https://github.com/swri-robotics/novatel_gps_driver/issues/108> from ksuszka/dashing-devel
  Fix compilation warning on Galactic
* Contributors: David Anthony, Krzysztof Suszka, Markus Hofstaetter, PBed
```

## novatel_gps_msgs

- No changes
