### PR TITLE
smacc: 0.9.4-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10204,6 +10204,20 @@ repositories:
       url: https://github.com/oKermorgant/slider_publisher.git
       version: ros1
     status: maintained
+  smacc:
+    release:
+      packages:
+      - smacc
+      - smacc_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/reelrbtx/SMACC-release.git
+      version: 0.9.4-3
+    source:
+      type: git
+      url: https://github.com/reelrbtx/SMACC.git
+      version: 0.9.4
+    status: developed
   snmp_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `smacc` to `0.9.4-3`:

- upstream repository: https://github.com/reelrbtx/SMACC
- release repository: https://github.com/reelrbtx/SMACC-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
