### PR TITLE
xacro: 2.0.8-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6331,7 +6331,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/xacro-release.git
-      version: 2.0.7-2
+      version: 2.0.8-1
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `2.0.8-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros2-gbp/xacro-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.7-2`

## xacro

```
* Install xacro using console_script entrypoint (#304 <https://github.com/ros/xacro/issues/304>)
* Provide xacro.process() returning the processed file (#229 <https://github.com/ros/xacro/issues/229>)
* Dotted YAML access from list iterator (#318 <https://github.com/ros/xacro/issues/318>)
* Optionally allow comment evaluation (#310 <https://github.com/ros/xacro/issues/310>)Comment evaluation can be enabled with a special comment:
  
    * ``<!-- xacro:eval-comments -->`` or
    * ``<!-- xacro:eval-comments:on -->``
  It remains active for the following comments until:
  
    * the current XML tag's scope is left (or a new tag entered)
    * another tag or non-whitespace text is processed
    * it becomes explicitly disabled via: ``<!-- xacro:eval-comments:off -->``
  
* Fix property resolution with namespace usage (#308 <https://github.com/ros/xacro/issues/308>)
  
    * Allow access to properties in parent scopes again (fixes #305 <https://github.com/ros/xacro/issues/305#issuecomment-1016811150>)
    * Pick correct scope when defining a property into the parent (fixes #307 <https://github.com/ros/xacro/issues/307>)Setting a property within the parent scope may occur in two contexts:From within a macro. In that case, one wants to set the property in the caller's scope.
      
      From within the included file. In that case, one wants to set the property in the includer's scope.
  
* Contributors: Chen Bainian, Gonzalo de Pedro, Gonzo, Jacob Perron, Melvin Wang, Robert Haschke, vandanamandlik
```
