### PR TITLE
robotont_description: 0.0.8-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8350,6 +8350,21 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/robotis_manipulator.git
       version: noetic-devel
     status: maintained
+  robotont_description:
+    doc:
+      type: git
+      url: https://github.com/robotont/robotont_description.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/robotont-release/robotont_description-release.git
+      version: 0.0.8-2
+    source:
+      type: git
+      url: https://github.com/robotont/robotont_description.git
+      version: noetic-devel
+    status: maintained
   robotraconteur:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `robotont_description` to `0.0.8-2`:

- upstream repository: https://github.com/robotont/robotont_description.git
- release repository: https://github.com/robotont-release/robotont_description-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
