### PR TITLE
cras_ros_utils: 2.0.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2067,7 +2067,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
-      version: 2.0.3-1
+      version: 2.0.5-1
     source:
       type: git
       url: https://github.com/ctu-vras/ros-utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_ros_utils` to `2.0.5-1`:

- upstream repository: https://github.com/ctu-vras/ros-utils
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.3-1`

## cras_cpp_common

```
* Added support for std::array parameters.
* Contributors: Martin Pecka
```

## cras_py_common

```
* Added static_transform_broadcaster docs to readme.
* Contributors: Martin Pecka
```

## cras_topic_tools

- No changes
