### PR TITLE
osqp_vendor: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6575,7 +6575,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/tier4/osqp_vendor.git
-      version: noetic
+      version: main
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -6584,7 +6584,7 @@ repositories:
     source:
       type: git
       url: https://github.com/tier4/osqp_vendor.git
-      version: noetic
+      version: main
     status: maintained
   outsight_alb_driver:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6580,7 +6580,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tier4/osqp_vendor-release.git
-      version: 0.1.2-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/tier4/osqp_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `osqp_vendor` to `0.2.0-1`:

- upstream repository: https://github.com/tier4/osqp_vendor.git
- release repository: https://github.com/tier4/osqp_vendor-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.1.2-1`

## osqp_vendor

```
* feat: enable to build with both ros1 and ros2 (#16 <https://github.com/tier4/osqp_vendor/issues/16>)
  * feat: enable to build with both ros1 and ros2
  * fix github action
* Contributors: Daisuke Nishimatsu
```
