### PR TITLE
osqp_vendor: 0.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2926,7 +2926,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/osqp_vendor-release.git
-      version: 0.0.4-3
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/tier4/osqp_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `osqp_vendor` to `0.2.0-1`:

- upstream repository: https://github.com/tier4/osqp_vendor.git
- release repository: https://github.com/ros2-gbp/osqp_vendor-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.0.4-3`

## osqp_vendor

```
* feat: enable to build with both ros1 and ros2 (#16 <https://github.com/tier4/osqp_vendor/issues/16>)
  * feat: enable to build with both ros1 and ros2
  * fix github action
* Contributors: Daisuke Nishimatsu
```
