### PR TITLE
add libcamera to humble and rolling

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2041,6 +2041,11 @@ repositories:
       type: git
       url: https://github.com/lgsvl/lgsvl_msgs.git
       version: foxy-devel
+  libcamera:
+    source:
+      type: git
+      url: https://git.libcamera.org/libcamera/libcamera.git
+      version: master
   libg2o:
     release:
       tags:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1960,6 +1960,11 @@ repositories:
       type: git
       url: https://github.com/lgsvl/lgsvl_msgs.git
       version: foxy-devel
+  libcamera:
+    source:
+      type: git
+      url: https://git.libcamera.org/libcamera/libcamera.git
+      version: master
   libg2o:
     release:
       tags:


### PR DESCRIPTION
Please add the following dependency to the rosdep database. This is only the `source` for now in order to prepare for a new release repo (https://docs.ros.org/en/foxy/How-To-Guides/Releasing/Release-Team-Repository.html#create-a-new-release-repository).

## Package name:

`libcamera`

## Package Upstream Source:

https://git.libcamera.org/libcamera/libcamera.git

## Purpose of using this:

libcamera is a library for using different kind of cameras.

# Please Add This Package to be indexed in the rosdistro.

humble, rolling
