### PR TITLE
kinematics_interface: 0.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1800,6 +1800,24 @@ repositories:
       url: https://github.com/ros-tooling/keyboard_handler.git
       version: main
     status: developed
+  kinematics_interface:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/kinematics_interface.git
+      version: master
+    release:
+      packages:
+      - kinematics_interface
+      - kinematics_interface_kdl
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/kinematics_interface-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/kinematics_interface.git
+      version: master
+    status: developed
   kobuki_ros_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematics_interface` to `0.0.2-1`:

- upstream repository: https://github.com/ros-controls/kinematics_interface.git
- release repository: https://github.com/ros2-gbp/kinematics_interface-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## kinematics_interface

- No changes

## kinematics_interface_kdl

- No changes
