### PR TITLE
pmb2_navigation: 3.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3199,6 +3199,25 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: humble
     status: maintained
+  pmb2_navigation:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pmb2_navigation.git
+      version: humble-devel
+    release:
+      packages:
+      - pmb2_2dnav
+      - pmb2_maps
+      - pmb2_navigation
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/pmb2_navigation-gbp.git
+      version: 3.0.2-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pmb2_navigation.git
+      version: humble-devel
+    status: developed
   pmb2_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_navigation` to `3.0.2-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_navigation.git
- release repository: https://github.com/pal-gbp/pmb2_navigation-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## pmb2_2dnav

```
* Merge branch 'missing_dependency' into 'humble-devel'
  add missing dependency
  See merge request robots/pmb2_navigation!58
* add missing dependencies
* Merge branch 'initial_pose' into 'humble-devel'
  Set initial pose automatically
  See merge request robots/pmb2_navigation!57
* set initial pose automatically
* Merge branch 'update_copyright' into 'humble-devel'
  Update copyright
  See merge request robots/pmb2_navigation!56
* update package format
* update copyright
* Merge branch 'update_maintainers' into 'humble-devel'
  Update maintainers
  See merge request robots/pmb2_navigation!55
* update maintainers
* Merge branch 'fix_robot_model_type' into 'humble-devel'
  humble fixes
  See merge request robots/pmb2_navigation!54
* linters
* use args for rviz
* update nav2 params file
* update nav2_bringup arguments
* update robot_model_type for humble
* Merge branch 'fix_bt_navigator' into 'galactic-devel'
  fix  bt_navigator libraries
  See merge request robots/pmb2_navigation!52
* undo change transform_timeout
* add bt_navigator libraries
* Contributors: Jordan Palacios, Noel Jimenez
```

## pmb2_maps

```
* Merge branch 'update_copyright' into 'humble-devel'
  Update copyright
  See merge request robots/pmb2_navigation!56
* update package format
* Merge branch 'update_maintainers' into 'humble-devel'
  Update maintainers
  See merge request robots/pmb2_navigation!55
* update maintainers
* Contributors: Jordan Palacios, Noel Jimenez
```

## pmb2_navigation

```
* Merge branch 'update_copyright' into 'humble-devel'
  Update copyright
  See merge request robots/pmb2_navigation!56
* update package format
* Merge branch 'update_maintainers' into 'humble-devel'
  Update maintainers
  See merge request robots/pmb2_navigation!55
* update maintainers
* Contributors: Jordan Palacios, Noel Jimenez
```
