### PR TITLE
kobuki_core: 1.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1791,6 +1791,22 @@ repositories:
       url: https://github.com/ros-tooling/keyboard_handler.git
       version: rolling
     status: developed
+  kobuki_core:
+    doc:
+      type: git
+      url: https://github.com/kobuki-base/kobuki_core.git
+      version: release/1.4.x
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/kobuki_core-release.git
+      version: 1.4.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/kobuki-base/kobuki_core.git
+      version: release/1.4.x
+    status: maintained
   kobuki_ros_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_core` to `1.4.0-1`:

- upstream repository: https://github.com/kobuki-base/kobuki_core.git
- release repository: https://github.com/ros2-gbp/kobuki_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## kobuki_core

```
* [demos] log levels demo added, #42 <https://github.com/kobuki-base/kobuki_core/issues/42>
* [driver] bugfix major, minor, patch macro conflicts, #44 <https://github.com/kobuki-base/kobuki_core/issues/44>
* [demos] style cleanups, #47 <https://github.com/kobuki-base/kobuki_core/pull/47>
* [driver] grammar fixes, #47 <https://github.com/kobuki-base/kobuki_core/pull/47>
```
