### PR TITLE
eiquadprog: 1.2.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2226,7 +2226,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/stack-of-tasks/eiquadprog-ros-release.git
-      version: 1.2.4-1
+      version: 1.2.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `eiquadprog` to `1.2.5-1`:

- upstream repository: https://github.com/stack-of-tasks/eiquadprog.git
- release repository: https://github.com/stack-of-tasks/eiquadprog-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.4-1`
