### PR TITLE
Update kobuki_core release repository for Foxy.

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2075,17 +2075,17 @@ repositories:
     doc:
       type: git
       url: https://github.com/kobuki-base/kobuki_core.git
-      version: release/1.3.x
+      version: release/1.4.x
     release:
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/stonier/kobuki_core-release.git
+      url: https://github.com/ros2-gbp/kobuki_core-release.git
       version: 1.3.1-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/kobuki-base/kobuki_core.git
-      version: devel
+      version: release/1.4.x
     status: maintained
   kobuki_firmware:
     doc:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2080,7 +2080,6 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/kobuki_core-release.git
-      version: 1.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
We've now moved it, so update the link.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>