### PR TITLE
twist_mux: 3.1.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10934,7 +10934,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/twist_mux-release.git
-      version: 3.1.2-1
+      version: 3.1.3-1
     source:
       type: git
       url: https://github.com/ros-teleop/twist_mux.git


### PR DESCRIPTION
Increasing version of package(s) in repository `twist_mux` to `3.1.3-1`:

- upstream repository: https://github.com/ros-teleop/twist_mux.git
- release repository: https://github.com/ros-gbp/twist_mux-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.1.2-1`

## twist_mux

```
* Fix tests for Python3 (#40 <https://github.com/ros-teleop/twist_mux/issues/40>)
* [ROS1] Fix Noetic release / Python3 (#39 <https://github.com/ros-teleop/twist_mux/issues/39>)
  Resolves #22 <https://github.com/ros-teleop/twist_mux/issues/22>
* [ROS1] Add GitHub Actions CI (#38 <https://github.com/ros-teleop/twist_mux/issues/38>)
* Contributors: Wolfgang Merkt
```
