### PR TITLE
kobuki_core: 1.4.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2080,6 +2080,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/kobuki_core-release.git
+      version: 1.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_core` to `1.4.0-1`:

- upstream repository: https://github.com/kobuki-base/kobuki_core.git
- release repository: https://github.com/ros2-gbp/kobuki_core-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## kobuki_core

```
* [demos] log levels demo added, #42 <https://github.com/kobuki-base/kobuki_core/issues/42>
* [driver] bugfix major, minor, patch macro conflicts, #44 <https://github.com/kobuki-base/kobuki_core/issues/44>
* [demos] style cleanups, #47 <https://github.com/kobuki-base/kobuki_core/pull/47>
* [driver] grammar fixes, #47 <https://github.com/kobuki-base/kobuki_core/pull/47>
```
