### PR TITLE
Revert "ros2_controllers: 2.13.0-1 in 'humble/distribution.yaml' [bloom]"

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4326,7 +4326,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.13.0-1
+      version: 2.12.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Reverts ros/rosdistro#34805

You can see here for more information: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/522#issuecomment-1288081581