### PR TITLE
webots_ros2: 2022.1.2-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6659,7 +6659,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/webots_ros2-release.git
-      version: 2022.1.2-1
+      version: 2022.1.2-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `webots_ros2` to `2022.1.2-2`:

- upstream repository: https://github.com/cyberbotics/webots_ros2.git
- release repository: https://github.com/ros2-gbp/webots_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2022.1.2-1`

## webots_ros2_driver

```
* Fix issue where relatively defined PROTO were not found.
* Added WSL support.
```

## webots_ros2_epuck

```
* Added WSL support.
```

## webots_ros2_mavic

```
* Added WSL support.
```

## webots_ros2_tesla

```
* Added WSL support.
```

## webots_ros2_tiago

```
* Added WSL support.
```

## webots_ros2_turtlebot

```
* Added WSL support.
```

## webots_ros2_universal_robot

```
* Added WSL support.
```
