### PR TITLE
ros_amr_interop: 1.1.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4309,6 +4309,24 @@ repositories:
       url: https://github.com/osrf/ros2launch_security.git
       version: main
     status: maintained
+  ros_amr_interop:
+    doc:
+      type: git
+      url: https://github.com/inorbit-ai/ros_amr_interop.git
+      version: galactic-devel
+    release:
+      packages:
+      - massrobotics_amr_sender
+      - vda5050_connector
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/inorbit-ai/ros_amr_interop-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/inorbit-ai/ros_amr_interop.git
+      version: galactic-devel
+    status: developed
   ros_canopen:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_amr_interop` to `1.1.0-1`:

- upstream repository: https://github.com/inorbit-ai/ros_amr_interop.git
- release repository: https://github.com/inorbit-ai/ros_amr_interop-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## massrobotics_amr_sender

```
* Updated schema to match the latest version of the AMR interop standard (May 2022) (#24 <https://github.com/inorbit-ai/ros_amr_interop/issues/24>)
  
    * Renamed planarDatum to planarDatumUUID
    * Removed planarDatum from velocity
  
* Added schema checking for all sent messages (#15 <https://github.com/inorbit-ai/ros_amr_interop/issues/15>)
* Added support for errorcodes (#14 <https://github.com/inorbit-ai/ros_amr_interop/issues/14>)
```

## vda5050_connector

```
* Added VDA5050 connector package (#28 <https://github.com/inorbit-ai/ros_amr_interop/issues/28>)
```
