### PR TITLE
libhri: 0.5.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6062,7 +6062,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros4hri/libhri-release.git
-      version: 0.5.1-1
+      version: 0.5.3-1
     source:
       type: git
       url: https://github.com/ros4hri/libhri.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libhri` to `0.5.3-1`:

- upstream repository: https://github.com/ros4hri/libhri.git
- release repository: https://github.com/ros4hri/libhri-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.5.1-1`

## hri

```

0.5.3 (2022-10-26)
------------------
* bodies: expose the skeleton2d points
* package.xml: add libhri URL
* Contributors: Séverin Lemaignan, lorenzoferrini

0.5.2 (2022-10-10)
------------------
* expose the 3D transform of the voices
* expose face + gaze transform
* expose the 3D transform of the bodies
* minor refactor for safer access to engagement_status
* Contributors: Séverin Lemaignan

0.5.1 (2022-08-31)
------------------
* add comparision between 'feature trackers'
* update to new hri_msgs-0.8.0 names
* Contributors: Séverin Lemaignan
```
