### PR TITLE
pyhri: 0.3.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7508,7 +7508,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros4hri/pyhri-release.git
-      version: 0.2.0-1
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/ros4hri/pyhri.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyhri` to `0.3.2-1`:

- upstream repository: https://github.com/ros4hri/pyhri.git
- release repository: https://github.com/ros4hri/pyhri-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.0-1`

## pyhri

```

0.3.2 (2022-10-25)
------------------
* fix RoI-related message types. Unit-tests pass again.
* Contributors: Séverin Lemaignan

0.3.1 (2022-10-26)
------------------
* voice: add support for is_speaking
* ensure known persons get their face/body/voice instances properly updated
  Fixes #4
* Contributors: Séverin Lemaignan

0.3.0 (2022-10-22)
------------------
* wire up callbacks for when features appear/disappear
* body: currently, hri_fullbody (incorrectly) returns a RegionOfInterest for the RoI, instead of a NormalisedRegionOfInterest2D
* body: skeleton2d now gives direct access to the list of joints coordinates
* voice: expose last recognised speech + transform
* use @property to make the API simpler and safer
  In particular, to transparently provide *copies* of the faces, bodies, voices, persons list in HRIListener
* body: expose skeleton2d, transform, {RegionOfInterest -> NormalizedRegionOfInterest2D} + doc
* face: {RegionOfInterest -> NormalizedRegionOfInterest2D} + doc
* Contributors: Séverin Lemaignan

```
