### PR TITLE
moveit_msgs: 2.2.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2439,7 +2439,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_msgs-release.git
-      version: 2.2.0-3
+      version: 2.2.1-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_msgs` to `2.2.1-1`:

- upstream repository: https://github.com/ros-planning/moveit_msgs.git
- release repository: https://github.com/ros2-gbp/moveit_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.0-3`

## moveit_msgs

```
* Add more MoveItErrorCodes to match all OMPL codes (#146 <https://github.com/ros-planning/moveit_msgs/issues/146>)
* Factor of 2 in OMPL orientation constraints, to match kinematic_constraints (#145 <https://github.com/ros-planning/moveit_msgs/issues/145>)
* Note on constraint tolerances (#141 <https://github.com/ros-planning/moveit_msgs/issues/141>)
* Humble CI and prerelease (#139 <https://github.com/ros-planning/moveit_msgs/issues/139>)
* Contributors: AndyZe, Vatan Aksoy Tezer
```
