### PR TITLE
pmb2_simulation: 3.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3256,6 +3256,25 @@ repositories:
       url: https://github.com/pal-robotics/pmb2_robot.git
       version: humble-devel
     status: maintained
+  pmb2_simulation:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pmb2_simulation.git
+      version: humble-devel
+    release:
+      packages:
+      - pmb2_2dnav_gazebo
+      - pmb2_gazebo
+      - pmb2_simulation
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/pmb2_simulation-gbp.git
+      version: 3.0.3-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pmb2_simulation.git
+      version: humble-devel
+    status: developed
   point_cloud_msg_wrapper:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_simulation` to `3.0.3-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_simulation.git
- release repository: https://github.com/pal-gbp/pmb2_simulation-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## pmb2_2dnav_gazebo

```
* Merge branch 'cleanup' into 'humble-devel'
  Update package.xml deps
  See merge request robots/pmb2_simulation!46
* update package.xml deps
* Merge branch 'refactor_launch_files' into 'humble-devel'
  Refactor ld population
  See merge request robots/pmb2_simulation!42
* refactor LaunchDescription population
* Merge branch 'update_copyright' into 'humble-devel'
  Update copyright and license
  See merge request robots/pmb2_simulation!41
* update copyright and license
* Merge branch 'update_maintainers' into 'humble-devel'
  update maintainers
  See merge request robots/pmb2_simulation!40
* update maintainers
* Contributors: Jordan Palacios, Noel Jimenez
```

## pmb2_gazebo

```
* Merge branch 'add_missing_dep' into 'humble-devel'
  add missing dependency
  See merge request robots/pmb2_simulation!47
* add missing dependency
* Merge branch 'cleanup' into 'humble-devel'
  Update package.xml deps
  See merge request robots/pmb2_simulation!46
* update package.xml deps
* Merge branch 'refactor_launch_files' into 'humble-devel'
  Refactor ld population
  See merge request robots/pmb2_simulation!42
* refactor LaunchDescription population
* Merge branch 'update_copyright' into 'humble-devel'
  Update copyright and license
  See merge request robots/pmb2_simulation!41
* update copyright and license
* Merge branch 'update_maintainers' into 'humble-devel'
  update maintainers
  See merge request robots/pmb2_simulation!40
* update maintainers
* Merge branch 'run_tests' into 'humble-devel'
  fix linter errors
  See merge request robots/pmb2_simulation!39
* linters
* Contributors: Jordan Palacios, Noel Jimenez
```

## pmb2_simulation

```
* Merge branch 'update_copyright' into 'humble-devel'
  Update copyright and license
  See merge request robots/pmb2_simulation!41
* update copyright and license
* Merge branch 'update_maintainers' into 'humble-devel'
  update maintainers
  See merge request robots/pmb2_simulation!40
* update maintainers
* Contributors: Jordan Palacios, Noel Jimenez
```
