### PR TITLE
Revert "euslime: 1.1.3-1 in 'melodic/distribution.yaml' [bloom] (#349…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2984,7 +2984,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/jsk-ros-pkg/euslime-release.git
-      version: 1.1.3-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/euslime.git


### PR DESCRIPTION
…10)"

This reverts commit 443f6c823e4e4336e000f7339420ca1c9381c761.

This update is failing to build; see https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__euslime__ubuntu_bionic_amd64__binary/79/ .  @Affonso-Gui FYI