### PR TITLE
Revert "libhri: 0.5.3-1 in 'melodic/distribution.yaml' [bloom] (#35053)"

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6062,7 +6062,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros4hri/libhri-release.git
-      version: 0.5.3-1
+      version: 0.5.1-1
     source:
       type: git
       url: https://github.com/ros4hri/libhri.git


### PR DESCRIPTION
This reverts commit 0a47f870e5dc3993b57390d728539af2f2a37c27.

This update is failing to build; see https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__hri__ubuntu_bionic_amd64__binary/12/console .

@severin-lemaignan FYI