### PR TITLE
Revert "qb_device: 3.0.5-1 in 'melodic/distribution.yaml' [bloom] (#3…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9806,7 +9806,6 @@ repositories:
       - qb_device_control
       - qb_device_description
       - qb_device_driver
-      - qb_device_gazebo
       - qb_device_hardware_interface
       - qb_device_msgs
       - qb_device_srvs
@@ -9814,7 +9813,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
-      version: 3.0.5-1
+      version: 2.0.1-0
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbdevice-ros.git


### PR DESCRIPTION
…4369)"

This reverts commit 16cc21b3883fca5532b10e54e433093fb299c50b.

This is causing downstream packages to fail to build, like: https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__qb_move_hardware_interface__ubuntu_bionic_amd64__binary/102/console

@umbertofontana93 FYI