### PR TITLE
Revert "mocap_nokov: 0.0.4-1 in 'melodic/distribution.yaml' [bloom] (…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6841,7 +6841,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/NOKOV-MOCAP/mocap_nokov_release.git
-      version: 0.0.4-1
+      version: 0.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
…#34402)"

This reverts commit 884b920a6796d27f65adbfdfa77fa08406f68c17.

This is currently failing to build on arm64: https://build.ros.org/view/Mbin_ubv8_uBv8/job/Mbin_ubv8_uBv8__mocap_nokov__ubuntu_bionic_arm64__binary/55/console .

@duguguang FYI