### PR TITLE
Revert "libhri: 0.5.1-1 in 'melodic/distribution.yaml' [bloom] (#34841)"

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6062,7 +6062,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros4hri/libhri-release.git
-      version: 0.5.1-1
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/ros4hri/libhri.git


### PR DESCRIPTION
This reverts commit d404fb435a55f32be21fa087ad3daaa892e4737d.
