### PR TITLE
Revert "mocap_nokov: 0.0.3-1 in 'melodic/distribution.yaml' [bloom] (…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6841,7 +6841,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/NOKOV-MOCAP/mocap_nokov_release.git
-      version: 0.0.3-1
+      version: 0.0.2-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
…#34342)"

This reverts commit 0573fce05d210ca1ccf47c0a31041a2bafb0bfee.