### PR TITLE
Revert "qb_hand: 3.0.2-1 in 'melodic/distribution.yaml' [bloom] (#346…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9829,12 +9829,11 @@ repositories:
       - qb_hand
       - qb_hand_control
       - qb_hand_description
-      - qb_hand_gazebo
       - qb_hand_hardware_interface
       tags:
         release: release/melodic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbhand-ros-release.git
-      version: 3.0.2-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbhand-ros.git


### PR DESCRIPTION
…13)"

This reverts commit 1d906033cb3f5f597b21f960fde009cbc29e9236.

This is failing to build: https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__qb_hand_gazebo__ubuntu_bionic_amd64__binary/4/console

@umbertofontana93 FYI