### PR TITLE
jsk_control: 0.1.16-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4100,6 +4100,34 @@ repositories:
       url: https://github.com/jsk-ros-pkg/jsk_common_msgs.git
       version: master
     status: developed
+  jsk_control:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_control.git
+      version: master
+    release:
+      packages:
+      - cmd_vel_smoother
+      - contact_states_observer
+      - eus_nlopt
+      - eus_qp
+      - eus_qpoases
+      - joy_mouse
+      - jsk_calibration
+      - jsk_control
+      - jsk_footstep_controller
+      - jsk_footstep_planner
+      - jsk_ik_server
+      - jsk_teleop_joy
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/tork-a/jsk_control-release.git
+      version: 0.1.16-1
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_control.git
+      version: master
+    status: developed
   jsk_model_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_control` to `0.1.16-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_control.git
- release repository: https://github.com/tork-a/jsk_control-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## cmd_vel_smoother

- No changes

## contact_states_observer

- No changes

## eus_nlopt

```
* use System nlopt library for noetic, skip compile if nlopt is missing (#773 <https://github.com/jsk-ros-pkg/jsk_control/issues/773>)
* Contributors: Kei Okada
```

## eus_qp

```
* check x::*display* is available before running graph-view (gnuplot) (#776 <https://github.com/jsk-ros-pkg/jsk_control/issues/776>)
* ptmotiongen: no visualization / print if argument is nil. (#729 <https://github.com/jsk-ros-pkg/jsk_control/issues/729>)
* [optmotiongen] inverse-kinematics for the discrete target (#728 <https://github.com/jsk-ros-pkg/jsk_control/issues/728>)
  
    * optmotiongen: add test of discrete-kinematics-configuration-task.
    * optmotiongen: update manual.pdf
    * optmotiongen: add manual for discrete target ik.
    * optmotiongen: add sample/sample-sqp-optimization-discrete-kinematics.l
    * optmotiongen: add sample function sample-arm-reach-ik-discrete-raw.
    * optmotiongen: add discrete-kinematics-configuration-task.l
    * optmotiongen: flatten for drawing kin coords list for support discrete-kinematics-configuration-task.
  
* [optmotiongen] add sample to maximize contact force (#727 <https://github.com/jsk-ros-pkg/jsk_control/issues/727>)
  
    * optmotiongen: update manual.pdf
    * optmotiongen: add demo-jaxon-hand-force.l
    * optmotiongen: add :wrench-maximize-regular-vector to instant-config-task.
    * optmotiongen: add norm-regular-scale-coeff to instant-config-task.
    * optmotiongen: enable to set nil for print-status-interval and update-viewer-interval.
    * optmotiongen: add sqp-convergence-check and sqp-failure-callback.
    * optmotiongen: enable to set external-wrench-list.
  
* [optmotiongen] visualize force fix (#722 <https://github.com/jsk-ros-pkg/jsk_control/issues/722>)
* fix for test (#723 <https://github.com/jsk-ros-pkg/jsk_control/issues/723>)
  
    * optmotiongen: fix and reduce some tests because travis does not finish within 50 min.
    * optmotiongen: fix for visualize contact force in sample-sqp-optimization-trajectory.l.
    * optmotiongen: add functions for visualizing force and moment in playing motion
  
* [eus_qp/optmotiongen] add target-posture-scale-list argument (#718 <https://github.com/jsk-ros-pkg/jsk_control/issues/718>)
  
    * optmotiongen: add target-posture-scale-list argument to instant-configuration-task :init method. support to change scale for each posture joint.
  
* add demo rhp4b reach suitcase instant manip (#715 <https://github.com/jsk-ros-pkg/jsk_control/issues/715>)
* [optmotiongen] fix gravity torque calculation (#714 <https://github.com/jsk-ros-pkg/jsk_control/issues/714>)
  
    * optmotiongen: update manual.pdf for gravity torque document.
    * optmotiongen: consider fixed link weight to calculate gravity torque. ToDo: The effect for centroid is not considered yet.
    * optmotiongen: update gravity-torque-jacobian calculation and document.
    * optmotiongen: add euslisp/demo/demo-rhp4b-torque-gradient.l
    * optmotiongen: test torque calculation with irtdyna result.
  
* [optmotiongen] Rebase https://github.com/jsk-ros-pkg/jsk_control/pull/711 (#713 <https://github.com/jsk-ros-pkg/jsk_control/issues/713>)
  
    * optmotiongen: update manual.pdf for torque gradient update.
    * optmotiongen: update torque gradient calculation (get-contact-torque-jacobian function) and update document.
    * optmotiongen: add sample and test of torque gradient.
  
* set adjacent regular scale as list format via :adjacent-regular-scale-list argument. add sample for that argument. (#708 <https://github.com/jsk-ros-pkg/jsk_control/issues/708>)
  
    * optmotiongen: add test of min/max angle of root virtual joint from ik wrapper.
    * optmotiongen: support min/max angle of root virtual joint from ik wrapper.
  
* set adjacent regular scale as list format via :adjacent-regular-scale-list argument. add sample for that argument. (#708 <https://github.com/jsk-ros-pkg/jsk_control/issues/708>)
* [eus_qp/optmotiongen] support min/max angle of root virtual joint (#709 <https://github.com/jsk-ros-pkg/jsk_control/issues/709>)
  
    * optmotiongen: add test of min/max angle of root virtual joint from ik wrapper.
    * optmotiongen: support min/max angle of root virtual joint from ik wrapper.
  
* [eus_qp/optmotiongen] dynamic motion generation with bspline (#705 <https://github.com/jsk-ros-pkg/jsk_control/issues/705>)
  
    * [eus_qp/optmotiongen/manual] update manual.pdf for bspline-dynamic-configuration-task.
    * [eus_qp/optmotiongen/euslisp/contact-kinematics.l] add look-at-contact class and sample, test for that.
    * [eus_qp/optmotiongen] update sample and test for bspline-dynamic-configuration-task.
    * [eus_qp/optmotiongen/euslisp/demo,sample] move from demo to sample directory.
    * [eus_qp/optmotiongen/euslisp/sample,test] add option to supress graph generation for travis test.
    * [eus_qp/CMakeLists.txt] install optmotiongen directories.
    * [eus_qp/optmotiongen/euslisp/demo] rename hrp2 line face sample.
    * [eus_qp/optmotiongen/test] fix test name to use '_' instead of '-'. cf. http://wiki.ros.org/Names
    * [eus_qp/optmotiongen/euslisp/sample] use irtviewer :draw-floor and :floor-color methods instead of direct slots access.
    * [eus_qp/optmotiongen/test,euslisp/sample] add sample and test with irteus sample-robot.
    * [eus_qp/optmotiongen/doc] add README for bspline-dynamic-configuration-task.
    * [eus_qp/optmotiongen/euslisp/bspline-configuration-task.l] support delta-time argument in :generate-angle-vector-sequence.
    * [eus_qp/euslisp/contact-optimization.l] change drawing color from white to yellow for visibility in white background viewer.
    * [eus_qp/optmotiongen/manual] update manual for bspline-dynamic-configuration-task.
    * [eus_qp/optmotiongen] add bspline-dynamic-configuration-task and sample.
    * [eus_qp] add test-load-euslisp-files.
  
* [eus_qp/optmotiongen] add sqp with multi solution candidates (#702 <https://github.com/jsk-ros-pkg/jsk_control/issues/702>)
* [eus_qp/optmotiongen] Test eus loading without bash script (#707 <https://github.com/jsk-ros-pkg/jsk_control/issues/707>)
  
    * [eus_qp/optmotiongen/euslisp/inverse-kinematics-wrapper.l] Fix load path
    * test-load-euslisp-files.l: run everything within euslisp code
    * [eus_qp] add test-load-euslisp-files.
    * [eus_qp/optmotiongen] add sqp-msc (multi solution candidates) feature. add manual and samples of sqp-msc.
    * [eus_qp/optmotiongen] fix variable name, _qp-retval.
    * [eus_qp/optmotiongen] set contact-ik-args name from argument.
  
* add two use case of optmotiongen (#701 <https://github.com/jsk-ros-pkg/jsk_control/issues/701>)
  
    * [eus_qp/optmotiongen] update README, gif, and generate-gif.l to generate demo images"
    * [eus_qp/optmotiongen] set name of face and line contact from argument.
    * [eus_qp/optmotiongen] add demo-pr2-regrasp-object.l
    * [eus_qp/optmotiongen] update manual.pdf
    * [eus_qp/optmotiongen] add fetch demo using :inverse-kinematics-optmotiongen
    * [eus_qp/optmotiongen] add line and face demo with hrp2
  
* add optimization motion generation (#700 <https://github.com/jsk-ros-pkg/jsk_control/issues/700>)
* Contributors: Kei Okada, Masaki Murooka, Naoya Yamaguchi, Riku Shigematsu, Satoshi Otsubo, Tatsuya Ishikawa, Weiqi Yang
```

## eus_qpoases

```
* https://projects.coin-or.org have mved to github (#776 <https://github.com/jsk-ros-pkg/jsk_control/issues/776>)
* add optimization motion generation (#700 <https://github.com/jsk-ros-pkg/jsk_control/issues/700>)
  
    * [eus_qpoases/src/eus_qpoases.cpp] change nWSR for large size QP problem: 1000 -> 10000
  
* Contributors: Kei Okada, Masaki Murooka
```

## joy_mouse

- No changes

## jsk_calibration

```
* remove roseus from CMakeLists.txt (#773 <https://github.com/jsk-ros-pkg/jsk_control/issues/773>)
* [joint_states_appender.py]add queue_size (#734 <https://github.com/jsk-ros-pkg/jsk_control/issues/734>)
* 0755 -> -h0o0755 : SyntaxError: leading zeros in decimal integer literals are not permitted; use an 0o prefix for octal integers, 2to3 -w -fprint . (#763 <https://github.com/jsk-ros-pkg/jsk_control/issues/763>)
* Contributors: Kei Okada, Naoki Hiraoka
```

## jsk_control

```
* [jsk_control] add url in package.xml of jsk_control (#744 <https://github.com/jsk-ros-pkg/jsk_control/issues/744>)
* Contributors: Shingo Kitagawa
```

## jsk_footstep_controller

```
* [jsk_footstep_controller] add head-controller.l, add base-controller.l (#758 <https://github.com/jsk-ros-pkg/jsk_control/issues/758>)
* [jsk_footstep_controler/robot-boundingbox.l] remove dependency on jsk_demos/drc_task_common (#764 <https://github.com/jsk-ros-pkg/jsk_control/issues/764>)
* [jsk_control]add queue_size (#735 <https://github.com/jsk-ros-pkg/jsk_control/issues/735>)
* [jsk_footstep_controller] add sole conf for JAXON_BLUE (#690 <https://github.com/jsk-ros-pkg/jsk_control/issues/690>)
* 2to3 -w -fprint . (#763 <https://github.com/jsk-ros-pkg/jsk_control/issues/763>)
* Add melodic support [jsk_footstep_controller] fix a bug in footcoords.cpp due to a bug of boost::assign::list_of (#740 <https://github.com/jsk-ros-pkg/jsk_control/issues/740>)
* [jsk_footstep_controller] install config (#725 <https://github.com/jsk-ros-pkg/jsk_control/issues/725>)
* jsk_footstep_controller: check SoundRequest  has volume attribute (#726 <https://github.com/jsk-ros-pkg/jsk_control/issues/726>, #724 <https://github.com/jsk-ros-pkg/jsk_control/issues/724>)
* add missing install directories (#699 <https://github.com/jsk-ros-pkg/jsk_control/issues/699>)
* Contributors: Kei Okada, Koki Shinjo, Masaki Murooka, Naoki Hiraoka, Yasuhiro Ishiguro, Kunio Kojima
```

## jsk_footstep_planner

```
* run 2to3 -w -f has_key . for python3 check (#776 <https://github.com/jsk-ros-pkg/jsk_control/issues/776>)
* fix for test (#773 <https://github.com/jsk-ros-pkg/jsk_control/issues/773>)
  
    * indigo requres to add find_pacakge(roseus) to compile roseus message
    * remove roseus from find_package(catkin at jsk_footstep_planner and jsk_ik_server
    * add from __future__ import print_function
  
* [jsk_footstep_planner] add an example of footstep planner client with disarranged goal footsteps (#739 <https://github.com/jsk-ros-pkg/jsk_control/issues/739>)
* [jsk_footstep_planner] add num_finalize_steps option to dynamic_reconfigure of jsk_footstep_planner (#741 <https://github.com/jsk-ros-pkg/jsk_control/issues/741>)
* 2to3 -w -fexcept ., 2to3 -w -fprint . (#763 <https://github.com/jsk-ros-pkg/jsk_control/issues/763>)
* add melodic support (#740 <https://github.com/jsk-ros-pkg/jsk_control/issues/740>)
  
    * [jsk_footstep_planner] fixed returned value of FootstepStateDiscreteCloseList::find()
    * [jsk_footstep_planner] fixed a returned value of FootstepStateDiscreteCloseList::find()
  
* Update README.md and Delete duplicated launch files (#733 <https://github.com/jsk-ros-pkg/jsk_control/issues/733>)
  
    * [jsk_footstep_planner] Update README.md to fix link to an image.
    * [jsk_footstep_planner] add footstep_planner_perception_sample.gif and update README.md to fix syntax error and add an image.
    * [jsk_footstep_planner] delete unintentionally duplicated launch files
    * [jsk_footstep_planner] update README.md to add notice about euslisp implementation
    * [jsk_footstep_planner] update README.md to add description about how to execute examples
  
* fix heightmap launch so that it can work with nodelet. (#694 <https://github.com/jsk-ros-pkg/jsk_control/issues/694>)
* Contributors: Kei Okada, Koki Shinjo, Riku Shigematsu, Yohei Kakiuchi
```

## jsk_ik_server

```
* [jsk_ik_server] add TABLIS reachability map (#777 <https://github.com/jsk-ros-pkg/jsk_control/issues/777>)
* https://projects.coin-or.org have mved to github (#776 <https://github.com/jsk-ros-pkg/jsk_control/issues/776>)
* [jsk_ik_server] add fetch ik reachability map script (#769 <https://github.com/jsk-ros-pkg/jsk_control/issues/769>)
* avoid zero division ik ik-evaluation.l (#767 <https://github.com/jsk-ros-pkg/jsk_control/issues/767>)
* [jsk_ik_server] add baxter reachability map script (#771 <https://github.com/jsk-ros-pkg/jsk_control/issues/771>)
  
    * add baxter ik reachability map images in readme
    * add fetch ik reachability map in readme
    * add baxter reachability map
  
* fix for test (#773 <https://github.com/jsk-ros-pkg/jsk_control/issues/773>)
  
    * indigo requres to add find_pacakge(roseus) to compile roseus message
    * remove roseus from find_package(catkin at jsk_footstep_planner and jsk_ik_server
  
* [jsk_ik_server] fix typo in hrp2.sh and pr2.sh (#768 <https://github.com/jsk-ros-pkg/jsk_control/issues/768>)
* [jsk_ik_server] add readme for jsk_ik_server (#772 <https://github.com/jsk-ros-pkg/jsk_control/issues/772>)
* 2to3 -w -fprint . (#763 <https://github.com/jsk-ros-pkg/jsk_control/issues/763>)
* Contributors: Kei Okada, Shingo Kitagawa
```

## jsk_teleop_joy

```
* fix for python3 (#776 <https://github.com/jsk-ros-pkg/jsk_control/issues/776>)
  
    * fix with 2to3 -w -f import, and fix ValueError: Attempted relative import in non-package
    * use raw_input for python2 c.f. https://stackoverflow.com/questions/5868506/backwards-compatible-input-calls-in-python
    * run 2to3 -w -f has_key . for python3 check
  
* add from __future__ import print_function (#773 <https://github.com/jsk-ros-pkg/jsk_control/issues/773>)
* [README.md] delete pip instruction and recommend apt version only (#760 <https://github.com/jsk-ros-pkg/jsk_control/issues/760>)
* fix for  python3 (#763 <https://github.com/jsk-ros-pkg/jsk_control/issues/763>)
  
    * 2to3 -w -fexcept .
    * 2to3 -w -fprint .
    * update readme
    * Update jsk_teleop_joy/README.md
  
* Add ipega controller support (#716 <https://github.com/jsk-ros-pkg/jsk_control/issues/716>)
  
    * Fixed a key setting mistake. Add controller_type ipega as a possible input for joy_status
    * Add ipega controller support
  
* Contributors: Shingo Kitagawa, Iki Yo, Kei Okada, Yoichiro Kawamura
```
