### PR TITLE
hey5_description: 3.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1508,6 +1508,21 @@ repositories:
       url: https://github.com/tier4/hash_library_vendor.git
       version: main
     status: maintained
+  hey5_description:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/hey5_description.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/hey5_description-release.git
+      version: 3.0.0-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/hey5_description.git
+      version: humble-devel
+    status: maintained
   hls_lfcd_lds_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hey5_description` to `3.0.0-1`:

- upstream repository: https://github.com/pal-robotics/hey5_description.git
- release repository: https://github.com/pal-gbp/hey5_description-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## hey5_description

```
* Merge branch 'linters' into 'humble-devel'
  add linters
  See merge request robots/hey5_description!7
* CONTRIBUTING.md
* add linters
* Merge branch 'update_copyright' into 'humble-devel'
  update copyright and license
  See merge request robots/hey5_description!6
* restore original LICENSE
* rename LICENSE
* update copyright and license
* Merge branch 'update_maintainers' into 'humble-devel'
  update maintainers
  See merge request robots/hey5_description!5
* update maintainers
* Merge branch 'migrate_gazebo_plugin_underactuated_finger' into 'foxy-devel'
  Migrate gazebo plugin underactuated finger
  See merge request robots/hey5_description!4
* change pid gains values
* add pid_gains to urdf
* Remove comments to workaround https://github.com/ros2/launch_ros/issues/214
* package.xml and CMakeLists.txt in ros2 format
* Contributors: Jordan Palacios, Noel Jimenez, cescfolch, victor
```
