### PR TITLE
pal_gripper: 3.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3014,6 +3014,25 @@ repositories:
       url: https://github.com/pal-robotics/pal_gazebo_worlds.git
       version: humble-devel
     status: maintained
+  pal_gripper:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pal_gripper.git
+      version: humble-devel
+    release:
+      packages:
+      - pal_gripper
+      - pal_gripper_controller_configuration
+      - pal_gripper_description
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/pal_gripper-release.git
+      version: 3.0.0-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pal_gripper.git
+      version: humble-devel
+    status: developed
   pal_statistics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_gripper` to `3.0.0-1`:

- upstream repository: https://github.com/pal-robotics/pal_gripper.git
- release repository: https://github.com/pal-gbp/pal_gripper-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## pal_gripper

```
* Merge branch 'update_copyright' into 'humble-devel'
  Update copyright and add LICENSE
  See merge request robots/pal_gripper!15
* update copyright and add license
* Merge branch 'update_maintainers' into 'humble-devel'
  update maintainers
  See merge request robots/pal_gripper!14
* update maintainers
* ros2 format. Disabled some packages
* Contributors: Jordan Palacios, Noel Jimenez
```

## pal_gripper_controller_configuration

```
* Merge branch 'linters' into 'humble-devel'
  Linters
  See merge request robots/pal_gripper!17
* linters
* add linters
* Merge branch 'update_copyright' into 'humble-devel'
  Update copyright and add LICENSE
  See merge request robots/pal_gripper!15
* update copyright and add license
* Merge branch 'update_maintainers' into 'humble-devel'
  update maintainers
  See merge request robots/pal_gripper!14
* update maintainers
* Merge branch 'move_gripper_controller_launch' into 'foxy-devel'
  move controller launch to tiago_controller_configuration
  See merge request robots/pal_gripper!12
* move controller launch to tiago_controller_configuration
* Added new parameters required for joint trajectory controllers
* Use correct namespacing for parameters
* Using controller_manager launch_utils
* Adapted pal_gripper_controller_configuration to ros2
  Added ros2_control xacro file
* ros2 format. Disabled some packages
* Contributors: Jordan Palacios, Noel Jimenez, cescfolch, victor
```

## pal_gripper_description

```
* Merge branch 'cleanup' into 'humble-devel'
  Remove ros deps
  See merge request robots/pal_gripper!18
* rm ros deps
* Merge branch 'linters' into 'humble-devel'
  Linters
  See merge request robots/pal_gripper!17
* add linters
* Merge branch 'add_friction' into 'humble-devel'
  Add friction to gripper fingers
  See merge request robots/pal_gripper!16
* add friction to gripper fingers
* Merge branch 'update_copyright' into 'humble-devel'
  Update copyright and add LICENSE
  See merge request robots/pal_gripper!15
* update copyright and add license
* Merge branch 'update_maintainers' into 'humble-devel'
  update maintainers
  See merge request robots/pal_gripper!14
* update maintainers
* Adapted pal_gripper_controller_configuration to ros2
  Added ros2_control xacro file
* ros2 format. Disabled some packages
* Contributors: Jordan Palacios, Noel Jimenez
```
