### PR TITLE
dynamixel_workbench_msgs: 2.0.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -850,6 +850,21 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
       version: galactic-devel
     status: developed
+  dynamixel_workbench_msgs:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
+      version: galactic-devel
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/dynamixel_workbench_msgs-release.git
+      version: 2.0.3-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
+      version: galactic-devel
+    status: maintained
   ecl_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_workbench_msgs` to `2.0.3-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
- release repository: https://github.com/ros2-gbp/dynamixel_workbench_msgs-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## dynamixel_workbench_msgs

```
* release for ROS2
* Contributors: Will Son
```
