### PR TITLE
dynamixel_workbench_msgs: 2.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -917,6 +917,21 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
       version: ros2
     status: maintained
+  dynamixel_workbench_msgs:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/dynamixel_workbench_msgs-release.git
+      version: 2.0.3-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
+      version: humble-devel
+    status: maintained
   ecl_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_workbench_msgs` to `2.0.3-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
- release repository: https://github.com/ros2-gbp/dynamixel_workbench_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## dynamixel_workbench_msgs

```
* release for ROS2
* Contributors: Will Son
```
