### PR TITLE
euslime: 1.1.4-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2324,7 +2324,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/jsk-ros-pkg/euslime-release.git
-      version: 1.1.4-1
+      version: 1.1.4-2
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/euslime.git


### PR DESCRIPTION
Increasing version of package(s) in repository `euslime` to `1.1.4-2`:

- upstream repository: https://github.com/jsk-ros-pkg/euslime.git
- release repository: https://github.com/jsk-ros-pkg/euslime-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.1.4-1`

## euslime

```
* Fix build
* Contributors: Guilherme Affonso
```
