### PR TITLE
Adding witmotion_ros to documentation index for Noetic and Melodic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -15385,11 +15385,6 @@ repositories:
       type: git
       url: https://github.com/ElettraSciComp/witmotion_IMU_ros.git
       version: main
-    release:
-      tags:
-        release: release/melodic/{package}/{version}
-      url: https://github.com/ElettraSciComp/witmotion_IMU_ros.git
-      version: 0.11.18
     source:
       type: git
       url: https://github.com/ElettraSciComp/witmotion_IMU_ros.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -15380,6 +15380,21 @@ repositories:
       url: https://github.com/clearpathrobotics/wireless.git
       version: master
     status: maintained
+  witmotion_ros:
+    doc:
+      type: git
+      url: https://github.com/ElettraSciComp/witmotion_IMU_ros.git
+      version: main
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ElettraSciComp/witmotion_IMU_ros.git
+      version: 0.11.18
+    source:
+      type: git
+      url: https://github.com/ElettraSciComp/witmotion_IMU_ros.git
+      version: main
+    status: maintained
   wu_ros_tools:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11818,6 +11818,21 @@ repositories:
       url: https://github.com/clearpathrobotics/wireless.git
       version: master
     status: maintained
+  witmotion_ros:
+    doc:
+      type: git
+      url: https://github.com/ElettraSciComp/witmotion_IMU_ros.git
+      version: main
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ElettraSciComp/witmotion_IMU_ros.git
+      version: 0.11.18
+    source:
+      type: git
+      url: https://github.com/ElettraSciComp/witmotion_IMU_ros.git
+      version: main
+    status: maintained
   wu_ros_tools:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11823,11 +11823,6 @@ repositories:
       type: git
       url: https://github.com/ElettraSciComp/witmotion_IMU_ros.git
       version: main
-    release:
-      tags:
-        release: release/noetic/{package}/{version}
-      url: https://github.com/ElettraSciComp/witmotion_IMU_ros.git
-      version: 0.11.18
     source:
       type: git
       url: https://github.com/ElettraSciComp/witmotion_IMU_ros.git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add Package `witmotion_ros` to be indexed in the rosdistro.

ROSDISTRO NAME: `noetic`, `melodic`

# The source is here:

https://github.com/ElettraSciComp/witmotion_IMU_ros

# The wiki page is here: 

https://wiki.ros.org/witmotion_ros

# Purpose of using this package

It is a ROS driver allowing the IMU sensors manufactured by [WitMotion Shenzhen Co.,Ltd](https://www.wit-motion.com/) to be used as a controllable provider of IMU information.

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
