### PR TITLE
generate_parameter_library: 0.2.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1279,7 +1279,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/PickNikRobotics/generate_parameter_library-release.git
-      version: 0.2.6-1
+      version: 0.2.7-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `generate_parameter_library` to `0.2.7-1`:

- upstream repository: https://github.com/PickNikRobotics/generate_parameter_library.git
- release repository: https://github.com/PickNikRobotics/generate_parameter_library-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.6-1`

## generate_parameter_library

```
* Standardize cmake (#79 <https://github.com/PickNikRobotics/generate_parameter_library/issues/79>)
* Contributors: Tyler Weaver
```

## generate_parameter_library_example

```
* Standardize cmake (#79 <https://github.com/PickNikRobotics/generate_parameter_library/issues/79>)
* Contributors: Tyler Weaver
```

## generate_parameter_library_py

- No changes

## parameter_traits

```
* lt/gt/lt_eq/gt_eq validators (#80 <https://github.com/PickNikRobotics/generate_parameter_library/issues/80>)
* Standardize cmake (#79 <https://github.com/PickNikRobotics/generate_parameter_library/issues/79>)
* Add missing tcb_span ament export dep (#78 <https://github.com/PickNikRobotics/generate_parameter_library/issues/78>)
* Contributors: Denis Štogl, Tyler Weaver
```
