### PR TITLE
Revert "euslime: 1.1.4-2 in 'melodic/distribution.yaml' [bloom] (#350…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2984,7 +2984,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/jsk-ros-pkg/euslime-release.git
-      version: 1.1.4-2
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/euslime.git


### PR DESCRIPTION
…88)"

This reverts commit 55996209651e640f9451f89dfda3a0fc573f36be.

This is failing to build on the buildfarm: https://build.ros.org/job/Mbin_uB64__euslime__ubuntu_bionic_amd64__binary/81/consoleFull