### PR TITLE
vision_msgs_layers: 0.0.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -6458,6 +6458,21 @@ repositories:
       url: https://github.com/ros-perception/vision_msgs.git
       version: galactic
     status: maintained
+  vision_msgs_layers:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/vision_msgs_layers.git
+      version: galactic
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/vision_msgs_layers-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-sports/vision_msgs_layers.git
+      version: galactic
+    status: developed
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_msgs_layers` to `0.0.1-1`:

- upstream repository: https://github.com/ros-sports/vision_msgs_layers.git
- release repository: https://github.com/ros2-gbp/vision_msgs_layers-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## vision_msgs_layers

```
* Ensure dependencies are exported (#8 <https://github.com/ros-sports/vision_msgs_layers/issues/8>)
* Add bounding box 2d layer
* Contributors: Kenji Brameld
```
