### PR TITLE
vision_msgs_layers: 0.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6518,6 +6518,21 @@ repositories:
       url: https://github.com/ros-perception/vision_msgs.git
       version: ros2
     status: developed
+  vision_msgs_layers:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/vision_msgs_layers.git
+      version: humble
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/vision_msgs_layers-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros-sports/vision_msgs_layers.git
+      version: humble
+    status: developed
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_msgs_layers` to `0.1.0-1`:

- upstream repository: https://github.com/ros-sports/vision_msgs_layers.git
- release repository: https://github.com/ros2-gbp/vision_msgs_layers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## vision_msgs_layers

```
* Ensure dependencies are exported (#7 <https://github.com/ros-sports/vision_msgs_layers/issues/7>)
* Add bounding box 2d layer
* Contributors: Kenji Brameld
```
