### PR TITLE
soccer_object_msgs: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5325,7 +5325,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/soccer_object_msgs-release.git
-      version: 1.0.1-3
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ijnek/soccer_object_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `soccer_object_msgs` to `1.1.0-1`:

- upstream repository: https://github.com/ijnek/soccer_object_msgs.git
- release repository: https://github.com/ros2-gbp/soccer_object_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.1-3`

## soccer_object_msgs

```
* Deprecate this package (#13 <https://github.com/ijnek/soccer_object_msgs/issues/13>)
* Contributors: Kenji Brameld
```
