### PR TITLE
soccer_visualization: 0.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5357,7 +5357,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/soccer_visualization-release.git
-      version: 0.0.2-2
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/ijnek/soccer_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `soccer_visualization` to `0.1.0-1`:

- upstream repository: https://github.com/ijnek/soccer_visualization.git
- release repository: https://github.com/ros2-gbp/soccer_visualization-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.2-2`

## soccer_marker_generation

```
* Deprecate package in favor of ros-sports/soccer_vision_3d_rviz_markers (#3 <https://github.com/ijnek/soccer_visualization/issues/3>)
* Contributors: Kenji Brameld
```
