### PR TITLE
robotont_nuc_description: 0.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8393,6 +8393,13 @@ repositories:
       url: https://github.com/robotont/robotont_description.git
       version: noetic-devel
     status: maintained
+  robotont_nuc_description:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/robotont-release/robotont_nuc_description-release.git
+      version: 0.0.2-1
+    status: maintained
   robotraconteur:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `robotont_nuc_description` to `0.0.2-1`:

- upstream repository: https://github.com/robotont/robotont_nuc_description.git
- release repository: https://github.com/robotont-release/robotont_nuc_description-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
