### PR TITLE
grepros: 0.5.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3231,7 +3231,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/suurjaak/grepros-release.git
-      version: 0.4.7-1
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/suurjaak/grepros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grepros` to `0.5.0-1`:

- upstream repository: https://github.com/suurjaak/grepros.git
- release repository: https://github.com/suurjaak/grepros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.7-1`

## grepros

```
* add --plugin grepros.plugins.mcap (MCAP input and output)
* refactor internal bag API
* fix message type definition parsing yielding duplicate subtypes
* fix error in example usage text
```
