### PR TITLE
Add python-box

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6117,6 +6117,7 @@ python3-boto3:
   ubuntu: [python3-boto3]
 python3-box:
   debian: [python-box]
+  fedora: [python-box]
 python3-box-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6115,6 +6115,12 @@ python3-boto3:
     '*': ['python%{python3_pkgversion}-boto3']
     '7': null
   ubuntu: [python3-boto3]
+python3-box:
+  debian: [python-box]
+python3-box-pip:
+  ubuntu:
+    pip:
+      packages: [python-box]
 python3-breathe:
   debian: [python3-breathe]
   fedora: [python3-breathe]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6121,7 +6121,7 @@ python3-box:
     buster:
       pip:
         packages: [python-box]
-  fedora: [python-box]
+  fedora: [python3-box]
   ubuntu:
     '*': [python3-box]
     bionic:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6117,11 +6117,10 @@ python3-boto3:
   ubuntu: [python3-boto3]
 python3-box:
   debian:
-    '*': [python-box]
+    '*': [python3-box]
     buster:
       pip:
         packages: [python-box]
-   
   fedora: [python-box]
   ubuntu:
     '*': [python3-box]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6116,12 +6116,21 @@ python3-boto3:
     '7': null
   ubuntu: [python3-boto3]
 python3-box:
-  debian: [python-box]
+  debian:
+    '*': [python-box]
+    buster:
+      pip:
+        packages: [python-box]
+   
   fedora: [python-box]
-python3-box-pip:
   ubuntu:
-    pip:
-      packages: [python-box]
+    '*': [python3-box]
+    bionic:
+      pip:
+        packages: [python-box]
+    focal:
+      pip:
+        packages: [python-box]
 python3-breathe:
   debian: [python3-breathe]
   fedora: [python3-breathe]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python-box

## Package Upstream Source:

source code: https://github.com/cdgriffith/Box
pip: Otherwise, use pip version [here](https://pypi.org/project/python-box/).

## Purpose of using this:

Box is recommended for unit testing with tavern to convert dictionaries to objects that can have dot access.
See [here](https://tavern.readthedocs.io/en/latest/basics.html#using-external-functions-for-other-things)

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://sources.debian.org/src/python-box/
  - REQUIRED
  - Exists for bullseye and bookworm only as debian package,
  -  Otherwise, use pip version [here](https://pypi.org/project/python-box/).
- Ubuntu: https://packages.ubuntu.com/jammy/python3-box
   - REQUIRED
   - Exists in jammy, impish, and kinetic
   - Otherwise, use pip version [here](https://pypi.org/project/python-box/).
 - Fedora: https://src.fedoraproject.org/rpms/python-box#bodhi_updates
   - OPTIONAL

The implementation here uses `apt` if it's debian, or users would then use `pip` to install it for ubuntu. Other distributions are not needed at this time by me. 
