### PR TITLE
Adding rosros to noetic and foxy, and to rosdep/python

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5710,6 +5710,21 @@ repositories:
       url: https://github.com/uos/rospy_message_converter.git
       version: foxy
     status: maintained
+  rosros:
+    doc:
+      type: git
+      url: https://github.com/suurjaak/rosros.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/suurjaak/rosros-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/suurjaak/rosros.git
+      version: master
+    status: developed
   rosxbee:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9177,6 +9177,21 @@ repositories:
       url: https://github.com/uos/rospy_message_converter.git
       version: master
     status: maintained
+  rosros:
+    doc:
+      type: git
+      url: https://github.com/suurjaak/rosros.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/suurjaak/rosros-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/suurjaak/rosros.git
+      version: master
+    status: developed
   rosserial:
     doc:
       type: git

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8800,6 +8800,19 @@ python3-rospkg-modules:
     pip:
       packages: [rospkg]
   ubuntu: [python3-rospkg-modules]
+python3-rosros-pip:
+  debian:
+    pip:
+      packages: [rosros]
+  fedora:
+    pip:
+      packages: [rosros]
+  osx:
+    pip:
+      packages: [rosros]
+  ubuntu:
+    pip:
+      packages: [rosros]
 python3-rtree:
   debian: [python3-rtree]
   fedora: [python3-rtree]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE
-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`rosros`

## Package Upstream Source:

https://github.com/suurjaak/rosros

## Purpose of using this:

rosros is a wrapper library for providing a convenient unified interface to ROS1 / ROS2 Python API.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Pip:
  - https://pypi.org/project/rosros


<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

noetic, foxy

# The source is here:

https://github.com/suurjaak/rosros



# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
