### PR TITLE
ros_amr_interop: 1.1.1-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4333,10 +4333,12 @@ repositories:
       packages:
       - massrobotics_amr_sender
       - vda5050_connector
+      - vda5050_msgs
+      - vda5050_serializer
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/inorbit-ai/ros_amr_interop-release.git
-      version: 1.1.0-1
+      version: 1.1.1-2
     source:
       type: git
       url: https://github.com/inorbit-ai/ros_amr_interop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_amr_interop` to `1.1.1-2`:

- upstream repository: https://github.com/inorbit-ai/ros_amr_interop.git
- release repository: https://github.com/inorbit-ai/ros_amr_interop-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-1`

## massrobotics_amr_sender

```
* Fixed ROS buildfarm job (#29 <https://github.com/inorbit-ai/ros_amr_interop/issues/29>)
```

## vda5050_connector

```
* Fixed ROS buildfarm job (#29 <https://github.com/inorbit-ai/ros_amr_interop/issues/29>)
```

## vda5050_msgs

```
* Fixed ROS buildfarm job (#29 <https://github.com/inorbit-ai/ros_amr_interop/issues/29>)
```

## vda5050_serializer

```
* Fixed ROS buildfarm job (#29 <https://github.com/inorbit-ai/ros_amr_interop/issues/29>)
```
