### PR TITLE
Added Python bindings for MARISA (trie implementation)

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7421,7 +7421,6 @@ python3-marisa:
   debian: [python3-marisa]
   fedora: [python3-marisa]
   gentoo: [dev-libs/marisa]
-  opensuse: [python3-marisa]
   ubuntu: [python3-marisa]
 python3-markdown:
   debian: [python3-markdown]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2700,6 +2700,14 @@ python-mako:
 python-mapnik:
   debian: [python-mapnik]
   ubuntu: [python-mapnik]
+python-marisa:
+  debian:
+    '*': null
+    buster: [python-marisa]
+    stretch: [python-marisa]
+  ubuntu:
+    '*': null
+    bionic: [python-marisa]
 python-markdown:
   debian: [python-markdown]
   fedora: [python-markdown]
@@ -7408,6 +7416,13 @@ python3-mapnik:
   fedora: [python3-mapnik]
   nixos: [python3Packages.python-mapnik]
   ubuntu: [python3-mapnik]
+python3-marisa:
+  arch: [python-marisa]
+  debian: [python3-marisa]
+  fedora: [python3-marisa]
+  gentoo: [dev-libs/marisa]
+  opensuse: [python3-marisa]
+  ubuntu: [python3-marisa]
 python3-markdown:
   debian: [python3-markdown]
   fedora: [python3-markdown]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python-marisa/python3-marisa

## Package Upstream Source:

https://github.com/s-yata/marisa-trie

## Purpose of using this:

This package is an efficient implementation of tries.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/stretch/python-marisa
  - https://packages.debian.org/stretch/python3-marisa
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/bionic/python-marisa
   - https://packages.ubuntu.com/focal/python3-marisa
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/marisa/python3-marisa/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/community/x86_64/python-marisa/
- Gentoo: https://packages.gentoo.org/
  - [IF AVAILABLE](https://packages.gentoo.org/packages/dev-libs/marisa)
- macOS: https://formulae.brew.sh/
  - N/A
- Alpine: https://pkgs.alpinelinux.org/packages
  - N/A
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=22.05&show=marisa&from=0&size=50&sort=relevance&type=packages&query=marisa
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python3-marisa (only available in tumbleweed and I don't know how to correctly write that down, so I ditched this entry)