### PR TITLE
 Adding fields2cover_ros to documentation index for Noetic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3365,7 +3365,7 @@ repositories:
     source:
       type: git
       url: https://github.com/Fields2Cover/fields2cover_ros.git
-      version: kinetic-devel
+      version: melodic-devel
     status: developed      
   filters:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3357,6 +3357,16 @@ repositories:
       url: https://github.com/UbiquityRobotics/fiducials.git
       version: kinetic-devel
     status: developed
+  fields2cover_ros:
+    doc:
+      type: git
+      url: https://github.com/Fields2Cover/fields2cover_ros
+      version: master  
+    source:
+      type: git
+      url: https://github.com/Fields2Cover/fields2cover_ros.git
+      version: kinetic-devel
+    status: developed      
   filters:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3356,7 +3356,7 @@ repositories:
       type: git
       url: https://github.com/UbiquityRobotics/fiducials.git
       version: kinetic-devel
-    status: developed   
+    status: developed
   filters:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3356,17 +3356,7 @@ repositories:
       type: git
       url: https://github.com/UbiquityRobotics/fiducials.git
       version: kinetic-devel
-    status: developed
-  fields2cover_ros:
-    doc:
-      type: git
-      url: https://github.com/Fields2Cover/fields2cover_ros
-      version: master  
-    source:
-      type: git
-      url: https://github.com/Fields2Cover/fields2cover_ros.git
-      version: melodic-devel
-    status: developed      
+    status: developed   
   filters:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2576,13 +2576,13 @@ repositories:
   fields2cover_ros:
     doc:
       type: git
-      url: https://github.com/Fields2Cover/fields2cover_ros
-      version: noetic-devel  
+      url: https://github.com/Fields2Cover/fields2cover_ros.git
+      version: noetic-devel
     source:
       type: git
       url: https://github.com/Fields2Cover/fields2cover_ros.git
       version: noetic-devel
-    status: developed      
+    status: developed
   filters:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2573,6 +2573,16 @@ repositories:
       url: https://github.com/UbiquityRobotics/fiducials.git
       version: noetic-devel
     status: maintained
+  fields2cover_ros:
+    doc:
+      type: git
+      url: https://github.com/Fields2Cover/fields2cover_ros
+      version: noetic-devel  
+    source:
+      type: git
+      url: https://github.com/Fields2Cover/fields2cover_ros.git
+      version: noetic-devel
+    status: developed      
   filters:
     doc:
       type: git


### PR DESCRIPTION

# Please Add This Package to be indexed in the rosdistro.

fields2cover-ros

# The source is here:

https://github.com/Fields2Cover/fields2cover_ros


# Checks
 - [ x] All packages have a declared license in the package.xml
 - [ x] This repository has a LICENSE file
 - [ x] This package is expected to build on the submitted rosdistro
