### PR TITLE
openvino: 2022.2.0-6 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3440,9 +3440,11 @@ repositories:
       url: https://github.com/ngaloppo/ros_openvino-release.git
       version: 2022.2.0-6
     source:
+      test_commits: false
+      test_pull_requests: false
       type: git
       url: https://github.com/openvinotoolkit/openvino.git
-      version: 2022.2.0
+      version: releases/2022/2
     status: developed
   openzen_driver:
     doc:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3433,6 +3433,17 @@ repositories:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros-gbp/ompl-release.git
       version: 1.5.0-1
+  openvino:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ngaloppo/ros_openvino-release.git
+      version: 2022.2.0-6
+    source:
+      type: git
+      url: https://github.com/openvinotoolkit/openvino.git
+      version: 2022.2.0
+    status: developed
   openzen_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openvino` to `2022.2.0-6`:

- upstream repository: https://github.com/openvinotoolkit/openvino.git
- release repository: https://github.com/ngaloppo/ros_openvino-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
