### PR TITLE
rtcm_msgs: 1.1.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12588,7 +12588,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/nobleo/rtcm_msgs-release.git
-      version: 1.1.2-1
+      version: 1.1.3-1
     source:
       type: git
       url: https://github.com/tilk/rtcm_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtcm_msgs` to `1.1.3-1`:

- upstream repository: https://github.com/tilk/rtcm_msgs.git
- release repository: https://github.com/nobleo/rtcm_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.2-1`
