### PR TITLE
rtcm_msgs: 1.1.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5125,7 +5125,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/nobleo/rtcm_msgs-release.git
-      version: 1.1.2-1
+      version: 1.1.3-1
     source:
       type: git
       url: https://github.com/tilk/rtcm_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtcm_msgs` to `1.1.3-1`:

- upstream repository: https://github.com/tilk/rtcm_msgs.git
- release repository: https://github.com/nobleo/rtcm_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.2-1`
