### PR TITLE
Move audibot source entry to master branch

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -312,7 +312,7 @@ repositories:
     source:
       type: git
       url: https://github.com/robustify/audibot.git
-      version: noetic-devel
+      version: master
     status: maintained
   audio_common:
     doc:


### PR DESCRIPTION
There is no `noetic-devel` branch in the upstream repo:

https://github.com/robustify/audibot/branches

FYI @robustify @TorBorve