### PR TITLE
rtcm_msgs: 1.1.4-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5202,7 +5202,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/nobleo/rtcm_msgs-release.git
-      version: 1.1.2-1
+      version: 1.1.4-1
     source:
       type: git
       url: https://github.com/tilk/rtcm_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtcm_msgs` to `1.1.4-1`:

- upstream repository: https://github.com/tilk/rtcm_msgs.git
- release repository: https://github.com/nobleo/rtcm_msgs-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.2-1`
