### PR TITLE
Revert "ros_gz: 0.244.8-1 in 'humble/distribution.yaml' [bloom]"

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4550,7 +4550,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 0.244.8-1
+      version: 0.244.6-1
     source:
       type: git
       url: https://github.com/gazebosim/ros_gz.git


### PR DESCRIPTION
Reverts ros/rosdistro#35094

This release seems to have introduced a build failure: https://build.ros2.org/view/Hbin_uJ64/job/Hbin_uJ64__ros_ign_interfaces__ubuntu_jammy_amd64__binary/13/.