### PR TITLE
audibot: 0.2.2-5 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -312,7 +312,7 @@ repositories:
     source:
       type: git
       url: https://github.com/robustify/audibot.git
-      version: noetic-devel
+      version: master
     status: maintained
   audio_common:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -308,7 +308,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/robustify/audibot-release.git
-      version: 0.2.1-1
+      version: 0.2.2-5
     source:
       type: git
       url: https://github.com/robustify/audibot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `audibot` to `0.2.2-5`:

- upstream repository: https://github.com/robustify/audibot.git
- release repository: https://github.com/robustify/audibot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.1-1`

## audibot

- No changes

## audibot_description

```
* Removed joint effort and velocity limits
* Contributors: Micho Radovnikovich
```

## audibot_gazebo

```
* Add nav_msgs dependency to audibot_gazebo
* Publish odometry and steering angle feedback
* Remove tf_prefixer.py that is no longer needed in ROS Noetic
* Contributors: Micho Radovnikovich, Tor Børve Rasmussen
```
