### PR TITLE
audibot: 0.2.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -672,7 +672,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/robustify/audibot-release.git
-      version: 0.1.1-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/robustify/audibot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `audibot` to `0.2.2-1`:

- upstream repository: https://github.com/robustify/audibot.git
- release repository: https://github.com/robustify/audibot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.1-1`

## audibot

- No changes

## audibot_description

```
* Removed joint effort and velocity limits
* Contributors: Micho Radovnikovich
```

## audibot_gazebo

```
* Add nav_msgs dependency to audibot_gazebo
* Publish odometry and steering angle feedback
* Remove tf_prefixer.py that is no longer needed in ROS Noetic
* Contributors: Micho Radovnikovich, Tor Børve Rasmussen
```
