### PR TITLE
yaml_cpp_vendor: 8.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6406,7 +6406,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
-      version: 8.1.0-1
+      version: 8.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `yaml_cpp_vendor` to `8.1.1-1`:

- upstream repository: https://github.com/ros2/yaml_cpp_vendor.git
- release repository: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `8.1.0-1`

## yaml_cpp_vendor

```
* Export YAML_CPP_DLL define on Windows (#30 <https://github.com/ros2/yaml_cpp_vendor/issues/30>) (#38 <https://github.com/ros2/yaml_cpp_vendor/issues/38>)
* Contributors: Jacob Perron
```
