### PR TITLE
rviz: 12.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5160,7 +5160,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 12.0.0-1
+      version: 12.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `12.1.0-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `12.0.0-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Remove YAML_CPP_DLL define (#831 <https://github.com/ros2/rviz/issues/831>)
* Contributors: Akash
```

## rviz_default_plugins

```
* Add Map Display binary option (#846 <https://github.com/ros2/rviz/issues/846>)
* Delete frame_locked_markers when reusing marker (#907 <https://github.com/ros2/rviz/issues/907>)
* Consider region of interest in CameraDisplay (#864 <https://github.com/ros2/rviz/issues/864>)
* std::copy fix - OccupancyGridUpdate - Data is not being processed correctly (#895 <https://github.com/ros2/rviz/issues/895>)
* Contributors: AndreasR30, Eric, Patrick Roncagliolo, Shane Loretz
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
