### PR TITLE
ros2cli: 0.21.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4240,7 +4240,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.20.0-1
+      version: 0.21.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.21.0-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.20.0-1`

## ros2action

- No changes

## ros2cli

- No changes

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

- No changes

## ros2interface

- No changes

## ros2lifecycle

- No changes

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

```
* Add --group and --port options to ros2 multicast (#770 <https://github.com/ros2/ros2cli/issues/770>)
* Contributors: Shane Loretz
```

## ros2node

- No changes

## ros2param

- No changes

## ros2pkg

- No changes

## ros2run

- No changes

## ros2service

- No changes

## ros2topic

```
* Add support use_sim_time for ros2 topic hz/bw/pub. (#754 <https://github.com/ros2/ros2cli/issues/754>)
* Use set_message_fields from rosidl_runtime_py (#761 <https://github.com/ros2/ros2cli/issues/761>)
* Contributors: Esteve Fernandez, Lei Liu
```
