### PR TITLE
rmw: 6.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3913,7 +3913,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 6.3.1-1
+      version: 6.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw` to `6.4.0-1`:

- upstream repository: https://github.com/ros2/rmw.git
- release repository: https://github.com/ros2-gbp/rmw-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `6.3.1-1`

## rmw

```
* Remove unused test_loaned_message_sequence.cpp (#336 <https://github.com/ros2/rmw/issues/336>)
* callback can be NULL to clear in Listener APIs. (#332 <https://github.com/ros2/rmw/issues/332>)
* Add rmw_get_gid_for_client method (#327 <https://github.com/ros2/rmw/issues/327>)
* Contributors: Brian, Nikolai Morin, Tomoya Fujita
```

## rmw_implementation_cmake

- No changes
