### PR TITLE
rmw_fastrtps: 6.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3986,7 +3986,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 6.4.0-1
+      version: 6.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `6.5.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `6.4.0-1`

## rmw_fastrtps_cpp

```
* Add rmw_get_gid_for_client impl (#631 <https://github.com/ros2/rmw_fastrtps/issues/631>)
* Contributors: Brian
```

## rmw_fastrtps_dynamic_cpp

```
* Add rmw_get_gid_for_client impl (#631 <https://github.com/ros2/rmw_fastrtps/issues/631>)
* Contributors: Brian
```

## rmw_fastrtps_shared_cpp

```
* Remove duplicated code (#637 <https://github.com/ros2/rmw_fastrtps/issues/637>)
* Call callbacks only if unread count > 0 (#634 <https://github.com/ros2/rmw_fastrtps/issues/634>)
* Add rmw_get_gid_for_client impl (#631 <https://github.com/ros2/rmw_fastrtps/issues/631>)
* Contributors: Barry Xu, Brian, mauropasse
```
