### PR TITLE
rcutils: 6.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3590,7 +3590,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 6.0.0-1
+      version: 6.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `6.0.1-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `6.0.0-1`

## rcutils

```
* Fix build on OpenHarmony (#395 <https://github.com/ros2/rcutils/issues/395>)
* regression of thread-safety for logging macros (#393 <https://github.com/ros2/rcutils/issues/393>)
* add portable nonnull macros (#382 <https://github.com/ros2/rcutils/issues/382>)
* Fix memory leak when adding the same key to the logger hash map multiple times (#391 <https://github.com/ros2/rcutils/issues/391>)
* time_unix: uses ZEPHYR_VERSION_CODE instead (#390 <https://github.com/ros2/rcutils/issues/390>)
* Cleanup time_unix.c (#389 <https://github.com/ros2/rcutils/issues/389>)
* time_unix: namespace zephyr headers (#383 <https://github.com/ros2/rcutils/issues/383>)
* Restrict overmatching MACH ifdef to only trigger on OSX and Mach (#386 <https://github.com/ros2/rcutils/issues/386>)
* Contributors: AIxWall, Chris Lalancette, Felipe Neves, Jacob Perron, Maximilian Downey Twiss, William Woodall
```
