### PR TITLE
rcpputils: 2.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3539,7 +3539,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 2.5.2-1
+      version: 2.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `2.6.0-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.5.2-1`

## rcpputils

```
* require C++17 and deprecate the rcppmath namespace (#165 <https://github.com/ros2/rcpputils/issues/165>)
* Contributors: William Woodall
```
