### PR TITLE
rclpy: 3.7.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3523,7 +3523,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 3.7.0-1
+      version: 3.7.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `3.7.1-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.7.0-1`

## rclpy

```
* Set the default number of threads of the MultiThreadedExecutor to 2 (#1031 <https://github.com/ros2/rclpy/issues/1031>)
* Update the rclpy method documentation. (#1026 <https://github.com/ros2/rclpy/issues/1026>)
* Revert "Raise user handler exception in MultiThreadedExecutor. (#984 <https://github.com/ros2/rclpy/issues/984>)" (#1017 <https://github.com/ros2/rclpy/issues/1017>)
* Waitable should check callback_group if it can be executed. (#1001 <https://github.com/ros2/rclpy/issues/1001>)
* Contributors: Chris Lalancette, Tomoya Fujita
```
