### PR TITLE
class_loader: 2.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -579,7 +579,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/class_loader-release.git
-      version: 2.3.1-1
+      version: 2.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `2.4.0-1`:

- upstream repository: https://github.com/ros/class_loader.git
- release repository: https://github.com/ros2-gbp/class_loader-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.1-1`

## class_loader

```
* Remove appveyor configuration. (#204 <https://github.com/ros/class_loader/issues/204>)
* Just fix a typo in a comment. (#203 <https://github.com/ros/class_loader/issues/203>)
* make the meta-object alive in the lifecycle of the registered plugin (#201 <https://github.com/ros/class_loader/issues/201>)
* Contributors: Chen Lihui, Chris Lalancette
```
