### PR TITLE
demos: 0.23.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -764,7 +764,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.22.0-1
+      version: 0.23.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.23.0-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.22.0-1`

## action_tutorials_cpp

- No changes

## action_tutorials_interfaces

- No changes

## action_tutorials_py

- No changes

## composition

```
* fix memory leak (#585 <https://github.com/ros2/demos/issues/585>)
* Contributors: Chen Lihui
```

## demo_nodes_cpp

```
* Demo for pre and post set parameter callback support (#565 <https://github.com/ros2/demos/issues/565>)
  * local parameter callback support
* Contributors: Deepanshu Bansal
```

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

```
* Demo for pre and post set parameter callback support (#565 <https://github.com/ros2/demos/issues/565>)
* Contributors: Deepanshu Bansal
```

## dummy_map_server

- No changes

## dummy_robot_bringup

- No changes

## dummy_sensors

- No changes

## image_tools

- No changes

## intra_process_demo

- No changes

## lifecycle

- No changes

## lifecycle_py

```
* Install the launch file for lifecycle_py. (#586 <https://github.com/ros2/demos/issues/586>)
* Contributors: Chris Lalancette
```

## logging_demo

- No changes

## pendulum_control

- No changes

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

- No changes

## quality_of_service_demo_py

- No changes

## topic_monitor

- No changes

## topic_statistics_demo

- No changes
