### PR TITLE
launch: 1.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1957,7 +1957,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 1.2.0-1
+      version: 1.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `1.3.0-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.0-1`

## launch

```
* Expect deprecation warnings in tests (#657 <https://github.com/ros2/launch/issues/657>)
* Fix the restoring of os.environ to maintain type. (#656 <https://github.com/ros2/launch/issues/656>)
* Implement Any, All, Equals, and NotEquals substitutions (#649 <https://github.com/ros2/launch/issues/649>)
* add LaunchLogDir substitution, replacing log_dir frontend only substitution (#652 <https://github.com/ros2/launch/issues/652>)
* Add special cases to coerce "1" and "0" to bool when using bool coercion only (#651 <https://github.com/ros2/launch/issues/651>)
* Contributors: Chris Lalancette, Jacob Perron, William Woodall, methylDragon
```

## launch_pytest

- No changes

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
