### PR TITLE
launch_ros: 0.22.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1992,7 +1992,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.21.0-1
+      version: 0.22.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.22.0-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.21.0-1`

## launch_ros

```
* RosTimer -> ROSTimer and PushRosNamespace -> PushROSNamespace, to follow PEP8 (#326 <https://github.com/ros2/launch_ros/issues/326>)
* add SetROSLogDir action (#325 <https://github.com/ros2/launch_ros/issues/325>)
* Contributors: William Woodall
```

## launch_testing_ros

- No changes

## ros2launch

- No changes
