### PR TITLE
rclcpp: 17.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3507,7 +3507,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 17.0.0-1
+      version: 17.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `17.1.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `17.0.0-1`

## rclcpp

```
* MultiThreadExecutor number of threads is at least 2+ in default. (#2032 <https://github.com/ros2/rclcpp/issues/2032>)
* Fix bug that a callback not reached (#1640 <https://github.com/ros2/rclcpp/issues/1640>)
* Set the minimum number of threads of the Multithreaded executor to 2 (#2030 <https://github.com/ros2/rclcpp/issues/2030>)
* check thread whether joinable before join (#2019 <https://github.com/ros2/rclcpp/issues/2019>)
* Set cpplint test timeout to 3 minutes (#2022 <https://github.com/ros2/rclcpp/issues/2022>)
* Make sure to include-what-you-use in the node_interfaces. (#2018 <https://github.com/ros2/rclcpp/issues/2018>)
* Do not clear entities callbacks on destruction (#2002 <https://github.com/ros2/rclcpp/issues/2002>)
* fix mismatched issue if using zero_allocate (#1995 <https://github.com/ros2/rclcpp/issues/1995>)
* Contributors: Alexis Paques, Chen Lihui, Chris Lalancette, Cristóbal Arroyo, Tomoya Fujita, mauropasse, uupks
```

## rclcpp_action

```
* Do not clear entities callbacks on destruction (#2002 <https://github.com/ros2/rclcpp/issues/2002>)
* Contributors: mauropasse
```

## rclcpp_components

```
* use unique ptr and remove unuseful container (#2013 <https://github.com/ros2/rclcpp/issues/2013>)
* Contributors: Chen Lihui
```

## rclcpp_lifecycle

```
* LifecycleNode on_configure doc fix. (#2034 <https://github.com/ros2/rclcpp/issues/2034>)
* Bugfix 20210810 get current state (#1756 <https://github.com/ros2/rclcpp/issues/1756>)
* Make lifecycle impl get_current_state() const. (#2031 <https://github.com/ros2/rclcpp/issues/2031>)
* Cleanup the lifecycle implementation (#2027 <https://github.com/ros2/rclcpp/issues/2027>)
* Cleanup the rclcpp_lifecycle dependencies. (#2021 <https://github.com/ros2/rclcpp/issues/2021>)
* Contributors: Chris Lalancette, Tomoya Fujita
```
