### PR TITLE
image_common: 4.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1641,7 +1641,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 4.0.0-2
+      version: 4.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `4.1.0-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.0-2`

## camera_calibration_parsers

```
* Add support for missing ROI and binning fields (#254 <https://github.com/ros-perception/image_common/issues/254>)
* Contributors: AndreasR30
```

## camera_info_manager

```
* Add lifecycle node compatibility to camera_info_manager (#190 <https://github.com/ros-perception/image_common/issues/190>)
* Contributors: Ramon Wijnands
```

## image_common

- No changes

## image_transport

- No changes
