### PR TITLE
libstatistics_collector: 1.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2055,7 +2055,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libstatistics_collector-release.git
-      version: 1.2.0-1
+      version: 1.2.1-1
     source:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libstatistics_collector` to `1.2.1-1`:

- upstream repository: https://github.com/ros-tooling/libstatistics_collector.git
- release repository: https://github.com/ros2-gbp/libstatistics_collector-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.0-1`

## libstatistics_collector

```
* Remove unnecessary build dependency on std_msgs. (#145 <https://github.com/ros-tooling/libstatistics_collector/issues/145>)
* Bump pascalgn/automerge-action from 0.15.2 to 0.15.3
* Cleanup the CI jobs on this repository. (#146 <https://github.com/ros-tooling/libstatistics_collector/issues/146>)
* Check if message has a "header" field with a stamp subfield of type builtin_interfaces::msg::Time (#54 <https://github.com/ros-tooling/libstatistics_collector/issues/54>)
* Mirror rolling to master
* Contributors: Audrow Nash, Chris Lalancette, Scott Mende, dependabot[bot]
```
