### PR TITLE
qt_gui_core: 2.3.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3244,7 +3244,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 2.3.1-1
+      version: 2.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `2.3.2-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.1-1`

## qt_dotgraph

```
* Add in LICENSE file
* Contributors: Chris Lalancette
```

## qt_gui

```
* Add in LICENSE file
* Contributors: Chris Lalancette
```

## qt_gui_app

```
* Add in LICENSE file
* Contributors: Chris Lalancette
```

## qt_gui_core

```
* Add in LICENSE file
* Contributors: Chris Lalancette
```

## qt_gui_cpp

```
* Add in LICENSE file
* Contributors: Chris Lalancette
```

## qt_gui_py_common

```
* Add in LICENSE file
* Contributors: Chris Lalancette
```
