### PR TITLE
libyaml_vendor: 1.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2066,7 +2066,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libyaml_vendor-release.git
-      version: 1.4.1-1
+      version: 1.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libyaml_vendor` to `1.4.2-1`:

- upstream repository: https://github.com/ros2/libyaml_vendor.git
- release repository: https://github.com/ros2-gbp/libyaml_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.4.1-1`

## libyaml_vendor

```
* Remove a warning message. (#51 <https://github.com/ros2/libyaml_vendor/issues/51>)
* check if libyaml is already present before building it (take 2) (#45 <https://github.com/ros2/libyaml_vendor/issues/45>)
* Contributors: Chris Lalancette, Silvio Traversaro
```
