### PR TITLE
rosbag2_storage_mcap: 0.5.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4710,11 +4710,11 @@ repositories:
       packages:
       - mcap_vendor
       - rosbag2_storage_mcap
-      - rosbag2_storage_mcap_test_fixture_interfaces
+      - rosbag2_storage_mcap_testdata
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2_storage_mcap-release.git
-      version: 0.4.0-1
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/ros-tooling/rosbag2_storage_mcap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2_storage_mcap` to `0.5.0-1`:

- upstream repository: https://github.com/ros-tooling/rosbag2_storage_mcap.git
- release repository: https://github.com/ros2-gbp/rosbag2_storage_mcap-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.0-1`

## mcap_vendor

```
* mcap_vendor: update to v0.6.0 (#69 <https://github.com/ros-tooling/rosbag2_storage_mcap/issues/69>)
* Cleanup in mcap_vendor package (#62 <https://github.com/ros-tooling/rosbag2_storage_mcap/issues/62>)
* Switch to using the vendored zstd library. (#59 <https://github.com/ros-tooling/rosbag2_storage_mcap/issues/59>)
* Contributors: Chris Lalancette, Michael Orlov, James Smith
```

## rosbag2_storage_mcap

```
* set defaults for SQLite plugin parity (#68 <https://github.com/ros-tooling/rosbag2_storage_mcap/issues/68>)
* rosbag2_storage_mcap: add storage preset profiles (#57 <https://github.com/ros-tooling/rosbag2_storage_mcap/issues/57>)
* rename test_fixture_interfaces package to testdata (#64 <https://github.com/ros-tooling/rosbag2_storage_mcap/issues/64>)
* Switch to using the vendored zstd library. (#59 <https://github.com/ros-tooling/rosbag2_storage_mcap/issues/59>)
* Add set_read_order reader API (#54 <https://github.com/ros-tooling/rosbag2_storage_mcap/issues/54>)
* Contributors: Chris Lalancette, Emerson Knapp, James Smith
```

## rosbag2_storage_mcap_testdata

```
* rename test_fixture_interfaces package to testdata (#64 <https://github.com/ros-tooling/rosbag2_storage_mcap/issues/64>)
* Contributors: James Smith
```
