### PR TITLE
webots_ros2: 2022.1.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6379,7 +6379,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/webots_ros2-release.git
-      version: 2022.1.2-2
+      version: 2022.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `webots_ros2` to `2022.1.3-1`:

- upstream repository: https://github.com/cyberbotics/webots_ros2.git
- release repository: https://github.com/ros2-gbp/webots_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2022.1.2-2`

## webots_ros2

```
* Added macOS support.
* Added reset handler to all examples to support simulation reset from Webots.
```

## webots_ros2_driver

```
* Added macOS support.
```

## webots_ros2_epuck

```
* Added macOS support.
* Added reset handler to support simulation reset from Webots.
```

## webots_ros2_mavic

```
* Added macOS support.
* Added reset handler to support simulation reset from Webots.
```

## webots_ros2_tesla

```
* Added macOS support.
* Added reset handler to support simulation reset from Webots.
```

## webots_ros2_tiago

```
* Added macOS support.
* Added reset handler to support simulation reset from Webots.
```

## webots_ros2_turtlebot

```
* Added macOS support.
* Added reset handler to support simulation reset from Webots.
```

## webots_ros2_universal_robot

```
* Added macOS support.
```
