### PR TITLE
depthai: 2.19.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1757,7 +1757,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/luxonis/depthai-core-release.git
-      version: 2.17.4-1
+      version: 2.19.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai` to `2.19.0-1`:

- upstream repository: https://github.com/luxonis/depthai-core.git
- release repository: https://github.com/luxonis/depthai-core-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.17.4-1`

## depthai

```
* Stability improvements #616
* isUserBootloaderSupported API
* Device.setTimesync(true/false) convenience function to enable or disable subsequent timesyncing
* Windows improvements with listing BOOTED devices ("udev permissions" issue)
* Fix OV9282 as MonoCamera on RGB socket (issue was black image)
* Fix crash under high load (regression with camera events streaming)
* Fix YOLOv5/7 decoding in case of a single class
* Fix image size when decimation filter is enabled
* Fix for certain OV9782 and OV9282 permutations/configs
* Reset Device timestamp on boot to zero
* Reworded "No available devices" error message when there are other connected devices connected.
* Update CI to Node16 compatible actions
```
