### PR TITLE
generate_parameter_library: 0.2.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1260,7 +1260,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/PickNikRobotics/generate_parameter_library-release.git
-      version: 0.2.7-1
+      version: 0.2.8-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `generate_parameter_library` to `0.2.8-1`:

- upstream repository: https://github.com/PickNikRobotics/generate_parameter_library.git
- release repository: https://github.com/PickNikRobotics/generate_parameter_library-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.7-1`

## generate_parameter_library

- No changes

## generate_parameter_library_example

- No changes

## generate_parameter_library_py

```
* Use typing syntax which is compatible with Python 3.6 (#87 <https://github.com/PickNikRobotics/generate_parameter_library/issues/87>)
* Use YAML loader which is compatible with PyYAML 3.12 (#88 <https://github.com/PickNikRobotics/generate_parameter_library/issues/88>)
* Contributors: Scott K Logan
```

## parameter_traits

- No changes
