### PR TITLE
swri_console: 2.0.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5588,6 +5588,21 @@ repositories:
       url: https://github.com/open-rmf/stubborn_buddies.git
       version: galactic
     status: developed
+  swri_console:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/swri_console.git
+      version: ros2-devel
+    release:
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/ros2-gbp/swri_console-release.git
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://github.com/swri-robotics/swri_console.git
+      version: ros2-devel
+    status: developed
   system_fingerprint:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_console` to `2.0.1-1`:

- upstream repository: https://github.com/swri-robotics/swri_console.git
- release repository: https://github.com/ros2-gbp/swri_console-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## swri_console

```
* Switching to system default QoS (#50 <https://github.com/swri-robotics/swri_console/issues/50>)
* Merge pull request #45 <https://github.com/swri-robotics/swri_console/issues/45> from rasmusan/bugfix/log_queue_not_emptied
  Fix: Before maximum 1 log entry every 50 ms was processed. Now all en…
* Merge pull request #44 <https://github.com/swri-robotics/swri_console/issues/44> from rasmusan/bugfix/rosout_qos_fixed
  Fix: Changed rosout subsciption to use rcl_qos_profile_rosout_default…
* Merge pull request #43 <https://github.com/swri-robotics/swri_console/issues/43> from nobleo/fix/boost-thread-dep
  Fix boost dependency
* Merge pull request #41 <https://github.com/swri-robotics/swri_console/issues/41> from nobleo/ros-ok
  Replace deprecated is_initialized() with ok()
* Merge pull request #36 <https://github.com/swri-robotics/swri_console/issues/36> from rasmusan/bugfix/fix_loglevel_masking
  Fixed loglevel masking (for ROS2)
* Merge pull request #42 <https://github.com/swri-robotics/swri_console/issues/42> from nobleo/libboost-thread
  More specific boost dependency
* Merge pull request #37 <https://github.com/swri-robotics/swri_console/issues/37> from rasmusan/feature/add-display-options
  Added options to show logger_name and function in each log line
* Fixed loglevel masking (for ROS2)
* Contributors: David Anthony, Matthew, Rasmus Skovgaard Andersen, Tim Clephas, rasmus.andersen
```
