### PR TITLE
swri_console: 2.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5771,6 +5771,21 @@ repositories:
       url: https://github.com/open-rmf/stubborn_buddies.git
       version: main
     status: developed
+  swri_console:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/swri_console.git
+      version: ros2-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/swri_console-release.git
+      version: 2.0.2-1
+    source:
+      type: git
+      url: https://github.com/swri-robotics/swri_console.git
+      version: ros2-devel
+    status: developed
   system_fingerprint:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_console` to `2.0.2-1`:

- upstream repository: https://github.com/swri-robotics/swri_console.git
- release repository: https://github.com/ros2-gbp/swri_console-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## swri_console

```
* Update Qt Flags (#52 <https://github.com/swri-robotics/swri_console/issues/52>)
  * Update to use new flags
* Contributors: David Anthony
```
