### PR TITLE
Add geos rule for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1311,6 +1311,7 @@ geos:
   fedora: [geos-devel]
   gentoo: [sci-libs/geos]
   nixos: [geos]
+  rhel: [geos-devel]
   ubuntu: [libgeos-dev]
 gettext-base:
   arch: [gettext]


### PR DESCRIPTION
In both RHEL 7 and RHEL 8, this package is provided by EPEL: https://packages.fedoraproject.org/pkgs/geos/geos-devel/