### PR TITLE
psen_scan_v2: 0.10.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9653,7 +9653,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/psen_scan_v2-release.git
-      version: 0.10.1-1
+      version: 0.10.2-1
     source:
       type: git
       url: https://github.com/PilzDE/psen_scan_v2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `psen_scan_v2` to `0.10.2-1`:

- upstream repository: https://github.com/PilzDE/psen_scan_v2.git
- release repository: https://github.com/PilzDE/psen_scan_v2-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.10.1-1`

## psen_scan_v2

```
* Remove zoneset bits from IOState.input field since its redundant to the active_zoneset field (#311)
* Inform about missing configuration confirmation
* Ignore changes of unused IOs. Fix #321
* Fill "io_states" vector as received instead of order by theta to avoid flickering. Fix #320
* Fixed bug of multiple zonesets being visible #328
* Contributors: Pilz GmbH and Co. KG
```
