### PR TITLE
Add rosdep keys for flake8 plugins in Jammy.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6807,34 +6807,74 @@ python3-flake8-blind-except-pip:
   ubuntu:
     pip:
       packages: [flake8-blind-except]
+python3-flake8-blind-except:
+  ubuntu:
+    '*': [python3-flake8-blind-except]
+    bionic: null
+    focal: null
 python3-flake8-builtins-pip:
   ubuntu:
     pip:
       packages: [flake8-builtins]
+python3-flake8-builtins:
+  ubuntu:
+    '*': [python3-flake8-builtins]
+    bionic: null
+    focal: null
 python3-flake8-class-newline-pip:
   ubuntu:
     pip:
       packages: [flake8-class-newline]
+python3-flake8-class-newline:
+  ubuntu:
+    '*': [python3-flake8-class-newline]
+    bionic: null
+    focal: null
 python3-flake8-comprehensions-pip:
   ubuntu:
     pip:
       packages: [flake8-comprehensions]
+python3-flake8-comprehensions:
+  ubuntu:
+    '*': [python3-flake8-comprehensions]
+    bionic: null
+    focal: null
 python3-flake8-deprecated-pip:
   ubuntu:
     pip:
       packages: [flake8-deprecated]
+python3-flake8-deprecated:
+  ubuntu:
+    '*': [python3-flake8-deprecated]
+    bionic: null
+    focal: null
 python3-flake8-docstrings-pip:
   ubuntu:
     pip:
       packages: [flake8-docstrings]
+python3-flake8-docstrings:
+  ubuntu:
+    '*': [python3-flake8-docstrings]
+    bionic: null
+    focal: null
 python3-flake8-import-order-pip:
   ubuntu:
     pip:
       packages: [flake8-import-order]
+python3-flake8-import-order:
+  ubuntu:
+    '*': [python3-flake8-import-order]
+    bionic: null
+    focal: null
 python3-flake8-quotes-pip:
   ubuntu:
     pip:
       packages: [flake8-quotes]
+python3-flake8-quotes:
+  ubuntu:
+    '*': [python3-flake8-quotes]
+    bionic: null
+    focal: null
 python3-flask:
   debian: [python3-flask]
   fedora: [python3-flask]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6877,6 +6877,7 @@ python3-flake8-import-order-pip:
     pip:
       packages: [flake8-import-order]
 python3-flake8-quotes:
+  opensuse: [python3-flake8-quotes]
   ubuntu:
     '*': [python3-flake8-quotes]
     bionic: null

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6812,6 +6812,7 @@ python3-flake8-blind-except:
     '*': [python3-flake8-blind-except]
     bionic: null
     focal: null
+  opensuse: [python3-flake8-blind-except]
 python3-flake8-builtins-pip:
   ubuntu:
     pip:
@@ -6821,6 +6822,7 @@ python3-flake8-builtins:
     '*': [python3-flake8-builtins]
     bionic: null
     focal: null
+  opensuse: [python3-flake8-builtins]
 python3-flake8-class-newline-pip:
   ubuntu:
     pip:
@@ -6830,6 +6832,7 @@ python3-flake8-class-newline:
     '*': [python3-flake8-class-newline]
     bionic: null
     focal: null
+  opensuse: [python3-flake8-class-newline]
 python3-flake8-comprehensions-pip:
   ubuntu:
     pip:
@@ -6848,12 +6851,14 @@ python3-flake8-deprecated:
     '*': [python3-flake8-deprecated]
     bionic: null
     focal: null
+  opensuse: [python3-flake8-deprecated]
 python3-flake8-docstrings-pip:
   ubuntu:
     pip:
       packages: [flake8-docstrings]
 python3-flake8-docstrings:
   debian: [python3-flake8-docstrings]
+  opensuse: [python3-flake8-docstrings]
   ubuntu: [python3-flake8-docstrings]
 python3-flake8-import-order-pip:
   ubuntu:
@@ -6864,6 +6869,7 @@ python3-flake8-import-order:
     '*': [python3-flake8-import-order]
     bionic: null
     focal: null
+  opensuse: [python3-flake8-import-order]
 python3-flake8-quotes-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6853,6 +6853,7 @@ python3-flake8-deprecated-pip:
     pip:
       packages: [flake8-deprecated]
 python3-flake8-docstrings:
+  arch: [python-flake8-docstrings]
   debian: [python3-flake8-docstrings]
   fedora: [python3-flake8-docstrings]
   opensuse: [python3-flake8-docstrings]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6853,10 +6853,8 @@ python3-flake8-docstrings-pip:
     pip:
       packages: [flake8-docstrings]
 python3-flake8-docstrings:
-  ubuntu:
-    '*': [python3-flake8-docstrings]
-    bionic: null
-    focal: null
+  debian: [python3-flake8-docstrings]
+  ubuntu: [python3-flake8-docstrings]
 python3-flake8-import-order-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6803,85 +6803,85 @@ python3-flake8:
     '*': ['python%{python3_pkgversion}-flake8']
     '7': null
   ubuntu: [python3-flake8]
-python3-flake8-blind-except-pip:
-  ubuntu:
-    pip:
-      packages: [flake8-blind-except]
 python3-flake8-blind-except:
+  opensuse: [python3-flake8-blind-except]
   ubuntu:
     '*': [python3-flake8-blind-except]
     bionic: null
     focal: null
-  opensuse: [python3-flake8-blind-except]
-python3-flake8-builtins-pip:
+python3-flake8-blind-except-pip:
   ubuntu:
     pip:
-      packages: [flake8-builtins]
+      packages: [flake8-blind-except]
 python3-flake8-builtins:
+  opensuse: [python3-flake8-builtins]
   ubuntu:
     '*': [python3-flake8-builtins]
     bionic: null
     focal: null
-  opensuse: [python3-flake8-builtins]
-python3-flake8-class-newline-pip:
+python3-flake8-builtins-pip:
   ubuntu:
     pip:
-      packages: [flake8-class-newline]
+      packages: [flake8-builtins]
 python3-flake8-class-newline:
+  opensuse: [python3-flake8-class-newline]
   ubuntu:
     '*': [python3-flake8-class-newline]
     bionic: null
     focal: null
-  opensuse: [python3-flake8-class-newline]
+python3-flake8-class-newline-pip:
+  ubuntu:
+    pip:
+      packages: [flake8-class-newline]
+python3-flake8-comprehensions:
+  ubuntu:
+    '*': [python3-flake8-comprehensions]
+    bionic: null
+    focal: null
 python3-flake8-comprehensions-pip:
   ubuntu:
     pip:
       packages: [flake8-comprehensions]
-python3-flake8-comprehensions:
+python3-flake8-deprecated:
+  opensuse: [python3-flake8-deprecated]
   ubuntu:
-    '*': [python3-flake8-comprehensions]
+    '*': [python3-flake8-deprecated]
     bionic: null
     focal: null
 python3-flake8-deprecated-pip:
   ubuntu:
     pip:
       packages: [flake8-deprecated]
-python3-flake8-deprecated:
-  ubuntu:
-    '*': [python3-flake8-deprecated]
-    bionic: null
-    focal: null
-  opensuse: [python3-flake8-deprecated]
-python3-flake8-docstrings-pip:
-  ubuntu:
-    pip:
-      packages: [flake8-docstrings]
 python3-flake8-docstrings:
   debian: [python3-flake8-docstrings]
   fedora: [python3-flake8-docstrings]
   opensuse: [python3-flake8-docstrings]
   rhel: [python3-flake8-docstrings]
   ubuntu: [python3-flake8-docstrings]
-python3-flake8-import-order-pip:
+python3-flake8-docstrings-pip:
   ubuntu:
     pip:
-      packages: [flake8-import-order]
+      packages: [flake8-docstrings]
 python3-flake8-import-order:
   fedora: [python3-flake8-import-order]
+  opensuse: [python3-flake8-import-order]
   ubuntu:
     '*': [python3-flake8-import-order]
     bionic: null
     focal: null
-  opensuse: [python3-flake8-import-order]
-python3-flake8-quotes-pip:
+python3-flake8-import-order-pip:
   ubuntu:
     pip:
-      packages: [flake8-quotes]
+      packages: [flake8-import-order]
 python3-flake8-quotes:
   ubuntu:
     '*': [python3-flake8-quotes]
     bionic: null
     focal: null
+python3-flake8-quotes-pip:
+  ubuntu:
+    pip:
+      packages: [flake8-quotes]
 python3-flask:
   debian: [python3-flask]
   fedora: [python3-flask]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6858,13 +6858,16 @@ python3-flake8-docstrings-pip:
       packages: [flake8-docstrings]
 python3-flake8-docstrings:
   debian: [python3-flake8-docstrings]
+  fedora: [python3-flake8-docstrings]
   opensuse: [python3-flake8-docstrings]
+  rhel: [python3-flake8-docstrings]
   ubuntu: [python3-flake8-docstrings]
 python3-flake8-import-order-pip:
   ubuntu:
     pip:
       packages: [flake8-import-order]
 python3-flake8-import-order:
+  fedora: [python3-flake8-import-order]
   ubuntu:
     '*': [python3-flake8-import-order]
     bionic: null

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6857,7 +6857,9 @@ python3-flake8-docstrings:
   debian: [python3-flake8-docstrings]
   fedora: [python3-flake8-docstrings]
   opensuse: [python3-flake8-docstrings]
-  rhel: [python3-flake8-docstrings]
+  rhel:
+    '*': [python3-flake8-docstrings]
+    '7': null
   ubuntu: [python3-flake8-docstrings]
 python3-flake8-docstrings-pip:
   ubuntu:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

- python3-flake8-blind-except
- python3-flake8-builtins
- python3-flake8-class-newline
- python3-flake8-comprehensions
- python3-flake8-deprecated
- python3-flake8-docstrings
- python3-flake8-import-order
- python3-flake8-quotes

## Purpose of using this:

These plugins are expected when using flake8 with ament_flake8 but haven't been available upstream until Ubuntu Jammy.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/python3-flake8-docstrings
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/jammy/python3-flake8-blind-except
  - https://packages.ubuntu.com/jammy/python3-flake8-builtins
  - https://packages.ubuntu.com/jammy/python3-flake8-class-newline
  - https://packages.ubuntu.com/jammy/python3-flake8-comprehensions
  - https://packages.ubuntu.com/jammy/python3-flake8-deprecated
  - https://packages.ubuntu.com/jammy/python3-flake8-docstrings
  - https://packages.ubuntu.com/jammy/python3-flake8-import-order
  - https://packages.ubuntu.com/jammy/python3-flake8-quotes
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-flake8-docstrings/python3-flake8-docstrings/
  - https://packages.fedoraproject.org/pkgs/python-flake8-import-order/python3-flake8-import-order/
- RHEL
  - https://packages.fedoraproject.org/pkgs/python-flake8-docstrings/python3-flake8-docstrings/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/community/any/python-flake8-docstrings/
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python3-flake8-blind-except
  - https://software.opensuse.org/package/python3-flake8-builtins
  - https://software.opensuse.org/package/python3-flake8-class-newline
  - https://software.opensuse.org/package/python3-flake8-deprecated
  - https://software.opensuse.org/package/python3-flake8-docstrings
  - https://software.opensuse.org/package/python3-flake8-import-order
  - https://software.opensuse.org/package/python3-flake8-quotes
