### PR TITLE
osrf_testing_tools_cpp: 1.5.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3032,7 +3032,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/osrf_testing_tools_cpp-release.git
-      version: 1.5.1-2
+      version: 1.5.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `osrf_testing_tools_cpp` to `1.5.2-1`:

- upstream repository: https://github.com/osrf/osrf_testing_tools_cpp.git
- release repository: https://github.com/ros2-gbp/osrf_testing_tools_cpp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.5.1-2`

## osrf_testing_tools_cpp

```
* Sets CMP0135 policy behavior to NEW (#73 <https://github.com/osrf/osrf_testing_tools_cpp/issues/73>)
* Fixes policy CMP0135 warning in CMake 3.24 (#71 <https://github.com/osrf/osrf_testing_tools_cpp/issues/71>)
* Add cstring include. (#70 <https://github.com/osrf/osrf_testing_tools_cpp/issues/70>)
* Contributors: Chris Lalancette, Cristóbal Arroyo
```
