### PR TITLE
rqt_bag: 1.1.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5054,7 +5054,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
-      version: 1.1.3-2
+      version: 1.1.4-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `1.1.4-1`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros2-gbp/rqt_bag-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.3-2`

## rqt_bag

```
* [Humble] Ensure data types match what PyQt expects (backport #118 <https://github.com/ros-visualization/rqt_bag/issues/118>) (#125 <https://github.com/ros-visualization/rqt_bag/issues/125>)
* Fix toggle thumbnails button (#117 <https://github.com/ros-visualization/rqt_bag/issues/117>) (#124 <https://github.com/ros-visualization/rqt_bag/issues/124>)
* [Fixes] Fix crash when no qos metadata, make scroll bar appear if needed, add gitignore (#113 <https://github.com/ros-visualization/rqt_bag/issues/113>) (#120 <https://github.com/ros-visualization/rqt_bag/issues/120>)
* Contributors: mergify[bot]
```

## rqt_bag_plugins

- No changes
