### PR TITLE
rcl_interfaces: 1.2.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3702,7 +3702,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_interfaces-release.git
-      version: 1.2.0-2
+      version: 1.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_interfaces` to `1.2.1-1`:

- upstream repository: https://github.com/ros2/rcl_interfaces.git
- release repository: https://github.com/ros2-gbp/rcl_interfaces-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.0-2`

## action_msgs

- No changes

## builtin_interfaces

- No changes

## composition_interfaces

- No changes

## lifecycle_msgs

```
* lifecycle_msgs: remove non-ASCII chars from field comments (#147 <https://github.com/ros2/rcl_interfaces/issues/147>) (#148 <https://github.com/ros2/rcl_interfaces/issues/148>)
* Contributors: mergify[bot]
```

## rcl_interfaces

- No changes

## rosgraph_msgs

- No changes

## statistics_msgs

- No changes

## test_msgs

- No changes
