### PR TITLE
rclcpp: 16.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3764,7 +3764,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 16.0.1-2
+      version: 16.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `16.0.2-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `16.0.1-2`

## rclcpp

```
* fix mismatched issue if using zero_allocate (#1995 <https://github.com/ros2/rclcpp/issues/1995>) (#2026 <https://github.com/ros2/rclcpp/issues/2026>)
* use regex for wildcard matching (backport #1839 <https://github.com/ros2/rclcpp/issues/1839>) (#1986 <https://github.com/ros2/rclcpp/issues/1986>)
* Drop wrong template specialization (#1926 <https://github.com/ros2/rclcpp/issues/1926>) (#1937 <https://github.com/ros2/rclcpp/issues/1937>)
* Add statistics for handle_loaned_message (#1927 <https://github.com/ros2/rclcpp/issues/1927>) (#1932 <https://github.com/ros2/rclcpp/issues/1932>)
* Contributors: mergify[bot]
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
