### PR TITLE
rmw: 6.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4173,7 +4173,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 6.1.0-2
+      version: 6.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw` to `6.1.1-1`:

- upstream repository: https://github.com/ros2/rmw.git
- release repository: https://github.com/ros2-gbp/rmw-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `6.1.0-2`

## rmw

```
* callback can be NULL to clear in Listener APIs. (#332 <https://github.com/ros2/rmw/issues/332>) (#333 <https://github.com/ros2/rmw/issues/333>)
* Contributors: mergify[bot]
```

## rmw_implementation_cmake

- No changes
