### PR TITLE
Only run on pushes to master _or_ pull requests.

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -1,5 +1,8 @@
 name: Validate rosdistro
-on: [push, pull_request]
+on:
+  push:
+    branches: ['master']
+  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
The current configuration is causing builds to be run twice, duplicating the results and creating confusion (in addition to burning CPU time needlessly).
