### PR TITLE
Use mirrorlist files for checking RPM repositories

### DIFF
--- a/test/rosdep_repo_check/config.py
+++ b/test/rosdep_repo_check/config.py
@@ -33,6 +33,7 @@ from .apk import apk_base_url
 from .deb import deb_base_url
 from .pacman import pacman_base_url
 from .rpm import rpm_base_url
+from .rpm import rpm_mirrorlist_url
 
 
 DEFAULT_CONFIG_PATH = os.path.join(
@@ -58,6 +59,10 @@ def load_rpm_base_url(loader, node):
     return rpm_base_url(node.value)
 
 
+def load_rpm_mirrorlist_url(loader, node):
+    return rpm_mirrorlist_url(node.value)
+
+
 def load_regex(loader, node):
     return re.compile(node.value)
 
@@ -70,6 +75,8 @@ yaml.add_constructor(
     u'!pacman_base_url', load_pacman_base_url, Loader=yaml.SafeLoader)
 yaml.add_constructor(
     u'!rpm_base_url', load_rpm_base_url, Loader=yaml.SafeLoader)
+yaml.add_constructor(
+    u'!rpm_mirrorlist_url', load_rpm_mirrorlist_url, Loader=yaml.SafeLoader)
 yaml.add_constructor(
     u'!regular_expression', load_regex, Loader=yaml.SafeLoader)
 

--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -14,28 +14,27 @@ package_sources:
   - !deb_base_url http://deb.debian.org/debian non-free
   - !deb_base_url http://repos.ros.org/repos/ros_bootstrap main
   fedora:
-  - !rpm_base_url https://dl.fedoraproject.org/pub/$distname/linux/releases/$releasever/Everything/$basearch/os/
-  - !rpm_base_url https://dl.fedoraproject.org/pub/$distname/linux/updates/$releasever/Everything/$basearch/
-  - !rpm_base_url https://download1.rpmfusion.org/free/$distname/releases/$releasever/Everything/$basearch/os/
+  - !rpm_mirrorlist_url https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
+  - !rpm_mirrorlist_url https://mirrors.fedoraproject.org/mirrorlist?repo=updates-released-f$releasever&arch=$basearch
+  - !rpm_mirrorlist_url https://mirrors.rpmfusion.org/mirrorlist?repo=free-fedora-$releasever&arch=$basearch
   opensuse:
   - !rpm_base_url http://download.opensuse.org/distribution/leap/$releasever/repo/oss/
   - !rpm_base_url http://download.opensuse.org/distribution/leap/$releasever/repo/non-oss/
   - !rpm_base_url http://download.opensuse.org/update/leap/$releasever/oss/
   - !rpm_base_url http://download.opensuse.org/update/leap/$releasever/non-oss/
   rhel:
+  - !rpm_mirrorlist_url https://mirrors.fedoraproject.org/mirrorlist?repo=epel-$releasever&arch=$basearch
   - '7':
-    - !rpm_base_url https://dl.fedoraproject.org/pub/epel/$releasever/$basearch/
-    - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/os/$basearch/
-    - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/updates/$basearch/
-    - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/extras/$basearch/
-    - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/sclo/$basearch/rh/
+    - !rpm_mirrorlist_url http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os
+    - !rpm_mirrorlist_url http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates
+    - !rpm_mirrorlist_url http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras
+    - !rpm_mirrorlist_url http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=sclo-sclo
     '8':
-    - !rpm_base_url https://dl.fedoraproject.org/pub/epel/$releasever/Everything/$basearch/
-    - !rpm_base_url https://repo.almalinux.org/almalinux/$releasever/BaseOS/$basearch/os/
-    - !rpm_base_url https://repo.almalinux.org/almalinux/$releasever/AppStream/$basearch/os/
-    - !rpm_base_url https://repo.almalinux.org/almalinux/$releasever/PowerTools/$basearch/os/
-    - !rpm_base_url https://repo.almalinux.org/almalinux/$releasever/extras/$basearch/os/
-  - !rpm_base_url https://download1.rpmfusion.org/free/el/updates/$releasever/$basearch/
+    - !rpm_mirrorlist_url https://mirrors.almalinux.org/mirrorlist/$releasever/baseos
+    - !rpm_mirrorlist_url https://mirrors.almalinux.org/mirrorlist/$releasever/appstream
+    - !rpm_mirrorlist_url https://mirrors.almalinux.org/mirrorlist/$releasever/powertools
+    - !rpm_mirrorlist_url https://mirrors.almalinux.org/mirrorlist/$releasever/extras
+  - !rpm_mirrorlist_url https://mirrors.rpmfusion.org/mirrorlist?repo=free-el-updates-released-$releasever&arch=$basearch
   ubuntu:
   - !deb_base_url http://archive.ubuntu.com/ubuntu main
   - !deb_base_url http://archive.ubuntu.com/ubuntu universe

--- a/test/rosdep_repo_check/rpm.py
+++ b/test/rosdep_repo_check/rpm.py
@@ -177,6 +177,8 @@ def enumerate_rpm_packages_from_mirrorlist(mirrorlist_url, os_name, os_code_name
         try:
             for pkg in enumerate_rpm_packages(base_url, os_name, os_code_name, os_arch):
                 yield pkg
+            else:
+                return
         except Exception as e:
             if not isinstance(e, (
                 ConnectionResetError,
@@ -188,8 +190,6 @@ def enumerate_rpm_packages_from_mirrorlist(mirrorlist_url, os_name, os_code_name
             print('Falling back to next available mirror...')
             # We may end up re-enumerating some packages, but it's better than
             # erroring out due to a connection reset...
-            continue
-        return
     else:
         raise RuntimeError('All mirrors were tried')
 

--- a/test/rosdep_repo_check/rpm.py
+++ b/test/rosdep_repo_check/rpm.py
@@ -31,6 +31,7 @@ from xml.etree import ElementTree
 from . import open_gz_url
 from . import PackageEntry
 from . import RepositoryCacheCollection
+from . import URLError
 
 
 def replace_tokens(string, os_name, os_code_name, os_arch):
@@ -69,6 +70,19 @@ def get_primary_name(repomd_url):
                 return data_child.attrib['href']
             root.clear()
     raise RuntimeError('Failed to determine primary data file name')
+
+
+def enumerate_base_urls(mirrorlist_url):
+    """Get candidate RPM repository base URLs from a mirrorlist file."""
+    with open_gz_url(mirrorlist_url) as f:
+        while True:
+            line = f.readline().decode('utf-8')
+            if not len(line):
+                break
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            yield line
 
 
 def enumerate_rpm_packages(base_url, os_name, os_code_name, os_arch):
@@ -146,6 +160,40 @@ def enumerate_rpm_packages(base_url, os_name, os_code_name, os_arch):
             element.clear()
 
 
+def enumerate_rpm_packages_from_mirrorlist(mirrorlist_url, os_name, os_code_name, os_arch):
+    """
+    Enumerate packages in an RPM repository using a mirrorlist.
+
+    :param mirrorlist_url: the RPM repository mirrorlist file URL.
+    :param os_name: the name of the OS associated with the repository.
+    :param os_code_name: the OS version associated with the repository.
+    :param os_arch: the system architecture associated with the repository.
+
+    :returns: an enumeration of package entries.
+    """
+    mirrorlist_url = replace_tokens(mirrorlist_url, os_name, os_code_name, os_arch)
+    print('Reading RPM mirrorlist from ' + mirrorlist_url)
+    for base_url in enumerate_base_urls(mirrorlist_url):
+        try:
+            for pkg in enumerate_rpm_packages(base_url, os_name, os_code_name, os_arch):
+                yield pkg
+        except Exception as e:
+            if not isinstance(e, (
+                ConnectionResetError,
+                RuntimeError,
+                URLError,
+            )):
+                raise
+            print("Error reading from mirror '%s': %s" % (base_url, str(e)))
+            print('Falling back to next available mirror...')
+            # We may end up re-enumerating some packages, but it's better than
+            # erroring out due to a connection reset...
+            continue
+        return
+    else:
+        raise RuntimeError('All mirrors were tried')
+
+
 def rpm_base_url(base_url):
     """
     Create an enumerable cache for an RPM repository.
@@ -157,3 +205,17 @@ def rpm_base_url(base_url):
     return RepositoryCacheCollection(
         lambda os_name, os_code_name, os_arch:
             enumerate_rpm_packages(base_url, os_name, os_code_name, os_arch))
+
+
+def rpm_mirrorlist_url(mirrorlist_url):
+    """
+    Create an enumerable cache for an RPM repository mirrorlist.
+
+    :param mirrorlist_url: the URL of the RPM repository mirrorlist file.
+
+    :returns: an enumerable repository cache instance.
+    """
+    return RepositoryCacheCollection(
+        lambda os_name, os_code_name, os_arch:
+            enumerate_rpm_packages_from_mirrorlist(
+                mirrorlist_url, os_name, os_code_name, os_arch))


### PR DESCRIPTION
There are three common ways to locate RPM metadata:
1. Base URL: A plain URL to the repository base
2. Mirror List: A URL to a plaintext file which contains a list of base URLs
3. Metalink: A URL to an XML file which contains hashes of the repomd.xml and various URLs to access it.

We're currently using (1). Option (3) is the way that modern Fedora instances find repositories, but isn't supported by CentOS or AlmaLinux. We'd also need to change some of the existing logic in our enumeration code to support that level of hash verification.

Option (2) is fairly trivial to implement and should make our metadata downloads faster and more reliable.