### PR TITLE
rviz: 12.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5178,7 +5178,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 12.1.0-1
+      version: 12.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `12.2.0-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `12.1.0-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

- No changes

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

```
* Remove broken rviz_ogre_vendor::RenderSystem_GL target (#920 <https://github.com/ros2/rviz/issues/920>)
* Contributors: Shane Loretz
```

## rviz_rendering

```
* add test to ensure binary STL files from SOLIDWORKS get imported without a warning (#917 <https://github.com/ros2/rviz/issues/917>)
* Contributors: Kenji Brameld
```

## rviz_rendering_tests

```
* add test to ensure binary STL files from SOLIDWORKS get imported without a warning (#917 <https://github.com/ros2/rviz/issues/917>)
* Contributors: Kenji Brameld
```

## rviz_visual_testing_framework

- No changes
