### PR TITLE
ur_description: 2.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5959,7 +5959,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.0.1-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-1`

## ur_description

```
* Add tool voltage and zero ft sensor to command interface (#38 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/38>)
  Added reverse ip and script command interface port as parameters
* use xacro.load_yaml in favor of deprecated version (#43 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/43>)
  Co-authored-by: aditya <mailto:aditya@nimble.ai>
* Use mock_components instead of fake_components (#37 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/37>)
  This has been renamed in ros2_control hardware_interface.
* Prepare for branching out galactic (#39 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/39>)
  * Add Humble to README and workflows
  * Use galactic branch for galactic stuff
* Contributors: Abishalini Sivaraman, Aditya Agarwal, Felix Exner, Mads Holm Peters
```
