### PR TITLE
tiago_robot: 4.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5988,6 +5988,26 @@ repositories:
       url: https://github.com/DLu/tf_transformations.git
       version: main
     status: maintained
+  tiago_robot:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/tiago_robot.git
+      version: humble-devel
+    release:
+      packages:
+      - tiago_bringup
+      - tiago_controller_configuration
+      - tiago_description
+      - tiago_robot
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/tiago_robot-release.git
+      version: 4.0.0-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/tiago_robot.git
+      version: humble-devel
+    status: developed
   tinyxml2_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_robot` to `4.0.0-1`:

- upstream repository: https://github.com/pal-robotics/tiago_robot
- release repository: https://github.com/pal-gbp/tiago_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## tiago_bringup

```
* Merge branch 'refactor_simulation_launchers' into 'humble-devel'
  Remove launching manipulation in tiago_bringup
  See merge request robots/tiago_robot!177
* rm launching manipulation
* Merge branch 'rm_launcher' into 'humble-devel'
  Remove tiago.launch.py and dependencies
  See merge request robots/tiago_robot!176
* rm tiago.launch.py and dependencies
* Merge branch 'cleanup' into 'humble-devel'
  Cleanup package.xml files and rm duplicated launcher
  See merge request robots/tiago_robot!174
* update package.xml deps
* Merge branch 'launch_move_group' into 'humble-devel'
  Launch move group
  See merge request robots/tiago_robot!172
* launch moveit2
* Merge branch 'update_copyright' into 'humble-devel'
  update copyright and license
  See merge request robots/tiago_robot!167
* update copyright and license
* Merge branch 'cleanup' into 'humble-devel'
  Cleanup
  See merge request robots/tiago_robot!165
* rm ros1 launchers
* Merge branch 'refactor_ld' into 'humble-devel'
  Refactor ld
  See merge request robots/tiago_robot!164
* refactor LaunchDescription population
* Merge branch 'update_maintainers' into 'humble-devel'
  Update maintainers
  See merge request robots/tiago_robot!163
* update maintainers
* Merge branch 'linters' into 'humble-devel'
  Linters
  See merge request robots/tiago_robot!159
* linters
* Merge branch 'launch_refactor' into 'humble-devel'
  launch files refactor
  See merge request robots/tiago_robot!158
* temporal fix deadman_buttons error when empty
* Merge branch 'tiago_launcher' into 'galactic-devel'
  Tiago launcher
  See merge request robots/tiago_robot!150
* tiago launcher
* Updating format of all motions
* Renegerating approach_planner config files
* Renegerating motions config files
* Removed disable_motion_planning
  Already set in approach plannaer config
* Not starting play_motion automatically since now requires moveit
* Using tiago hw suffix to load the proper config files
* Get robot_description using tiago_launch_utils
* Load robot_description_semantic into play_motion
* Rename some tiago hw options, add camera_model and add tests
* Added play_motion to tiago_bringup
* UNDO: Disabling motion planning for now
* Removed rgdb and use launch_pal arg_utils and tiago lauch utils
* play_motion launch.py
* Regenerate motions (incomplete) and approach_planner config for ROS2
* Added new parameters required for joint trajectory controllers
  Also, enabled default controllers
* Added some ToDo's
* Added joy_teleop to the tiago_bringup
  Also updated joy_teleop.yaml.em and regenerated config files
* Added twist_mux to the tiago bringup
  mobile_base_controller now uses the twist unstamped topic instead
* First version of the tiago_bringup.launch.py
* tiago_bringup is now a ROS2 package
* Ignoring tiago_bringup and tiago_controller_configuration for now
* Contributors: Jordan Palacios, Noel Jimenez, Noel Jimenez Garcia, Victor Lopez
```

## tiago_controller_configuration

```
* Merge branch 'cleanup' into 'humble-devel'
  Cleanup package.xml files and rm duplicated launcher
  See merge request robots/tiago_robot!174
* rm duplicated launcher
* update package.xml deps
* Merge branch 'fix_substitution' into 'humble-devel'
  fix end effector substitution
  See merge request robots/tiago_robot!169
* fix end effector substitution
* Merge branch 'default_robot_name' into 'humble-devel'
  Add missing default robot name
  See merge request robots/tiago_robot!168
* add missing default robot name
* Merge branch 'update_copyright' into 'humble-devel'
  update copyright and license
  See merge request robots/tiago_robot!167
* update copyright and license
* Merge branch 'cleanup' into 'humble-devel'
  Cleanup
  See merge request robots/tiago_robot!165
* rm ros1 launchers
* Merge branch 'update_maintainers' into 'humble-devel'
  Update maintainers
  See merge request robots/tiago_robot!163
* update maintainers
* Merge branch 'linters' into 'humble-devel'
  Linters
  See merge request robots/tiago_robot!159
* rm print
* linters
* Merge branch 'launch_refactor' into 'humble-devel'
  launch files refactor
  See merge request robots/tiago_robot!158
* launch files refactor
* Merge branch 'tiago_launcher' into 'galactic-devel'
  Tiago launcher
  See merge request robots/tiago_robot!150
* add todo
* Merge branch 'pal-hey5-ros2' into 'foxy-devel'
  pal-hey5 launch files and config
  See merge request robots/tiago_robot!130
* use tiago_launch_utils
* add pal-gripper launch
* update default controllers launch file
* pal-hey5 launch files and config
* Add basic tests to tiago_controller_configuration
* Add extra joints
* Add use_sim_time to controllers as a workaround for https://github.com/ros-controls/ros2_control/issues/325
* Added new parameters required for joint trajectory controllers
  Also, enabled default controllers
* Lower controller manager to 100hz
* Using joint_state_broadcaster instead of controller
* Increased controller manager update rate to match gazebo's
* Added twist_mux to the tiago bringup
  mobile_base_controller now uses the twist unstamped topic instead
* Use correct namespacing for parameters
* Using controller_manager launch_utils
* Support for pal-gripper end effector
* Now uses launch_pal utils
* Added wrist to arm_controller
* Added arm_controller, no wrists
* Added head_controller
* Added torso_controller
* Added default_controllers with mobile_base and joint_state controllers
* Added gazebo_controller_manager_cfg.yaml
* tiago_controller_configuration readded and migrated to ros2
* Ignoring tiago_bringup and tiago_controller_configuration for now
* Contributors: Jordan Palacios, Noel Jimenez, Noel Jimenez Garcia, Victor Lopez, cescfolch, victor
```

## tiago_description

```
* Merge branch 'mv_calibration_files' into 'humble-devel'
  Move tiago_description_calibration xacro files to tiago_description
  See merge request robots/tiago_robot!178
* move tiago_description_calibration xacro files to tiago_description
* Merge branch 'cleanup' into 'humble-devel'
  Cleanup package.xml files and rm duplicated launcher
  See merge request robots/tiago_robot!174
* update package.xml deps
* Merge branch 'linters' into 'humble-devel'
  linter fix
  See merge request robots/tiago_robot!173
* linter fix
* Merge branch 'refactor_hw_suffix_method' into 'humble-devel'
  refactor get_tiago_hw_suffix to avoid using launch substitutions
  See merge request robots/tiago_robot!171
* refactor get_tiago_hw_suffix to avoid using launch substitutions
* Merge branch 'adjust_friction_dumping' into 'humble-devel'
  Adjust arm friction and dumping
  See merge request robots/tiago_robot!170
* adjust arm friction and dumping
* Merge branch 'update_copyright' into 'humble-devel'
  update copyright and license
  See merge request robots/tiago_robot!167
* update copyright and license
* Merge branch 'fix_warns' into 'humble-devel'
  fix remmaping warns
  See merge request robots/tiago_robot!166
* fix remmaping warns
* Merge branch 'cleanup' into 'humble-devel'
  Cleanup
  See merge request robots/tiago_robot!165
* rm ros1 launchers
* Merge branch 'refactor_ld' into 'humble-devel'
  Refactor ld
  See merge request robots/tiago_robot!164
* refactor LaunchDescription population
* Merge branch 'update_maintainers' into 'humble-devel'
  Update maintainers
  See merge request robots/tiago_robot!163
* update maintainers
* Merge branch 'fix_tests' into 'humble-devel'
  Comment end-effectors not migrated yet for urdf tests success
  See merge request robots/tiago_robot!161
* comment end-effectors not migrated yet to avoid tests errors
* Merge branch 'robot_name' into 'humble-devel'
  Robot name
  See merge request robots/tiago_robot!160
* change default robot_name value
* Merge branch 'linters' into 'humble-devel'
  Linters
  See merge request robots/tiago_robot!159
* linters
* Merge branch 'launch_refactor' into 'humble-devel'
  launch files refactor
  See merge request robots/tiago_robot!158
* update arm friction and damping
* launch files refactor
* Merge branch 'humble_fixes' into 'humble-devel'
  add missing materials
  See merge request robots/tiago_robot!157
* add missing materials
* Merge branch 'tiago_launcher' into 'galactic-devel'
  Tiago launcher
  See merge request robots/tiago_robot!150
* add use_sim arg
* Merge branch 'add_role_to_ros2_control' into 'foxy-devel'
  Change <type> to <plugin> and add role
  See merge request robots/tiago_robot!136
* Add role param to plugin urdf
* Merge branch 'pal-hey5-ros2' into 'foxy-devel'
  pal-hey5 launch files and config
  See merge request robots/tiago_robot!130
* pal-hey5 launch files and config
* Rename some tiago hw options, add camera_model and add tests
* Add description
* Add missing dependency
* Make robot_description easy to reuse
* Move tiago_launch_utils from pmb2_description
* Remove rgbd_sensors from tiago, as is only for courier
* Rename xtion camera to head_front_camera
* Migrate camera to ROS2
* Fixes to name and topic remaps for p3d plugin
* Use p3d gazebo plugin instead of ros_world_odometry
* Add IMU and FT ROS2 Control sensors
* Add IMU gazebo plugin
* Support for pal-gripper end effector
* Added support for arm and ft_sensor args
* Launch file for showing the description in rviz2
* Formatting
* Added wrist to arm_controller
* Added arm_controller, no wrists
* Added head_controller
* All joints now form part of a single ros2_control system
* ros2_control gazebo system for torso
* Using gazebo_ros2_control plugin
* Remove comments to workaround https://github.com/ros2/launch_ros/issues/214
* First version of the robot_state_publisher.launch.py
* Migrated package.xml and CMakeLists.txt to ros2 format
* Contributors: Jordan Palacios, Noel Jimenez, Noel Jimenez Garcia, Victor Lopez, cescfolch, victor
```

## tiago_robot

```
* Merge branch 'update_maintainers' into 'humble-devel'
  Update maintainers
  See merge request robots/tiago_robot!163
* update maintainers
* Migrated package.xml and CMakeLists.txt to ros2 format
* Contributors: Jordan Palacios, Noel Jimenez
```
