### PR TITLE
tiago_navigation: 4.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6012,6 +6012,24 @@ repositories:
       url: https://github.com/DLu/tf_transformations.git
       version: main
     status: maintained
+  tiago_navigation:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/tiago_navigation.git
+      version: humble-devel
+    release:
+      packages:
+      - tiago_2dnav
+      - tiago_navigation
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/tiago_navigation-release.git
+      version: 4.0.0-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/tiago_navigation.git
+      version: humble-devel
+    status: developed
   tiago_robot:
     doc:
       type: git
@@ -6030,24 +6048,6 @@ repositories:
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_robot.git
-      version: humble-devel
-    status: developed
-  tiago_navigation:
-    doc:
-      type: git
-      url: https://github.com/pal-robotics/tiago_navigation.git
-      version: humble-devel
-    release:
-      packages:
-      - tiago_2dnav
-      - tiago_navigation
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/tiago_navigation-release.git
-      version: 4.0.0-1
-    source:
-      type: git
-      url: https://github.com/pal-robotics/tiago_navigation.git
       version: humble-devel
     status: developed
   tinyxml2_vendor:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6032,6 +6032,24 @@ repositories:
       url: https://github.com/pal-robotics/tiago_robot.git
       version: humble-devel
     status: developed
+  tiago_navigation:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/tiago_navigation.git
+      version: humble-devel
+    release:
+      packages:
+      - tiago_2dnav
+      - tiago_navigation
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/tiago_navigation-release.git
+      version: 4.0.0-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/tiago_navigation.git
+      version: humble-devel
+    status: developed
   tinyxml2_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_navigation` to `4.0.0-1`:

- upstream repository: https://github.com/pal-robotics/tiago_navigation.git
- release repository: https://github.com/pal-gbp/tiago_navigation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## tiago_2dnav

```
* Merge branch 'update_copyright' into 'humble-devel'
  Update copyright
  See merge request robots/tiago_navigation!65
* update package format
* update copyright
* Merge branch 'update_maintainers' into 'humble-devel'
  update maintainers
  See merge request robots/tiago_navigation!64
* update maintainers
* Merge branch 'linters' into 'humble-devel'
  linters
  See merge request robots/tiago_navigation!63
* linters
* First version of foxy-devel tiago_2dnav
* Contributors: Jordan Palacios, Noel Jimenez, Victor Lopez
```

## tiago_navigation

```
* Merge branch 'update_copyright' into 'humble-devel'
  Update copyright
  See merge request robots/tiago_navigation!65
* update package format
* Merge branch 'update_maintainers' into 'humble-devel'
  update maintainers
  See merge request robots/tiago_navigation!64
* update maintainers
* First version of foxy-devel tiago_2dnav
* Contributors: Jordan Palacios, Noel Jimenez, Victor Lopez
```
