### PR TITLE
pmb2_simulation: 4.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3340,13 +3340,12 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - pmb2_2dnav_gazebo
       - pmb2_gazebo
       - pmb2_simulation
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/pmb2_simulation-gbp.git
-      version: 3.0.3-1
+      url: https://github.com/pal-gbp/pmb2_simulation-release.git
+      version: 4.0.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_simulation` to `4.0.0-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_simulation.git
- release repository: https://github.com/pal-gbp/pmb2_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.3-1`

## pmb2_gazebo

```
* Merge branch 'refactor_simulation_launchers' into 'humble-devel'
  Refactor simulation launchers
  See merge request robots/pmb2_simulation!50
* move navigation to simulation launcher
* Contributors: Jordan Palacios, Noel Jimenez
```

## pmb2_simulation

```
* Merge branch 'refactor_simulation_launchers' into 'humble-devel'
  Refactor simulation launchers
  See merge request robots/pmb2_simulation!50
* move navigation to simulation launcher
* Contributors: Jordan Palacios, Noel Jimenez
```
