### PR TITLE
keyboard_handler: 0.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1851,7 +1851,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/keyboard_handler-release.git
-      version: 0.0.4-2
+      version: 0.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `keyboard_handler` to `0.0.5-1`:

- upstream repository: https://github.com/ros-tooling/keyboard_handler.git
- release repository: https://github.com/ros2-gbp/keyboard_handler-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.4-2`

## keyboard_handler

```
* Force exit from main thread on signal handling in keyboard_handler (#23 <https://github.com/ros-tooling/keyboard_handler/issues/23>) (#25 <https://github.com/ros-tooling/keyboard_handler/issues/25>)
* Contributors: mergify[bot]
```
