### PR TITLE
rcutils: 5.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3830,7 +3830,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 5.1.1-2
+      version: 5.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `5.1.2-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `5.1.1-2`

## rcutils

```
* Change syntax __VAR_ARGS__ to __VA_ARGS__ (#376 <https://github.com/ros2/rcutils/issues/376>) (#377 <https://github.com/ros2/rcutils/issues/377>)
* Clarify duration arg description in logging macros (#359 <https://github.com/ros2/rcutils/issues/359>) (#360 <https://github.com/ros2/rcutils/issues/360>)
* Contributors: mergify[bot]
```
