### PR TITLE
robot_upstart: 1.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4361,6 +4361,21 @@ repositories:
       url: https://github.com/ros/robot_state_publisher.git
       version: humble
     status: maintained
+  robot_upstart:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/robot_upstart.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/robot_upstart-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/robot_upstart.git
+      version: foxy-devel
+    status: maintained
   robotraconteur:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_upstart` to `1.0.2-1`:

- upstream repository: https://github.com/clearpathrobotics/robot_upstart.git
- release repository: https://github.com/clearpath-gbp/robot_upstart-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## robot_upstart

```
* Removed whitespace
* Use a single rmw_config arg for both fastrtps and cyclonedds
* Added ROS_DOMAIN_ID arg
* Removed master_uri, added rmw, cyclonedds_config, and fastrtps_config
* Contributors: Roni Kreinin
```
