### PR TITLE
openvino: 2022.2.0-6 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3466,7 +3466,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ngaloppo/ros_openvino-release.git
-      version: 2022.2.0-5
+      version: 2022.2.0-6
     source:
       type: git
       url: https://github.com/openvinotoolkit/openvino.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openvino` to `2022.2.0-6`:

- upstream repository: https://github.com/openvinotoolkit/openvino.git
- release repository: https://github.com/ngaloppo/ros_openvino-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2022.2.0-5`
