### PR TITLE
septentrio_gnss_driver: 1.2.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6319,7 +6319,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/septentrio-users/septentrio_gnss_driver_ros2-release.git
-      version: 1.2.2-2
+      version: 1.2.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `septentrio_gnss_driver` to `1.2.3-1`:

- upstream repository: https://github.com/septentrio-gnss/septentrio_gnss_driver
- release repository: https://github.com/septentrio-users/septentrio_gnss_driver_ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `1.2.2-2`

## septentrio_gnss_driver

```
* New Features
  
  Twist output option
  
  Example config files for GNSS and INS
  
  Get leap seconds from receiver
  
  Firmware check
  
  VSM from odometry or twist ROS messages
  
  Add receiver type in case INS is used in GNSS mode
  
  Add publishing of base vector topics
* Improvements
  
  Rework RTK corrections parameters and improve flexibility
* Fixes
  
  /tf not being published without /localization
  
  Twist covariance matrix of localization
  
  Support 5 ms period for IMU explicitly
```
