### PR TITLE
rosbag2: 0.15.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4747,7 +4747,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.15.2-1
+      version: 0.15.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.15.3-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.15.2-1`

## ros2bag

```
* Fix for ros2 bag play exit with non-zero code on SIGINT (#1126 <https://github.com/ros2/rosbag2/issues/1126>) (#1147 <https://github.com/ros2/rosbag2/issues/1147>)
* Readers/info can accept a single bag storage file, and detect its storage id automatically (#1072 <https://github.com/ros2/rosbag2/issues/1072>) (#1077 <https://github.com/ros2/rosbag2/issues/1077>)
* Revert "[humble] Backport. Added support for filtering topics via regular expressions (#1034 <https://github.com/ros2/rosbag2/issues/1034>)- (#1039 <https://github.com/ros2/rosbag2/issues/1039>)" (#1069 <https://github.com/ros2/rosbag2/issues/1069>)
* [humble] Backport. Added support for filtering topics via regular expressions (#1034 <https://github.com/ros2/rosbag2/issues/1034>)- (#1039 <https://github.com/ros2/rosbag2/issues/1039>)
* Backport. Add use_sim_time option to record verb (#1017 <https://github.com/ros2/rosbag2/issues/1017>)
* Make unpublished topics unrecorded by default (#968 <https://github.com/ros2/rosbag2/issues/968>) (#1008 <https://github.com/ros2/rosbag2/issues/1008>)
* Contributors: Esteve Fernandez, Keisuke Shima, Sean Kelly, mergify[bot]
```

## rosbag2

- No changes

## rosbag2_compression

```
* Backport. Add use_sim_time option to record verb (#1017 <https://github.com/ros2/rosbag2/issues/1017>)
* Contributors: Keisuke Shima
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Readers/info can accept a single bag storage file, and detect its storage id automatically (#1072 <https://github.com/ros2/rosbag2/issues/1072>) (#1077 <https://github.com/ros2/rosbag2/issues/1077>)
* Notification of significant events during bag recording and playback (#908 <https://github.com/ros2/rosbag2/issues/908>) (#1037 <https://github.com/ros2/rosbag2/issues/1037>)
* Backport. Add use_sim_time option to record verb (#1017 <https://github.com/ros2/rosbag2/issues/1017>)
* Contributors: Geoffrey Biggs, Keisuke Shima, mergify[bot]
```

## rosbag2_interfaces

```
* Notification of significant events during bag recording and playback (#908 <https://github.com/ros2/rosbag2/issues/908>) (#1037 <https://github.com/ros2/rosbag2/issues/1037>)
* Contributors: Geoffrey Biggs
```

## rosbag2_performance_benchmarking

- No changes

## rosbag2_py

```
* Revert "[humble] Backport. Added support for filtering topics via regular expressions (#1034 <https://github.com/ros2/rosbag2/issues/1034>)- (#1039 <https://github.com/ros2/rosbag2/issues/1039>)" (#1069 <https://github.com/ros2/rosbag2/issues/1069>)
* [humble] Backport. Added support for filtering topics via regular expressions (#1034 <https://github.com/ros2/rosbag2/issues/1034>)- (#1039 <https://github.com/ros2/rosbag2/issues/1039>)
* Backport. Add use_sim_time option to record verb (#1017 <https://github.com/ros2/rosbag2/issues/1017>)
* Make unpublished topics unrecorded by default (#968 <https://github.com/ros2/rosbag2/issues/968>) (#1008 <https://github.com/ros2/rosbag2/issues/1008>)
* Contributors: Esteve Fernandez, Keisuke Shima, Sean Kelly
```

## rosbag2_storage

```
* Readers/info can accept a single bag storage file, and detect its storage id automatically (#1072 <https://github.com/ros2/rosbag2/issues/1072>) (#1077 <https://github.com/ros2/rosbag2/issues/1077>)
* Revert "[humble] Backport. Added support for filtering topics via regular expressions (#1034 <https://github.com/ros2/rosbag2/issues/1034>)- (#1039 <https://github.com/ros2/rosbag2/issues/1039>)" (#1069 <https://github.com/ros2/rosbag2/issues/1069>)
* [humble] Backport. Added support for filtering topics via regular expressions (#1034 <https://github.com/ros2/rosbag2/issues/1034>)- (#1039 <https://github.com/ros2/rosbag2/issues/1039>)
* Contributors: Esteve Fernandez, mergify[bot]
```

## rosbag2_storage_default_plugins

```
* Add support for old db3 schema used on distros prior to Foxy (#1090 <https://github.com/ros2/rosbag2/issues/1090>) (#1094 <https://github.com/ros2/rosbag2/issues/1094>)
* Revert "[humble] Backport. Added support for filtering topics via regular expressions (#1034 <https://github.com/ros2/rosbag2/issues/1034>)- (#1039 <https://github.com/ros2/rosbag2/issues/1039>)" (#1069 <https://github.com/ros2/rosbag2/issues/1069>)
* [humble] Backport. Added support for filtering topics via regular expressions (#1034 <https://github.com/ros2/rosbag2/issues/1034>)- (#1039 <https://github.com/ros2/rosbag2/issues/1039>)
* Contributors: Esteve Fernandez, mergify[bot]
```

## rosbag2_test_common

```
* Fix for ros2 bag play exit with non-zero code on SIGINT (#1126 <https://github.com/ros2/rosbag2/issues/1126>) (#1147 <https://github.com/ros2/rosbag2/issues/1147>)
* Contributors: mergify[bot]
```

## rosbag2_tests

```
* Fix for ros2 bag play exit with non-zero code on SIGINT (#1126 <https://github.com/ros2/rosbag2/issues/1126>) (#1147 <https://github.com/ros2/rosbag2/issues/1147>)
* Get rid from attempt to open DB file in wait_for_db() test fixture (#1141 <https://github.com/ros2/rosbag2/issues/1141>) (#1148 <https://github.com/ros2/rosbag2/issues/1148>)
* Readers/info can accept a single bag storage file, and detect its storage id automatically (#1072 <https://github.com/ros2/rosbag2/issues/1072>) (#1077 <https://github.com/ros2/rosbag2/issues/1077>)
* Contributors: mergify[bot]
```

## rosbag2_transport

```
* Mark test_play_services as xfail for FastRTPS and CycloneDDS (#1091 <https://github.com/ros2/rosbag2/issues/1091>) (#1136 <https://github.com/ros2/rosbag2/issues/1136>)
* Fix hangout in rosbag2 player and recorder when pressing CTRL+C (#1081 <https://github.com/ros2/rosbag2/issues/1081>) (#1085 <https://github.com/ros2/rosbag2/issues/1085>)
* make writer and option variables private instead of protected (#1097 <https://github.com/ros2/rosbag2/issues/1097>)
* Revert "[humble] Backport. Added support for filtering topics via regular expressions (#1034 <https://github.com/ros2/rosbag2/issues/1034>)- (#1039 <https://github.com/ros2/rosbag2/issues/1039>)" (#1069 <https://github.com/ros2/rosbag2/issues/1069>)
* Notification of significant events during bag recording and playback (#908 <https://github.com/ros2/rosbag2/issues/908>) (#1037 <https://github.com/ros2/rosbag2/issues/1037>)
* Backport. Add use_sim_time option to record verb (#1017 <https://github.com/ros2/rosbag2/issues/1017>)
* Fix for rosbag2::Player freeze when ctrl+c in pause mode (#1002 <https://github.com/ros2/rosbag2/issues/1002>) (#1016 <https://github.com/ros2/rosbag2/issues/1016>)
* Make unpublished topics unrecorded by default (#968 <https://github.com/ros2/rosbag2/issues/968>) (#1008 <https://github.com/ros2/rosbag2/issues/1008>)
* Contributors: Bernardo Taveira, Esteve Fernandez, Geoffrey Biggs, Keisuke Shima, Michael Orlov, Sean Kelly, mergify[bot]
```

## shared_queues_vendor

```
* man_farmer
  
  Fixes policy CMP0135 warning for CMake >= 3.24 (#1084) (#1096)
* Contributors: mergify[bot]
```

## sqlite3_vendor

```
* man_farmer
  
  Fixes policy CMP0135 warning for CMake >= 3.24 (#1084) (#1096)
* Contributors: mergify[bot]
```

## zstd_vendor

- No changes
