### PR TITLE
microstrain_inertial: 2.7.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -2258,7 +2258,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/microstrain_inertial-release.git
-      version: 2.7.0-1
+      version: 2.7.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `2.7.1-1`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/ros2-gbp/microstrain_inertial-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.7.0-1`

## microstrain_inertial_driver

```
* Updates submodule with CV7 mag aiding bugfix (#188 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/188>)
* Enable usage of substitution arguments in override params YAML file. (#187 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/187>)
* ROS Do not error when the device does not support antenna offset or S2V commands (#182 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/182>)
  * Do not error when the device does not support antenna offset or S2V commands
* Contributors: Joey Yang, Rob
```

## microstrain_inertial_examples

- No changes

## microstrain_inertial_msgs

- No changes

## microstrain_inertial_rqt

- No changes
