### PR TITLE
smacc: 0.9.5-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10276,7 +10276,7 @@ repositories:
     source:
       type: git
       url: https://github.com/robosoft-ai/SMACC.git
-      version: 0.9.5-2
+      version: 0.9.5
     status: developed
   snmp_ros:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10267,50 +10267,8 @@ repositories:
   smacc:
     release:
       packages:
-      - backward_global_planner
-      - backward_local_planner
-      - battery_monitor_client
-      - eg_conditional_generator
-      - eg_random_generator
-      - forward_global_planner
-      - forward_local_planner
-      - keyboard_client
-      - move_base_z_client_plugin
-      - move_eye_client
-      - move_group_interface_client
-      - multirole_sensor_client
-      - pure_spinning_local_planner
-      - ros_publisher_client
-      - ros_timer_client
-      - sm_atomic
-      - sm_atomic_cb
-      - sm_atomic_services
-      - sm_calendar_week
-      - sm_coretest_transition_speed_1
-      - sm_coretest_x_y_1
-      - sm_coretest_x_y_2
-      - sm_coretest_x_y_3
-      - sm_dance_bot
-      - sm_dance_bot_2
-      - sm_dance_bot_strikes_back
-      - sm_ferrari
-      - sm_packml
-      - sm_respira_1
-      - sm_ridgeback_barrel_search_1
-      - sm_ridgeback_barrel_search_2
-      - sm_starcraft_ai
-      - sm_subscriber
-      - sm_three_some
-      - sm_update_loop
-      - sm_viewer_sim
       - smacc
       - smacc_msgs
-      - smacc_runtime_test
-      - smacc_rviz_plugin
-      - sr_all_events_go
-      - sr_conditional
-      - sr_event_countdown
-      - undo_path_global_planner
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/robosoft-ai/SMACC-release.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10264,6 +10264,62 @@ repositories:
       url: https://github.com/oKermorgant/slider_publisher.git
       version: ros1
     status: maintained
+  smacc:
+    release:
+      packages:
+      - backward_global_planner
+      - backward_local_planner
+      - battery_monitor_client
+      - eg_conditional_generator
+      - eg_random_generator
+      - forward_global_planner
+      - forward_local_planner
+      - keyboard_client
+      - move_base_z_client_plugin
+      - move_eye_client
+      - move_group_interface_client
+      - multirole_sensor_client
+      - pure_spinning_local_planner
+      - ros_publisher_client
+      - ros_timer_client
+      - sm_atomic
+      - sm_atomic_cb
+      - sm_atomic_services
+      - sm_calendar_week
+      - sm_coretest_transition_speed_1
+      - sm_coretest_x_y_1
+      - sm_coretest_x_y_2
+      - sm_coretest_x_y_3
+      - sm_dance_bot
+      - sm_dance_bot_2
+      - sm_dance_bot_strikes_back
+      - sm_ferrari
+      - sm_packml
+      - sm_respira_1
+      - sm_ridgeback_barrel_search_1
+      - sm_ridgeback_barrel_search_2
+      - sm_starcraft_ai
+      - sm_subscriber
+      - sm_three_some
+      - sm_update_loop
+      - sm_viewer_sim
+      - smacc
+      - smacc_msgs
+      - smacc_runtime_test
+      - smacc_rviz_plugin
+      - sr_all_events_go
+      - sr_conditional
+      - sr_event_countdown
+      - undo_path_global_planner
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/robosoft-ai/SMACC-release.git
+      version: 0.9.5-2
+    source:
+      type: git
+      url: https://github.com/robosoft-ai/SMACC.git
+      version: 0.9.5-2
+    status: developed
   snmp_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `smacc` to `0.9.5-2`:

- upstream repository: https://github.com/robosoft-ai/SMACC
- release repository: https://github.com/robosoft-ai/SMACC-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
