### PR TITLE
moveit: 2.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2377,7 +2377,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/moveit/moveit2-release.git
-      version: 2.5.3-1
+      version: 2.6.0-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.6.0-1`:

- upstream repository: https://github.com/ros-planning/moveit2.git
- release repository: https://github.com/moveit/moveit2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.5.3-1`

## chomp_motion_planner

```
* Replace C array with std::array in std::vector template argument to improve compatibility with clang compiler and libc++ (#1612 <https://github.com/ros-planning/moveit2/issues/1612>)
  Co-authored-by: Tyler Weaver <mailto:tyler@picknik.ai>
* updated comment formatting for correct doxygen generation (#1582 <https://github.com/ros-planning/moveit2/issues/1582>)
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Remove __has_include statements (#1481 <https://github.com/ros-planning/moveit2/issues/1481>)
* Contributors: Michael Wrock, Sebastian Jahr, Vatan Aksoy Tezer, light-tech
```

## moveit

```
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Contributors: Sebastian Jahr
```

## moveit_chomp_optimizer_adapter

```
* Short-circuit planning adapters (#1694 <https://github.com/ros-planning/moveit2/issues/1694>)
  * Revert "Planning request adapters: short-circuit if failure, return code rather than bool (#1605 <https://github.com/ros-planning/moveit2/issues/1605>)"
  This reverts commit 66a64b4a72b6ddef1af2329f20ed8162554d5bcb.
  * Add debug message in call stack of planning_request_adapters
  * Short-circuit planning request adapters
  * Replace if-elseif cascade with switch
  * Cleanup translation of MoveItErrorCode to string
  - Move default code to moveit_core/utils
  - Override defaults in existing getActionResultString()
  - Provide translations for all error codes defined in moveit_msgs
  * Fix comment according to review
  * Add braces
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  * Add braces
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
* Planning request adapters: short-circuit if failure, return code rather than bool (#1605 <https://github.com/ros-planning/moveit2/issues/1605>)
  * Return code rather than bool
  * Remove all debug prints
  * Small fixup
  * Minor cleanup of comment and error handling
  * void return from PlannerFn
  * Control reaches end of non-void function
  * Use a MoveItErrorCode cast
  * More efficient callAdapter()
  * More MoveItErrorCode
  * CI fixup attempt
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Contributors: AndyZe, Robert Haschke, Sebastian Jahr
```

## moveit_common

```
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Contributors: Sebastian Jahr
```

## moveit_configs_utils

```
* Do not add Pilz parameters to MoveIt Configs Utils if Pilz is not used (#1583 <https://github.com/ros-planning/moveit2/issues/1583>)
* Use MoveItConfigsBuilder in Pilz test launch file (#1571 <https://github.com/ros-planning/moveit2/issues/1571>)
* Only require Cartesian limits if Pilz is used (#1519 <https://github.com/ros-planning/moveit2/issues/1519>)
* Typo fix (#1518 <https://github.com/ros-planning/moveit2/issues/1518>)
* Contributors: Abishalini Sivaraman, Stephanie Eng
```

## moveit_core

```
* Short-circuit planning adapters (#1694 <https://github.com/ros-planning/moveit2/issues/1694>)
  * Revert "Planning request adapters: short-circuit if failure, return code rather than bool (#1605 <https://github.com/ros-planning/moveit2/issues/1605>)"
  This reverts commit 66a64b4a72b6ddef1af2329f20ed8162554d5bcb.
  * Add debug message in call stack of planning_request_adapters
  * Short-circuit planning request adapters
  * Replace if-elseif cascade with switch
  * Cleanup translation of MoveItErrorCode to string
  - Move default code to moveit_core/utils
  - Override defaults in existing getActionResultString()
  - Provide translations for all error codes defined in moveit_msgs
  * Fix comment according to review
  * Add braces
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  * Add braces
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
* Parallel planning pipelines (#1420 <https://github.com/ros-planning/moveit2/issues/1420>)
  * Add setTrajectoryConstraints() to PlanningComponent
  * Add planning time to PlanningComponent::PlanSolution
  * Replace PlanSolution with MotionPlanResponse
  * Address review
  * Add MultiPipelinePlanRequestParameters
  Add plan(const MultiPipelinePlanRequestParameters& parameters)
  Add mutex to avoid segfaults
  Add optional stop_criterion_callback and solution_selection_callback
  Remove stop_criterion_callback
  Make default solution_selection_callback = nullptr
  Remove parameter handling copy&paste code in favor of a template
  Add TODO to refactor pushBack() method into insert()
  Fix selection criteria and add RCLCPP_INFO output
  Changes due to rebase and formatting
  Fix race condition and segfault when no solution is found
  Satisfy clang tidy
  Remove mutex and thread safety TODOs
  Add stopping functionality to parallel planning
  Remove unnecessary TODOs
  * Fix unused plan solution with failure
  * Add sanity check for number of parallel planning problems
  * Check stopping criterion when new solution is generated + make thread safe
  * Add terminatePlanningPipeline() to MoveItCpp interface
  * Format!
  * Bug fixes
  * Move getShortestSolution callback into own function
  * No east const
  * Remove PlanSolutions and make planner_id accessible
  * Make solution executable
  * Rename update_last_solution to store_solution
  * Alphabetize includes and include plan_solutions.hpp instead of .h
  * Address review
  * Add missing header
  * Apply suggestions from code review
  Co-authored-by: AndyZe <andyz@utexas.edu>
  Co-authored-by: AndyZe <andyz@utexas.edu>
* Deprecate lookupParam function (#1681 <https://github.com/ros-planning/moveit2/issues/1681>)
* Add new error types (moveit_msgs #146 <https://github.com/ros-planning/moveit2/issues/146>) (#1683 <https://github.com/ros-planning/moveit2/issues/1683>)
  * Add new error types (moveit_msgs #146 <https://github.com/ros-planning/moveit2/issues/146>)
  * Add default case
  * Small change to the default case
  Co-authored-by: Tyler Weaver <mailto:maybe@tylerjw.dev>
  Co-authored-by: Tyler Weaver <mailto:maybe@tylerjw.dev>
* Planning request adapters: short-circuit if failure, return code rather than bool (#1605 <https://github.com/ros-planning/moveit2/issues/1605>)
  * Return code rather than bool
  * Remove all debug prints
  * Small fixup
  * Minor cleanup of comment and error handling
  * void return from PlannerFn
  * Control reaches end of non-void function
  * Use a MoveItErrorCode cast
  * More efficient callAdapter()
  * More MoveItErrorCode
  * CI fixup attempt
* Improve Cartesian interpolation (#1547 <https://github.com/ros-planning/moveit2/issues/1547>)
  * Generalize computeCartesianPath() to consider a link_offset
  which allows performing a circular motion about a non-link origin.
  * Augment reference to argument global_reference_frame
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
* Remove unused clock from RobotTrajectory (#1639 <https://github.com/ros-planning/moveit2/issues/1639>)
* Added brace intialization in moveit_core/collision_detection_fcl & moveit_core/collision_detection_field (#1622 <https://github.com/ros-planning/moveit2/issues/1622>)
* added brace intialization (#1615 <https://github.com/ros-planning/moveit2/issues/1615>)
* Merge PR #1553 <https://github.com/ros-planning/moveit2/issues/1553>: Improve cmake files
* Use standard exported targets: export_${PROJECT_NAME} -> ${PROJECT_NAME}Targets
* moveit_core/collision_detection: fix include order
  moveit_planning_scene's include directories have to be appended
  to the include directories found by ament_target_dependencies().
* Add missing srdfdom dependency
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* size_t bijection index type (#1544 <https://github.com/ros-planning/moveit2/issues/1544>)
* Free functions for calculating properties of trajectories (#1503 <https://github.com/ros-planning/moveit2/issues/1503>)
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Const ptr to jmg arg for cost function (#1537 <https://github.com/ros-planning/moveit2/issues/1537>)
* Add planner configurations to CHOMP and PILZ (#1522 <https://github.com/ros-planning/moveit2/issues/1522>)
* Add error_code_to_string function (#1523 <https://github.com/ros-planning/moveit2/issues/1523>)
* Use pragma once as header include guard (#1525 <https://github.com/ros-planning/moveit2/issues/1525>)
* Unified code comment style (#1053 <https://github.com/ros-planning/moveit2/issues/1053>)
  * Changes the comment style from /**/ to //
  Co-authored-by: JafarAbdi <mailto:cafer.abdi@gmail.com>
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Remove sensor manager (#1172 <https://github.com/ros-planning/moveit2/issues/1172>)
* Fixed fabs() use in quaternion interpolation (#1479 <https://github.com/ros-planning/moveit2/issues/1479>)
  * Interpolate using Eigen::Quaternion::slerp() to (hopefully) save us further headaches and take advantage of Eigen probably having a better implementation than us.
  * Created a test case that fails for the old version, but passes for the new.
  Co-authored-by: AndyZe <zelenak@picknik.ai>
* Fixes for using generate_state_database (#1412 <https://github.com/ros-planning/moveit2/issues/1412>)
* fix path to constraints parameters
* Remove __has_include statements (#1481 <https://github.com/ros-planning/moveit2/issues/1481>)
* Merge https://github.com/ros-planning/moveit/commit/a63580edd05b01d9480c333645036e5b2b222da9
* Remove ConstraintSampler::project() (#3170 <https://github.com/ros-planning/moveit2/issues/3170>)
  * Remove unused ompl_interface::ValidConstrainedSampler
  Last usage was removed in f2f6097ab7e272568d6ab258a53be3c7ca67cf3b.
  * Remove ConstraintSampler::project()
  sample() and project() only differ in whether they perform random sampling
  of the reference joint pose or not. Both of them are sampling.
  This was highly confusing, as from project() one wouldn't expect sampling.
* Add and fix dual arm test (#3119 <https://github.com/ros-planning/moveit2/issues/3119>)
  * Add dual arm test
  * Fix and simplify UnionConstraintSampler: update joint transforms
  Co-authored-by: Cristian Beltran <mailto:cristianbehe@gmail.com>
  Co-authored-by: Robert Haschke <mailto:rhaschke@techfak.uni-bielefeld.de>
* Contributors: Abhijeet Das Gupta, Abishalini Sivaraman, Alaa, AndyZe, Henning Kayser, J. Javan, Michael Marron, Robert Haschke, Sebastian Jahr, Tyler Weaver, Vatan Aksoy Tezer, abishalini, cambel, werner291
```

## moveit_hybrid_planning

```
* Parallel planning pipelines (#1420 <https://github.com/ros-planning/moveit2/issues/1420>)
  * Add setTrajectoryConstraints() to PlanningComponent
  * Add planning time to PlanningComponent::PlanSolution
  * Replace PlanSolution with MotionPlanResponse
  * Address review
  * Add MultiPipelinePlanRequestParameters
  Add plan(const MultiPipelinePlanRequestParameters& parameters)
  Add mutex to avoid segfaults
  Add optional stop_criterion_callback and solution_selection_callback
  Remove stop_criterion_callback
  Make default solution_selection_callback = nullptr
  Remove parameter handling copy&paste code in favor of a template
  Add TODO to refactor pushBack() method into insert()
  Fix selection criteria and add RCLCPP_INFO output
  Changes due to rebase and formatting
  Fix race condition and segfault when no solution is found
  Satisfy clang tidy
  Remove mutex and thread safety TODOs
  Add stopping functionality to parallel planning
  Remove unnecessary TODOs
  * Fix unused plan solution with failure
  * Add sanity check for number of parallel planning problems
  * Check stopping criterion when new solution is generated + make thread safe
  * Add terminatePlanningPipeline() to MoveItCpp interface
  * Format!
  * Bug fixes
  * Move getShortestSolution callback into own function
  * No east const
  * Remove PlanSolutions and make planner_id accessible
  * Make solution executable
  * Rename update_last_solution to store_solution
  * Alphabetize includes and include plan_solutions.hpp instead of .h
  * Address review
  * Add missing header
  * Apply suggestions from code review
  Co-authored-by: AndyZe <andyz@utexas.edu>
  Co-authored-by: AndyZe <andyz@utexas.edu>
* Merge PR #1553 <https://github.com/ros-planning/moveit2/issues/1553>: Improve cmake files
* Cleanup cmake files
  - Replace ament_export_libraries() -> ament_export_targets(HAS_LIBRARY_TARGET)
  - Replace ament_export_include_directories() -> INCLUDES DESTINATION include
  See https://docs.ros.org/en/foxy/How-To-Guides/Ament-CMake-Documentation.html#building-a-library
* Use standard exported targets: export_${PROJECT_NAME} -> ${PROJECT_NAME}Targets
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Contributors: Robert Haschke, Sebastian Jahr
```

## moveit_kinematics

```
* Use generate_parameter_library to load KDL kinematics parameters (#1671 <https://github.com/ros-planning/moveit2/issues/1671>)
* Use generate_parameter_library to load ikfast kinematics parameters (#1675 <https://github.com/ros-planning/moveit2/issues/1675>)
* Use generate_parameter_library to load cached IK kinematics parameters (#1677 <https://github.com/ros-planning/moveit2/issues/1677>)
* Use generate_parameter_library to load srv kinematics parameters (#1674 <https://github.com/ros-planning/moveit2/issues/1674>)
* Use generate_parameter_library to load LMA kinematics parameters (#1673 <https://github.com/ros-planning/moveit2/issues/1673>)
* Merge PR #1553 <https://github.com/ros-planning/moveit2/issues/1553>: Improve cmake files
* Use standard exported targets: export_${PROJECT_NAME} -> ${PROJECT_NAME}Targets
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Use pragma once as header include guard (#1525 <https://github.com/ros-planning/moveit2/issues/1525>)
* Unified code comment style (#1053 <https://github.com/ros-planning/moveit2/issues/1053>)
  * Changes the comment style from /**/ to //
  Co-authored-by: JafarAbdi <mailto:cafer.abdi@gmail.com>
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Remove __has_include statements (#1481 <https://github.com/ros-planning/moveit2/issues/1481>)
* Merge https://github.com/ros-planning/moveit/commit/a63580edd05b01d9480c333645036e5b2b222da9
* Merge PR #3172 <https://github.com/ros-planning/moveit2/issues/3172>: Fix CI
* Fix test_ikfast_plugins.sh
  - Create panda.urdf using catkin build panda_description
  - Improve debug output
* Fix run_quiet()
  - Show output on error
  - Restore both stdout and stderr
* auto_create_ikfast_moveit_plugin.sh: allow xacro input
* Contributors: Abishalini Sivaraman, J. Javan, Michael Marron, Robert Haschke, Sebastian Jahr, Vatan Aksoy Tezer, abishalini
```

## moveit_planners

```
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Contributors: Sebastian Jahr
```

## moveit_planners_chomp

```
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Add planner configurations to CHOMP and PILZ (#1522 <https://github.com/ros-planning/moveit2/issues/1522>)
* Contributors: Sebastian Jahr
```

## moveit_planners_ompl

```
* Fix logic with enforcing constrained planning state space in OMPL (#1589 <https://github.com/ros-planning/moveit2/issues/1589>)
* Convert OMPL status to MoveItErrorCode in the OMPL interface (#1606 <https://github.com/ros-planning/moveit2/issues/1606>)
* Factor of 2 in OMPL orientation constraints, to match kinematic_constraints (#1592 <https://github.com/ros-planning/moveit2/issues/1592>)
* Merge PR #1553 <https://github.com/ros-planning/moveit2/issues/1553>: Improve cmake files
* Use standard exported targets: export_${PROJECT_NAME} -> ${PROJECT_NAME}Targets
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* size_t bijection index type (#1544 <https://github.com/ros-planning/moveit2/issues/1544>)
* Fixes for using generate_state_database (#1412 <https://github.com/ros-planning/moveit2/issues/1412>)
* simplify_solution per planning context (#1437 <https://github.com/ros-planning/moveit2/issues/1437>)
  * Allowing to dynamically change the parameter simplify_solutions
  * Delete this configuration because it overrides the configuration loaded
  The parameters simplify_solutions is passed to the context trough the configuration of each planner but this function overrides it and seems to be contradictory to rest of the implementation. simplify_solutions shouldn't be considered as the rest of the other parameters, like interpolate or hybridize ?
  * Remove simplify_solutions_ from OMPL interface and all its setter/getter
  * Clean-up code without ConfigureContext and unneeded code related to simplify_solution
* correctly initialize rmw_serialized_message_t
* automatically declare parameters from overrides
* Remove __has_include statements (#1481 <https://github.com/ros-planning/moveit2/issues/1481>)
* Merge https://github.com/ros-planning/moveit/commit/a63580edd05b01d9480c333645036e5b2b222da9
* Remove ConstraintSampler::project() (#3170 <https://github.com/ros-planning/moveit2/issues/3170>)
  * Remove unused ompl_interface::ValidConstrainedSampler
  Last usage was removed in f2f6097ab7e272568d6ab258a53be3c7ca67cf3b.
  * Remove ConstraintSampler::project()
  sample() and project() only differ in whether they perform random sampling
  of the reference joint pose or not. Both of them are sampling.
  This was highly confusing, as from project() one wouldn't expect sampling.
* Contributors: Alaa, AndyZe, Antoine Duplex, Henning Kayser, Robert Haschke, Sebastian Jahr, Stephanie Eng, Tyler Weaver, Vatan Aksoy Tezer, abishalini
```

## moveit_plugins

```
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Contributors: Sebastian Jahr
```

## moveit_resources_prbt_ikfast_manipulator_plugin

```
* Add missing depend (#1684 <https://github.com/ros-planning/moveit2/issues/1684>)
* Use generate_parameter_library to load prbt ikfast kinematics parameters (#1680 <https://github.com/ros-planning/moveit2/issues/1680>)
* Merge PR #1553 <https://github.com/ros-planning/moveit2/issues/1553>: Improve cmake files
* Use standard exported targets: export_${PROJECT_NAME} -> ${PROJECT_NAME}Targets
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Use pragma once as header include guard (#1525 <https://github.com/ros-planning/moveit2/issues/1525>)
* Remove __has_include statements (#1481 <https://github.com/ros-planning/moveit2/issues/1481>)
* Contributors: Abishalini Sivaraman, J. Javan, Robert Haschke, Sebastian Jahr, Vatan Aksoy Tezer
```

## moveit_resources_prbt_moveit_config

```
* Use generate_parameter_library to load kinematics parameters (#1568 <https://github.com/ros-planning/moveit2/issues/1568>)
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Contributors: Abishalini Sivaraman, Sebastian Jahr
```

## moveit_resources_prbt_pg70_support

```
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Contributors: Sebastian Jahr
```

## moveit_resources_prbt_support

```
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Contributors: Sebastian Jahr
```

## moveit_ros

```
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Contributors: Sebastian Jahr
```

## moveit_ros_benchmarks

```
* Remove unused benchmark_execution.cpp file (#1535 <https://github.com/ros-planning/moveit2/issues/1535>)
* Merge PR #1553 <https://github.com/ros-planning/moveit2/issues/1553>: Improve cmake files
* Use standard exported targets: export_${PROJECT_NAME} -> ${PROJECT_NAME}Targets
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Free functions for calculating properties of trajectories (#1503 <https://github.com/ros-planning/moveit2/issues/1503>)
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Remove __has_include statements (#1481 <https://github.com/ros-planning/moveit2/issues/1481>)
* Contributors: Robert Haschke, Sebastian Jahr, Tyler Weaver, Vatan Aksoy Tezer
```

## moveit_ros_control_interface

```
* Rename MoveItControllerManager. Add deprecation warning (#1601 <https://github.com/ros-planning/moveit2/issues/1601>)
  * Rename MoveItControllerManager->Ros2ControlManager. Add deprecation warning.
  * Do not rename base class
  * Still allow users to load plugins by the old names
  Co-authored-by: Jafar <mailto:jafar.uruc@gmail.com>
* Merge PR #1553 <https://github.com/ros-planning/moveit2/issues/1553>: Improve cmake files
* Use standard exported targets: export_${PROJECT_NAME} -> ${PROJECT_NAME}Targets
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Support chained controllers (#1482 <https://github.com/ros-planning/moveit2/issues/1482>)
  * fix controller list if chained controllers exist
  * add comments and clean code
  * added additional comments
  * fix formatting
  * fix white space
  * add const reference and chhnage variable name
  * simplify logic to only  work with one layer chain
  * Don't return false when not finding optional parameter
  * Update moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * add debug information
  * print controller names
  * print controllers with not known type
  * load controller dependencies
  * start chained controllers in switch
  * reverse order of activate controllers
  * prevent stoppping controller twice
  * revert all debug changes
  * add ROS error if a controller chains to more than one
  * use loop to index chained connections
  * update ros_control
  * add empty controller allocator for admittance controller
  * fix plugin xml
  * Update moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * Update moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * Update moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * Update moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * fix map indexing
  * add comment
  * Update moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
  Co-authored-by: Tyler Weaver <mailto:squirrel428@protonmail.com>
  * Typos
  Co-authored-by: JafarAbdi <mailto:cafer.abdi@gmail.com>
  Co-authored-by: Jafar <mailto:jafar.uruc@gmail.com>
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  Co-authored-by: Vatan Aksoy Tezer <mailto:vatan@picknik.ai>
  Co-authored-by: Tyler Weaver <mailto:squirrel428@protonmail.com>
  Co-authored-by: AndyZe <mailto:zelenak@picknik.ai>
* Contributors: AndyZe, Paul Gesel, Robert Haschke, Sebastian Jahr
```

## moveit_ros_move_group

```
* Short-circuit planning adapters (#1694 <https://github.com/ros-planning/moveit2/issues/1694>)
  * Revert "Planning request adapters: short-circuit if failure, return code rather than bool (#1605 <https://github.com/ros-planning/moveit2/issues/1605>)"
  This reverts commit 66a64b4a72b6ddef1af2329f20ed8162554d5bcb.
  * Add debug message in call stack of planning_request_adapters
  * Short-circuit planning request adapters
  * Replace if-elseif cascade with switch
  * Cleanup translation of MoveItErrorCode to string
  - Move default code to moveit_core/utils
  - Override defaults in existing getActionResultString()
  - Provide translations for all error codes defined in moveit_msgs
  * Fix comment according to review
  * Add braces
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  * Add braces
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
* avoid implicit conversions (#1593 <https://github.com/ros-planning/moveit2/issues/1593>)
* Remove unused header (#1572 <https://github.com/ros-planning/moveit2/issues/1572>)
* Merge PR #1553 <https://github.com/ros-planning/moveit2/issues/1553>: Improve cmake files
* Use standard exported targets: export_${PROJECT_NAME} -> ${PROJECT_NAME}Targets
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Removed plan_with_sensing (#1142 <https://github.com/ros-planning/moveit2/issues/1142>)
* Remove __has_include statements (#1481 <https://github.com/ros-planning/moveit2/issues/1481>)
* Contributors: Abishalini Sivaraman, Robert Haschke, Sarah Nix, Sebastian Jahr, Stephanie Eng, Vatan Aksoy Tezer
```

## moveit_ros_occupancy_map_monitor

```
* Merge PR #1553 <https://github.com/ros-planning/moveit2/issues/1553>: Improve cmake files
* Use standard exported targets: export_${PROJECT_NAME} -> ${PROJECT_NAME}Targets
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Contributors: Robert Haschke, Sebastian Jahr
```

## moveit_ros_perception

```
* Merge PR #1553 <https://github.com/ros-planning/moveit2/issues/1553>: Improve cmake files
* Use standard exported targets: export_${PROJECT_NAME} -> ${PROJECT_NAME}Targets
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Remove __has_include statements (#1481 <https://github.com/ros-planning/moveit2/issues/1481>)
* Contributors: Robert Haschke, Sebastian Jahr, Vatan Aksoy Tezer
```

## moveit_ros_planning

```
* Short-circuit planning adapters (#1694 <https://github.com/ros-planning/moveit2/issues/1694>)
  * Revert "Planning request adapters: short-circuit if failure, return code rather than bool (#1605 <https://github.com/ros-planning/moveit2/issues/1605>)"
  This reverts commit 66a64b4a72b6ddef1af2329f20ed8162554d5bcb.
  * Add debug message in call stack of planning_request_adapters
  * Short-circuit planning request adapters
  * Replace if-elseif cascade with switch
  * Cleanup translation of MoveItErrorCode to string
  - Move default code to moveit_core/utils
  - Override defaults in existing getActionResultString()
  - Provide translations for all error codes defined in moveit_msgs
  * Fix comment according to review
  * Add braces
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  * Add braces
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
* Fixup for #1420 <https://github.com/ros-planning/moveit2/issues/1420>: Restore constness of generatePlan() (#1699 <https://github.com/ros-planning/moveit2/issues/1699>)
* Parallel planning pipelines (#1420 <https://github.com/ros-planning/moveit2/issues/1420>)
  * Add setTrajectoryConstraints() to PlanningComponent
  * Add planning time to PlanningComponent::PlanSolution
  * Replace PlanSolution with MotionPlanResponse
  * Address review
  * Add MultiPipelinePlanRequestParameters
  Add plan(const MultiPipelinePlanRequestParameters& parameters)
  Add mutex to avoid segfaults
  Add optional stop_criterion_callback and solution_selection_callback
  Remove stop_criterion_callback
  Make default solution_selection_callback = nullptr
  Remove parameter handling copy&paste code in favor of a template
  Add TODO to refactor pushBack() method into insert()
  Fix selection criteria and add RCLCPP_INFO output
  Changes due to rebase and formatting
  Fix race condition and segfault when no solution is found
  Satisfy clang tidy
  Remove mutex and thread safety TODOs
  Add stopping functionality to parallel planning
  Remove unnecessary TODOs
  * Fix unused plan solution with failure
  * Add sanity check for number of parallel planning problems
  * Check stopping criterion when new solution is generated + make thread safe
  * Add terminatePlanningPipeline() to MoveItCpp interface
  * Format!
  * Bug fixes
  * Move getShortestSolution callback into own function
  * No east const
  * Remove PlanSolutions and make planner_id accessible
  * Make solution executable
  * Rename update_last_solution to store_solution
  * Alphabetize includes and include plan_solutions.hpp instead of .h
  * Address review
  * Add missing header
  * Apply suggestions from code review
  Co-authored-by: AndyZe <andyz@utexas.edu>
  Co-authored-by: AndyZe <andyz@utexas.edu>
* Fixed typo in deprecation warning in ControllerManager (#1688 <https://github.com/ros-planning/moveit2/issues/1688>)
  * fixed typo as suggested by  @AndyZe
  * Update naming
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
* Planning request adapters: short-circuit if failure, return code rather than bool (#1605 <https://github.com/ros-planning/moveit2/issues/1605>)
  * Return code rather than bool
  * Remove all debug prints
  * Small fixup
  * Minor cleanup of comment and error handling
  * void return from PlannerFn
  * Control reaches end of non-void function
  * Use a MoveItErrorCode cast
  * More efficient callAdapter()
  * More MoveItErrorCode
  * CI fixup attempt
* Rename MoveItControllerManager. Add deprecation warning (#1601 <https://github.com/ros-planning/moveit2/issues/1601>)
  * Rename MoveItControllerManager->Ros2ControlManager. Add deprecation warning.
  * Do not rename base class
  * Still allow users to load plugins by the old names
  Co-authored-by: Jafar <mailto:jafar.uruc@gmail.com>
* Use generate_parameter_library to load kinematics parameters (#1568 <https://github.com/ros-planning/moveit2/issues/1568>)
* Merge PR #1553 <https://github.com/ros-planning/moveit2/issues/1553>: Improve cmake files
* Use standard exported targets: export_${PROJECT_NAME} -> ${PROJECT_NAME}Targets
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Disable flaky test_servo_singularity + test_rdf_integration (#1530 <https://github.com/ros-planning/moveit2/issues/1530>)
* Remove sensor manager (#1172 <https://github.com/ros-planning/moveit2/issues/1172>)
* Removed plan_with_sensing (#1142 <https://github.com/ros-planning/moveit2/issues/1142>)
* Remove __has_include statements (#1481 <https://github.com/ros-planning/moveit2/issues/1481>)
* Merge https://github.com/ros-planning/moveit/commit/a63580edd05b01d9480c333645036e5b2b222da9
* Default destructor for PlanningComponent (#1470 <https://github.com/ros-planning/moveit2/issues/1470>)
* trajectory execution manager: reactivate tests (#3177 <https://github.com/ros-planning/moveit2/issues/3177>)
* Clean up TrajectoryExecutionManager API: remove unused code (#3178 <https://github.com/ros-planning/moveit2/issues/3178>)
  * Clean up unused code
  * Add a comment to MIGRATION.md
  Co-authored-by: Cristian Beltran <mailto:cristianbehe@gmail.com>
* Merge PR #3172 <https://github.com/ros-planning/moveit2/issues/3172>: Fix CI
* Load robot_description via planning_context.launch
* TrajectoryExecutionManager: Use local LOGNAME instead of member name_ (#3168 <https://github.com/ros-planning/moveit2/issues/3168>)
* Contributors: Abhijeet Das Gupta, Abishalini Sivaraman, AndyZe, Robert Haschke, Sebastian Jahr, Stephanie Eng, Tyler Weaver, Vatan Aksoy Tezer, abishalini, cambel
```

## moveit_ros_planning_interface

```
* Log error when named joint state target does not exist (#1580 <https://github.com/ros-planning/moveit2/issues/1580>)
* Express Humble/Rolling differences in #if (#1620 <https://github.com/ros-planning/moveit2/issues/1620>)
* Fix deprecated declaration usage (#1598 <https://github.com/ros-planning/moveit2/issues/1598>)
  * Fix type
  * Suppress warning
  * Add TODO
* Merge PR #1553 <https://github.com/ros-planning/moveit2/issues/1553>: Improve cmake files
* Remove callback_executor_.is_spinning()
* Use standard exported targets: export_${PROJECT_NAME} -> ${PROJECT_NAME}Targets
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Remove __has_include statements (#1481 <https://github.com/ros-planning/moveit2/issues/1481>)
* Merge https://github.com/ros-planning/moveit/commit/a63580edd05b01d9480c333645036e5b2b222da9
* Fix callback execution in MGI (#1305 <https://github.com/ros-planning/moveit2/issues/1305>)
  The initial implementation with the private node allowed for concurrent spinning of the same node, producing runtime exceptions. This change removes the need for a private node by letting MGI manage its own CallbackGroup and Executor thread.
* Changed 'return false' in plan, move and execute such that MoveItErrorCode is returned (#1266 <https://github.com/ros-planning/moveit2/issues/1266>)
* Add and fix dual arm test (#3119 <https://github.com/ros-planning/moveit2/issues/3119>)
  * Add dual arm test
  * Fix and simplify UnionConstraintSampler: update joint transforms
  Co-authored-by: Cristian Beltran <mailto:cristianbehe@gmail.com>
  Co-authored-by: Robert Haschke <mailto:rhaschke@techfak.uni-bielefeld.de>
* Contributors: Abishalini Sivaraman, Henning Kayser, Robert Haschke, Rufus Wong, Sebastian Jahr, Tyler Weaver, Vatan Aksoy Tezer, abishalini, cambel, tbastiaens-riwo
```

## moveit_ros_robot_interaction

```
* Add moveit_core dependency to robot_interaction (#1617 <https://github.com/ros-planning/moveit2/issues/1617>)
* Merge PR #1553 <https://github.com/ros-planning/moveit2/issues/1553>: Improve cmake files
* Use standard exported targets: export_${PROJECT_NAME} -> ${PROJECT_NAME}Targets
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Remove __has_include statements (#1481 <https://github.com/ros-planning/moveit2/issues/1481>)
* Contributors: Robert Haschke, Sebastian Castro, Sebastian Jahr, Vatan Aksoy Tezer
```

## moveit_ros_visualization

```
* Check valid interactive marker pointer before trying to update pose (#1581 <https://github.com/ros-planning/moveit2/issues/1581>)
* Merge PR #1553 <https://github.com/ros-planning/moveit2/issues/1553>: Improve cmake files
* Use standard exported targets: export_${PROJECT_NAME} -> ${PROJECT_NAME}Targets
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Use pragma once as header include guard (#1525 <https://github.com/ros-planning/moveit2/issues/1525>)
* Remove __has_include statements (#1481 <https://github.com/ros-planning/moveit2/issues/1481>)
* Contributors: J. Javan, Robert Haschke, Sebastian Castro, Sebastian Jahr, Vatan Aksoy Tezer
```

## moveit_ros_warehouse

```
* Restructure moveit warehouse package (#1551 <https://github.com/ros-planning/moveit2/issues/1551>)
  * Restructure warhouse package to match other packages, remove manifest.xml
  * Cleanup CMakeLists.txt file
  * Remove dublicate install command
  * Export ${PROJECT_NAME}Targets
* Merge PR #1553 <https://github.com/ros-planning/moveit2/issues/1553>: Improve cmake files
* Use standard exported targets: export_${PROJECT_NAME} -> ${PROJECT_NAME}Targets
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Remove __has_include statements (#1481 <https://github.com/ros-planning/moveit2/issues/1481>)
* Contributors: Robert Haschke, Sebastian Jahr, Vatan Aksoy Tezer
```

## moveit_runtime

```
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Uncomment moveit_ros_perception dependency (#1463 <https://github.com/ros-planning/moveit2/issues/1463>)
* Contributors: AndyZe, Sebastian Jahr
```

## moveit_servo

```
* Fix dead tutorial link (#1701 <https://github.com/ros-planning/moveit2/issues/1701>)
  When we refactored the tutorials site it looks like we killed some links. Do we not have a CI job to catch dead links?
* [Servo] CI simplification (#1556 <https://github.com/ros-planning/moveit2/issues/1556>)
  This reverts commit 3322f19056d10d5e5c95c0276e383b048a840573.
* [Servo] Remove the option for "stop distance"-based collision checking (#1574 <https://github.com/ros-planning/moveit2/issues/1574>)
* Merge PR #1553 <https://github.com/ros-planning/moveit2/issues/1553>: Improve cmake files
* Use standard exported targets: export_${PROJECT_NAME} -> ${PROJECT_NAME}Targets
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* [Servo] Use a WallRate so the clock is monotonically increasing (#1543 <https://github.com/ros-planning/moveit2/issues/1543>)
  * [Servo] Use a WallRate so the clock is monotonically increasing
  * Re-enable a commented integration test
* Disable flaky test_servo_singularity + test_rdf_integration (#1530 <https://github.com/ros-planning/moveit2/issues/1530>)
* Enforce singularity threshold when moving away from a singularity (#620 <https://github.com/ros-planning/moveit2/issues/620>)
  * Enforce singularity threshold behavior even when moving away from a singularity
  - Prevent uncontrolled behavior when servo starts close to a singularity and then servos away from it
  - Scale velocity at a different rate when approaching/leaving singularity
  - Add status code to distinguish between velocity scaling when moving towards/away from the singularity
  * Work on expanding servo singularity tests
  * Pre-commit
  * removed duplicate input checking
  * added 2 other tests
  * undid changes to singularity test
  * Update moveit_ros/moveit_servo/src/servo_calcs.cpp with Nathan's suggestion
  Co-authored-by: Nathan Brooks <mailto:nbbrooks@gmail.com>
  * readability changes and additional servo parameter check
  * updating to newest design
  * added warning message
  * added missing semicolon
  * made optional parameter nicer
  * Remove outdated warning
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * Removing inaccurate comment
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * making Andy's suggested changes, added some comments and defaults, moved code block next to relevant singularity code
  * removed part of comment that does not apply any more
  * Mention "deprecation" in the warning
  Co-authored-by: Henry Moore <mailto:henrygerardmoore@gmail.com>
  Co-authored-by: Henry Moore <mailto:44307180+henrygerardmoore@users.noreply.github.com>
  Co-authored-by: AndyZe <mailto:zelenak@picknik.ai>
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
* Remove __has_include statements (#1481 <https://github.com/ros-planning/moveit2/issues/1481>)
* Servo: check for and enable a realtime kernel (#1464 <https://github.com/ros-planning/moveit2/issues/1464>)
  * Check for and enable a realtime kernel
  * Set thread priority to 40. Link against controller_mgr.
  * Do it from the right thread
* Contributors: AndyZe, Nathan Brooks, Robert Haschke, Sebastian Jahr, Vatan Aksoy Tezer
```

## moveit_setup_app_plugins

```
* Merge PR #1553 <https://github.com/ros-planning/moveit2/issues/1553>: Improve cmake files
* Cleanup cmake files
  - Replace ament_export_libraries() -> ament_export_targets(HAS_LIBRARY_TARGET)
  - Replace ament_export_include_directories() -> INCLUDES DESTINATION include
  See https://docs.ros.org/en/foxy/How-To-Guides/Ament-CMake-Documentation.html#building-a-library
* Use standard exported targets: export_${PROJECT_NAME} -> ${PROJECT_NAME}Targets
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Contributors: Robert Haschke, Sebastian Jahr
```

## moveit_setup_assistant

```
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Contributors: Sebastian Jahr
```

## moveit_setup_controllers

```
* Merge PR #1553 <https://github.com/ros-planning/moveit2/issues/1553>: Improve cmake files
* Cleanup cmake files
  - Replace ament_export_libraries() -> ament_export_targets(HAS_LIBRARY_TARGET)
  - Replace ament_export_include_directories() -> INCLUDES DESTINATION include
  See https://docs.ros.org/en/foxy/How-To-Guides/Ament-CMake-Documentation.html#building-a-library
* Use standard exported targets: export_${PROJECT_NAME} -> ${PROJECT_NAME}Targets
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* MSA: write the default controller namespace (#1515 <https://github.com/ros-planning/moveit2/issues/1515>)
  * Write the default controller namespace
  * Check for a sane controller type
  * Revert the check for FollowJointTrajectory type
* Contributors: AndyZe, Robert Haschke, Sebastian Jahr
```

## moveit_setup_core_plugins

```
* Merge PR #1553 <https://github.com/ros-planning/moveit2/issues/1553>: Improve cmake files
* Cleanup cmake files
  - Replace ament_export_libraries() -> ament_export_targets(HAS_LIBRARY_TARGET)
  - Replace ament_export_include_directories() -> INCLUDES DESTINATION include
  See https://docs.ros.org/en/foxy/How-To-Guides/Ament-CMake-Documentation.html#building-a-library
* Use standard exported targets: export_${PROJECT_NAME} -> ${PROJECT_NAME}Targets
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Contributors: Robert Haschke, Sebastian Jahr
```

## moveit_setup_framework

```
* Merge PR #1553 <https://github.com/ros-planning/moveit2/issues/1553>: Improve cmake files
* Cleanup cmake files
  - Replace ament_export_libraries() -> ament_export_targets(HAS_LIBRARY_TARGET)
  - Replace ament_export_include_directories() -> INCLUDES DESTINATION include
  See https://docs.ros.org/en/foxy/How-To-Guides/Ament-CMake-Documentation.html#building-a-library
* Use standard exported targets: export_${PROJECT_NAME} -> ${PROJECT_NAME}Targets
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Contributors: Robert Haschke, Sebastian Jahr
```

## moveit_setup_srdf_plugins

```
* Merge PR #1553 <https://github.com/ros-planning/moveit2/issues/1553>: Improve cmake files
* Cleanup cmake files
  - Replace ament_export_libraries() -> ament_export_targets(HAS_LIBRARY_TARGET)
  - Replace ament_export_include_directories() -> INCLUDES DESTINATION include
  See https://docs.ros.org/en/foxy/How-To-Guides/Ament-CMake-Documentation.html#building-a-library
* Use standard exported targets: export_${PROJECT_NAME} -> ${PROJECT_NAME}Targets
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Contributors: Robert Haschke, Sebastian Jahr
```

## moveit_simple_controller_manager

```
* Merge PR #1553 <https://github.com/ros-planning/moveit2/issues/1553>: Improve cmake files
* Use standard exported targets: export_${PROJECT_NAME} -> ${PROJECT_NAME}Targets
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Support chained controllers (#1482 <https://github.com/ros-planning/moveit2/issues/1482>)
  * fix controller list if chained controllers exist
  * add comments and clean code
  * added additional comments
  * fix formatting
  * fix white space
  * add const reference and chhnage variable name
  * simplify logic to only  work with one layer chain
  * Don't return false when not finding optional parameter
  * Update moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * add debug information
  * print controller names
  * print controllers with not known type
  * load controller dependencies
  * start chained controllers in switch
  * reverse order of activate controllers
  * prevent stoppping controller twice
  * revert all debug changes
  * add ROS error if a controller chains to more than one
  * use loop to index chained connections
  * update ros_control
  * add empty controller allocator for admittance controller
  * fix plugin xml
  * Update moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * Update moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * Update moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * Update moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * fix map indexing
  * add comment
  * Update moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
  Co-authored-by: Tyler Weaver <mailto:squirrel428@protonmail.com>
  * Typos
  Co-authored-by: JafarAbdi <mailto:cafer.abdi@gmail.com>
  Co-authored-by: Jafar <mailto:jafar.uruc@gmail.com>
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  Co-authored-by: Vatan Aksoy Tezer <mailto:vatan@picknik.ai>
  Co-authored-by: Tyler Weaver <mailto:squirrel428@protonmail.com>
  Co-authored-by: AndyZe <mailto:zelenak@picknik.ai>
* Contributors: Paul Gesel, Robert Haschke, Sebastian Jahr
```

## pilz_industrial_motion_planner

```
* Use generate_parameter_library to load pilz cartesian limit parameters (#1577 <https://github.com/ros-planning/moveit2/issues/1577>)
* Add joint acceleration validator methods to Pilz limits container (#1638 <https://github.com/ros-planning/moveit2/issues/1638>)
* Use MoveItConfigsBuilder in Pilz test launch file (#1571 <https://github.com/ros-planning/moveit2/issues/1571>)
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Add planner configurations to CHOMP and PILZ (#1522 <https://github.com/ros-planning/moveit2/issues/1522>)
* Use pragma once as header include guard (#1525 <https://github.com/ros-planning/moveit2/issues/1525>)
* Removed plan_with_sensing (#1142 <https://github.com/ros-planning/moveit2/issues/1142>)
* Remove __has_include statements (#1481 <https://github.com/ros-planning/moveit2/issues/1481>)
* Merge https://github.com/ros-planning/moveit/commit/a63580edd05b01d9480c333645036e5b2b222da9
* Add missing header for std::unique_ptr (#3180 <https://github.com/ros-planning/moveit2/issues/3180>)
* Contributors: Abishalini Sivaraman, J. Javan, Jochen Sprickerhof, Sebastian Castro, Sebastian Jahr, Stephanie Eng, Vatan Aksoy Tezer, abishalini
```

## pilz_industrial_motion_planner_testutils

```
* Merge PR #1553 <https://github.com/ros-planning/moveit2/issues/1553>: Improve cmake files
* Use standard exported targets: export_${PROJECT_NAME} -> ${PROJECT_NAME}Targets
* Improve CMake usage (#1550 <https://github.com/ros-planning/moveit2/issues/1550>)
* Remove __has_include statements (#1481 <https://github.com/ros-planning/moveit2/issues/1481>)
* Contributors: Robert Haschke, Sebastian Jahr, Vatan Aksoy Tezer
```
