### PR TITLE
tiago_robot: 4.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6026,7 +6026,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_robot-release.git
-      version: 4.0.0-1
+      version: 4.0.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_robot` to `4.0.1-1`:

- upstream repository: https://github.com/pal-robotics/tiago_robot
- release repository: https://github.com/pal-gbp/tiago_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.0-1`

## tiago_bringup

```
* Merge branch 'update_license' into 'humble-devel'
  Update license
  See merge request robots/tiago_robot!180
* update license
* Contributors: Jordan Palacios, Noel Jimenez
```

## tiago_controller_configuration

```
* Merge branch 'update_license' into 'humble-devel'
  Update license
  See merge request robots/tiago_robot!180
* update license
* Merge branch 'fix_dependency' into 'humble-devel'
  fix buildtool dependency
  See merge request robots/tiago_robot!179
* fix buildtool dependency
* Contributors: Jordan Palacios, Noel Jimenez
```

## tiago_description

- No changes

## tiago_robot

```
* Merge branch 'update_license' into 'humble-devel'
  Update license
  See merge request robots/tiago_robot!180
* update license
* Contributors: Jordan Palacios, Noel Jimenez
```
