### PR TITLE
maliput: 1.0.8-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2529,7 +2529,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput-release.git
-      version: 1.0.7-1
+      version: 1.0.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput` to `1.0.8-1`:

- upstream repository: https://github.com/maliput/maliput.git
- release repository: https://github.com/ros2-gbp/maliput-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.7-1`

## maliput

```
* Brings range validator from maliput_malidrive. (#529 <https://github.com/maliput/maliput/issues/529>)
* Update triage.yml (#526 <https://github.com/maliput/maliput/issues/526>)
* Adds convenient test utility method. (#525 <https://github.com/maliput/maliput/issues/525>)
* Adds a test function for LaneEnds. (#524 <https://github.com/maliput/maliput/issues/524>)
* Adds IsLanePositionResultClose macro. (#522 <https://github.com/maliput/maliput/issues/522>)
* Contributors: Agustin Alba Chicar, Franco Cipollone
```
