### PR TITLE
Add python3-babeltrace rule for RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6028,6 +6028,9 @@ python3-babeltrace:
   fedora: [python3-babeltrace]
   gentoo: [dev-util/babeltrace]
   opensuse: [python3-babeltrace]
+  rhel:
+    '*': [python3-babeltrace]
+    '7': null
   ubuntu: [python3-babeltrace]
 python3-backoff-pip:
   arch:


### PR DESCRIPTION
In RHEL 8, this package is part of `PowerTools`: http://or-mirror.iwebfusion.net/almalinux/8.7/PowerTools/x86_64/os/Packages/python3-babeltrace-1.5.4-4.el8.x86_64.rpm