### PR TITLE
add ubuntu focal to python-yaml deps

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5808,6 +5808,9 @@ python-yaml:
   ubuntu:
     artful: [python-yaml]
     bionic: [python-yaml]
+    focal:
+      pip:
+        packages: [PyYAML]
     lucid: [python-yaml]
     maverick: [python-yaml]
     natty: [python-yaml]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5808,9 +5808,7 @@ python-yaml:
   ubuntu:
     artful: [python-yaml]
     bionic: [python-yaml]
-    focal:
-      pip:
-        packages: [PyYAML]
+    focal: [python-yaml]
     lucid: [python-yaml]
     maverick: [python-yaml]
     natty: [python-yaml]


### PR DESCRIPTION
# Please Add This Change to rosdep to be indexed in the rosdistro.

rosdep > python.yaml

added support for ubuntu focal. 

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
