### PR TITLE
universal_robots: 1.3.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -14414,6 +14414,32 @@ repositories:
       url: https://github.com/ros-geographic-info/unique_identifier.git
       version: master
     status: maintained
+  universal_robots:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/universal_robot.git
+      version: melodic
+    release:
+      packages:
+      - universal_robots
+      - ur10_moveit_config
+      - ur10e_moveit_config
+      - ur16e_moveit_config
+      - ur3_moveit_config
+      - ur3e_moveit_config
+      - ur5_moveit_config
+      - ur5e_moveit_config
+      - ur_description
+      - ur_gazebo
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-industrial-release/universal_robot-release.git
+      version: 1.3.1-1
+    source:
+      type: git
+      url: https://github.com/ros-industrial/universal_robot.git
+      version: melodic-devel
+    status: developed
   uos_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `universal_robots` to `1.3.1-1`:

- upstream repository: https://github.com/ros-industrial/universal_robot.git
- release repository: https://github.com/ros-industrial-release/universal_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## universal_robots

```
* [meta]: Remove ur_kinematics package for now (#620 <https://github.com/ros-industrial/universal_robot/issues/620>)
  With the dependency we cannot release the metapackage for now, since it is not released.
* Contributors: Felix Exner (fexner)
```

## ur10_moveit_config

- No changes

## ur10e_moveit_config

- No changes

## ur16e_moveit_config

- No changes

## ur3_moveit_config

- No changes

## ur3e_moveit_config

- No changes

## ur5_moveit_config

- No changes

## ur5e_moveit_config

- No changes

## ur_description

- No changes

## ur_gazebo

- No changes
