### PR TITLE
Add rcl_logging_rcutils to documentation index

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3503,7 +3503,7 @@ repositories:
   rcl_logging_rcutils:
     doc:
       type: git
-      url: https://github.com/ros2/rcl_logging_rcutils.git
+      url: https://github.com/sloretz/rcl_logging_rcutils.git
       version: master
     source:
       test_pull_requests: true

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3500,6 +3500,17 @@ repositories:
       url: https://github.com/ros2/rcl_logging.git
       version: rolling
     status: maintained
+  rcl_logging_rcutils:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcl_logging_rcutils.git
+      version: master
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/sloretz/rcl_logging_rcutils.git
+      version: master
+    status: maintained
   rclc:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

Rolling

# The source is here:
https://github.com/sloretz/rcl_logging_rcutils



# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
