### PR TITLE
foros: 0.4.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1192,6 +1192,16 @@ repositories:
       type: git
       url: https://github.com/42dot/foros.git
       version: humble
+    release:
+      packages:
+      - foros
+      - foros_examples
+      - foros_inspector
+      - foros_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/foros-release.git
+      version: 0.4.1-2
     source:
       type: git
       url: https://github.com/42dot/foros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foros` to `0.4.1-2`:

- upstream repository: https://github.com/42dot/foros.git
- release repository: https://github.com/ros2-gbp/foros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## foros

```
* foros: update package.xml test_depend
  add ament_cmake_gtest, ament_cmake_gmock
* foros: update package.xml depend
  libleveldb-dev -> leveldb
* Contributors: Wonguk Jeong
```

## foros_examples

- No changes

## foros_inspector

```
* foros_inspector: update package.xml depend
  ncurses -> libncurses-dev
* Contributors: Wonguk Jeong
```

## foros_msgs

- No changes
