### PR TITLE
rosdep: added dependencies for openembedded:

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -50,6 +50,7 @@ alsa-oss:
   debian: [alsa-oss]
   gentoo: [media-libs/alsa-oss]
   nixos: [alsaOss]
+  openembedded: [alsa-oss@meta-oe]
   opensuse: [alsa-oss]
   ubuntu: [alsa-oss]
 alsa-utils:
@@ -519,6 +520,7 @@ clang:
   fedora: [clang]
   gentoo: [sys-devel/clang]
   nixos: [clang]
+  openembedded: [clang-native@meta-clang]
   rhel:
     '*': [clang]
     '7': null
@@ -1018,6 +1020,7 @@ file:
   debian: [file]
   fedora: [file]
   nixos: [file]
+  openembedded: [file@openembedded-core]
   rhel: [file]
   ubuntu: [file]
 filezilla:
@@ -1104,6 +1107,7 @@ fmt:
   fedora: [fmt-devel]
   gentoo: [dev-libs/libfmt]
   nixos: [fmt]
+  openembedded: [fmt@meta-oe]
   rhel: [fmt-devel]
   ubuntu: [libfmt-dev]
 fonts-noto:
@@ -2308,6 +2312,7 @@ jq:
   fedora: [jq]
   gentoo: [app-misc/jq]
   nixos: [jq]
+  openembedded: [jq@meta-oe]
   rhel: [jq]
   ubuntu: [jq]
 julius-voxforge:
@@ -2381,6 +2386,7 @@ libabsl-dev:
   fedora: [abseil-cpp-devel]
   gentoo: [dev-cpp/abseil-cpp]
   nixos: [abseil-cpp]
+  openembedded: [abseil-cpp@meta-oe]
   rhel:
     '*': [abseil-cpp-devel]
     '7': null
@@ -4107,6 +4113,7 @@ liblttng-ust-dev:
   fedora: [lttng-ust-devel]
   gentoo: [dev-util/lttng-ust]
   nixos: [lttng-ust]
+  openembedded: [lttng-ust@openembedded-core]
   rhel: [lttng-ust-devel]
   ubuntu: [liblttng-ust-dev]
 liblzma-dev:
@@ -4438,6 +4445,7 @@ libopencv-imgproc-dev:
   debian: [libopencv-imgproc-dev]
   fedora: [opencv-devel]
   gentoo: [media-libs/opencv]
+  openembedded: [opencv@meta-oe]
   rhel: [opencv-devel]
   ubuntu: [libopencv-imgproc-dev]
 libopenexr-dev:
@@ -7027,6 +7035,7 @@ pybind11-dev:
   debian: [pybind11-dev]
   fedora: [pybind11-devel]
   nixos: [pythonPackages.pybind11]
+  openembedded: [python3-pybind11@meta-python]
   rhel:
     '*': [pybind11-devel]
     '7': null
@@ -7959,6 +7968,7 @@ uncrustify:
   fedora: [uncrustify]
   gentoo: [uncrustify]
   nixos: [uncrustify]
+  openembedded: [uncrustify@meta-ros-common]
   osx:
     homebrew:
       packages: [uncrustify]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6438,6 +6438,7 @@ python3-dbus:
   debian: [python3-dbus]
   fedora: [python3-dbus]
   nixos: [python3Packages.dbus-python]
+  openembedded: [python3-dbus@openembedded-core]
   rhel: [python3-dbus]
   ubuntu: [python3-dbus]
 python3-decorator:
@@ -9749,6 +9750,7 @@ python3-whichcraft:
   fedora: [python3-whichcraft]
   gentoo: [dev-python/whichcraft]
   nixos: [python3Packages.whichcraft]
+  openembedded: [python3-whichcraft@meta-ros-common]
   rhel:
     '*': [python3-whichcraft]
     '7': null


### PR DESCRIPTION
Added dependencies for openembedded for

* alsa-oss: https://layers.openembedded.org/layerindex/recipe/1161/
 * clang-native: https://layers.openembedded.org/layerindex/recipe/31565/
 * file: https://layers.openembedded.org/layerindex/recipe/4681/
 * fmt: https://layers.openembedded.org/layerindex/recipe/104406/
 * jq: https://layers.openembedded.org/layerindex/recipe/27305/
 * abseil-cpp: https://layers.openembedded.org/layerindex/recipe/120200/
 * lttng-ust-dev: https://layers.openembedded.org/layerindex/recipe/6147/
 * opencv-imgproc-dev: https://layers.openembedded.org/layerindex/recipe/39865/
 * python3-pybind11: https://layers.openembedded.org/layerindex/recipe/56447/
 * uncrustify: meta-ros via pull request https://github.com/ros/meta-ros/pull/1031
 * python3-dbus: https://layers.openembedded.org/layerindex/recipe/51342/
 * python3-whichcraft: meta-ros via pull request https://github.com/ros/meta-ros/pull/1031

Signed-off-by: Matthias Schoepfer <m.schoepfer@rethinkrobotics.com>


