### PR TITLE
aruco_ros: 3.1.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -222,7 +222,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/pal-gbp/aruco_ros-release.git
-      version: 3.0.1-3
+      version: 3.1.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/aruco_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_ros` to `3.1.2-1`:

- upstream repository: https://github.com/pal-robotics/aruco_ros.git
- release repository: https://github.com/pal-gbp/aruco_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.1-3`

## aruco

```
* disable the shadow compilation flag
* Contributors: Sai Kishor Kothakota
```

## aruco_msgs

- No changes

## aruco_ros

```
* Merge branch 'feat/aruco-3.1.5-migration' into 'ferrum-devel' ArUCO 3.1.5 migration See merge request ros-overlays/aruco_ros!4
* Add correct fisheye distortion functionality
* migrate to 3.1.5
* Contributors: josegarcia, saikishor
```

