### PR TITLE
aruco_ros: 2.2.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -287,6 +287,10 @@ repositories:
       version: 1.3.2-1
     status: developed
   aruco_ros:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/aruco_ros.git
+      version: melodic-devel
     release:
       packages:
       - aruco
@@ -295,7 +299,12 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/pal-gbp/aruco_ros-release.git
-      version: 2.1.1-1
+      version: 2.2.1-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/aruco_ros.git
+      version: melodic-devel
+    status: developed
   asr_aruco_marker_recognition:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_ros` to `2.2.1-1`:

- upstream repository: https://github.com/pal-robotics/aruco_ros.git
- release repository: https://github.com/pal-gbp/aruco_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.1-1`

## aruco

```
* Merge branch 'fix_disable_pal_flags' into 'ferrum-devel'
  disable the shadow compilation flag
  See merge request ros-overlays/aruco_ros!7
* disable the shadow compilation flag
* Contributors: Sai Kishor Kothakota, saikishor
```

## aruco_msgs

- No changes

## aruco_ros

```
* Merge branch 'feat/aruco-3.1.5-migration' into 'ferrum-devel' ArUCO 3.1.5 migration See merge request ros-overlays/aruco_ros!4
* Add correct fisheye distortion functionality
* migrate to 3.1.5
* Contributors: josegarcia, saikishor
```

