### PR TITLE
Add python3-graphviz to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8335,7 +8335,6 @@ python3-pygments:
   ubuntu: [python3-pygments]
 python3-pygraphviz:
   alpine: [py3-graphviz]
-  arch: [python-graphviz]
   debian: [python3-pygraphviz]
   fedora: [python3-pygraphviz]
   freebsd: [py-pygraphviz]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8334,7 +8334,7 @@ python3-pygments:
     '7': null
   ubuntu: [python3-pygments]
 python3-pygraphviz:
-  alpine: [py3-graphviz]
+  alpine: [py3-pygraphviz]
   debian: [python3-pygraphviz]
   fedora: [python3-pygraphviz]
   freebsd: [py-pygraphviz]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7144,6 +7144,7 @@ python3-graphviz:
   fedora: [python3-graphviz]
   gentoo: [dev-python/graphviz]
   nixos: [python39Packages.graphviz]
+  opensuse: [python3-graphviz]
   ubuntu: [python3-graphviz]
 python3-grpc-tools:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7137,6 +7137,14 @@ python3-gql-pip:
   ubuntu:
     pip:
       packages: [gql]
+python3-graphviz:
+  alpine: [py3-graphviz]
+  arch: [python-graphviz]
+  debian: [python3-graphviz]
+  fedora: [python3-graphviz]
+  gentoo: [dev-python/graphviz]
+  nixos: [python39Packages.graphviz]
+  ubuntu: [python3-graphviz]
 python3-grpc-tools:
   debian:
     '*': [python3-grpc-tools]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-graphviz

## Package Upstream Source:

Source: https://github.com/xflr6/graphviz
Docs: https://graphviz.readthedocs.io/

## Purpose of using this:

This package is a pure Python implementation for creating dot graphs, which can then be rendered with Graphviz.

It was added to rosdep as a pip entry in pull request https://github.com/ros/rosdistro/pull/16412 . That was 2017, by now many Linux distros have this available as native packages.

There are other rules with similar names:
- `python-graphviz-pip`: this is the pip version
- `python-pygraphviz` and `python3-pygraphviz`: Python wrappers for the Graphviz C library
- `graphviz`: Graphviz itself.

The rule for `python-pygraphviz` had incorrect references for Arch (non-existent) and Alpine ([package link](https://pkgs.alpinelinux.org/packages?name=py3-pygraphviz&branch=edge&repo=&arch=&maintainer=)), which I also fixed.

Distro packaging links:

- Debian: https://packages.debian.org/search?keywords=python3-graphviz&searchon=names&suite=all&section=all
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/search?keywords=python3-graphviz&searchon=names&suite=all&section=all
   - REQUIRED
- Fedora: https://packages.fedoraproject.org/pkgs/python-graphviz/python3-graphviz/
  - IF AVAILABLE
- Arch: https://archlinux.org/packages/community/any/python-graphviz/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/packages/dev-python/graphviz
  - IF AVAILABLE
- macOS: not available
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages?name=py3-pygraphviz&branch=edge&repo=&arch=&maintainer=
  - IF AVAILABLE
- NixOS/nixpkgs: [link](https://search.nixos.org/packages?channel=22.05&show=python39Packages.graphviz&from=0&size=50&buckets=%7B%22package_attr_set%22%3A%5B%22python39Packages%22%5D%2C%22package_license_set%22%3A%5B%5D%2C%22package_maintainers_set%22%3A%5B%5D%2C%22package_platforms%22%3A%5B%5D%7D&sort=relevance&type=packages&query=graphviz)
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/python3-graphviz
  - IF AVAILABLE

