### PR TITLE
rsl: 0.2.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5116,7 +5116,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/PickNikRobotics/RSL-release.git
-      version: 0.1.1-1
+      version: 0.2.0-2
     source:
       type: git
       url: https://github.com/PickNikRobotics/RSL.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rsl` to `0.2.0-2`:

- upstream repository: https://github.com/PickNikRobotics/RSL.git
- release repository: https://github.com/PickNikRobotics/RSL-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.1-1`

## rsl

```
* New features
  * rclcpp::Parameter validator functions
  * Algorithms from parameter_traits
  * rsl::StaticVector and rsl::StaticString
* Doxygen site: https://picknikrobotics.github.io/RSL/files.html
  * Link to the docs from the README
  * Use doxygen-awesome documentation style
  * Deploy documentation website from CI
  * Add Doxygen comments for rsl::Overload
  * Add Doxygen comments for TRY
* Cleanups
  * Prevent unnecessary string copy
  * Ensure global constants do not violate the ODR
  * Hide rsl::NoDiscard implementation details
  * Use more [[nodiscard]]
  * Fix to_vector for vector<bool>
  * Ensure static container iterators are used
  * Default to building a shared library
  * Use generator-agnostic CMake commands
  * Remove C compiler settings
  * Don't require compiler extensions
  * Use more expressive path variable
  * Add clang-tidy integration and fix errors
  * Address clang-tidy findings
  * Update FindCatch2 module
  * Update Catch2
* Contributors: Chris Thrasher, Tyler Weaver
```
