### PR TITLE
generate_parameter_library: 0.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1298,7 +1298,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/PickNikRobotics/generate_parameter_library-release.git
-      version: 0.2.8-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `generate_parameter_library` to `0.3.0-1`:

- upstream repository: https://github.com/PickNikRobotics/generate_parameter_library.git
- release repository: https://github.com/PickNikRobotics/generate_parameter_library-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.8-1`

## generate_parameter_library

```
* Migrate from parameter_traits to RSL (take 2) (#91 <https://github.com/PickNikRobotics/generate_parameter_library/issues/91>)
* Contributors: Tyler Weaver
```

## generate_parameter_library_example

```
* Migrate from parameter_traits to RSL (take 2) (#91 <https://github.com/PickNikRobotics/generate_parameter_library/issues/91>)
* Contributors: Tyler Weaver
```

## generate_parameter_library_py

```
* Migrate from parameter_traits to RSL (take 2) (#91 <https://github.com/PickNikRobotics/generate_parameter_library/issues/91>)
* Add missing dependency on PyYAML (#89 <https://github.com/PickNikRobotics/generate_parameter_library/issues/89>)
* Contributors: Scott K Logan, Tyler Weaver
```

## parameter_traits

```
* Migrate from parameter_traits to RSL (take 2) (#91 <https://github.com/PickNikRobotics/generate_parameter_library/issues/91>)
* Contributors: Tyler Weaver
```
