### PR TITLE
control_toolbox: 2.1.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -628,7 +628,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros-gbp/control_toolbox-release.git
-      version: 2.1.1-1
+      version: 2.1.2-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `2.1.2-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros-gbp/control_toolbox-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.1-1`

## control_toolbox

```
* export missing dependency (#128 <https://github.com/ros-controls/control_toolbox/issues/128>)
* Contributors: Noel Jiménez García
```
