### PR TITLE
Add spconv python package rosdep keys

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9321,6 +9321,56 @@ python3-sparkfun-ublox-gps-pip:
   ubuntu:
     pip:
       packages: [sparkfun-ublox-gps]
+python3-spconv-pip:
+  debian:
+    pip:
+      packages: [spconv]
+  fedora:
+    pip:
+      packages: [spconv]
+  ubuntu:
+    pip:
+      packages: [spconv]
+python3-spconv-cuda-114-pip:
+  debian:
+    pip:
+      packages: [spconv-cu114]
+  fedora:
+    pip:
+      packages: [spconv-cu114]
+  ubuntu:
+    pip:
+      packages: [spconv-cu114]
+python3-spconv-cuda-116-pip:
+  debian:
+    pip:
+      packages: [spconv-cu116]
+  fedora:
+    pip:
+      packages: [spconv-cu116]
+  ubuntu:
+    pip:
+      packages: [spconv-cu116]
+python3-spconv-cuda-117-pip:
+  debian:
+    pip:
+      packages: [spconv-cu117]
+  fedora:
+    pip:
+      packages: [spconv-cu117]
+  ubuntu:
+    pip:
+      packages: [spconv-cu117]
+python3-spconv-cuda-118-pip:
+  debian:
+    pip:
+      packages: [spconv-cu118]
+  fedora:
+    pip:
+      packages: [spconv-cu118]
+  ubuntu:
+    pip:
+      packages: [spconv-cu118]
 python3-sphinx:
   debian: [python3-sphinx]
   fedora: [python3-sphinx]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9331,7 +9331,7 @@ python3-spconv-pip:
   ubuntu:
     pip:
       packages: [spconv]
-python3-spconv-cuda-114-pip:
+python3-spconv-cu114-pip:
   debian:
     pip:
       packages: [spconv-cu114]
@@ -9341,7 +9341,7 @@ python3-spconv-cuda-114-pip:
   ubuntu:
     pip:
       packages: [spconv-cu114]
-python3-spconv-cuda-116-pip:
+python3-spconv-cu116-pip:
   debian:
     pip:
       packages: [spconv-cu116]
@@ -9351,7 +9351,7 @@ python3-spconv-cuda-116-pip:
   ubuntu:
     pip:
       packages: [spconv-cu116]
-python3-spconv-cuda-117-pip:
+python3-spconv-cu117-pip:
   debian:
     pip:
       packages: [spconv-cu117]
@@ -9361,7 +9361,7 @@ python3-spconv-cuda-117-pip:
   ubuntu:
     pip:
       packages: [spconv-cu117]
-python3-spconv-cuda-118-pip:
+python3-spconv-cu118-pip:
   debian:
     pip:
       packages: [spconv-cu118]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`spconv`: Spatially Sparce Convolutional Library

## Package Upstream Source:

https://github.com/traveller59/spconv

## Purpose of using this:

This is a dependency of several SLAM algorithms including hdl_graph_slam and hdl_localization. These provide some of the best results that I've seen for map generation and localization.

## Links to Distribution Packages
- https://pypi.org/project/spconv/
- https://pypi.org/project/spconv-cu114/
- https://pypi.org/project/spconv-cu116/
- https://pypi.org/project/spconv-cu117/
- https://pypi.org/project/spconv-cu118/