### PR TITLE
rosbag2: 0.18.0-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4429,11 +4429,13 @@ repositories:
       - rosbag2_compression
       - rosbag2_compression_zstd
       - rosbag2_cpp
+      - rosbag2_examples_cpp
       - rosbag2_interfaces
       - rosbag2_performance_benchmarking
       - rosbag2_py
       - rosbag2_storage
       - rosbag2_storage_default_plugins
+      - rosbag2_storage_sqlite3
       - rosbag2_test_common
       - rosbag2_tests
       - rosbag2_transport
@@ -4443,7 +4445,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.17.0-2
+      version: 0.18.0-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.18.0-3`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.17.0-2`

## ros2bag

```
* rosbag2_storage: expose default storage ID as method (#1146 <https://github.com/ros2/rosbag2/issues/1146>)
* Fix for ros2 bag play exit with non-zero code on SIGINT (#1126 <https://github.com/ros2/rosbag2/issues/1126>)
* ros2bag: move storage preset validation to sqlite3 plugin (#1135 <https://github.com/ros2/rosbag2/issues/1135>)
* Add option to prevent message loss while converting (#1058 <https://github.com/ros2/rosbag2/issues/1058>)
* Added support for excluding topics via regular expressions (#1046 <https://github.com/ros2/rosbag2/issues/1046>)
* Readers/info can accept a single bag storage file, and detect its storage id automatically (#1072 <https://github.com/ros2/rosbag2/issues/1072>)
* Add short -v option to ros2 bag list for verbose (#1065 <https://github.com/ros2/rosbag2/issues/1065>)
* Contributors: DensoADAS, Emerson Knapp, Esteve Fernandez, Michael Orlov, james-rms
```

## rosbag2

```
* Move sqlite3 storage implementation to rosbag2_storage_sqlite3 package (#1113 <https://github.com/ros2/rosbag2/issues/1113>)
* Contributors: Emerson Knapp
```

## rosbag2_compression

```
* Reverse read order API and sqlite storage implementation (#1083 <https://github.com/ros2/rosbag2/issues/1083>)
* Add option to prevent message loss while converting (#1058 <https://github.com/ros2/rosbag2/issues/1058>)
* set default metadata of compressed message (in case compressor does not set it) (#1060 <https://github.com/ros2/rosbag2/issues/1060>)
* Contributors: DensoADAS, Emerson Knapp
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* rosbag2_storage: expose default storage ID as method (#1146 <https://github.com/ros2/rosbag2/issues/1146>)
* Don't reopen file for every seek if we don't have to. Search directionally for the correct file (#1117 <https://github.com/ros2/rosbag2/issues/1117>)
* Add SplitBagfile recording service. (#1115 <https://github.com/ros2/rosbag2/issues/1115>)
* Reverse read order API and sqlite storage implementation (#1083 <https://github.com/ros2/rosbag2/issues/1083>)
* Replace std::filesystem::path(..) with rcpputils::fs::path(..) (#1104 <https://github.com/ros2/rosbag2/issues/1104>)
* Fix issue where sequentialwriter only sets metadata duration to the duration of the final file (#1098 <https://github.com/ros2/rosbag2/issues/1098>)
* Delete obsolete compression_options.cpp from rosbag2_cpp (#1078 <https://github.com/ros2/rosbag2/issues/1078>)
* Readers/info can accept a single bag storage file, and detect its storage id automatically (#1072 <https://github.com/ros2/rosbag2/issues/1072>)
* Remove deprecated rosbag2_cpp/storage_options.hpp, for post-Humble releases (#1064 <https://github.com/ros2/rosbag2/issues/1064>)
* Contributors: Emerson Knapp, Michael Orlov, james-rms, rshanor
```

## rosbag2_examples_cpp

```
* Add API samples on main branch - Rolling C++ API examples (#1068 <https://github.com/ros2/rosbag2/issues/1068>)
* Contributors: Emerson Knapp
```

## rosbag2_interfaces

```
* Add SplitBagfile recording service. (#1115 <https://github.com/ros2/rosbag2/issues/1115>)
* Contributors: rshanor
```

## rosbag2_performance_benchmarking

- No changes

## rosbag2_py

```
* rosbag2_storage: expose default storage ID as method (#1146 <https://github.com/ros2/rosbag2/issues/1146>)
* rosbag2_py: set defaults for config when bag rewriting (#1121 <https://github.com/ros2/rosbag2/issues/1121>)
* Reverse read order API and sqlite storage implementation (#1083 <https://github.com/ros2/rosbag2/issues/1083>)
* expose py Reader metadata, improve rosbag2_py.BagMetadata usability (#1082 <https://github.com/ros2/rosbag2/issues/1082>)
* Added support for excluding topics via regular expressions (#1046 <https://github.com/ros2/rosbag2/issues/1046>)
* Contributors: Emerson Knapp, Esteve Fernandez, james-rms
```

## rosbag2_storage

```
* rosbag2_storage: expose default storage ID as method (#1146 <https://github.com/ros2/rosbag2/issues/1146>)
* Don't reopen file for every seek if we don't have to. Search directionally for the correct file (#1117 <https://github.com/ros2/rosbag2/issues/1117>)
* Reverse read order API and sqlite storage implementation (#1083 <https://github.com/ros2/rosbag2/issues/1083>)
* Remove YAML_CPP_DLL define (#964 <https://github.com/ros2/rosbag2/issues/964>)
* Added support for excluding topics via regular expressions (#1046 <https://github.com/ros2/rosbag2/issues/1046>)
* Readers/info can accept a single bag storage file, and detect its storage id automatically (#1072 <https://github.com/ros2/rosbag2/issues/1072>)
* Contributors: Akash, Emerson Knapp, Esteve Fernandez, james-rms
```

## rosbag2_storage_default_plugins

```
* Move sqlite3 storage implementation to rosbag2_storage_sqlite3 package (#1113 <https://github.com/ros2/rosbag2/issues/1113>)
* Reverse read order API and sqlite storage implementation (#1083 <https://github.com/ros2/rosbag2/issues/1083>)
* Add support for old db3 schema used on distros prior to Foxy (#1090 <https://github.com/ros2/rosbag2/issues/1090>)
* Added support for excluding topics via regular expressions (#1046 <https://github.com/ros2/rosbag2/issues/1046>)
* Contributors: Emerson Knapp, Esteve Fernandez, Michael Orlov
```

## rosbag2_storage_sqlite3

```
* ros2bag: move storage preset validation to sqlite3 plugin (#1135 <https://github.com/ros2/rosbag2/issues/1135>)
* Move sqlite3 storage implementation to rosbag2_storage_sqlite3 package (#1113 <https://github.com/ros2/rosbag2/issues/1113>)
* Contributors: Emerson Knapp, james-rms
```

## rosbag2_test_common

```
* Fix for ros2 bag play exit with non-zero code on SIGINT (#1126 <https://github.com/ros2/rosbag2/issues/1126>)
* Contributors: Michael Orlov
```

## rosbag2_tests

```
* Get rid from attempt to open DB file in wait_for_db() test fixture (#1141 <https://github.com/ros2/rosbag2/issues/1141>)
* Fix for ros2 bag play exit with non-zero code on SIGINT (#1126 <https://github.com/ros2/rosbag2/issues/1126>)
* Move sqlite3 storage implementation to rosbag2_storage_sqlite3 package (#1113 <https://github.com/ros2/rosbag2/issues/1113>)
* Readers/info can accept a single bag storage file, and detect its storage id automatically (#1072 <https://github.com/ros2/rosbag2/issues/1072>)
* Contributors: Emerson Knapp, Michael Orlov
```

## rosbag2_transport

```
* Add pause and resume service calls for rosbag2 recorder (#1131 <https://github.com/ros2/rosbag2/issues/1131>)
* Redesign record_services tests to make them more deterministic (#1122 <https://github.com/ros2/rosbag2/issues/1122>)
* Add SplitBagfile recording service. (#1115 <https://github.com/ros2/rosbag2/issues/1115>)
* Reverse read order API and sqlite storage implementation (#1083 <https://github.com/ros2/rosbag2/issues/1083>)
* make recorder node composable by inheritance (#1093 <https://github.com/ros2/rosbag2/issues/1093>)
* Mark test_play_services as xfail for FastRTPS and CycloneDDS (#1091 <https://github.com/ros2/rosbag2/issues/1091>)
* fixed typo (#1057 <https://github.com/ros2/rosbag2/issues/1057>)
* Fix hangout in rosbag2 player and recorder when pressing CTRL+C (#1081 <https://github.com/ros2/rosbag2/issues/1081>)
* Added support for excluding topics via regular expressions (#1046 <https://github.com/ros2/rosbag2/issues/1046>)
* Contributors: Bernardo Taveira, Cristóbal Arroyo, DensoADAS, Emerson Knapp, Esteve Fernandez, Michael Orlov, rshanor
```

## shared_queues_vendor

```
* Fixes policy CMP0135 warning for CMake >= 3.24 (#1084 <https://github.com/ros2/rosbag2/issues/1084>)
* Contributors: Cristóbal Arroyo
```

## sqlite3_vendor

```
* Fixes policy CMP0135 warning for CMake >= 3.24 (#1084 <https://github.com/ros2/rosbag2/issues/1084>)
* Contributors: Cristóbal Arroyo
```

## zstd_vendor

```
* Bump zstd to 1.4.8 in zstd_vendor package (#1132 <https://github.com/ros2/rosbag2/issues/1132>)
* Fix/zstd vendor does not find system zstd (#1111 <https://github.com/ros2/rosbag2/issues/1111>)
* Contributors: DasRoteSkelett, Michael Orlov
```
