### PR TITLE
robotont_msgs: 0.0.2-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8403,6 +8403,17 @@ repositories:
       url: https://github.com/robotont/robotont_description.git
       version: noetic-devel
     status: maintained
+  robotont_msgs:
+    doc:
+      type: git
+      url: https://github.com/robotont/robotont_msgs.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/robotont-release/robotont_msgs-release.git
+      version: 0.0.2-2
+    status: maintained
   robotont_nuc_description:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `robotont_msgs` to `0.0.2-2`:

- upstream repository: https://github.com/robotont/robotont_msgs.git
- release repository: https://github.com/robotont-release/robotont_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
