### PR TITLE
image_common: 4.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1669,7 +1669,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 4.1.0-1
+      version: 4.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `4.1.1-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.1.0-1`

## camera_calibration_parsers

```
* Add alias library targets for all libraries (#259 <https://github.com/ros-perception/image_common/issues/259>)
* Contributors: RFRIEDM-Trimble
```

## camera_info_manager

```
* Add alias library targets for all libraries (#259 <https://github.com/ros-perception/image_common/issues/259>)
* Contributors: RFRIEDM-Trimble
```

## image_common

- No changes

## image_transport

```
* Add alias library targets for all libraries (#259 <https://github.com/ros-perception/image_common/issues/259>)
* Contributors: RFRIEDM-Trimble
```
