### PR TITLE
image_common: 3.1.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1693,7 +1693,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 3.1.4-2
+      version: 3.1.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `3.1.5-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.1.4-2`

## camera_calibration_parsers

```
* Add alias library targets for all libraries (#260 <https://github.com/ros-perception/image_common/issues/260>)
* Contributors: Geoffrey Biggs
```

## camera_info_manager

```
* Add alias library targets for all libraries (#260 <https://github.com/ros-perception/image_common/issues/260>)
* Contributors: Geoffrey Biggs
```

## image_common

- No changes

## image_transport

```
* Add alias library targets for all libraries (#260 <https://github.com/ros-perception/image_common/issues/260>)
* Contributors: Geoffrey Biggs
```
