### PR TITLE
image_common: 2.5.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1590,7 +1590,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 2.5.0-1
+      version: 2.5.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `2.5.1-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.5.0-1`

## camera_calibration_parsers

```
* Add alias library targets for all libraries (#261 <https://github.com/ros-perception/image_common/issues/261>)
* Contributors: Geoffrey Biggs
```

## camera_info_manager

```
* Add alias library targets for all libraries (#261 <https://github.com/ros-perception/image_common/issues/261>)
* Contributors: Geoffrey Biggs
```

## image_common

- No changes

## image_transport

```
* Add alias library targets for all libraries (#261 <https://github.com/ros-perception/image_common/issues/261>)
* Contributors: Geoffrey Biggs
```
