### PR TITLE
jackal: 0.8.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3930,7 +3930,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.8.4-1
+      version: 0.8.6-1
     source:
       type: git
       url: https://github.com/jackal/jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.8.6-1`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.8.4-1`

## jackal_control

- No changes

## jackal_description

```
* Set the GPS plugin's reference heading to 90 so it's ENU
* Use xacro properties defined from environment variables for Microstrain URDF (#123 <https://github.com/jackal/jackal/issues/123>)
* Add GAZEBO_WORLD_{LAT|LON} envars to change the reference coordinate of the robot's integral GPS
* Contributors: Chris Iverach-Brereton, Joey Yang
```

## jackal_msgs

- No changes

## jackal_navigation

- No changes

## jackal_tutorials

- No changes
