### PR TITLE
cob_command_tools: 0.6.30-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -962,7 +962,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_command_tools-release.git
-      version: 0.6.29-1
+      version: 0.6.30-2
     source:
       type: git
       url: https://github.com/ipa320/cob_command_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.30-2`:

- upstream repository: https://github.com/ipa320/cob_command_tools.git
- release repository: https://github.com/ipa320/cob_command_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.29-1`

## cob_command_gui

- No changes

## cob_command_tools

- No changes

## cob_dashboard

- No changes

## cob_helper_tools

- No changes

## cob_interactive_teleop

- No changes

## cob_monitoring

```
* Merge pull request #322 <https://github.com/ipa320/cob_command_tools/issues/322> from Deleh/fix/wlan_monitor_diagnostics
  Set diagnostic level to ERROR on exception
* harmonization
* set diagnostic level to ERROR on exception
* Merge pull request #321 <https://github.com/ipa320/cob_command_tools/issues/321> from LoyVanBeek/fix/netdata_based_diagnostics
  Fix/netdata based diagnostics
* Split CPU load diagnostics from uptime stats
* Try both spellings of core temp module name
* fixing crashed thread if netdata data was malformed and make netdata module name for core temps in api calls configurable
* Contributors: Björn Eistel, Denis Lehmann, Felix Messmer, Loy van Beek, fmessmer
```

## cob_script_server

- No changes

## cob_teleop

- No changes

## generic_throttle

- No changes

## scenario_test_tools

- No changes

## service_tools

- No changes
