### PR TITLE
cob_control: 0.8.20-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1017,7 +1017,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_control-release.git
-      version: 0.8.19-1
+      version: 0.8.20-1
     source:
       type: git
       url: https://github.com/ipa320/cob_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.8.20-1`:

- upstream repository: https://github.com/ipa320/cob_control.git
- release repository: https://github.com/ipa320/cob_control-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.8.19-1`

## cob_base_controller_utils

```
* Merge pull request #271 <https://github.com/ipa320/cob_control/issues/271> from Deleh/feature/halt_detector
  Add halt_detector
* track stuck thresholds per wheel
* add install tag for cob_halt_detector
* add warning if wheel exceeds stuck threshold
* add halt_detector
* add recovering check
* use ROS_INFO_STREAM
* simplify stop detector
* Contributors: Denis Lehmann, Felix Messmer
```

## cob_base_velocity_smoother

- No changes

## cob_cartesian_controller

- No changes

## cob_collision_velocity_filter

- No changes

## cob_control

- No changes

## cob_control_mode_adapter

- No changes

## cob_control_msgs

- No changes

## cob_footprint_observer

- No changes

## cob_frame_tracker

- No changes

## cob_hardware_emulation

- No changes

## cob_mecanum_controller

- No changes

## cob_model_identifier

- No changes

## cob_obstacle_distance

- No changes

## cob_omni_drive_controller

- No changes

## cob_trajectory_controller

- No changes

## cob_tricycle_controller

- No changes

## cob_twist_controller

- No changes
