### PR TITLE
cob_supported_robots: 0.6.17-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1281,7 +1281,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_supported_robots-release.git
-      version: 0.6.16-1
+      version: 0.6.17-1
     source:
       type: git
       url: https://github.com/ipa320/cob_supported_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_supported_robots` to `0.6.17-1`:

- upstream repository: https://github.com/ipa320/cob_supported_robots.git
- release repository: https://github.com/ipa320/cob_supported_robots-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.16-1`

## cob_supported_robots

```
* fix travis badge
* Merge pull request #31 <https://github.com/ipa320/cob_supported_robots/issues/31> from fmessmer/add_cob4-30_ostwestfalen
  add cob4-30 ostwestfalen
* add cob4-30 ostwestfalen
* Merge pull request #30 <https://github.com/ipa320/cob_supported_robots/issues/30> from fmessmer/add_cob4-29_goettingen
  add cob4-29 goettingen
* add cob4-29 goettingen
* Contributors: Felix Messmer, fmessmer
```
