### PR TITLE
cob_calibration_data: 0.6.18-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -935,7 +935,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_calibration_data-release.git
-      version: 0.6.17-1
+      version: 0.6.18-1
     source:
       type: git
       url: https://github.com/ipa320/cob_calibration_data.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_calibration_data` to `0.6.18-1`:

- upstream repository: https://github.com/ipa320/cob_calibration_data.git
- release repository: https://github.com/ipa320/cob_calibration_data-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.17-1`

## cob_calibration_data

```
* fix travis badge
* Merge pull request #169 <https://github.com/ipa320/cob_calibration_data/issues/169> from fmessmer/add_cob4-30_ostwestfalen
  add cob4-30 ostwestfalen
* add cob4-30 ostwestfalen
* Merge pull request #168 <https://github.com/ipa320/cob_calibration_data/issues/168> from fmessmer/add_cob4-29_goettingen
  add cob4-29 goettingen
* add cob4-29 goettingen
* Contributors: Felix Messmer, fmessmer
```
