### PR TITLE
cob_driver: 0.7.14-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1053,7 +1053,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_driver-release.git
-      version: 0.7.13-1
+      version: 0.7.14-1
     source:
       type: git
       url: https://github.com/ipa320/cob_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_driver` to `0.7.14-1`:

- upstream repository: https://github.com/ipa320/cob_driver.git
- release repository: https://github.com/ipa320/cob_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.13-1`

## cob_base_drive_chain

- No changes

## cob_bms_driver

```
* Merge pull request #437 <https://github.com/ipa320/cob_driver/issues/437> from Deleh/fix/power_consume
  Fix power consumption of fake BMS
* round remaining capacity for publisher and diagnostics
* remove round of remaining capacity
* Merge pull request #436 <https://github.com/ipa320/cob_driver/issues/436> from HannesBachter/audi_scenario
  configurable battery details
* get battery details from parameter server
* adjust battery capacity and discharging values to new diff base
* Contributors: Denis Lehmann, Felix Messmer, HannesBachter, fmessmer
```

## cob_canopen_motor

- No changes

## cob_driver

- No changes

## cob_elmo_homing

- No changes

## cob_generic_can

- No changes

## cob_light

- No changes

## cob_mimic

- No changes

## cob_phidget_em_state

- No changes

## cob_phidget_power_state

- No changes

## cob_phidgets

```
* Merge pull request #438 <https://github.com/ipa320/cob_driver/issues/438> from fmessmer/feature/phidgets_emulation
  [WIP] minimal emulation for phidget_sensors node
* minimal emulation for phidget_sensors node
* Contributors: Felix Messmer, fmessmer
```

## cob_relayboard

- No changes

## cob_scan_unifier

- No changes

## cob_sick_lms1xx

- No changes

## cob_sick_s300

- No changes

## cob_sound

- No changes

## cob_undercarriage_ctrl

- No changes

## cob_utilities

- No changes

## cob_voltage_control

- No changes

## laser_scan_densifier

- No changes
