### PR TITLE
Rename dynamixel_control to dynamixel_hardware

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1069,14 +1069,14 @@ repositories:
       url: https://github.com/stack-of-tasks/dynamic-graph.git
       version: devel
     status: maintained
-  dynamixel_control:
+  dynamixel_hardware:
     doc:
       type: git
-      url: https://github.com/youtalk/dynamixel_control.git
+      url: https://github.com/dynamixel-community/dynamixel_hardware.git
       version: foxy
     source:
       type: git
-      url: https://github.com/youtalk/dynamixel_control.git
+      url: https://github.com/dynamixel-community/dynamixel_hardware.git
       version: foxy
     status: developed
   dynamixel_hardware_interface:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -898,14 +898,14 @@ repositories:
       url: https://github.com/ros2/domain_bridge.git
       version: humble
     status: developed
-  dynamixel_control:
+  dynamixel_hardware:
     doc:
       type: git
-      url: https://github.com/youtalk/dynamixel_control.git
+      url: https://github.com/dynamixel-community/dynamixel_hardware.git
       version: humble
     source:
       type: git
-      url: https://github.com/youtalk/dynamixel_control.git
+      url: https://github.com/dynamixel-community/dynamixel_hardware.git
       version: humble
     status: developed
   dynamixel_sdk:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -844,14 +844,14 @@ repositories:
       url: https://github.com/ros2/domain_bridge.git
       version: main
     status: developed
-  dynamixel_control:
+  dynamixel_hardware:
     doc:
       type: git
-      url: https://github.com/youtalk/dynamixel_control.git
+      url: https://github.com/dynamixel-community/dynamixel_hardware.git
       version: rolling
     source:
       type: git
-      url: https://github.com/youtalk/dynamixel_control.git
+      url: https://github.com/dynamixel-community/dynamixel_hardware.git
       version: rolling
     status: developed
   dynamixel_sdk:


### PR DESCRIPTION
Signed-off-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>

# Please Add This Package to be indexed in the rosdistro.

I've changed the package name from dynamixel_control to dynamixel_hardware to contain 1 package inside the repository.
And I've also transferred the organization from my own to the dynamixel-community.

- Foxy
- Humble
- Rolling

# The source is here:

- https://github.com/dynamixel-community/dynamixel_hardware/tree/foxy
- https://github.com/dynamixel-community/dynamixel_hardware/tree/humble
- https://github.com/dynamixel-community/dynamixel_hardware/tree/rolling

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
