### PR TITLE
ament_black: 0.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -92,6 +92,20 @@ repositories:
       url: https://github.com/ros-acceleration/ament_acceleration.git
       version: rolling
     status: developed
+  ament_black:
+    release:
+      packages:
+      - ament_black
+      - ament_cmake_black
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/Timple/ament_black-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/Timple/ament_black.git
+      version: main
+    status: maintained
   ament_cmake:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_black` to `0.1.0-1`:

- upstream repository: https://github.com/Timple/ament_black.git
- release repository: https://github.com/Timple/ament_black-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
