### PR TITLE
webots_ros2: 2022.1.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6429,7 +6429,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/webots_ros2-release.git
-      version: 2022.1.3-1
+      version: 2022.1.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `webots_ros2` to `2022.1.4-1`:

- upstream repository: https://github.com/cyberbotics/webots_ros2.git
- release repository: https://github.com/ros2-gbp/webots_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2022.1.3-1`

## webots_ros2

```
* Fix the camera focal length in the CameraInfo topic.
* Upgraded to urdf2webots 2.0.3
* Update the calculation of CameraRecognitionObject messages to the RDF convention of R2022b.
```

## webots_ros2_driver

```
* Fix the camera focal length in the CameraInfo topic.
* Update the calculation of CameraRecognitionObject messages to the RDF convention of R2022b.
```

## webots_ros2_importer

```
* Upgraded to urdf2webots 2.0.3
```

## webots_ros2_tests

```
* Add a system test for the R2022b RDF convention for cameras.
```
