### PR TITLE
foxglove_msgs: 2.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1217,7 +1217,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_foxglove_msgs-release.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/foxglove/schemas.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_msgs` to `2.1.0-1`:

- upstream repository: https://github.com/foxglove/schemas.git
- release repository: https://github.com/ros2-gbp/ros_foxglove_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-1`

## foxglove_msgs

```
* Add frame_id to RawImage, CompressedImage, and CameraCalibration
* Add new SceneEntity and Primitive types
* Updated documentation for several types and fields
```
