### PR TITLE
smacc: 1.3.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13209,55 +13209,8 @@ repositories:
   smacc:
     release:
       packages:
-      - backward_global_planner
-      - backward_local_planner
-      - battery_monitor_client
-      - eg_conditional_generator
-      - eg_random_generator
-      - forward_global_planner
-      - forward_local_planner
-      - keyboard_client
-      - microstrain_mips_client
-      - move_base_z_client_plugin
-      - move_eye_client
-      - move_group_interface_client
-      - multirole_sensor_client
-      - pure_spinning_local_planner
-      - ros_publisher_client
-      - ros_timer_client
-      - sm_atomic
-      - sm_atomic_cb
-      - sm_atomic_services
-      - sm_calendar_week
-      - sm_coretest_transition_speed_1
-      - sm_coretest_x_y_1
-      - sm_coretest_x_y_2
-      - sm_coretest_x_y_3
-      - sm_dance_bot
-      - sm_dance_bot_2
-      - sm_dance_bot_strikes_back
-      - sm_ferrari
-      - sm_fetch_screw_loop_1
-      - sm_fetch_six_table_pick_n_sort_1
-      - sm_fetch_two_table_pick_n_place_1
-      - sm_fetch_two_table_whiskey_pour
-      - sm_packml
-      - sm_respira_1
-      - sm_ridgeback_barrel_search_1
-      - sm_ridgeback_barrel_search_2
-      - sm_starcraft_ai
-      - sm_subscriber
-      - sm_three_some
-      - sm_update_loop
-      - sm_viewer_sim
       - smacc
       - smacc_msgs
-      - smacc_runtime_test
-      - smacc_rviz_plugin
-      - sr_all_events_go
-      - sr_conditional
-      - sr_event_countdown
-      - undo_path_global_planner
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/robosoft-ai/smacc-release.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13206,6 +13206,67 @@ repositories:
       url: https://github.com/SteveMacenski/slam_toolbox.git
       version: melodic-devel
     status: maintained
+  smacc:
+    release:
+      packages:
+      - backward_global_planner
+      - backward_local_planner
+      - battery_monitor_client
+      - eg_conditional_generator
+      - eg_random_generator
+      - forward_global_planner
+      - forward_local_planner
+      - keyboard_client
+      - microstrain_mips_client
+      - move_base_z_client_plugin
+      - move_eye_client
+      - move_group_interface_client
+      - multirole_sensor_client
+      - pure_spinning_local_planner
+      - ros_publisher_client
+      - ros_timer_client
+      - sm_atomic
+      - sm_atomic_cb
+      - sm_atomic_services
+      - sm_calendar_week
+      - sm_coretest_transition_speed_1
+      - sm_coretest_x_y_1
+      - sm_coretest_x_y_2
+      - sm_coretest_x_y_3
+      - sm_dance_bot
+      - sm_dance_bot_2
+      - sm_dance_bot_strikes_back
+      - sm_ferrari
+      - sm_fetch_screw_loop_1
+      - sm_fetch_six_table_pick_n_sort_1
+      - sm_fetch_two_table_pick_n_place_1
+      - sm_fetch_two_table_whiskey_pour
+      - sm_packml
+      - sm_respira_1
+      - sm_ridgeback_barrel_search_1
+      - sm_ridgeback_barrel_search_2
+      - sm_starcraft_ai
+      - sm_subscriber
+      - sm_three_some
+      - sm_update_loop
+      - sm_viewer_sim
+      - smacc
+      - smacc_msgs
+      - smacc_runtime_test
+      - smacc_rviz_plugin
+      - sr_all_events_go
+      - sr_conditional
+      - sr_event_countdown
+      - undo_path_global_planner
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/robosoft-ai/smacc-release.git
+      version: 1.3.2-1
+    source:
+      type: git
+      url: https://github.com/robosoft-ai/smacc.git
+      version: melodic-devel
+    status: maintained
   snmp_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `smacc` to `1.3.2-1`:

- upstream repository: https://github.com/robosoft-ai/SMACC
- release repository: https://github.com/robosoft-ai/smacc-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## backward_global_planner

```
* Initial SMACC version
* Contributors: Pablo Iñigo Blasco
```

## backward_local_planner

- No changes

## battery_monitor_client

```
* added server folders to client library
* Merge branch 'master' into melodic-devel
* fixed Doxygen Client Namespaces
* refactoring client namespaces names
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Added Readme's to Client Library
* Merge branch 'master' into melodic-devel
* some refactoring in orthogonals relation with clients
* lord microstrain client, subscriber component
* missed a step
* last few touchups
* battery monitor client, and minor change on the smaccsubscriber base client
* Contributors: Brett Aldrich, Pablo Iñigo Blasco, Pabo Iñigo Blasco, brettpac, pablo.inigo.blasco
```

## eg_conditional_generator

```
* Renamed sr_conditional & eg_random_generator
* Contributors: Brett Aldrich
* Renamed sr_conditional & eg_random_generator
* Contributors: Brett Aldrich
```

## eg_random_generator

```
* Renamed sr_conditional & eg_random_generator
* Contributors: Brett Aldrich
* Renamed sr_conditional & eg_random_generator
* Contributors: Brett Aldrich
```

## forward_global_planner

```
* Initial SMACC version
* Contributors: Pablo Iñigo Blasco
```

## forward_local_planner

```
* Initial SMACC version
* Contributors: Pablo Iñigo Blasco
```

## keyboard_client

```
* added server folders to client library
* Merge branch 'master' into melodic-devel
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Redoing Client Namespaces
* Added Readme's to Client Library
* Merge branch 'master' into melodic-devel
* smacc improvements
* improving/fixing bugs on smacc signals related with the smacc objects life-time. Also clients improved in the related to this.
* battery monitor client, and minor change on the smaccsubscriber base client
* unpushed code
* sm_dance_bot_2
* fixing broken build
* second pass refactoring namespaces
* Contributors: Brett Aldrich, Pablo Iñigo Blasco, Pabo Iñigo Blasco, brettpac, pablo.inigo.blasco
* added server folders to client library
* Merge branch 'master' into melodic-devel
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Redoing Client Namespaces
* Added Readme's to Client Library
* Merge branch 'master' into melodic-devel
* smacc improvements
* improving/fixing bugs on smacc signals related with the smacc objects life-time. Also clients improved in the related to this.
* battery monitor client, and minor change on the smaccsubscriber base client
* unpushed code
* sm_dance_bot_2
* fixing broken build
* second pass refactoring namespaces
* Contributors: Brett Aldrich, Pablo Iñigo Blasco, Pabo Iñigo Blasco, brettpac, pablo.inigo.blasco
* added server folders to client library
* Merge branch 'master' into melodic-devel
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Redoing Client Namespaces
* Added Readme's to Client Library
* Merge branch 'master' into melodic-devel
* smacc improvements
* improving/fixing bugs on smacc signals related with the smacc objects life-time. Also clients improved in the related to this.
* battery monitor client, and minor change on the smaccsubscriber base client
* unpushed code
* sm_dance_bot_2
* fixing broken build
* second pass refactoring namespaces
* Contributors: Brett Aldrich, Pablo Iñigo Blasco, Pabo Iñigo Blasco, brettpac, pablo.inigo.blasco
* added server folders to client library
* Merge branch 'master' into melodic-devel
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Redoing Client Namespaces
* Added Readme's to Client Library
* Merge branch 'master' into melodic-devel
* smacc improvements
* improving/fixing bugs on smacc signals related with the smacc objects life-time. Also clients improved in the related to this.
* battery monitor client, and minor change on the smaccsubscriber base client
* unpushed code
* sm_dance_bot_2
* fixing broken build
* second pass refactoring namespaces
* Contributors: Brett Aldrich, Pablo Iñigo Blasco, Pabo Iñigo Blasco, brettpac, pablo.inigo.blasco
```

## microstrain_mips_client

```
* Merge branch 'master' into melodic-devel
* fixed Doxygen Client Namespaces
* refactoring client namespaces names
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Added Readme's to Client Library
* Merge branch 'master' into melodic-devel
* lord microstrain client, subscriber component
* Contributors: Pablo Iñigo Blasco, Pabo Iñigo Blasco, brettpac, pablo.inigo.blasco
* Merge branch 'master' into melodic-devel
* fixed Doxygen Client Namespaces
* refactoring client namespaces names
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Added Readme's to Client Library
* Merge branch 'master' into melodic-devel
* lord microstrain client, subscriber component
* Contributors: Pablo Iñigo Blasco, Pabo Iñigo Blasco, brettpac, pablo.inigo.blasco
```

## move_base_z_client_plugin

```
* Initial SMACC version
* Contributors: Pablo Iñigo Blasco
```

## move_eye_client

```
* move_eye package
* Contributors: Pabo Iñigo Blasco
* move_eye package
* Contributors: Pabo Iñigo Blasco
* move_eye package
* Contributors: Pabo Iñigo Blasco
* move_eye package
* Contributors: Pabo Iñigo Blasco
```

## move_group_interface_client

```
* progress on cubes collisions
* adding threads to moveit client behaviors
* some improvements in move_group_interface_client and examples
* improving sm_moveit
* improving move it clients known-states and also adding the joint_state_viewer.launch
* progressing in sm moveit client behavior known states
* adding some code related with move z client
* adding set named target moveit_z_clent funcionality
* Major Merge -> now master is unstable melodic-branch
* minor improvements in moveit cartesian behaviors
* progressing in melodic
* Merge branch 'feature/moving_melodic' into melodic-devel
* Merge branch 'master' into melodic-devel
* some changes for melodic
* some improvements in move_group_interface_client and other fixes
* fixing smacc_viewer in melodic
* testing the move joint behaviors
* refactoring names and fixing broken build
* progressing in moveit behaviors
* improving sm_moveit demo
* fixing functioning in moveit example
* trying to improve the example
* fixing broken build
* refactoring sm_moveit example, and creating library sm_moveit_z
* Contributors: Pablo Iñigo Blasco, Pabo Iñigo Blasco, Unknown, pablo.inigo.blasco, pibgeus
* progress on cubes collisions
* adding threads to moveit client behaviors
* some improvements in move_group_interface_client and examples
* improving sm_moveit
* improving move it clients known-states and also adding the joint_state_viewer.launch
* progressing in sm moveit client behavior known states
* adding some code related with move z client
* adding set named target moveit_z_clent funcionality
* Major Merge -> now master is unstable melodic-branch
* minor improvements in moveit cartesian behaviors
* progressing in melodic
* Merge branch 'feature/moving_melodic' into melodic-devel
* Merge branch 'master' into melodic-devel
* some changes for melodic
* some improvements in move_group_interface_client and other fixes
* fixing smacc_viewer in melodic
* testing the move joint behaviors
* refactoring names and fixing broken build
* progressing in moveit behaviors
* improving sm_moveit demo
* fixing functioning in moveit example
* trying to improve the example
* fixing broken build
* refactoring sm_moveit example, and creating library sm_moveit_z
* Contributors: Pablo Iñigo Blasco, Pabo Iñigo Blasco, Unknown, pablo.inigo.blasco, pibgeus
```

## multirole_sensor_client

```
* Initial SMACC version
* Contributors: Pablo Iñigo Blasco
```

## pure_spinning_local_planner

```
* Major Merge -> now master is unstable melodic-branch
* fixing sm_moveit demo for melodic and creating pure spinning local planner
* Merge branch 'master' into melodic-devel
* large refactoring in navigation planners and behaviors to improve quality
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Redoing Client Namespaces
* Merge branch 'master' into melodic-devel
* fixing fmottion bug and planners config
* unpushed code
* Contributors: Pablo Iñigo Blasco, Pabo Iñigo Blasco, Unknown, brettpac, pablo.inigo.blasco
* Major Merge -> now master is unstable melodic-branch
* fixing sm_moveit demo for melodic and creating pure spinning local planner
* Merge branch 'master' into melodic-devel
* large refactoring in navigation planners and behaviors to improve quality
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Redoing Client Namespaces
* Merge branch 'master' into melodic-devel
* fixing fmottion bug and planners config
* unpushed code
* Contributors: Pablo Iñigo Blasco, Pabo Iñigo Blasco, Unknown, brettpac, pablo.inigo.blasco
```

## ros_publisher_client

```
* Merge branch 'master' into melodic-devel
* fixed Doxygen Client Namespaces
* refactoring client namespaces names
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Added Readme's to Client Library
* Merge branch 'master' into melodic-devel
* unpushed code
* second pass refactoring namespaces
* more refactoring/renaming and refining examples
* ros publisher client
* segregating ros_publisher_client
* Contributors: Pablo Iñigo Blasco, Pabo Iñigo Blasco, brettpac, pablo.inigo.blasco
* Merge branch 'master' into melodic-devel
* fixed Doxygen Client Namespaces
* refactoring client namespaces names
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Added Readme's to Client Library
* Merge branch 'master' into melodic-devel
* unpushed code
* second pass refactoring namespaces
* more refactoring/renaming and refining examples
* ros publisher client
* segregating ros_publisher_client
* Contributors: Pablo Iñigo Blasco, Pabo Iñigo Blasco, brettpac, pablo.inigo.blasco
```

## ros_timer_client

```
* Merge branch 'master' into melodic-devel
* fixed Doxygen Client Namespaces
* refactoring client namespaces names
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Added Readme's to Client Library
* Merge branch 'master' into melodic-devel
* improving/fixing bugs on smacc signals related with the smacc objects life-time. Also clients improved in the related to this.
* standarizing private/public access to state machine reference, current state, clients, etc
* unpushed code
* more refactoring and renaming examples and namespaces
* progressing in the API and testing timers and callbacks
* ros timer client behaviors, refactoring sm_atomic and logic unit hierarchy. other improvements on rosout
* renaming move_base client to ClMoveBaseZ (zorro)
* more on refactoring renaming
* fixing broken build related with C++11/14 build for package ros_timer_client
* ros_timer_client refactoring
* Contributors: Pablo Iñigo Blasco, Pabo Iñigo Blasco, brettpac, pablo.inigo.blasco
```

## sm_atomic

```
* creating feature smacc_runtime test
* Merge branch 'master' into melodic-devel
* adding xterm dependency to examples
* Final CbTimer Push
* Merge branch 'master' into melodic-devel
* fixed Doxygen Client Namespaces
* refactoring client namespaces names
* Merge branch 'master' into melodic-devel
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Update README.md
* sm_atomic diagrams
* Update README.md
* Update README.md
* Update README.md
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Improved sm_atomic
* more formatting & commenting
* renaming runtimeConfiguration to runtimeConfigure
* pushing renaming of runtimeConfigure
* more on smacc behaviors
* Changed static_configure to configure_orthogonal
* unpushed code
* Replaced all smacc::transition's with Transition
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Update README.md
* Update README.md
* Adding sm images
* Update README.md
* Update README.md
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Update README.md
* adding launch file to sm_atomic
* Renaming transition
* sm dance bot and refactoring namings
* namespaces iteration 3, orthogonal recurrent pattern, more tsts on sm_dance_bot_2
* more refactoring and renaming examples and namespaces
* progressing in the API and testing timers and callbacks
* ros timer client behaviors, refactoring sm_atomic and logic unit hierarchy. other improvements on rosout
* Update README.md
* Update README.md
* Update README.md
* Update README.md
* Update README.md
* Update README.md
* Create README.md
* more naming refactoring in move_base_z_client
* renaming move_base client to ClMoveBaseZ (zorro)
* renaming orthogonals
* more on refactoring renaming
* adding object tagging to clients, specifically action clients
* renaming consistently SmAtomic
* testing countdown logic unit more refactoring and analyzing propagating issue
* Contributors: Brett Aldrich, Pablo Iñigo Blasco, Pabo Iñigo Blasco, Unknown, Víctor Ferrer García, mailto:brett2@reelrobotics.com, brettpac, pablo.inigo.blasco, reelrbtx
* creating feature smacc_runtime test
* Merge branch 'master' into melodic-devel
* adding xterm dependency to examples
* Final CbTimer Push
* Merge branch 'master' into melodic-devel
* fixed Doxygen Client Namespaces
* refactoring client namespaces names
* Merge branch 'master' into melodic-devel
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Update README.md
* sm_atomic diagrams
* Update README.md
* Update README.md
* Update README.md
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Improved sm_atomic
* more formatting & commenting
* renaming runtimeConfiguration to runtimeConfigure
* pushing renaming of runtimeConfigure
* more on smacc behaviors
* Changed static_configure to configure_orthogonal
* unpushed code
* Replaced all smacc::transition's with Transition
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Update README.md
* Update README.md
* Adding sm images
* Update README.md
* Update README.md
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Update README.md
* adding launch file to sm_atomic
* Renaming transition
* sm dance bot and refactoring namings
* namespaces iteration 3, orthogonal recurrent pattern, more tsts on sm_dance_bot_2
* more refactoring and renaming examples and namespaces
* progressing in the API and testing timers and callbacks
* ros timer client behaviors, refactoring sm_atomic and logic unit hierarchy. other improvements on rosout
* Update README.md
* Update README.md
* Update README.md
* Update README.md
* Update README.md
* Update README.md
* Create README.md
* more naming refactoring in move_base_z_client
* renaming move_base client to ClMoveBaseZ (zorro)
* renaming orthogonals
* more on refactoring renaming
* adding object tagging to clients, specifically action clients
* renaming consistently SmAtomic
* testing countdown logic unit more refactoring and analyzing propagating issue
* Contributors: Brett Aldrich, Pablo Iñigo Blasco, Pabo Iñigo Blasco, Unknown, Víctor Ferrer García, mailto:brett2@reelrobotics.com, brettpac, pablo.inigo.blasco, reelrbtx
```

## sm_atomic_cb

```
* Merge branch 'master' into melodic-devel
* adding xterm dependency to examples
* Updated CbTimer CB function Comments
* Final CbTimer Push
* Contributors: Brett Aldrich, Unknown
* Merge branch 'master' into melodic-devel
* adding xterm dependency to examples
* Updated CbTimer CB function Comments
* Final CbTimer Push
* Contributors: Brett Aldrich, Unknown
```

## sm_atomic_services

```
* creating feature smacc_runtime test
* Merge branch 'master' into melodic-devel
* adding xterm dependency to examples
* Final CbTimer Push
* Merge branch 'master' into melodic-devel
* fixed Doxygen Client Namespaces
* refactoring client namespaces names
* Merge branch 'master' into melodic-devel
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Update README.md
* sm_atomic diagrams
* Update README.md
* Update README.md
* Update README.md
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Improved sm_atomic
* more formatting & commenting
* renaming runtimeConfiguration to runtimeConfigure
* pushing renaming of runtimeConfigure
* more on smacc behaviors
* Changed static_configure to configure_orthogonal
* unpushed code
* Replaced all smacc::transition's with Transition
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Update README.md
* Update README.md
* Adding sm images
* Update README.md
* Update README.md
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Update README.md
* adding launch file to sm_atomic
* Renaming transition
* sm dance bot and refactoring namings
* namespaces iteration 3, orthogonal recurrent pattern, more tsts on sm_dance_bot_2
* more refactoring and renaming examples and namespaces
* progressing in the API and testing timers and callbacks
* ros timer client behaviors, refactoring sm_atomic and logic unit hierarchy. other improvements on rosout
* Update README.md
* Update README.md
* Update README.md
* Update README.md
* Update README.md
* Update README.md
* Create README.md
* more naming refactoring in move_base_z_client
* renaming move_base client to ClMoveBaseZ (zorro)
* renaming orthogonals
* more on refactoring renaming
* adding object tagging to clients, specifically action clients
* renaming consistently SmAtomic
* testing countdown logic unit more refactoring and analyzing propagating issue
* Contributors: Brett Aldrich, Pablo Iñigo Blasco, Pabo Iñigo Blasco, Unknown, Víctor Ferrer García, mailto:brett2@reelrobotics.com, brettpac, pablo.inigo.blasco, reelrbtx
* creating feature smacc_runtime test
* Merge branch 'master' into melodic-devel
* adding xterm dependency to examples
* Final CbTimer Push
* Merge branch 'master' into melodic-devel
* fixed Doxygen Client Namespaces
* refactoring client namespaces names
* Merge branch 'master' into melodic-devel
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Update README.md
* sm_atomic diagrams
* Update README.md
* Update README.md
* Update README.md
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Improved sm_atomic
* more formatting & commenting
* renaming runtimeConfiguration to runtimeConfigure
* pushing renaming of runtimeConfigure
* more on smacc behaviors
* Changed static_configure to configure_orthogonal
* unpushed code
* Replaced all smacc::transition's with Transition
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Update README.md
* Update README.md
* Adding sm images
* Update README.md
* Update README.md
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Update README.md
* adding launch file to sm_atomic
* Renaming transition
* sm dance bot and refactoring namings
* namespaces iteration 3, orthogonal recurrent pattern, more tsts on sm_dance_bot_2
* more refactoring and renaming examples and namespaces
* progressing in the API and testing timers and callbacks
* ros timer client behaviors, refactoring sm_atomic and logic unit hierarchy. other improvements on rosout
* Update README.md
* Update README.md
* Update README.md
* Update README.md
* Update README.md
* Update README.md
* Create README.md
* more naming refactoring in move_base_z_client
* renaming move_base client to ClMoveBaseZ (zorro)
* renaming orthogonals
* more on refactoring renaming
* adding object tagging to clients, specifically action clients
* renaming consistently SmAtomic
* testing countdown logic unit more refactoring and analyzing propagating issue
* Contributors: Brett Aldrich, Pablo Iñigo Blasco, Pabo Iñigo Blasco, Unknown, Víctor Ferrer García, mailto:brett2@reelrobotics.com, brettpac, pablo.inigo.blasco, reelrbtx
```

## sm_calendar_week

```
* Initial SMACC version
* Contributors: Pablo Iñigo Blasco
```

## sm_coretest_transition_speed_1

```
* moved /test folder to top-level
* Contributors: Brett Aldrich
* moved /test folder to top-level
* Contributors: Brett Aldrich
```

## sm_coretest_x_y_1

```
* moved /test folder to top-level
* Contributors: Brett Aldrich
* moved /test folder to top-level
* Contributors: Brett Aldrich
```

## sm_coretest_x_y_2

```
* moved /test folder to top-level
* Contributors: Brett Aldrich
* moved /test folder to top-level
* Contributors: Brett Aldrich
```

## sm_coretest_x_y_3

```
* moved /test folder to top-level
* Contributors: Brett Aldrich
* moved /test folder to top-level
* Contributors: Brett Aldrich
```

## sm_dance_bot

```
* Initial SMACC version
* Contributors: Pablo Iñigo Blasco, mailto:brett2@reelrobotics.com, reelrbtx
```

## sm_dance_bot_2

```
* Initial SMACC version
* Contributors: Pablo Iñigo Blasco, mailto:brett2@reelrobotics.com, reelrbtx
```

## sm_dance_bot_strikes_back

```
* Initial SMACC version
* Contributors: Pablo Iñigo Blasco, mailto:brett2@reelrobotics.com, reelrbtx
```

## sm_ferrari

```
* Initial SMACC version
* Contributors: Pablo Iñigo Blasco
```

## sm_fetch_screw_loop_1

```
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* sm_fetch_screw_loop_1
* Contributors: Brett Aldrich, Pablo Iñigo Blasco
```

## sm_fetch_six_table_pick_n_sort_1

```
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* sm_fetch_six_table_pick_n_sort_1
* Contributors: Brett Aldrich, Pablo Iñigo Blasco
```

## sm_fetch_two_table_pick_n_place_1

```
* improving opencv2 box detection and also restoring sm_fetch_two_table_pick_n_place_1 example
* Added sm_fetch_two_table_pick_n_place_1_2
* improving sm_fetch_two_table_pick_n_place_1
* improving move it clients known-states and also adding the joint_state_viewer.launch
* progressing in sm moveit client behavior known states
* Merge branch 'master' into melodic-devel
* minor fix in smacc_base and improving the funcioning of the sm_fetch_two_table_pick_n_place_1 demo
* Merge branch 'master' into melodic-devel
* adding xterm dependency and adding scrollbars
* adding xterm dependency to examples
* updated sm_fetch_two_table_pick_n_place_1 readme
* Major Merge -> now master is unstable melodic-branch
* fixing sm_fetch_two_table_pick_n_place_1 demo for melodic and creating pure spinning local planner
* improing sm_fetch_two_table_pick_n_place_1 demo
* preparing examples for debian files
* minor workaround
* preparing examples for debian files
* progressing in melodic
* fixing demos
* Merge branch 'feature/moving_melodic' into melodic-devel
* Merge branch 'master' into melodic-devel
* some changes for melodic
* some improvements in move_group_interface_client and other fixes
* fixing smacc_viewer in melodic
* minor change
* Cleaning up Warnings
* minor changes
* testing the move joint behaviors
* refactoring names and fixing broken build
* progressing in moveit behaviors
* refining demo
* more work on demo
* improving sm_fetch_two_table_pick_n_place_1 demo
* fixing functioning in moveit example
* trying to improve the example
* fixing broken build
* refactoring sm_fetch_two_table_pick_n_place_1 example, and creating library sm_fetch_two_table_pick_n_place_1_z
* progressing in moveit example
* fixing broken build
* progressing in the moveit example, some refactoring in Pose Component. Adding also new funcionality for createNamedComponents, now components can be named and not just identified by its type. For example we can have two different Pose components in one single client
* build fix
* progress in moveit example
* initials for the moveit smacc demo
* Contributors: Brett Aldrich, Pablo Iñigo Blasco, Pabo Iñigo Blasco, Unknown, brettpac, pablo.inigo.blasco
* improving opencv2 box detection and also restoring sm_fetch_two_table_pick_n_place_1 example
* Added sm_fetch_two_table_pick_n_place_1_2
* improving sm_fetch_two_table_pick_n_place_1
* improving move it clients known-states and also adding the joint_state_viewer.launch
* progressing in sm moveit client behavior known states
* Merge branch 'master' into melodic-devel
* minor fix in smacc_base and improving the funcioning of the sm_fetch_two_table_pick_n_place_1 demo
* Merge branch 'master' into melodic-devel
* adding xterm dependency and adding scrollbars
* adding xterm dependency to examples
* updated sm_fetch_two_table_pick_n_place_1 readme
* Major Merge -> now master is unstable melodic-branch
* fixing sm_fetch_two_table_pick_n_place_1 demo for melodic and creating pure spinning local planner
* improing sm_fetch_two_table_pick_n_place_1 demo
* preparing examples for debian files
* minor workaround
* preparing examples for debian files
* progressing in melodic
* fixing demos
* Merge branch 'feature/moving_melodic' into melodic-devel
* Merge branch 'master' into melodic-devel
* some changes for melodic
* some improvements in move_group_interface_client and other fixes
* fixing smacc_viewer in melodic
* minor change
* Cleaning up Warnings
* minor changes
* testing the move joint behaviors
* refactoring names and fixing broken build
* progressing in moveit behaviors
* refining demo
* more work on demo
* improving sm_fetch_two_table_pick_n_place_1 demo
* fixing functioning in moveit example
* trying to improve the example
* fixing broken build
* refactoring sm_fetch_two_table_pick_n_place_1 example, and creating library sm_fetch_two_table_pick_n_place_1_z
* progressing in moveit example
* fixing broken build
* progressing in the moveit example, some refactoring in Pose Component. Adding also new funcionality for createNamedComponents, now components can be named and not just identified by its type. For example we can have two different Pose components in one single client
* build fix
* progress in moveit example
* initials for the moveit smacc demo
* Contributors: Brett Aldrich, Pablo Iñigo Blasco, Pabo Iñigo Blasco, Unknown, brettpac, pablo.inigo.blasco
```

## sm_fetch_two_table_whiskey_pour

```
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* sm_moveit_screw_loop
* Contributors: Brett Aldrich, Pablo Iñigo Blasco
```

## sm_packml

```
* Initial SMACC version
* Contributors: Pablo Iñigo Blasco
```

## sm_respira_1

```
* Initial SMACC version
* Contributors: Pablo Iñigo Blasco
```

## sm_ridgeback_barrel_search_1

```
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Changing waypoints in sm_ridgeback_barrel_search_1
* improving opencv2 box detection and also restoring sm_moveit example
* fixing some visual issue in smacc opencv2 demo
* Merge branch 'master' into melodic-devel
* progress in opencv2 example
* missing reference
* Merge branch 'master' into melodic-devel
* fixing opencv demos and other minor issues
* Merge branch 'master' into melodic-devel
* adding xterm dependency and adding scrollbars
* adding xterm dependency to examples
* improving opencv example state machines with the debug image showing the rectangle of the detected object
* Added Readme's to OpenCV SM's
* Began to implement new folder structure
* Renaming OpenCV Perception Node Mains
* Tweaking OpenCV SM's
* New OpenCV based SM's
* Contributors: Brett Aldrich, Pablo Iñigo Blasco, Unknown, pablo.inigo.blasco, pibgeus
```

## sm_ridgeback_barrel_search_2

```
* Added gazebo camera changes to sm_opencv and sm_ridgeback_barrel_search_2
* Merge branch 'master' into melodic-devel
* fixing opencv demos and other minor issues
* Merge branch 'master' into melodic-devel
* adding xterm dependency and adding scrollbars
* adding xterm dependency to examples
* improving opencv example state machines with the debug image showing the rectangle of the detected object
* Added Readme's to OpenCV SM's
* Began to implement new folder structure
* Renaming OpenCV Perception Node Mains
* Tweaking OpenCV SM's
* New OpenCV based SM's
* Contributors: Brett Aldrich, Pabo Iñigo Blasco, Unknown, pablo.inigo.blasco
```

## sm_starcraft_ai

```
* Initial SMACC version
* Contributors: Pablo Iñigo Blasco
```

## sm_subscriber

```
* melodic-master
* updating melodic fix
* code format melodic
* better subscribers client behaviors
* Contributors: pabloinigoblasco
```

## sm_three_some

```
* Initial SMACC version
* Contributors: Pablo Iñigo Blasco
```

## sm_update_loop

```
* Merge branch 'master' into melodic-devel
* adding xterm dependency to examples
* More CbTimer Updating
* cbtimer cleanup
* Merge branch 'master' into melodic-devel
* sm_update_loop renaming
* Contributors: Brett Aldrich, Unknown, brettpac, pablo.inigo.blasco
* Merge branch 'master' into melodic-devel
* adding xterm dependency to examples
* More CbTimer Updating
* cbtimer cleanup
* Merge branch 'master' into melodic-devel
* sm_update_loop renaming
* Contributors: Brett Aldrich, Unknown, brettpac, pablo.inigo.blasco
```

## sm_viewer_sim

```
* Initial SMACC version
* Contributors: Pablo Iñigo Blasco
```

## smacc

```
* Progressing on transition log
* dynamic behavior
* progress on viewer, modestates and history mode
* smacc megastate example
* missing changes on previous commit
* more improvements on status message on the viewer and the smacc core
* some stable version of the viewer, code cleaning, fixes on dancebot
* progress in the viewer, creating a new concept of transition tag
* progress in the viewer
* SMACC improvements on the viewer and loop branching funcionality
* progressing in the smacc viewer
* fixing logic units event source information
* progressing in viewer and metainformation
* progressing in the viewer and adding more metaknoledge about triggering events of logic units
* progress in the viewer and examples
* fixing eveng aggregator compilation issue
* more fixings and progressing to the smacc_viewer
* recurrent pattern for sensors and substate behaviors
* template recurrent pattern, string type walker, showing string for smacc viewer
* adding transition file
* moving behavior creation of sm_dance_bot to static staticConfigure
* action client moving to event convention Ev<TSource>
* logic units, better output of the state machine knowledge at the startup
* StateTransition info structure
* creating static staticConfigure functionality
* removing obsolete state funcionality
* broken build orthogonal fix
* changes on architecture, orthogonal role, client role and component role changes, fixing all examples
* adding service client
* smacc_msgs dependencies
* smacc_msgs dependencies
* gh-pages travis
* ff pattern and spattern first implementation
* fixing build
* testing status message, creation of rviz display plugin, refactoring of sm_dance_bot.launch to make it lightweight, readme.md for launching
* adding SmaccStatus message funcionality
* PackML inspired funcionalities for SM: stop, estop, reset
* several improvements: adding topicPublisherClient, fixing install build, further testing of sm_dance_bot on install workspace
* adding publisher client
* working on fixing travis build
* working on fixing travis
* superstates improving the viewer for the dance_bot
* many core fixes and refactorings, substate behavior destroying, dance_bot keyboard separated in two files, topic sensor separated in two files too for the client and the substate behavior
* progressing on keyboard
* introducing the client concept and moving smacc topic subscriber to the smacc 'core' package
* ClMultiroleSensor and TopicSubscriber
* detaching substatebehaviors from component and renaming class refactoring
* making smacc_viewer run and also refactoring smacc_state_info headers
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* minor changes
* Minor commenting edits
* more improvements on sensor topics keyboard events, and architecture improvements
* refactoring smacc substate behaviors and states
* changes on code
* better rosout and some progress on sm_dance_bot and fixing travis build
* runtime testing of examples
* hard renaming - namming convention - initial integration of smach_viewer
* Folder Renaming
* SMACC building
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* fixing smacc for melodic
* c++11 for indigo in some projects
* Merge branch 'master' into indigo-devel
* removing boost demangle dependency to make build indigo
* makin build SMACC for indigo
* Merge branch 'master' into indigo-devel
* merge on melodic
* updating backward and forward local planners
* Merge remote-tracking branch 'origin/master' into melodic-devel
* Merge branch 'master' into indigo-devel
* updating cmakelists
* Merge branch 'master' of https://github.com/pabloinigoblasco/SMACC
* Merge pull request #1 <https://github.com/reelrbtx/SMACC/issues/1> from reelrbtx/master
  merging
* smacc improvements
* minor
* navigation improvements and syntax improvements in example
* final waypoints tests
* progress on waypoints
* renaming getglobalData setGlobalData
* authory in code files and more in documentation
* important refactoring and fixes, and the creation of the radial_motion example
* syntax improvement to remove the context from smacc code
* adapting to the smacc requiresComponent method refactoring
* refactoring smacc to support other kind of plugins beyond actionclients, such as the odom tracker, also ading a custom radial_motion_example independent to the reel
* refactoring SMACC to contain navigation plugins
* adding planners to SMACC
* package version
* package.xml format
* adding feedback message information to feedback events
* syntax improvement for better action result reaction
* some refactoring on smacc code
* more on documentation
* fixing ros parameters
* Tool orthogonal line and wiki documentation
* cleaning and refactoring smacc library
* adding tool orthogonal line
* Adapting to smacc feedback message improvemnts. Now, the transitions reacts on these action feedback messages, instead of action results
* minor changes on radial motion sample
* feedback message support
* refactoring, renamings, documenting smacc
* some more on style
* more comments and style
* some more comments
* large refactoring of the smacc example code and comments
* minor
* initial version of radial motion example
* going forward to radial example
* minor to show some example
* going forward to smacc
* minor fixes
* initials on smacc
* Moved SMACC to it's own repo..
* Contributors: Pablo Inigo Blasco, Pablo Iñigo Blasco, mailto:brett2@reelrobotics.com, brettpac, travis
```

## smacc_msgs

```
* removing error changelog
* Contributors: Pablo Iñigo Blasco
* removing error changelog
* Contributors: Pablo Iñigo Blasco
```

## smacc_runtime_test

```
* melodic-master
* code format melodic
* fixing some package xmls
* fixing build with catkin_make
* updating melodic
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* creating feature smacc_runtime test
* Contributors: Pablo Iñigo Blasco, Pabo Iñigo Blasco, pabloinigoblasco
```

## smacc_rviz_plugin

```
* Progressing on transition log
* progress on viewer, modestates and history mode
* progress in the viewer and examples
* Merge branch 'master' of https://github.com/reelrbtx/SMACC
* Added SMACC thumbnail for RViz Plugin
* creating four rays for dance_bot and media folder missing
* fixing-moving from cxx version from 17 to 14
* fixing build
* missing file
* testing status message, creation of rviz display plugin, refactoring of sm_dance_bot.launch to make it lightweight, readme.md for launching
* Contributors: Pablo Iñigo Blasco, mailto:brett2@reelrobotics.com
```

## sr_all_events_go

```
* Initial SMACC version
* Contributors: Pablo Iñigo Blasco
```

## sr_conditional

```
* Renamed sr_conditional & eg_random_generator
* Contributors: Brett Aldrich
* Renamed sr_conditional & eg_random_generator
* Contributors: Brett Aldrich
* Renamed sr_conditional & eg_random_generator
* Contributors: Brett Aldrich
* Renamed sr_conditional & eg_random_generator
* Contributors: Brett Aldrich
```

## sr_event_countdown

```
* Renamed event_countdown to sr_event_countdown
* Contributors: Brett Aldrich
* Renamed event_countdown to sr_event_countdown
* Contributors: Brett Aldrich
```

## undo_path_global_planner

```
* Initial SMACC version
* Contributors: Pablo Iñigo Blasco
```
