### PR TITLE
rcl_logging: 2.4.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3493,7 +3493,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 2.4.2-1
+      version: 2.4.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `2.4.3-1`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.4.2-1`

## rcl_logging_interface

```
* Updated maintainers - 2022-11-07 (#96 <https://github.com/ros2/rcl_logging/issues/96>)
* Contributors: Audrow Nash
```

## rcl_logging_noop

```
* Updated maintainers - 2022-11-07 (#96 <https://github.com/ros2/rcl_logging/issues/96>)
* Contributors: Audrow Nash
```

## rcl_logging_spdlog

```
* change flushing behavior for spdlog log files, and add env var to use old style (no explicit flushing) (#95 <https://github.com/ros2/rcl_logging/issues/95>)
  * now flushes every ERROR message and periodically every 5 seconds
  * can set ``RCL_LOGGING_SPDLOG_EXPERIMENTAL_OLD_FLUSHING_BEHAVIOR=1`` to get old behavior
* Updated maintainers - 2022-11-07 (#96 <https://github.com/ros2/rcl_logging/issues/96>)
* Contributors: Audrow Nash, William Woodall
```
