### PR TITLE
realtime_tools: 2.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3664,7 +3664,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 2.2.0-2
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `2.4.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.0-2`

## realtime_tools

```
* bug fix for RealtimePublisher with NON_POLLING (#85 <https://github.com/ros-controls/realtime_tools/issues/85>)
* ci: :construction_worker: update rhel container (#92 <https://github.com/ros-controls/realtime_tools/issues/92>)
* Make thread_priority a shared library (#91 <https://github.com/ros-controls/realtime_tools/issues/91>)
* Contributors: Andy Zelenak, Jaron Lundwall, Yoav Fekete, Denis Štogl
```
