### PR TITLE
Add socat entry for rhel

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7487,6 +7487,7 @@ socat:
   fedora: [socat]
   gentoo: [net-misc/socat]
   nixos: [socat]
+  rhel: [socat]
   ubuntu: [socat]
 sound-theme-freedesktop:
   debian: [sound-theme-freedesktop]


### PR DESCRIPTION
Since `socat` already exists inside the rosdep/base, I'll skip most of the template. I hope, that's fine.

## Package name:

socat

## Purpose of using this:

We use it in the ur_robot_driver as a runtime dependency since 2.2.5, see #35373 

## Links to Distribution Packages

Since I'm only adding the entry for rhel, I only provide the link for rhel

- rhel: https://centos.pkgs.org/8-stream/centos-appstream-x86_64/socat-1.7.4.1-1.el8.x86_64.rpm.html
