### PR TITLE
marvelmind_nav: 1.0.13-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4975,7 +4975,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/MarvelmindRobotics/marvelmind_nav-release.git
-      version: 1.0.11-1
+      version: 1.0.13-1
     source:
       type: git
       url: https://bitbucket.org/marvelmind_robotics/ros_marvelmind_package.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marvelmind_nav` to `1.0.13-1`:

- upstream repository: https://bitbucket.org/marvelmind_robotics/ros_marvelmind_package
- release repository: https://github.com/MarvelmindRobotics/marvelmind_nav-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.11-1`

## marvelmind_nav

- No changes
