### PR TITLE
ros_foxglove_bridge: 0.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8712,6 +8712,14 @@ repositories:
       url: https://github.com/shadow-robot/ros_ethercat_eml.git
       version: noetic-devel
     status: maintained
+  ros_foxglove_bridge:
+    release:
+      packages:
+      - foxglove_bridge
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/foxglove/ros_foxglove_bridge-release.git
+      version: 0.1.0-1
   ros_ign:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_foxglove_bridge` to `0.1.0-1`:

- upstream repository: https://github.com/foxglove/ros-foxglove-bridge.git
- release repository: https://github.com/foxglove/ros_foxglove_bridge-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## foxglove_bridge

```
* Initial release, topic subscription only
```
