### PR TITLE
Add pip3 simplification package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8795,6 +8795,16 @@ python3-simplejson:
   nixos: [python3Packages.simplejson]
   openembedded: [python3-simplejson@meta-python]
   ubuntu: [python3-simplejson]
+python3-simplification-pip:
+  debian:
+    pip:
+      packages: [simplification]
+  fedora:
+    pip:
+      packages: [simplification]
+  ubuntu:
+    pip:
+      packages: [simplification]
 python3-sip:
   debian: [python3-sip-dev]
   fedora: [python3-sip-devel]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

pip/pip3 simplification

## Package Upstream Source:

https://github.com/urschrei/simplification

## Purpose of using this:

This dependency is used to simplify a LineString using the [Ramer–Douglas–Peucker](https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm) or [Visvalingam-Whyatt](https://bost.ocks.org/mike/simplify/) algorithms.


## Links to Distribution Packages

- Pip: https://pypi.org/project/simplification/
