### PR TITLE
Add libmbedtls-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4135,6 +4135,7 @@ libmarble-dev:
   gentoo: [kde-base/marble]
   ubuntu: [libmarble-dev]
 libmbedtls-dev:
+  debian: [libmbedtls-dev]
   ubuntu: [libmbedtls-dev]
 libmicrohttpd:
   debian: [libmicrohttpd-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4134,6 +4134,8 @@ libmarble-dev:
   fedora: [marble-widget-qt5-devel]
   gentoo: [kde-base/marble]
   ubuntu: [libmarble-dev]
+libmbedtls-dev:
+  ubuntu: [libmbedtls-dev]
 libmicrohttpd:
   debian: [libmicrohttpd-dev]
   fedora: [libmicrohttpd-devel]


### PR DESCRIPTION
## Purpose of using this:

OPCUA is a common protocol used in industry. There's also a ROS package, [ros_opcua_communication](https://github.com/iirob/ros_opcua_communication) which used [freeopcua](https://github.com/FreeOpcUa/freeopcua) internally. The library libmbedtls-dev is required as mentioned [here](https://github.com/FreeOpcUa/freeopcua/issues/326) which is mandatory to build the freeopcua and ros_opcua_communication accordingly.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - [libmbedtls-dev](https://packages.debian.org/bullseye/libmbedtls-dev)
- Ubuntu: https://packages.ubuntu.com/
   - [libmbedtls-dev](https://packages.ubuntu.com/jammy/libmbedtls-dev)
- Fedora: https://packages.fedoraproject.org/
  - not available
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available
- openSUSE: https://software.opensuse.org/package/
  - not available
