### PR TITLE
Renamed branch from master to rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1159,7 +1159,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git
-      version: master
+      version: rolling
     release:
       packages:
       - fmi_adapter
@@ -1171,7 +1171,7 @@ repositories:
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git
-      version: master
+      version: rolling
     status: maintained
   fmilibrary_vendor:
     release:
@@ -1182,7 +1182,7 @@ repositories:
     source:
       type: git
       url: https://github.com/boschresearch/fmilibrary_vendor.git
-      version: master
+      version: rolling
     status: maintained
   foonathan_memory_vendor:
     release:


### PR DESCRIPTION
Renamed branch of fmi_adapter and fmilibrary_vendor from master to rolling.