### PR TITLE
imu_pipeline: 0.2.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4791,7 +4791,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/imu_pipeline-release.git
-      version: 0.2.3-0
+      version: 0.2.4-1
     source:
       type: git
       url: https://github.com/ros-perception/imu_pipeline.git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_pipeline` to `0.2.4-1`:

- upstream repository: https://github.com/ros-perception/imu_pipeline
- release repository: https://github.com/ros-gbp/imu_pipeline-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.3-0`

## imu_pipeline

```
* Updated to package.xml format 2.
* Contributors: Tony Baltovski
```

## imu_processors

```
* Updated to package.xml format 2.
* Contributors: Tony Baltovski
```

## imu_transformer

```
* imu_transformer: Fix transformation of the orientation of IMU.
  The previous computation was wrong. According to REP-145, IMU orientation should express attitude of the sensor frame in a world frame. imu_transformer changes the sensor frame, so it should just recompute the new attitude by transforming the old sensor frame into the new one.
* Updated to package.xml format 2.
* Contributors: Martin Pecka, Tony Baltovski
```
