### PR TITLE
leo_examples: 0.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4548,7 +4548,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_examples-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_examples.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_examples` to `0.1.1-1`:

- upstream repository: https://github.com/LeoRover/leo_examples.git
- release repository: https://github.com/fictionlab-gbp/leo_examples-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.0-1`

## leo_example_follow_ar_tag

```
* Merge branch 'master' of github.com:LeoRover/leo_examples
* Change default marker size
* Contributors: Piotr Szlachcic
```

## leo_example_line_follower

```
* fixed grammar errors in package.xml descriptions for object_detection and line_follower packages
* Contributors: Aleksander Szymański
```

## leo_example_object_detection

```
* object_detection: object_detector: changed compression format of image_compressed to jpeg
* fixed grammar errors in package.xml descriptions for object_detection and line_follower packages
* Contributors: Aleksander Szymański
```

## leo_examples

```
* Fix image conversion
* Change default marker size
* Contributors: Piotr Szlachcic
```
