### PR TITLE
teleop_tools: 1.3.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6695,7 +6695,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros-gbp/teleop_tools-release.git
-      version: 1.2.1-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_tools` to `1.3.0-1`:

- upstream repository: https://github.com/ros-teleop/teleop_tools.git
- release repository: https://github.com/ros-gbp/teleop_tools-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.1-1`

## joy_teleop

```
* launch: fix deprecated attributes
* Fix some warnings from tests.
  In here are some flake8 fixes and fixes to the joy_teleop tests
  now that some of the error messages have changed.
* Allow a value type within an axis mapping. Useful for frame data.
* Add offsets to example yaml
* add ci & lint
* joy_teleop: convert current time to message type for timestamping
* Contributors: AndyZe, Chris Lalancette, Kazunari Tanaka, Marcel Zeilinger, Russ Webber
```

## key_teleop

```
* Fix some warnings from tests.
  In here are some flake8 fixes and fixes to the joy_teleop tests
  now that some of the error messages have changed.
* added ability to use twiststamped
* add ci & lint
* Add QoS profile to key_teleop publisher
* Contributors: Andreas Klintberg, Chris Lalancette, Kazunari Tanaka, nfry321
```

## mouse_teleop

```
* launch: fix deprecated attributes
* add ci & lint
* Contributors: Kazunari Tanaka, Russ Webber
```

## teleop_tools

- No changes

## teleop_tools_msgs

- No changes
