### PR TITLE
aruco_ros: 2.2.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -299,7 +299,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/pal-gbp/aruco_ros-release.git
-      version: 2.2.1-1
+      version: 2.2.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/aruco_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_ros` to `2.2.2-1`:

- upstream repository: https://github.com/pal-robotics/aruco_ros.git
- release repository: https://github.com/pal-gbp/aruco_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.1-1`

## aruco

```
* Merge branch 'fix/109/ferrum/cornerupsample' into 'ferrum-devel'
  Fix/109/ferrum/cornerupsample
  See merge request ros-overlays/aruco_ros!9
* Fix/109/ferrum/cornerupsample
* Contributors: josegarcia, saikishor
```

## aruco_msgs

- No changes

## aruco_ros

- No changes
