### PR TITLE
Add RHEL 9 rule for python3-opencv

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7859,6 +7859,10 @@ python3-opencv:
   nixos: [python3Packages.opencv3]
   openembedded: [opencv@meta-oe]
   opensuse: [python3-opencv]
+  rhel:
+    '*': [python3-opencv]
+    '7': null
+    '8': null
   ubuntu: [python3-opencv]
 python3-opengl:
   debian: [python3-opengl]


### PR DESCRIPTION
This package is currently available in RHEL 9 via EPEL: https://packages.fedoraproject.org/pkgs/opencv/python3-opencv/

It is not currently available for RHEL 7 or RHEL 8.