### PR TITLE
kaon_test: 0.0.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1769,6 +1769,23 @@ repositories:
       url: https://github.com/ros-drivers/joystick_drivers.git
       version: foxy-devel
     status: maintained
+  kaon_test:
+    doc:
+      type: git
+      url: https://github.com/LoVisHolic/kaon_test_public.git
+      version: galactic
+    release:
+      packages:
+      - py_pubsub
+      tags:
+        release: release/galactic/{package}/{version}
+      url: https://github.com/LoVisHolic/kaon_test-release.git
+      version: 0.0.0-1
+    source:
+      type: git
+      url: https://github.com/LoVisHolic/kaon_test.git
+      version: galactic
+    status: end-of-life
   kdl_parser:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kaon_test` to `0.0.0-1`:

- upstream repository: https://github.com/LoVisHolic/kaon_test.git
- release repository: https://github.com/LoVisHolic/kaon_test-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
