### PR TITLE
Add python3-libgpiod

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7430,6 +7430,20 @@ python3-lark-parser:
     '*': [python3-lark]
     bionic: [python3-lark-parser]
     xenial: [python3-lark-parser]
+python3-libgpiod:
+  alpine: [py3-libgpiod]
+  arch: [libgpiod]
+  debian: [python3-libgpiod]
+  fedora: [python3-libgpiod]
+  gentoo: [dev-libs/libgpiod]
+  nixos: [python3Packages.libgpiod]
+  opensuse: [python3-gpiod]
+  rhel:
+    '*': [python3-libgpiod]
+    '7': null
+  ubuntu:
+    '*': [python3-libgpiod]
+    bionic: null
 python3-lingua-franca-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-libgpiod

## Package Upstream Source:

https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git

## Purpose of using this:

Provides Python bindings to libgpiod (added in: https://github.com/ros/rosdistro/pull/29081).
The source is the same, however most distributions package it independently of the main `libgpiod-dev`.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/python3-libgpiod
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/source/jammy/libgpiod
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/libgpiod/python3-libgpiod/index.html
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/community/x86_64/libgpiod/
  - Note: in Arch, main `libgpiod` is packaged along with python bindings
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-libs/libgpiod
  - Note: requires `python` use flag
- macOS: https://formulae.brew.sh/
  - not available / not applicable
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/v3.16/community/x86_64/py3-libgpiod
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?query=python310packages.libgpiod
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python3-gpiod

