### PR TITLE
ign_ros2_control: 0.1.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1887,7 +1887,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 0.1.4-1
+      version: 0.1.5-1
     source:
       type: git
       url: https://github.com/ignitionrobotics/ign_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ign_ros2_control` to `0.1.5-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.4-1`

## ign_ros2_control

```
* Force setting use_sim_time parameter when using plugin. (#100 <https://github.com/ros-controls/gz_ros2_control//issues/100>) (#102 <https://github.com/ros-controls/gz_ros2_control//issues/102>)
  Co-authored-by: Denis Štogl <mailto:denis@stogl.de>
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Enable loading params from multiple yaml files (#94 <https://github.com/ros-controls/gz_ros2_control//issues/94>)
* Contributors: Alejandro Hernández Cordero
```

## ign_ros2_control_demos

```
* Fixed URIS (#93 <https://github.com/ros-controls/gz_ros2_control//issues/93>)
* Contributors: Alejandro Hernández Cordero
```
