### PR TITLE
behaviortree_cpp: 3.8.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -504,7 +504,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/BehaviorTree/behaviortree_cpp-release.git
-      version: 3.8.0-1
+      version: 3.8.1-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp` to `3.8.1-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/BehaviorTree/behaviortree_cpp-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.8.0-1`

## behaviortree_cpp_v3

```
* fix catkin installation #478 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/478>
* cherry picking changes from v4
* fix #227 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/227>
* fix issue #461 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/461>
* fix issue #413 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/413> (Delay logic)
* Update README.md
* Contributors: Davide Faconti
```
