### PR TITLE
ros2_control: 3.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4156,11 +4156,12 @@ repositories:
       - ros2_control
       - ros2_control_test_assets
       - ros2controlcli
+      - rqt_controller_manager
       - transmission_interface
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.3.0-1
+      version: 3.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.4.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.3.0-1`

## controller_interface

- No changes

## controller_manager

```
* Use a thread priority library from realtime_tools (#794 <https://github.com/ros-controls/ros2_control/issues/794>)
* [Doc] Correct type of update_rate parameter (#858 <https://github.com/ros-controls/ros2_control/issues/858>)
* Contributors: Andy Zelenak, Denis Štogl, Bence Magyar
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

```
* rqt controller manager ros 2 port (#813 <https://github.com/ros-controls/ros2_control/issues/813>)
* Contributors: Kenji Brameld
```

## transmission_interface

- No changes
