### PR TITLE
rosbag2_storage_mcap: 0.6.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4574,7 +4574,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2_storage_mcap-release.git
-      version: 0.5.0-1
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/ros-tooling/rosbag2_storage_mcap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2_storage_mcap` to `0.6.0-1`:

- upstream repository: https://github.com/ros-tooling/rosbag2_storage_mcap.git
- release repository: https://github.com/ros2-gbp/rosbag2_storage_mcap-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.5.0-1`

## mcap_vendor

```
* Fix Windows build (#73 <https://github.com/ros-tooling/rosbag2_storage_mcap/issues/73>)
  Update mcap version to newest windows-compatible release.
  Add visibility macros for tests.
  Add clang-format preprocessor indentation for visibility_control to be readable.
* Contributors: Emerson Knapp
```

## rosbag2_storage_mcap

```
* mcap_storage: 'none' is a valid storage preset profile (#86 <https://github.com/ros-tooling/rosbag2_storage_mcap/issues/86>)
* mcap_storage: handle update_metadata call (#83 <https://github.com/ros-tooling/rosbag2_storage_mcap/issues/83>)
* Update clang-format rules to fit ROS 2 style guide (#80 <https://github.com/ros-tooling/rosbag2_storage_mcap/issues/80>)
* Revert "read_order: throw exception from set_read_order for unsupported orders"
  This reverts commit aef9b9a65293f9e5d80a858ef84e485a8655a0c0.
* read_order: throw exception from set_read_order for unsupported orders
* Fix compile flags to work on rosbag_storage:0.17.x (#78 <https://github.com/ros-tooling/rosbag2_storage_mcap/issues/78>)
  This fixes the compile flags for rolling, which has two versions -- one that does not support read order (0.17.x) and one that does support read order (0.18.x).
* Fix Windows build (#73 <https://github.com/ros-tooling/rosbag2_storage_mcap/issues/73>)
  Update mcap version to newest windows-compatible release.
  Add visibility macros for tests.
  Add clang-format preprocessor indentation for visibility_control to be readable.
* Contributors: Andrew Symington, Emerson Knapp, James Smith, james-rms
```

## rosbag2_storage_mcap_testdata

- No changes
