### PR TITLE
Add geojson and kml2geojson pip packages

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6990,6 +6990,16 @@ python3-geographiclib:
     '*': [python3-GeographicLib]
     '7': null
   ubuntu: [python3-geographiclib]
+python3-geojson-pip:
+  debian:
+    pip:
+      packages: [geojson]
+  fedora:
+    pip:
+      packages: [geojson]
+  ubuntu:
+    pip:
+      packages: [geojson]
 python3-geomag-pip:
   debian:
     pip:
@@ -7414,6 +7424,16 @@ python3-kiwisolver:
     bionic:
       pip:
         packages: [kiwisolver]
+python3-kml2geojson-pip:
+  debian:
+    pip:
+      packages: [kml2geojson]
+  fedora:
+    pip:
+      packages: [kml2geojson]
+  ubuntu:
+    pip:
+      packages: [kml2geojson]
 python3-lark-parser:
   alpine: [py3-lark-parser]
   arch: [python-lark-parser]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6990,16 +6990,10 @@ python3-geographiclib:
     '*': [python3-GeographicLib]
     '7': null
   ubuntu: [python3-geographiclib]
-python3-geojson-pip:
-  debian:
-    pip:
-      packages: [geojson]
-  fedora:
-    pip:
-      packages: [geojson]
-  ubuntu:
-    pip:
-      packages: [geojson]
+python3-geojson:
+  debian: [python3-geojson]
+  fedora: [python3-geojson]
+  ubuntu: [python3-geojson]
 python3-geomag-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6991,8 +6991,10 @@ python3-geographiclib:
     '7': null
   ubuntu: [python3-geographiclib]
 python3-geojson:
+  arch: [python-geojson]
   debian: [python3-geojson]
   fedora: [python3-geojson]
+  opensuse: [python3-geojson]
   ubuntu: [python3-geojson]
 python3-geomag-pip:
   debian:


### PR DESCRIPTION
Please add the following dependencies to the rosdep database.

## Package name: `geojson`

python3-geojson

## Package Upstream Source:

https://github.com/jazzband/geojson

## Purpose of using this:

This dependency provides python functions for encoding and decoding [GeoJSON](http://geojson.org/) formatted data


## Links to Distribution Packages

- Arch: https://archlinux.org/packages/community/any/python-geojson/
- Debian: https://packages.debian.org/bullseye/python3-geojson
- Fedora: https://packages.fedoraproject.org/pkgs/python-geojson/python3-geojson/
- openSUSE: https://software.opensuse.org/package/python3-geojson?search_term=python3-geojson
- Ubuntu: https://packages.ubuntu.com/focal/python3-geojson

---

## Package name: `kml2geojson`

pip/pip3 kml2geojson

## Package Upstream Source:

https://gitlab.com/mrcagney/kml2geojson

## Purpose of using this:

This dependency is a Python library to covert KML files to GeoJSON files


## Links to Distribution Packages

- Pip: https://pypi.org/project/kml2geojson/

