### PR TITLE
depthai: 2.19.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -797,7 +797,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/luxonis/depthai-core-release.git
-      version: 2.19.0-1
+      version: 2.19.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai` to `2.19.1-1`:

- upstream repository: https://github.com/luxonis/depthai-core.git
- release repository: https://github.com/luxonis/depthai-core-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.19.0-1`

## depthai

```
* Added Device getDeviceName API
* OAK-FFC 4P (R5M1E5) IR/Dot support
* Additional Stability bugfixes to go along with 2.19.0 for PoE devices
* Protected productName field in EEPROM
* Contributors: Alex Bougdan, Szabolcs Gergely, Martin Peterlin
```
