### PR TITLE
ur_robot_driver: 2.2.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6399,7 +6399,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
-      version: main
+      version: humble
     release:
       packages:
       - ur
@@ -6416,7 +6416,7 @@ repositories:
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
-      version: main
+      version: humble
     status: developed
   urdf:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6412,7 +6412,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.2.5-1
+      version: 2.2.6-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.2.6-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.5-1`

## ur

- No changes

## ur_bringup

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* Ros2 controllers 2.14 (#547 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/547>)
* Contributors: Felix Exner
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

- No changes

## ur_robot_driver

```
* Cleanup humble branch (#545 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/545>)
* Contributors: Felix Exner (fexner)
```
