### PR TITLE
maliput: 1.0.9-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2529,7 +2529,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput-release.git
-      version: 1.0.8-1
+      version: 1.0.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput` to `1.0.9-1`:

- upstream repository: https://github.com/maliput/maliput.git
- release repository: https://github.com/ros2-gbp/maliput-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.8-1`

## maliput

```
* Provides default populated discrete and range value rule state providers. (#533 <https://github.com/maliput/maliput/issues/533>)
* Adds a default populated ManualPhaseProvider. (#530 <https://github.com/maliput/maliput/issues/530>)
* Maliput Plugin: Adds interface for providing default parameters from the backends (#532 <https://github.com/maliput/maliput/issues/532>)
* Contributors: Franco Cipollone
```
