### PR TITLE
simple_term_menu: 1.5.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5706,6 +5706,21 @@ repositories:
       url: https://github.com/oKermorgant/simple_launch.git
       version: devel
     status: maintained
+  simple_term_menu:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/simple-term-menu.git
+      version: humble
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/simple_term_menu-release.git
+      version: 1.5.2-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/simple-term-menu.git
+      version: humble
+    status: developed
   slam_toolbox:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_term_menu` to `1.5.2-1`:

- upstream repository: https://github.com/clearpathrobotics/simple-term-menu.git
- release repository: https://github.com/clearpath-gbp/simple_term_menu-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## simple_term_menu

```
* Initial ROS package
* Contributors: Roni Kreinin
```
