### PR TITLE
gps_umd: 0.3.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3177,7 +3177,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/gps_umd-release.git
-      version: 0.3.2-1
+      version: 0.3.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_umd` to `0.3.3-1`:

- upstream repository: https://github.com/swri-robotics/gps_umd.git
- release repository: https://github.com/swri-robotics-gbp/gps_umd-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.2-1`

## gps_common

```
* Fix truncation warning for UTM zone snprintf() (#44 <https://github.com/swri-robotics/gps_umd/issues/44>)
* Contributors: Kevin Hallenbeck
```

## gps_umd

- No changes

## gpsd_client

```
* Adding better debugging output to help diagnose corner case (#59 <https://github.com/swri-robotics/gps_umd/issues/59>)
  * Adding better debugging output to help diagnose corner case
  DISTRIBUTION A. Approved for public release; distribution unlimited. OPSEC #4584 <https://github.com/swri-robotics/gps_umd/issues/4584>
* Merge pull request #39 <https://github.com/swri-robotics/gps_umd/issues/39> from shr-project/jansa/gpsd
  Fix build with gpsd-3.21
* Fix build with gpsd-3.21
  Adapt to changes from this commit:
  https://gitlab.com/gpsd/gpsd/-/commit/29991d6ffeb41ecfc8297db68bb68be0128c8514
* Contributors: David Anthony, Martin Jansa
```
