### PR TITLE
rqt_human_radar: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9422,6 +9422,20 @@ repositories:
       url: https://github.com/ros-visualization/rqt_graph.git
       version: master
     status: maintained
+  rqt_human_radar:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/rqt_human_radar.git
+      version: main
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros4hri/rqt_human_radar-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/ros4hri/rqt_human_radar.git
+      version: main
   rqt_image_view:
     doc:
       type: git


### PR DESCRIPTION
New release of `rqt_human_radar`, a RQT plugin to visualise ROS4HRI-compatible information about humans.

Screenshot:

![rqt_humans](https://user-images.githubusercontent.com/385379/204489121-b564b794-4016-45c5-9495-2bf558641d51.png)

---

Increasing version of package(s) in repository `rqt_human_radar` to `0.2.0-1`:

- upstream repository: https://github.com/ros4hri/rqt_human_radar.git
- release repository: https://github.com/ros4hri/rqt_human_radar-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## rqt_human_radar

```
* {rqt_engagement_radar->rqt_human_radar}
* add BSD license
* removed scripts folder installation
  since scripts folder was not used in the end, removed any reference
  to its installation in the CMakelists.txt
* removed .png person icon (now using .svg)
* Using body position for people placing.
  No more using face for icon placing in the radar canvas.
  Commented the code to make it more understandable.
* removed unused tick boxes
* removed leftover code
* fixed graphics and resizing
* distance information displayed
  it is now possible displaying the distance information by clicking
  on a person icon
* added pixels-per-meter spinbox
  in setting it is now possible to set the pixels per meter.
  Spinbox info:
  - minimum = 50
  - maximum = 600
  - single step = 10
* removed any reference to attention/fov cones
* svg object management
  - size of the polygon containing the svg based on the svg size
  - defined constants for the rendering size
  - removed references to the .png person image
  - introduced a check on right loading of the svg image
* ranges and agles info visualization
  adding information about the distance each range represents and
  angles visualization
* [wip] rendering person icon from svg
* revisited range painting process
* [WiP] display of person info
  display of person info when hovering with mouse over the image
  of a person
* Fixed person image rotation process
* Multitab version plugin - first version
  First, semi-mockup version of the multitab version of the rada
  plugin. Two different tabs: one for the radar itself, one for the
  settings.
* add BSD license
* Contributors: Séverin Lemaignan, lorenzoferrini
```
