### PR TITLE
Add intel-opencl-icd

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2197,7 +2197,9 @@ imagemagick:
   nixos: [imagemagick]
   ubuntu: [imagemagick]
 intel-opencl-icd:
-  debian: [intel-opencl-icd]
+  debian:
+    '*': [intel-opencl-icd]
+    buster: null
   ubuntu:
     '*': [intel-opencl-icd]
     bionic: null

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2196,6 +2196,9 @@ imagemagick:
   gentoo: [virtual/imagemagick-tools]
   nixos: [imagemagick]
   ubuntu: [imagemagick]
+intel-opencl-icd:
+  debian: [intel-opencl-icd]
+  ubuntu: [intel-opencl-icd]
 intltool:
   arch: [intltool]
   debian: [intltool]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2198,7 +2198,9 @@ imagemagick:
   ubuntu: [imagemagick]
 intel-opencl-icd:
   debian: [intel-opencl-icd]
-  ubuntu: [intel-opencl-icd]
+  ubuntu:
+    '*': [intel-opencl-icd]
+    bionic: null
 intltool:
   arch: [intltool]
   debian: [intltool]


### PR DESCRIPTION
## Purpose of using this:

It's an [Intel's OpenCL Driver](https://github.com/intel/compute-runtime) which enable iGPU on Intel CPU. Useful when using with [OpenVINO](https://docs.openvino.ai/latest/index.html) aka. Intel's Neural Network Inference Engine.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/sid/intel-opencl-icd
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/focal/intel-opencl-icd
- Fedora: https://packages.fedoraproject.org/
  - NOT AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - NOT AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - NOT AVAILABLE
- macOS: https://formulae.brew.sh/
  - NOT AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - NOT AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - NOT AVAILABLE
- openSUSE: https://software.opensuse.org/package/
  - NOT AVAILABLE
