### PR TITLE
webots_ros: 2023.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11840,7 +11840,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/cyberbotics/webots_ros-release.git
-      version: 2022.1.0-1
+      version: 2023.0.0-1
     source:
       type: git
       url: https://github.com/cyberbotics/webots_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `webots_ros` to `2023.0.0-1`:

- upstream repository: https://github.com/cyberbotics/webots_ros.git
- release repository: https://github.com/cyberbotics/webots_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2022.1.0-1`
