### PR TITLE
tiago_navigation: 4.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6083,6 +6083,24 @@ repositories:
       url: https://github.com/pal-robotics/tiago_moveit_config.git
       version: humble-devel
     status: developed
+  tiago_navigation:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/tiago_navigation.git
+      version: humble-devel
+    release:
+      packages:
+      - tiago_2dnav
+      - tiago_navigation
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/tiago_navigation-release.git
+      version: 4.0.1-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/tiago_navigation.git
+      version: humble-devel
+    status: developed
   tiago_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_navigation` to `4.0.1-1`:

- upstream repository: https://github.com/pal-robotics/tiago_navigation.git
- release repository: https://github.com/pal-gbp/tiago_navigation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## tiago_2dnav

```
* Merge branch 'mlu/fix/tiago_2dnav_buildtool' into 'humble-devel'
  Fix  buildtool_depend of tiago_2dnav
  See merge request robots/tiago_navigation!68
* Fix  buildtool_depend of tiago_2dnav
  Must be ament_cmake_auto
* Contributors: Noel Jimenez, mathiasluedtke
```

## tiago_navigation

- No changes
