### PR TITLE
Add several python3 packages

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6948,7 +6948,9 @@ python3-flask-migrate:
   gentoo: [dev-python/flask-migrate]
   opensuse: [python310-Flask-Migrate]
   ubuntu: [python3-flask-migrate]
-  rhel: ['python%{python3_pkgversion}-flask-migrate']
+  rhel:
+    '*': ['python%{python3_pkgversion}-flask-migrate']
+    '7': null
 python3-flask-restplus-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7522,6 +7522,13 @@ python3-markdown:
   gentoo: [dev-python/markdown]
   nixos: [python3Packages.markdown]
   ubuntu: [python3-markdown]
+python3-marshmallow:
+  debian: [python3-marshmallow]
+  fedora: [python3-marshmallow]
+  gentoo: [dev-python/marshmallow]
+  nixos: [python39Packages.marshmallow]
+  opensuse: [python3-marshmallow]
+  ubuntu: [python3-marshmallow]
 python3-marshmallow-dataclass-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6059,6 +6059,7 @@ python3-bcrypt:
   nixos: [python39Packages.bcrypt]
   opensuse: [python3-bcrypt]
   ubuntu: [python3-bcrypt]
+  rhel: ['python%{python3_pkgversion}-bcrypt']
 python3-bitarray:
   debian: [python3-bitarray]
   fedora: [python3-bitarray]
@@ -6270,6 +6271,7 @@ python3-certifi:
   nixos: [python39Packages.certifi]
   opensuse: [python3-certifi]
   ubuntu: [python3-certifi]
+  rhel: ['python%{python3_pkgversion}-certifi']
 python3-cffi:
   debian: [python3-cffi]
   fedora: [python3-cffi]
@@ -6944,9 +6946,9 @@ python3-flask-migrate:
   debian: [python3-flask-migrate]
   fedora: [python3-flask-migrate]
   gentoo: [dev-python/flask-migrate]
-  nixos: [python39Packages.flask_migrate]
   opensuse: [python310-Flask-Migrate]
   ubuntu: [python3-flask-migrate]
+  rhel: ['python%{python3_pkgversion}-flask-migrate']
 python3-flask-restplus-pip:
   ubuntu:
     pip:
@@ -7540,6 +7542,7 @@ python3-marshmallow:
   nixos: [python39Packages.marshmallow]
   opensuse: [python3-marshmallow]
   ubuntu: [python3-marshmallow]
+  rhel: ['python%{python3_pkgversion}-marshmallow']
 python3-marshmallow-dataclass-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6940,6 +6940,13 @@ python3-flask-jwt-extended:
     bionic:
       pip:
         packages: [flask-jwt-extended]
+python3-flask-migrate:
+  debian: [python3-flask-migrate]
+  fedora: [python3-flask-migrate]
+  gentoo: [dev-python/flask-migrate]
+  nixos: [python39Packages.flask_migrate]
+  opensuse: [python310-Flask-Migrate]
+  ubuntu: [python3-flask-migrate]
 python3-flask-restplus-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6263,7 +6263,7 @@ python3-catkin-tools:
   fedora: [python3-catkin_tools]
   openembedded: [python3-catkin-tools@meta-ros-common]
   ubuntu: [python3-catkin-tools]
-python3-bcrypt:
+python3-certifi:
   debian: [python3-certifi]
   fedora: [python3-certifi]
   gentoo: [dev-python/certifi]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6946,7 +6946,6 @@ python3-flask-migrate:
   debian: [python3-flask-migrate]
   fedora: [python3-flask-migrate]
   gentoo: [dev-python/flask-migrate]
-  opensuse: [python310-Flask-Migrate]
   rhel:
     '*': ['python%{python3_pkgversion}-flask-migrate']
     '7': null
@@ -7543,7 +7542,9 @@ python3-marshmallow:
   gentoo: [dev-python/marshmallow]
   nixos: [python39Packages.marshmallow]
   opensuse: [python3-marshmallow]
-  rhel: ['python%{python3_pkgversion}-marshmallow']
+  rhel:
+    '*': ['python%{python3_pkgversion}-marshmallow']
+    '7': null
   ubuntu: [python3-marshmallow]
 python3-marshmallow-dataclass-pip:
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6058,8 +6058,8 @@ python3-bcrypt:
   gentoo: [dev-python/bcrypt]
   nixos: [python39Packages.bcrypt]
   opensuse: [python3-bcrypt]
-  ubuntu: [python3-bcrypt]
   rhel: ['python%{python3_pkgversion}-bcrypt']
+  ubuntu: [python3-bcrypt]
 python3-bitarray:
   debian: [python3-bitarray]
   fedora: [python3-bitarray]
@@ -6270,8 +6270,8 @@ python3-certifi:
   gentoo: [dev-python/certifi]
   nixos: [python39Packages.certifi]
   opensuse: [python3-certifi]
-  ubuntu: [python3-certifi]
   rhel: ['python%{python3_pkgversion}-certifi']
+  ubuntu: [python3-certifi]
 python3-cffi:
   debian: [python3-cffi]
   fedora: [python3-cffi]
@@ -6947,10 +6947,10 @@ python3-flask-migrate:
   fedora: [python3-flask-migrate]
   gentoo: [dev-python/flask-migrate]
   opensuse: [python310-Flask-Migrate]
-  ubuntu: [python3-flask-migrate]
   rhel:
     '*': ['python%{python3_pkgversion}-flask-migrate']
     '7': null
+  ubuntu: [python3-flask-migrate]
 python3-flask-restplus-pip:
   ubuntu:
     pip:
@@ -7543,8 +7543,8 @@ python3-marshmallow:
   gentoo: [dev-python/marshmallow]
   nixos: [python39Packages.marshmallow]
   opensuse: [python3-marshmallow]
-  ubuntu: [python3-marshmallow]
   rhel: ['python%{python3_pkgversion}-marshmallow']
+  ubuntu: [python3-marshmallow]
 python3-marshmallow-dataclass-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6052,6 +6052,13 @@ python3-backoff-pip:
   ubuntu:
     pip:
       packages: [backoff]
+python3-bcrypt:
+  debian: [python3-bcrypt]
+  fedora: [python3-bcrypt]
+  gentoo: [dev-python/bcrypt]
+  nixos: [python39Packages.bcrypt]
+  opensuse: [python3-bcrypt]
+  ubuntu: [python3-bcrypt]
 python3-bitarray:
   debian: [python3-bitarray]
   fedora: [python3-bitarray]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6263,6 +6263,13 @@ python3-catkin-tools:
   fedora: [python3-catkin_tools]
   openembedded: [python3-catkin-tools@meta-ros-common]
   ubuntu: [python3-catkin-tools]
+python3-bcrypt:
+  debian: [python3-certifi]
+  fedora: [python3-certifi]
+  gentoo: [dev-python/certifi]
+  nixos: [python39Packages.certifi]
+  opensuse: [python3-certifi]
+  ubuntu: [python3-certifi]
 python3-cffi:
   debian: [python3-cffi]
   fedora: [python3-cffi]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6912,6 +6912,10 @@ python3-flask:
   nixos: [python3Packages.flask]
   rhel: [python3-flask]
   ubuntu: [python3-flask]
+python3-flask-bcrypt:
+  debian: [python3-flask-bcrypt]
+  nixos: [python39Packages.flask-bcrypt]
+  ubuntu: [python3-flask-bcrypt]
 python3-flask-cors:
   debian: [python3-flask-cors]
   fedora: [python3-flask-cors]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

- python3-bcrypt
- python3-certifi
- python3-marshmallow
- python3-flask-bcrypt
- python3-flask-migrate

## Package Upstream Source:

- https://github.com/pyca/bcrypt
- https://github.com/certifi/python-certifi
- https://github.com/marshmallow-code/marshmallow
- https://github.com/maxcountryman/flask-bcrypt
- https://github.com/miguelgrinberg/Flask-Migrate

## Purpose of using this:

Create server-client setup.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

### python3-bcrypt
- Debian: https://packages.debian.org/sid/python3-bcrypt
- Ubuntu: https://packages.ubuntu.com/bionic/python3-bcrypt
   - REQUIRED
- Fedora: https://packages.fedoraproject.org/pkgs/python-bcrypt/python3-bcrypt/index.html

- Gentoo:https://packages.gentoo.org/packages/dev-python/bcrypt

- openSUSE: https://opensuse.pkgs.org/15.3/opensuse-oss-x86_64/python3-bcrypt-3.2.0-1.10.x86_64.rpm.html

### python3-certifi
- Debian: https://packages.debian.org/sid/python3-certifi
- Ubuntu: https://packages.ubuntu.com/focal/python3-certifi
   - REQUIRED
- Fedora: https://packages.fedoraproject.org/pkgs/python-certifi/python3-certifi/

- Gentoo:https://packages.gentoo.org/packages/dev-python/certifi

- openSUSE: https://opensuse.pkgs.org/15.3/opensuse-oss-x86_64/python3-certifi-2018.1.18-1.18.noarch.rpm.html

### python3-marshmallow
- Debian: https://packages.debian.org/sid/python3-marshmallow
- Ubuntu: https://packages.ubuntu.com/bionic/python3-marshmallow
   - REQUIRED
- Fedora: https://packages.fedoraproject.org/pkgs/python-marshmallow/python3-marshmallow/

- Gentoo:https://packages.gentoo.org/packages/dev-python/marshmallow

- openSUSE: https://opensuse.pkgs.org/15.4/opensuse-oss-x86_64/python3-marshmallow-3.5.1-bp154.1.20.noarch.rpm.html

### python3-flask-bcrypt
- Debian: https://packages.debian.org/sid/python3-flask-bcrypt
- Ubuntu: https://packages.ubuntu.com/bionic/python3-flask-bcrypt
   - REQUIRED

### python3-flask-migrate
- Debian: https://packages.debian.org/sid/python3-flask-migrate
- Ubuntu: https://packages.ubuntu.com/bionic/python3-flask-migrate
   - REQUIRED
- Fedora: https://packages.fedoraproject.org/pkgs/python-flask-migrate/python3-flask-migrate/

- Gentoo:https://packages.gentoo.org/packages/dev-python/flask-migrate

- openSUSE: https://opensuse.pkgs.org/tumbleweed/opensuse-oss-x86_64/python310-Flask-Migrate-3.0.1-1.8.noarch.rpm.html
