### PR TITLE
maliput_osm: 0.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2671,6 +2671,22 @@ repositories:
       url: https://github.com/maliput/maliput_object_py.git
       version: main
     status: developed
+  maliput_osm:
+    doc:
+      type: git
+      url: https://github.com/maliput/maliput_osm.git
+      version: main
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/maliput_osm-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/maliput/maliput_osm.git
+      version: main
+    status: developed
   maliput_py:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_osm` to `0.1.0-1`:

- upstream repository: https://github.com/maliput/maliput_osm.git
- release repository: https://github.com/ros2-gbp/maliput_osm-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## maliput_osm

```
* Uses default providers offered by maliput base. (#47 <https://github.com/maliput/maliput_osm/issues/47>)
* Provides default parameters for the road network loader. (#46 <https://github.com/maliput/maliput_osm/issues/46>)
* Improves documentation. (#45 <https://github.com/maliput/maliput_osm/issues/45>)
* Adds circuit.osm map. (#44 <https://github.com/maliput/maliput_osm/issues/44>)
* Adds t_shape_road.osm map. (#43 <https://github.com/maliput/maliput_osm/issues/43>)
* Supports multiple segments per junction when correspond (#42 <https://github.com/maliput/maliput_osm/issues/42>)
* Fixes bug on connections (#41 <https://github.com/maliput/maliput_osm/issues/41>)
* Adds y_shape_road.osm map. (#39 <https://github.com/maliput/maliput_osm/issues/39>)
* Build branchpoints. (#33 <https://github.com/maliput/maliput_osm/issues/33>)
* Support loading yaml files for populating RoadNetwork's books. (#35 <https://github.com/maliput/maliput_osm/issues/35>)
* Adds loop_road_pedestrian_crosswalk map with yaml files. (#34 <https://github.com/maliput/maliput_osm/issues/34>)
* Parses connections from osm map. (#32 <https://github.com/maliput/maliput_osm/issues/32>)
* Adds l_shape_road map. (#31 <https://github.com/maliput/maliput_osm/issues/31>)
* Supports multiple lanes per segment. (#28 <https://github.com/maliput/maliput_osm/issues/28>)
* Adds c_shape_superelevated_road.osm. (#29 <https://github.com/maliput/maliput_osm/issues/29>)
* Parses adjacent lane information from osm maps. (#27 <https://github.com/maliput/maliput_osm/issues/27>)
* Adds multi_lanes_road map. (#25 <https://github.com/maliput/maliput_osm/issues/25>)
* Adds elevated_arc_lane map. (#23 <https://github.com/maliput/maliput_osm/issues/23>)
* Adds missing ament macro for exporting targets. (#20 <https://github.com/maliput/maliput_osm/issues/20>)
* Matches with branchpoint builder implementation. (#24 <https://github.com/maliput/maliput_osm/issues/24>)
* Adds arc_lane and arc_lane_dense maps. (#19 <https://github.com/maliput/maliput_osm/issues/19>)
* Adds RoadNetwork plugin. (#15 <https://github.com/maliput/maliput_osm/issues/15>)
* Adds RoadNetworkBuilder. (#14 <https://github.com/maliput/maliput_osm/issues/14>)
* Adds RoadGeometryBuilder. (#13 <https://github.com/maliput/maliput_osm/issues/13>)
* Adds OSMManager (#7 <https://github.com/maliput/maliput_osm/issues/7>)
  * Add straight_forward.osm map
* Fixes triage workflow. (#17 <https://github.com/maliput/maliput_osm/issues/17>)
* Implements osm::Lane and osm::Segment classes. (#5 <https://github.com/maliput/maliput_osm/issues/5>)
* Base configuration of the package/repository. (#4 <https://github.com/maliput/maliput_osm/issues/4>)
* Initial commit
* Contributors: Franco Cipollone
```
