### PR TITLE
foxglove_msgs: 2.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3590,7 +3590,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/foxglove/ros_foxglove_msgs-release.git
-      version: 2.1.0-2
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/foxglove/schemas.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_msgs` to `2.1.1-1`:

- upstream repository: https://github.com/foxglove/schemas.git
- release repository: https://github.com/foxglove/ros_foxglove_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.0-2`

## foxglove_msgs

```
* Fix typo in CubePrimitive comments
```
