### PR TITLE
foxglove_msgs: 2.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1508,7 +1508,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_foxglove_msgs-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/foxglove/schemas.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_msgs` to `2.1.1-1`:

- upstream repository: https://github.com/foxglove/schemas.git
- release repository: https://github.com/ros2-gbp/ros_foxglove_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.0-1`

## foxglove_msgs

```
* Fix typo in CubePrimitive comments
```
