### PR TITLE
rsl: 0.2.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5456,7 +5456,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/PickNikRobotics/RSL-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/RSL.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rsl` to `0.2.1-1`:

- upstream repository: https://github.com/PickNikRobotics/RSL.git
- release repository: https://github.com/PickNikRobotics/RSL-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.0-1`

## rsl

```
* Use constructors over factory functions when possible
* Implement rsl::rng with std::optional
* Fix bug when trying to seed rng from first call
* Make rsl::rng() tests more strenuous
  Seeding on the first call tests a code path that hadn't yet been
  tested but is a valid use of the API.
* Change version of range-v3 to allow building on Ubuntu Focal (#73 <https://github.com/PickNikRobotics/RSL/issues/73>)
* Add missing header
  Fixes a build issue when using GCC 12
* Make it easy for users to override
* Update Catch2
* Add tests for rsl::to_parameter_result_msg
* Contributors: Chris Thrasher, Tony Najjar, Tyler Weaver
```
