### PR TITLE
marti_common: 3.5.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2747,18 +2747,24 @@ repositories:
       version: dashing-devel
     release:
       packages:
+      - marti_data_structures
+      - swri_cli_tools
       - swri_console_util
       - swri_dbw_interface
       - swri_geometry_util
       - swri_image_util
       - swri_math_util
+      - swri_nodelet
       - swri_opencv_util
       - swri_prefix_tools
       - swri_roscpp
+      - swri_rospy
       - swri_route_util
       - swri_serial_util
+      - swri_string_util
       - swri_system_util
       - swri_transform_util
+      - swri_yaml_util
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2744,7 +2744,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/swri-robotics/marti_common.git
-      version: dashing-devel
+      version: ros2-devel
     release:
       packages:
       - marti_data_structures
@@ -2767,13 +2767,13 @@ repositories:
       - swri_yaml_util
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 3.4.1-1
+      url: https://github.com/ros2-gbp/marti_common-release.git
+      version: 3.5.1-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/swri-robotics/marti_common.git
-      version: dashing-devel
+      version: ros2-devel
     status: developed
   marti_messages:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `3.5.1-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.5.1-1`
