### PR TITLE
rmw_gurumdds: 1.3.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4996,12 +4996,12 @@ repositories:
       version: foxy
     release:
       packages:
+      - gurumdds_cmake_module
       - rmw_gurumdds_cpp
-      - rmw_gurumdds_shared_cpp
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
-      version: 1.2.0-1
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/ros2/rmw_gurumdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_gurumdds` to `1.3.1-1`:

- upstream repository: https://github.com/ros2/rmw_gurumdds.git
- release repository: https://github.com/ros2-gbp/rmw_gurumdds-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.0-1`

## gurumdds_cmake_module

- No changes

## rmw_gurumdds_cpp

```
* Remove sleep from entity creation
* Contributors: Youngjin Yun
```
