### PR TITLE
rmw_gurumdds: 4.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4054,12 +4054,12 @@ repositories:
       version: master
     release:
       packages:
+      - gurumdds_cmake_module
       - rmw_gurumdds_cpp
-      - rmw_gurumdds_shared_cpp
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
-      version: 4.0.0-1
+      version: 4.1.2-1
     source:
       type: git
       url: https://github.com/ros2/rmw_gurumdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_gurumdds` to `4.1.2-1`:

- upstream repository: https://github.com/ros2/rmw_gurumdds.git
- release repository: https://github.com/ros2-gbp/rmw_gurumdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.0-1`

## gurumdds_cmake_module

- No changes

## rmw_gurumdds_cpp

```
* Remove sleep from entity creation
* Contributors: Youngjin Yun
```
