### PR TITLE
ur_client_library: 1.3.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -14503,7 +14503,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git
-      version: boost
+      version: master
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -14512,7 +14512,7 @@ repositories:
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git
-      version: boost
+      version: master
     status: developed
   ur_msgs:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -14508,7 +14508,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
-      version: 0.4.0-1
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `1.3.1-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.0-1`

## ur_client_library

```
* CI: Add a prerelease check that calls bloom-generate (#134 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/134>)
* Contributors: Felix Exner
```
