### PR TITLE
webots_ros2: 2023.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6887,7 +6887,6 @@ repositories:
       packages:
       - webots_ros2
       - webots_ros2_control
-      - webots_ros2_core
       - webots_ros2_driver
       - webots_ros2_epuck
       - webots_ros2_importer
@@ -6901,7 +6900,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/webots_ros2-release.git
-      version: 2022.1.4-2
+      version: 2023.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `webots_ros2` to `2023.0.0-1`:

- upstream repository: https://github.com/cyberbotics/webots_ros2.git
- release repository: https://github.com/ros2-gbp/webots_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2022.1.4-2`

## webots_ros2

```
* Add support for the new Python API of Webots R2023a
* Convert C++ controller API functions to C
* Replace libController submodule by commited source files
* Removed 'webots_ros2_core' package (deprecated).
* Allow custom motor-encoder pair.
```

## webots_ros2_control

```
* Convert C++ controller API functions to C
* Allow custom motor-encoder pair.
```

## webots_ros2_driver

```
* Add support for the new Python API of Webots R2023a
* Convert C++ controller API functions to C
* Replace libController submodule by commited source files
```
