### PR TITLE
hydrographic_msgs: 1.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3550,6 +3550,20 @@ repositories:
       url: https://github.com/husky/husky.git
       version: noetic-devel
     status: maintained
+  hydrographic_msgs:
+    release:
+      packages:
+      - acoustic_msgs
+      - environmental_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/apl-ocean-engineering/hydrographic_msgs-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/apl-ocean-engineering/hydrographic_msgs.git
+      version: main
+    status: developed
   ifm3d:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `hydrographic_msgs` to `1.1.0-1`:

- upstream repository: https://github.com/apl-ocean-engineering/hydrographic_msgs.git
- release repository: https://github.com/apl-ocean-engineering/hydrographic_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## acoustic_msgs

```
* Fix ProjectedSonarImage comments about frame (#26 <https://github.com/apl-ocean-engineering/hydrographic_msgs/issues/26>)
* Add CI, pre-commit, prerelease and dependabot (#27 <https://github.com/apl-ocean-engineering/hydrographic_msgs/issues/27>)
  Co-authored-by: Laura Lindzey <mailto:lindzey@uw.edu>
* Merge pull request #25 <https://github.com/apl-ocean-engineering/hydrographic_msgs/issues/25> from apl-ocean-engineering/add_migration_rule
  Add migration rule from v0.0.1 to 28ec6a7
* Add migration rule from v0.0.1 to 28ec6a7
* Merge pull request #22 <https://github.com/apl-ocean-engineering/hydrographic_msgs/issues/22> from rolker/fix_variable_name
* Rename num_beams to beam_count.
* Merge pull request #21 <https://github.com/apl-ocean-engineering/hydrographic_msgs/issues/21> from CaptKrasno/acoustic_msg_devel
* Contributors: CaptKrasno, Laura Lindzey, Roland Arsenault, Vatan Aksoy Tezer, lauralindzey
```

## environmental_msgs

```
* Add CI, pre-commit, prerelease and dependabot (#27 <https://github.com/apl-ocean-engineering/hydrographic_msgs/issues/27>)
  Co-authored-by: Laura Lindzey <mailto:lindzey@uw.edu>
* Fix typo in package.xml
* Contributors: Laura Lindzey, Vatan Aksoy Tezer
```
