### PR TITLE
Add python3-flake8-import-order rules for RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6873,6 +6873,10 @@ python3-flake8-docstrings-pip:
 python3-flake8-import-order:
   fedora: [python3-flake8-import-order]
   opensuse: [python3-flake8-import-order]
+  rhel:
+    '*': [python3-flake8-import-order]
+    '7': null
+    '8': null
   ubuntu:
     '*': [python3-flake8-import-order]
     bionic: null


### PR DESCRIPTION
For RHEL 9, this package is supplied by EPEL: https://packages.fedoraproject.org/pkgs/python-flake8-import-order/python3-flake8-import-order/

This package is not currently available for RHEL 7 or RHEL 8.