### PR TITLE
python3-deprecated added to rosdep dependencies

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -169,13 +169,6 @@ cython3:
   gentoo: [dev-python/cython]
   nixos: [python3Packages.cython]
   ubuntu: [cython3]
-python3-deprecated:
-  debian:
-    '*': [python3-deprecated]
-    buster: null
-  ubuntu:
-    '*': [python3-deprecated]
-    bionic: null
 dpath-pip:
   ubuntu:
     pip:
@@ -6479,6 +6472,13 @@ python3-defusedxml:
   opensuse: [python3-defusedxml]
   rhel: ['python%{python3_pkgversion}-defusedxml']
   ubuntu: [python3-defusedxml]
+python3-deprecated:
+  debian:
+    '*': [python3-deprecated]
+    buster: null
+  ubuntu:
+    '*': [python3-deprecated]
+    bionic: null
 python3-depthai-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -169,13 +169,13 @@ cython3:
   gentoo: [dev-python/cython]
   nixos: [python3Packages.cython]
   ubuntu: [cython3]
-deprecated-pip:
+python3-deprecated:
   debian:
-    pip:
-      packages: [Deprecated]
+    '*': [python3-deprecated]
+    buster: null
   ubuntu:
-    pip:
-      packages: [Deprecated]
+    '*': [python3-deprecated]
+    bionic: null
 dpath-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6477,7 +6477,7 @@ python3-deprecated:
     '*': [python3-deprecated]
     buster: null
   fedora: [python3-deprecated]
-  rhel: 
+  rhel:
     '*': [python3-deprecated]
     '7': null
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -169,6 +169,13 @@ cython3:
   gentoo: [dev-python/cython]
   nixos: [python3Packages.cython]
   ubuntu: [cython3]
+deprecated-pip:
+  debian:
+    pip:
+      packages: [Deprecated]
+  ubuntu:
+    pip:
+      packages: [Deprecated]
 dpath-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6476,6 +6476,8 @@ python3-deprecated:
   debian:
     '*': [python3-deprecated]
     buster: null
+  fedora: [python3-deprecated]
+  rhel: [python3-deprecated]
   ubuntu:
     '*': [python3-deprecated]
     bionic: null

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6477,7 +6477,9 @@ python3-deprecated:
     '*': [python3-deprecated]
     buster: null
   fedora: [python3-deprecated]
-  rhel: [python3-deprecated]
+  rhel: 
+    '*': [python3-deprecated]
+    '7': null
   ubuntu:
     '*': [python3-deprecated]
     bionic: null


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:  
Deprecated 

## Package Upstream Source: 
https://github.com/tantale/deprecated

## Purpose of using this:
This dependency is Python @deprecated decorator to deprecate old python classes, functions, or methods

## Links to Distribution Packages
- Debian: https://packages.debian.org/bullseye/python3-deprecated
- Ubuntu: https://packages.ubuntu.com/jammy/python3-deprecated

