### PR TITLE
phidgets_drivers: 1.0.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6869,7 +6869,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
-      version: 1.0.5-1
+      version: 1.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `1.0.6-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.5-1`

## libphidget22

```
* Merge pull request #129 <https://github.com/ros-drivers/phidgets_drivers/issues/129> from mintar/feat-pre-commit
  Add pre-commit, move from travis to GitHub actions, fix style
* libphidget22: Use install FILES for libraries
* Contributors: Martin Günther
```

## phidgets_accelerometer

```
* Merge pull request #129 <https://github.com/ros-drivers/phidgets_drivers/issues/129> from mintar/feat-pre-commit
  Add pre-commit, move from travis to GitHub actions, fix style
* Don't modify CMAKE_CXX_FLAGS
* Fix clang-format
* Add support for VINT networkhub (#127 <https://github.com/ros-drivers/phidgets_drivers/issues/127>)
* Contributors: James Haley, Martin Günther
```

## phidgets_analog_inputs

```
* Merge pull request #129 <https://github.com/ros-drivers/phidgets_drivers/issues/129> from mintar/feat-pre-commit
* Don't modify CMAKE_CXX_FLAGS
* Fix clang-format
* Add support for VINT networkhub (#127 <https://github.com/ros-drivers/phidgets_drivers/issues/127>)
* Contributors: James Haley, Martin Günther
```

## phidgets_analog_outputs

```
* Merge pull request #129 <https://github.com/ros-drivers/phidgets_drivers/issues/129> from mintar/feat-pre-commit
  Add pre-commit, move from travis to GitHub actions, fix style
* Don't modify CMAKE_CXX_FLAGS
* Fix clang-format
* Add support for VINT networkhub (#127 <https://github.com/ros-drivers/phidgets_drivers/issues/127>)
* Contributors: James Haley, Martin Günther
```

## phidgets_api

```
* Merge pull request #153 <https://github.com/ros-drivers/phidgets_drivers/issues/153> from naturerobots/noetic
  Add support for onboard orientation estimation and other new PhidgetSpatial features of MOT0109 and onwards
* Support configuring encoder data interval and IO Mode (#137 <https://github.com/ros-drivers/phidgets_drivers/issues/137>)
* Merge pull request #129 <https://github.com/ros-drivers/phidgets_drivers/issues/129> from mintar/feat-pre-commit
  Add pre-commit, move from travis to GitHub actions, fix style
* Don't modify CMAKE_CXX_FLAGS
* Contributors: Ben Schattinger, Malte kl. Piening, Martin Günther
```

## phidgets_digital_inputs

```
* Merge pull request #129 <https://github.com/ros-drivers/phidgets_drivers/issues/129> from mintar/feat-pre-commit
  Add pre-commit, move from travis to GitHub actions, fix style
* Don't modify CMAKE_CXX_FLAGS
* Fix clang-format
* Add support for VINT networkhub (#127 <https://github.com/ros-drivers/phidgets_drivers/issues/127>)
* Contributors: James Haley, Martin Günther
```

## phidgets_digital_outputs

```
* Merge pull request #129 <https://github.com/ros-drivers/phidgets_drivers/issues/129> from mintar/feat-pre-commit
  Add pre-commit, move from travis to GitHub actions, fix style
* Don't modify CMAKE_CXX_FLAGS
* Fix clang-format
* Add support for VINT networkhub (#127 <https://github.com/ros-drivers/phidgets_drivers/issues/127>)
* Contributors: James Haley, Martin Günther
```

## phidgets_drivers

- No changes

## phidgets_gyroscope

```
* Merge pull request #129 <https://github.com/ros-drivers/phidgets_drivers/issues/129> from mintar/feat-pre-commit
  Add pre-commit, move from travis to GitHub actions, fix style
* Don't modify CMAKE_CXX_FLAGS
* Fix clang-format
* Add support for VINT networkhub (#127 <https://github.com/ros-drivers/phidgets_drivers/issues/127>)
* Contributors: James Haley, Martin Günther
```

## phidgets_high_speed_encoder

```
* Support configuring encoder data interval and IO Mode (#137 <https://github.com/ros-drivers/phidgets_drivers/issues/137>)
* Merge pull request #129 <https://github.com/ros-drivers/phidgets_drivers/issues/129> from mintar/feat-pre-commit
  Add pre-commit, move from travis to GitHub actions, fix style
* Don't modify CMAKE_CXX_FLAGS
* Fix clang-format
* Add support for VINT networkhub (#127 <https://github.com/ros-drivers/phidgets_drivers/issues/127>)
* BUGFIX: duplicated values for all encoders (#124 <https://github.com/ros-drivers/phidgets_drivers/issues/124>)
* Contributors: Ben Schattinger, James Haley, Jose Luis Blanco-Claraco, Martin Günther
```

## phidgets_ik

- No changes

## phidgets_magnetometer

```
* Merge pull request #129 <https://github.com/ros-drivers/phidgets_drivers/issues/129> from mintar/feat-pre-commit
  Add pre-commit, move from travis to GitHub actions, fix style
* Don't modify CMAKE_CXX_FLAGS
* Fix clang-format
* Add support for VINT networkhub (#127 <https://github.com/ros-drivers/phidgets_drivers/issues/127>)
* Contributors: James Haley, Martin Günther
```

## phidgets_motors

```
* Merge pull request #129 <https://github.com/ros-drivers/phidgets_drivers/issues/129> from mintar/feat-pre-commit
  Add pre-commit, move from travis to GitHub actions, fix style
* Don't modify CMAKE_CXX_FLAGS
* Fix clang-format
* Add support for VINT networkhub (#127 <https://github.com/ros-drivers/phidgets_drivers/issues/127>)
* Contributors: James Haley, Martin Günther
```

## phidgets_msgs

```
* Merge pull request #129 <https://github.com/ros-drivers/phidgets_drivers/issues/129> from mintar/feat-pre-commit
  Add pre-commit, move from travis to GitHub actions, fix style
* Fix trailing whitespace
* Don't modify CMAKE_CXX_FLAGS
* Contributors: Martin Günther
```

## phidgets_spatial

```
* Merge pull request #153 <https://github.com/ros-drivers/phidgets_drivers/issues/153> from naturerobots/noetic
  Add support for onboard orientation estimation and other new PhidgetSpatial features of MOT0109 and onwards
* Merge pull request #129 <https://github.com/ros-drivers/phidgets_drivers/issues/129> from mintar/feat-pre-commit
  Add pre-commit, move from travis to GitHub actions, fix style
* Don't modify CMAKE_CXX_FLAGS
* Fix clang-format
* Add support for VINT networkhub (#127 <https://github.com/ros-drivers/phidgets_drivers/issues/127>)
* Contributors: James Haley, Malte kl. Piening, Martin Günther
```

## phidgets_temperature

```
* Merge pull request #129 <https://github.com/ros-drivers/phidgets_drivers/issues/129> from mintar/feat-pre-commit
  Add pre-commit, move from travis to GitHub actions, fix style
* Don't modify CMAKE_CXX_FLAGS
* Fix clang-format
* Add support for VINT networkhub (#127 <https://github.com/ros-drivers/phidgets_drivers/issues/127>)
* Contributors: James Haley, Martin Günther
```
