### PR TITLE
foxglove_bridge: 0.2.0-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1212,7 +1212,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 0.1.0-2
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_bridge` to `0.2.0-1`:

- upstream repository: https://github.com/foxglove/ros-foxglove-bridge.git
- release repository: https://github.com/ros2-gbp/foxglove_bridge-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.0-2`

## foxglove_bridge

```
* Add support for client channels (#66 <https://github.com/foxglove/ros-foxglove-bridge/issues/66>)
* Add smoke tests (#72 <https://github.com/foxglove/ros-foxglove-bridge/issues/72>)
* Update package maintainers (#70 <https://github.com/foxglove/ros-foxglove-bridge/issues/70>)
* [ROS2]: Fix messages not being received anymore after unsubscribing a topic (#92 <https://github.com/foxglove/ros-foxglove-bridge/issues/92>)
* [ROS2]: Refactor node as a component (#63 <https://github.com/foxglove/ros-foxglove-bridge/issues/63>)
* [ROS2]: Fix message definition loading for .msg or .idl files not located in msg/ (#95 <https://github.com/foxglove/ros-foxglove-bridge/issues/95>)
* [ROS1]: Mirror ROS 2 node behavior when /clock` topic is present (#99 <https://github.com/foxglove/ros-foxglove-bridge/issues/99>)
* [ROS1]: Fix topic discovery function not being called frequently at startup (#68 <https://github.com/foxglove/ros-foxglove-bridge/issues/68>)
* Contributors: Hans-Joachim Krauch, Jacob Bandes-Storch, John Hurliman
```
