### PR TITLE
dbw_fca_ros: 1.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1670,7 +1670,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_fca_ros-release.git
-      version: 1.2.1-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/dbw_fca_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_fca_ros` to `1.3.0-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/dbw_fca_ros.git
- release repository: https://github.com/DataspeedInc-release/dbw_fca_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.1-1`

## dbw_fca

```
* Fix ROS install key after they changed it
* Contributors: Kevin Hallenbeck
```

## dbw_fca_can

```
* Bump firmware versions
* Change unsigned vehicle speed to signed vehicle velocity
* Contributors: Kevin Hallenbeck
```

## dbw_fca_description

- No changes

## dbw_fca_joystick_demo

- No changes

## dbw_fca_msgs

- No changes
