### PR TITLE
dbw_polaris_ros: 1.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2276,7 +2276,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_polaris_ros-release.git
-      version: 1.0.1-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/dbw_polaris_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_polaris_ros` to `1.1.0-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/dbw_polaris_ros.git
- release repository: https://github.com/DataspeedInc-release/dbw_polaris_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.1-1`

## dbw_polaris

```
* Fix ROS install key after they changed it
* Contributors: Kevin Hallenbeck
```

## dbw_polaris_can

```
* Bump firmware versions
* Change unsigned vehicle speed to signed vehicle velocity
* Periodically publish DBW enabled status in addition to latched and on change
* Contributors: Kevin Hallenbeck
```

## dbw_polaris_description

- No changes

## dbw_polaris_joystick_demo

- No changes

## dbw_polaris_msgs

- No changes
