### PR TITLE
dbw_ros: 2.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -895,7 +895,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_ros-release.git
-      version: 2.0.1-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://bitbucket.org/dataspeedinc/dbw_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_ros` to `2.1.0-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/dbw_ros.git
- release repository: https://github.com/DataspeedInc-release/dbw_ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.1-1`

## dataspeed_dbw_common

```
* Remove unused dependency
* Add missing ament_cmake_gtest dependency
* Sync ament_cmake and ament_cmake_ros in each CMakeLists.txt/package.xml
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```

## dataspeed_dbw_gateway

```
* Add missing ament_cmake_gtest dependency
* Add missing dependencies for dataspeed_dbw_gateway
* Sync ament_cmake and ament_cmake_ros in each CMakeLists.txt/package.xml
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```

## dataspeed_dbw_msgs

- No changes

## dataspeed_ulc

- No changes

## dataspeed_ulc_can

```
* Reconfigure CAN and ROS messages for new ULC capability
* Sync ament_cmake and ament_cmake_ros in each CMakeLists.txt/package.xml
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```

## dataspeed_ulc_msgs

```
* Reconfigure CAN and ROS messages for new ULC capability
* Contributors: Micho Radovnikovich
```

## dbw_fca

- No changes

## dbw_fca_can

```
* Bump firmware versions
* Add missing ament_cmake_gtest dependency
* Sync ament_cmake and ament_cmake_ros in each CMakeLists.txt/package.xml
* Change unsigned vehicle speed to signed vehicle velocity
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```

## dbw_fca_description

```
* Sync ament_cmake and ament_cmake_ros in each CMakeLists.txt/package.xml
* Contributors: Kevin Hallenbeck
```

## dbw_fca_joystick_demo

```
* Sync ament_cmake and ament_cmake_ros in each CMakeLists.txt/package.xml
* Contributors: Kevin Hallenbeck
```

## dbw_fca_msgs

- No changes

## dbw_ford

- No changes

## dbw_ford_can

```
* Bump firmware versions
* Add missing ament_cmake_gtest dependency
* Sync ament_cmake and ament_cmake_ros in each CMakeLists.txt/package.xml
* Change unsigned vehicle speed to signed vehicle velocity
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```

## dbw_ford_description

```
* Sync ament_cmake and ament_cmake_ros in each CMakeLists.txt/package.xml
* Contributors: Kevin Hallenbeck
```

## dbw_ford_joystick_demo

```
* Sync ament_cmake and ament_cmake_ros in each CMakeLists.txt/package.xml
* Contributors: Kevin Hallenbeck
```

## dbw_ford_msgs

- No changes

## dbw_polaris

- No changes

## dbw_polaris_can

```
* Bump firmware versions
* Add missing ament_cmake_gtest dependency
* Sync ament_cmake and ament_cmake_ros in each CMakeLists.txt/package.xml
* Change unsigned vehicle speed to signed vehicle velocity
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```

## dbw_polaris_description

```
* Sync ament_cmake and ament_cmake_ros in each CMakeLists.txt/package.xml
* Contributors: Kevin Hallenbeck
```

## dbw_polaris_joystick_demo

```
* Sync ament_cmake and ament_cmake_ros in each CMakeLists.txt/package.xml
* Contributors: Kevin Hallenbeck
```

## dbw_polaris_msgs

- No changes
