### PR TITLE
lusb: 2.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2262,6 +2262,21 @@ repositories:
       url: https://github.com/boschglobal/locator_ros_bridge.git
       version: main
     status: maintained
+  lusb:
+    doc:
+      type: git
+      url: https://bitbucket.org/dataspeedinc/lusb.git
+      version: ros2
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/DataspeedInc-release/lusb-release.git
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://bitbucket.org/dataspeedinc/lusb.git
+      version: ros2
+    status: developed
   magic_enum:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lusb` to `2.0.1-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/lusb
- release repository: https://github.com/DataspeedInc-release/lusb-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## lusb

```
* Add README and example
* Fix cmake problems and update for best practices
* Add pkg-config build dependency
* Contributors: Kevin Hallenbeck
```
