### PR TITLE
moose_firmware: 0.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6942,6 +6942,21 @@ repositories:
       url: https://github.com/moose-cpr/moose_desktop.git
       version: kinetic-devel
     status: maintained
+  moose_firmware:
+    doc:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/research/moose_firmware.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://gitlab.clearpathrobotics.com/gbp/moose_firmware-gbp.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://gitlab.clearpathrobotics.com/research/moose_firmware.git
+      version: melodic-devel
+    status: maintained
   moose_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moose_firmware` to `0.2.0-1`:

- upstream repository: http://gitlab.clearpathrobotics.com/research/moose_firmware.git
- release repository: https://gitlab.clearpathrobotics.com/gbp/moose_firmware-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## moose_firmware

```
* Updated for melodic on bionic.
* Contributors: Tony Baltovski
```
