### PR TITLE
Revert "foxglove_bridge: 0.2.0-1 in 'melodic/distribution.yaml' [bloom]"

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3576,12 +3576,11 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/foxglove/ros_foxglove_bridge-release.git
-      version: 0.2.0-1
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git
       version: main
-    status: developed
   foxglove_msgs:
     doc:
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#35495 due to outdated bloom version.