### PR TITLE
Revert "foxglove_bridge: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]"

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2763,12 +2763,11 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/foxglove/ros_foxglove_bridge-release.git
-      version: 0.2.0-1
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git
       version: main
-    status: developed
   foxglove_msgs:
     doc:
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#35496 due to outdated bloom version.