### PR TITLE
Revert "foxglove_bridge: 0.2.0-1 in 'galactic/distribution.yaml' [bloom]"

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1212,7 +1212,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 0.2.0-1
+      version: 0.1.0-2
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git


### PR DESCRIPTION
Reverts ros/rosdistro#35498 due to outdated bloom version.