### PR TITLE
Revert "foxglove_bridge: 0.2.0-1 in 'humble/distribution.yaml' [bloom]"

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1241,7 +1241,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 0.2.0-1
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git


### PR DESCRIPTION
Reverts ros/rosdistro#35499 due to outdated bloom version.