### PR TITLE
object_msgs: 0.4.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3394,6 +3394,12 @@ repositories:
       url: https://github.com/LORD-MicroStrain/ntrip_client.git
       version: ros2
     status: developed
+  object_msgs:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_object_msgs-release.git
+      version: 0.4.0-1
   object_recognition_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `object_msgs` to `0.4.0-1`:

- upstream repository: https://github.com/intel/ros2_object_msgs.git
- release repository: https://github.com/ros2-gbp/ros2_object_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## object_msgs

```
* Merge pull request #3 <https://github.com/RachelRen05/ros2_object_msgs/issues/3> from chaoli2/master
  Revert "update object message type to support multiple device"
* Revert "update object message type to support multiple device"
  This reverts commit a2dcbd98a705e881692e636a34d1029afd41fb90.
* Merge pull request #2 <https://github.com/RachelRen05/ros2_object_msgs/issues/2> from chaoli2/support_parallel
  update object message type to support multiple device
* update object message type to support multiple device
  Signed-off-by: Chao Li <mailto:chao1.li@intel.com>
* Contributors: Chao Li
```
