### PR TITLE
add python3-qrcode key to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8726,6 +8726,16 @@ python3-pyxdg-pip:
   ubuntu:
     pip:
       packages: [pyxdg]
+python3-qrcode:
+  arch: [python-qrcode]
+  debian: [python3-qrcode]
+  fedora: [python3-qrcode]
+  gentoo: [dev-python/qrcode]
+  nixos: [python39Packages.qrcode]
+  opensuse: [python3-qrcode]
+  rhel:
+    '8': [python3-qrcode]
+  ubuntu: [python3-qrcode]
 python3-qt5-bindings:
   alpine: [py3-qt5]
   arch: [python-pyqt5]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-qrcode

## Package Upstream Source:

https://github.com/lincolnloop/python-qrcode

## Purpose of using this:

Python library for generating QR codes

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/python3-flask-sqlalchemy
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/focal/python3-qrcode
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-qrcode/python3-qrcode/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/community/any/python-qrcode/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/qrcode
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=22.11&show=python39Packages.qrcode&from=0&size=50&buckets=%7B%22package_attr_set%22%3A%5B%22python39Packages%22%5D%2C%22package_license_set%22%3A%5B%5D%2C%22package_maintainers_set%22%3A%5B%5D%2C%22package_platforms%22%3A%5B%5D%7D&sort=relevance&type=packages&query=qrcode
