### PR TITLE
velodyne_simulator: 2.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6249,7 +6249,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/velodyne_simulator-release.git
-      version: 2.0.2-2
+      version: 2.0.3-1
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne_simulator` to `2.0.3-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
- release repository: https://github.com/ros2-gbp/velodyne_simulator-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.2-2`

## velodyne_description

```
* Add dummy collision to avoid moveit warnings
* Remove gazebo_ros dependency for velodyne_description
* Contributors: Filip Sund, Kevin Hallenbeck
```

## velodyne_gazebo_plugins

```
* Fix logger print warning
* Update cmake for best practices based on other packages
* Default to C++17
* Contributors: Kevin Hallenbeck
```

## velodyne_simulator

- No changes
