### PR TITLE
dbw_ros: 2.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -783,6 +783,43 @@ repositories:
       url: https://bitbucket.org/dataspeedinc/dataspeed_can.git
       version: ros2
     status: developed
+  dbw_ros:
+    doc:
+      type: git
+      url: https://bitbucket.org/dataspeedinc/dbw_ros.git
+      version: ros2
+    release:
+      packages:
+      - dataspeed_dbw_common
+      - dataspeed_dbw_gateway
+      - dataspeed_dbw_msgs
+      - dataspeed_ulc
+      - dataspeed_ulc_can
+      - dataspeed_ulc_msgs
+      - dbw_fca
+      - dbw_fca_can
+      - dbw_fca_description
+      - dbw_fca_joystick_demo
+      - dbw_fca_msgs
+      - dbw_ford
+      - dbw_ford_can
+      - dbw_ford_description
+      - dbw_ford_joystick_demo
+      - dbw_ford_msgs
+      - dbw_polaris
+      - dbw_polaris_can
+      - dbw_polaris_description
+      - dbw_polaris_joystick_demo
+      - dbw_polaris_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/DataspeedInc-release/dbw_ros-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://bitbucket.org/dataspeedinc/dbw_ros.git
+      version: ros2
+    status: developed
   demos:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_ros` to `2.1.0-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/dbw_ros.git
- release repository: https://github.com/DataspeedInc-release/dbw_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## dataspeed_dbw_common

```
* Remove unused dependency
* Add missing ament_cmake_gtest dependency
* Sync ament_cmake and ament_cmake_ros in each CMakeLists.txt/package.xml
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```

## dataspeed_dbw_gateway

```
* Add missing ament_cmake_gtest dependency
* Add missing dependencies for dataspeed_dbw_gateway
* Sync ament_cmake and ament_cmake_ros in each CMakeLists.txt/package.xml
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```

## dataspeed_dbw_msgs

- No changes

## dataspeed_ulc

- No changes

## dataspeed_ulc_can

```
* Reconfigure CAN and ROS messages for new ULC capability
* Sync ament_cmake and ament_cmake_ros in each CMakeLists.txt/package.xml
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```

## dataspeed_ulc_msgs

```
* Reconfigure CAN and ROS messages for new ULC capability
* Contributors: Micho Radovnikovich
```

## dbw_fca

- No changes

## dbw_fca_can

```
* Bump firmware versions
* Add missing ament_cmake_gtest dependency
* Sync ament_cmake and ament_cmake_ros in each CMakeLists.txt/package.xml
* Change unsigned vehicle speed to signed vehicle velocity
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```

## dbw_fca_description

```
* Sync ament_cmake and ament_cmake_ros in each CMakeLists.txt/package.xml
* Contributors: Kevin Hallenbeck
```

## dbw_fca_joystick_demo

```
* Sync ament_cmake and ament_cmake_ros in each CMakeLists.txt/package.xml
* Contributors: Kevin Hallenbeck
```

## dbw_fca_msgs

- No changes

## dbw_ford

- No changes

## dbw_ford_can

```
* Bump firmware versions
* Add missing ament_cmake_gtest dependency
* Sync ament_cmake and ament_cmake_ros in each CMakeLists.txt/package.xml
* Change unsigned vehicle speed to signed vehicle velocity
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```

## dbw_ford_description

```
* Sync ament_cmake and ament_cmake_ros in each CMakeLists.txt/package.xml
* Contributors: Kevin Hallenbeck
```

## dbw_ford_joystick_demo

```
* Sync ament_cmake and ament_cmake_ros in each CMakeLists.txt/package.xml
* Contributors: Kevin Hallenbeck
```

## dbw_ford_msgs

- No changes

## dbw_polaris

- No changes

## dbw_polaris_can

```
* Bump firmware versions
* Add missing ament_cmake_gtest dependency
* Sync ament_cmake and ament_cmake_ros in each CMakeLists.txt/package.xml
* Change unsigned vehicle speed to signed vehicle velocity
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```

## dbw_polaris_description

```
* Sync ament_cmake and ament_cmake_ros in each CMakeLists.txt/package.xml
* Contributors: Kevin Hallenbeck
```

## dbw_polaris_joystick_demo

```
* Sync ament_cmake and ament_cmake_ros in each CMakeLists.txt/package.xml
* Contributors: Kevin Hallenbeck
```

## dbw_polaris_msgs

- No changes
