### PR TITLE
marti_common: 3.5.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2777,8 +2777,8 @@ repositories:
       - swri_transform_util
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 3.4.1-1
+      url: https://github.com/ros2-gbp/marti_common-release.git
+      version: 3.5.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `3.5.1-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/ros2-gbp/marti_common-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.4.1-1`

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

```
* Fixing how the GEOS library is found (#697 <https://github.com/swri-robotics/marti_common/issues/697>)
* Contributors: David Anthony
```

## swri_image_util

- No changes

## swri_math_util

- No changes

## swri_opencv_util

- No changes

## swri_prefix_tools

- No changes

## swri_roscpp

- No changes

## swri_route_util

- No changes

## swri_serial_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

- No changes
