### PR TITLE
Galactic: Update upstream development ref for Fast-CDR

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1090,7 +1090,7 @@ repositories:
       test_pull_requests: false
       type: git
       url: https://github.com/eProsima/Fast-CDR.git
-      version: v1.0.13
+      version: v1.0.20
     status: maintained
   fastrtps:
     release:


### PR DESCRIPTION
Humble and Rolling use `master` here, but that seems like an aggressive change given the pending EOL of Galactic. We can at least make sure the same version is used as in the release.