### PR TITLE
launch: 0.17.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1921,7 +1921,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.17.1-1
+      version: 0.17.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.17.2-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.17.1-1`

## launch

```
* Add missing exec dependency on PyYAML (#682 <https://github.com/ros2/launch/issues/682>)
* Support scoping environment variables (#631 <https://github.com/ros2/launch/issues/631>)
* Contributors: Jacob Perron, Scott K Logan
```

## launch_testing

```
* Inherit markers from generate_test_description (#675 <https://github.com/ros2/launch/issues/675>)
* Fix Typo (#643 <https://github.com/ros2/launch/issues/643>)
* Add compatitibility with pytest 7 (#629 <https://github.com/ros2/launch/issues/629>)
* Mention that ready_fn in generate_test_description is deprecated (#623 <https://github.com/ros2/launch/issues/623>)
* Switch to using a comprehension for process_names. (#616 <https://github.com/ros2/launch/issues/616>)
* Contributors: Bi0T1N, Chris Lalancette, Kenji Brameld, Scott K Logan, Shane Loretz
```

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* Support scoping environment variables (#631 <https://github.com/ros2/launch/issues/631>)
* Contributors: Jacob Perron
```

## launch_yaml

```
* Support scoping environment variables (#631 <https://github.com/ros2/launch/issues/631>)
* Contributors: Jacob Perron
```
