### PR TITLE
rosidl: 2.2.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4624,7 +4624,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 2.2.2-1
+      version: 2.2.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `2.2.3-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.2-1`

## rosidl_adapter

- No changes

## rosidl_cli

```
* Add missing f for format string (#718 <https://github.com/ros2/rosidl/issues/718>)
* Contributors: Shane Loretz
```

## rosidl_cmake

```
* Use target output name for exporting typesupport library (#638 <https://github.com/ros2/rosidl/issues/638>)
* Contributors: Jonathan Selling
```

## rosidl_generator_c

- No changes

## rosidl_generator_cpp

- No changes

## rosidl_parser

```
* Always include whitespace in string literals (#690 <https://github.com/ros2/rosidl/issues/690>)
* Contributors: Shane Loretz
```

## rosidl_runtime_c

- No changes

## rosidl_runtime_cpp

- No changes

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

- No changes

## rosidl_typesupport_introspection_cpp

- No changes
