### PR TITLE
rviz: 8.5.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -5305,7 +5305,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 8.5.1-1
+      version: 8.5.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `8.5.2-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `8.5.1-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

- No changes

## rviz_default_plugins

```
* Delete frame_locked_markers when reusing marker (#911 <https://github.com/ros2/rviz/issues/911>)
* Set error status when duplicate markers are in the same MarkerArray (#900 <https://github.com/ros2/rviz/issues/900>)
* Make Axes display use latest transform (#903 <https://github.com/ros2/rviz/issues/903>)
* Contributors: Shane Loretz
```

## rviz_ogre_vendor

```
* Fix interface link libraries in ogre vendor (#879 <https://github.com/ros2/rviz/issues/879>)
* Contributors: Laszlo Turanyi
```

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
