### PR TITLE
pluginlib: 5.0.1-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3206,7 +3206,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 5.0.0-2
+      version: 5.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `5.0.1-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `5.0.0-2`

## pluginlib

```
* extend termination condition to avoid infinite loop if package.xml is not found (#243 <https://github.com/ros/pluginlib/issues/243>)
* Contributors: Alberto Soragna
```
