### PR TITLE
rmw_cyclonedds: 0.22.6-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4059,7 +4059,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 0.22.5-1
+      version: 0.22.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `0.22.6-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.22.5-1`

## rmw_cyclonedds_cpp

```
* Handle allocation errors during message deserialization (#418 <https://github.com/ros2/rmw_cyclonedds/issues/418>)
* Adds topic name to error msg when create_topic fails (#421 <https://github.com/ros2/rmw_cyclonedds/issues/421>)
* Improve error message when create_topic fails (#407 <https://github.com/ros2/rmw_cyclonedds/issues/407>)
* Contributors: Jacob Perron, Michel Hidalgo, Shane Loretz, Voldivh
```
