### PR TITLE
launch_ros: 0.14.4-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1956,7 +1956,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.14.3-1
+      version: 0.14.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.14.4-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.14.3-1`

## launch_ros

- No changes

## launch_testing_ros

```
* Inherit markers from generate_test_description (#333 <https://github.com/ros2/launch_ros/issues/333>)
* Contributors: Scott K Logan
```

## ros2launch

- No changes
