### PR TITLE
ros2_control: 2.18.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4522,7 +4522,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.17.0-1
+      version: 2.18.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.18.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.17.0-1`

## controller_interface

- No changes

## controller_manager

```
* Use a thread priority library from realtime_tools (#794 <https://github.com/ros-controls/ros2_control/issues/794>) (#868 <https://github.com/ros-controls/ros2_control/issues/868>)
* Fix const-ness in std::chrono::time_point construction and explicitly use std::chrono::nanoseconds as std::chrono::time_point template parameter to help compilation on macOS as its std::chrono::system_clock::time_point defaults to std::chrono::milliseconds for duration type (#848 <https://github.com/ros-controls/ros2_control/issues/848>) (#866 <https://github.com/ros-controls/ros2_control/issues/866>)
* Contributors: Andy Zelenak, light-tech
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Fix hardware interface CLI description (#864 <https://github.com/ros-controls/ros2_control/issues/864>) (#869 <https://github.com/ros-controls/ros2_control/issues/869>)
* Contributors: Christoph Fröhlich
```

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
