### PR TITLE
casadi: 3.5.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -713,6 +713,12 @@ repositories:
       type: git
       url: https://github.com/PickNikRobotics/cartesian_msgs.git
       version: jade-devel
+  casadi:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/yakunouyang/casadi-release.git
+      version: 3.5.5-3
   catch_ros:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -718,7 +718,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/yakunouyang/casadi-release.git
-      version: 3.5.5-3
+      version: 3.5.5-1
   catch_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `casadi` to `3.5.5-1`:

- upstream repository: https://github.com/casadi/casadi.git
- release repository: https://github.com/yakunouyang/casadi-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
