### PR TITLE
image_pipeline: 2.3.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1929,10 +1929,11 @@ repositories:
       - image_rotate
       - image_view
       - stereo_image_proc
+      - tracetools_image_pipeline
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 2.2.1-1
+      version: 2.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `2.3.0-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.1-1`

## camera_calibration

```
* Remove random tab
* Remove lines from cameracalibrator.py and simplify service creation
* Read camera_names
* Read params
* added missing imports
* update pytest.ini
* implemented fisheye mono and stereo calibration based on the melodic branch
* trimmed whitespace at line endings
* Update camera_calibration setup.cfg to use underscores (#688 <https://github.com/ros-perception/image_pipeline/issues/688>)
  Fixes a deprecation warning.
* Add maintainer (#667 <https://github.com/ros-perception/image_pipeline/issues/667>)
* Fixed crash when rosargs are given (#597 <https://github.com/ros-perception/image_pipeline/issues/597>)
  Co-authored-by: Matthijs den Toom <mailto:mdentoom@lely.com>
* Contributors: Gabor Soros, Jacob Perron, Matthijs den Toom, Patrick Musau, Wouter Heerwegh, jaiveersinghNV
```

## depth_image_proc

```
* Fix linker error caused by templating in the conversions.cpp file (#718 <https://github.com/ros-perception/image_pipeline/issues/718>)
* Fixed typo in pointcloudxyz launch file
* use unique_ptrs, remove unused code, add back in missing initMatrix call
* add xyzrgb radial node
* Use RCLCPP_WARN_THROTTLE (10 secs) to avoid terminal spam
* Fix tiny error in comment
* Warning instead of fatal error when frames are differents
* revert a293252
* Replace deprecated geometry2 headers
  tf2_geometry_msgs.h was deprecated in https://github.com/ros2/geometry2/pull/418
  tf2_eigen.h was deprecated in https://github.com/ros2/geometry2/pull/413
* Add maintainer (#667 <https://github.com/ros-perception/image_pipeline/issues/667>)
* move to hpp/cpp structure, create conversions file
* Fix deprecation warning calling declare_parameter
  As of https://github.com/ros2/rclcpp/pull/1522, we must also declare the type of the parameter.
  We can do this implicitly by providing a default value.
  Prior to this change, distance_ was being default-initialized to 0.0 anyways.
* Contributors: Evan Flynn, Francisco Martin Rico, Francisco Martín Rico, Harshal Deshpande, Jacob Perron, Patrick Musau
```

## image_pipeline

```
* Add maintainer (#667 <https://github.com/ros-perception/image_pipeline/issues/667>)
* Contributors: Jacob Perron
```

## image_proc

```
* Add conversion from YUV422-YUY2
* Remove unnecessary find_package
  tracetools_image_pipeline included in package.xml and
  fetched by ament_auto_find_build_dependencies().
* Deal with uncrustify and cpplint
* LTTng instrument image_proc::RectifyNode and image_proc::ResizeNode
* bring over ros1 fix for missing roi resize
* Add maintainer (#667 <https://github.com/ros-perception/image_pipeline/issues/667>)
* Fix build with later versions of OpenCV 3
  This first regressed in 2b17a38a5e3d4aef9c6a51c2de10d7396c521648.
  Support for OpenCV 3.2 was re-added in
  2e0c6d42cb650534e4aeea586482030e5c0d46c8. This fixes the build with
  OpenCV 3.3 and newer.
* Refactor image_proc and stereo_image_proc launch files (#583 <https://github.com/ros-perception/image_pipeline/issues/583>)
  * Allow passing container name to image_proc launch file
  If a container name is provided, then load the image_proc nodes
  into that container. Otherwise, launch a container to load the nodes into.
  * Include the image_proc launch file in the stereo_image_proc launch file
  This resolves a TODO, making the launch file have similar behavior as the version from ROS 1.
  Also expose a new launch argument for optionally providing a container (similar to image_proc's launch file).
  * Minor refactor to stereo_image_proc launch file
  * Fix lint errors
  Removing vestigial imports.
  * Rename namespace launch arguments
  * Make image_proc nodes optional
  Default to launching the image_proc nodes.
  * Remap topics from stereo nodes based on namespace arguments
* Contributors: Evan Flynn, Jacob Perron, Scott K Logan, Tillmann Falck, Víctor Mayoral Vilches
```

## image_publisher

```
* Add retry video capture feature with timeout
  Retry onInit() if the loading image fails or if the image is empty.
  This is useful if the stream is lost for a while or if the stream
  is not ready in the beginning.
* changes per comments
* fix for stereo_image_proc_tests
* Add maintainer (#667 <https://github.com/ros-perception/image_pipeline/issues/667>)
* Contributors: Ashwin Sushil, Jacob Perron, Patrick Musau
```

## image_rotate

```
* revert a293252
* Replace deprecated geometry2 headers
  tf2_geometry_msgs.h was deprecated in https://github.com/ros2/geometry2/pull/418
  tf2_eigen.h was deprecated in https://github.com/ros2/geometry2/pull/413
* Add maintainer (#667 <https://github.com/ros-perception/image_pipeline/issues/667>)
* Contributors: Jacob Perron, Patrick Musau
```

## image_view

```
* Fix image saver bug and time-based image saving
  Add missing 'request_start_end' ROS parameter (from ROS 1) and ensure related
  member variables are initialized properly. This restores the time-based image
  saving feature from ROS 1 and fixes a bug where member variables
  'save_image_service' and 'request_start_end' were not initialized properly
  which could lead to images not properly saving.
  I've also renamed some member variables to have a trailing underscore, for
  consistency with other members.
* replace ROSTIME
* Changing to RCL_SYSTEM_TIME
* Fix timestamp creation
* changes per comments
* fix for stereo_image_proc_tests
* Add maintainer (#667 <https://github.com/ros-perception/image_pipeline/issues/667>)
* Fix wrong usage of rclcpp::Duration constructor
* Contributors: Ivan Santiago Paunovic, Jacob Perron, Lars Lorentz Ludvigsen, Patrick Musau
```

## stereo_image_proc

```
* Add missing test dependency
* Add color param to stereo_image_proc (#661 <https://github.com/ros-perception/image_pipeline/issues/661>)
  * Add color param to point cloud node in stereo_image_proc
  * Add test for point cloud node with color disabled
  * Fix style issues
  * Rename test node
  * Remove repeated line
* fix for stereo_image_proc_tests
* Add maintainer (#667 <https://github.com/ros-perception/image_pipeline/issues/667>)
* Add disparity node parameters to launch file
  This makes the launch file more flexible for including in other launch files.
* Fix disparity node parameter name
  Rename the parameter 'texture_ratio' to 'texture_threshold'.
  The parameter was incorrectly named during the port from ROS 1 to ROS 2.
* Expose avoid_point_cloud_padding parameter in stereo_image_proc launch file (#599 <https://github.com/ros-perception/image_pipeline/issues/599>)
* Refactor image_proc and stereo_image_proc launch files (#583 <https://github.com/ros-perception/image_pipeline/issues/583>)
  * Allow passing container name to image_proc launch file
  If a container name is provided, then load the image_proc nodes
  into that container. Otherwise, launch a container to load the nodes into.
  * Include the image_proc launch file in the stereo_image_proc launch file
  This resolves a TODO, making the launch file have similar behavior as the version from ROS 1.
  Also expose a new launch argument for optionally providing a container (similar to image_proc's launch file).
  * Minor refactor to stereo_image_proc launch file
  * Fix lint errors
  Removing vestigial imports.
  * Rename namespace launch arguments
  * Make image_proc nodes optional
  Default to launching the image_proc nodes.
  * Remap topics from stereo nodes based on namespace arguments
* Contributors: Jacob Perron, Patrick Musau, Rebecca Butler
```

## tracetools_image_pipeline

```
* Add initial CHANGELOG for tracetools_image_pipeline.
* tracetools_image_pipeline version consistent with repo
* Omit changelogfile
  See https://github.com/ros-perception/image_pipeline/pull/717#discussion_r781637389
* Deal with uncrustify and cpplint
* Add tracetools_image_pipeline package to the pipeline
  Add an LTTng tracing provider wrapper for image_pipeline
  metapackage. Include tracepoints for two initial ROS 2
  components: image_proc::RectifyNode and ResizeNode
* Contributors: Víctor Mayoral Vilches
```
