### PR TITLE
image_pipeline: 3.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1715,7 +1715,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `3.0.1-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.0-1`

## camera_calibration

```
* add python3-opencv to camera calibration dependency
* port changes from #755 <https://github.com/ros-perception/image_pipeline/issues/755> to rolling branch
* Contributors: Kenji Brameld
```

## depth_image_proc

```
* Replace deprecated headers
  Fixing compiler warnings.
* Contributors: Jacob Perron
```

## image_pipeline

- No changes

## image_proc

```
* Replace deprecated headers
  Fixing compiler warnings.
* add NOLINT to keep cpplint happy about curly brace being on new line
* Add conversion from YUV422-YUY2
* Contributors: Jacob Perron, Kenji Brameld, Tillmann Falck
```

## image_publisher

```
* Replace deprecated headers
  Fixing compiler warnings.
* Contributors: Jacob Perron
```

## image_rotate

```
* Replace deprecated headers
  Fixing compiler warnings.
* Contributors: Jacob Perron
```

## image_view

```
* Replace deprecated headers
  Fixing compiler warnings.
* Contributors: Jacob Perron
```

## stereo_image_proc

```
* Replace deprecated headers
  Fixing compiler warnings.
* Add support for ApproximateEpsilonTime in stereo_image_proc and disparity_node
* Forward container namespace from stereo_image_proc -> image_proc (#752 <https://github.com/ros-perception/image_pipeline/issues/752>)
* Contributors: Brian, Ivan Santiago Paunovic, Jacob Perron
```

## tracetools_image_pipeline

- No changes
