### PR TITLE
foxglove_bridge: 0.2.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3576,7 +3576,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/foxglove/ros_foxglove_bridge-release.git
-      version: 0.2.0-3
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_bridge` to `0.2.1-1`:

- upstream repository: https://github.com/foxglove/ros-foxglove-bridge.git
- release repository: https://github.com/foxglove/ros_foxglove_bridge-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.0-3`

## foxglove_bridge

```
* Fix compilation on platforms where size_t is defined as unsigned int
* Contributors: Hans-Joachim Krauch
```
