### PR TITLE
ros2_control: 3.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4166,7 +4166,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.4.0-1
+      version: 3.5.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.5.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.4.0-1`

## controller_interface

- No changes

## controller_manager

```
* Rename class type to plugin name #api-breaking #abi-breaking (#780 <https://github.com/ros-controls/ros2_control/issues/780>)
* Namespace Loaded Controllers (#852 <https://github.com/ros-controls/ros2_control/issues/852>)
* Contributors: Bence Magyar, sp-sophia-labs
```

## controller_manager_msgs

```
* Rename class type to plugin name #api-breaking #abi-breaking (#780 <https://github.com/ros-controls/ros2_control/issues/780>)
* Contributors: Bence Magyar
```

## hardware_interface

```
* ResourceManager doesn't always log an error on shutdown anymore (#867 <https://github.com/ros-controls/ros2_control/issues/867>)
* Rename class type to plugin name #api-breaking #abi-breaking (#780 <https://github.com/ros-controls/ros2_control/issues/780>)
* Contributors: Bence Magyar, Christopher Wecht
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

```
* Rename class type to plugin name #api-breaking #abi-breaking (#780 <https://github.com/ros-controls/ros2_control/issues/780>)
* Contributors: Bence Magyar
```

## ros2controlcli

```
* Fix hardware interface CLI description (#864 <https://github.com/ros-controls/ros2_control/issues/864>)
* Contributors: Christoph Fröhlich
```

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
