### PR TITLE
ros2_controllers: 2.15.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4197,7 +4197,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.14.0-1
+      version: 2.15.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.15.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.14.0-1`

## admittance_controller

- No changes

## diff_drive_controller

```
* [DiffDriveController] Use generate parameter library (#386 <https://github.com/ros-controls/ros2_controllers/issues/386>)
* [DiffDriveController] Change units of velocity feedback (#452 <https://github.com/ros-controls/ros2_controllers/issues/452>)
* Contributors: Maciej Stępień, Paul Gesel, Denis Štogl, Bence Magyar
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gripper_controllers

```
* Add basic gripper controller tests (#459 <https://github.com/ros-controls/ros2_controllers/issues/459>)
* Contributors: Bence Magyar
```

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

- No changes

## position_controllers

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## tricycle_controller

```
* [TricycleController] Removed “publish period” functionality ⏱ #abi-break #behavior-break (#468 <https://github.com/ros-controls/ros2_controllers/issues/468>)
* Contributors: Robotgir, Denis Štogl
```

## velocity_controllers

- No changes
