### PR TITLE
pybind11_vendor: 3.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3227,7 +3227,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pybind11_vendor-release.git
-      version: 3.0.1-1
+      version: 3.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pybind11_vendor` to `3.0.2-1`:

- upstream repository: https://github.com/ros2/pybind11_vendor.git
- release repository: https://github.com/ros2-gbp/pybind11_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.1-1`

## pybind11_vendor

```
* Add missing buildtool dependency on git (#19 <https://github.com/ros2/pybind11_vendor/issues/19>)
* Update maintainers (#17 <https://github.com/ros2/pybind11_vendor/issues/17>)
* Contributors: Audrow Nash, Scott K Logan
```
