### PR TITLE
rclcpp: 9.2.2-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3626,7 +3626,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 9.2.1-1
+      version: 9.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `9.2.2-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `9.2.1-1`

## rclcpp

```
* Fix returning invalid namespace if sub_namespace is empty (#1810 <https://github.com/ros2/rclcpp/issues/1810>)
* use regex for wildcard matching (#1987 <https://github.com/ros2/rclcpp/issues/1987>)
* Add statistics for handle_loaned_message (#1933 <https://github.com/ros2/rclcpp/issues/1933>)
* Contributors: Aaron Lipinski, Barry Xu, Chen Lihui, M. Hofstätter
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
