### PR TITLE
rclpy: 1.9.3-1 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -3642,7 +3642,7 @@ repositories:
       tags:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 1.9.2-1
+      version: 1.9.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `1.9.3-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.9.2-1`

## rclpy

```
* remove feedback callback when the goal has been completed. (#932 <https://github.com/ros2/rclpy/issues/932>)
* Waitable should check callback_group if it can be executed. (#1014 <https://github.com/ros2/rclpy/issues/1014>)
* support wildcard matching for params file (#1003 <https://github.com/ros2/rclpy/issues/1003>)
* Contributors: Chen Lihui, Tomoya Fujita
```
