### PR TITLE
pybind11_json_vendor: 0.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3212,7 +3212,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pybind11_json_vendor-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/open-rmf/pybind11_json_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pybind11_json_vendor` to `0.2.2-1`:

- upstream repository: https://github.com/open-rmf/pybind11_json_vendor
- release repository: https://github.com/ros2-gbp/pybind11_json_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.1-1`
