### PR TITLE
imu_tools: 2.1.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1757,7 +1757,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/imu_tools-release.git
-      version: 2.1.2-1
+      version: 2.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `2.1.3-1`:

- upstream repository: https://github.com/CCNYRoboticsLab/imu_tools.git
- release repository: https://github.com/ros2-gbp/imu_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.2-1`

## imu_complementary_filter

```
* complementary: Build shared library
  See #172 <https://github.com/CCNYRoboticsLab/imu_tools/issues/172>.
* Update CMakeLists to use targets
* Remove node_ prefix. (#163 <https://github.com/CCNYRoboticsLab/imu_tools/issues/163>)
* Contributors: Martin Günther, Max Polzin
```

## imu_filter_madgwick

```
* Update CMakeLists to use targets
* Remove node_ prefix. (#163 <https://github.com/CCNYRoboticsLab/imu_tools/issues/163>)
* Contributors: Martin Günther, Max Polzin
```

## imu_tools

- No changes

## rviz_imu_plugin

- No changes
