### PR TITLE
Add missing source stanza for ros2cli_common_extensions

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -4372,6 +4372,10 @@ repositories:
         release: release/galactic/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli_common_extensions-release.git
       version: 0.1.1-2
+    source:
+      type: git
+      url: https://github.com/ros2/ros2cli_common_extensions.git
+      version: galactic
     status: maintained
   ros2launch_security:
     doc:


### PR DESCRIPTION
While not strictly required, this stanza enables functionality in tools like `rosinstall_generator`.