### PR TITLE
pick_ik: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3068,7 +3068,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/PickNikRobotics/pick_ik-release.git
+      url: https://github.com/ros2-gbp/pick_ik-release.git
       version: 1.0.0-1
     source:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3060,6 +3060,21 @@ repositories:
       url: https://github.com/ros-drivers/phidgets_drivers.git
       version: rolling
     status: maintained
+  pick_ik:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/pick_ik.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/PickNikRobotics/pick_ik-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/pick_ik.git
+      version: main
+    status: developed
   picknik_ament_copyright:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pick_ik` to `1.0.0-1`:

- upstream repository: https://github.com/PickNikRobotics/pick_ik.git
- release repository: https://github.com/PickNikRobotics/pick_ik-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## pick_ik

```
* pick_ik inverse kinematics plugin compatible with MoveIt 2
* Numeric gradient descent (local) solver
* Memetic algorithm (global solver), configurable for single or multi-threading
* Basic goal functions: joint centering, avoid joint limits, minimal joint displacement
* Support for position-only IK and approximate solutions
* Dynamic parameter switching at runtime using generate_parameter_library <https://github.com/PickNikRobotics/generate_parameter_library>
* Docker devcontainer workflow for VSCode
* Contributors: Chris Thrasher, Sebastian Castro, Tyler Weaver
```
