### PR TITLE
ur_robot_driver: 2.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -14535,6 +14535,21 @@ repositories:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver.git
       version: master
+    release:
+      packages:
+      - controller_stopper
+      - ur_calibration
+      - ur_dashboard_msgs
+      - ur_robot_driver
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver.git
+      version: master
+    status: developed
   urdf:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.1.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver.git
- release repository: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## controller_stopper

```
* Drop old C++ compiler flags (#577 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/577>)
  Co-authored-by: Jochen Sprickerhof <mailto:git@jochen.sprickerhof.de>
* Remove boilerplate comments from package.xml files (#528 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/528>)
* Contributors: Felix Exner, Michael Görner
```

## ur_calibration

```
* fix dependency for the organization calibration package (#549 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/549>)
* Drop old C++ compiler flags (#577 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/577>)
  Co-authored-by: Jochen Sprickerhof <mailto:git@jochen.sprickerhof.de>
* Remove boilerplate comments from package.xml files (#528 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/528>)
* Contributors: Captain Yoshi, Felix Exner, Michael Görner
```

## ur_dashboard_msgs

```
* Use the RobotMode message inside the SetMode action (#381 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/381>)
  This way we can make use of the predefined constants inside the RobotMode message.
* Drop old C++ compiler flags (#577 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/577>)
  Co-authored-by: Jochen Sprickerhof <mailto:git@jochen.sprickerhof.de>
* Remove boilerplate comments from package.xml files (#528 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/528>)
* Dashboard service to query whether the robot is in remote control (#561 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/561>)
  * new dashboard msg to check remote control
* Contributors: Felix Exner, Felix Exner (fexner), Michael Görner, Mingu Kwon
```

## ur_robot_driver

```
* delete ros_control.urscript (#593 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/593>)
  We've been using the script from the library for a while now
* Use the RobotMode message inside the SetMode action (#381 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/381>)
  This way we can make use of the predefined constants inside the RobotMode message.
* Make several members of hw_interface atomic, for thread safety (#448 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/448>)
  Co-authored-by: Felix Exner (fexner) <mailto:exner@fzi.de>
* Updated transformForceTorque to handle wheter it is a cb3 or an e-Series robot (#566 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/566>)
  The force torque is returned at the tool flange on e-series robots and at the tcp for CB3, this is now handled correctly, so that all force/torque measurements will be relative to the active TCP
* Updated set payload, zero ftsensor and set tool voltage to use the ur… (#567 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/567>)
  * Updated set payload, zero ftsensor and set tool voltage to use the urdriver
  This makes it possible to call the commands when the robot is in local control if the external control script is running on the robot.
  * Update ROS interface docs
  * Fix argument passing in include instruction
  Co-authored-by: Miguel Prada <mailto:miguel.prada@tecnalia.com>
* Remove URCap installation files from driver and replace references (#580 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/580>)
  Link to the respective Github release pages instead.
* Drop old C++ compiler flags (#577 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/577>)
  Co-authored-by: Jochen Sprickerhof <mailto:git@jochen.sprickerhof.de>
* Fix MoveIt! command in Example (#575 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/575>)
* Allow empty stopped_controllers argument. (#572 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/572>)
* Dashboard service to query whether the robot is in remote control (#561 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/561>)
  * new dashboard msg to check remote control
* test_move: Load controller only if it is not already loaded (#552 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/552>)
* Add optional topic rename for speed scaling factor (#544 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/544>)
  * Add optional topic rename for speed scaling factor
  * Update ROS_INTERFACE.md
* Wait for controller action server in test_move. (#535 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/535>)
* Minor update to display robot_ip parameter without _ (#521 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/521>)
* Make hw_interface-node required-argument optional (#450 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/450>)
  The UR-robot is only one part of our roslaunch-setup, so I would like to be able to have the rest of the system (non-UR) continue to run even if the ur_hardware_interface-node dies.
* Fix test move python3 (#492 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/492>)
  * make test_move work with python2 and python3
  As suggested in http://wiki.ros.org/UsingPython3/SourceCodeChanges#Changing_shebangs
  - Use a version-independent shebang
  - Use catkin_install_python to install the test_move script
* Update feature list (#490 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/490>)
  Some minor formatting and reducing the wrench features to one features to make it more clear.
* Contributors: Adam Heins, AndyZe, Felix Exner, Felix Exner (fexner), Johnson, Mads Holm Peters, Michael Görner, Mingu Kwon, steinmn, teapfw, williamnavaraj
```
