### PR TITLE
rename ros2 to rolling branch in image_transport_plugins

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1726,7 +1726,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/image_transport_plugins.git
-      version: ros2
+      version: rolling
     release:
       packages:
       - compressed_depth_image_transport
@@ -1741,7 +1741,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/image_transport_plugins.git
-      version: ros2
+      version: rolling
     status: maintained
   imu_tools:
     doc:


### PR DESCRIPTION
The ros2 branch has been renamed to rolling, to match core-package recommendations.