### PR TITLE
simple_term_menu_vendor: 1.5.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5792,7 +5792,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/simple_term_menu_vendor-release.git
-      version: 1.5.4-1
+      version: 1.5.5-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/simple-term-menu.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_term_menu_vendor` to `1.5.5-1`:

- upstream repository: https://github.com/clearpathrobotics/simple-term-menu.git
- release repository: https://github.com/clearpath-gbp/simple_term_menu_vendor-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.5.4-1`

## simple_term_menu_vendor

```
* Added ament_cmake_python buildtool_depend
* Contributors: Roni Kreinin
```
