### PR TITLE
rtabmap: 0.20.22-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5555,7 +5555,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/introlab/rtabmap.git
-      version: rolling-devel
+      version: humble-devel
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -5564,7 +5564,7 @@ repositories:
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
-      version: rolling-devel
+      version: humble-devel
     status: maintained
   rtabmap_ros:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5560,7 +5560,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rtabmap-release.git
-      version: 0.20.21-1
+      version: 0.20.22-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap` to `0.20.22-1`:

- upstream repository: https://github.com/introlab/rtabmap.git
- release repository: https://github.com/ros2-gbp/rtabmap-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.20.21-1`
