### PR TITLE
find_object_2d: 0.7.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1432,6 +1432,21 @@ repositories:
       url: https://github.com/ros/filters.git
       version: ros2
     status: maintained
+  find_object_2d:
+    doc:
+      type: git
+      url: https://github.com/introlab/find-object.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/introlab/find_object_2d-release.git
+      version: 0.7.0-1
+    source:
+      type: git
+      url: https://github.com/introlab/find-object.git
+      version: foxy-devel
+    status: maintained
   fluent_rviz:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `find_object_2d` to `0.7.0-1`:

- upstream repository: https://github.com/introlab/find-object.git
- release repository: https://github.com/introlab/find_object_2d-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
