### PR TITLE
find_object_2d: 0.7.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2608,7 +2608,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/introlab/find_object_2d-release.git
-      version: 0.6.3-5
+      version: 0.7.0-2
     source:
       type: git
       url: https://github.com/introlab/find-object.git


### PR DESCRIPTION
Increasing version of package(s) in repository `find_object_2d` to `0.7.0-2`:

- upstream repository: https://github.com/introlab/find-object.git
- release repository: https://github.com/introlab/find_object_2d-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.3-5`
