### PR TITLE
ur_robot_driver: 2.0.2-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -7089,6 +7089,7 @@ repositories:
     release:
       packages:
       - ur_bringup
+      - ur_calibration
       - ur_controllers
       - ur_dashboard_msgs
       - ur_description
@@ -7097,7 +7098,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.0.1-1
+      version: 2.0.2-2
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.0.2-2`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.1-1`

## ur_bringup

```
* executable name change (#514 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/514>)
* Don't attempt to start dashboard_client when use_fake_hardware is true (#486 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/486>)
* Contributors: Felix Exner, mertgungor
```

## ur_calibration

```
* Added changelog of ur_calibration
* Fixed package version of ur_calibration
  That one was old
* Add ur_calibration package (#451 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/451>)
  Co-authored-by: Mads Holm Peters <mailto:79145214+urmahp@users.noreply.github.com>
* Contributors: Felix Exner
* Add ur_calibration package (#451 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/451>)
  Co-authored-by: Mads Holm Peters <mailto:79145214+urmahp@users.noreply.github.com>
* Contributors: Felix Exner
```

## ur_controllers

- No changes

## ur_dashboard_msgs

- No changes

## ur_description

- No changes

## ur_moveit_config

- No changes

## ur_robot_driver

- No changes
