### PR TITLE
magic_enum: 0.8.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2348,7 +2348,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/nobleo/magic_enum-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       type: git
       url: https://github.com/Neargye/magic_enum.git


### PR DESCRIPTION
Increasing version of package(s) in repository `magic_enum` to `0.8.2-1`:

- upstream repository: https://github.com/Neargye/magic_enum.git
- release repository: https://github.com/nobleo/magic_enum-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.8.1-1`
