### PR TITLE
aruco_opencv: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -368,6 +368,24 @@ repositories:
       url: https://github.com/AprilRobotics/apriltag.git
       version: master
     status: maintained
+  aruco_opencv:
+    doc:
+      type: git
+      url: https://github.com/fictionlab/ros_aruco_opencv.git
+      version: humble
+    release:
+      packages:
+      - aruco_opencv
+      - aruco_opencv_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/aruco_opencv-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/fictionlab/ros_aruco_opencv.git
+      version: humble
+    status: maintained
   async_web_server_cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_opencv` to `2.0.0-1`:

- upstream repository: https://github.com/fictionlab/ros_aruco_opencv.git
- release repository: https://github.com/ros2-gbp/aruco_opencv-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## aruco_opencv

```
* Better camera calibration handling (#3 <https://github.com/fictionlab/aruco_opencv/issues/3>) (#4 <https://github.com/fictionlab/aruco_opencv/issues/4>)
  * Support different distortion models
  * Support rectified images
* Use the custom QoS for image subscription
* Fix autostart node activation
* Use newer headers for tf2_geometry_msgs
* Fix aruco library linking
* Fix build for Humble
* Remove image_transport parameter
* Add marker_dict parameter
* Unsubscribe from image topic on shutdown
* Add single_marker_tracker_autostart node
* Reformat code with uncrustify
* Use cv::parallel_for_ in PnP pose computation
* Refactor parameter declaration and retrieval, add utils.hpp
* Initial LifecycleNode implementation
* Update project dependencies
* Add copyright notice
* Install config directory
* Port launch and config file to ROS2
* Remove old dynamic reconfigure config
* Declare the rest of the parameters
* Initial port for ROS2 Foxy
* Simplify filling the camera matrix from camera info
* Contributors: Błażej Sowa
```

## aruco_opencv_msgs

```
* Initial port for ROS2 Foxy
* Contributors: Błażej Sowa
```
