### PR TITLE
foxglove_bridge: 0.2.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1297,7 +1297,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_bridge` to `0.2.2-1`:

- upstream repository: https://github.com/foxglove/ros-foxglove-bridge.git
- release repository: https://github.com/ros2-gbp/foxglove_bridge-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.1-1`

## foxglove_bridge

```
* Fix messages not being received anymore after unadvertising a client publication (#109 <https://github.com/foxglove/ros-foxglove-bridge/issues/109>)
* Allow to whitelist topics via a ROS paramater (#108 <https://github.com/foxglove/ros-foxglove-bridge/issues/108>)
* Contributors: Hans-Joachim Krauch
```
