### PR TITLE
maliput_sparse: 0.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2728,7 +2728,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput_sparse-release.git
-      version: 0.1.0-1
+      version: 0.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_sparse` to `0.2.0-1`:

- upstream repository: https://github.com/maliput/maliput_sparse.git
- release repository: https://github.com/ros2-gbp/maliput_sparse-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.0-1`

## maliput_sparse

```
* Builds up RoadGeometry out of parsed information. (#40 <https://github.com/maliput/maliput_sparse/issues/40>)
* Contributors: Franco Cipollone
```
