### PR TITLE
maliput_dragway: 0.1.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2561,7 +2561,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput_dragway-release.git
-      version: 0.1.3-1
+      version: 0.1.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_dragway` to `0.1.4-1`:

- upstream repository: https://github.com/maliput/maliput_dragway.git
- release repository: https://github.com/ros2-gbp/maliput_dragway-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.3-1`

## maliput_dragway

```
* Implements plugin interface for providing default parameters. (#79 <https://github.com/maliput/maliput_dragway/issues/79>)
* Updates triage workflow. (#77 <https://github.com/maliput/maliput_dragway/issues/77>)
* Contributors: Franco Cipollone
```
