### PR TITLE
turbojpeg_compressed_image_transport: 0.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6353,6 +6353,21 @@ repositories:
       url: https://github.com/ros-drivers/transport_drivers.git
       version: main
     status: developed
+  turbojpeg_compressed_image_transport:
+    doc:
+      type: git
+      url: https://github.com/wep21/turbojpeg_compressed_image_transport.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/turbojpeg_compressed_image_transport-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/wep21/turbojpeg_compressed_image_transport.git
+      version: main
+    status: maintained
   turtlebot3:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turbojpeg_compressed_image_transport` to `0.1.1-1`:

- upstream repository: https://github.com/wep21/turbojpeg_compressed_image_transport.git
- release repository: https://github.com/ros2-gbp/turbojpeg_compressed_image_transport-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## turbojpeg_compressed_image_transport

```
* chore: update license and author in package.xml
* Contributors: Daisuke Nishimatsu
```
