### PR TITLE
maliput_osm: 0.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2714,7 +2714,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput_osm-release.git
-      version: 0.1.0-1
+      version: 0.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_osm` to `0.2.0-1`:

- upstream repository: https://github.com/maliput/maliput_osm.git
- release repository: https://github.com/ros2-gbp/maliput_osm-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.0-1`

## maliput_osm

```
* Consumes RoadNetworkLoader from maliput_sparse. (#30 <https://github.com/maliput/maliput_osm/issues/30>)
* Use SPDX identifier in license tag. (#48 <https://github.com/maliput/maliput_osm/issues/48>)
  This updates the license tag to use the SPDX identifier for the 3 clause BSD license: https://opensource.org/licenses/BSD-3-Clause
* Contributors: Franco Cipollone, Steven! Ragnarök
```
