### PR TITLE
maliput_viz: 0.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2753,6 +2753,22 @@ repositories:
       url: https://github.com/maliput/maliput_sparse.git
       version: main
     status: developed
+  maliput_viz:
+    doc:
+      type: git
+      url: https://github.com/maliput/maliput_viz.git
+      version: main
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/maliput_viz-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/maliput/maliput_viz.git
+      version: main
+    status: developed
   map_transformer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_viz` to `0.1.0-1`:

- upstream repository: https://github.com/maliput/maliput_viz.git
- release repository: https://github.com/ros2-gbp/maliput_viz-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## maliput_viz

```
* Adds command line support for the maliput viz app. (#18 <https://github.com/maliput/maliput_viz/issues/18>)
* Fills edition boxes when a parameter is clicked. (#17 <https://github.com/maliput/maliput_viz/issues/17>)
* Uses env hooks instead of compiled paths. (#10 <https://github.com/maliput/maliput_viz/issues/10>)
* Updates README file. (#6 <https://github.com/maliput/maliput_viz/issues/6>)
* Adds missing doxygen file. (#8 <https://github.com/maliput/maliput_viz/issues/8>)
* Bring maliput_viewer application from delphyne_gui (#1 <https://github.com/maliput/maliput_viz/issues/1>)
* Initial commit
* Contributors: Franco Cipollone
```
