### PR TITLE
Fedora 35 is EOL, long live Fedora 37

### DIFF
--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -64,8 +64,8 @@ supported_versions:
   - buster
   - bullseye
   fedora:
-  - '35'
   - '36'
+  - '37'
   opensuse:
   - '15.2'
   rhel:
@@ -94,9 +94,9 @@ supported_arches:
 
 name_replacements:
   fedora:
-    '35':
-      '%{__isa_name}': 'x86'
     '36':
+      '%{__isa_name}': 'x86'
+    '37':
       '%{__isa_name}': 'x86'
   rhel:
     '7':


### PR DESCRIPTION
...or at least for the next year or so.

https://docs.fedoraproject.org/en-US/releases/eol/