### PR TITLE
maliput_integration: 0.1.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2627,7 +2627,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput_integration-release.git
-      version: 0.1.3-1
+      version: 0.1.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_integration` to `0.1.4-1`:

- upstream repository: https://github.com/maliput/maliput_integration.git
- release repository: https://github.com/ros2-gbp/maliput_integration-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.3-1`

## maliput_integration

```
* Adds missing dependency to maliput_sparse (#127 <https://github.com/maliput/maliput_integration/issues/127>)
* Adds maliput_osm backend to the applications. (#124 <https://github.com/maliput/maliput_integration/issues/124>)
* Updates triage workflow. (#125 <https://github.com/maliput/maliput_integration/issues/125>)
* Contributors: Franco Cipollone
```
