### PR TITLE
mapviz: 1.4.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4902,7 +4902,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/mapviz-release.git
-      version: 1.4.1-2
+      version: 1.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `1.4.2-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.4.1-2`

## mapviz

```
* Merge pull request #721 <https://github.com/swri-robotics/mapviz/issues/721> from rjb0026/720-allow-building-with-c++14-for-version-greater-than-kinetic
  720 allow building with c++14 for version greater than kinetic
* Conditionally setting c++ standard per target.
* Removed explicit setting of compile flags for c++ standard version and replaced with conditional for building with C++11 in kinetic for mapviz and mapviz_plugins.
* Contributors: Matthew, rjb0026
```

## mapviz_plugins

```
* Merge pull request #716 <https://github.com/swri-robotics/mapviz/issues/716> from swri-robotics/pose_publisher
  Pose publisher
* Merge pull request #752 <https://github.com/swri-robotics/mapviz/issues/752> from matt-attack/add-stuff
  Add bus features
* Update dates
* Add bus features
* Merge pull request #734 <https://github.com/swri-robotics/mapviz/issues/734> from matt-attack/improve-textured-marker
  Fix Issues With Textured Marker Plugin
* Make sure textured marker can handle delayed transforms and use marker alpha values
* Merge pull request #715 <https://github.com/swri-robotics/mapviz/issues/715> from swri-robotics/posearray
  Add visualizer for PoseArray
* Merge pull request #718 <https://github.com/swri-robotics/mapviz/issues/718> from agyoungs/fix-text-marker-disable
  Allow text markers to be enabled/disabled via their namespace using the marker plugin checkboxes
* Merge pull request #721 <https://github.com/swri-robotics/mapviz/issues/721> from rjb0026/720-allow-building-with-c++14-for-version-greater-than-kinetic
  720 allow building with c++14 for version greater than kinetic
* Conditionally setting c++ standard per target.
* Removed explicit setting of compile flags for c++ standard version and replaced with conditional for building with C++11 in kinetic for mapviz and mapviz_plugins.
* Allow text markers to be enabled/disabled via their namespace using the marker plugin checkboxes
* Add visualizer for PoseArray
* Contributors: Alex Youngs, David Anthony, Kevin Nickels, Matthew, Matthew Bries, rjb0026
```

## multires_image

```
* Merge pull request #721 <https://github.com/swri-robotics/mapviz/issues/721> from rjb0026/720-allow-building-with-c++14-for-version-greater-than-kinetic
  720 allow building with c++14 for version greater than kinetic
* Conditionally setting c++ standard per target.
* Added conditional for building with C++11 in kinetic for multires_image and tile_map packages
* Contributors: Matthew, rjb0026
```

## tile_map

```
* Merge pull request #721 <https://github.com/swri-robotics/mapviz/issues/721> from rjb0026/720-allow-building-with-c++14-for-version-greater-than-kinetic
  720 allow building with c++14 for version greater than kinetic
* Conditionally setting c++ standard per target.
* Added conditional for building with C++11 in kinetic for multires_image and tile_map packages
* [tile_map] Output human-readable error message (#703 <https://github.com/swri-robotics/mapviz/issues/703>)
  * [tile_map] Output human-readable error message
* Contributors: Dominik Kleiser, Matthew, rjb0026
```
