### PR TITLE
rqt_human_radar: 0.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9433,7 +9433,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros4hri/rqt_human_radar-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/ros4hri/rqt_human_radar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_human_radar` to `0.2.1-1`:

- upstream repository: https://github.com/ros4hri/rqt_human_radar.git
- release repository: https://github.com/ros4hri/rqt_human_radar-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.0-1`

## rqt_human_radar

```
* changing variable names to overcome shadowing errors
* fixed CMakeLists.txt to overcome shadowing issues
* adding missing build dependencies
  The package was previously missing a series of build dependencies:
  - tf
  - hri
  - qt5base
  - gt5svg5
* Contributors: lorenzoferrini
```
