### PR TITLE
find_object_2d: 0.7.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1192,6 +1192,21 @@ repositories:
       url: https://github.com/ros/filters.git
       version: ros2
     status: maintained
+  find_object_2d:
+    doc:
+      type: git
+      url: https://github.com/introlab/find-object.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/introlab/find_object_2d-release.git
+      version: 0.7.0-1
+    source:
+      type: git
+      url: https://github.com/introlab/find-object.git
+      version: humble-devel
+    status: maintained
   fluent_rviz:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `find_object_2d` to `0.7.0-1`:

- upstream repository: https://github.com/introlab/find-object.git
- release repository: https://github.com/introlab/find_object_2d-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
