### PR TITLE
find_object_2d: 0.7.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1163,6 +1163,21 @@ repositories:
       url: https://github.com/ros/filters.git
       version: ros2
     status: maintained
+  find_object_2d:
+    doc:
+      type: git
+      url: https://github.com/introlab/find-object.git
+      version: rolling-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/introlab/find_object_2d-release.git
+      version: 0.7.0-2
+    source:
+      type: git
+      url: https://github.com/introlab/find-object.git
+      version: rolling-devel
+    status: maintained
   fluent_rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `find_object_2d` to `0.7.0-2`:

- upstream repository: https://github.com/introlab/find-object.git
- release repository: https://github.com/introlab/find_object_2d-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
