### PR TITLE
Add python3-transformers-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5336,13 +5336,6 @@ python-transforms3d-pip:
     jammy:
       pip:
         packages: [transforms3d]
-python3-transformers-pip:
-  debian:
-    pip:
-      packages: [transformers]
-  ubuntu:
-    pip:
-      packages: [transformers]
 python-transitions:
   debian:
     '*': [python-transitions]
@@ -9578,6 +9571,13 @@ python3-tqdm:
   ubuntu:
     '*': [python3-tqdm]
     xenial: null
+python3-transformers-pip:
+  debian:
+    pip:
+      packages: [transformers]
+  ubuntu:
+    pip:
+      packages: [transformers]
 python3-transforms3d:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5321,13 +5321,6 @@ python-tqdm:
     xenial:
       pip:
         packages: [tqdm]
-python3-transformers-pip:
-  debian:
-    pip:
-      packages: [transformers]
-  ubuntu:
-    pip:
-      packages: [transformers]
 python-transforms3d-pip:
   debian:
     pip:
@@ -5343,6 +5336,13 @@ python-transforms3d-pip:
     jammy:
       pip:
         packages: [transforms3d]
+python3-transformers-pip:
+  debian:
+    pip:
+      packages: [transformers]
+  ubuntu:
+    pip:
+      packages: [transformers]
 python-transitions:
   debian:
     '*': [python-transitions]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5321,6 +5321,13 @@ python-tqdm:
     xenial:
       pip:
         packages: [tqdm]
+python-transformers-pip:
+  debian:
+    pip:
+      packages: [transformers]
+  ubuntu:
+    pip:
+      packages: [transformers]
 python-transforms3d-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5321,7 +5321,7 @@ python-tqdm:
     xenial:
       pip:
         packages: [tqdm]
-python-transformers-pip:
+python3-transformers-pip:
   debian:
     pip:
       packages: [transformers]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

transformers

## Package Upstream Source:

https://pypi.org/project/transformers/

## Purpose of using this:

Transformers provides thousands of models for various machine-learning tasks like text, image or audio. It is backed by Jax, PyTorch and Tensorflow and provides seamless integration.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://pypi.org/project/transformers/
- Ubuntu: https://pypi.org/project/transformers/
