### PR TITLE
pmb2_navigation: 4.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3459,7 +3459,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_navigation-gbp.git
-      version: 3.0.2-1
+      version: 4.0.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_navigation` to `4.0.0-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_navigation.git
- release repository: https://github.com/pal-gbp/pmb2_navigation-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.2-1`

## pmb2_2dnav

```
* Merge pull request #1 from jmguerreroh/humble-devel
  Enhancing Tiago's navigation parameters
* Updating Tiago parameters
* Enhancing Tiago's navigation parameters
* Contributors: Sai Kishor Kothakota, jmguerreroh
```

## pmb2_maps

- No changes

## pmb2_navigation

- No changes
