### PR TITLE
pal_gripper: 3.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3237,7 +3237,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_gripper-release.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_gripper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_gripper` to `3.0.1-1`:

- upstream repository: https://github.com/pal-robotics/pal_gripper.git
- release repository: https://github.com/pal-gbp/pal_gripper-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.0-1`

## pal_gripper

- No changes

## pal_gripper_controller_configuration

```
* Merge branch 'sim_time' into 'humble-devel'
  set sim time param
  See merge request robots/pal_gripper!20
* set sim time param
* Contributors: Jordan Palacios, Noel Jimenez
```

## pal_gripper_description

- No changes
