### PR TITLE
lsc_ros2_driver: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2324,6 +2324,22 @@ repositories:
       url: https://github.com/boschglobal/locator_ros_bridge.git
       version: main
     status: maintained
+  lsc_ros2_driver:
+    doc:
+      type: git
+      url: https://github.com/AutonicsLiDAR/lsc_ros2_driver.git
+      version: humble
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/AutonicsLiDAR-release/lsc_ros2_driver-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/AutonicsLiDAR/lsc_ros2_driver.git
+      version: humble
+    status: maintained
   lusb:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lsc_ros2_driver` to `1.0.0-1`:

- upstream repository: https://github.com/AutonicsLiDAR/lsc_ros2_driver.git
- release repository: https://github.com/AutonicsLiDAR-release/lsc_ros2_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## lsc_ros2_driver

```
* Initial release
```
