### PR TITLE
lsc_ros2_driver: 1.0.0-9 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2524,6 +2524,21 @@ repositories:
       url: https://github.com/boschglobal/locator_ros_bridge.git
       version: foxy
     status: maintained
+  lsc_ros2_driver:
+    doc:
+      type: git
+      url: https://github.com/AutonicsLiDAR/lsc_ros2_driver.git
+      version: foxy
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/AutonicsLiDAR-release/lsc_ros2_driver-release.git
+      version: 1.0.0-9
+    source:
+      type: git
+      url: https://github.com/AutonicsLiDAR/lsc_ros2_driver.git
+      version: foxy
+    status: maintained
   lua_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lsc_ros2_driver` to `1.0.0-9`:

- upstream repository: https://github.com/AutonicsLiDAR/lsc_ros2_driver.git
- release repository: https://github.com/AutonicsLiDAR-release/lsc_ros2_driver-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## lsc_ros2_driver

```
* Initial release
```
