### PR TITLE
Add python3-reportlab key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8880,7 +8880,7 @@ python3-reportlab:
   arch: [python-reportlab]
   debian: [python3-reportlab]
   fedora: [python3-reportlab]
-  gentoo: [reportlab]
+  gentoo: [dev-python/reportlab]
   nixos: [python3Packages.reportlab]
   opensuse: [python3-reportlab]
   osx:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8886,6 +8886,7 @@ python3-reportlab:
   osx:
     pip:
       packages: [reportlab]
+  rhel: [python3-reportlab]
   ubuntu: [python3-reportlab]
 python3-requests:
   debian: [python3-requests]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8886,7 +8886,9 @@ python3-reportlab:
   osx:
     pip:
       packages: [reportlab]
-  rhel: [python3-reportlab]
+  rhel:
+    '*': [python3-reportlab]
+    '7': null
   ubuntu: [python3-reportlab]
 python3-requests:
   debian: [python3-requests]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8876,6 +8876,17 @@ python3-rdflib:
   rhel:
     '8': ['python%{python3_pkgversion}-rdflib']
   ubuntu: [python3-rdflib]
+python3-reportlab:
+  arch: [python-reportlab]
+  debian: [python3-reportlab]
+  fedora: [python3-reportlab]
+  gentoo: [reportlab]
+  nixos: [python3Packages.reportlab]
+  opensuse: [python3-reportlab]
+  osx:
+    pip:
+      packages: [reportlab]
+  ubuntu: [python3-reportlab]
 python3-requests:
   debian: [python3-requests]
   fedora: [python3-requests]


### PR DESCRIPTION
## Package name:
`reportlab`

## Package Upstream Source:
homepage: https://www.reportlab.com/
repo: https://hg.reportlab.com/hg-public/reportlab/

## Purpose of using this:
An Open Source Python library for generating PDFs and graphics.

## Links to Distribution Packages
arch: https://archlinux.org/packages/community/x86_64/python-reportlab/
debian: https://packages.debian.org/search?keywords=python3-reportlab
fedora: https://src.fedoraproject.org/rpms/python-reportlab
gentoo https://packages.gentoo.org/packages/dev-python/reportlab
nixos: https://search.nixos.org/packages?channel=22.11&show=python39Packages.reportlab&from=0&size=50&sort=relevance&type=packages&query=reportlab
opensuse: https://software.opensuse.org/package/python3-reportlab
pip: https://pypi.org/project/reportlab/
ubuntu: https://packages.ubuntu.com/bionic/python3-reportlab
