### PR TITLE
nixos: Add libflann value

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3287,6 +3287,7 @@ libflann:
   fedora: [flann]
   gentoo: [sci-libs/flann]
   macports: [flann]
+  nixos: [flann]
   openembedded: [libflann@meta-ros-common]
   rhel: [flann]
   ubuntu:


### PR DESCRIPTION
It was already specified for libflann-dev.

- NixOS/nixpkgs: https://search.nixos.org/packages
  - [OPTIONAL](https://search.nixos.org/packages?channel=22.11&show=flann&from=0&size=50&sort=relevance&type=packages&query=flann)