### PR TITLE
maliput_full: 0.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2626,7 +2626,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput_infrastructure-release.git
-      version: 0.1.0-2
+      version: 0.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_full` to `0.2.0-1`:

- upstream repository: https://github.com/maliput/maliput_infrastructure.git
- release repository: https://github.com/ros2-gbp/maliput_infrastructure-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.0-2`

## maliput_full

```
* Adds maliput_sparse, maliput_osm and maliput_viz to maliput_full package. (#294 <https://github.com/maliput/maliput_infrastructure/issues/294>)
* Contributors: Franco Cipollone
```
