### PR TITLE
VDA 5050 Connector for mobile transport robots in intralogistics

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -14811,6 +14811,16 @@ repositories:
       url: https://github.com/anybotics/variant-release.git
       version: 0.1.6-1
     status: maintained
+  vda5050_connector:
+    doc:
+      type: git
+      url: https://github.com/tum-fml/vda5050_connector.git
+      version: v0.0.3
+    source:
+      type: git
+      url: https://github.com/tum-fml/vda5050_connector.git
+      version: v0.0.3
+    status: maintained
   velo2cam_calibration:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11423,6 +11423,16 @@ repositories:
       url: https://github.com/anybotics/variant-release.git
       version: 0.1.6-1
     status: maintained
+  vda5050_connector:
+    doc:
+      type: git
+      url: https://github.com/tum-fml/vda5050_connector.git
+      version: v0.0.3
+    source:
+      type: git
+      url: https://github.com/tum-fml/vda5050_connector.git
+      version: v0.0.3
+    status: maintained
   velo2cam_calibration:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

melodic vda5050_connector
noetic vda5050_connector

# The source is here:

https://github.com/tum-fml/vda5050_connector.git



# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
