### PR TITLE
Add python3-parse

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8048,6 +8048,9 @@ python3-parse:
   fedora: [python3-parse]
   gentoo: [dev-python/parse]
   opensuse: [python3-parse]
+  rhel:
+    '*': [python3-parse]
+    '7': null
   ubuntu: [python3-parse]
 python3-pcg-gazebo-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8042,6 +8042,10 @@ python3-paramiko:
   opensuse: [python3-paramiko]
   rhel: ['python%{python3_pkgversion}-paramiko']
   ubuntu: [python3-paramiko]
+python3-parse:
+  debian: [python3-parse]
+  fedora: [python3-parse]
+  ubuntu: [python3-parse]
 python3-pcg-gazebo-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8043,8 +8043,11 @@ python3-paramiko:
   rhel: ['python%{python3_pkgversion}-paramiko']
   ubuntu: [python3-paramiko]
 python3-parse:
+  arch: [python-parse]
   debian: [python3-parse]
   fedora: [python3-parse]
+  gentoo: [dev-python/parse]
+  opensuse: [python3-parse]
   ubuntu: [python3-parse]
 python3-pcg-gazebo-pip:
   debian:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`parse`

## Package Upstream Source:

Repository: https://github.com/r1chardj0n3s/parse

## Purpose of using this:

Parse strings using a specification based on the Python format() syntax.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=python3-parse
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/search?keywords=python3-parse
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-parse/python3-parse
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/community/any/python-parse/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/parse
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python3-parse
- RHEL: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-parse/python3-parse/

## Note
There is a big gap between the native and `pip` package versions, so at first I was going to add this as `python3-parse-pip`.
However, looking at recently declined `*-pip` PRs and https://github.com/ros/rosdistro/pull/33017#pullrequestreview-1028893193, it seems that `python3-parse-pip` would not be accepted. Please let me know if I am mistaken, and I will happily add the `python3-parse-pip` entry as well.
