### PR TITLE
moveit: 1.1.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5454,7 +5454,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 1.1.10-1
+      version: 1.1.11-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `1.1.11-1`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.10-1`

## chomp_motion_planner

- No changes

## moveit

- No changes

## moveit_chomp_optimizer_adapter

- No changes

## moveit_commander

```
* Fix some consistency issues in PlanningScene handling (#3298 <https://github.com/ros-planning/moveit/issues/3298>)
  
    * Allow Plane collision-object creation from rviz
    * Allow to create cone collision-object from python PSI
    * rviz: Visualize PLANE shapes as a large, thin box
  
* Merge fixes+improvements to ``PlanningScene`` editing in rviz: #3263 <https://github.com/ros-planning/moveit/issues/3263>, #3264 <https://github.com/ros-planning/moveit/issues/3264>, #3296 <https://github.com/ros-planning/moveit/issues/3296>
* ``moveit_commander.PlanningSceneInterface``: use synchronous interface by default
* Contributors: Robert Haschke
```

## moveit_core

```
* Fix some consistency issues in PlanningScene handling (#3298 <https://github.com/ros-planning/moveit/issues/3298>)
* Backport ruckig trajectory_processing plugin (#2902 <https://github.com/ros-planning/moveit/issues/2902>)
* version.h: automatically bump patch number for devel builds (#3211 <https://github.com/ros-planning/moveit/issues/3211>)
* Merge fixes+improvements to ``PlanningScene`` editing in rviz: #3263 <https://github.com/ros-planning/moveit/issues/3263>, #3264 <https://github.com/ros-planning/moveit/issues/3264>, #3296 <https://github.com/ros-planning/moveit/issues/3296>
* Fix loading of ``PlanningScene`` from ``.scene`` text file: Replace existing world objects
* Drop return value from ``IKCallbackFn`` usage (#3277 <https://github.com/ros-planning/moveit/issues/3277>)
* Allow planning with multiple pipelines in parallel with ``moveit_cpp`` (#3244 <https://github.com/ros-planning/moveit/issues/3244>)
* MotionPlanningDisplay: only allow execution if start state is up-to-date
* Merge PR #3262 <https://github.com/ros-planning/moveit/issues/3262>: Short-circuit planning adapters
  
    * Early return from failing planning adapters, namely ``FixStartStateCollision`` and ``FixStartStatePathConstraint``
    * Propagate the error code via ``MotionPlanResponse::error_code_``
    * Add string translations for all error codes
  
* Cleanup translation of MoveItErrorCode to string
  
    * Move default code to moveit_core/utils
    * Override defaults in existing getActionResultString()
    * Provide translations for all error codes defined in moveit_msgs
  
* Add debug message in call stack of planning_request_adapters
* Contributors: Robert Haschke, Simon Schmeisser
```

## moveit_fake_controller_manager

- No changes

## moveit_kinematics

```
* kinematics: add ``program_options`` as required boost component (#3269 <https://github.com/ros-planning/moveit/issues/3269>)
* Contributors: Jochen Sprickerhof
```

## moveit_planners

- No changes

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

```
* Improve processing of multiple planning attempts: skip remaining planning attempts if solution was found (#3261 <https://github.com/ros-planning/moveit/issues/3261>)
* Convert OMPL status to ``MoveItErrorCode`` in the OMPL interface (#3257 <https://github.com/ros-planning/moveit/issues/3257>)
* Contributors: AndyZe, Robert Haschke
```

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

- No changes

## moveit_ros_move_group

```
* Merge PR #3262 <https://github.com/ros-planning/moveit/issues/3262>: Short-circuit planning adapters
  
    * Early return from failing planning adapters, namely FixStartStateCollision and FixStartStatePathConstraint
    * Propagate the error code via MotionPlanResponse::error_code_
    * Add string translations for all error codes
  
* Cleanup translation of MoveItErrorCode to string
  
    * Move default code to moveit_core/utils
    * Override defaults in existing getActionResultString()
    * Provide translations for all error codes defined in moveit_msgs
  
* Drop shortcut avoiding planning when all constraints are already met (#3228 <https://github.com/ros-planning/moveit/issues/3228>)When calling the PlanAndExcute action, there was a shortcut avoiding planning (and execution) when all goal constraints were already met.
  However, this check also succeeded when there was an error, e.g. resolving link names.
  As proper link resolution might require some planning request adapters to be executed, e.g. ResolveConstraintFrames, we should not skip planning.
  Note, calling the ``PlanOnly`` action, didn't have this shortcut as well, resulting in inconsistent behavior.
* Contributors: Robert Haschke
```

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

- No changes

## moveit_ros_planning

```
* Backport ruckig trajectory_processing plugin (#2902 <https://github.com/ros-planning/moveit/issues/2902>)
* Allow planning with multiple pipelines in parallel with moveit_cpp (#3244 <https://github.com/ros-planning/moveit/issues/3244>)
* Merge PR #3262 <https://github.com/ros-planning/moveit/issues/3262>: Short-circuit planning adapters
  
    * Early return from failing planning adapters, namely FixStartStateCollision and FixStartStatePathConstraint
    * Propagate the error code via MotionPlanResponse::error_code_
    * Add string translations for all error codes
  
* Cleanup translation of MoveItErrorCode to string
  
    * Move default code to moveit_core/utils
    * Override defaults in existing getActionResultString()
    * Provide translations for all error codes defined in moveit_msgs
  
* Short-circuit planning request adapters
* Contributors: Robert Haschke, Simon Schmeisser
```

## moveit_ros_planning_interface

- No changes

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

```
* Fix some consistency issues in PlanningScene handling (#3298 <https://github.com/ros-planning/moveit/issues/3298>)
  
    * Allow Plane collision-object creation from rviz
    * Simplify Cone rendering
    * Visualize PLANE shapes as a large, thin box
  
* Merge fixes+improvements to ``PlanningScene`` editing in rviz: #3263 <https://github.com/ros-planning/moveit/issues/3263>, #3264 <https://github.com/ros-planning/moveit/issues/3264>, #3296 <https://github.com/ros-planning/moveit/issues/3296>
  
    * Fix error "QBackingStore::endPaint() called with active painter"
    * Remove limitation to one-shape collision objects
    * Fix segfault on object scaling: only update a _valid_ scene marker
    * JointsWidget: Copy full RobotState on updates (attached collision objects were missing)
    * Factor out ``addCollisionObjectToList()`` from ``populateCollisionObjectsList()``
    * Simplify ``MotionPlanningFrame::addSceneObject``
    * Directly call ``populateCollisionObjectsList()`` if possibleCalling was previously deferred into a main loop job, because most
      callers already held a PlanningScene lock, thus causing recursive locking and a deadlock.
      By simply passing the locked scene, these issues can be avoided.
      As a fallback, the PlanningScene lock is still acquired in the function.
    * ``updateQueryStates()`` after removal of attached objects
    * Clear scene objects: only clear locally. To publish changes, one should explicitly click the "Publish" button.
    * Scene Object List: allow extended selection mode
    * always update query states - even if they are disabled for visualization
    * only allow execution if start state is up-to-date
  
* Merge PR #3227 <https://github.com/ros-planning/moveit/issues/3227>: Improve MotionPlanning plugin's JointsWidget
  * Add units to sliders in JointsWidget and to spinbox editor
  * Avoid need for extra click to operate joint slider
  * allow control of joints via keyboard
* Contributors: Robert Haschke
```

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_servo

- No changes

## moveit_setup_assistant

```
* MSA: Cleanup SimulationWidget (#3281 <https://github.com/ros-planning/moveit/issues/3281>)
  
    * Don't rewrite ``gazebo.launch`` after user changes
    * Only offer to write ``gazebo\_*.urdf`` if content would be non-empty
    * Clarify usage
    * Graceful opening of editor
    * Disable "overwrite" button if there are no changes
    * If overwriting fails: ``write gazebo\_*.urdf`` as fallback
  
* Remove capabilities declaration from pipeline configs (#3274 <https://github.com/ros-planning/moveit/issues/3274>)Capabilities are global to the ``move_group`` node and not specific to pipleline configs.
  As the latter ones load their parameters into a namespace, e.g. ``/move_group/planning_pipelines/ompl/*``,
  loading a capability as suggested by the comments, didn't have any effect.
* Expose ``world_name`` and ``world_pose`` args in ``*gazebo.launch`` (#3238 <https://github.com/ros-planning/moveit/issues/3238>)
* run-depend on all default MoveIt planners
* Start ``robot_state_publisher`` in ``gazebo.launch`` (#3236 <https://github.com/ros-planning/moveit/issues/3236>)
* Generalize sizing of joint list widgets (#3219 <https://github.com/ros-planning/moveit/issues/3219>)
* Contributors: Robert Haschke, Robert Kampf
```

## moveit_simple_controller_manager

- No changes

## pilz_industrial_motion_planner

```
* Merge fixes+improvements to ``PlanningScene`` editing in rviz: #3263 <https://github.com/ros-planning/moveit/issues/3263>, #3264 <https://github.com/ros-planning/moveit/issues/3264>, #3296 <https://github.com/ros-planning/moveit/issues/3296>
* Contributors: Robert Haschke
```

## pilz_industrial_motion_planner_testutils

- No changes
