### PR TITLE
aerostack2: 0.2.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -66,6 +66,63 @@ repositories:
       url: https://github.com/ros-acceleration/adaptive_component.git
       version: rolling
     status: developed
+  aerostack2:
+    release:
+      packages:
+      - aerostack2
+      - as2_aerial_platform
+      - as2_alphanumeric_viewer
+      - as2_aruco_detector
+      - as2_behavior
+      - as2_behavior_tree
+      - as2_behaviors
+      - as2_cli
+      - as2_controller
+      - as2_controller_manager
+      - as2_controller_plugin_base
+      - as2_controller_plugin_differential_flatness
+      - as2_controller_plugin_speed_controller
+      - as2_core
+      - as2_crazyflie_platform
+      - as2_gazebo_assets
+      - as2_hardware_drivers
+      - as2_ignition_platform
+      - as2_keyboard_teleoperation
+      - as2_motion_reference_handlers
+      - as2_movement_behaviors
+      - as2_msgs
+      - as2_pixhawk_platform
+      - as2_platform_behaviors
+      - as2_python_api
+      - as2_realsense_interface
+      - as2_simulation_assets
+      - as2_state_estimator
+      - as2_state_estimator_plugin_base
+      - as2_state_estimator_plugin_external_odom
+      - as2_state_estimator_plugin_ground_truth
+      - as2_state_estimator_plugin_mocap
+      - as2_tello_platform
+      - as2_trajectory_generator
+      - as2_usb_camera_interface
+      - as2_user_interface
+      - follow_path_behaviour
+      - follow_path_plugin_base
+      - follow_path_plugins
+      - goto_behaviour
+      - goto_plugin_base
+      - goto_plugins
+      - ignition_assets
+      - land_behaviour
+      - land_plugin_base
+      - land_plugins
+      - takeoff_behaviour
+      - takeoff_plugin_base
+      - takeoff_plugins
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/aerostack2/aerostack2-release.git
+      version: 0.2.2-1
+    status: developed
   affordance_primitives:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `aerostack2` to `0.2.2-1`:

- upstream repository: https://github.com/aerostack2/aerostack2.git
- release repository: https://github.com/aerostack2/aerostack2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## aerostack2

- No changes

## as2_aerial_platform

- No changes

## as2_alphanumeric_viewer

```
* Merge pull request #88 <https://github.com/aerostack2/aerostack2/issues/88> from aerostack2/main
  update with main
* Merge pull request #85 <https://github.com/aerostack2/aerostack2/issues/85> from aerostack2/as2_movement_behaviors_rename
  rename movement_behavior to as2_movement_behaviors
* as2_alphanumeric_viewer
* Contributors: Miguel, Miguel Fernandez-Cortizas, Rafael Pérez
```

## as2_aruco_detector

```
* Merge pull request #88 <https://github.com/aerostack2/aerostack2/issues/88> from aerostack2/main
  update with main
* Merge pull request #85 <https://github.com/aerostack2/aerostack2/issues/85> from aerostack2/as2_movement_behaviors_rename
  rename movement_behavior to as2_movement_behaviors
* rename
* Contributors: Miguel, Miguel Fernandez-Cortizas, Rafael Pérez
```

## as2_behavior

- No changes

## as2_behavior_tree

- No changes

## as2_behaviors

```
* Merge pull request #88 <https://github.com/aerostack2/aerostack2/issues/88> from aerostack2/main
  update with main
* Merge pull request #85 <https://github.com/aerostack2/aerostack2/issues/85> from aerostack2/as2_movement_behaviors_rename
  rename movement_behavior to as2_movement_behaviors
* rename
* Contributors: Miguel, Miguel Fernandez-Cortizas, Rafael Pérez
```

## as2_cli

- No changes

## as2_controller

- No changes

## as2_controller_manager

- No changes

## as2_controller_plugin_base

- No changes

## as2_controller_plugin_differential_flatness

```
* Merge pull request #88 <https://github.com/aerostack2/aerostack2/issues/88> from aerostack2/main
  update with main
* Merge pull request #85 <https://github.com/aerostack2/aerostack2/issues/85> from aerostack2/as2_movement_behaviors_rename
  rename movement_behavior to as2_movement_behaviors
* reformat
* Clang test df
* Contributors: Miguel, Miguel Fernandez-Cortizas, RPS98, Rafael Pérez
```

## as2_controller_plugin_speed_controller

- No changes

## as2_core

- No changes

## as2_crazyflie_platform

```
* Merge pull request #88 <https://github.com/aerostack2/aerostack2/issues/88> from aerostack2/main
  update with main
* Merge pull request #85 <https://github.com/aerostack2/aerostack2/issues/85> from aerostack2/as2_movement_behaviors_rename
  rename movement_behavior to as2_movement_behaviors
* reformat
* Contributors: Miguel, Miguel Fernandez-Cortizas, Rafael Pérez
```

## as2_gazebo_assets

- No changes

## as2_hardware_drivers

- No changes

## as2_keyboard_teleoperation

```
* Merge pull request #86 <https://github.com/aerostack2/aerostack2/issues/86> from aerostack2/changed_name_keyboard_teleoperation
  keyboard teleoperation name updated, behavior control updated
* copyright test passed
* keyboard teleoperation name updated, behavior control updated
* Contributors: Javilinos, Miguel Fernandez-Cortizas
```

## as2_motion_reference_handlers

- No changes

## as2_movement_behaviors

```
* Merge pull request #88 <https://github.com/aerostack2/aerostack2/issues/88> from aerostack2/main
  update with main
* Merge pull request #85 <https://github.com/aerostack2/aerostack2/issues/85> from aerostack2/as2_movement_behaviors_rename
  rename movement_behavior to as2_movement_behaviors
* rename
* Contributors: Miguel, Miguel Fernandez-Cortizas, Rafael Pérez
```

## as2_msgs

- No changes

## as2_pixhawk_platform

- No changes

## as2_platform_behaviors

- No changes

## as2_python_api

```
* Merge pull request #89 <https://github.com/aerostack2/aerostack2/issues/89> from aerostack2/python-new-name
  [as2_python_api] Renamed following naming convention
* moved to examples folder
* as2_python_api renamed following naming convention
* Contributors: Miguel Fernandez-Cortizas, pariaspe
```

## as2_realsense_interface

- No changes

## as2_simulation_assets

- No changes

## as2_state_estimator

- No changes

## as2_state_estimator_plugin_base

- No changes

## as2_state_estimator_plugin_external_odom

- No changes

## as2_state_estimator_plugin_ground_truth

- No changes

## as2_state_estimator_plugin_mocap

- No changes

## as2_tello_platform

- No changes

## as2_trajectory_generator

```
* Merge pull request #88 <https://github.com/aerostack2/aerostack2/issues/88> from aerostack2/main
  update with main
* Merge pull request #85 <https://github.com/aerostack2/aerostack2/issues/85> from aerostack2/as2_movement_behaviors_rename
  rename movement_behavior to as2_movement_behaviors
* Change trajectory generator name
* Contributors: Miguel Fernandez-Cortizas, RPS98, Rafael Pérez
```

## as2_usb_camera_interface

- No changes

## as2_user_interface

- No changes

## follow_path_behaviour

```
* Merge pull request #88 <https://github.com/aerostack2/aerostack2/issues/88> from aerostack2/main
  update with main
* Merge pull request #85 <https://github.com/aerostack2/aerostack2/issues/85> from aerostack2/as2_movement_behaviors_rename
  rename movement_behavior to as2_movement_behaviors
* rename
* Contributors: Miguel, Miguel Fernandez-Cortizas, Rafael Pérez
```

## follow_path_plugin_base

```
* Merge pull request #88 <https://github.com/aerostack2/aerostack2/issues/88> from aerostack2/main
  update with main
* Merge pull request #85 <https://github.com/aerostack2/aerostack2/issues/85> from aerostack2/as2_movement_behaviors_rename
  rename movement_behavior to as2_movement_behaviors
* rename
* Contributors: Miguel, Miguel Fernandez-Cortizas, Rafael Pérez
```

## follow_path_plugins

```
* Merge pull request #88 <https://github.com/aerostack2/aerostack2/issues/88> from aerostack2/main
  update with main
* Merge pull request #85 <https://github.com/aerostack2/aerostack2/issues/85> from aerostack2/as2_movement_behaviors_rename
  rename movement_behavior to as2_movement_behaviors
* rename
* Contributors: Miguel, Miguel Fernandez-Cortizas, Rafael Pérez
```

## goto_behaviour

```
* Merge pull request #88 <https://github.com/aerostack2/aerostack2/issues/88> from aerostack2/main
  update with main
* Merge pull request #85 <https://github.com/aerostack2/aerostack2/issues/85> from aerostack2/as2_movement_behaviors_rename
  rename movement_behavior to as2_movement_behaviors
* rename
* Contributors: Miguel, Miguel Fernandez-Cortizas, Rafael Pérez
```

## goto_plugin_base

```
* Merge pull request #88 <https://github.com/aerostack2/aerostack2/issues/88> from aerostack2/main
  update with main
* Merge pull request #85 <https://github.com/aerostack2/aerostack2/issues/85> from aerostack2/as2_movement_behaviors_rename
  rename movement_behavior to as2_movement_behaviors
* rename
* Contributors: Miguel, Miguel Fernandez-Cortizas, Rafael Pérez
```

## goto_plugins

```
* Merge pull request #88 <https://github.com/aerostack2/aerostack2/issues/88> from aerostack2/main
  update with main
* Merge pull request #85 <https://github.com/aerostack2/aerostack2/issues/85> from aerostack2/as2_movement_behaviors_rename
  rename movement_behavior to as2_movement_behaviors
* rename
* Contributors: Miguel, Miguel Fernandez-Cortizas, Rafael Pérez
```

## land_behaviour

```
* Merge pull request #88 <https://github.com/aerostack2/aerostack2/issues/88> from aerostack2/main
  update with main
* Merge pull request #85 <https://github.com/aerostack2/aerostack2/issues/85> from aerostack2/as2_movement_behaviors_rename
  rename movement_behavior to as2_movement_behaviors
* rename
* Contributors: Miguel, Miguel Fernandez-Cortizas, Rafael Pérez
```

## land_plugin_base

```
* Merge pull request #88 <https://github.com/aerostack2/aerostack2/issues/88> from aerostack2/main
  update with main
* Merge pull request #85 <https://github.com/aerostack2/aerostack2/issues/85> from aerostack2/as2_movement_behaviors_rename
  rename movement_behavior to as2_movement_behaviors
* rename
* Contributors: Miguel, Miguel Fernandez-Cortizas, Rafael Pérez
```

## land_plugins

```
* Merge pull request #88 <https://github.com/aerostack2/aerostack2/issues/88> from aerostack2/main
  update with main
* Merge pull request #85 <https://github.com/aerostack2/aerostack2/issues/85> from aerostack2/as2_movement_behaviors_rename
  rename movement_behavior to as2_movement_behaviors
* rename
* Contributors: Miguel, Miguel Fernandez-Cortizas, Rafael Pérez
```

## takeoff_behaviour

```
* Merge pull request #88 <https://github.com/aerostack2/aerostack2/issues/88> from aerostack2/main
  update with main
* Merge pull request #85 <https://github.com/aerostack2/aerostack2/issues/85> from aerostack2/as2_movement_behaviors_rename
  rename movement_behavior to as2_movement_behaviors
* rename
* Contributors: Miguel, Miguel Fernandez-Cortizas, Rafael Pérez
```

## takeoff_plugin_base

```
* Merge pull request #88 <https://github.com/aerostack2/aerostack2/issues/88> from aerostack2/main
  update with main
* Merge pull request #85 <https://github.com/aerostack2/aerostack2/issues/85> from aerostack2/as2_movement_behaviors_rename
  rename movement_behavior to as2_movement_behaviors
* rename
* Contributors: Miguel, Miguel Fernandez-Cortizas, Rafael Pérez
```

## takeoff_plugins

```
* Merge pull request #88 <https://github.com/aerostack2/aerostack2/issues/88> from aerostack2/main
  update with main
* Merge pull request #85 <https://github.com/aerostack2/aerostack2/issues/85> from aerostack2/as2_movement_behaviors_rename
  rename movement_behavior to as2_movement_behaviors
* rename
* Contributors: Miguel, Miguel Fernandez-Cortizas, Rafael Pérez
```
