### PR TITLE
Split off humble branch for zbar_ros

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7071,7 +7071,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/zbar_ros.git
-      version: ros2
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -7080,7 +7080,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/zbar_ros.git
-      version: ros2
+      version: humble
     status: maintained
   zenoh_bridge_dds:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6473,7 +6473,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/zbar_ros.git
-      version: ros2
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -6482,7 +6482,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/zbar_ros.git
-      version: ros2
+      version: rolling
     status: maintained
   zenoh_bridge_dds:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6473,7 +6473,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/zbar_ros.git
-      version: rolling
+      version: ros2
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -6482,7 +6482,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/zbar_ros.git
-      version: rolling
+      version: ros2
     status: maintained
   zenoh_bridge_dds:
     doc:


### PR DESCRIPTION
Splits off [humble branch](https://github.com/ros-drivers/zbar_ros/tree/humble) due to an API breaking change in an underlying library.