### PR TITLE
audio_common: 0.3.16-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -329,7 +329,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/audio_common-release.git
-      version: 0.3.15-1
+      version: 0.3.16-1
     source:
       type: git
       url: https://github.com/ros-drivers/audio_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common` to `0.3.16-1`:

- upstream repository: https://github.com/ros-drivers/audio_common.git
- release repository: https://github.com/ros-gbp/audio_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.3.15-1`

## audio_capture

```
* Merge pull request #204 <https://github.com/ros-drivers/audio_common/issues/204> from knorth55/audio-capture-stamped
* add todo comment
* publish audio stamped in audio_capture.cpp
* Merge pull request #216 <https://github.com/ros-drivers/audio_common/issues/216> from knorth55/launch-update
* update audio_capture launch
* Contributors: Shingo Kitagawa
```

## audio_common

- No changes

## audio_common_msgs

```
* Merge pull request #202 <https://github.com/ros-drivers/audio_common/issues/202> from knorth55/audio-stamped-msg
* add AudioDataStamped.msg
* Contributors: Shingo Kitagawa
```

## audio_play

```
* Merge pull request #216 <https://github.com/ros-drivers/audio_common/issues/216> from knorth55/launch-update
* update play.launch
* Merge pull request #206 <https://github.com/ros-drivers/audio_common/issues/206> from knorth55/fix-205
* unref buffer in audio_play to avoid memory leak
* Contributors: Shingo Kitagawa
```

## sound_play

```
* Merge pull request #203 <https://github.com/ros-drivers/audio_common/issues/203> from nakane11/timeout
* refactor libsoundplay.py
* Add timeout to wait_for_server and wait_for_result
* Contributors: Aoi Nakane, Shingo Kitagawa
```
