### PR TITLE
camera_aravis: 4.0.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -627,7 +627,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/FraunhoferIOSB/camera_aravis-release.git
-      version: 4.0.3-1
+      version: 4.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_aravis` to `4.0.4-1`:

- upstream repository: https://github.com/FraunhoferIOSB/camera_aravis.git
- release repository: https://github.com/FraunhoferIOSB/camera_aravis-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.3-1`

## camera_aravis

```
* Update package maintainer
* Refactor node params (#21 <https://github.com/FraunhoferIOSB/camera_aravis/issues/21>)
  * Refactor node params
  * Rename extended_camera_info_ -> pub_ext_camera_info_
  * Move stream parameters to the top of onInit()
* fix: only reset PTP clock when in "Faulty" or "Disabled" state (#23 <https://github.com/FraunhoferIOSB/camera_aravis/issues/23>)
* Update industrial_ci default branch to main
* Contributors: Dominik Kleiser, Peter Mortimer, Ruf, Boitumelo
```
