### PR TITLE
robot_calibration: 0.7.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8233,7 +8233,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/robot_calibration-release.git
-      version: 0.7.1-1
+      version: 0.7.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_calibration` to `0.7.2-1`:

- upstream repository: https://github.com/mikeferguson/robot_calibration.git
- release repository: https://github.com/ros-gbp/robot_calibration-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.1-1`

## robot_calibration

```
* calibrate falling attributes as well if they exist (#144 <https://github.com/mikeferguson/robot_calibration/issues/144>)
  For continuous joints actually both flags could be specified.
* Changes for Ubuntu 22.04 (#141 <https://github.com/mikeferguson/robot_calibration/issues/141>)
  * no longer use c++11
  * Add missing boost header
  * Switch to non deprecated pluginlib header
* Contributors: Jochen Sprickerhof, Michael Görner
```

## robot_calibration_msgs

- No changes
