### PR TITLE
Added openai python

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -295,7 +295,7 @@ opcua-pip:
   ubuntu:
     pip:
       packages: [opcua]
-openai:
+python3-openai-pip:
   debian:
     pip:
       packages: [openai]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3132,16 +3132,6 @@ python-open3d-pip:
   ubuntu:
     pip:
       packages: [open3d-python]
-python3-openai-pip:
-  debian:
-    pip:
-      packages: [openai]
-  fedora:
-    pip:
-      packages: [openai]
-  ubuntu:
-    pip:
-      packages: [openai]
 python-opencv:
   arch: [opencv, python2-numpy]
   debian: [python-opencv]
@@ -7966,6 +7956,16 @@ python3-open3d-pip:
   ubuntu:
     pip:
       packages: [open3d]
+python3-openai-pip:
+  debian:
+    pip:
+      packages: [openai]
+  fedora:
+    pip:
+      packages: [openai]
+  ubuntu:
+    pip:
+      packages: [openai]
 python3-opencv:
   debian: [python3-opencv]
   fedora: [python3-opencv]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -295,6 +295,16 @@ opcua-pip:
   ubuntu:
     pip:
       packages: [opcua]
+openai:
+  debian:
+    pip:
+      packages: [openai]
+  fedora:
+    pip:
+      packages: [openai]
+  ubuntu:
+    pip:
+      packages: [openai]
 paramiko:
   alpine: [py-paramiko]
   arch: [python2-paramiko]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -295,16 +295,6 @@ opcua-pip:
   ubuntu:
     pip:
       packages: [opcua]
-python3-openai-pip:
-  debian:
-    pip:
-      packages: [openai]
-  fedora:
-    pip:
-      packages: [openai]
-  ubuntu:
-    pip:
-      packages: [openai]
 paramiko:
   alpine: [py-paramiko]
   arch: [python2-paramiko]
@@ -3142,6 +3132,16 @@ python-open3d-pip:
   ubuntu:
     pip:
       packages: [open3d-python]
+python3-openai-pip:
+  debian:
+    pip:
+      packages: [openai]
+  fedora:
+    pip:
+      packages: [openai]
+  ubuntu:
+    pip:
+      packages: [openai]
 python-opencv:
   arch: [opencv, python2-numpy]
   debian: [python-opencv]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

openai

## Package Upstream Source:

https://github.com/openai/openai-python

## Purpose of using this:

This dependency allows access to OpenAI's servers for off-robot AI processing

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - pip
    - https://pypi.org/project/openai/
- Ubuntu: https://packages.ubuntu.com/
  - pip
    - https://pypi.org/project/openai/
- Fedora: https://packages.fedoraproject.org/
  - pip
    - https://pypi.org/project/openai/
