### PR TITLE
Revert "rm_control: 0.1.16-1 in 'noetic/distribution.yaml' [bloom] (#…

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8154,11 +8154,10 @@ repositories:
       - rm_gazebo
       - rm_hw
       - rm_msgs
-      - rm_referee
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/rm-controls/rm_control-release.git
-      version: 0.1.16-1
+      version: 0.1.15-1
     source:
       type: git
       url: https://github.com/rm-controls/rm_control.git


### PR DESCRIPTION
Reverts #35414

This reverts commit 40339157c191e128ee9c2d406711019fb52734c9. Maybe this will fix the regressions in rm_control and rm_controllers since 0.1.15-1 is the version in main now.

@qiayuanliao FYI

![image](https://user-images.githubusercontent.com/4175662/209986705-cc544aba-bffb-47dd-ac2a-7e7825611f5a.png)

It seems the source job is failing: #35709

https://build.ros.org/job/Nsrc_uF__rm_msgs__ubuntu_focal__source/
