### PR TITLE
ntpd_driver: 1.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6225,7 +6225,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/vooon/ntpd_driver-release.git
-      version: 1.2.0-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/vooon/ntpd_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ntpd_driver` to `1.3.0-1`:

- upstream repository: https://github.com/vooon/ntpd_driver.git
- release repository: https://github.com/vooon/ntpd_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.0-1`

## ntpd_driver

```
* ci: return semgrep default rule set
* ci: update ros-i ci action
* ci: add industrial CI
* shm_driver: remove time_ref topic parameter to improve secutiry, please use remap
  Fixes #9 <https://github.com/vooon/ntpd_driver/issues/9>
* add license file
* Contributors: Vladimir Ermakov
```
