### PR TITLE
ntpd_driver: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2770,7 +2770,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ntpd_driver-release.git
-      version: 2.1.0-2
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/vooon/ntpd_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ntpd_driver` to `2.2.0-1`:

- upstream repository: https://github.com/vooon/ntpd_driver.git
- release repository: https://github.com/ros2-gbp/ntpd_driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.0-2`

## ntpd_driver

```
* include: fix include warnings, arain
* fix ament_cpplint warnings
* node: remove time_ref_topic parameter, port for for #9 <https://github.com/vooon/ntpd_driver/issues/9>
* Merge branch 'master' into ros2
  * master:
  1.3.0
  update changelog
  ci: return semgrep default rule set
  ci: update ros-i ci action
  ci: add industrial CI
  shm_driver: remove time_ref topic parameter to improve secutiry, please use remap
  add license file
* 1.3.0
* update changelog
* ci: return semgrep default rule set
* ci: update ros-i ci action
* ci: add industrial CI
* shm_driver: remove time_ref topic parameter to improve secutiry, please use remap
  Fixes #9 <https://github.com/vooon/ntpd_driver/issues/9>
* add license file
* Contributors: Vladimir Ermakov
```
