### PR TITLE
mavlink: 2022.12.30-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2484,7 +2484,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mavlink-gbp-release.git
-      version: 2022.8.8-1
+      version: 2022.12.30-1
     source:
       type: git
       url: https://github.com/ros2-gbp/mavlink-gbp-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavlink` to `2022.12.30-1`:

- upstream repository: https://github.com/mavlink/mavlink.git
- release repository: https://github.com/ros2-gbp/mavlink-gbp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2022.8.8-1`
