### PR TITLE
cascade_lifecycle: 1.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -599,7 +599,7 @@ repositories:
       - rclcpp_cascade_lifecycle
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/fmrico/cascade_lifecycle-release.git
+      url: https://github.com/ros2-gbp/cascade_lifecycle-release.git
       version: 1.0.3-1
     source:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -588,6 +588,24 @@ repositories:
       url: https://github.com/ros2/cartographer_ros.git
       version: ros2
     status: maintained
+  cascade_lifecycle:
+    doc:
+      type: git
+      url: https://github.com/fmrico/cascade_lifecycle.git
+      version: rolling-devel
+    release:
+      packages:
+      - cascade_lifecycle_msgs
+      - rclcpp_cascade_lifecycle
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/fmrico/cascade_lifecycle-release.git
+      version: 1.0.3-1
+    source:
+      type: git
+      url: https://github.com/fmrico/cascade_lifecycle.git
+      version: rolling-devel
+    status: maintained
   class_loader:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cascade_lifecycle` to `1.0.3-1`:

- upstream repository: https://github.com/fmrico/cascade_lifecycle.git
- release repository: https://github.com/fmrico/cascade_lifecycle-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## cascade_lifecycle_msgs

- No changes

## rclcpp_cascade_lifecycle

```
* Update to Rolling
* Contributors: Francisco Martín Rico
```
