### PR TITLE
mavros: 2.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2265,7 +2265,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mavros-release.git
-      version: 2.3.0-1
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `2.4.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/ros2-gbp/mavros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.0-1`

## libmavconn

```
* Merge branch 'master' into ros2
  * master:
  1.15.0
  update changelog
  ci: update actions
  Implement debug float array handler
  mavros_extras: Fix a sequence point warning
  mavros_extras: Fix a comparison that shouldn't be bitwise
  mavros: Fix some warnings
  mavros_extras: Fix buggy check for lat/lon ignored
  libmavconn: fix MAVLink v1.0 output selection
* 1.15.0
* update changelog
* Merge pull request #1794 <https://github.com/mavlink/mavros/issues/1794> from rossizero/master
  libmavconn: fix MAVLink v1.0 output selection
* libmavconn: fix MAVLink v1.0 output selection
  Fix #1787 <https://github.com/mavlink/mavros/issues/1787>
* Contributors: Vladimir Ermakov, rosrunne
```

## mavros

```
* ci: ignore xml lib warn
* Merge branch 'master' into ros2
  * master:
  1.15.0
  update changelog
  ci: update actions
  Implement debug float array handler
  mavros_extras: Fix a sequence point warning
  mavros_extras: Fix a comparison that shouldn't be bitwise
  mavros: Fix some warnings
  mavros_extras: Fix buggy check for lat/lon ignored
  libmavconn: fix MAVLink v1.0 output selection
* 1.15.0
* update changelog
* Merge pull request #1806 <https://github.com/mavlink/mavros/issues/1806> from scoutdi/fix-some-warnings
  mavros: Fix some warnings
* mavros: Fix some warnings
* Contributors: Morten Fyhn Amundsen, Vladimir Ermakov
```

## mavros_extras

```
* extras: uncrustify
* extras: fix build, 2
* extras: fix build
* extras: fix cog
* Merge branch 'master' into ros2
  * master:
  1.15.0
  update changelog
  ci: update actions
  Implement debug float array handler
  mavros_extras: Fix a sequence point warning
  mavros_extras: Fix a comparison that shouldn't be bitwise
  mavros: Fix some warnings
  mavros_extras: Fix buggy check for lat/lon ignored
  libmavconn: fix MAVLink v1.0 output selection
* 1.15.0
* update changelog
* Merge pull request #1811 <https://github.com/mavlink/mavros/issues/1811> from scoutdi/debug-float-array
  Implement debug float array handler
* Implement debug float array handler
  Co-authored-by: Morten Fyhn Amundsen <mailto:morten.f.amundsen@scoutdi.com>
* Merge pull request #1807 <https://github.com/mavlink/mavros/issues/1807> from scoutdi/fix-bitwise-comparison
  mavros_extras: Fix a comparison that shouldn't be bitwise
* Merge pull request #1808 <https://github.com/mavlink/mavros/issues/1808> from scoutdi/fix-sequence-point-warning
  mavros_extras: Fix a sequence point warning
* mavros_extras: Fix a sequence point warning
* mavros_extras: Fix a comparison that shouldn't be bitwise
* Merge pull request #1805 <https://github.com/mavlink/mavros/issues/1805> from scoutdi/fix-latlon-check
  mavros_extras: Fix buggy check for lat/lon ignored
* mavros_extras: Fix buggy check for lat/lon ignored
* Contributors: Morten Fyhn Amundsen, Sverre Velten Rothmund, Vladimir Ermakov
```

## mavros_msgs

```
* msgs: re-generate
* Merge branch 'master' into ros2
  * master:
  1.15.0
  update changelog
  ci: update actions
  Implement debug float array handler
  mavros_extras: Fix a sequence point warning
  mavros_extras: Fix a comparison that shouldn't be bitwise
  mavros: Fix some warnings
  mavros_extras: Fix buggy check for lat/lon ignored
  libmavconn: fix MAVLink v1.0 output selection
* 1.15.0
* update changelog
* Merge pull request #1811 <https://github.com/mavlink/mavros/issues/1811> from scoutdi/debug-float-array
  Implement debug float array handler
* Implement debug float array handler
  Co-authored-by: Morten Fyhn Amundsen <mailto:morten.f.amundsen@scoutdi.com>
* Contributors: Sverre Velten Rothmund, Vladimir Ermakov
```
