### PR TITLE
mvsim: update the source and doc branch name

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3179,7 +3179,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/MRPT/mvsim.git
-      version: master
+      version: develop
     release:
       tags:
         release: release/foxy/{package}/{version}
@@ -3188,7 +3188,7 @@ repositories:
     source:
       type: git
       url: https://github.com/MRPT/mvsim.git
-      version: master
+      version: develop
     status: developed
   naoqi_bridge_msgs:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2778,7 +2778,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/MRPT/mvsim.git
-      version: master
+      version: develop
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -2787,7 +2787,7 @@ repositories:
     source:
       type: git
       url: https://github.com/MRPT/mvsim.git
-      version: master
+      version: develop
     status: developed
   nao_button_sim:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7512,7 +7512,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/MRPT/mvsim.git
-      version: master
+      version: develop
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -7522,7 +7522,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/MRPT/mvsim.git
-      version: master
+      version: develop
     status: maintained
   nanomsg:
     release:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5799,7 +5799,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ual-arm-ros-pkg/mvsim.git
-      version: master
+      version: develop
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -5808,7 +5808,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ual-arm-ros-pkg/mvsim.git
-      version: master
+      version: develop
     status: developed
   nao_meshes:
     release:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2559,7 +2559,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/MRPT/mvsim.git
-      version: master
+      version: develop
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2568,7 +2568,7 @@ repositories:
     source:
       type: git
       url: https://github.com/MRPT/mvsim.git
-      version: master
+      version: develop
     status: developed
   nao_button_sim:
     doc:


### PR DESCRIPTION
This just updates the branch name for doc and source from `master` to `develop`, for all active distributions.
