### PR TITLE
schunk_svh_ros_driver: 0.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10119,6 +10119,27 @@ repositories:
       url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_library.git
       version: main
     status: developed
+  schunk_svh_ros_driver:
+    doc:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_ros_driver.git
+      version: main
+    release:
+      packages:
+      - schunk_svh
+      - schunk_svh_description
+      - schunk_svh_driver
+      - schunk_svh_msgs
+      - schunk_svh_simulation
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_ros_driver-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_ros_driver.git
+      version: main
+    status: developed
   sciurus17:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_svh_ros_driver` to `0.1.1-1`:

- upstream repository: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_ros_driver.git
- release repository: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_ros_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## schunk_svh

```
* Merge branch 'update-license-ros1' into 'update-and-upgrade'
  Switch license to the GPLv3
  See merge request ros/schunk_svh_driver!23
* Update SPDX license indicator in package.xml
  This is according to here <https://www.gnu.org/licenses/identify-licenses-clearly.html>.
* Add schunk_svh_msgs to meta package.xml
* Merge branch 'meta-package' into 'update-and-upgrade'
  Meta package
  See merge request ros/schunk_svh_driver!20
* Add the description package in the package.xml
* Add meta package to the repository
* Contributors: Stefan Scherzinger
```

## schunk_svh_description

```
* Merge pull request #18 <https://github.com/fzi-forschungszentrum-informatik/schunk_svh_ros_driver/issues/18> from fzi-forschungszentrum-informatik/add-gazebo-example
  Add an example setup for Gazebo
* Update the plugin to mimic joints
  The new plugin is now maintained
  here <https://github.com/roboticsgroup/roboticsgroup_upatras_gazebo_plugins>.
  Also add suitable PID gains for the mimicked joints.
* Add a minimal Gazebo example
* Update maintainer info
* Merge branch 'description_package_xml' into 'update-and-upgrade'
  Description package xml
  See merge request ros/schunk_svh_driver!25
* Added xml schema
* Removed boilerplate comments from svh_description package.xml
* Merge branch 'update-license-ros1' into 'update-and-upgrade'
  Switch license to the GPLv3
  See merge request ros/schunk_svh_driver!23
* Update cmake version for the description package
  We used an ancient version without no reason.
  CMake 3.10 is Bionic's (Ubuntu 18.04) shipping version.
* Update SPDX license indicator in package.xml
  This is according to
  here <https://www.gnu.org/licenses/identify-licenses-clearly.html>.
* Support left and right hands through launch parameters
  We now load the correct ROS-control configuration depending on whether
  users start a right_hand or a left_hand.
  This is also passed to the URDF robot description.
* Update top-level readme
  Also add lightweight readmes for each sub package.
* Merge branch 'meta-package' into 'update-and-upgrade'
  Meta package
  See merge request ros/schunk_svh_driver!20
* Fix installs
* Merge remote-tracking branch 'schunk_svh_description/prepare-inclusion-into-meta-package' into meta-package
  We continue the schunk_svh_description within this meta repository.
* Move everything into an equally named sub package
  We will later merge this package into the schunk_svh_ros_driver meta
  repository.
* Contributors: Felix Exner, Stefan Scherzinger
```

## schunk_svh_driver

```
* Update the plugin to mimic joints
  The new plugin is now maintained
  here <https://github.com/roboticsgroup/roboticsgroup_upatras_gazebo_plugins>.
  Also add suitable PID gains for the mimicked joints.
* Add PID gains for Gazebo
  We now have stable joint position control.
* Use a gazebo-specific controllers file
  We'll probably need a specifically tweaked set of PID gains for
  Gazebo. The default position controllers are not stable.
* Add a minimal Gazebo example
* Remove unused launch parameters
* Add missing install for the dynamic parameter test
* Remove unused simulation parameter from launch
  That's no longer supported.
* Add joint_state_controller as run dependency
* Run-depend on joint_trajectory_controller
  We need this thing for joint actuation in the examples.
* Merge branch 'fix-license-typo' into 'update-and-upgrade'
  Fix typo in license notice
  See merge request ros/schunk_svh_driver!26
* Fix typo in license notice
* Merge branch 'update-license-ros1' into 'update-and-upgrade'
  Switch license to the GPLv3
  See merge request ros/schunk_svh_driver!23
* Apply clang-format through pre-commit hook
* Add license notice to all development files
  The text is in accordance with the recommendations from
  here <https://www.gnu.org/licenses/gpl-howto.html>
  in the section *The license notices*.
* Remove old license texts
* Update SPDX license indicator in package.xml
  This is according to
  here <https://www.gnu.org/licenses/identify-licenses-clearly.html>.
* Support left and right hands through launch parameters
  We now load the correct ROS-control configuration depending on whether
  users start a right_hand or a left_hand.
  This is also passed to the URDF robot description.
* Update top-level readme
  Also add lightweight readmes for each sub package.
* Merge branch 'meta-package' into 'update-and-upgrade'
  Meta package
  See merge request ros/schunk_svh_driver!20
* Fix installs
* Use the new schunk_svh_msgs package
* Start making this a meta package
  We move everything into an equally called sub package.
  This should maintain our Git history.
* Contributors: Stefan Scherzinger
```

## schunk_svh_msgs

```
* Merge branch 'update-license-ros1' into 'update-and-upgrade'
  Switch license to the GPLv3
  See merge request ros/schunk_svh_driver!23
* Update SPDX license indicator in package.xml
  This is according to
  here <https://www.gnu.org/licenses/identify-licenses-clearly.html>.
* Update top-level readme
  Also add lightweight readmes for each sub package.
* Merge branch 'meta-package' into 'update-and-upgrade'
  Meta package
  See merge request ros/schunk_svh_driver!20
* Fix message_runtime dependency for msgs
* Add a sub package for messages
  That's cleaner for releases.
* Contributors: Stefan Scherzinger
```

## schunk_svh_simulation

```
* Merge pull request #18 <https://github.com/fzi-forschungszentrum-informatik/schunk_svh_ros_driver/issues/18> from fzi-forschungszentrum-informatik/add-gazebo-example
  Add an example setup for Gazebo
* Add a readme for the simulation
* Add a dedicated simulation package
  That's cleaner and keeps Gazebo simulation specific configuration
  separate from the actual driver.
* Contributors: Stefan Scherzinger
```
