### PR TITLE
Change doc and source branch of image_transport_plugins in melodic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4758,7 +4758,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/image_transport_plugins.git
-      version: indigo-devel
+      version: melodic-devel
     release:
       packages:
       - compressed_depth_image_transport
@@ -4772,7 +4772,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-perception/image_transport_plugins.git
-      version: indigo-devel
+      version: melodic-devel
     status: maintained
   imagezero_transport:
     doc:


### PR DESCRIPTION
A [melodic branch](https://github.com/ros-perception/image_transport_plugins/tree/melodic-devel) has been split off in image_transport_plugins due to a backported feature which is untested in previous eol distros.