### PR TITLE
neonavigation: 0.11.8-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6021,7 +6021,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.11.7-1
+      version: 0.11.8-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.11.8-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.11.7-1`

## costmap_cspace

- No changes

## joystick_interrupt

- No changes

## map_organizer

- No changes

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

- No changes

## obj_to_pointcloud

- No changes

## planner_cspace

```
* planner_cspace: add missing array include (#658 <https://github.com/at-wat/neonavigation/issues/658>)
* Contributors: Atsushi Watanabe
```

## safety_limiter

```
* safety_limiter: make sure to keep margin from obstacles (#654 <https://github.com/at-wat/neonavigation/issues/654>)
* Contributors: Kazuki Takahashi
```

## track_odometry

- No changes

## trajectory_tracker

- No changes
