### PR TITLE
mcl_3dl: 0.6.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5041,7 +5041,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/at-wat/mcl_3dl-release.git
-      version: 0.6.0-1
+      version: 0.6.1-1
     source:
       type: git
       url: https://github.com/at-wat/mcl_3dl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mcl_3dl` to `0.6.1-1`:

- upstream repository: https://github.com/at-wat/mcl_3dl.git
- release repository: https://github.com/at-wat/mcl_3dl-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.0-1`

## mcl_3dl

```
* Update assets to v0.4.1 (#400 <https://github.com/at-wat/mcl_3dl/issues/400>)
* Support PCL 1.11 and later (#397 <https://github.com/at-wat/mcl_3dl/issues/397>)
* Update assets to v0.4.0 (#395 <https://github.com/at-wat/mcl_3dl/issues/395>)
* Update assets to v0.3.4 (#392 <https://github.com/at-wat/mcl_3dl/issues/392>)
* Remove old workarounds for PCL<1.8 (#389 <https://github.com/at-wat/mcl_3dl/issues/389>)
* Update assets to v0.3.3 (#388 <https://github.com/at-wat/mcl_3dl/issues/388>)
* Update assets to v0.3.2 (#387 <https://github.com/at-wat/mcl_3dl/issues/387>)
* Update code format (#386 <https://github.com/at-wat/mcl_3dl/issues/386>)
* Contributors: Atsushi Watanabe
```
