### PR TITLE
cob_robots: 0.7.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1223,7 +1223,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_robots-release.git
-      version: 0.7.8-1
+      version: 0.7.9-1
     source:
       type: git
       url: https://github.com/ipa320/cob_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_robots` to `0.7.9-1`:

- upstream repository: https://github.com/ipa320/cob_robots.git
- release repository: https://github.com/ipa320/cob_robots-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.8-1`

## cob_bringup

```
* Merge pull request #830 <https://github.com/ipa320/cob_robots/issues/830> from fmessmer/fix/ci
  update ci
* fix catkin_lint
* indentation
* Merge pull request #828 <https://github.com/ipa320/cob_robots/issues/828> from HannesBachter/feature/diagnostics
  Feature/diagnostics
* fix roslaunch checks
* use default name for scan unifier node
* enable halt_detector
* publish diagnostics in launchfiles of respective components
* fix diagnostics
* publish diagnostics in launchfiles of respective components
* update launchfiles for D435
* Merge pull request #827 <https://github.com/ipa320/cob_robots/issues/827> from floweisshardt/feature/diagnostics
  add station reflector diagnostics
* add station reflector diagnostics
* Merge pull request #826 <https://github.com/ipa320/cob_robots/issues/826> from fmessmer/feature/cob4-29
  Feature/cob4 29
* assign arm and gripper to correct pc
* cob4-29 realsense serial_no
* cob4-30 realsense serial_no
* fix cob_bringup env.sh for noetic
* Contributors: Denis Lehmann, Felix Messmer, Florian Weisshardt, HannesBachter, floweisshardt, fmessmer, mailto:robot@cob4-29, mailto:robot@cob4-30
```

## cob_default_robot_behavior

- No changes

## cob_default_robot_config

- No changes

## cob_hardware_config

```
* Merge pull request #829 <https://github.com/ipa320/cob_robots/issues/829> from HannesBachter/setup_cob4-30
  setup cob4-30
* use /dev/headcam as video device for head cam
* Merge pull request #828 <https://github.com/ipa320/cob_robots/issues/828> from HannesBachter/feature/diagnostics
  Feature/diagnostics
* fix roslaunch checks
* enable halt_detector
* fix tf exceptions for invlid prefix
* fix diagnostics
* use /dev/headcam for head video
* update number of leds
* add new docking_stations structure
* publish diagnostics in launchfiles of respective components
* Merge pull request #826 <https://github.com/ipa320/cob_robots/issues/826> from fmessmer/feature/cob4-29
  Feature/cob4 29
* update teleop.yaml
* calibrate cob4-29 base
* update teleop.yaml
* calibrate cob4-30 base
* Contributors: Denis Lehmann, Felix Messmer, Florian Weisshardt, HannesBachter, floweisshardt, fmessmer, pgehring, mailto:robot@cob4-29, mailto:robot@cob4-30
```

## cob_moveit_config

- No changes

## cob_robots

- No changes
