### PR TITLE
care-o-bot: 0.7.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -658,12 +658,13 @@ repositories:
     release:
       packages:
       - care_o_bot
+      - care_o_bot_desktop
       - care_o_bot_robot
       - care_o_bot_simulation
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/care-o-bot-release.git
-      version: 0.7.9-1
+      version: 0.7.10-1
     source:
       type: git
       url: https://github.com/ipa320/care-o-bot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `care-o-bot` to `0.7.10-1`:

- upstream repository: https://github.com/ipa320/care-o-bot.git
- release repository: https://github.com/ipa320/care-o-bot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.9-1`

## care_o_bot

```
* Merge pull request #63 <https://github.com/ipa320/care-o-bot/issues/63> from fmessmer/fix/ci
  update ci
* update ci
* Merge pull request #62 <https://github.com/ipa320/care-o-bot/issues/62> from fmessmer/fix/ci
  fix ci
* bump cmake version
* Contributors: Felix Messmer, fmessmer
```

## care_o_bot_desktop

```
* Merge pull request #63 <https://github.com/ipa320/care-o-bot/issues/63> from fmessmer/fix/ci
  update ci
* update ci
* Merge pull request #62 <https://github.com/ipa320/care-o-bot/issues/62> from fmessmer/fix/ci
  fix ci
* bump cmake version
* Contributors: Felix Messmer, fmessmer
```

## care_o_bot_robot

```
* Merge pull request #63 <https://github.com/ipa320/care-o-bot/issues/63> from fmessmer/fix/ci
  update ci
* update ci
* Merge pull request #62 <https://github.com/ipa320/care-o-bot/issues/62> from fmessmer/fix/ci
  fix ci
* bump cmake version
* Contributors: Felix Messmer, fmessmer
```

## care_o_bot_simulation

```
* Merge pull request #63 <https://github.com/ipa320/care-o-bot/issues/63> from fmessmer/fix/ci
  update ci
* update ci
* Merge pull request #62 <https://github.com/ipa320/care-o-bot/issues/62> from fmessmer/fix/ci
  fix ci
* bump cmake version
* Contributors: Felix Messmer, fmessmer
```
