### PR TITLE
foxglove_bridge: 0.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1330,7 +1330,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 0.2.2-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_bridge` to `0.3.0-1`:

- upstream repository: https://github.com/foxglove/ros-foxglove-bridge.git
- release repository: https://github.com/ros2-gbp/foxglove_bridge-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.2-1`

## foxglove_bridge

```
* Add launch files, add install instructions to README (#125 <https://github.com/foxglove/ros-foxglove-bridge/issues/125>)
* Drop messages when connection send buffer limit has been reached (#126 <https://github.com/foxglove/ros-foxglove-bridge/issues/126>)
* Remove references to galactic support from README (#117 <https://github.com/foxglove/ros-foxglove-bridge/issues/117>)
* Add missing build instructions (#123 <https://github.com/foxglove/ros-foxglove-bridge/issues/123>)
* Use a single reentrant callback group for all subscriptions (#122 <https://github.com/foxglove/ros-foxglove-bridge/issues/122>)
* Fix clang compilation errors (#119 <https://github.com/foxglove/ros-foxglove-bridge/issues/119>)
* Publish binary time data when use_sim_time parameter is true (#114 <https://github.com/foxglove/ros-foxglove-bridge/issues/114>)
* Optimize Dockerfiles (#110 <https://github.com/foxglove/ros-foxglove-bridge/issues/110>)
* Contributors: Hans-Joachim Krauch, Ruffin
```
