### PR TITLE
maliput_sparse: 0.2.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2761,7 +2761,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput_sparse-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_sparse` to `0.2.1-1`:

- upstream repository: https://github.com/maliput/maliput_sparse.git
- release repository: https://github.com/ros2-gbp/maliput_sparse-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.0-1`

## maliput_sparse

```
* Implements range validator for the geometry::utils methods. (#48 <https://github.com/maliput/maliput_sparse/issues/48>)
* Uses the closest point to calculate the equivalent p in a boundary. (#46 <https://github.com/maliput/maliput_sparse/issues/46>)
* Adds a adjacency checker for the builder. (#45 <https://github.com/maliput/maliput_sparse/issues/45>)
* Contributors: Franco Cipollone
```
