### PR TITLE
hri_msgs: 0.8.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4537,7 +4537,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros4hri/hri_msgs-release.git
-      version: 0.7.1-1
+      version: 0.8.0-1
     source:
       type: git
       url: https://github.com/ros4hri/hri_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hri_msgs` to `0.8.0-1`:

- upstream repository: https://github.com/ros4hri/hri_msgs.git
- release repository: https://github.com/ros4hri/hri_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.1-1`

## hri_msgs

```
* add Stamped and unstamped versions of NormalizedPointOfInterest2d
* move LookAtWithStyle.msg to hri_actions_msgs
* Rename point and region of interest messages to
  'Normalized[PointOfInterest2d|RegionOfInterest2D]'
* Add RegionOfInterest2D messages
  This message represents a 2D region-of-interest with an associated confidence. The message contains a Header-type field to allow easy synchronisation with other messages.
* Contributors: Francesco Tonini, Séverin Lemaignan
```
