### PR TITLE
behaviortree_cpp: 3.8.2-1 in 'foxy/distribution.yaml' [manual]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -442,8 +442,6 @@ repositories:
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
       version: v3.8
     release:
-      packages:
-      - behaviortree_cpp_v3
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/BehaviorTree/behaviortree_cpp_v3-release.git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -436,22 +436,22 @@ repositories:
       url: https://github.com/pal-robotics/backward_ros.git
       version: foxy-devel
     status: maintained
-  behaviortree_cpp:
+  behaviortree_cpp_v3:
     doc:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-      version: master
+      version: v3.8
     release:
       packages:
       - behaviortree_cpp_v3
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/BehaviorTree/behaviortree_cpp-release.git
-      version: 3.8.0-1
+      url: https://github.com/BehaviorTree/behaviortree_cpp_v3-release.git
+      version: 3.8.2-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-      version: master
+      version: v3.8
     status: developed
   bno055:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository behaviortree_cpp to 3.8.2-1:

Note that this PR was done by hand instead of blook, because I got this error: 

`Failed to open pull request: AssertionError - Duplicate package name 'behaviortree_cpp_v3' exists in repository 'behaviortree_cpp_v3' as well as in repository 'behaviortree_cpp'`

This changes should fix the mess