### PR TITLE
add 'apriltag_msgs' and 'apriltag_ros' to 'humble' and 'rolling'

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -368,6 +368,16 @@ repositories:
       url: https://github.com/AprilRobotics/apriltag.git
       version: master
     status: maintained
+  apriltag_msgs:
+    source:
+      type: git
+      url: https://github.com/christianrauch/apriltag_msgs.git
+      version: master
+  apriltag_ros:
+    source:
+      type: git
+      url: https://github.com/christianrauch/apriltag_ros.git
+      version: master
   aruco_opencv:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -344,6 +344,16 @@ repositories:
       url: https://github.com/AprilRobotics/apriltag.git
       version: master
     status: maintained
+  apriltag_msgs:
+    source:
+      type: git
+      url: https://github.com/christianrauch/apriltag_msgs.git
+      version: master
+  apriltag_ros:
+    source:
+      type: git
+      url: https://github.com/christianrauch/apriltag_ros.git
+      version: master
   aruco_opencv:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

`humble` and `rolling`

# The source is here:

- https://github.com/christianrauch/apriltag_msgs
- https://github.com/christianrauch/apriltag_ros



# Checks
 - [x] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
