### PR TITLE
schunk_svh_ros_driver: 0.1.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10134,7 +10134,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_ros_driver-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_ros_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_svh_ros_driver` to `0.1.2-1`:

- upstream repository: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_ros_driver.git
- release repository: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_ros_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.1-1`

## schunk_svh

- No changes

## schunk_svh_description

- No changes

## schunk_svh_driver

- No changes

## schunk_svh_msgs

- No changes

## schunk_svh_simulation

```
* Correctly depend on schunk_svh_description
  We only need that as an execution dependency.
* Contributors: Stefan Scherzinger
```
