### PR TITLE
Migrate release repos into ros2-gbp

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1415,7 +1415,7 @@ repositories:
   generate_parameter_library:
     doc:
       type: git
-      url: https://github.com/PickNikRobotics/generate_parameter_library-release.git
+      url: https://github.com/PickNikRobotics/generate_parameter_library.git
       version: main
     release:
       packages:
@@ -1425,7 +1425,7 @@ repositories:
       - parameter_traits
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/PickNikRobotics/generate_parameter_library-release.git
+      url: https://github.com/ros2-gbp/generate_parameter_library-release.git
       version: 0.3.0-1
     source:
       type: git
@@ -3420,7 +3420,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/PickNikRobotics/pick_ik-release.git
+      url: https://github.com/ros2-gbp/pick_ik-release.git
       version: 1.0.0-1
     source:
       type: git
@@ -5589,7 +5589,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/PickNikRobotics/RSL-release.git
+      url: https://github.com/ros2-gbp/RSL-release.git
       version: 0.2.1-1
     source:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1359,7 +1359,7 @@ repositories:
       - parameter_traits
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/PickNikRobotics/generate_parameter_library-release.git
+      url: https://github.com/ros2-gbp/generate_parameter_library-release.git
       version: 0.3.0-1
     source:
       type: git
@@ -5156,7 +5156,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/PickNikRobotics/RSL-release.git
+      url: https://github.com/ros2-gbp/RSL-release.git
       version: 0.2.1-1
     source:
       type: git


### PR DESCRIPTION
Per this change to migrate release repos into the ros2-gbp org, here is a change to update the entries to point to the new home of the release repos: https://github.com/ros2-gbp/ros2-gbp-github-org/issues/163