### PR TITLE
marti_messages: 1.4.0-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2450,7 +2450,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/marti_messages-release.git
-      version: 1.3.0-3
+      version: 1.4.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_messages` to `1.4.0-2`:

- upstream repository: https://github.com/swri-robotics/marti_messages.git
- release repository: https://github.com/ros2-gbp/marti_messages-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.0-3`

## marti_introspection_msgs

```
* Add Introspection Messages (#123 <https://github.com/swri-robotics/marti_messages/issues/123>)
  * Updating authors' and maintainers' information
  * Adding introspection messages
* Contributors: David Anthony
```
