### PR TITLE
marti_messages: 1.4.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2869,7 +2869,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/marti_messages-release.git
-      version: 1.3.0-1
+      version: 1.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_messages` to `1.4.0-1`:

- upstream repository: https://github.com/swri-robotics/marti_messages.git
- release repository: https://github.com/ros2-gbp/marti_messages-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.0-1`

## marti_introspection_msgs

```
* Add Introspection Messages (#123 <https://github.com/swri-robotics/marti_messages/issues/123>)
  * Updating authors' and maintainers' information
  * Adding introspection messages
* Contributors: David Anthony
```
