### PR TITLE
gazebo_ros2_control: 0.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1297,7 +1297,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.4.0-1
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros2_control` to `0.5.0-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros2_control.git
- release repository: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.0-1`

## gazebo_ros2_control

```
* Force setting use_sim_time parameter when using plugin. (#171 <https://github.com/ros-controls/gazebo_ros2_control/issues/171>)
* Improve error message if robot_description_ param is wrong (#168 <https://github.com/ros-controls/gazebo_ros2_control/issues/168>)
* Rename hw info class type to plugin name (#169 <https://github.com/ros-controls/gazebo_ros2_control/issues/169>)
* Removed warning (#162 <https://github.com/ros-controls/gazebo_ros2_control/issues/162>)
* Mimic joint should have the same control mode as mimicked joint. (#154 <https://github.com/ros-controls/gazebo_ros2_control/issues/154>)
* Enable loading params from multiple yaml files (#149 <https://github.com/ros-controls/gazebo_ros2_control/issues/149>)
* Contributors: Alejandro Hernández Cordero, Christoph Fröhlich, Denis Štogl, Tony Najjar
```

## gazebo_ros2_control_demos

```
* Add tricycle controller demo (#145 <https://github.com/ros-controls/gazebo_ros2_control/issues/145>)
* Contributors: Tony Najjar
```
