### PR TITLE
ros2_control: 2.19.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4622,7 +4622,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.18.0-1
+      version: 2.19.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.19.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.18.0-1`

## controller_interface

- No changes

## controller_manager

```
* Prevent controller manager from crashing when controller's plugin has error during loading. (#881 <https://github.com/ros-controls/ros2_control/issues/881>) (#882 <https://github.com/ros-controls/ros2_control/issues/882>)
* Contributors: Denis Štogl
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* ResourceManager doesn't always log an error on shutdown anymore (#867 <https://github.com/ros-controls/ros2_control/issues/867>) (#871 <https://github.com/ros-controls/ros2_control/issues/871>)
* Contributors: Christopher Wecht
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
