### PR TITLE
Grace_Proj_Msgs: 0.0.1-4 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8,6 +8,14 @@ release_platforms:
   ubuntu:
   - focal
 repositories:
+  Grace_Proj_Msgs:
+    release:
+      packages:
+      - grace_attn_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/HKUST-NISL/Grace_Proj_Msgs.git
+      version: 0.0.1-4
   abb_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `Grace_Proj_Msgs` to `0.0.1-4`:

- upstream repository: https://github.com/HKUST-NISL/Grace_Proj_Msgs.git
- release repository: https://github.com/HKUST-NISL/Grace_Proj_Msgs.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
