### PR TITLE
Set test_pull_requests to true for image_transport_plugins in melodic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4770,6 +4770,7 @@ repositories:
       url: https://github.com/ros-gbp/image_transport_plugins-release.git
       version: 1.9.5-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/image_transport_plugins.git
       version: melodic-devel


### PR DESCRIPTION
Enable pull request testing for image_transport_plugins in melodic.