### PR TITLE
Add libboost-coroutine(-dev) to rosdep

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2598,7 +2598,9 @@ libboost-coroutine:
   nixos: [boost]
   openembedded: [boost@openembedded-core]
   opensuse: [libboost_coroutine1_66_0]
-  rhel: [boost-coroutine]
+  rhel:
+    '*': [boost-coroutine]
+    '7': null
   ubuntu:
     bionic: [libboost-coroutine1.65.1]
     eoan: [libboost-coroutine1.67.0]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2589,6 +2589,31 @@ libboost-chrono-dev:
   opensuse: [libboost_chrono1_66_0-devel]
   rhel: [boost-devel]
   ubuntu: [libboost-chrono-dev]
+libboost-coroutine:
+  debian:
+    bullseye: [libboost-coroutine1.74.0]
+    buster: [libboost-coroutine1.67.0]
+  fedora: [boost-coroutine]
+  gentoo: [dev-libs/boost]
+  nixos: [boost]
+  openembedded: [boost@openembedded-core]
+  opensuse: [libboost_coroutine1_66_0]
+  rhel: [boost-coroutine]
+  ubuntu:
+    bionic: [libboost-coroutine1.65.1]
+    eoan: [libboost-coroutine1.67.0]
+    focal: [libboost-coroutine1.71.0]
+    jammy: [libboost-coroutine1.74.0]
+    xenial: [libboost-coroutine1.58.0]
+libboost-coroutine-dev:
+  debian: [libboost-coroutine-dev]
+  fedora: [boost-devel]
+  gentoo: [dev-libs/boost]
+  nixos: [boost]
+  openembedded: [boost@openembedded-core]
+  opensuse: [libboost_coroutine1_66_0-devel]
+  rhel: [boost-devel]
+  ubuntu: [libboost-coroutine-dev]
 libboost-date-time:
   debian:
     bullseye: [libboost-date-time1.74.0]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2609,6 +2609,7 @@ libboost-coroutine:
     jammy: [libboost-coroutine1.74.0]
     xenial: [libboost-coroutine1.58.0]
 libboost-coroutine-dev:
+  alpine: [boost-dev]
   debian: [libboost-coroutine-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2590,6 +2590,7 @@ libboost-chrono-dev:
   rhel: [boost-devel]
   ubuntu: [libboost-chrono-dev]
 libboost-coroutine:
+  alpine: [boost-dev]
   debian:
     bullseye: [libboost-coroutine1.74.0]
     buster: [libboost-coroutine1.67.0]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

- libboost-coroutine
- libboost-coroutine-dev

## Package Upstream Source:

- https://github.com/boostorg/coroutine

## Purpose of using this:

Useful when you only want to install the boost coroutine library and not the full boost library.

## Links to Distribution Packages

### libboost-coroutine
- Debian:
  - Bullseye: https://packages.debian.org/bullseye/libboost-coroutine1.74.0
  - Buster: https://packages.debian.org/buster/libboost-coroutine1.67.0
- Fedora: https://packages.fedoraproject.org/pkgs/boost/boost-coroutine/
- Gentoo: https://packages.gentoo.org/packages/dev-libs/boost
- NixOS: https://search.nixos.org/packages?channel=22.11&show=boost&from=0&size=50&sort=relevance&type=packages&query=boost
- openSUSE: https://software.opensuse.org/package/libboost_coroutine1_66_0
- RHEL: https://pkgs.org/search/?q=boost-coroutine
- Ubuntu:
  - Bionic:  https://packages.ubuntu.com/bionic/libboost-coroutine1.65.1
  - Eoan: https://packages.ubuntu.com/eoan/libboost-coroutine1.67.0 (EOL)
  - Focal: https://packages.ubuntu.com/focal/libboost-coroutine1.71.0
  - Jammy: https://packages.ubuntu.com/jammy/libboost-coroutine1.74.0
  - Xenial: https://packages.ubuntu.com/xenial/libboost-coroutine1.58.0 (EOL)

### libboost-coroutine-dev
- Debian: 
  - Bullseye: https://packages.debian.org/bullseye/libboost-coroutine-dev
  - Buster:  https://packages.debian.org/buster/libboost-coroutine-dev
- Fedora: https://packages.fedoraproject.org/pkgs/boost/boost-devel/
- Gentoo: https://packages.gentoo.org/packages/dev-libs/boost
- NixOS: https://search.nixos.org/packages?channel=22.11&show=boost&from=0&size=50&sort=relevance&type=packages&query=boost
- openSUSE: https://software.opensuse.org/package/libboost_coroutine1_66_0-devel?search_term=libboost_coroutine1_66_0-devel
- RHEL: https://pkgs.org/search/?q=boost-devel
- Ubuntu: https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=libboost-coroutine-dev&searchon=names

