### PR TITLE
qb_move: 3.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9873,11 +9873,12 @@ repositories:
       - qb_move
       - qb_move_control
       - qb_move_description
+      - qb_move_gazebo
       - qb_move_hardware_interface
       tags:
         release: release/melodic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbmove-ros-release.git
-      version: 2.0.0-1
+      version: 3.0.0-1
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbmove-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_move` to `3.0.0-1`:

- upstream repository: https://bitbucket.org/qbrobotics/qbmove-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbmove-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-1`

## qb_move

- No changes

## qb_move_control

- No changes

## qb_move_description

```
* Modified .xacro files in order to fit new xacro package version. This commint is suitable with xacro version 1.13.15 -- see https://github.com/ros/xacro/commit/7b5c20907375400cf4db6993a13238e86b38acf3 for more details.
* Fixed errors on URDFs files
```

## qb_move_gazebo

```
* Set c++ standard 17 in gazebo packages
```

## qb_move_hardware_interface

```
* removed some debug std::cout. Control period setted to 200 Hz because at 1 kHz communication errors occur.
* Modified some vector types according to new API methods.
* Fixed too high qbmove shaft limits
```
