### PR TITLE
behaviortree_cpp: 3.8.2-1 in 'rolling/distribution.yaml' [manual]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -483,22 +483,20 @@ repositories:
       url: https://github.com/wep21/bag2_to_image.git
       version: main
     status: maintained
-  behaviortree_cpp:
+  behaviortree_cpp_v3:
     doc:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-      version: master
+      version: v3.8
     release:
-      packages:
-      - behaviortree_cpp_v3
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/behaviortree_cpp-release.git
-      version: 3.8.0-1
+      url: https://github.com/BehaviorTree/behaviortree_cpp_v3-release.git
+      version: 3.8.2-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-      version: master
+      version: v3.8
     status: developed
   bno055:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -491,7 +491,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/BehaviorTree/behaviortree_cpp_v3-release.git
+      url: https://github.com/ros2-gbp/behaviortree_cpp-release.git
       version: 3.8.2-1
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository behaviortree_cpp to 3.8.2-1

Done manually to fix other issues