### PR TITLE
launch: 1.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2137,7 +2137,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `1.0.4-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.3-1`

## launch

```
* Allow ReadyToTest() usage in event handler (#681 <https://github.com/ros2/launch/issues/681>)
* Contributors: Nikolai Morin
```

## launch_pytest

- No changes

## launch_testing

```
* Allow ReadyToTest() usage in event handler (#681 <https://github.com/ros2/launch/issues/681>)
* Inherit markers from generate_test_description (#670 <https://github.com/ros2/launch/issues/670>) (#674 <https://github.com/ros2/launch/issues/674>)
* Contributors: Nikolai Morin, mergify[bot]
```

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
