### PR TITLE
launch_ros: 0.19.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2187,7 +2187,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.19.3-1
+      version: 0.19.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.19.4-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.19.3-1`

## launch_ros

```
* fix: return text value to avoid exception (#338 <https://github.com/ros2/launch_ros/issues/338>) (#340 <https://github.com/ros2/launch_ros/issues/340>)
* Contributors: Daisuke Nishimatsu
```

## launch_testing_ros

```
* Inherit markers from generate_test_description (#330 <https://github.com/ros2/launch_ros/issues/330>) (#332 <https://github.com/ros2/launch_ros/issues/332>)
* Contributors: mergify[bot]
```

## ros2launch

- No changes
