### PR TITLE
rclpy: 3.3.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3994,7 +3994,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 3.3.5-1
+      version: 3.3.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `3.3.6-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.3.5-1`

## rclpy

```
* decorator should not be callable. (#1050 <https://github.com/ros2/rclpy/issues/1050>) (#1051 <https://github.com/ros2/rclpy/issues/1051>)
* Add parallel callback test (#1044 <https://github.com/ros2/rclpy/issues/1044>) (#1052 <https://github.com/ros2/rclpy/issues/1052>)
* Contributors: mergify[bot]
```
