### PR TITLE
rmw_implementation: 2.8.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4494,7 +4494,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_implementation-release.git
-      version: 2.8.1-2
+      version: 2.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_implementation` to `2.8.2-1`:

- upstream repository: https://github.com/ros2/rmw_implementation.git
- release repository: https://github.com/ros2-gbp/rmw_implementation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.8.1-2`

## rmw_implementation

```
* Build-time RMW selection does not need ament_index_cpp (#210 <https://github.com/ros2/rmw_implementation/issues/210>) (#211 <https://github.com/ros2/rmw_implementation/issues/211>)
* Contributors: mergify[bot]
```
