### PR TITLE
ros2cli: 0.18.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4785,7 +4785,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.18.4-1
+      version: 0.18.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.18.5-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.18.4-1`

## ros2action

- No changes

## ros2cli

```
* Fix network aware node issue (#785 <https://github.com/ros2/ros2cli/issues/785>) (#786 <https://github.com/ros2/ros2cli/issues/786>)
* Contributors: mergify[bot]
```

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

- No changes

## ros2interface

- No changes

## ros2lifecycle

- No changes

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

- No changes

## ros2param

- No changes

## ros2pkg

- No changes

## ros2run

- No changes

## ros2service

- No changes

## ros2topic

```
* Extend timeout to shutdown the command line process. (#783 <https://github.com/ros2/ros2cli/issues/783>) (#784 <https://github.com/ros2/ros2cli/issues/784>)
* Add support use_sim_time for ros2 topic hz/bw/pub. (#754 <https://github.com/ros2/ros2cli/issues/754>) (#777 <https://github.com/ros2/ros2cli/issues/777>)
* Contributors: Tomoya Fujita, mergify[bot]
```
