### PR TITLE
spdlog_vendor: 1.3.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6000,7 +6000,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/spdlog_vendor-release.git
-      version: 1.3.0-3
+      version: 1.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `spdlog_vendor` to `1.3.1-1`:

- upstream repository: https://github.com/ros2/spdlog_vendor.git
- release repository: https://github.com/ros2-gbp/spdlog_vendor-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.0-3`

## spdlog_vendor

```
* Fixes policy CMP0135 warning for CMake >= 3.24 (#30 <https://github.com/ros2/spdlog_vendor/issues/30>) (#32 <https://github.com/ros2/spdlog_vendor/issues/32>)
* Contributors: mergify[bot]
```
