### PR TITLE
yaml_cpp_vendor: 8.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7138,7 +7138,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
-      version: 8.0.1-2
+      version: 8.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `yaml_cpp_vendor` to `8.0.2-1`:

- upstream repository: https://github.com/ros2/yaml_cpp_vendor.git
- release repository: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `8.0.1-2`

## yaml_cpp_vendor

```
* Fixes policy CMP0135 warning for CMake >= 3.24 (#35 <https://github.com/ros2/yaml_cpp_vendor/issues/35>) (#41 <https://github.com/ros2/yaml_cpp_vendor/issues/41>)
* Contributors: mergify[bot]
```
