### PR TITLE
rviz: 11.2.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5688,7 +5688,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 11.2.4-1
+      version: 11.2.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `11.2.5-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `11.2.4-1`

## rviz2

- No changes

## rviz_assimp_vendor

```
* Fixes policy CMP0135 warning for CMake >= 3.24 (#898 <https://github.com/ros2/rviz/issues/898>) (#936 <https://github.com/ros2/rviz/issues/936>)
* Contributors: mergify[bot]
```

## rviz_common

- No changes

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

```
* Fixes policy CMP0135 warning for CMake >= 3.24 (#898 <https://github.com/ros2/rviz/issues/898>) (#936 <https://github.com/ros2/rviz/issues/936>)
* Contributors: mergify[bot]
```

## rviz_rendering

```
* add test to ensure binary STL files from SOLIDWORKS get imported without a warning (#917 <https://github.com/ros2/rviz/issues/917>) (#931 <https://github.com/ros2/rviz/issues/931>)
* Contributors: mergify[bot]
```

## rviz_rendering_tests

```
* add test to ensure binary STL files from SOLIDWORKS get imported without a warning (#917 <https://github.com/ros2/rviz/issues/917>) (#931 <https://github.com/ros2/rviz/issues/931>)
* Contributors: mergify[bot]
```

## rviz_visual_testing_framework

- No changes
