### PR TITLE
resource_retriever: 3.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4117,7 +4117,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 3.1.0-2
+      version: 3.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `3.1.1-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros2-gbp/resource_retriever-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.1.0-2`

## libcurl_vendor

```
* Sets CMP0135 policy behavior to NEW (backport #79 <https://github.com/ros/resource_retriever/issues/79>) (#82 <https://github.com/ros/resource_retriever/issues/82>)
* Contributors: mergify[bot]
```

## resource_retriever

- No changes
