### PR TITLE
python3-cbor2: in rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6267,6 +6267,22 @@ python3-catkin-tools:
   fedora: [python3-catkin_tools]
   openembedded: [python3-catkin-tools@meta-ros-common]
   ubuntu: [python3-catkin-tools]
+python3-cbor2:
+  arch: [python-cbor2]
+  debian:
+    '*': [python3-cbor2]
+    buster:
+      pip:
+        packages: [cbor2]
+  fedora: [python3-cbor2]
+  osx:
+    pip:
+      packages: [cbor2]
+  ubuntu:
+    '*': [python3-cbor2]
+    focal:
+      pip:
+        packages: [cbor2]
 python3-certifi:
   debian: [python3-certifi]
   fedora: [python3-certifi]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6275,6 +6275,9 @@ python3-cbor2:
       pip:
         packages: [cbor2]
   fedora: [python3-cbor2]
+  gentoo: [dev-python/cbor2]
+  nixos: [python39Packages.cbor2]
+  opensuse: [python-cbor2]
   osx:
     pip:
       packages: [cbor2]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6283,6 +6283,9 @@ python3-cbor2:
       packages: [cbor2]
   ubuntu:
     '*': [python3-cbor2]
+    bionic:
+      pip:
+        packages: [cbor2]
     focal:
       pip:
         packages: [cbor2]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-cbor2

## Package Upstream Source:

[github.com/agronholm/cbor2](https://github.com/agronholm/cbor2)

## Purpose of using this:

[cbor2](https://pypi.org/project/cbor2/) seems to be the only implementation for [CBOR serialization format](http://cbor.io/) in Python ecosystem, that is maintained, well-documented, and popular. The only CBOR package that is currently available in rosdistro is [python-cbor](https://github.com/ros/rosdistro/blob/512e6ebffade99895d33c4aa81ff58bf6f75ef14/rosdep/python.yaml#L1045) ([PyPI page](https://pypi.org/project/cbor/)), which appears to be unmaintained for years, doesn't have documentation, and the source code isn't available anymore.

## Links to Distribution Packages

- Debian: [python3-cbor2](https://packages.debian.org/bullseye/python3-cbor2)
- Ubuntu: [python3-cbor2](https://packages.ubuntu.com/jammy/python3-cbor2)
- Fedora: [python3-cbor2](https://packages.fedoraproject.org/pkgs/python-cbor2/python3-cbor2)
- Arch: [python-cbor2](https://archlinux.org/packages/community/x86_64/python-cbor2)
- Gentoo: [dev-python/cbor2](https://packages.gentoo.org/packages/dev-python/cbor2)
- macOS: not available
- Alpine: not available
- NixOS/nixpkgs: [python39Packages.cbor2](https://search.nixos.org/packages?channel=22.11&show=python39Packages.cbor2), [python310Packages.cbor2](https://search.nixos.org/packages?channel=22.11&show=python310Packages.cbor2)
- openSUSE: [python-cbor2](https://software.opensuse.org/package/python-cbor2)


# Checks
 - [ ] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
