### PR TITLE
navigation: 1.17.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5904,7 +5904,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.17.2-1
+      version: 1.17.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.17.3-1`:

- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.17.2-1`

## amcl

```
* [AMCL] Add option to force nomotion update after initialpose (#1226 <https://github.com/ros-planning/navigation/issues/1226>)
  * Adds a new boolean parameter force_update_after_initialpose. When set to true, an update is forced on the next laser scan callback, such as when the /request_nomotion_update service is called. This often results in an improved robot pose after a manual (not very precise) re-localization - without a need for the robot to move.
  * Fixes a bunch of compiler warnings (unused variable now, catching exceptions by value), normalizes how tf exceptions are caught
* [ROS-O] various patches (#1225 <https://github.com/ros-planning/navigation/issues/1225>)
  * do not specify obsolete c++11 standard
  this breaks with current versions of log4cxx.
  * update pluginlib include paths
  the non-hpp headers have been deprecated since kinetic
  * use lambdas in favor of boost::bind
  Using boost's _1 as a global system is deprecated since C++11.
  The ROS packages in Debian removed the implicit support for the global symbols,
  so this code fails to compile there without the patch.
* Contributors: Michael Görner, Stephan
```

## base_local_planner

```
* [ROS-O] various patches (#1225 <https://github.com/ros-planning/navigation/issues/1225>)
  * do not specify obsolete c++11 standard
  this breaks with current versions of log4cxx.
  * update pluginlib include paths
  the non-hpp headers have been deprecated since kinetic
  * use lambdas in favor of boost::bind
  Using boost's _1 as a global system is deprecated since C++11.
  The ROS packages in Debian removed the implicit support for the global symbols,
  so this code fails to compile there without the patch.
* Contributors: Michael Görner
```

## carrot_planner

```
* [ROS-O] various patches (#1225 <https://github.com/ros-planning/navigation/issues/1225>)
  * do not specify obsolete c++11 standard
  this breaks with current versions of log4cxx.
  * update pluginlib include paths
  the non-hpp headers have been deprecated since kinetic
  * use lambdas in favor of boost::bind
  Using boost's _1 as a global system is deprecated since C++11.
  The ROS packages in Debian removed the implicit support for the global symbols,
  so this code fails to compile there without the patch.
* Contributors: Michael Görner
```

## clear_costmap_recovery

```
* [ROS-O] various patches (#1225 <https://github.com/ros-planning/navigation/issues/1225>)
  * do not specify obsolete c++11 standard
  this breaks with current versions of log4cxx.
  * update pluginlib include paths
  the non-hpp headers have been deprecated since kinetic
  * use lambdas in favor of boost::bind
  Using boost's _1 as a global system is deprecated since C++11.
  The ROS packages in Debian removed the implicit support for the global symbols,
  so this code fails to compile there without the patch.
* Contributors: Michael Görner
```

## costmap_2d

```
* [ROS-O] various patches (#1225 <https://github.com/ros-planning/navigation/issues/1225>)
  * do not specify obsolete c++11 standard
  this breaks with current versions of log4cxx.
  * update pluginlib include paths
  the non-hpp headers have been deprecated since kinetic
  * use lambdas in favor of boost::bind
  Using boost's _1 as a global system is deprecated since C++11.
  The ROS packages in Debian removed the implicit support for the global symbols,
  so this code fails to compile there without the patch.
* Contributors: Michael Görner
```

## dwa_local_planner

```
* [ROS-O] various patches (#1225 <https://github.com/ros-planning/navigation/issues/1225>)
  * do not specify obsolete c++11 standard
  this breaks with current versions of log4cxx.
  * update pluginlib include paths
  the non-hpp headers have been deprecated since kinetic
  * use lambdas in favor of boost::bind
  Using boost's _1 as a global system is deprecated since C++11.
  The ROS packages in Debian removed the implicit support for the global symbols,
  so this code fails to compile there without the patch.
* Contributors: Michael Görner
```

## fake_localization

```
* [ROS-O] various patches (#1225 <https://github.com/ros-planning/navigation/issues/1225>)
  * do not specify obsolete c++11 standard
  this breaks with current versions of log4cxx.
  * update pluginlib include paths
  the non-hpp headers have been deprecated since kinetic
  * use lambdas in favor of boost::bind
  Using boost's _1 as a global system is deprecated since C++11.
  The ROS packages in Debian removed the implicit support for the global symbols,
  so this code fails to compile there without the patch.
* Contributors: Michael Görner
```

## global_planner

```
* [ROS-O] various patches (#1225 <https://github.com/ros-planning/navigation/issues/1225>)
  * do not specify obsolete c++11 standard
  this breaks with current versions of log4cxx.
  * update pluginlib include paths
  the non-hpp headers have been deprecated since kinetic
  * use lambdas in favor of boost::bind
  Using boost's _1 as a global system is deprecated since C++11.
  The ROS packages in Debian removed the implicit support for the global symbols,
  so this code fails to compile there without the patch.
* Contributors: Michael Görner
```

## map_server

```
* [ROS-O] various patches (#1225 <https://github.com/ros-planning/navigation/issues/1225>)
  * do not specify obsolete c++11 standard
  this breaks with current versions of log4cxx.
  * update pluginlib include paths
  the non-hpp headers have been deprecated since kinetic
  * use lambdas in favor of boost::bind
  Using boost's _1 as a global system is deprecated since C++11.
  The ROS packages in Debian removed the implicit support for the global symbols,
  so this code fails to compile there without the patch.
* Contributors: Michael Görner
```

## move_base

```
* [ROS-O] various patches (#1225 <https://github.com/ros-planning/navigation/issues/1225>)
  * do not specify obsolete c++11 standard
  this breaks with current versions of log4cxx.
  * update pluginlib include paths
  the non-hpp headers have been deprecated since kinetic
  * use lambdas in favor of boost::bind
  Using boost's _1 as a global system is deprecated since C++11.
  The ROS packages in Debian removed the implicit support for the global symbols,
  so this code fails to compile there without the patch.
* Contributors: Michael Görner
```

## move_slow_and_clear

```
* [ROS-O] various patches (#1225 <https://github.com/ros-planning/navigation/issues/1225>)
  * do not specify obsolete c++11 standard
  this breaks with current versions of log4cxx.
  * update pluginlib include paths
  the non-hpp headers have been deprecated since kinetic
  * use lambdas in favor of boost::bind
  Using boost's _1 as a global system is deprecated since C++11.
  The ROS packages in Debian removed the implicit support for the global symbols,
  so this code fails to compile there without the patch.
* Contributors: Michael Görner
```

## nav_core

- No changes

## navfn

```
* [ROS-O] various patches (#1225 <https://github.com/ros-planning/navigation/issues/1225>)
  * do not specify obsolete c++11 standard
  this breaks with current versions of log4cxx.
  * update pluginlib include paths
  the non-hpp headers have been deprecated since kinetic
  * use lambdas in favor of boost::bind
  Using boost's _1 as a global system is deprecated since C++11.
  The ROS packages in Debian removed the implicit support for the global symbols,
  so this code fails to compile there without the patch.
* Contributors: Michael Görner
```

## navigation

- No changes

## rotate_recovery

```
* [ROS-O] various patches (#1225 <https://github.com/ros-planning/navigation/issues/1225>)
  * do not specify obsolete c++11 standard
  this breaks with current versions of log4cxx.
  * update pluginlib include paths
  the non-hpp headers have been deprecated since kinetic
  * use lambdas in favor of boost::bind
  Using boost's _1 as a global system is deprecated since C++11.
  The ROS packages in Debian removed the implicit support for the global symbols,
  so this code fails to compile there without the patch.
* Contributors: Michael Görner
```

## voxel_grid

- No changes
