### PR TITLE
l3cam_srv: 0.0.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4373,6 +4373,22 @@ repositories:
       url: https://github.com/MITRE/kvh_geo_fog_3d.git
       version: noetic-devel
     status: maintained
+  l3cam_srv:
+    doc:
+      type: git
+      url: https://github.com/adrisubi/l3cam_srv
+      version: main
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/adrisubi/l3cam_srv-release
+      version: 0.0.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/adrisubi/l3cam_srv
+      version: main
+    status: maintained
   lanelet2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `l3cam_srv` to `0.0.1-2`:

- upstream repository: https://github.com/adrisubi/l3cam_srv
- release repository: https://github.com/adrisubi/l3cam_srv-release
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## l3cam_srv

```
* first commit
* first commit
* Contributors: asubirana
```
