### PR TITLE
nerian_stereo_ros2: 1.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2651,6 +2651,23 @@ repositories:
       url: https://github.com/neobotix/neo_simulation2.git
       version: main
     status: maintained
+  nerian_stereo_ros2:
+    doc:
+      type: git
+      url: https://github.com/nerian-vision/nerian_stereo_ros2.git
+      version: master
+    release:
+      packages:
+      - nerian_stereo
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/nerian-vision/nerian_stereo_ros2-release.git
+      version: 1.1.1-1
+    source:
+      type: git
+      url: https://github.com/nerian-vision/nerian_stereo_ros2.git
+      version: master
+    status: developed
   nlohmann_json_schema_validator_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nerian_stereo_ros2` to `1.1.1-1`:

- upstream repository: https://github.com/nerian-vision/nerian_stereo_ros2.git
- release repository: https://github.com/nerian-vision/nerian_stereo_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
