### PR TITLE
nerian_stereo_ros2: 1.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2932,7 +2932,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/nerian-vision/nerian_stereo_ros2-release.git
-      version: 1.1.1-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/nerian-vision/nerian_stereo_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nerian_stereo_ros2` to `1.2.0-1`:

- upstream repository: https://github.com/nerian-vision/nerian_stereo_ros2.git
- release repository: https://github.com/nerian-vision/nerian_stereo_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.1-1`

## nerian_stereo

```
* Fixed parameter issue. Enabled NERIAN_ROS_DEBUG="params" for extra logging.
* Added log messages about actively served topics (based on run-time conf)
* Support for third camera (Ruby), selected for point cloud if active
* Contributors: Dr. Konstantin Schauwecker, Ramin Yaghoubzadeh Torky
```
