### PR TITLE
nerian_stereo: 3.11.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7825,7 +7825,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/nerian-vision/nerian_stereo-release.git
-      version: 3.10.0-1
+      version: 3.11.0-1
     source:
       type: git
       url: https://github.com/nerian-vision/nerian_stereo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nerian_stereo` to `3.11.0-1`:

- upstream repository: https://github.com/nerian-vision/nerian_stereo.git
- release repository: https://github.com/nerian-vision/nerian_stereo-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.10.0-1`

## nerian_stereo

```
* Added log messages about actively served topics (based on run-time conf)
* Added support for auto color from third Ruby camera (if enabled)
* Better conformity with new parameter types
* Initiate image tranfer despite any failure to connect to parameter server
  (No dynamic parameters will be available; a verbose error is logged.)
* Contributors: Dr. Konstantin Schauwecker, Ramin Yaghoubzadeh Torky
```
