### PR TITLE
leo_robot: 1.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2243,7 +2243,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/leo_robot-release.git
-      version: 1.2.1-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_robot-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_robot` to `1.3.0-1`:

- upstream repository: https://github.com/LeoRover/leo_robot-ros2.git
- release repository: https://github.com/ros2-gbp/leo_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.1-1`

## leo_bringup

- No changes

## leo_fw

```
* Show which wheels failed when testing encoders or torque sensors
* Update hw tests
* Refactor test result printing
* Add timeout for get_board_type and get_firmware_version services
* Include newer firmware binaries
* Use DirectNode in hardware tester
* Update flash logic
* Fix checking if uros agent is active when the service is disabled
* Contributors: Błażej Sowa
```

## leo_robot

- No changes
