### PR TITLE
rosdep: Added m2r package

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6596,6 +6596,32 @@ lz4:
   rhel: [lz4-devel]
   slackware: [lz4]
   ubuntu: [liblz4-dev]
+m2r:
+  alpine:
+    pip:
+      packages: [m2r]
+  arch:
+    pip:
+      packages: [m2r]
+  debian:
+    '*': [m2r]
+    buster:
+      pip:
+        packages: [m2r]
+  fedora: [python3-m2r]
+  gentoo:
+    pip:
+      packages: [m2r]
+  nixos: [m2r]
+  opensuse: [python3-m2r]
+  osx:
+    pip:
+      packages: [m2r]
+  ubuntu:
+    '*': [m2r]
+    bionic:
+      pip:
+        packages: ['m2r<0.3']
 m4:
   arch: [m4]
   debian: [m4]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6619,9 +6619,7 @@ m2r:
       packages: [m2r]
   ubuntu:
     '*': [m2r]
-    bionic:
-      pip:
-        packages: ['m2r<0.3']
+    bionic: null
 m4:
   arch: [m4]
   debian: [m4]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

m2r

## Package Upstream Source:

https://github.com/miyakogi/m2r

## Purpose of using this:

This package allows including Markdown files in RST docs, as e.g. mentioned here: https://stackoverflow.com/a/46012023/1076564 .

## Links to Distribution Packages

- Debian: https://packages.debian.org/bullseye/m2r (buster via pip)
- Ubuntu: https://packages.ubuntu.com/jammy/m2r (bionic via pip)
- Fedora: https://packages.fedoraproject.org/pkgs/python-m2r/python3-m2r/
- Arch: not available ([pip](https://pypi.org/project/m2r/))
- Gentoo: not available ([pip](https://pypi.org/project/m2r/))
- macOS: not available ([pip](https://pypi.org/project/m2r/))
- Alpine: not available ([pip](https://pypi.org/project/m2r/))
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=22.11&show=m2r&from=0&size=50&sort=relevance&type=packages&query=m2r
- openSUSE: https://software.opensuse.org/package/python3-m2r

penSUSE: [python-cbor2](https://software.opensuse.org/package/python-cbor2)

## Checks

- [ ] All packages have a declared license in the package.xml
- [x] This repository has a LICENSE file
- [ ] This package is expected to build on the submitted rosdistro