### PR TITLE
Remove rosbag2_storage_mcap

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4977,25 +4977,6 @@ repositories:
       url: https://github.com/ros2/rosbag2_bag_v2.git
       version: master
     status: maintained
-  rosbag2_storage_mcap:
-    doc:
-      type: git
-      url: https://github.com/ros-tooling/rosbag2_storage_mcap.git
-      version: main
-    release:
-      packages:
-      - mcap_vendor
-      - rosbag2_storage_mcap
-      - rosbag2_storage_mcap_testdata
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/ros2-gbp/rosbag2_storage_mcap-release.git
-      version: 0.6.0-1
-    source:
-      type: git
-      url: https://github.com/ros-tooling/rosbag2_storage_mcap.git
-      version: main
-    status: developed
   rosbridge_suite:
     doc:
       type: git


### PR DESCRIPTION
I'm removing this package because I'm not able to release ros2bag because both of these repositories contain a `mcap_vendor` package. Here's the exact error from Bloom:

> Failed to open pull request: AssertionError - Duplicate package name 'mcap_vendor' exists in repository 'rosbag2_storage_mcap' as well as in repository 'rosbag2'