### PR TITLE
ruckig: 0.9.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6317,7 +6317,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/pantor/ruckig-release.git
-      version: 0.6.3-1
+      version: 0.9.1-1
     source:
       type: git
       url: https://github.com/pantor/ruckig.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ruckig` to `0.9.1-1`:

- upstream repository: https://github.com/pantor/ruckig.git
- release repository: https://github.com/pantor/ruckig-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.3-1`
