### PR TITLE
microstrain_inertial: 3.0.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6739,7 +6739,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/LORD-MicroStrain/microstrain_inertial-release.git
-      version: 2.7.1-1
+      version: 3.0.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `3.0.0-2`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/LORD-MicroStrain/microstrain_inertial-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.7.1-1`

## microstrain_inertial_driver

```
* Fixes for devices that do not support the extended descriptor set command in ROS (#216 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/216>)
  * Fixes for devices that do not support the extended descriptor set command in ROS
* Validates that all publishers are documented on the wiki for ROS (#211 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/211>)
  * Fixes time_ref topics and validates that wiki has all publishers documented
* Adds IMU overrange status publishers for ROS (#207 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/207>)
  * Adds IMU overrange status publishers for ROS
* Adds RF error detection publishers for ROS (#206 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/206>)
  * Adds RF error detection to ROS
* Adds SBAS info publishers for ROS (#204 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/204>)
  * Adds SBAS info publishers for ROS
* Adds SBAS settings support to ROS (#202 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/202>)
  * Adds SBAS settings support to ROS
* ROS Implements the filter lever arm offset command (#196 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/196>)
  * Adds ability to configure filter lever arm offset
* Feature/ros nmea main port (#192 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/192>)
  * Adds ability to parse and publish NMEA from the main port
* Feature/ros mip sdk (#191 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/191>)
  * Converts to use the mip_sdk instead of MSCL
  * BREAKING Removes publish_* configuration options and instead relies on more granular *_data_rate options to enable/disable data streams
  * Switches to compile as a static binary
* Contributors: Rob
```

## microstrain_inertial_examples

- No changes

## microstrain_inertial_msgs

```
* Adds IMU overrange status publishers for ROS (#207 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/207>)
  * Adds IMU overrange status publishers for ROS
* Adds RF error detection publishers for ROS (#206 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/206>)
  * Adds RF error detection to ROS
* Adds SBAS info publishers for ROS (#204 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/204>)
  * Adds SBAS info publishers for ROS
  * Updates submodule to main
* Contributors: Rob
```

## microstrain_inertial_rqt

- No changes
