### PR TITLE
rosbag2: 0.15.4-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4933,6 +4933,7 @@ repositories:
       version: humble
     release:
       packages:
+      - mcap_vendor
       - ros2bag
       - rosbag2
       - rosbag2_compression
@@ -4943,6 +4944,8 @@ repositories:
       - rosbag2_py
       - rosbag2_storage
       - rosbag2_storage_default_plugins
+      - rosbag2_storage_mcap
+      - rosbag2_storage_mcap_testdata
       - rosbag2_test_common
       - rosbag2_tests
       - rosbag2_transport
@@ -4952,7 +4955,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.15.3-1
+      version: 0.15.4-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.15.4-2`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.15.3-1`

## mcap_vendor

```
* [backport humble #1208 <https://github.com/ros2/rosbag2/issues/1208>] Fixes policy CMP0135 warning for CMake >= 3.24 for mcap_vendor (#1227 <https://github.com/ros2/rosbag2/issues/1227>)
* mcap_vendor: only install public headers (backport #1207 <https://github.com/ros2/rosbag2/issues/1207>) (#1214 <https://github.com/ros2/rosbag2/issues/1214>)
* rosbag2_storage_mcap: fix rosbag2_cpp tests (#1205 <https://github.com/ros2/rosbag2/issues/1205>)
* Use mcap tarball rather than git clone (#1200 <https://github.com/ros2/rosbag2/issues/1200>)
* [Humble backport] rosbag2_storage_mcap: merge into rosbag2 repo (#1163 <https://github.com/ros2/rosbag2/issues/1163>) (#1189 <https://github.com/ros2/rosbag2/issues/1189>)
* Contributors: Michael Carroll, james-rms, mergify[bot]
```

## ros2bag

```
* ros2bag: move storage preset validation to sqlite3 plugin (#1135 <https://github.com/ros2/rosbag2/issues/1135>) (#1184 <https://github.com/ros2/rosbag2/issues/1184>)
* Contributors: Daisuke Nishimatsu
```

## rosbag2

- No changes

## rosbag2_compression

- No changes

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* [Humble] Reader and writer can use default storage by not specifying (backport #1167 <https://github.com/ros2/rosbag2/issues/1167>) (#1174 <https://github.com/ros2/rosbag2/issues/1174>)
* Contributors: mergify[bot]
```

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_py

- No changes

## rosbag2_storage

```
* Disable false message about plugin not found. (#1219 <https://github.com/ros2/rosbag2/issues/1219>)
* Contributors: Michael Orlov
```

## rosbag2_storage_default_plugins

```
* ros2bag: move storage preset validation to sqlite3 plugin (#1135 <https://github.com/ros2/rosbag2/issues/1135>) (#1184 <https://github.com/ros2/rosbag2/issues/1184>)
* [humble] Store db schema version and ROS_DISTRO name in db3 files (backport #1156 <https://github.com/ros2/rosbag2/issues/1156>) (#1175 <https://github.com/ros2/rosbag2/issues/1175>)
* Contributors: Daisuke Nishimatsu, mergify[bot]
```

## rosbag2_storage_mcap

```
* rosbag2_storage_mcap: fix rosbag2_cpp tests (#1205 <https://github.com/ros2/rosbag2/issues/1205>)
* [Humble backport] rosbag2_storage_mcap: merge into rosbag2 repo (#1163 <https://github.com/ros2/rosbag2/issues/1163>) (#1189 <https://github.com/ros2/rosbag2/issues/1189>)
* Contributors: james-rms
```

## rosbag2_storage_mcap_testdata

```
* [Humble backport] rosbag2_storage_mcap: merge into rosbag2 repo (#1163 <https://github.com/ros2/rosbag2/issues/1163>) (#1189 <https://github.com/ros2/rosbag2/issues/1189>)
* Contributors: james-rms
```

## rosbag2_test_common

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

- No changes

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

```
* [Humble backport] rosbag2_storage_mcap: merge into rosbag2 repo (#1163 <https://github.com/ros2/rosbag2/issues/1163>) (#1189 <https://github.com/ros2/rosbag2/issues/1189>)
* Contributors: james-rms
```
