### PR TITLE
Added package python-mistune

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2771,6 +2771,24 @@ python-mechanize:
   gentoo: [dev-python/mechanize]
   nixos: [pythonPackages.mechanize]
   ubuntu: [python-mechanize]
+python-mistune:
+  alpine:
+    pip:
+      packages: [mistune]
+  arch: [python-mistune]
+  debian:
+    '*': [python3-mistune]
+    buster: [python-mistune]
+  fedora: [python3-mistune]
+  gentoo: [dev-python/mistune]
+  nixos: [python39Packages.mistune]
+  opensuse: [python3-mistune]
+  osx:
+    pip:
+      packages: [mistune]
+  ubuntu:
+    '*': [python3-mistune]
+    bionic: [python-mistune]
 python-mock:
   alpine: [py-mock]
   arch: [python2-mock]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2772,22 +2772,13 @@ python-mechanize:
   nixos: [pythonPackages.mechanize]
   ubuntu: [python-mechanize]
 python-mistune:
-  alpine:
-    pip:
-      packages: [mistune]
-  arch: [python-mistune]
   debian:
-    '*': [python3-mistune]
+    '*': null
     buster: [python-mistune]
-  fedora: [python3-mistune]
-  gentoo: [dev-python/mistune]
-  nixos: [python39Packages.mistune]
-  opensuse: [python3-mistune]
-  osx:
-    pip:
-      packages: [mistune]
+  fedora: [python2-mistune]
+  opensuse: [python2-mistune]
   ubuntu:
-    '*': [python3-mistune]
+    '*': null
     bionic: [python-mistune]
 python-mock:
   alpine: [py-mock]
@@ -7667,6 +7658,20 @@ python3-meson-pip:
   ubuntu:
     pip:
       packages: [meson]
+python3-mistune:
+  alpine:
+    pip:
+      packages: [mistune]
+  arch: [python-mistune]
+  debian: [python3-mistune]
+  fedora: [python3-mistune]
+  gentoo: [dev-python/mistune]
+  nixos: [python39Packages.mistune]
+  opensuse: [python3-mistune]
+  osx:
+    pip:
+      packages: [mistune]
+  ubuntu: [python3-mistune]
 python3-mlflow:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2775,7 +2775,6 @@ python-mistune:
   debian:
     '*': null
     buster: [python-mistune]
-  fedora: [python2-mistune]
   opensuse: [python2-mistune]
   ubuntu:
     '*': null


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python-mistune

## Package Upstream Source:

https://github.com/lepture/mistune

## Purpose of using this:

Markdown parser, useful for documentation tools.

## Links to Distribution Packages

- Debian: https://packages.debian.org/buster/python-mistune
- Ubuntu: https://packages.ubuntu.com/bionic/python-mistune
- Fedora: https://packages.fedoraproject.org/pkgs/python-mistune/python3-mistune/
- Arch: https://archlinux.org/packages/community/any/python-mistune/
- Gentoo: https://packages.gentoo.org/packages/dev-python/mistune
- macOS: not available (via [pip](https://pypi.org/project/mistune/))
- Alpine: not available (via [pip](https://pypi.org/project/mistune/))
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=22.11&show=m2r&from=0&size=50&sort=relevance&type=packages&query=mistune
- openSUSE: https://software.opensuse.org/package/python3-mistune

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
