### PR TITLE
ros2_control: 3.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4215,7 +4215,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.5.1-1
+      version: 3.6.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.6.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.5.1-1`

## controller_interface

```
* Update imu_sensor.hpp (#893 <https://github.com/ros-controls/ros2_control/issues/893>)
  Covariances values should come from the IMU_Broadcaster, like the frame_id or the time
* Contributors: flochre
```

## controller_manager

```
* Fix QoS deprecation warnings (#879 <https://github.com/ros-controls/ros2_control/issues/879>)
* Add backward_ros to controller_manager (#886 <https://github.com/ros-controls/ros2_control/issues/886>)
* Contributors: Andy McEvoy, Bence Magyar
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* 🔧 Fixes and updated on pre-commit hooks and their action (#890 <https://github.com/ros-controls/ros2_control/issues/890>)
* Contributors: Denis Štogl
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

```
* 🔧 Fixes and updated on pre-commit hooks and their action (#890 <https://github.com/ros-controls/ros2_control/issues/890>)
* Contributors: Denis Štogl
```

## transmission_interface

- No changes
