### PR TITLE
ros2_controllers: 2.16.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4246,7 +4246,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.15.0-1
+      version: 2.16.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.16.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.15.0-1`

## admittance_controller

```
* Add backward_ros to all controllers (#489 <https://github.com/ros-controls/ros2_controllers/issues/489>)
* Contributors: Bence Magyar
```

## diff_drive_controller

```
* diff_drive base_frame_id param (#495 <https://github.com/ros-controls/ros2_controllers/issues/495>)
  changed default value from odom -> base_link
* Add backward_ros to all controllers (#489 <https://github.com/ros-controls/ros2_controllers/issues/489>)
* Remove compilation warnings from DiffDriveController (#477 <https://github.com/ros-controls/ros2_controllers/issues/477>)
* Contributors: Bence Magyar, Denis Štogl, Jakub Delicat
```

## effort_controllers

```
* Add backward_ros to all controllers (#489 <https://github.com/ros-controls/ros2_controllers/issues/489>)
* Contributors: Bence Magyar
```

## force_torque_sensor_broadcaster

```
* Add backward_ros to all controllers (#489 <https://github.com/ros-controls/ros2_controllers/issues/489>)
* Contributors: Bence Magyar
```

## forward_command_controller

```
* Add backward_ros to all controllers (#489 <https://github.com/ros-controls/ros2_controllers/issues/489>)
* Contributors: Bence Magyar
```

## gripper_controllers

```
* Add backward_ros to all controllers (#489 <https://github.com/ros-controls/ros2_controllers/issues/489>)
* Contributors: Bence Magyar
```

## imu_sensor_broadcaster

```
* Add backward_ros to all controllers (#489 <https://github.com/ros-controls/ros2_controllers/issues/489>)
* Contributors: Bence Magyar
```

## joint_state_broadcaster

```
* Add backward_ros to all controllers (#489 <https://github.com/ros-controls/ros2_controllers/issues/489>)
* Contributors: Bence Magyar
```

## joint_trajectory_controller

```
* [JTC] Add pid gain structure to documentation (#485 <https://github.com/ros-controls/ros2_controllers/issues/485>)
* [JTC] Activate test for only velocity controller (#487 <https://github.com/ros-controls/ros2_controllers/issues/487>)
* [JTC] Allow ff_velocity_scale=0 without deprecated warning (#490 <https://github.com/ros-controls/ros2_controllers/issues/490>)
* Add backward_ros to all controllers (#489 <https://github.com/ros-controls/ros2_controllers/issues/489>)
* Fix markup in userdoc.rst (#480 <https://github.com/ros-controls/ros2_controllers/issues/480>)
* [JTC] Remove deprecation from parameters validation file. (#476 <https://github.com/ros-controls/ros2_controllers/issues/476>)
* Contributors: Bence Magyar, Christoph Fröhlich, Denis Štogl
```

## position_controllers

```
* Add backward_ros to all controllers (#489 <https://github.com/ros-controls/ros2_controllers/issues/489>)
* Contributors: Bence Magyar
```

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

```
* 🔧 Fixes and updated on pre-commit hooks and their action (#492 <https://github.com/ros-controls/ros2_controllers/issues/492>)
* Contributors: Denis Štogl
```

## tricycle_controller

```
* Add backward_ros to all controllers (#489 <https://github.com/ros-controls/ros2_controllers/issues/489>)
* Fix deprecation warnings when compiling (#478 <https://github.com/ros-controls/ros2_controllers/issues/478>)
* Contributors: Bence Magyar, Denis Štogl
```

## velocity_controllers

```
* Add backward_ros to all controllers (#489 <https://github.com/ros-controls/ros2_controllers/issues/489>)
* Contributors: Bence Magyar
```
