### PR TITLE
ros2_control: 2.20.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4620,7 +4620,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.19.0-1
+      version: 2.20.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.20.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.19.0-1`

## controller_interface

```
* Update imu_sensor.hpp (#893 <https://github.com/ros-controls/ros2_control/issues/893>) (#896 <https://github.com/ros-controls/ros2_control/issues/896>)
* Contributors: flochre
```

## controller_manager

```
* Add backward_ros to controller_manager (#886 <https://github.com/ros-controls/ros2_control/issues/886>) (#892 <https://github.com/ros-controls/ros2_control/issues/892>)
* Contributors: Bence Magyar
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* 🔧 Fixes and updated on pre-commit hooks and their action (backport #890 <https://github.com/ros-controls/ros2_control/issues/890>) (#895 <https://github.com/ros-controls/ros2_control/issues/895>)
* Contributors: Denis Štogl
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

```
* 🔧 Fixes and updated on pre-commit hooks and their action (backport #890 <https://github.com/ros-controls/ros2_control/issues/890>) (#895 <https://github.com/ros-controls/ros2_control/issues/895>)
* Contributors: Denis Štogl
```

## transmission_interface

- No changes
