### PR TITLE
warthog: 0.1.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -15315,7 +15315,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/warthog-release.git
-      version: 0.1.5-1
+      version: 0.1.6-1
     source:
       type: git
       url: https://github.com/warthog-cpr/warthog.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog` to `0.1.6-1`:

- upstream repository: https://github.com/warthog-cpr/warthog.git
- release repository: https://github.com/clearpath-gbp/warthog-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.5-1`

## warthog_control

- No changes

## warthog_description

```
* Change the GPS plugin reference heading to 90 so it's ENU
* Add missing xacro tags for ROS Noetic (and backwards compatability)
* Add GAZEBO_WORLD_{LAT|LON} envars to change the reference coordinate of the robot's integral GPS
* Contributors: Chris Iverach-Brereton, Joey Yang
```

## warthog_msgs

- No changes
