### PR TITLE
mrpt2: 2.6.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5650,7 +5650,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt2-release.git
-      version: 2.5.8-1
+      version: 2.6.0-1
     source:
       type: git
       url: https://github.com/mrpt/mrpt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt2` to `2.6.0-1`:

- upstream repository: https://github.com/MRPT/mrpt.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt2-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.5.8-1`
