### PR TITLE
rosbag2: 0.19.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4495,6 +4495,7 @@ repositories:
       version: rolling
     release:
       packages:
+      - mcap_vendor
       - ros2bag
       - rosbag2
       - rosbag2_compression
@@ -4503,9 +4504,12 @@ repositories:
       - rosbag2_examples_cpp
       - rosbag2_interfaces
       - rosbag2_performance_benchmarking
+      - rosbag2_performance_benchmarking_msgs
       - rosbag2_py
       - rosbag2_storage
       - rosbag2_storage_default_plugins
+      - rosbag2_storage_mcap
+      - rosbag2_storage_mcap_testdata
       - rosbag2_storage_sqlite3
       - rosbag2_test_common
       - rosbag2_tests
@@ -4516,7 +4520,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.18.0-3
+      version: 0.19.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.19.0-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.18.0-3`

## mcap_vendor

```
* mcap_vendor: add readme with versioning procedure (#1230 <https://github.com/ros2/rosbag2/issues/1230>)
* Add Michael Orlov as maintainer in rosbag2 packages (#1215 <https://github.com/ros2/rosbag2/issues/1215>)
* mcap_vendor: only install public headers (#1207 <https://github.com/ros2/rosbag2/issues/1207>)
* Fixes policy CMP0135 warning for CMake >= 3.24 for mcap_vendor (#1208 <https://github.com/ros2/rosbag2/issues/1208>)
* mcap_vendor: download MCAP source via tarball (#1204 <https://github.com/ros2/rosbag2/issues/1204>)
* rosbag2_cpp: test more than one storage plugin (#1196 <https://github.com/ros2/rosbag2/issues/1196>)
* rosbag2_storage_mcap: merge into rosbag2 repo (#1163 <https://github.com/ros2/rosbag2/issues/1163>)
* Contributors: Cristóbal Arroyo, Michael Orlov, james-rms
```

## ros2bag

```
* Fix up some of the wording in the record help text. (#1228 <https://github.com/ros2/rosbag2/issues/1228>)
* Add topic_name option to info verb (#1217 <https://github.com/ros2/rosbag2/issues/1217>)
* rosbag2_storage: set MCAP as default plugin (#1160 <https://github.com/ros2/rosbag2/issues/1160>)
* rosbag2_py: parametrize tests across storage plugins (#1203 <https://github.com/ros2/rosbag2/issues/1203>)
* Added option to change node name for the recorder from the Python API (#1180 <https://github.com/ros2/rosbag2/issues/1180>)
* rosbag2_cpp: test more than one storage plugin (#1196 <https://github.com/ros2/rosbag2/issues/1196>)
* Contributors: Chris Lalancette, Keisuke Shima, Michael Orlov, james-rms, ricardo-manriquez
```

## rosbag2

```
* Add Michael Orlov as maintainer in rosbag2 packages (#1215 <https://github.com/ros2/rosbag2/issues/1215>)
* Contributors: Michael Orlov
```

## rosbag2_compression

```
* set_read_order: return success (#1177 <https://github.com/ros2/rosbag2/issues/1177>)
* Add update_metadata(BagMetadata) API for storage plugin interface (#1149 <https://github.com/ros2/rosbag2/issues/1149>)
* Contributors: Michael Orlov, james-rms
```

## rosbag2_compression_zstd

```
* Add Michael Orlov as maintainer in rosbag2 packages (#1215 <https://github.com/ros2/rosbag2/issues/1215>)
* Contributors: Michael Orlov
```

## rosbag2_cpp

```
* Expose more Writer methods in python interface (#1220 <https://github.com/ros2/rosbag2/issues/1220>)
* rosbag2_storage: set MCAP as default plugin (#1160 <https://github.com/ros2/rosbag2/issues/1160>)
* Parametrize all rosbag2_tests for both supported storage plugins (#1221 <https://github.com/ros2/rosbag2/issues/1221>)
* rosbag2_cpp: test more than one storage plugin (#1196 <https://github.com/ros2/rosbag2/issues/1196>)
* Replace language for "db3"/"db"/"database" (#1194 <https://github.com/ros2/rosbag2/issues/1194>)
* set_read_order: return success (#1177 <https://github.com/ros2/rosbag2/issues/1177>)
* Remove explicit sqlite3 from code (#1166 <https://github.com/ros2/rosbag2/issues/1166>)
* Add update_metadata(BagMetadata) API for storage plugin interface (#1149 <https://github.com/ros2/rosbag2/issues/1149>)
* Reader and writer can use default storage by not specifying (#1167 <https://github.com/ros2/rosbag2/issues/1167>)
* Contributors: Emerson Knapp, Michael Orlov, james-rms
```

## rosbag2_examples_cpp

```
* Add Michael Orlov as maintainer in rosbag2 packages (#1215 <https://github.com/ros2/rosbag2/issues/1215>)
* Contributors: Michael Orlov
```

## rosbag2_interfaces

```
* Add Michael Orlov as maintainer in rosbag2 packages (#1215 <https://github.com/ros2/rosbag2/issues/1215>)
* Contributors: Michael Orlov
```

## rosbag2_performance_benchmarking

```
* Add option to specify a message type (#1153 <https://github.com/ros2/rosbag2/issues/1153>)
* Add Michael Orlov as maintainer in rosbag2 packages (#1215 <https://github.com/ros2/rosbag2/issues/1215>)
* Replace language for "db3"/"db"/"database" (#1194 <https://github.com/ros2/rosbag2/issues/1194>)
* Remove explicit sqlite3 from code (#1166 <https://github.com/ros2/rosbag2/issues/1166>)
* Contributors: Emerson Knapp, Michael Orlov, carlossvg
```

## rosbag2_py

```
* Expose more Writer methods in python interface (#1220 <https://github.com/ros2/rosbag2/issues/1220>)
* rosbag2_storage: set MCAP as default plugin (#1160 <https://github.com/ros2/rosbag2/issues/1160>)
* Add Michael Orlov as maintainer in rosbag2 packages (#1215 <https://github.com/ros2/rosbag2/issues/1215>)
* rosbag2_py: parametrize tests across storage plugins (#1203 <https://github.com/ros2/rosbag2/issues/1203>)
* Added option to change node name for the recorder from the Python API (#1180 <https://github.com/ros2/rosbag2/issues/1180>)
* Replace language for "db3"/"db"/"database" (#1194 <https://github.com/ros2/rosbag2/issues/1194>)
* Remove explicit sqlite3 from code (#1166 <https://github.com/ros2/rosbag2/issues/1166>)
* Move python get_default_storage_id to storage module instead of writer (#1165 <https://github.com/ros2/rosbag2/issues/1165>)
* Contributors: Emerson Knapp, Michael Orlov, james-rms, ricardo-manriquez
```

## rosbag2_storage

```
* rosbag2_storage: set MCAP as default plugin (#1160 <https://github.com/ros2/rosbag2/issues/1160>)
* Add Michael Orlov as maintainer in rosbag2 packages (#1215 <https://github.com/ros2/rosbag2/issues/1215>)
* set_read_order: return success (#1177 <https://github.com/ros2/rosbag2/issues/1177>)
* Remove explicit sqlite3 from code (#1166 <https://github.com/ros2/rosbag2/issues/1166>)
* Add update_metadata(BagMetadata) API for storage plugin interface (#1149 <https://github.com/ros2/rosbag2/issues/1149>)
* Contributors: Emerson Knapp, Michael Orlov, james-rms
```

## rosbag2_storage_default_plugins

```
* rosbag2_storage: set MCAP as default plugin (#1160 <https://github.com/ros2/rosbag2/issues/1160>)
* Add Michael Orlov as maintainer in rosbag2 packages (#1215 <https://github.com/ros2/rosbag2/issues/1215>)
* Contributors: Michael Orlov, james-rms
```

## rosbag2_storage_mcap

```
* Add Michael Orlov as maintainer in rosbag2 packages (#1215 <https://github.com/ros2/rosbag2/issues/1215>)
* rosbag2_cpp: test more than one storage plugin (#1196 <https://github.com/ros2/rosbag2/issues/1196>)
* set_read_order: return success (#1177 <https://github.com/ros2/rosbag2/issues/1177>)
* rosbag2_storage_mcap: merge into rosbag2 repo (#1163 <https://github.com/ros2/rosbag2/issues/1163>)
* Contributors: Michael Orlov, james-rms
```

## rosbag2_storage_mcap_testdata

```
* Add Michael Orlov as maintainer in rosbag2 packages (#1215 <https://github.com/ros2/rosbag2/issues/1215>)
* rosbag2_storage_mcap: merge into rosbag2 repo (#1163 <https://github.com/ros2/rosbag2/issues/1163>)
* Contributors: Michael Orlov, james-rms
```

## rosbag2_storage_sqlite3

```
* Add Michael Orlov as maintainer in rosbag2 packages (#1215 <https://github.com/ros2/rosbag2/issues/1215>)
* Remove sqlite3-specific info from main README, make it more storage agnostic and point to plugin-specific README (#1193 <https://github.com/ros2/rosbag2/issues/1193>)
* set_read_order: return success (#1177 <https://github.com/ros2/rosbag2/issues/1177>)
* Add update_metadata(BagMetadata) API for storage plugin interface (#1149 <https://github.com/ros2/rosbag2/issues/1149>)
* Store db schema version and ROS_DISTRO name in db3 files (#1156 <https://github.com/ros2/rosbag2/issues/1156>)
* Contributors: Emerson Knapp, Michael Orlov, james-rms
```

## rosbag2_test_common

```
* Add Michael Orlov as maintainer in rosbag2 packages (#1215 <https://github.com/ros2/rosbag2/issues/1215>)
* rosbag2_py: parametrize tests across storage plugins (#1203 <https://github.com/ros2/rosbag2/issues/1203>)
* Contributors: Michael Orlov, james-rms
```

## rosbag2_tests

```
* rosbag2_storage: set MCAP as default plugin (#1160 <https://github.com/ros2/rosbag2/issues/1160>)
* Add Michael Orlov as maintainer in rosbag2 packages (#1215 <https://github.com/ros2/rosbag2/issues/1215>)
* Parametrize all rosbag2_tests for both supported storage plugins (#1221 <https://github.com/ros2/rosbag2/issues/1221>)
* Make rosbag2_tests agnostic to storage implementation (#1192 <https://github.com/ros2/rosbag2/issues/1192>)
* Contributors: Emerson Knapp, Michael Orlov, james-rms
```

## rosbag2_transport

```
* Print "Hidden topics are not recorded" only once. (#1225 <https://github.com/ros2/rosbag2/issues/1225>)
* rosbag2_storage: set MCAP as default plugin (#1160 <https://github.com/ros2/rosbag2/issues/1160>)
* Add Michael Orlov as maintainer in rosbag2 packages (#1215 <https://github.com/ros2/rosbag2/issues/1215>)
* rosbag2_transport: parametrize test_rewrite (#1206 <https://github.com/ros2/rosbag2/issues/1206>)
* rosbag2_cpp: test more than one storage plugin (#1196 <https://github.com/ros2/rosbag2/issues/1196>)
* Replace language for "db3"/"db"/"database" (#1194 <https://github.com/ros2/rosbag2/issues/1194>)
* set_read_order: return success (#1177 <https://github.com/ros2/rosbag2/issues/1177>)
* Remove explicit sqlite3 from code (#1166 <https://github.com/ros2/rosbag2/issues/1166>)
* Contributors: Emerson Knapp, Michael Orlov, james-rms, rshanor
```

## shared_queues_vendor

```
* Add Michael Orlov as maintainer in rosbag2 packages (#1215 <https://github.com/ros2/rosbag2/issues/1215>)
* Contributors: Michael Orlov
```

## sqlite3_vendor

```
* Add Michael Orlov as maintainer in rosbag2 packages (#1215 <https://github.com/ros2/rosbag2/issues/1215>)
* Contributors: Michael Orlov
```

## zstd_vendor

```
* Add Michael Orlov as maintainer in rosbag2 packages (#1215 <https://github.com/ros2/rosbag2/issues/1215>)
* Contributors: Michael Orlov
```
