### PR TITLE
bno055: 0.4.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -455,7 +455,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/flynneva/bno055.git
-      version: develop
+      version: main
     release:
       tags:
         release: release/foxy/{package}/{version}
@@ -464,8 +464,8 @@ repositories:
     source:
       type: git
       url: https://github.com/flynneva/bno055.git
-      version: develop
-    status: developed
+      version: main
+    status: maintained
   bond_core:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -459,8 +459,8 @@ repositories:
     release:
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/flynneva/bno055-release.git
-      version: 0.3.0-1
+      url: git@github.com:ros2-gbp/bno055-release.git
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/flynneva/bno055.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bno055` to `0.4.0-1`:

- upstream repository: https://github.com/flynneva/bno055.git
- release repository: git@github.com:ros2-gbp/bno055-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.0-1`
