### PR TITLE
mod: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2619,6 +2619,18 @@ repositories:
       url: https://github.com/dfki-ric/mir_robot.git
       version: humble
     status: developed
+  mod:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://bitbucket.org/mapsofdynamics/mod-release.git
+      version: 1.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://bitbucket.org/mapsofdynamics/mod
+      version: master
+    status: developed
   moveit:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2623,12 +2623,12 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://bitbucket.org/mapsofdynamics/mod-release.git
+      url: https://github.com/OrebroUniversity/mod-release.git
       version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git
-      url: https://bitbucket.org/mapsofdynamics/mod
+      url: https://github.com/OrebroUniversity/mod.git
       version: master
     status: developed
   moveit:


### PR DESCRIPTION
Increasing version of package(s) in repository `mod` to `1.1.0-1`:

- upstream repository: https://bitbucket.org/mapsofdynamics/mod [EDIT: Mirrored on [https://github.com/OrebroUniversity/mod](https://github.com/OrebroUniversity/mod)]
- release repository: https://bitbucket.org/mapsofdynamics/mod-release.git [EDIT: Mirrored on [https://github.com/OrebroUniversity/mod-release.git](https://github.com/OrebroUniversity/mod-release.git)]
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
