### PR TITLE
bno055: 0.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -507,7 +507,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/bno055-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/flynneva/bno055.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bno055` to `0.4.1-1`:

- upstream repository: https://github.com/flynneva/bno055.git
- release repository: https://github.com/ros2-gbp/bno055-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.0-1`

## bno055

```
* Update CHANGELOG
* Bump patch version after small bug fix
* Fix i2c issues found (param and division by zero) (#56 <https://github.com/flynneva/bno055/issues/56>)
```
