### PR TITLE
Adding new repository for indexing: swarm_ros_bridge

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13602,6 +13602,11 @@ repositories:
       url: https://github.com/hbanzhaf/steering_functions.git
       version: master
     status: maintained
+  swarm_ros_bridge:
+    doc:
+      type: git
+      url: https://github.com/shupx/swarm_ros_bridge.git
+      version: master
   swri_console:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

swarm_ros_bridge

# The source is here:

https://github.com/shupx/swarm_ros_bridge.git

# Introduction

This is a lightweight middle interface ROS package that enables the specified ROS message transmission among swarm robots through ZeroMQ socket communication.

Compared with ROS1 multi-robot wireless communication configuration, it has the following benefits:

-  **Robust**: No need for base station ROS master launching first. Support each robot launching in a random sequence and connecting each other autonomously.

-  **Flexible**:  You can choose the sending/receiving ROS topics rather than transferring all topics as ROS1 does.

-  **Easy to use**:  Specify all the IP and ROS topics in one configuration file.

Compared with ROS2 DDS communication, it has the following benefits:

-  **Lightweight**: It is a small ROS bridge node subscribing and sending remote ROS topics, so connecting with other ROS1 nodes is easy.

-  **Reliable**: It uses ZeroMQ socket communication based on TCP protocol while ROS2 is based on DDS, whose default protocol is UDP (unreliable). 