### PR TITLE
Add joy_tester to index (foxy, galactic, humble, rolling)

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2107,6 +2107,16 @@ repositories:
       url: https://github.com/ros/joint_state_publisher.git
       version: foxy
     status: maintained
+  joy_tester:
+    doc:
+      type: git
+      url: https://github.com/joshnewans/joy_tester.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/joshnewans/joy_tester.git
+      version: main
+    status: maintained
   joystick_drivers:
     doc:
       type: git

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1746,6 +1746,16 @@ repositories:
       url: https://github.com/ros/joint_state_publisher.git
       version: galactic
     status: maintained
+  joy_tester:
+    doc:
+      type: git
+      url: https://github.com/joshnewans/joy_tester.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/joshnewans/joy_tester.git
+      version: main
+    status: maintained
   joystick_drivers:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1939,6 +1939,16 @@ repositories:
       url: https://github.com/ros/joint_state_publisher.git
       version: ros2
     status: maintained
+  joy_tester:
+    doc:
+      type: git
+      url: https://github.com/joshnewans/joy_tester.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/joshnewans/joy_tester.git
+      version: main
+    status: maintained
   joystick_drivers:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1830,6 +1830,16 @@ repositories:
       url: https://github.com/ros/joint_state_publisher.git
       version: ros2
     status: maintained
+  joy_tester:
+    doc:
+      type: git
+      url: https://github.com/joshnewans/joy_tester.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/joshnewans/joy_tester.git
+      version: main
+    status: maintained
   joystick_drivers:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

foxy galactic humble rolling

(If it is not OK to submit for multiple distros, please let me know and I will split up the PRs)

# The source is here:

https://github.com/joshnewans/joy_tester



# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
