### PR TITLE
ruckig: 0.9.2-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5214,7 +5214,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ruckig-release.git
-      version: 0.9.1-1
+      version: 0.9.2-2
     source:
       type: git
       url: https://github.com/pantor/ruckig.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ruckig` to `0.9.2-2`:

- upstream repository: https://github.com/pantor/ruckig.git
- release repository: https://github.com/ros2-gbp/ruckig-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.9.1-1`
