### PR TITLE
l3cam_ros: 1.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4373,6 +4373,21 @@ repositories:
       url: https://github.com/MITRE/kvh_geo_fog_3d.git
       version: noetic-devel
     status: maintained
+  l3cam_ros:
+    doc:
+      type: git
+      url: https://github.com/beamaginelidar/l3cam_ros.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/beamaginelidar/l3cam_ros-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/beamaginelidar/l3cam_ros.git
+      version: master
+    status: maintained
   lanelet2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `l3cam_ros` to `1.0.2-1`:

- upstream repository: https://github.com/beamaginelidar/l3cam_ros.git
- release repository: https://github.com/beamaginelidar/l3cam_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
