### PR TITLE
apriltag_ros: 3.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -350,10 +350,16 @@ repositories:
       url: https://github.com/christianrauch/apriltag_msgs.git
       version: master
   apriltag_ros:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/apriltag_ros-release.git
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/christianrauch/apriltag_ros.git
       version: master
+    status: developed
   aruco_opencv:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_ros` to `3.1.0-1`:

- upstream repository: https://github.com/christianrauch/apriltag_ros.git
- release repository: https://github.com/ros2-gbp/apriltag_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
