### PR TITLE
create3_sim: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -764,6 +764,26 @@ repositories:
       url: https://github.com/PickNikRobotics/cpp_polyfills.git
       version: main
     status: maintained
+  create3_sim:
+    release:
+      packages:
+      - irobot_create_common_bringup
+      - irobot_create_control
+      - irobot_create_description
+      - irobot_create_gazebo_bringup
+      - irobot_create_gazebo_plugins
+      - irobot_create_gazebo_sim
+      - irobot_create_ignition_bringup
+      - irobot_create_ignition_plugins
+      - irobot_create_ignition_sim
+      - irobot_create_ignition_toolbox
+      - irobot_create_nodes
+      - irobot_create_toolbox
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/create3_sim-release.git
+      version: 2.0.0-1
+    status: developed
   cudnn_cmake_module:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `create3_sim` to `2.0.0-1`:

- upstream repository: https://github.com/iRobotEducation/create3_sim.git
- release repository: https://github.com/ros2-gbp/create3_sim-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## irobot_create_common_bringup

```
* Update to ROS 2 Humble (#197 <https://github.com/iRobotEducation/create3_sim/issues/197>)
  * Update message names to https://github.com/iRobotEducation/irobot_create_msgs/pull/10
  * rename dock topic into dock_status
  * comment ign_ros2_control dependency as it must be built from sources
  Co-authored-by: Francisco Martín Rico <mailto:fmrico@gmail.com>
* add missing dependency to irobot-create-common-bringup (#186 <https://github.com/iRobotEducation/create3_sim/issues/186>)
* Contributors: Alberto Soragna, Francisco Martín Rico
```

## irobot_create_control

```
* Update to ROS 2 Humble (#197 <https://github.com/iRobotEducation/create3_sim/issues/197>)
  * Update message names to https://github.com/iRobotEducation/irobot_create_msgs/pull/10
  * rename dock topic into dock_status
  * comment ign_ros2_control dependency as it must be built from sources
  Co-authored-by: Francisco Martín Rico <mailto:fmrico@gmail.com>
* add missing dependency to irobot-create-common-bringup (#186 <https://github.com/iRobotEducation/create3_sim/issues/186>)
* Contributors: Alberto Soragna, Francisco Martín Rico
```

## irobot_create_description

```
* Update to ROS 2 Humble (#197 <https://github.com/iRobotEducation/create3_sim/issues/197>)
  * Update message names to https://github.com/iRobotEducation/irobot_create_msgs/pull/10
  * rename dock topic into dock_status
  * comment ign_ros2_control dependency as it must be built from sources
  Co-authored-by: Francisco Martín Rico <mailto:fmrico@gmail.com>
* add missing dependency to irobot-create-common-bringup (#186 <https://github.com/iRobotEducation/create3_sim/issues/186>)
* Contributors: Alberto Soragna, Francisco Martín Rico
```

## irobot_create_gazebo_bringup

```
* make gazebo classic and ignition build time dependency if they are needed by CMakeLists.txt (#179 <https://github.com/iRobotEducation/create3_sim/issues/179>)
* fix dependency tree of create3_sim packages (#177 <https://github.com/iRobotEducation/create3_sim/issues/177>)
* fix setting environment variable GAZEBO_MODEL_PATH for aws models (#174 <https://github.com/iRobotEducation/create3_sim/issues/174>)
* Contributors: Alberto Soragna, crthilakraj
```

## irobot_create_gazebo_plugins

```
* Update to ROS 2 Humble (#197 <https://github.com/iRobotEducation/create3_sim/issues/197>)
  * Update message names to https://github.com/iRobotEducation/irobot_create_msgs/pull/10
  * rename dock topic into dock_status
  * comment ign_ros2_control dependency as it must be built from sources
  Co-authored-by: Francisco Martín Rico <mailto:fmrico@gmail.com>
* add missing dependency to irobot-create-common-bringup (#186 <https://github.com/iRobotEducation/create3_sim/issues/186>)
* Contributors: Alberto Soragna, Francisco Martín Rico
```

## irobot_create_gazebo_sim

```
* fix dependency tree of create3_sim packages (#177 <https://github.com/iRobotEducation/create3_sim/issues/177>)
* Contributors: Alberto Soragna
```

## irobot_create_ignition_bringup

```
* Update to ROS 2 Humble (#197 <https://github.com/iRobotEducation/create3_sim/issues/197>)
  * Update message names to https://github.com/iRobotEducation/irobot_create_msgs/pull/10
  * rename dock topic into dock_status
  * comment ign_ros2_control dependency as it must be built from sources
  Co-authored-by: Francisco Martín Rico <mailto:fmrico@gmail.com>
* add missing dependency to irobot-create-common-bringup (#186 <https://github.com/iRobotEducation/create3_sim/issues/186>)
* Contributors: Alberto Soragna, Francisco Martín Rico
```

## irobot_create_ignition_plugins

```
* Update to ROS 2 Humble (#197 <https://github.com/iRobotEducation/create3_sim/issues/197>)
  * Update message names to https://github.com/iRobotEducation/irobot_create_msgs/pull/10
  * rename dock topic into dock_status
  * comment ign_ros2_control dependency as it must be built from sources
  Co-authored-by: Francisco Martín Rico <mailto:fmrico@gmail.com>
* add missing dependency to irobot-create-common-bringup (#186 <https://github.com/iRobotEducation/create3_sim/issues/186>)
* Contributors: Alberto Soragna, Francisco Martín Rico
```

## irobot_create_ignition_sim

```
* fix dependency tree of create3_sim packages (#177 <https://github.com/iRobotEducation/create3_sim/issues/177>)
* Contributors: Alberto Soragna
```

## irobot_create_ignition_toolbox

```
* Update to ROS 2 Humble (#197 <https://github.com/iRobotEducation/create3_sim/issues/197>)
  * Update message names to https://github.com/iRobotEducation/irobot_create_msgs/pull/10
  * rename dock topic into dock_status
  * comment ign_ros2_control dependency as it must be built from sources
  Co-authored-by: Francisco Martín Rico <mailto:fmrico@gmail.com>
* add missing dependency to irobot-create-common-bringup (#186 <https://github.com/iRobotEducation/create3_sim/issues/186>)
* Renamed Ignition Toolbox libraries (#178 <https://github.com/iRobotEducation/create3_sim/issues/178>)
  * Renamed Ignition Toolbox libraries
  * Pre-pend library names with irobot_create_ignition
* Contributors: Alberto Soragna, Francisco Martín Rico, roni-kreinin
```

## irobot_create_nodes

```
* Update to ROS 2 Humble (#197 <https://github.com/iRobotEducation/create3_sim/issues/197>)
  * Update message names to https://github.com/iRobotEducation/irobot_create_msgs/pull/10
  * rename dock topic into dock_status
  * comment ign_ros2_control dependency as it must be built from sources
  Co-authored-by: Francisco Martín Rico <mailto:fmrico@gmail.com>
* add missing dependency to irobot-create-common-bringup (#186 <https://github.com/iRobotEducation/create3_sim/issues/186>)
* Contributors: Alberto Soragna, Francisco Martín Rico
```

## irobot_create_toolbox

- No changes
