### PR TITLE
mir_robot: 1.1.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5267,7 +5267,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/uos-gbp/mir_robot-release.git
-      version: 1.1.6-1
+      version: 1.1.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mir_robot` to `1.1.7-1`:

- upstream repository: https://github.com/dfki-ric/mir_robot.git
- release repository: https://github.com/uos-gbp/mir_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.6-1`

## mir_actions

```
* Update MirMoveBase action to 2.10.3.1
* Don't set cmake_policy CMP0048
* Contributors: Martin Günther
```

## mir_description

```
* Don't set cmake_policy CMP0048
* Contributors: Martin Günther
```

## mir_driver

```
* Don't set cmake_policy CMP0048
* Fix pydocstyle errors
* Add license headers
* Fix flake8 warnings
* Contributors: Martin Günther
```

## mir_dwb_critics

```
* Don't set cmake_policy CMP0048
* Drop old C++ compiler flags
* Add license headers
* Contributors: Martin Günther
```

## mir_gazebo

```
* Don't set cmake_policy CMP0048
* Contributors: Martin Günther
```

## mir_msgs

```
* Build new msgs (#117 <https://github.com/dfki-ric/mir_robot/issues/117>)
  Need to build new msg files. The files were added in a previous commit, but not added here for build and installation.
* Update MirMoveBase action to 2.10.3.1
* Update BMSData.msg to MiR software 2.13.2
  This is an "unsafe" change (it breaks compatibility with MiR versions <=
  2.13.2), but since BMSData is not published by the mir_driver currently,
  it should be ok.
* Add new messages added in MiR software 2.13.4.1
  This does not break compatibility with earlier versions (like 2.8.3.1),
  because these messages did not exist before.
  Actually, these messages were added in 2.10.3.1 (all other messages) and
  2.13.0.4 (ServiceResponseHeader.msg).
* Update Brake, Gripper + Height State msg to 2.13.4.1
  These are "unsafe" message changes (fields have been removed), but it
  should be ok because these are only used in HookExtendedStatus, and that
  message isn't forwarded by the mir_driver.
* Partially update messages to MiR software 2.13.4.1
  This only contains the "safe" changes, where fields were added. Also, it
  doesn't include the move of some messages to mir_hook_shared_interface,
  but keeps them here.
* Don't set cmake_policy CMP0048
* Contributors: Martin Günther, moooeeeep
```

## mir_navigation

```
* Don't set cmake_policy CMP0048
* Add license headers
* Fix flake8 warnings
* Contributors: Martin Günther
```

## mir_robot

- No changes

## sdc21x0

```
* Don't set cmake_policy CMP0048
* Contributors: Martin Günther
```
