### PR TITLE
orocos_kdl_vendor: 0.2.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3206,7 +3206,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
-      version: 0.2.4-1
+      version: 0.2.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_kdl_vendor` to `0.2.5-1`:

- upstream repository: https://github.com/ros2/orocos_kdl_vendor.git
- release repository: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.4-1`

## orocos_kdl_vendor

- No changes

## python_orocos_kdl_vendor

```
* Fixes policy CMP0135 warning for CMake >= 3.24 (#16 <https://github.com/ros2/orocos_kdl_vendor/issues/16>) (#18 <https://github.com/ros2/orocos_kdl_vendor/issues/18>)
* Contributors: mergify[bot]
```
