### PR TITLE
py_trees_js: 0.6.3-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3256,6 +3256,22 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
       version: master
     status: maintained
+  py_trees_js:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_js.git
+      version: devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/stonier/py_trees_js-release.git
+      version: 0.6.3-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees_js.git
+      version: devel
+    status: maintained
   py_trees_ros_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_js` to `0.6.3-2`:

- upstream repository: https://github.com/splintered-reality/py_trees_js.git
- release repository: https://github.com/stonier/py_trees_js-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## py_trees_js

```
* [js] remove buggy early view update and optimise them, #142 <https://github.com/splintered-reality/py_trees_js/pull/142>
```
