### PR TITLE
py_trees_ros_interfaces: 2.0.3-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3265,7 +3265,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/stonier/py_trees_ros_interfaces-release.git
-      version: 2.0.3-1
+      version: 2.0.3-3
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees_ros_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros_interfaces` to `2.0.3-3`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros_interfaces.git
- release repository: https://github.com/stonier/py_trees_ros_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.3-1`
