### PR TITLE
feature: add pyjwt to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3724,6 +3724,16 @@ python-pyinotify:
   fedora: [python-inotify]
   gentoo: [dev-python/pyinotify]
   ubuntu: [python-pyinotify]
+python-pyjwt-pip:
+  debian:
+    pip:
+      packages: [pyjwt]
+  fedora:
+    pip:
+      packages: [pyjwt]
+  ubuntu:
+    pip:
+      packages: [pyjwt]
 python-pykalman:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

pyjwt

## Package Upstream Source:

https://github.com/jpadilla/pyjwt

## Purpose of using this:

pyjwt is more user-friendly and better documented than python-jwt, which is already in python.yaml.

I am using it at Robotnik for a replacement of rosauth, to add jwt-based security to rosbridge_server, so that we can restrict which topics, services and actions are accessible to users via roslibjs. Currently I use Supbase for generating JWTs, and the JWTs encode a list of user-groups. Once our end-to-end system is running, I will look into contributing these features to Robot Web Tools, and I may translate the JWT validation into C++ and augment the features of the original rosauth package.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - N/A - pip only
- Ubuntu: https://packages.ubuntu.com/
   - N/A - pip only
