### PR TITLE
rtabmap: 0.20.23-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6276,7 +6276,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.20.22-1
+      version: 0.20.23-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap` to `0.20.23-1`:

- upstream repository: https://github.com/introlab/rtabmap.git
- release repository: https://github.com/introlab/rtabmap-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.20.22-1`
