### PR TITLE
py_trees: 2.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3646,6 +3646,22 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
       version: master
     status: maintained
+  py_trees:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees.git
+      version: release/2.2.x
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/stonier/py_trees-release.git
+      version: 2.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees.git
+      version: release/2.2.x
+    status: maintained
   pybind11_json_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `2.2.0-1`:

- upstream repository: https://github.com/splintered-reality/py_trees.git
- release repository: https://github.com/stonier/py_trees-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
