### PR TITLE
ur_robot_driver: 2.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11287,6 +11287,25 @@ repositories:
       url: https://github.com/ros-industrial/ur_msgs.git
       version: melodic-devel
     status: maintained
+  ur_robot_driver:
+    doc:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver.git
+      version: master
+    release:
+      packages:
+      - ur_calibration
+      - ur_dashboard_msgs
+      - ur_robot_driver
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release.git
+      version: 2.1.1-1
+    source:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver.git
+      version: master
+    status: developed
   urdf:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.1.1-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver.git
- release repository: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## ur_calibration

- No changes

## ur_dashboard_msgs

- No changes

## ur_robot_driver

```
* Move controller_stopper to ur_robot_driver
  Since a standalone package with that name was declined during the release
  process, we decided to move the controller_stopper package over to the driver.
* Update minimal required polyscope version in docs
* Contributors: Felix Exner
```
