### PR TITLE
ur_robot_driver: 2.1.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -14573,6 +14573,20 @@ repositories:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver.git
       version: master
+    release:
+      packages:
+      - ur_calibration
+      - ur_dashboard_msgs
+      - ur_robot_driver
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release.git
+      version: 2.1.2-1
+    source:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver.git
+      version: master
+    status: developed
   urdf:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.1.2-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver.git
- release repository: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## ur_calibration

- No changes

## ur_dashboard_msgs

```
* Add license file at root and in msgs package (#594 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/594>)
* Contributors: Felix Exner (fexner)
```

## ur_robot_driver

- No changes
