### PR TITLE
simple_launch: 1.6.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5844,7 +5844,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/simple_launch-release.git
-      version: 1.6.1-1
+      version: 1.6.2-1
     source:
       type: git
       url: https://github.com/oKermorgant/simple_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_launch` to `1.6.2-1`:

- upstream repository: https://github.com/oKermorgant/simple_launch.git
- release repository: https://github.com/ros2-gbp/simple_launch-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.6.1-1`

## simple_launch

```
* add .rviz shortcut, clean Python scripts
* Contributors: Olivier Kermorgant
```
