### PR TITLE
Revert "ros2_controllers: 3.0.0-1 in 'humble/distribution.yaml' [bloom]"

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4673,7 +4673,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 3.0.0-1
+      version: 2.15.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Reverts ros/rosdistro#35892

It seems that this release has a missing source file so it fails to build. FYI @bmagyar. Here's the build job:

https://build.ros2.org/view/Hbin_uJ64/job/Hbin_uJ64__diff_drive_controller__ubuntu_jammy_amd64__binary/47/