### PR TITLE
rviz_tool_path_display: 0.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9971,6 +9971,12 @@ repositories:
       url: https://github.com/nobleo/rviz_satellite.git
       version: master
     status: maintained
+  rviz_tool_path_display:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-industrial-release/rviz_tool_path_display-release.git
+      version: 0.1.1-1
   rviz_visual_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_tool_path_display` to `0.1.1-1`:

- upstream repository: https://github.com/marip8/rviz_tool_path_display.git
- release repository: https://github.com/ros-industrial-release/rviz_tool_path_display-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## rviz_tool_path_display

```
* Merge pull request #2 <https://github.com/marip8/rviz_tool_path_display/issues/2> from marip8/updates
  Renamed helper functions
* Renamed helper functions
* Contributors: Michael Ripperger
```
