### PR TITLE
rviz_tool_cursor: 1.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9971,6 +9971,12 @@ repositories:
       url: https://github.com/nobleo/rviz_satellite.git
       version: master
     status: maintained
+  rviz_tool_cursor:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-industrial-release/rviz_tool_cursor.git
+      version: 1.0.1-1
   rviz_visual_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_tool_cursor` to `1.0.1-1`:

- upstream repository: https://github.com/marip8/rviz_tool_cursor.git
- release repository: https://github.com/ros-industrial-release/rviz_tool_cursor.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## rviz_tool_cursor

```
* Added install of icons directory (#21 <https://github.com/marip8/rviz_tool_cursor/issues/21>)
* Contributors: Michael Ripperger
```
