### PR TITLE
Add python3-catkin-sphinx, stop offering the python2 version on focal+

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6295,6 +6295,7 @@ python3-catkin-sphinx:
   osx:
     pip:
       packages: [catkin_sphinx]
+  rhel: [python3-catkin-sphinx]
   ubuntu:
     '*': null
     focal: [python3-catkin-sphinx]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1028,11 +1028,22 @@ python-catkin-pkg-modules:
       packages: [catkin-pkg]
   ubuntu: [python-catkin-pkg-modules]
 python-catkin-sphinx:
+  arch:
+    pip:
+      packages: [catkin_sphinx]
+  debian:
+    pip:
+      packages: [catkin_sphinx]
   fedora: [python-catkin-sphinx]
+  gentoo:
+    pip:
+      packages: [catkin_sphinx]
   osx:
     pip:
       packages: [catkin_sphinx]
-  ubuntu: [python-catkin-sphinx]
+  ubuntu:
+    '*': null
+    bionic: [python-catkin-sphinx]
 python-catkin-tools:
   arch: [python2-catkin-tools]
   debian: [python-catkin-tools]
@@ -6270,6 +6281,23 @@ python3-catkin-pkg-modules:
       packages: [catkin-pkg]
   rhel: ['python%{python3_pkgversion}-catkin_pkg']
   ubuntu: [python3-catkin-pkg-modules]
+python3-catkin-sphinx:
+  arch:
+    pip:
+      packages: [catkin_sphinx]
+  debian:
+    pip:
+      packages: [catkin_sphinx]
+  fedora: [python3-catkin-sphinx]
+  gentoo:
+    pip:
+      packages: [catkin_sphinx]
+  osx:
+    pip:
+      packages: [catkin_sphinx]
+  ubuntu:
+    '*': [python3-catkin-sphinx]
+    bionic: null
 python3-catkin-tools:
   debian: [python3-catkin-tools]
   fedora: [python3-catkin_tools]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6296,8 +6296,8 @@ python3-catkin-sphinx:
     pip:
       packages: [catkin_sphinx]
   ubuntu:
-    '*': [python3-catkin-sphinx]
-    bionic: null
+    '*': null
+    focal: [python3-catkin-sphinx]
 python3-catkin-tools:
   debian: [python3-catkin-tools]
   fedora: [python3-catkin_tools]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

catkin_sphinx

## Package Upstream Source:

https://github.com/ros-infrastructure/catkin-sphinx

## Purpose of using this:

For a weird reason, this package was never rosdepped as python 3, although the binaries are being built: http://packages.ros.org/ros/ubuntu/pool/main/p/python3-catkin-sphinx/ . However, the CI only finds them for Focal and not for Jammy. Maybe a ROS 2 build would need to be uploaded?

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - pip
- Ubuntu: https://packages.ubuntu.com/
   - http://packages.ros.org/ros/ubuntu/pool/main/p/python3-catkin-sphinx/
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-catkin-sphinx/python3-catkin-sphinx/
- Arch: https://www.archlinux.org/packages/
  - pip
- Gentoo: https://packages.gentoo.org/
  - pip
- macOS: https://formulae.brew.sh/
  - pip
- Alpine: https://pkgs.alpinelinux.org/packages
  - not examined
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not examined
- openSUSE: https://software.opensuse.org/package/
  - not examined