### PR TITLE
ros2_control: 2.21.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4642,7 +4642,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.20.0-1
+      version: 2.21.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.21.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.20.0-1`

## controller_interface

- No changes

## controller_manager

```
* ControllerManager: catch exception by reference (#906 <https://github.com/ros-controls/ros2_control/issues/906>) (#907 <https://github.com/ros-controls/ros2_control/issues/907>)
* Fix update rate setting from gazebo_ros2_control (backport #874 <https://github.com/ros-controls/ros2_control/issues/874>) (#904 <https://github.com/ros-controls/ros2_control/issues/904>)
* Contributors: Christopher Wecht, Tony Najjar, Denis Stogl
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
