### PR TITLE
Revert "rtabmap_ros: 0.20.23-1 in 'humble/distribution.yaml' [bloom]"

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5642,7 +5642,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.20.23-1
+      version: 0.20.22-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Reverts ros/rosdistro#35918

This seems to introduce a regression:
https://build.ros2.org/view/Hbin_uJ64/job/Hbin_uJ64__rtabmap_ros__ubuntu_jammy_amd64__binary/35/

FYI @matlabbe 