### PR TITLE
ros2_control: 3.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4235,7 +4235,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.6.0-1
+      version: 3.7.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.7.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.6.0-1`

## controller_interface

- No changes

## controller_manager

```
* Do not use CLI calls but direct API for setting parameters. (#910 <https://github.com/ros-controls/ros2_control/issues/910>)
* Optimize output of controller spawner (#909 <https://github.com/ros-controls/ros2_control/issues/909>)
* ControllerManager: catch exception by reference (#906 <https://github.com/ros-controls/ros2_control/issues/906>)
* Test fix: don't keep reference to the controller in the test when it should be destroyed in the controller manager (#883 <https://github.com/ros-controls/ros2_control/issues/883>)
* Merge branch 'fix-update-rate' into humble (#874 <https://github.com/ros-controls/ros2_control/issues/874>)
* Contributors: Christopher Wecht, Dr. Denis, Tony Najjar, sgmurray
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Make double parsing locale independent (#921 <https://github.com/ros-controls/ros2_control/issues/921>)
* Contributors: Henning Kayser
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Do not use CLI calls but direct API for setting parameters. (#910 <https://github.com/ros-controls/ros2_control/issues/910>)
* Contributors: Dr. Denis
```

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
