### PR TITLE
added python3-gtsam-pip to rosdep python

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7239,6 +7239,16 @@ python3-grpcio:
     '*': [python3-grpcio]
     bionic: null
     xenial: null
+python3-gtsam-pip:
+  debian:
+    pip:
+      packages: [gtsam]
+  fedora:
+    pip:
+      packages: [gtsam]
+  ubuntu:
+    pip:
+      packages: [gtsam]
 python3-gurobipy-pip: *migrate_eol_2025_04_30_python3_gurobipy_pip
 python3-gz-math6:
   ubuntu:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

gtsam

## Package Upstream Source:

https://github.com/borglab/gtsam

## Purpose of using this:

Python Wrapper for GTSAM for Smoothing and Mapping (SAM) in robotics.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- PyPi
  - https://pypi.org/project/gtsam/


<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

Please add this package to the rosdep database.
