### PR TITLE
ros2_controllers: 3.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4294,7 +4294,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 3.0.0-1
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `3.1.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.0-1`

## admittance_controller

- No changes

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gripper_controllers

```
* Changing to_chrono to use nanoseconds & Reset gripper action goal timer to match JTC impl (#507 <https://github.com/ros-controls/ros2_controllers/issues/507>)
* Contributors: Dan Wahl
```

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* ported the joint_trajectory_controller query_state service to ROS2 (#481 <https://github.com/ros-controls/ros2_controllers/issues/481>)
* [JTC] Configurable joint positon error normalization behavior (#491 <https://github.com/ros-controls/ros2_controllers/issues/491>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota, Bence Magyar
```

## position_controllers

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

```
* add publisher topic parameter to forward_position_controller (#494 <https://github.com/ros-controls/ros2_controllers/issues/494>)
* Contributors: Manuel Muth
```

## rqt_joint_trajectory_controller

- No changes

## tricycle_controller

- No changes

## velocity_controllers

- No changes
