### PR TITLE
diagnostics: 3.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -945,12 +945,14 @@ repositories:
     release:
       packages:
       - diagnostic_aggregator
+      - diagnostic_common_diagnostics
       - diagnostic_updater
+      - diagnostics
       - self_test
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 3.0.0-1
+      version: 3.1.0-1
     source:
       test_pull_requests: true
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -941,7 +941,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/diagnostics.git
-      version: ros2-devel
+      version: ros2
     release:
       packages:
       - diagnostic_aggregator
@@ -957,7 +957,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/diagnostics.git
-      version: ros2-devel
+      version: ros2
     status: maintained
   dolly:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `3.1.0-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.0-1`

## diagnostic_aggregator

```
* Merge of foxy and humble history into rolling for future maintenance from one branch only.
* Adding READMEs to the repo (#270 <https://github.com/ros/diagnostics/issues/270>)
* License fixes (#263 <https://github.com/ros/diagnostics/issues/263>)
* Fix/cleanup ros1 (#257 <https://github.com/ros/diagnostics/issues/257>)
* Use regex to search AnalyzerGroup
* Contributors: Alberto Soragna, Austin, Christian Henkel, Keisuke Shima, Ralph Lange
```

## diagnostic_common_diagnostics

```
* Adding READMEs to the repo (#270 <https://github.com/ros/diagnostics/issues/270>)
* License fixes (#263 <https://github.com/ros/diagnostics/issues/263>)
* Fix/cleanup ros1 (#257 <https://github.com/ros/diagnostics/issues/257>)
* Port ntp_monitor to ROS2 (#242 <https://github.com/ros/diagnostics/issues/242>)
* Contributors: Austin, Christian Henkel, RFRIEDM-Trimble, Ralph Lange
```

## diagnostic_updater

```
* Merge of foxy and humble history into rolling for future maintenance from one branch only.
* Adding READMEs to the repo (#270 <https://github.com/ros/diagnostics/issues/270>)
* License fixes (#263 <https://github.com/ros/diagnostics/issues/263>)
* Fix/cleanup ros1 (#257 <https://github.com/ros/diagnostics/issues/257>)
* Fixed DiagnosedPublisher and switched to ROS_TIME (#243 <https://github.com/ros/diagnostics/issues/243>)
* Check if parameter is already declared to avoid re-declaring it. (#227 <https://github.com/ros/diagnostics/issues/227>)
* Update CMakeLists.txt to support modern cmake syntax
* Fix diagnostic_updater cmake
* Fix implicit conversion warnings
* Contributors: Alberto Soragna, Austin, Christian Henkel, Grzegorz Głowacki, Nikos Koukis, Ralph Lange
```

## diagnostics

```
* Adding READMEs to the repo (#270 <https://github.com/ros/diagnostics/issues/270>)
* License fixes (#263 <https://github.com/ros/diagnostics/issues/263>)
* Fix/cleanup ros1 (#257 <https://github.com/ros/diagnostics/issues/257>)
* Contributors: Austin, Christian Henkel, Ralph Lange
```

## self_test

```
* Merge of foxy and humble history into rolling for future maintenance from one branch only.
* Adding READMEs to the repo (#270 <https://github.com/ros/diagnostics/issues/270>)
* License fixes (#263 <https://github.com/ros/diagnostics/issues/263>)
* Fix/cleanup ros1 (#257 <https://github.com/ros/diagnostics/issues/257>)
* Contributors: Austin, Christian Henkel, Ralph Lange
```
