### PR TITLE
mvsim: 0.5.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3192,7 +3192,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/mvsim-release.git
-      version: 0.5.0-1
+      version: 0.5.0-2
     source:
       type: git
       url: https://github.com/MRPT/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.5.0-2`:

- upstream repository: https://github.com/MRPT/mvsim.git
- release repository: https://github.com/ros2-gbp/mvsim-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.5.0-1`

## mvsim

```
* New warehouse demo world file, including ros2 launch.
* New feature: download models from remote servers.
* Add 3D Lidar sensor.
* Add support for headless simulations (mvsim launch --headless), suitable for running inside docker containers
* New world element: vertical planes.
* Add <for /> loops in XML world files
* Support for formulas in XML files via  exprtk expressions
* Fix naming convention; fix warnings
* Move to clang-format-11
* More consistent class member naming convention
* Add simple Velodyne sensor DAE model
* Add wget as build and runtime dep
* PubSub system: Implemented the feature to notify subscribed clients about a new publisher for a topic
* New 3D model: pioneer3
* ROS: Add build and test dep python3-protobuf
* Added unit tests
* mvsim cli: add the --realtime-factor flag
* more topic echo types
* publish 2D lidar observations as custom protobuf msgs too
* Add new protobuf msg type ObservationLidar2D.proto
* add shutdown service
* Fixed Python topic subscription and parsing
* avoid potential crash during shutdown
* FIX: Timelogger verbosity level is now copied from the main World object.
* BUGFIX: Lidar sensors with ignore_parent_body=true should neither see the wheels
* Tune PID parameters of examples
* Refactoring and simplification of mutexes
* cache GetServiceInfoRequest() calls (more efficient service calls in comms::Client)
* factorize World services into its own .cpp file for clarity
* Contributors: Jose Luis Blanco-Claraco
```
