### PR TITLE
mvsim: 0.5.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5803,7 +5803,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
-      version: 0.5.1-1
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/ual-arm-ros-pkg/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.5.2-1`:

- upstream repository: https://github.com/ual-arm-ros-pkg/mvsim.git
- release repository: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.5.1-1`

## mvsim

```
* FIX build farm errors in armhf builds
* Contributors: Jose Luis Blanco-Claraco
```
