### PR TITLE
pilz_robots, pilz_industrial_motion: end-of-life

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6946,7 +6946,8 @@ repositories:
       type: git
       url: https://github.com/PilzDE/pilz_industrial_motion.git
       version: noetic-devel
-    status: maintained
+    status: end-of-life
+    status_description: The pilz planner has been integrated into moveit. See https://moveit.ros.org/documentation/planners/
   pilz_robots:
     doc:
       type: git
@@ -6970,7 +6971,7 @@ repositories:
       type: git
       url: https://github.com/PilzDE/pilz_robots.git
       version: noetic-devel
-    status: maintained
+    status: end-of-life
   pincher_arm:
     doc:
       type: git


### PR DESCRIPTION
`melodic/distribution.yaml` was already updated. We just forgot to submit these changes for noetic.