### PR TITLE
apriltag_ros: 3.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -384,7 +384,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag_ros-release.git
-      version: 3.1.0-1
+      version: 3.1.1-1
     source:
       type: git
       url: https://github.com/christianrauch/apriltag_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_ros` to `3.1.1-1`:

- upstream repository: https://github.com/christianrauch/apriltag_ros.git
- release repository: https://github.com/ros2-gbp/apriltag_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.1.0-1`
