### PR TITLE
kinematics_interface: 0.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2040,7 +2040,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
-      version: 0.0.2-1
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematics_interface` to `0.1.0-1`:

- upstream repository: https://github.com/ros-controls/kinematics_interface.git
- release repository: https://github.com/ros2-gbp/kinematics_interface-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.2-1`

## kinematics_interface

```
* Fix overriding of install (#13 <https://github.com/ros-controls/kinematics_interface/issues/13>)
* [CI] Fix and update formatting workflow and hooks (#14 <https://github.com/ros-controls/kinematics_interface/issues/14>)
* Contributors: Dr. Denis, Tyler Weaver
```

## kinematics_interface_kdl

```
* Fix overriding of install (#13 <https://github.com/ros-controls/kinematics_interface/issues/13>)
* Contributors: Tyler Weaver
```
