### PR TITLE
py_trees_ros_interfaces: 2.0.3-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3727,6 +3727,22 @@ repositories:
       url: https://github.com/splintered-reality/py_trees.git
       version: release/2.2.x
     status: maintained
+  py_trees_ros_interfaces:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
+      version: release/2.0.x
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/stonier/py_trees_ros_interfaces-release.git
+      version: 2.0.3-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
+      version: release/2.0.x
+    status: maintained
   pybind11_json_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros_interfaces` to `2.0.3-2`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros_interfaces.git
- release repository: https://github.com/stonier/py_trees_ros_interfaces-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`