### PR TITLE
py_trees, py_trees_js, py_trees_ros_interfaces in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3286,6 +3286,37 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
       version: master
     status: maintained
+  py_trees:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees.git
+      version: devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/py_trees-release.git
+      version: 2.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees.git
+      version: devel
+    status: developed
+  py_trees_js:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_js.git
+      version: devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/py_trees_js-release.git
+      version: 0.6.3-1
+    source:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_js.git
+      version: devel
+    status: maintained
   py_trees_ros_interfaces:
     doc:
       type: git
@@ -3294,8 +3325,8 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/stonier/py_trees_ros_interfaces-release.git
-      version: 2.0.3-3
+      url: https://github.com/ros2-gbp/py_trees_ros_interfaces-release.git
+      version: 2.0.3-4
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees_ros_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `2.2.1-1`:

- upstream repository: https://github.com/splintered-reality/py_trees.git
- release repository: https://github.com/ros2-gbp/py_trees-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## py_trees

```
* [tox] format with black, usort and fix flake8 warnings, #397 <https://github.com/splintered-reality/py_trees/pull/397>
* [docs] sphinx 1.4 -> 5.3, #391 <https://github.com/splintered-reality/py_trees/pull/391>
```
----

Increasing version of package(s) in repository `py_trees_js` to `0.6.3-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_js.git
- release repository: https://github.com/ros2-gbp/py_trees_js-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## py_trees_js

```
* [js] remove buggy early view update and optimise them, #142 <https://github.com/splintered-reality/py_trees_js/pull/142>
```
----
Increasing version of package(s) in repository `py_trees_ros_interfaces` to `2.0.3-4`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros_interfaces
- release repository: https://github.com/ros2-gbp/py_trees_ros_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.3-3`

