### PR TITLE
cascade_lifecycle: 1.0.2-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -632,8 +632,8 @@ repositories:
       - rclcpp_cascade_lifecycle
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/fmrico/cascade_lifecycle-release.git
-      version: 1.0.2-1
+      url: https://github.com/ros2-gbp/cascade_lifecycle-release.git
+      version: 1.0.2-2
     source:
       type: git
       url: https://github.com/fmrico/cascade_lifecycle.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cascade_lifecycle` to `1.0.2-2`:

- upstream repository: https://github.com/fmrico/cascade_lifecycle.git
- release repository: https://github.com/ros2-gbp/cascade_lifecycle-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.2-1`

## cascade_lifecycle_msgs

- No changes

## rclcpp_cascade_lifecycle

```
* Fix new deactivation publishers policy
* Contributors: Francisco Martín Rico
```
