### PR TITLE
realtime_tools: 2.5.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4200,7 +4200,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 2.4.0-1
+      version: 2.5.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `2.5.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.4.0-1`

## realtime_tools

```
* Fix overriding of install (#105 <https://github.com/ros-controls/realtime_tools/issues/105>)
* Add missing test dependency on ament_cmake_gmock (#94 <https://github.com/ros-controls/realtime_tools/issues/94>)
* Contributors: Bence Magyar, Denis Štogl, Scott K Logan, Tyler Weaver
```
