### PR TITLE
joy_tester: 0.0.2-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2114,6 +2114,11 @@ repositories:
       type: git
       url: https://github.com/joshnewans/joy_tester.git
       version: main
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/joy_tester-release.git
+      version: 0.0.2-2
     source:
       type: git
       url: https://github.com/joshnewans/joy_tester.git


### PR DESCRIPTION
Increasing version of package(s) in repository `joy_tester` to `0.0.2-2`:

- upstream repository: https://github.com/joshnewans/joy_tester
- release repository: https://github.com/ros2-gbp/joy_tester-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## joy_tester

```
* Fixed copyright and linting issues.
* Clean up loop
* Added missing dependencies to package.xml
* Contributors: Josh Newans
```
