### PR TITLE
depthai: 2.20.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1756,7 +1756,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/luxonis/depthai-core-release.git
-      version: 2.19.1-1
+      version: 2.20.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai` to `2.20.1-1`:

- upstream repository: https://github.com/luxonis/depthai-core.git
- release repository: https://github.com/luxonis/depthai-core-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.19.1-1`

## depthai

```
* Modified OpenVINO::VERSION_UNIVERSAL API improvements / backward compatibility
* Bootloader version 0.0.24 (fixes for standalone / flashed usecases)
* [FW] Status LEDs on some additional devices
* Contributors: Alex Bougdan, Szabolcs Gergely, Martin Peterlin
```
