### PR TITLE
raspimouse2: 1.1.1-7 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3879,6 +3879,24 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: ros2
     status: maintained
+  raspimouse2:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspimouse2.git
+      version: humble-devel
+    release:
+      packages:
+      - raspimouse
+      - raspimouse_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/raspimouse2-release.git
+      version: 1.1.1-7
+    source:
+      type: git
+      url: https://github.com/rt-net/raspimouse2.git
+      version: humble-devel
+    status: maintained
   rc_common_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspimouse2` to `1.1.1-7`:

- upstream repository: https://github.com/rt-net/raspimouse2.git
- release repository: https://github.com/ros2-gbp/raspimouse2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## raspimouse

```
* Humble対応 (#48 <https://github.com/rt-net/raspimouse2/issues/48>)
* Contributors: Shuhei Kozasa, Daisuke Sato
```

## raspimouse_msgs

- No changes
