### PR TITLE
rt_usb_9axisimu_driver: 2.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5699,6 +5699,21 @@ repositories:
       url: https://github.com/rt-net/rt_manipulators_cpp.git
       version: ros2
     status: maintained
+  rt_usb_9axisimu_driver:
+    doc:
+      type: git
+      url: https://github.com/rt-net/rt_usb_9axisimu_driver.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/rt_usb_9axisimu_driver-release.git
+      version: 2.0.2-1
+    source:
+      type: git
+      url: https://github.com/rt-net/rt_usb_9axisimu_driver.git
+      version: humble-devel
+    status: maintained
   rtabmap:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rt_usb_9axisimu_driver` to `2.0.2-1`:

- upstream repository: https://github.com/rt-net/rt_usb_9axisimu_driver.git
- release repository: https://github.com/ros2-gbp/rt_usb_9axisimu_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## rt_usb_9axisimu_driver

```
* Support Humble (#42 <https://github.com/rt-net/rt_usb_9axisimu_driver/issues/42>)
* Update README to add Foxy support (ROS 2 branch) (#33 <https://github.com/rt-net/rt_usb_9axisimu_driver/issues/33>)
* Contributors: Daisuke Sato, Shuhei Kozasa
```
