### PR TITLE
[rosdep] add paramiko-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -312,6 +312,16 @@ paramiko:
   rhel:
     '7': [python-paramiko]
   ubuntu: [python-paramiko]
+paramiko-pip:
+  debian:
+    pip:
+      packages: [paramiko]
+  fedora:
+    pip:
+      packages: [paramiko]
+  ubuntu:
+    pip:
+      packages: [paramiko]
 pi-ina219-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

- `paramiko`

## Package Upstream Source:

- https://github.com/paramiko/paramiko

## Purpose of using this:

The pip package and the apt package have a dependency conflict of `cryptography` and we need at least version 2.11 of `paramiko`. The rosdep key allows only to install version 2.6 via apt.
To be able to install the pip package with `rosdep` we need the key `paramiko-pip` in the `python.yaml`.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- https://pypi.org/project/paramiko/

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
