### PR TITLE
dingo: 0.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1855,7 +1855,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/dingo-release.git
-      version: 0.2.0-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/dingo-cpr/dingo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo` to `0.3.0-1`:

- upstream repository: https://github.com/dingo-cpr/dingo.git
- release repository: https://github.com/clearpath-gbp/dingo-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.0-1`

## dingo_control

- No changes

## dingo_description

```
* Change Microstrain IMU default parent link from imu_link to base_link
* Contributors: Joey Yang
```

## dingo_msgs

```
* Added Hardware ID's
  Added shore_power_ov and manual_charger_connected status for D150
* Contributors: Roni Kreinin
```

## dingo_navigation

- No changes
