### PR TITLE
neonavigation_msgs: 0.12.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6042,7 +6042,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/at-wat/neonavigation_msgs-release.git
-      version: 0.8.0-1
+      version: 0.12.0-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation_msgs` to `0.12.0-1`:

- upstream repository: https://github.com/at-wat/neonavigation_msgs.git
- release repository: https://github.com/at-wat/neonavigation_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.8.0-1`

## costmap_cspace_msgs

- No changes

## map_organizer_msgs

- No changes

## neonavigation_msgs

- No changes

## planner_cspace_msgs

```
* planner_cspace_msgs: add continuous movement mode to MoveWithTolerance action (#56 <https://github.com/at-wat/neonavigation_msgs/issues/56>)
* Contributors: Naotaka Hatao
```

## safety_limiter_msgs

```
* safety_limiter_msgs: fix maintainer email (#29 <https://github.com/at-wat/neonavigation_msgs/issues/29>)
* Contributors: Atsushi Watanabe
```

## trajectory_tracker_msgs

```
* trajectory_tracker_msgs: rename test target (#37 <https://github.com/at-wat/neonavigation_msgs/issues/37>)
* Contributors: f-fl0
```
