### PR TITLE
rclcpp: 19.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3700,7 +3700,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 18.0.0-1
+      version: 19.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `19.0.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `18.0.0-1`

## rclcpp

```
* Add default constructor to NodeInterfaces (#2094 <https://github.com/ros2/rclcpp/issues/2094>)
* Fix clock state cached time to be a copy, not a reference. (#2092 <https://github.com/ros2/rclcpp/issues/2092>)
* Fix -Wmaybe-uninitialized warning (#2081 <https://github.com/ros2/rclcpp/issues/2081>)
* Fix the keep_last warning when using system defaults. (#2082 <https://github.com/ros2/rclcpp/issues/2082>)
* Add in a fix for older compilers. (#2075 <https://github.com/ros2/rclcpp/issues/2075>)
* Contributors: Alexander Hans, Chris Lalancette, Shane Loretz
```

## rclcpp_action

- No changes

## rclcpp_components

```
* Improve component_manager_isolated shutdown (#2085 <https://github.com/ros2/rclcpp/issues/2085>)
* Contributors: Michael Carroll
```

## rclcpp_lifecycle

- No changes
