### PR TITLE
image_transport_plugins: 1.9.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4765,8 +4765,8 @@ repositories:
       - theora_image_transport
       tags:
         release: release/melodic/{package}/{version}
-      url: https://github.com/ros-gbp/image_transport_plugins-release.git
-      version: 1.9.5-0
+      url: https://github.com/ros2-gbp/image_transport_plugins-release.git
+      version: 1.9.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `1.9.6-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.9.5-0`

## compressed_depth_image_transport

```
* Update maintainer in ros1 branches (#133 <https://github.com/ros-perception/image_transport_plugins/issues/133>)
* Make the default compressed depth png_level 1 instead of 9 to save cpu (#131 <https://github.com/ros-perception/image_transport_plugins/issues/131>)
* Fix uninitialized memory usage in compressedDepth transport (#126 <https://github.com/ros-perception/image_transport_plugins/issues/126>)
* Fix binary install locations for Windows build. (#34 <https://github.com/ros-perception/image_transport_plugins/issues/34>)
* Add legacy constants when using opencv4. (#32 <https://github.com/ros-perception/image_transport_plugins/issues/32>)
* Contributors: David Gossow, Hans Gaiser, Kenji Brameld, Lucas Walter, Martin Pecka, Sean Yen, Shuntaro Yamazaki, ijnek
```

## compressed_image_transport

```
* Update maintainer in ros1 branches ( #133 <https://github.com/ros-perception/image_transport_plugins/issues/133>)
* Performance optimizations for JPEG decompression (#123 <https://github.com/ros-perception/image_transport_plugins/issues/123>)
* Fixed warning when resubscribing (#25 <https://github.com/ros-perception/image_transport_plugins/issues/25>)
* Fix binary install locations for Windows build. (#34 <https://github.com/ros-perception/image_transport_plugins/issues/34>)
* Add legacy constants when using opencv4. (#32 <https://github.com/ros-perception/image_transport_plugins/issues/32>)
* Contributors: David Gossow, Hans Gaiser, Kenji Brameld, Max Schwarz, Sean Yen, Till Grenzdörffer, Yuki Furuta, ijnek
```

## image_transport_plugins

```
* Update maintainer in ros1 branches (#133 <https://github.com/ros-perception/image_transport_plugins/issues/133>)
* Contributors: Kenji Brameld, ijnek
```

## theora_image_transport

```
* Update maintainer in ros1 branches (#133 <https://github.com/ros-perception/image_transport_plugins/issues/133>)
* Fix binary install locations for Windows build. (#34 <https://github.com/ros-perception/image_transport_plugins/issues/34>)
* Contributors: David Gossow, Kenji Brameld, Sean Yen, ijnek
```
