### PR TITLE
raspimouse_description: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3919,6 +3919,21 @@ repositories:
       url: https://github.com/rt-net/raspimouse2.git
       version: humble-devel
     status: maintained
+  raspimouse_description:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspimouse_description.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/raspimouse_description-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/rt-net/raspimouse_description.git
+      version: humble-devel
+    status: maintained
   rc_common_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspimouse_description` to `1.0.1-1`:

- upstream repository: https://github.com/rt-net/raspimouse_description.git
- release repository: https://github.com/ros2-gbp/raspimouse_description-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## raspimouse_description

```
* Updates README
* Update the license year to 2022
* Adds LiDAR (#38 <https://github.com/rt-net/raspimouse_description/issues/38>)
* Update library to rviz2 (#36 <https://github.com/rt-net/raspimouse_description/issues/36>)
* Update tread (ROS 2) (#32 <https://github.com/rt-net/raspimouse_description/issues/32>)
* Update README for ROS 2 (#26 <https://github.com/rt-net/raspimouse_description/issues/26>)
* Support ROS 2 Foxy (#24 <https://github.com/rt-net/raspimouse_description/issues/24>)
* Create LICENSE
* Contributors: Daisuke Sato, Shota Aoki, Shuhei Kozasa
```
