### PR TITLE
ros_controllers: 0.21.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8654,7 +8654,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.21.0-1
+      version: 0.21.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.21.1-1`:

- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.21.0-1`

## ackermann_steering_controller

```
* Don't hardcode plugin library path
* Install headers of ackermann_steering_controller
* Contributors: Jochen Sprickerhof, Martin Pecka
```

## diff_drive_controller

```
* Don't hardcode plugin library path
* Contributors: Jochen Sprickerhof
```

## effort_controllers

```
* Don't hardcode plugin library path
* Contributors: Jochen Sprickerhof
```

## force_torque_sensor_controller

```
* Don't hardcode plugin library path
* Contributors: Jochen Sprickerhof
```

## forward_command_controller

- No changes

## four_wheel_steering_controller

```
* Don't hardcode plugin library path
* add_dependencies was added to the CMakeLists.txt in four_wheel_steering_controller
* Contributors: Jochen Sprickerhof, pavel
```

## gripper_action_controller

```
* Don't hardcode plugin library path
* Contributors: Jochen Sprickerhof
```

## imu_sensor_controller

```
* Don't hardcode plugin library path
* Contributors: Jochen Sprickerhof
```

## joint_state_controller

```
* Don't hardcode plugin library path
* Contributors: Jochen Sprickerhof
```

## joint_trajectory_controller

```
* Don't hardcode plugin library path
* Contributors: Jochen Sprickerhof
```

## position_controllers

```
* Don't hardcode plugin library path
* Contributors: Jochen Sprickerhof
```

## ros_controllers

- No changes

## rqt_joint_trajectory_controller

- No changes

## velocity_controllers

```
* Don't hardcode plugin library path
* Contributors: Jochen Sprickerhof
```
