### PR TITLE
ros2_control: 2.22.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4773,7 +4773,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.21.0-1
+      version: 2.22.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.22.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.21.0-1`

## controller_interface

- No changes

## controller_manager

```
* Optimize output of controller spawner (backport #909 <https://github.com/ros-controls/ros2_control/issues/909>) (#911 <https://github.com/ros-controls/ros2_control/issues/911>)
* Namespace Loaded Controllers (#852 <https://github.com/ros-controls/ros2_control/issues/852>) (#914 <https://github.com/ros-controls/ros2_control/issues/914>)
* Add diagnostics (backport #820 <https://github.com/ros-controls/ros2_control/issues/820>) (#922 <https://github.com/ros-controls/ros2_control/issues/922>)
* Contributors: Bence Magyar, Denis Stogl, Tony Najjar
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Make double parsing locale independent (#921 <https://github.com/ros-controls/ros2_control/issues/921>) (#924 <https://github.com/ros-controls/ros2_control/issues/924>)
* Contributors: Henning Kayser
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
