### PR TITLE
pinocchio: 2.6.15-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7005,7 +7005,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/stack-of-tasks/pinocchio-ros-release.git
-      version: 2.6.14-1
+      version: 2.6.15-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/pinocchio.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pinocchio` to `2.6.15-1`:

- upstream repository: https://github.com/stack-of-tasks/pinocchio.git
- release repository: https://github.com/stack-of-tasks/pinocchio-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.6.14-1`
