### PR TITLE
pinocchio: 2.6.15-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3847,7 +3847,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/pinocchio-release.git
-      version: 2.6.14-1
+      version: 2.6.15-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/pinocchio.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pinocchio` to `2.6.15-1`:

- upstream repository: https://github.com/stack-of-tasks/pinocchio.git
- release repository: https://github.com/ros2-gbp/pinocchio-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.6.14-1`
