### PR TITLE
aerostack2 doc and source entries

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -66,6 +66,17 @@ repositories:
       url: https://github.com/ros-acceleration/adaptive_component.git
       version: rolling
     status: developed
+  aerostack2:
+    doc:
+      type: git
+      url: https://github.com/aerostack2/aerostack2.git
+      version: main
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/aerostack2/aerostack2.git
+      version: main
+    status: developed
   affordance_primitives:
     release:
       tags:


### PR DESCRIPTION
Following the indications from #35691

# Please Add This Package to be indexed in the rosdistro.

aerostack2

# The source is here:

https://github.com/aerostack2/aerostack2.git

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
