### PR TITLE
add rosdep package libadolc-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2402,11 +2402,9 @@ libabsl-dev:
     bionic: null
     focal: null
 libadolc-dev:
-  arch: [adol-c]
   debain: [libadolc-dev]
   gentoo: [sci-libs/adolc]
   nixos: [adolc]
-  opensuse: [adolc]
   ubuntu: [libadolc-dev]
 libalglib-dev:
   debian: [libalglib-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2401,6 +2401,13 @@ libabsl-dev:
     '*': [libabsl-dev]
     bionic: null
     focal: null
+libadolc-dev:
+  arch: [adol-c]
+  debain: [libadolc-dev]
+  gentoo: [sci-libs/adolc]
+  nixos: [adolc]
+  opensuse: [adolc]
+  ubuntu: [libadolc-dev]
 libalglib-dev:
   debian: [libalglib-dev]
   fedora: [alglib-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2402,9 +2402,10 @@ libabsl-dev:
     bionic: null
     focal: null
 libadolc-dev:
-  debain: [libadolc-dev]
+  debian: [libadolc-dev]
   gentoo: [sci-libs/adolc]
   nixos: [adolc]
+  opensuse: [adolc-devel]
   ubuntu: [libadolc-dev]
 libalglib-dev:
   debian: [libalglib-dev]

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -179,6 +179,10 @@ jasper:
   osx:
     homebrew:
       packages: [jasper]
+libadolc-dev:
+  osx:
+    homebrew:
+      packages: [homebrew/science/adol-c]
 libccd-dev:
   osx:
     homebrew:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name: libadolc-dev

## Package Upstream Source:

https://github.com/coin-or/adol-c

## Purpose of using this:

This dependency is being used for automatic differentiation along with [IPOPT](https://github.com/coin-or/Ipopt) in optimal control applications.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/libadolc-dev
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/search?searchon=names&keywords=libadolc-dev
- Fedora: https://packages.fedoraproject.org/
  - not available
- Arch: https://www.archlinux.org/packages/
  - https://aur.archlinux.org/packages/adol-c
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/sci-libs/adolc
- macOS: https://formulae.brew.sh/
  - https://github.com/brewsci/homebrew-science/blob/master/Formula/adol-c.rb
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=22.11&show=adolc&from=0&size=50&sort=relevance&type=packages&query=adolc
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/adolc

