### PR TITLE
eigenpy: 2.9.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1288,7 +1288,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/stack-of-tasks/eigenpy-ros-release.git
-      version: 2.9.1-1
+      version: 2.9.2-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/eigenpy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `eigenpy` to `2.9.2-1`:

- upstream repository: https://github.com/stack-of-tasks/eigenpy.git
- release repository: https://github.com/stack-of-tasks/eigenpy-ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.9.1-1`
