### PR TITLE
rosdep: catkin_sphinx: Fix rosdep pip keys

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1030,17 +1030,17 @@ python-catkin-pkg-modules:
 python-catkin-sphinx:
   arch:
     pip:
-      packages: [catkin_sphinx]
+      packages: [catkin-sphinx]
   debian:
     pip:
-      packages: [catkin_sphinx]
+      packages: [catkin-sphinx]
   fedora: [python-catkin-sphinx]
   gentoo:
     pip:
-      packages: [catkin_sphinx]
+      packages: [catkin-sphinx]
   osx:
     pip:
-      packages: [catkin_sphinx]
+      packages: [catkin-sphinx]
   ubuntu:
     '*': null
     bionic: [python-catkin-sphinx]
@@ -6284,17 +6284,17 @@ python3-catkin-pkg-modules:
 python3-catkin-sphinx:
   arch:
     pip:
-      packages: [catkin_sphinx]
+      packages: [catkin-sphinx]
   debian:
     pip:
-      packages: [catkin_sphinx]
+      packages: [catkin-sphinx]
   fedora: [python3-catkin-sphinx]
   gentoo:
     pip:
-      packages: [catkin_sphinx]
+      packages: [catkin-sphinx]
   osx:
     pip:
-      packages: [catkin_sphinx]
+      packages: [catkin-sphinx]
   rhel: [python3-catkin-sphinx]
   ubuntu:
     '*': null


### PR DESCRIPTION
Whoops, this has popped up to me in a Noetic-Debian Buster Jenkins job making use of the rosdep key added in #35931:

```
Resolved the dependencies to the following binary packages:
  - catkin_sphinx
  - libboost-all-dev
  - libeigen3-dev
  - liburdfdom-headers-dev
  - python3-catkin-lint
  - python3-marisa
  - python3-mistune
  - python3-numpy
  - python3-tqdm
  - ros-noetic-bondcpp
  - ros-noetic-class-loader
  - ros-noetic-diagnostic-msgs
  - ros-noetic-diagnostic-updater
  - ros-noetic-dynamic-reconfigure
  - ros-noetic-filters
  - ros-noetic-geometry-msgs
  - ros-noetic-image-transport
  - ros-noetic-nodelet
  - ros-noetic-pluginlib
  - ros-noetic-rosbag
  - ros-noetic-rosconsole
  - ros-noetic-roscpp
  - ros-noetic-rosdoc-lite
  - ros-noetic-rosgraph
  - ros-noetic-rosgraph-msgs
  - ros-noetic-roslaunch
  - ros-noetic-roslib
  - ros-noetic-roslint
  - ros-noetic-rospy
  - ros-noetic-rostest
  - ros-noetic-rostopic
  - ros-noetic-rosunit
  - ros-noetic-sensor-msgs
  - ros-noetic-std-msgs
  - ros-noetic-tf
  - ros-noetic-tf2
  - ros-noetic-tf2-msgs
  - ros-noetic-tf2-ros
  - ros-noetic-topic-tools
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/apt/cache.py", line 297, in __getitem__
    rawpkg = self._cache[key]
KeyError: 'catkin_sphinx'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tmp/ros_buildfarm/scripts/devel/create_devel_task_generator.py", line 21, in <module>
    run_module('ros_buildfarm.scripts.devel.create_devel_task_generator', run_name='__main__')
  File "/usr/lib/python3.7/runpy.py", line 208, in run_module
    return _run_code(code, {}, init_globals, run_name, mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/tmp/ros_buildfarm/ros_buildfarm/scripts/devel/create_devel_task_generator.py", line 304, in <module>
    sys.exit(main())
  File "/tmp/ros_buildfarm/ros_buildfarm/scripts/devel/create_devel_task_generator.py", line 152, in main
    get_binary_package_versions(apt_cache, debian_pkg_names_testing))
  File "/tmp/ros_buildfarm/ros_buildfarm/common.py", line 175, in get_binary_package_versions
    pkg = apt_cache[debian_pkg_name]
  File "/usr/lib/python3/dist-packages/apt/cache.py", line 299, in __getitem__
    raise KeyError('The cache has no package named %r' % key)
```

It seems something is resolving pip name catkin_sphinx, while other things do catkin-sphinx. On pypi, the package is called caktin-sphinx. When installed, the directory is called catkin_sphinx. I've read that Python does some autoconversions of dashes and underscores in package names, so it might be just this.

What I don't understand is why the CI did not catch this...