### PR TITLE
rosdep: python3-catkin-sphinx: Add Buster APT version

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6286,8 +6286,10 @@ python3-catkin-sphinx:
     pip:
       packages: [catkin_sphinx]
   debian:
-    pip:
-      packages: [catkin_sphinx]
+    '*':
+      pip:
+        packages: [catkin_sphinx]
+    buster: [python3-catkin-sphinx]
   fedora: [python3-catkin-sphinx]
   gentoo:
     pip:


### PR DESCRIPTION
Followup to #35931. I figured out there (probably) actually is an APT version of catkin_sphinx for Debian Buster (I guess it just uses the same repo as Ubuntu?).

This is needed for buildfarm jobs using this package to succeed. And Buster is one of the required platforms for Noetic.