### PR TITLE
Add python3-inject-pip alias

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2421,7 +2421,7 @@ python-influxdb:
     bionic: [python-influxdb]
     disco: [python-influxdb]
     xenial: [python-influxdb]
-python-inject-pip:
+python-inject-pip: &migrate_eol_2030_04_30_python3_inject_pip
   ubuntu:
     pip:
       packages: [inject]
@@ -7417,6 +7417,7 @@ python3-influxdb-client-pip:
   ubuntu:
     pip:
       packages: [influxdb-client]
+python3-inject-pip: *migrate_eol_2030_04_30_python3_inject_pip
 python3-inputimeout-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2421,7 +2421,7 @@ python-influxdb:
     bionic: [python-influxdb]
     disco: [python-influxdb]
     xenial: [python-influxdb]
-python-inject-pip: &migrate_eol_2030_04_30_python3_inject_pip
+python-inject-pip: &migrate_eol_2025_04_30_python3_inject_pip
   ubuntu:
     pip:
       packages: [inject]
@@ -7417,7 +7417,7 @@ python3-influxdb-client-pip:
   ubuntu:
     pip:
       packages: [influxdb-client]
-python3-inject-pip: *migrate_eol_2030_04_30_python3_inject_pip
+python3-inject-pip: *migrate_eol_2025_04_30_python3_inject_pip
 python3-inputimeout-pip:
   debian:
     pip:


### PR DESCRIPTION
Simply adds an anchor and alias for the python3 version of the `inject` package, which is already specified in the python.yaml as `python-inject-pip`.

EOL date for ubuntu 20.04 LTS from [here](https://wiki.ubuntu.com/Releases#:~:text=April%202025-,April%202030,-Ubuntu%2020.04.3%20LTS).