### PR TITLE
jackal: 1.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2060,7 +2060,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/jackal/jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `1.0.2-1`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.1-1`

## jackal_control

```
* Uncomment dependency on imu_filter_madgwick; it is now installable as a deb in Foxy.
* Contributors: Joey Yang
```

## jackal_description

```
* Add missing dependency to velodyne_description.
* Contributors: Joey Yang
```

## jackal_msgs

```
* Added SetDomainId service
* Contributors: Roni Kreinin
```

## jackal_navigation

- No changes
