### PR TITLE
flatland: 1.3.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2662,6 +2662,23 @@ repositories:
       url: https://github.com/fkie/potree_rviz_plugin.git
       version: master
     status: maintained
+  flatland:
+    release:
+      packages:
+      - flatland
+      - flatland_msgs
+      - flatland_plugins
+      - flatland_server
+      - flatland_viz
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/avidbots/flatland-release.git
+      version: 1.3.2-1
+    source:
+      type: git
+      url: https://github.com/avidbots/flatland.git
+      version: master
+    status: maintained
   flexbe:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `flatland` to `1.3.2-1`:

- upstream repository: https://github.com/avidbots/flatland.git
- release repository: https://github.com/avidbots/flatland-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
