### PR TITLE
moveit_task_constructor: 0.1.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5579,7 +5579,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit_task_constructor-release.git
-      version: 0.1.0-1
+      version: 0.1.0-2
     source:
       type: git
       url: https://github.com/ros-planning/moveit_task_constructor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_task_constructor` to `0.1.0-2`:

- upstream repository: https://github.com/ros-planning/moveit_task_constructor.git
- release repository: https://github.com/ros-gbp/moveit_task_constructor-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.0-1`

## moveit_task_constructor_capabilities

```
* Initial release
* Contributors: Michael Görner, Robert Haschke
```

## moveit_task_constructor_core

```
* Initial release
* Contributors: Michael Görner, Robert Haschke, Captain Yoshi, Christian Petersmeier, Henning Kayser, Jafar Abdi, Tyler Weaver
```

## moveit_task_constructor_demo

```
* Initial release
* Contributors: Michael Görner, Robert Haschke
```

## moveit_task_constructor_msgs

```
* Initial release
* Contributors: Michael Görner, Robert Haschke
```

## moveit_task_constructor_visualization

```
* Initial release
* Contributors: Robert Haschke, Michael Görner
```

## rviz_marker_tools

```
* Initial release
* Contributors: Robert Haschke, Michael Görner
```
