### PR TITLE
robotraconteur: 0.16.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4764,6 +4764,11 @@ repositories:
       version: foxy-devel
     status: maintained
   robotraconteur:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/robotraconteur-packaging/robotraconteur-ros2-release.git
+      version: 0.16.0-1
     source:
       type: git
       url: https://github.com/robotraconteur/robotraconteur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotraconteur` to `0.16.0-1`:

- upstream repository: https://github.com/robotraconteur/robotraconteur.git
- release repository: https://github.com/robotraconteur-packaging/robotraconteur-ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
