### PR TITLE
Add apa102-pi in 'rosdep/python.yaml'

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6003,7 +6003,7 @@ python3-anytree-pip:
   ubuntu:
     pip:
       packages: [anytree]
-python3-apa102-pi:
+python3-apa102-pi-pip:
   debian:
     pip:
       depends: [python-rpi.gpio-pip]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6003,6 +6003,15 @@ python3-anytree-pip:
   ubuntu:
     pip:
       packages: [anytree]
+python3-apa102-pi:
+  debian:
+    pip:
+      depends: [python-rpi.gpio-pip]
+      packages: [apa102-pi]
+  ubuntu:
+    pip:
+      depends: [python-rpi.gpio-pip]
+      packages: [apa102-pi]
 python3-argcomplete:
   alpine: [py3-argcomplete]
   arch: [python-argcomplete]


### PR DESCRIPTION
## Package name:

python3-apa102-pi-pip

## Package Upstream Source:

https://github.com/tinue/apa102-pi

## Purpose of using this:

APA102 LED driver for Raspberry Pi. Useful for LED animations without use of microcontrollers.

## Links to Distribution Packages

- Debian: not available (via [pip](https://pypi.org/project/apa102-pi/))
- Ubuntu: not available (via [pip](https://pypi.org/project/apa102-pi/))
- Fedora: not available
- Arch:  not available
- Gentoo:  not available
- macOS: not available
- Alpine: not available
- NixOS/nixpkgs: not available
- openSUSE: not available


# Checks
 - [ ] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
