### PR TITLE
py_trees_ros_interfaces: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3336,17 +3336,18 @@ repositories:
     doc:
       type: git
       url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
-      version: release/2.0.x
+      version: devel
     release:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_ros_interfaces-release.git
-      version: 2.0.3-4
+      version: 2.1.0-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
       version: devel
-    status: maintained
+    status: developed
   pybind11_json_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros_interfaces` to `2.1.0-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros_interfaces
- release repository: https://github.com/ros2-gbp/py_trees_ros_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.3-4`
