### PR TITLE
Added python3-open3d via .deb package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8010,9 +8010,14 @@ python3-onnxruntime-pip:
       packages: [onnxruntime]
 python3-open3d:
   debian:
-    bullseye: [python3-open3d]
+    '*': [python3-open3d]
+    buster: null
+    stretch: null
   ubuntu:
-    jammy: [python3-open3d]
+    '*': [python3-open3d]
+    artful: null
+    bionic: null
+    focal: null
 python3-open3d-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8008,6 +8008,11 @@ python3-onnxruntime-pip:
   ubuntu:
     pip:
       packages: [onnxruntime]
+python3-open3d:
+  debian:
+    bullseye: [python3-open3d]
+  ubuntu:
+    jammy: [python3-open3d]
 python3-open3d-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-open3d

## Package Upstream Source:

https://github.com/isl-org/Open3D

## Purpose of using this:

This package already exists in the index as a PIP dependency, this adds it as a distribution package (for Ubuntu and Debian, I couldn't find it for Fedora)

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/python3-open3d
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/jammy/python3-open3d