### PR TITLE
webots_ros2: 2023.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7297,7 +7297,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/webots_ros2-release.git
-      version: 2023.0.1-1
+      version: 2023.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `webots_ros2` to `2023.0.2-1`:

- upstream repository: https://github.com/cyberbotics/webots_ros2.git
- release repository: https://github.com/ros2-gbp/webots_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2023.0.1-1`

## webots_ros2

```
* Drop support for Galactic.
* Fixed the spawn of URDF robots in WSL and macOS when using full path.
* Fixed relative assets in macOS.
* Ros2Supervisor is now optional.
```

## webots_ros2_driver

```
* Fixed the spawn of URDF robots in WSL and macOS when using full path.
* Fixed relative assets in macOS.
* Added Ros2Supervisor creation.
```

## webots_ros2_epuck

```
* Updated supervisor launch.
```

## webots_ros2_mavic

```
* Updated supervisor launch.
```

## webots_ros2_tesla

```
* Updated supervisor launch.
```

## webots_ros2_tiago

```
* Updated supervisor launch.
```

## webots_ros2_turtlebot

```
* Updated supervisor launch.
```

## webots_ros2_universal_robot

```
* Fixed URDF relative URLs to assets.
* Updated supervisor launch.
```
