### PR TITLE
gazebo_ros2_control: 0.4.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1406,7 +1406,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros2_control` to `0.4.1-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros2_control.git
- release repository: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.0-1`

## gazebo_ros2_control

```
* Force setting use_sim_time parameter when using plugin. (#171 <https://github.com/ros-controls/gazebo_ros2_control/issues/171>)
* Removed warning (#162 <https://github.com/ros-controls/gazebo_ros2_control/issues/162>)
* Mimic joint should have the same control mode as mimicked joint. (#154 <https://github.com/ros-controls/gazebo_ros2_control/issues/154>)
* Enable loading params from multiple yaml files (#149 <https://github.com/ros-controls/gazebo_ros2_control/issues/149>)
* Contributors: Alejandro Hernández Cordero, Denis Štogl, Tony Najjar
```

## gazebo_ros2_control_demos

```
* Add tricycle controller demo (#145 <https://github.com/ros-controls/gazebo_ros2_control/issues/145>)
* Contributors: Tony Najjar
```
