### PR TITLE
ign_ros2_control: 0.6.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1701,7 +1701,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 0.6.0-1
+      version: 0.6.1-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ign_ros2_control` to `0.6.1-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.0-1`

## ign_ros2_control

```
* Various bug fixes (#114 <https://github.com/ros-controls/gz_ros2_control/issues/114>)
* Contributors: AndyZe
```

## ign_ros2_control_demos

- No changes
