### PR TITLE
pmb2_robot: 5.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3654,7 +3654,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_robot-gbp.git
-      version: 4.0.5-1
+      version: 5.0.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_robot` to `5.0.0-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_robot.git
- release repository: https://github.com/pal-gbp/pmb2_robot-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.5-1`

## pmb2_bringup

```
* Merge branch 'robot_state_publisher' into 'humble-devel'
  launch robot_state_publisher from pmb2_bringup
  See merge request robots/pmb2_robot!90
* launch robot_state_publisher from pmb2_bringup
* Contributors: Jordan Palacios, Noel Jimenez
```

## pmb2_controller_configuration

- No changes

## pmb2_description

```
* Merge branch 'transmissions' into 'humble-devel'
  Update wheels transmissions
  See merge request robots/pmb2_robot!91
* update wheels transmissions
* Contributors: Jordan Palacios, Noel Jimenez
```

## pmb2_robot

- No changes
