### PR TITLE
pmb2_simulation: 4.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3672,7 +3672,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_simulation-release.git
-      version: 4.0.1-1
+      version: 4.0.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_simulation` to `4.0.2-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_simulation.git
- release repository: https://github.com/pal-gbp/pmb2_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.1-1`

## pmb2_gazebo

```
* Merge branch 'fix/2dnav' into 'humble-devel'
  using pmb2_2dnav
  See merge request robots/pmb2_simulation!55
* using pmb2_2dnav
* Merge branch 'robot_state_publisher' into 'humble-devel'
  remove robot_state_publisher from pmb2_spawn
  See merge request robots/pmb2_simulation!53
* remove robot_state_publisher from pmb2_spawn
* Contributors: Jordan Palacios, Noel Jimenez, antoniobrandi
```

## pmb2_simulation

- No changes
