### PR TITLE
pal_gripper: 3.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3397,7 +3397,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_gripper-release.git
-      version: 3.0.1-1
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_gripper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_gripper` to `3.0.2-1`:

- upstream repository: https://github.com/pal-robotics/pal_gripper.git
- release repository: https://github.com/pal-gbp/pal_gripper-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.1-1`

## pal_gripper

- No changes

## pal_gripper_controller_configuration

- No changes

## pal_gripper_description

```
* Merge branch 'update_transmissions' into 'humble-devel'
  ros2 update transmissions for pal-gripper
  See merge request robots/pal_gripper!22
* ros2 update transmissions for pal-gripper
* Contributors: Jordan Palacios, Noel Jimenez
```
