### PR TITLE
tiago_robot: 4.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6473,7 +6473,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_robot-release.git
-      version: 4.0.1-1
+      version: 4.0.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_robot` to `4.0.2-1`:

- upstream repository: https://github.com/pal-robotics/tiago_robot
- release repository: https://github.com/pal-gbp/tiago_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.1-1`

## tiago_bringup

```
* Merge branch 'robot_state_publisher' into 'humble-devel'
  Launch robot_state_publisher from tiago_bringup
  See merge request robots/tiago_robot!185
* robot_state_publisher from tiago_bringup
* Contributors: Jordan Palacios, Noel Jimenez
```

## tiago_controller_configuration

- No changes

## tiago_description

```
* Merge branch 'transmissions' into 'humble-devel'
  Set transmissions inside the ros2_control tag
  See merge request robots/tiago_robot!186
* update transmissions for arm, head and torso
* update transmission tags for ros2
* set transmissions inside the ros2_control tag
* Contributors: Jordan Palacios, Noel Jimenez
```

## tiago_robot

- No changes
