### PR TITLE
tiago_moveit_config: 3.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6435,7 +6435,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_moveit_config-release.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_moveit_config` to `3.0.1-1`:

- upstream repository: https://github.com/pal-robotics/tiago_moveit_config.git
- release repository: https://github.com/pal-gbp/tiago_moveit_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.0-1`

## tiago_moveit_config

```
* Merge branch 'fix_move_group' into 'humble-devel'
  Add missing pilz_cartesian_limits for moveit config
  See merge request robots/tiago_moveit_config!50
* add missing pilz_cartesian_limits for moveit config
* Contributors: Jordan Palacios, Noel Jimenez
```
