### PR TITLE
tiago_simulation: 4.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6491,7 +6491,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_simulation-release.git
-      version: 4.0.0-1
+      version: 4.0.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_simulation` to `4.0.1-1`:

- upstream repository: https://github.com/pal-robotics/tiago_simulation
- release repository: https://github.com/pal-gbp/tiago_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.0-1`

## tiago_gazebo

```
* Merge branch 'robot_state_publisher' into 'humble-devel'
  Remove robot_state_publisher from tiago_spawn
  See merge request robots/tiago_simulation!105
* remove robot_state_publisher from tiago_spawn
* Contributors: Jordan Palacios, Noel Jimenez
```

## tiago_simulation

- No changes
