### PR TITLE
aruco_ros: 5.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -431,11 +431,11 @@ repositories:
       - aruco_ros
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/aruco_ros-release.git
+      url: https://github.com/pal-robotics/aruco_ros.git
       version: 5.0.0-1
     source:
       type: git
-      url: https://github.com/pal-gbp/aruco_ros-release.git
+      url: https://github.com/pal-robotics/aruco_ros.git
       version: humble-devel
     status: developed
   async_web_server_cpp:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -419,6 +419,25 @@ repositories:
       url: https://github.com/fictionlab/ros_aruco_opencv.git
       version: humble
     status: maintained
+  aruco_ros:
+    doc:
+      type: git
+      url: https://github.com/pal-gbp/aruco_ros-release.git
+      version: humble-devel
+    release:
+      packages:
+      - aruco
+      - aruco_msgs
+      - aruco_ros
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/aruco_ros-release.git
+      version: 5.0.0-1
+    source:
+      type: git
+      url: https://github.com/pal-gbp/aruco_ros-release.git
+      version: humble-devel
+    status: developed
   async_web_server_cpp:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -422,7 +422,7 @@ repositories:
   aruco_ros:
     doc:
       type: git
-      url: https://github.com/pal-gbp/aruco_ros-release.git
+      url: https://github.com/pal-robotics/aruco_ros.git
       version: humble-devel
     release:
       packages:
@@ -431,7 +431,7 @@ repositories:
       - aruco_ros
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-robotics/aruco_ros.git
+      url: https://github.com/pal-gbp/aruco_ros-release.git
       version: 5.0.0-1
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_ros` to `5.0.0-1`:

- upstream repository: https://github.com/pal-robotics/aruco_ros.git
- release repository: https://github.com/pal-gbp/aruco_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## aruco

```
* fixed cornerUpsample slicing bug issue
* disable tests for package aruco
* added missing ament exports in CMakeLists.txt
* added ament_lint test to the packages aruco and aruco_msgs
* added minor fix in aruco CMakeLists.txt
* added the ament configuration to build with colcon
* Contributors: Noel Jimenez, Sai Kishor Kothakota, josegarcia
```

## aruco_msgs

```
* added ament_lint test to the packages aruco and aruco_msgs
* aruco_msgs - added the ament configuration to build ROS2 msgs
* Contributors: Sai Kishor Kothakota
```

## aruco_ros

```
* ament uncrustify lint
* create subnode to namespace the topics and changed default node names
* declare params and fix launchers
* disable copyright check
* linters fixes
* add tests
* remove wrong copyright
* params fix
* port launchers to ros2
* declare node parameters
* migrate the aruco_ros double node to ROS2
* added some fixes for the aruco_simple ros2 node
* migrate the node aruco_simple to ROS2
* refactor marker_publisher for the setup to work correctly
* migrated the marker publish node to ROS2
* migrated the aruco_ros_utils.cpp to ros2
* added temporary changes of humble
* Contributors: Noel Jimenez, Sai Kishor Kothakota
```
