### PR TITLE
Add python3-sshtunnel

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9524,10 +9524,20 @@ python3-squaternion-pip:
 python3-sshtunnel:
   debian: [python3-sshtunnel]
   fedora: [python3-sshtunnel]
-  ubuntu: [python3-sshtunnel]
   ubuntu:
-    pip:
-      packages: [sshtunnel]
+    '*': [python3-sshtunnel]
+    focal:
+      pip:
+        packages: [sshtunnel]
+    jammy:
+      pip:
+        packages: [sshtunnel]
+    kinetic:
+      pip:
+        packages: [sshtunnel]
+    lunar:
+      pip:
+        packages: [sshtunnel]
 python3-stable-baselines3-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9525,13 +9525,8 @@ python3-sshtunnel:
   debian: [python3-sshtunnel]
   fedora: [python3-sshtunnel]
   ubuntu:
-    '*': [python3-sshtunnel]
-    focal:
-      pip:
-        packages: [sshtunnel]
-    jammy:
-      pip:
-        packages: [sshtunnel]
+    focal: [python3-sshtunnel]
+    jammy: [python3-sshtunnel]
 python3-stable-baselines3-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9532,12 +9532,6 @@ python3-sshtunnel:
     jammy:
       pip:
         packages: [sshtunnel]
-    kinetic:
-      pip:
-        packages: [sshtunnel]
-    lunar:
-      pip:
-        packages: [sshtunnel]
 python3-stable-baselines3-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9521,6 +9521,13 @@ python3-squaternion-pip:
   ubuntu:
     pip:
       packages: [squaternion]
+python3-sshtunnel:
+  debian: [python3-sshtunnel]
+  fedora: [python3-sshtunnel]
+  ubuntu: [python3-sshtunnel]
+  ubuntu:
+    pip:
+      packages: [sshtunnel]
 python3-stable-baselines3-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

sshtunnel

## Package Upstream Source:

https://github.com/pahaz/sshtunnel

## Purpose of using this:

sshtunnel offers pure python way to ssh on different machines. The following use case is copied from https://github.com/pahaz/sshtunnel/#usage-scenarios

> One of the typical scenarios where sshtunnel is helpful is depicted in the figure below. User may need to connect a port of a remote server (i.e. 8080) where only SSH port (usually port 22) is reachable.

```

    ----------------------------------------------------------------------

                                |
    -------------+              |    +----------+
        LOCAL    |              |    |  REMOTE  | :22 SSH
        CLIENT   | <== SSH ========> |  SERVER  | :8080 web service
    -------------+              |    +----------+
                                |
                             FIREWALL (only port 22 is open)

    ----------------------------------------------------------------------
```

> Fig1: How to connect to a service blocked by a firewall through SSH tunnel.

In my use case it is used to access ROS logs/bags saved in mongo DBs on different machines via a mongo client with help of the sshtunnel's `SSHTunnelForwarder` class.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/unstable/python3-sshtunnel
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/focal/python3-sshtunnel
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-sshtunnel/python3-sshtunnel/
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available
- openSUSE: https://software.opensuse.org/package/
  - not available