### PR TITLE
mod: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2447,6 +2447,18 @@ repositories:
       url: https://github.com/dfki-ric/mir_robot.git
       version: rolling
     status: developed
+  mod:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/OrebroUniversity/mod-release.git
+      version: 1.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/OrebroUniversity/mod.git
+      version: master
+    status: developed
   moveit:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mod` to `1.1.0-1`:

- upstream repository: https://bitbucket.org/mapsofdynamics/mod
- release repository: https://github.com/OrebroUniversity/mod-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
