### PR TITLE
cras_ros_utils: 2.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2069,12 +2069,14 @@ repositories:
     release:
       packages:
       - cras_cpp_common
+      - cras_docs_common
       - cras_py_common
       - cras_topic_tools
+      - image_transport_codecs
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
-      version: 2.0.10-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/ctu-vras/ros-utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_ros_utils` to `2.1.0-1`:

- upstream repository: https://github.com/ctu-vras/ros-utils
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.10-1`

## cras_cpp_common

```
* log_utils: Added a method to set logger to HasLogger class.
* c_api: Added outputRosMessage() method that directly serializes ROS messages into allocated buffers.
* log_utils: Added MemoryLogHelper, reworked the interface of LogHelper a bit.
* Completely reworked log_utils to use macros instead of functions.
  This was needed because of the static log_location variables inside ROS_ macros - e.g. _ONCE was only triggered once regardless of where was it called from. There were also not so helpful file:line data in the logged messages.
  Backwards compatibility was kept 99%, but there are subtle cases where it will fail - e.g. if there was this->log->logError() right after an if or else without braces.
* Added c_api.h.
* Added cras::expected.
* Fixed doxygen configuration and a few documentation errors.
  To get a clean rosdoc_lite run, set
  INPUT_FILTER = "sed 's/([ <])::/1/g'"
  in doxy.template in rosdoc_lite .
* xmlrpc_value_utils: Added conversion to dynamic_reconfigure/Config message.
* string_utils: Added cras::strip().
* Added std::any shim.
* Contributors: Martin Pecka
```

## cras_docs_common

```
* Add python3-catkin-sphinx dependency as it has been added to rosdep.
* Install the Spinx theme files.
* Improved Sphinx CSS.
* Fix tests.
* Temporarily disable python3-catkin-sphinx until the rosdep key exists.
* Added license.
* Added cras_docs_common with a common Sphinx configuration.
* Contributors: Martin Pecka
```

## cras_py_common

```
* ctypes_utils: Added specialized allocators for ROS messages and for rosconsole logs.
* string_utils: Register genpy Time and Duration for to_str() conversion, too.
* ctypes_utils: Do not add one byte to StringAlloc allocated size. The caller has to do it now.
* ctypes_utils: Autodetection of length of a BufferStringIO stream.
* ctypes_utils: Added get_ro_c_buffer.
* Added utilities for working with ctypes.
* Allow resetting nodes by topic.
* Added support for enums in to_str() and param utils.
* Hide tf2_ros includes in geometry_utils.py inside function calls.
* Contributors: Martin Pecka
```

## cras_topic_tools

```
* Added cras::ShapeShifter as a memory-safe option for Melodic.
* Added a method to convert a message instance to ShapeShifter.
* Contributors: Martin Pecka
```

## image_transport_codecs

```
* Verify that compressedDepth decoder input is large enough to avoid accessing invalid memory.
* Added basic input checking to RVL.
* Added image_transport_codecs.
* Contributors: Martin Pecka
```
