### PR TITLE
maliput: 1.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2593,7 +2593,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput-release.git
-      version: 1.0.9-1
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput` to `1.1.0-1`:

- upstream repository: https://github.com/maliput/maliput.git
- release repository: https://github.com/ros2-gbp/maliput-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.9-1`

## maliput

```
* Adds dimension static const to vector class. (#541 <https://github.com/maliput/maliput/issues/541>)
* Fixes logger-level-0ff behavior. (#540 <https://github.com/maliput/maliput/issues/540>)
* Adds maliput profiler (#538 <https://github.com/maliput/maliput/issues/538>)
* Provides a default ToRoadPosition/FindRoadPosition implementations using kdtree data structure (#517 <https://github.com/maliput/maliput/issues/517>)
* PhaseRingBookLoader supporting empty rules for the phases. (#536 <https://github.com/maliput/maliput/issues/536>)
* Provides new-rule-api compatible RoadNetwork's constructor. (#535 <https://github.com/maliput/maliput/issues/535>)
* Contributors: Franco Cipollone
```
