### PR TITLE
Ubuntu jammy entry for python3-udev

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4082,7 +4082,12 @@ python-pyudev:
     trusty_python3: [python3-pyudev]
     xenial_python3: [python3-pyudev]
     zesty_python3: [python3-pyudev]
-    jammy: [python3-pyudev]
+python3-pyudev:
+  debian: [python3-pyudev]
+  fedora: [python3-pyudev]
+  gentoo: [dev-python/pyudev]
+  nixos: [pythonPackages.pyudev]
+  ubuntu: [python3-pyudev]
 python-pyusb-pip:
   debian:
     pip: [pyusb]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4082,6 +4082,7 @@ python-pyudev:
     trusty_python3: [python3-pyudev]
     xenial_python3: [python3-pyudev]
     zesty_python3: [python3-pyudev]
+    jammy: [python3-pyudev]
 python-pyusb-pip:
   debian:
     pip: [pyusb]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4082,12 +4082,6 @@ python-pyudev:
     trusty_python3: [python3-pyudev]
     xenial_python3: [python3-pyudev]
     zesty_python3: [python3-pyudev]
-python3-pyudev:
-  debian: [python3-pyudev]
-  fedora: [python3-pyudev]
-  gentoo: [dev-python/pyudev]
-  nixos: [pythonPackages.pyudev]
-  ubuntu: [python3-pyudev]
 python-pyusb-pip:
   debian:
     pip: [pyusb]
@@ -8907,6 +8901,12 @@ python3-pytrinamic-pip:
   ubuntu:
     pip:
       packages: [pytrinamic]
+python3-pyudev:
+  debian: [python3-pyudev]
+  fedora: [python3-pyudev]
+  gentoo: [dev-python/pyudev]
+  nixos: [pythonPackages.pyudev]
+  ubuntu: [python3-pyudev]
 python3-pyvista-pip:
   debian:
     pip:


### PR DESCRIPTION
## Package name:

python3-udev

## Package Upstream Source:

https://packages.ubuntu.com/source/jammy/pyudev

## Purpose of using this:

Adding an entry for Ubuntu jammy so the default "python-udev" is not used.

## Links to Distribution Packages

https://packages.ubuntu.com/jammy/python3-pyudev


