### PR TITLE
py_trees_ros: 2.2.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3789,6 +3789,22 @@ repositories:
       url: https://github.com/splintered-reality/py_trees_js.git
       version: release/0.6.x
     status: maintained
+  py_trees_ros:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros.git
+      version: release/2.2.x
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/py_trees_ros-release.git
+      version: 2.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros.git
+      version: release/2.2.x
+    status: developed
   py_trees_ros_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `2.2.1-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros
- release repository: https://github.com/ros2-gbp/py_trees_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## py_trees_ros

```
* [behaviours] eliminate more arg name defaults, #201 <https://github.com/splintered-reality/py_trees_ros/pull/201>
```
