### PR TITLE
wall_follower_ros2: 0.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7256,6 +7256,11 @@ repositories:
       version: master
     status: maintained
   wall_follower_ros2:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/wall_follower_ros2-release.git
+      version: 0.0.1-1
     source:
       type: git
       url: https://github.com/rfzeg/wall_follower_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wall_follower_ros2` to `0.0.1-1`:

- upstream repository: https://github.com/rfzeg/wall_follower_ros2
- release repository: https://github.com/ros2-gbp/wall_follower_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## wall_follower_ros2

```
* Add initial version with logical behavoir depending upon 5 zones around the robot
* Contributors: Roberto Zegers
```
