### PR TITLE
Python: Add MCAP ROS 2 support python package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -277,6 +277,25 @@ jupyter-notebook:
 libgv-python:
   debian: [libgv-python]
   ubuntu: [libgv-python]
+mcap-ros2-support:
+  debian:
+    pip:
+      packages: [mcap-ros2-support]
+  fedora:
+    pip:
+      packages: [mcap-ros2-support]
+  gentoo:
+    pip:
+      packages: [mcap-ros2-support]
+  nixos:
+    pip:
+      packages: [mcap-ros2-support]
+  osx:
+    pip:
+      packages: [mcap-ros2-support]
+  ubuntu:
+    pip:
+      packages: [mcap-ros2-support]
 mercurial:
   osx:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

mcaps-ros2-support

## Package Upstream Source:

PyPi entry: https://pypi.org/project/mcap-ros2-support/
Github Repo: https://github.com/foxglove/mcap

## Purpose of using this:

This provides a python interface to reading/writing MCAP files with ROS 2 messages in them.  It has no dependencies on ROS 2 itself, but can be used in workspaces that are producing/consuming MCAP files with ROS 2 messages in them.

This is a peer to the `mcap_vendor` which is used in `rosbag2`, which only provides the equivalent C++ implmementatin.

## Links to Distribution Packages

As far as I'm aware, this is only available through PyPI, and not directly packaged for any distributions at the moment.