### PR TITLE
pybind11_catkin: 2.10.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7589,11 +7589,19 @@ repositories:
       version: release/0.6.x
     status: maintained
   pybind11_catkin:
+    doc:
+      type: git
+      url: https://github.com/wxmerkt/pybind11_catkin.git
+      version: master
     release:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/wxmerkt/pybind11_catkin-release.git
-      version: 2.5.0-1
+      version: 2.10.3-1
+    source:
+      type: git
+      url: https://github.com/wxmerkt/pybind11_catkin.git
+      version: master
     status: maintained
   pyhri:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `pybind11_catkin` to `2.10.3-1`:

- upstream repository: https://github.com/ipab-slmc/pybind11_catkin.git
- release repository: https://github.com/wxmerkt/pybind11_catkin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.5.0-1`

## pybind11_catkin

```
* Ignore DESTDIR for the internal ExternalProject_Add() command (#19 <https://github.com/ipab-slmc/pybind11_catkin/issues/19>)
* Update CI from Travis to GitHub Actions
* Update pybind11 to version 2.10.3 to support python3.11 (#21 <https://github.com/ipab-slmc/pybind11_catkin/issues/21>)
* Update pybind to version 2.6.1 (#13 <https://github.com/ipab-slmc/pybind11_catkin/issues/13>)
* Contributors: Henry Schreiner, Hongzhuo Liang, Johannes Meyer, Wolfgang Merkt
```
