### PR TITLE
pal_gazebo_plugins: 4.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3388,6 +3388,21 @@ repositories:
       url: https://github.com/OUXT-Polaris/ouxt_common.git
       version: master
     status: developed
+  pal_gazebo_plugins:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pal_gazebo_plugins.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/pal_gazebo_plugins-release.git
+      version: 4.0.1-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pal_gazebo_plugins.git
+      version: humble-devel
+    status: developed
   pal_gazebo_worlds:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_gazebo_plugins` to `4.0.1-1`:

- upstream repository: https://github.com/pal-robotics/pal_gazebo_plugins.git
- release repository: https://github.com/pal-gbp/pal_gazebo_plugins-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## pal_gazebo_plugins

```
* Merge branch 'fix_dependency' into 'humble-devel'
  change gazebo dependency to gazebo_dev
  See merge request common/pal_gazebo_plugins!21
* change gazebo dependency to gazebo_dev
* Contributors: Jordan Palacios, Noel Jimenez
```
