### PR TITLE
ros2_control: 3.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4312,7 +4312,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.7.0-1
+      version: 3.8.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.8.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.7.0-1`

## controller_interface

```
* Fix CMake install so overriding works (#926 <https://github.com/ros-controls/ros2_control/issues/926>)
* Async params (#927 <https://github.com/ros-controls/ros2_control/issues/927>)
* Contributors: Márk Szitanics, Tyler Weaver
```

## controller_manager

```
* Fix CMake install so overriding works (#926 <https://github.com/ros-controls/ros2_control/issues/926>)
* 🖤 Add Black formatter for Python files. (#936 <https://github.com/ros-controls/ros2_control/issues/936>)
* Add list_hardware_components CLI <https://github.com/ros-controls/ros2_control/issues/796>`_ - Adds list_hardware_components to CLI (#891 <https://github.com/ros-controls/ros2_control/issues/891>)
* Contributors: Andy McEvoy, Dr. Denis, Tyler Weaver
```

## controller_manager_msgs

```
* Fix CMake install so overriding works (#926 <https://github.com/ros-controls/ros2_control/issues/926>)
* Contributors: Tyler Weaver
```

## hardware_interface

```
* Fix CMake install so overriding works (#926 <https://github.com/ros-controls/ros2_control/issues/926>)
* Async params (#927 <https://github.com/ros-controls/ros2_control/issues/927>)
* Contributors: Márk Szitanics, Tyler Weaver
```

## joint_limits

```
* Fix CMake install so overriding works (#926 <https://github.com/ros-controls/ros2_control/issues/926>)
* 🖤 Add Black formatter for Python files. (#936 <https://github.com/ros-controls/ros2_control/issues/936>)
* Contributors: Dr. Denis, Tyler Weaver
```

## ros2_control

```
* Fix CMake install so overriding works (#926 <https://github.com/ros-controls/ros2_control/issues/926>)
* Contributors: Tyler Weaver
```

## ros2_control_test_assets

```
* Fix CMake install so overriding works (#926 <https://github.com/ros-controls/ros2_control/issues/926>)
* Contributors: Tyler Weaver
```

## ros2controlcli

```
* 🖤 Add Black formatter for Python files. (#936 <https://github.com/ros-controls/ros2_control/issues/936>)
* Add list_hardware_components CLI  <https://github.com/ros-controls/ros2_control/issues/796>`_ - Adds list_hardware_components to CLI (#891 <https://github.com/ros-controls/ros2_control/issues/891>)
* Contributors: Andy McEvoy, Dr. Denis
```

## rqt_controller_manager

```
* 🖤 Add Black formatter for Python files. (#936 <https://github.com/ros-controls/ros2_control/issues/936>)
* Contributors: Dr. Denis
```

## transmission_interface

```
* Fix CMake install so overriding works (#926 <https://github.com/ros-controls/ros2_control/issues/926>)
* Contributors: Tyler Weaver
```
