### PR TITLE
ros2_controllers: 3.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4343,7 +4343,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 3.1.0-1
+      version: 3.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `3.2.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.1.0-1`

## admittance_controller

```
* Fix overriding of install (#510 <https://github.com/ros-controls/ros2_controllers/issues/510>)
* Contributors: Tyler Weaver, Chris Thrasher
```

## diff_drive_controller

```
* Fix overriding of install (#510 <https://github.com/ros-controls/ros2_controllers/issues/510>)
* Remove compile warnings. (#519 <https://github.com/ros-controls/ros2_controllers/issues/519>)
* Contributors: Dr. Denis, Tyler Weaver, Chris Thrasher
```

## effort_controllers

```
* Fix overriding of install (#510 <https://github.com/ros-controls/ros2_controllers/issues/510>)
* Contributors: Tyler Weaver, Chris Thrasher
```

## force_torque_sensor_broadcaster

```
* Fix overriding of install (#510 <https://github.com/ros-controls/ros2_controllers/issues/510>)
* Contributors: Tyler Weaver, Chris Thrasher
```

## forward_command_controller

```
* Fix overriding of install (#510 <https://github.com/ros-controls/ros2_controllers/issues/510>)
* Contributors: Tyler Weaver, Chris Thrasher
```

## gripper_controllers

```
* Fix overriding of install (#510 <https://github.com/ros-controls/ros2_controllers/issues/510>)
* Contributors: Tyler Weaver, Chris Thrasher
```

## imu_sensor_broadcaster

```
* Fix overriding of install (#510 <https://github.com/ros-controls/ros2_controllers/issues/510>)
* Contributors: Tyler Weaver, Chris Thrasher
```

## joint_state_broadcaster

```
* Fix overriding of install (#510 <https://github.com/ros-controls/ros2_controllers/issues/510>)
* Contributors: Tyler Weaver, Chris Thrasher
```

## joint_trajectory_controller

```
* fix JTC segfault (#518 <https://github.com/ros-controls/ros2_controllers/issues/518>)
* fix interpolation logic (#516 <https://github.com/ros-controls/ros2_controllers/issues/516>)
* Fix overriding of install (#510 <https://github.com/ros-controls/ros2_controllers/issues/510>)
* Add JTC normalize_error parameter to doc (#511 <https://github.com/ros-controls/ros2_controllers/issues/511>)
* Fix JTC segfault on unload (#515 <https://github.com/ros-controls/ros2_controllers/issues/515>)
* Don't set interpolation_method_ twice (#517 <https://github.com/ros-controls/ros2_controllers/issues/517>)
* Remove compile warnings. (#519 <https://github.com/ros-controls/ros2_controllers/issues/519>)
* Contributors: Andy Zelenak, Christoph Fröhlich, Dr. Denis, Michael Wiznitzer, Márk Szitanics, Solomon Wiznitzer, Tyler Weaver, Chris Thrasher
```

## position_controllers

```
* Fix overriding of install (#510 <https://github.com/ros-controls/ros2_controllers/issues/510>)
* Contributors: Tyler Weaver, Chris Thrasher
```

## ros2_controllers

```
* Fix overriding of install (#510 <https://github.com/ros-controls/ros2_controllers/issues/510>)
* Contributors: Tyler Weaver, Chris Thrasher
```

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## tricycle_controller

```
* Fix overriding of install (#510 <https://github.com/ros-controls/ros2_controllers/issues/510>)
* Contributors: Tyler Weaver, Chris Thrasher
```

## velocity_controllers

```
* Fix overriding of install (#510 <https://github.com/ros-controls/ros2_controllers/issues/510>)
* Contributors: Tyler Weaver, Chris Thrasher
```
