### PR TITLE
microstrain_inertial: 3.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2414,7 +2414,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/microstrain_inertial-release.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `3.0.1-1`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/ros2-gbp/microstrain_inertial-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.0-1`

## microstrain_inertial_driver

```
* Publishes after every packet to fix lower data rate problem (#229 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/229>)
  * Publishes after every packet to fix lower data rate problem
* Updates submodule with microseconds to nanoseconds fix (#227 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/227>)
* ROS Fixes odom data rate mapping to refer to the correct topic (#224 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/224>)
  * Fixes odom data rate mapping to refer to the correct topic
* Contributors: Rob
```

## microstrain_inertial_examples

- No changes

## microstrain_inertial_msgs

- No changes

## microstrain_inertial_rqt

- No changes
