### PR TITLE
rosidl_python: 0.17.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4762,7 +4762,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.16.1-1
+      version: 0.17.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_python` to `0.17.0-1`:

- upstream repository: https://github.com/ros2/rosidl_python.git
- release repository: https://github.com/ros2-gbp/rosidl_python-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.16.1-1`

## rosidl_generator_py

```
* Service introspection (#178 <https://github.com/ros2/rosidl_python/issues/178>)
* [rolling] Update maintainers - 2022-11-07 (#189 <https://github.com/ros2/rosidl_python/issues/189>)
* Contributors: Audrow Nash, Brian
```
