### PR TITLE
rosidl: 3.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4688,7 +4688,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 3.3.1-1
+      version: 3.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `3.4.0-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.3.1-1`

## rosidl_adapter

```
* rosidl_adapter/cmake/rosidl_adapt_interfaces.cmake: Make ament free (#709 <https://github.com/ros2/rosidl/issues/709>)
* [service introspection] generate service_event messages (#700 <https://github.com/ros2/rosidl/issues/700>)
* Adding tests for unicode support in message comments. (#720 <https://github.com/ros2/rosidl/issues/720>)
* [rolling] Update maintainers - 2022-11-07 (#717 <https://github.com/ros2/rosidl/issues/717>)
* Contributors: Audrow Nash, Brian, Guilherme Henrique Galelli Christmann, Yasushi SHOJI
```

## rosidl_cli

```
* [rolling] Update maintainers - 2022-11-07 (#717 <https://github.com/ros2/rosidl/issues/717>)
* Contributors: Audrow Nash
```

## rosidl_cmake

```
* [service introspection] generate service_event messages (#700 <https://github.com/ros2/rosidl/issues/700>)
* [rolling] Update maintainers - 2022-11-07 (#717 <https://github.com/ros2/rosidl/issues/717>)
* Contributors: Audrow Nash, Brian
```

## rosidl_generator_c

```
* [service introspection] generate service_event messages (#700 <https://github.com/ros2/rosidl/issues/700>)
* [rolling] Update maintainers - 2022-11-07 (#717 <https://github.com/ros2/rosidl/issues/717>)
* Contributors: Audrow Nash, Brian
```

## rosidl_generator_cpp

```
* [service introspection] generate service_event messages (#700 <https://github.com/ros2/rosidl/issues/700>)
* [rolling] Update maintainers - 2022-11-07 (#717 <https://github.com/ros2/rosidl/issues/717>)
* Contributors: Audrow Nash, Brian
```

## rosidl_parser

```
* [service introspection] generate service_event messages (#700 <https://github.com/ros2/rosidl/issues/700>)
* [rolling] Update maintainers - 2022-11-07 (#717 <https://github.com/ros2/rosidl/issues/717>)
* Contributors: Audrow Nash, Brian
```

## rosidl_pycommon

```
* [rolling] Update maintainers - 2022-11-07 (#717 <https://github.com/ros2/rosidl/issues/717>)
* Contributors: Audrow Nash
```

## rosidl_runtime_c

```
* [service introspection] generate service_event messages (#700 <https://github.com/ros2/rosidl/issues/700>)
* [rolling] Update maintainers - 2022-11-07 (#717 <https://github.com/ros2/rosidl/issues/717>)
* Contributors: Audrow Nash, Brian
```

## rosidl_runtime_cpp

```
* [service introspection] generate service_event messages (#700 <https://github.com/ros2/rosidl/issues/700>)
* [rolling] Update maintainers - 2022-11-07 (#717 <https://github.com/ros2/rosidl/issues/717>)
* fix conversion to ‘std::streamsize’ {aka ‘long int’} from ‘size_t’ {aka ‘long unsigned int’} may change the sign of the result (#715 <https://github.com/ros2/rosidl/issues/715>)
* Contributors: Audrow Nash, Brian, ralwing
```

## rosidl_typesupport_interface

```
* [service introspection] generate service_event messages (#700 <https://github.com/ros2/rosidl/issues/700>)
* [rolling] Update maintainers - 2022-11-07 (#717 <https://github.com/ros2/rosidl/issues/717>)
* Contributors: Audrow Nash, Brian
```

## rosidl_typesupport_introspection_c

```
* [service introspection] generate service_event messages (#700 <https://github.com/ros2/rosidl/issues/700>)
* [rolling] Update maintainers - 2022-11-07 (#717 <https://github.com/ros2/rosidl/issues/717>)
* Contributors: Audrow Nash, Brian
```

## rosidl_typesupport_introspection_cpp

```
* Make sure to add the event message to typesupport introspection cpp. (#724 <https://github.com/ros2/rosidl/issues/724>)
* [service introspection] generate service_event messages (#700 <https://github.com/ros2/rosidl/issues/700>)
* [rolling] Update maintainers - 2022-11-07 (#717 <https://github.com/ros2/rosidl/issues/717>)
* Contributors: Audrow Nash, Brian, Chris Lalancette
```
