### PR TITLE
rmw_dds_common: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4171,7 +4171,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_dds_common-release.git
-      version: 1.7.1-1
+      version: 2.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_dds_common` to `2.0.0-1`:

- upstream repository: https://github.com/ros2/rmw_dds_common.git
- release repository: https://github.com/ros2-gbp/rmw_dds_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.7.1-1`

## rmw_dds_common

```
* Update rmw_dds_common to C++17. (#69 <https://github.com/ros2/rmw_dds_common/issues/69>)
* Change Gid.msg to be 16 bytes. (#68 <https://github.com/ros2/rmw_dds_common/issues/68>)
* Minor cleanups of test_qos. (#67 <https://github.com/ros2/rmw_dds_common/issues/67>)
* [rolling] Update maintainers - 2022-11-07 (#65 <https://github.com/ros2/rmw_dds_common/issues/65>)
* Contributors: Audrow Nash, Chris Lalancette
```
