### PR TITLE
rmw: 7.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4118,7 +4118,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 6.4.0-1
+      version: 7.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw` to `7.0.0-1`:

- upstream repository: https://github.com/ros2/rmw.git
- release repository: https://github.com/ros2-gbp/rmw-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `6.4.0-1`

## rmw

```
* Add rmw count clients, services (#334 <https://github.com/ros2/rmw/issues/334>)
* make writer_guid uint8_t[] instead of int8_t for consistency with rmw_gid_t (#329 <https://github.com/ros2/rmw/issues/329>)
* Update rmw to C++17. (#346 <https://github.com/ros2/rmw/issues/346>)
* Reduce GID storage to 16 bytes. (#345 <https://github.com/ros2/rmw/issues/345>)
* Move the RMW_CHECK_TYPE_IDENTIFIERS_MATCH macro to a C header. (#343 <https://github.com/ros2/rmw/issues/343>)
* [rolling] Update maintainers - 2022-11-07 (#337 <https://github.com/ros2/rmw/issues/337>)
* Contributors: Audrow Nash, Brian, Chris Lalancette, Minju, Lee
```

## rmw_implementation_cmake

```
* [rolling] Update maintainers - 2022-11-07 (#337 <https://github.com/ros2/rmw/issues/337>)
* Contributors: Audrow Nash
```
