### PR TITLE
rcpputils: 2.6.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3760,7 +3760,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 2.6.0-1
+      version: 2.6.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `2.6.1-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.6.0-1`

## rcpputils

```
* Add missing header for strlen (#169 <https://github.com/ros2/rcpputils/issues/169>)
* issue-167 (#172 <https://github.com/ros2/rcpputils/issues/172>)
* [rolling] Update maintainers - 2022-11-07 (#166 <https://github.com/ros2/rcpputils/issues/166>)
* Contributors: Audrow Nash, Sebastian Freitag, bijoua29
```
