### PR TITLE
rcutils: 6.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3811,7 +3811,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 6.0.1-1
+      version: 6.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `6.1.0-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `6.0.1-1`

## rcutils

```
* Add SHA256 utility implementation (#408 <https://github.com/ros2/rcutils/issues/408>)
* Upgrade rcutils to C++17. (#392 <https://github.com/ros2/rcutils/issues/392>)
* [rolling] Update maintainers - 2022-11-07 (#404 <https://github.com/ros2/rcutils/issues/404>)
* Contributors: Audrow Nash, Chris Lalancette, Emerson Knapp
```
