### PR TITLE
rclpy: 3.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3744,7 +3744,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 3.7.1-1
+      version: 3.8.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `3.8.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.7.1-1`

## rclpy

```
* Force C++17 support on. (#1076 <https://github.com/ros2/rclpy/issues/1076>)
* Use RCPPUTILS_SCOPE_EXIT to cleanup unparsed_indices_c. (#1075 <https://github.com/ros2/rclpy/issues/1075>)
* Explicitly link atomic when building with Clang (#1065 <https://github.com/ros2/rclpy/issues/1065>)
* Fix test_publisher linter for pydocstyle 6.2.2 (#1063 <https://github.com/ros2/rclpy/issues/1063>)
* Add default preset qos profile (#1062 <https://github.com/ros2/rclpy/issues/1062>)
* Add on_parameter_event method to the AsyncParameterClient. (#1061 <https://github.com/ros2/rclpy/issues/1061>)
* Add documentation page for rclpy.clock (#1055 <https://github.com/ros2/rclpy/issues/1055>)
* Rewrite test code without depending on parameter client (#1045 <https://github.com/ros2/rclpy/issues/1045>)
* Add parallel callback test (#1044 <https://github.com/ros2/rclpy/issues/1044>)
* decorator should not be callable. (#1050 <https://github.com/ros2/rclpy/issues/1050>)
* typo fix. (#1049 <https://github.com/ros2/rclpy/issues/1049>)
* Add in a warning for a depth of 0 with KEEP_LAST. (#1048 <https://github.com/ros2/rclpy/issues/1048>)
* Add feature of wait for message (#953 <https://github.com/ros2/rclpy/issues/953>). (#960 <https://github.com/ros2/rclpy/issues/960>)
* Document rclpy.time.Time class (#1040 <https://github.com/ros2/rclpy/issues/1040>)
* Deal with ParameterUninitializedException for parameter service (#1033 <https://github.com/ros2/rclpy/issues/1033>)
* Improve documentation in rclpy.utilities (#1038 <https://github.com/ros2/rclpy/issues/1038>)
* Document rclpy.utilities.remove_ros_args (#1036 <https://github.com/ros2/rclpy/issues/1036>)
* Fix incorrect comparsion on whether parameter type is NOT_SET (#1032 <https://github.com/ros2/rclpy/issues/1032>)
* [rolling] Update maintainers (#1035 <https://github.com/ros2/rclpy/issues/1035>)
* Contributors: Audrow Nash, Barry Xu, Chris Lalancette, Cristóbal Arroyo, Florian Vahl, Ivan Santiago Paunovic, Lei Liu, Sebastian Freitag, Shane Loretz, Tomoya Fujita
```
