### PR TITLE
test_interface_files: 0.10.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5783,7 +5783,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/test_interface_files-release.git
-      version: 0.10.1-1
+      version: 0.10.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `test_interface_files` to `0.10.2-1`:

- upstream repository: https://github.com/ros2/test_interface_files.git
- release repository: https://github.com/ros2-gbp/test_interface_files-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.10.1-1`

## test_interface_files

```
* [rolling] Update maintainers - 2022-11-07 (#21 <https://github.com/ros2/test_interface_files/issues/21>)
* Contributors: Audrow Nash
```
