### PR TITLE
spdlog_vendor: 1.4.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5592,7 +5592,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/spdlog_vendor-release.git
-      version: 1.4.2-1
+      version: 1.4.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `spdlog_vendor` to `1.4.3-1`:

- upstream repository: https://github.com/ros2/spdlog_vendor.git
- release repository: https://github.com/ros2-gbp/spdlog_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.4.2-1`

## spdlog_vendor

```
* [rolling] Update maintainers - 2022-11-07 (#31 <https://github.com/ros2/spdlog_vendor/issues/31>)
* Contributors: Audrow Nash
```
