### PR TITLE
kdl_parser: 2.9.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1929,7 +1929,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/kdl_parser-release.git
-      version: 2.8.2-1
+      version: 2.9.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kdl_parser` to `2.9.0-1`:

- upstream repository: https://github.com/ros/kdl_parser.git
- release repository: https://github.com/ros2-gbp/kdl_parser-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.8.2-1`

## kdl_parser

```
* Switch some tests to use unique pointers instead of raw pointers. (#74 <https://github.com/ros/kdl_parser/issues/74>)
* log link children as DEBUG instead of INFO (#71 <https://github.com/ros/kdl_parser/issues/71>)
* Contributors: Chris Lalancette, Joseph Schornak
```
