### PR TITLE
rosidl_runtime_py: 0.11.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4794,7 +4794,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
-      version: 0.11.0-1
+      version: 0.11.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_runtime_py` to `0.11.1-1`:

- upstream repository: https://github.com/ros2/rosidl_runtime_py.git
- release repository: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.11.0-1`

## rosidl_runtime_py

```
* [rolling] Update maintainers - 2022-11-07 (#21 <https://github.com/ros2/rosidl_runtime_py/issues/21>)
* Contributors: Audrow Nash
```
