### PR TITLE
rosidl_core: 0.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4723,7 +4723,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_core-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_core` to `0.1.1-1`:

- upstream repository: https://github.com/ros2/rosidl_core.git
- release repository: https://github.com/ros2-gbp/rosidl_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.0-1`

## rosidl_core_generators

```
* [rolling] Update maintainers - 2022-11-07 (#2 <https://github.com/ros2/rosidl_core/issues/2>)
* Contributors: Audrow Nash
```

## rosidl_core_runtime

```
* [rolling] Update maintainers - 2022-11-07 (#2 <https://github.com/ros2/rosidl_core/issues/2>)
* Contributors: Audrow Nash
```
