### PR TITLE
ament_cmake_ros: 0.11.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -148,7 +148,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake_ros-release.git
-      version: 0.11.1-1
+      version: 0.11.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake_ros` to `0.11.2-1`:

- upstream repository: https://github.com/ros2/ament_cmake_ros.git
- release repository: https://github.com/ros2-gbp/ament_cmake_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.11.1-1`

## ament_cmake_ros

```
* [rolling] Update maintainers - 2022-11-07 (#16 <https://github.com/ros2/ament_cmake_ros/issues/16>)
* Contributors: Audrow Nash
```

## domain_coordinator

```
* [rolling] Update maintainers - 2022-11-07 (#16 <https://github.com/ros2/ament_cmake_ros/issues/16>)
* Contributors: Audrow Nash
```
