### PR TITLE
robot_state_publisher: 3.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4287,7 +4287,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/robot_state_publisher-release.git
-      version: 3.1.1-1
+      version: 3.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `3.1.2-1`:

- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros2-gbp/robot_state_publisher-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.1.1-1`

## robot_state_publisher

```
* [rolling] Update maintainers - 2022-11-07 (#203 <https://github.com/ros/robot_state_publisher/issues/203>)
* Contributors: Audrow Nash
```
