### PR TITLE
urdf: 2.8.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6206,7 +6206,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdf-release.git
-      version: 2.8.1-1
+      version: 2.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf` to `2.8.2-1`:

- upstream repository: https://github.com/ros2/urdf.git
- release repository: https://github.com/ros2-gbp/urdf-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.8.1-1`

## urdf

```
* [rolling] Update maintainers - 2022-11-07 (#35 <https://github.com/ros2/urdf/issues/35>)
* Contributors: Audrow Nash
```

## urdf_parser_plugin

```
* [rolling] Update maintainers - 2022-11-07 (#35 <https://github.com/ros2/urdf/issues/35>)
* Contributors: Audrow Nash
```
