### PR TITLE
ros_testing: 0.5.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4584,7 +4584,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_testing-release.git
-      version: 0.5.1-1
+      version: 0.5.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_testing` to `0.5.2-1`:

- upstream repository: https://github.com/ros2/ros_testing.git
- release repository: https://github.com/ros2-gbp/ros_testing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.5.1-1`

## ros2test

```
* [rolling] Update maintainers - 2022-11-07 (#12 <https://github.com/ros2/ros_testing/issues/12>)
* Contributors: Audrow Nash
```

## ros_testing

```
* [rolling] Update maintainers - 2022-11-07 (#12 <https://github.com/ros2/ros_testing/issues/12>)
* Contributors: Audrow Nash
```
