### PR TITLE
libyaml_vendor: 1.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2212,7 +2212,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libyaml_vendor-release.git
-      version: 1.4.2-1
+      version: 1.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libyaml_vendor` to `1.5.0-1`:

- upstream repository: https://github.com/ros2/libyaml_vendor.git
- release repository: https://github.com/ros2-gbp/libyaml_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.4.2-1`

## libyaml_vendor

```
* Fix system package dependency (#54 <https://github.com/ros2/libyaml_vendor/issues/54>)
* Update libyaml_vendor to C++17. (#55 <https://github.com/ros2/libyaml_vendor/issues/55>)
* [rolling] Update maintainers - 2022-11-07 (#53 <https://github.com/ros2/libyaml_vendor/issues/53>)
* Contributors: Audrow Nash, Chris Lalancette, Scott K Logan
```
