### PR TITLE
class_loader: 2.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -635,7 +635,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/class_loader-release.git
-      version: 2.4.0-1
+      version: 2.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `2.5.0-1`:

- upstream repository: https://github.com/ros/class_loader.git
- release repository: https://github.com/ros2-gbp/class_loader-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.4.0-1`

## class_loader

```
* make sanitizer happy (#205 <https://github.com/ros/class_loader/issues/205>)
* [rolling] Update maintainers - 2022-11-07 (#206 <https://github.com/ros/class_loader/issues/206>)
* Contributors: Audrow Nash, Chen Lihui
```
