### PR TITLE
locator_ros_bridge: 2.1.8-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2227,10 +2227,11 @@ repositories:
     release:
       packages:
       - bosch_locator_bridge
+      - bosch_locator_bridge_utils
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/locator_ros_bridge-release.git
-      version: 2.1.7-1
+      version: 2.1.8-1
     source:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `locator_ros_bridge` to `2.1.8-1`:

- upstream repository: https://github.com/boschglobal/locator_ros_bridge.git
- release repository: https://github.com/ros2-gbp/locator_ros_bridge-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.7-1`

## bosch_locator_bridge

```
* Support setting arbitrary Locator config entries
* Update module versions in server node
* Use mutex to just make one json_rpc_call at a time
* Contributors: Fabian König, Stefan Laible
```

## bosch_locator_bridge_utils

```
* Initial version
* Contributors: Fabian König, Stefan Laible
```
