### PR TITLE
Revert "ament_cmake: 1.5.3-1 in 'rolling/distribution.yaml' [bloom]"

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -114,7 +114,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 1.5.3-1
+      version: 1.5.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Looks like this has caused major regressions in the buildfarm.  Reverting until we can determine the best route forward.

Reverts ros/rosdistro#36137