### PR TITLE
tlsf: 0.8.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5854,7 +5854,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tlsf-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tlsf` to `0.8.2-1`:

- upstream repository: https://github.com/ros2/tlsf.git
- release repository: https://github.com/ros2-gbp/tlsf-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.8.1-1`

## tlsf

```
* [rolling] Update maintainers - 2022-11-07 (#13 <https://github.com/ros2/tlsf/issues/13>)
* Contributors: Audrow Nash
```
