### PR TITLE
rclcpp: 19.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3728,7 +3728,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 19.0.0-1
+      version: 19.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `19.1.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `19.0.0-1`

## rclcpp

```
* Add support for timers on reset callback (#1979 <https://github.com/ros2/rclcpp/issues/1979>)
* Topic node guard condition in executor (#2074 <https://github.com/ros2/rclcpp/issues/2074>)
* Fix bug on the disorder of calling shutdown callback (#2097 <https://github.com/ros2/rclcpp/issues/2097>)
* Contributors: Barry Xu, Chen Lihui, mauropasse
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
