### PR TITLE
ros2cli: 0.22.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4464,7 +4464,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.21.0-1
+      version: 0.22.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.22.0-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.21.0-1`

## ros2action

```
* [rolling] Update maintainers - 2022-11-07 (#776 <https://github.com/ros2/ros2cli/issues/776>)
* Contributors: Audrow Nash
```

## ros2cli

```
* Save method list via connection check to XMLRPC server. (#796 <https://github.com/ros2/ros2cli/issues/796>)
* ZSH argcomplete: call compinit only if needed (#750 <https://github.com/ros2/ros2cli/issues/750>)
* Fix network aware node issue (#785 <https://github.com/ros2/ros2cli/issues/785>)
* [rolling] Update maintainers - 2022-11-07 (#776 <https://github.com/ros2/ros2cli/issues/776>)
* Contributors: Audrow Nash, Ivan Santiago Paunovic, Tomoya Fujita, mjbogusz
```

## ros2cli_test_interfaces

```
* [rolling] Update maintainers - 2022-11-07 (#776 <https://github.com/ros2/ros2cli/issues/776>)
* Contributors: Audrow Nash
```

## ros2component

```
* [rolling] Update maintainers - 2022-11-07 (#776 <https://github.com/ros2/ros2cli/issues/776>)
* Contributors: Audrow Nash
```

## ros2doctor

```
* [rolling] Update maintainers - 2022-11-07 (#776 <https://github.com/ros2/ros2cli/issues/776>)
* Contributors: Audrow Nash
```

## ros2interface

```
* [rolling] Update maintainers - 2022-11-07 (#776 <https://github.com/ros2/ros2cli/issues/776>)
* Contributors: Audrow Nash
```

## ros2lifecycle

```
* [rolling] Update maintainers - 2022-11-07 (#776 <https://github.com/ros2/ros2cli/issues/776>)
* Contributors: Audrow Nash
```

## ros2lifecycle_test_fixtures

```
* Update the ros2cli test fixture to C++17. (#789 <https://github.com/ros2/ros2cli/issues/789>)
* [rolling] Update maintainers - 2022-11-07 (#776 <https://github.com/ros2/ros2cli/issues/776>)
* Contributors: Audrow Nash, Chris Lalancette
```

## ros2multicast

```
* [rolling] Update maintainers - 2022-11-07 (#776 <https://github.com/ros2/ros2cli/issues/776>)
* Contributors: Audrow Nash
```

## ros2node

```
* [rolling] Update maintainers - 2022-11-07 (#776 <https://github.com/ros2/ros2cli/issues/776>)
* Updated wording in list.py (#775 <https://github.com/ros2/ros2cli/issues/775>)
* Contributors: Audrow Nash, Michael Wrock
```

## ros2param

```
* Fix printing of integer and double arrays. (#804 <https://github.com/ros2/ros2cli/issues/804>)
* [rolling] Update maintainers - 2022-11-07 (#776 <https://github.com/ros2/ros2cli/issues/776>)
* Contributors: Audrow Nash, Chris Lalancette
```

## ros2pkg

```
* resolve #790 <https://github.com/ros2/ros2cli/issues/790> (#801 <https://github.com/ros2/ros2cli/issues/801>)
* Add alias library targets for CMake (#718 <https://github.com/ros2/ros2cli/issues/718>)
* [rolling] Update maintainers - 2022-11-07 (#776 <https://github.com/ros2/ros2cli/issues/776>)
* Contributors: Audrow Nash, Kenji Brameld, RFRIEDM-Trimble
```

## ros2run

```
* [rolling] Update maintainers - 2022-11-07 (#776 <https://github.com/ros2/ros2cli/issues/776>)
* Contributors: Audrow Nash
```

## ros2service

```
* [rolling] Update maintainers - 2022-11-07 (#776 <https://github.com/ros2/ros2cli/issues/776>)
* Contributors: Audrow Nash
```

## ros2topic

```
* Fix some flake8 warnings related to style. (#805 <https://github.com/ros2/ros2cli/issues/805>)
* Adds a timeout feature to rostopic echo (#792 <https://github.com/ros2/ros2cli/issues/792>)
* Refactor common types (#791 <https://github.com/ros2/ros2cli/issues/791>)
* Allow configuring liveliness in ros2 topic echo and pub (#788 <https://github.com/ros2/ros2cli/issues/788>)
* Extend timeout to shutdown the command line process. (#783 <https://github.com/ros2/ros2cli/issues/783>)
* [rolling] Update maintainers - 2022-11-07 (#776 <https://github.com/ros2/ros2cli/issues/776>)
* a couple of typo fixes. (#774 <https://github.com/ros2/ros2cli/issues/774>)
* Contributors: Arjo Chakravarty, Audrow Nash, Chris Lalancette, Ivan Santiago Paunovic, Tomoya Fujita
```
