### PR TITLE
launch: 1.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2103,7 +2103,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 1.3.0-1
+      version: 1.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `1.4.0-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.0-1`

## launch

```
* Pass modules to PythonExpression (#655 <https://github.com/ros2/launch/issues/655>)
* Allow ReadyToTest() usage in event handler (#665 <https://github.com/ros2/launch/issues/665>)
* Expose emulate_tty to xml and yaml launch (#669 <https://github.com/ros2/launch/issues/669>)
* Expose sigterm_timeout and sigkill_timeout to xml frontend (#667 <https://github.com/ros2/launch/issues/667>)
* [rolling] Update maintainers - 2022-11-07 (#671 <https://github.com/ros2/launch/issues/671>)
* Contributors: Aditya Pande, Audrow Nash, Blake Anderson, Nikolai Morin
```

## launch_pytest

```
* Drop unused data_files entry for example_processes (#680 <https://github.com/ros2/launch/issues/680>)
* Spelling correction
* [rolling] Update maintainers - 2022-11-07 (#671 <https://github.com/ros2/launch/issues/671>)
* Contributors: Audrow Nash, Geoffrey Biggs, Scott K Logan
```

## launch_testing

```
* Allow ReadyToTest() usage in event handler (#665 <https://github.com/ros2/launch/issues/665>)
* Inherit markers from generate_test_description (#670 <https://github.com/ros2/launch/issues/670>)
* [rolling] Update maintainers - 2022-11-07 (#671 <https://github.com/ros2/launch/issues/671>)
* Contributors: Audrow Nash, Nikolai Morin, Scott K Logan
```

## launch_testing_ament_cmake

```
* [rolling] Update maintainers - 2022-11-07 (#671 <https://github.com/ros2/launch/issues/671>)
* Contributors: Audrow Nash
```

## launch_xml

```
* Expose emulate_tty to xml and yaml launch (#669 <https://github.com/ros2/launch/issues/669>)
* Expose sigterm_timeout and sigkill_timeout to xml frontend (#667 <https://github.com/ros2/launch/issues/667>)
* [rolling] Update maintainers - 2022-11-07 (#671 <https://github.com/ros2/launch/issues/671>)
* Contributors: Aditya Pande, Audrow Nash
```

## launch_yaml

```
* Expose emulate_tty to xml and yaml launch (#669 <https://github.com/ros2/launch/issues/669>)
* Expose sigterm_timeout and sigkill_timeout to xml frontend (#667 <https://github.com/ros2/launch/issues/667>)
* [rolling] Update maintainers - 2022-11-07 (#671 <https://github.com/ros2/launch/issues/671>)
* Contributors: Aditya Pande, Audrow Nash
```
