### PR TITLE
launch_ros: 0.23.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2138,7 +2138,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.22.0-1
+      version: 0.23.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.23.0-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.22.0-1`

## launch_ros

```
* Fix normalize_parameters_dict for multiple nodes in the same namespace (#347 <https://github.com/ros2/launch_ros/issues/347>)
* Implement None check for ComposableNodeContainer (#341 <https://github.com/ros2/launch_ros/issues/341>)
* Add LifecyleTransition action (#317 <https://github.com/ros2/launch_ros/issues/317>)
* Improve evaluate_paramenter_dict exceptions error message (#320 <https://github.com/ros2/launch_ros/issues/320>)
* Ensure load_composable_nodes respects condition (#339 <https://github.com/ros2/launch_ros/issues/339>)
* fix: return text value to avoid exception (#338 <https://github.com/ros2/launch_ros/issues/338>)
* [rolling] Update maintainers - 2022-11-07 (#331 <https://github.com/ros2/launch_ros/issues/331>)
* Contributors: Alexey Merzlyakov, Audrow Nash, Christoph Hellmann Santos, Daisuke Nishimatsu, Felipe Gomes de Melo, methylDragon
```

## launch_testing_ros

```
* Inherit markers from generate_test_description (#330 <https://github.com/ros2/launch_ros/issues/330>)
* [rolling] Update maintainers - 2022-11-07 (#331 <https://github.com/ros2/launch_ros/issues/331>)
* Contributors: Audrow Nash, Scott K Logan
```

## ros2launch

```
* [rolling] Update maintainers - 2022-11-07 (#331 <https://github.com/ros2/launch_ros/issues/331>)
* Contributors: Audrow Nash
```
