### PR TITLE
google_benchmark_vendor: 0.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1500,7 +1500,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/google_benchmark_vendor-release.git
-      version: 0.2.0-1
+      version: 0.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `google_benchmark_vendor` to `0.3.0-1`:

- upstream repository: https://github.com/ament/google_benchmark_vendor.git
- release repository: https://github.com/ros2-gbp/google_benchmark_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.0-1`

## google_benchmark_vendor

```
* Actually update to 1.6.1. (#25 <https://github.com/ament/google_benchmark_vendor/issues/25>)
  We claimed we were, but in fact we were pinned to the 1.5.3 git hash.
* Remove set but unused variable (#24 <https://github.com/ament/google_benchmark_vendor/issues/24>)
  Clang checks -Wunused-but-set-variable.
  This fails the build with -Werror also enabled.
* [rolling] Update maintainers - 2022-11-07 (#22 <https://github.com/ament/google_benchmark_vendor/issues/22>)
* Mirror rolling to main
* Contributors: Audrow Nash, Chris Lalancette, Michael Carroll
```
