### PR TITLE
Adding rosdep rule for python3-pymap3d

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8268,7 +8268,8 @@ python3-pylibdmtx:
       pip:
         packages: [pylibdmtx]
 python3-pymap3d:
-  debian: [python3-pymap3d]
+  debian:
+    bullseye: [python3-pymap3d]
   ubuntu:
     jammy: [python3-pymap3d]
 python3-pymesh2-pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8267,6 +8267,8 @@ python3-pylibdmtx:
     focal:
       pip:
         packages: [pylibdmtx]
+python3-pymap3d:
+  ubuntu: [python3-pymap3d]
 python3-pymesh2-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -392,8 +392,16 @@ pyflakes3:
   ubuntu: [pyflakes3]
 pymap3d-pip:
   debian:
-    pip:
-      packages: [pymap3d]
+    '*': null
+    buster:
+      pip:
+        packages: [pymap3d]
+    stretch:
+      pip:
+        packages: [pymap3d]
+    jessie:
+      pip:
+        packages: [pymap3d]
   fedora:
     pip:
       packages: [pymap3d]
@@ -401,8 +409,13 @@ pymap3d-pip:
     pip:
       packages: [pymap3d]
   ubuntu:
-    pip:
-      packages: [pymap3d]
+    '*': null
+    focal:
+      pip:
+        packages: [pymap3d]
+    bionic:
+      pip:
+        packages: [pymap3d]
 pymodbustcp-pip:
   debian:
     pip:
@@ -8638,10 +8651,15 @@ python3-pylibdmtx:
         packages: [pylibdmtx]
 python3-pymap3d:
   debian:
-    bullseye: [python3-pymap3d]
+    '*': [python3-pymap3d]
+    buster: null
+    stretch: null
+    jessie: null
   gentoo: [sci-geosciences/pymap3d]
   ubuntu:
-    jammy: [python3-pymap3d]
+    '*': [python3-pymap3d]
+    focal: null
+    bionic: null
 python3-pymesh2-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -396,10 +396,10 @@ pymap3d-pip:
     buster:
       pip:
         packages: [pymap3d]
-    stretch:
+    jessie:
       pip:
         packages: [pymap3d]
-    jessie:
+    stretch:
       pip:
         packages: [pymap3d]
   fedora:
@@ -410,10 +410,10 @@ pymap3d-pip:
       packages: [pymap3d]
   ubuntu:
     '*': null
-    focal:
+    bionic:
       pip:
         packages: [pymap3d]
-    bionic:
+    focal:
       pip:
         packages: [pymap3d]
 pymodbustcp-pip:
@@ -8653,13 +8653,13 @@ python3-pymap3d:
   debian:
     '*': [python3-pymap3d]
     buster: null
-    stretch: null
     jessie: null
+    stretch: null
   gentoo: [sci-geosciences/pymap3d]
   ubuntu:
     '*': [python3-pymap3d]
-    focal: null
     bionic: null
+    focal: null
 python3-pymesh2-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8268,7 +8268,7 @@ python3-pylibdmtx:
       pip:
         packages: [pylibdmtx]
 python3-pymap3d:
-  ubuntu: 
+  ubuntu:
     jammy: [python3-pymap3d]
 python3-pymesh2-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8268,6 +8268,7 @@ python3-pylibdmtx:
       pip:
         packages: [pylibdmtx]
 python3-pymap3d:
+  debian: [python3-pymap3d]
   ubuntu:
     jammy: [python3-pymap3d]
 python3-pymesh2-pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8268,7 +8268,8 @@ python3-pylibdmtx:
       pip:
         packages: [pylibdmtx]
 python3-pymap3d:
-  ubuntu: [python3-pymap3d]
+  ubuntu: 
+    jammy: [python3-pymap3d]
 python3-pymesh2-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8639,6 +8639,7 @@ python3-pylibdmtx:
 python3-pymap3d:
   debian:
     bullseye: [python3-pymap3d]
+  gentoo: [sci-geosciences/pymap3d]
   ubuntu:
     jammy: [python3-pymap3d]
 python3-pymesh2-pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-pymap3d

## Package Upstream Source:

https://github.com/geospace-code/pymap3d

## Purpose of using this:

As explained in #36088, `pymap3d-pip` key is not available in Ubuntu Jammy. Following Steve's suggestion, I'm opening this PR. 

Distro packaging links:

## Links to Distribution Packages

- Debian:
  - https://packages.debian.org/bullseye/python3-pymap3d
- Ubuntu:
   - https://packages.ubuntu.com/jammy/python3-pymap3d
- Fedora:
  - Not Available
- Arch:
  - Not Available
- Gentoo:
  - https://packages.gentoo.org/packages/sci-geosciences/pymap3d
- macOS:
  - Not Available
- Alpine:
  - Not Available
- NixOS/nixpkgs:
  - Not Available
- openSUSE:
  - Not Available