### PR TITLE
interactive_markers: 2.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1856,7 +1856,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/interactive_markers-release.git
-      version: 2.3.2-1
+      version: 2.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_markers` to `2.4.0-1`:

- upstream repository: https://github.com/ros-visualization/interactive_markers.git
- release repository: https://github.com/ros2-gbp/interactive_markers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.2-1`

## interactive_markers

```
* Update interactive_markers to C++17. (#99 <https://github.com/ros-visualization/interactive_markers/issues/99>)
* Update maintainers (#98 <https://github.com/ros-visualization/interactive_markers/issues/98>)
* Mirror rolling to ros2
* update maintainer (#92 <https://github.com/ros-visualization/interactive_markers/issues/92>)
* Contributors: Audrow Nash, Chris Lalancette, Dharini Dutia
```
