### PR TITLE
laser_geometry: 2.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2064,7 +2064,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/laser_geometry-release.git
-      version: 2.4.0-1
+      version: 2.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_geometry` to `2.5.0-1`:

- upstream repository: https://github.com/ros-perception/laser_geometry.git
- release repository: https://github.com/ros2-gbp/laser_geometry-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.4.0-1`

## laser_geometry

```
* Update laser_geometry to C++17. (#90 <https://github.com/ros-perception/laser_geometry/issues/90>)
* Update Maintainers (#88 <https://github.com/ros-perception/laser_geometry/issues/88>)
* Mirror rolling to ros2
* Contributors: Audrow Nash, Chris Lalancette
```
