### PR TITLE
ament_index: 1.5.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -182,7 +182,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_index-release.git
-      version: 1.5.1-1
+      version: 1.5.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_index` to `1.5.2-1`:

- upstream repository: https://github.com/ament/ament_index.git
- release repository: https://github.com/ros2-gbp/ament_index-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.5.1-1`

## ament_index_cpp

```
* [rolling] Update maintainers - 2022-11-07 (#89 <https://github.com/ament/ament_index/issues/89>)
* Contributors: Audrow Nash
```

## ament_index_python

```
* [rolling] Update maintainers - 2022-11-07 (#89 <https://github.com/ament/ament_index/issues/89>)
* Contributors: Audrow Nash
```
