### PR TITLE
rqt_srv: 1.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5225,7 +5225,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_srv-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_srv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_srv` to `1.1.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_srv.git
- release repository: https://github.com/ros2-gbp/rqt_srv-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-1`

## rqt_srv

```
* [rolling] Update maintainers - 2022-11-07 (#10 <https://github.com/ros-visualization/rqt_srv/issues/10>)
* Contributors: Audrow Nash, Jacob Perron
```
