### PR TITLE
rqt_console: 2.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4979,7 +4979,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_console-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_console` to `2.1.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_console.git
- release repository: https://github.com/ros2-gbp/rqt_console-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.0-1`

## rqt_console

```
* [rolling] Update maintainers - 2022-11-07 (#39 <https://github.com/ros-visualization/rqt_console/issues/39>)
* Contributors: Arne Hitzmann, Audrow Nash
```
