### PR TITLE
rqt_action: 2.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4931,7 +4931,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_action-release.git
-      version: 2.1.1-1
+      version: 2.1.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_action.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_action` to `2.1.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_action.git
- release repository: https://github.com/ros2-gbp/rqt_action-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.1-1`

## rqt_action

```
* [rolling] Update maintainers - 2022-11-07 (#14 <https://github.com/ros-visualization/rqt_action/issues/14>)
* Contributors: Audrow Nash
```
