### PR TITLE
osrf_pycommon: 2.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3015,7 +3015,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/osrf_pycommon-release.git
-      version: 2.1.0-1
+      version: 2.1.2-1
     source:
       type: git
       url: https://github.com/osrf/osrf_pycommon.git


### PR DESCRIPTION
Increasing version of package(s) in repository `osrf_pycommon` to `2.1.2-1`:

- upstream repository: https://github.com/osrf/osrf_pycommon.git
- release repository: https://github.com/ros2-gbp/osrf_pycommon-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.0-1`

## osrf_pycommon

```
* [master] Update maintainers - 2022-11-07 (#89 <https://github.com/osrf/osrf_pycommon/issues/89>)
* Contributors: Audrow Nash
```
