### PR TITLE
rqt_bag: 1.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4949,7 +4949,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
-      version: 1.2.1-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `1.3.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros2-gbp/rqt_bag-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.1-1`

## rqt_bag

```
* Use rosbag2_py API instead of direct bag parsing
* [rolling] Update maintainers - 2022-11-07 (#132 <https://github.com/ros-visualization/rqt_bag/issues/132>)
* For get_entry_after, bump by 1 nanosecond otherwise always get the same message equal to the timestamp
* Use rosbag2_py.reader for all message queries, remove sqlite3 direct usage
* Cleanup for review
* Improved logging
* Use a rosbag2_py.Reader to get bag metadata
* Disable reading from bag while recording - use direct caching to index for timeline
* Contributors: Audrow Nash, Emerson Knapp
```

## rqt_bag_plugins

```
* [rolling] Update maintainers - 2022-11-07 (#132 <https://github.com/ros-visualization/rqt_bag/issues/132>)
* Contributors: Audrow Nash
```
