### PR TITLE
quaternion_operation: 0.0.12-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3941,7 +3941,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/quaternion_operation-release.git
-      version: 0.0.11-1
+      version: 0.0.12-2
     source:
       type: git
       url: https://github.com/OUXT-Polaris/quaternion_operation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `quaternion_operation` to `0.0.12-2`:

- upstream repository: https://github.com/OUXT-Polaris/quaternion_operation.git
- release repository: https://github.com/ros2-gbp/quaternion_operation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.11-1`

## quaternion_operation

```
* add header file (#63 <https://github.com/OUXT-Polaris/quaternion_operation/issues/63>)
* Setup workflow (#62 <https://github.com/OUXT-Polaris/quaternion_operation/issues/62>)
* [Bot] Update workflow (#61 <https://github.com/OUXT-Polaris/quaternion_operation/issues/61>)
  * Setup workflow
  * empty commit
  Co-authored-by: Masaya Kataoka <mailto:ms.kataoka@gmail.com>
* Contributors: Masaya Kataoka, wam-v-tan
```
