### PR TITLE
add rig_reconfigure source repo

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4367,6 +4367,13 @@ repositories:
       url: https://github.com/ros/resource_retriever.git
       version: humble
     status: maintained
+  rig_reconfigure:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/teamspatzenhirn/rig_reconfigure.git
+      version: master
+    status: developed
   rmf_api_msgs:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3872,6 +3872,13 @@ repositories:
       url: https://github.com/ros/resource_retriever.git
       version: rolling
     status: maintained
+  rig_reconfigure:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/teamspatzenhirn/rig_reconfigure.git
+      version: master
+    status: developed
   rmf_api_msgs:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

New package `rig_reconfigure` for `humble` and `rolling` distribution.

# The source is here:

https://github.com/teamspatzenhirn/rig_reconfigure

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
