### PR TITLE
rosbag2: 0.20.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4635,7 +4635,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.19.0-1
+      version: 0.20.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.20.0-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.19.0-1`

## mcap_vendor

- No changes

## ros2bag

```
* CLI: Get storage-specific values from plugin (#1209 <https://github.com/ros2/rosbag2/issues/1209>)
* Contributors: Emerson Knapp
```

## rosbag2

- No changes

## rosbag2_compression

- No changes

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

- No changes

## rosbag2_examples_cpp

- No changes

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

```
* Skip ament_package() call when not building rosbag2_performance_benchmarking (#1242 <https://github.com/ros2/rosbag2/issues/1242>)
* Contributors: Shane Loretz
```

## rosbag2_performance_benchmarking_msgs

```
* Skip ament_package() call when not building rosbag2_performance_benchmarking (#1242 <https://github.com/ros2/rosbag2/issues/1242>)
* Contributors: Shane Loretz
```

## rosbag2_py

- No changes

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

```
* CLI: Get storage-specific values from plugin (#1209 <https://github.com/ros2/rosbag2/issues/1209>)
* Contributors: Emerson Knapp
```

## rosbag2_storage_mcap_testdata

- No changes

## rosbag2_storage_sqlite3

```
* CLI: Get storage-specific values from plugin (#1209 <https://github.com/ros2/rosbag2/issues/1209>)
* Contributors: Emerson Knapp
```

## rosbag2_test_common

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

- No changes

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
