### PR TITLE
ros2_tracing: 5.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4417,7 +4417,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 4.1.0-1
+      version: 5.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `5.0.0-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.1.0-1`

## tracetools

```
* Update tracing to C++17. (#33 <https://github.com/ros2/ros2_tracing/issues/33>)
* Contributors: Chris Lalancette
```

## tracetools_launch

```
* Remove deprecated context_names parameter (#38 <https://github.com/ros2/ros2_tracing/issues/38>)
* Contributors: Christophe Bedard
```

## tracetools_trace

```
* Replace distutils.version.StrictVersion with packaging.version.Version (#42 <https://github.com/ros2/ros2_tracing/issues/42>)
* Remove deprecated context_names parameter (#38 <https://github.com/ros2/ros2_tracing/issues/38>)
* Contributors: Christophe Bedard
```
