### PR TITLE
executive_smach: 2.5.1-1 in 'noetic/distribution.yaml' [non-bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2361,7 +2361,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/executive_smach-release.git
-      version: 2.5.0-1
+      version: 2.5.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `executive_smach` to 2.5.1-1:

- upstream repository: https://github.com/ros/executive_smach.git
- release repository: https://github.com/ros-gbp/executive_smach-release.git
- distro file: noetic/distribution.yaml
- bloom version: 0.11.2
- previous version for package: 2.5.0-1