### PR TITLE
ros_comm: 1.16.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8613,7 +8613,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.15.15-1
+      version: 1.16.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.16.0-1`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.15.15-1`

## message_filters

- No changes

## ros_comm

- No changes

## rosbag

```
* add missing repeat_latched initialization (#2314 <https://github.com/ros/ros_comm/issues/2314>)
* Contributors: Robin Vanhove
```

## rosbag_storage

- No changes

## roscpp

- No changes

## rosgraph

```
* Fix determining supported kernel version for HTTP 1.1 (#2202 <https://github.com/ros/ros_comm/issues/2202>)
* Contributors: Martin Pecka
```

## roslaunch

- No changes

## roslz4

- No changes

## rosmaster

- No changes

## rosmsg

- No changes

## rosnode

- No changes

## rosout

- No changes

## rosparam

- No changes

## rospy

- No changes

## rosservice

```
* --noarr and --nostr option in rosservice call (#2307 <https://github.com/ros/ros_comm/issues/2307>)
* Contributors: Shingo Kitagawa
```

## rostest

- No changes

## rostopic

- No changes

## roswtf

- No changes

## topic_tools

- No changes

## xmlrpcpp

- No changes
