### PR TITLE
maliput_sparse: 0.2.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2776,7 +2776,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput_sparse-release.git
-      version: 0.2.2-1
+      version: 0.2.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_sparse` to `0.2.3-1`:

- upstream repository: https://github.com/maliput/maliput_sparse.git
- release repository: https://github.com/ros2-gbp/maliput_sparse-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.2-1`

## maliput_sparse

```
* Relies on GetClosestPoint for the GetClosestPointUsing2dProjection method. (#53 <https://github.com/maliput/maliput_sparse/issues/53>)
* Stores linestring's points in a kdtree. (#52 <https://github.com/maliput/maliput_sparse/issues/52>)
* Precomputes linestring's segments intervals (#51 <https://github.com/maliput/maliput_sparse/issues/51>)
* Contributors: Franco Cipollone
```
