### PR TITLE
maliput_integration: 0.1.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2657,7 +2657,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput_integration-release.git
-      version: 0.1.4-1
+      version: 0.1.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_integration` to `0.1.5-1`:

- upstream repository: https://github.com/maliput/maliput_integration.git
- release repository: https://github.com/ros2-gbp/maliput_integration-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.4-1`

## maliput_integration

```
* Adds GetConfluentBranches and GetOngoingBranches query support. (#130 <https://github.com/maliput/maliput_integration/issues/130>)
* Adds queries to get parameter list from backends. (#129 <https://github.com/maliput/maliput_integration/issues/129>)
* Contributors: Franco Cipollone
```
