### PR TITLE
roslisp: 1.9.25-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11649,7 +11649,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/roslisp-release.git
-      version: 1.9.24-1
+      version: 1.9.25-1
     source:
       type: git
       url: https://github.com/ros/roslisp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roslisp` to `1.9.25-1`:

- upstream repository: git://github.com/ros/roslisp.git
- release repository: https://github.com/ros-gbp/roslisp-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.9.24-1`
