### PR TITLE
Run checks with pytest

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -8,8 +8,8 @@ permissions:
   contents: read
 
 jobs:
-  nosetests:
-    name: Nosetests
+  checks:
+    name: rosdistro / rosdep checks
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -28,8 +28,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install -r test/requirements.txt
+    - name: Run Tests
+      run: pytest -s
     - name: Run Nose Tests
-      run: nosetests -s
+      run: |
+        pip install nose
+        nosetests -s
   yamllint:
     name: Yaml Linting
     runs-on: ubuntu-20.04

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -27,11 +27,7 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install PyYAML argparse
-        pip install catkin-pkg ros-buildfarm rosdistro nose coverage
-        pip install unidiff
-        pip install rosdep
-        pip install PyGithub
+        python -m pip install -r test/requirements.txt
     - name: Run Nose Tests
       run: nosetests -s
   yamllint:

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -29,7 +29,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install -r test/requirements.txt
     - name: Run Tests
-      run: pytest -s
+      run: pytest -s test
     - name: Run Nose Tests
       run: |
         pip install nose

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,0 +1,8 @@
+PyGitHub
+PyYAML
+catkin_pkg
+pytest
+ros_buildfarm
+rosdep
+rosdistro
+unidiff


### PR DESCRIPTION
nose isn't maintained and does not work with Python 3.10. We've moved most of the rest of our infrastructure package tests to pytest.

While in the tests I also added a `requirements.txt` file for test dependencies and pruned `argparse`, which is in the standard library as of Python 3.2 and `coverage` which does not appear to be used in this project.