### PR TITLE
foxglove_bridge: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2782,7 +2782,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/foxglove/ros_foxglove_bridge-release.git
-      version: 0.3.0-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_bridge` to `0.4.0-1`:

- upstream repository: https://github.com/foxglove/ros-foxglove-bridge.git
- release repository: https://github.com/foxglove/ros_foxglove_bridge-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.0-1`

## foxglove_bridge

```
* Update README with suggestion to build from source, minor fixes
* Do not build docker images, remove corresponding documentation (#159 <https://github.com/foxglove/ros-foxglove-bridge/issues/159>)
* Add option to use permessage-deflate compression (#152 <https://github.com/foxglove/ros-foxglove-bridge/issues/152>)
* Improve launch file documentation, add missing launch file arguments (#158 <https://github.com/foxglove/ros-foxglove-bridge/issues/158>)
* Allow unsetting (deleting) parameters (#145 <https://github.com/foxglove/ros-foxglove-bridge/issues/145>)
* Improve mutex usage (#154 <https://github.com/foxglove/ros-foxglove-bridge/issues/154>)
* Add sessionId to serverInfo (#153 <https://github.com/foxglove/ros-foxglove-bridge/issues/153>)
* Performance improvements (#151 <https://github.com/foxglove/ros-foxglove-bridge/issues/151>)
* Add ROS2 support for calling server-advertised services (#142 <https://github.com/foxglove/ros-foxglove-bridge/issues/142>)
* Add ROS1 support for calling server-advertised services (#136 <https://github.com/foxglove/ros-foxglove-bridge/issues/136>)
* ROS2 smoke test: Increase default timeout 8->10 seconds (#143 <https://github.com/foxglove/ros-foxglove-bridge/issues/143>)
* Fix flaky parameter test (noetic) (#141 <https://github.com/foxglove/ros-foxglove-bridge/issues/141>)
* Always --pull when building docker images in the makefile (#140 <https://github.com/foxglove/ros-foxglove-bridge/issues/140>)
* Fix failed tests not causing CI to fail (#138 <https://github.com/foxglove/ros-foxglove-bridge/issues/138>)
* Fix setting int / int[] parameters not working (ROS 1) (#135 <https://github.com/foxglove/ros-foxglove-bridge/issues/135>)
* Send ROS_DISTRO to clients via metadata field (#134 <https://github.com/foxglove/ros-foxglove-bridge/issues/134>)
* Communicate supported encodings for client-side publishing (#131 <https://github.com/foxglove/ros-foxglove-bridge/issues/131>)
* Fix client advertised channels not being updated on unadvertise (#132 <https://github.com/foxglove/ros-foxglove-bridge/issues/132>)
* Add support for optional request id for setParameter operation (#133 <https://github.com/foxglove/ros-foxglove-bridge/issues/133>)
* Fix exception when setting parameter to empty array (#130 <https://github.com/foxglove/ros-foxglove-bridge/issues/130>)
* Fix wrong parameter field names being used (#129 <https://github.com/foxglove/ros-foxglove-bridge/issues/129>)
* Add parameter support (#112 <https://github.com/foxglove/ros-foxglove-bridge/issues/112>)
* Add throttled logging when send buffer is full (#128 <https://github.com/foxglove/ros-foxglove-bridge/issues/128>)
* Contributors: Hans-Joachim Krauch, John Hurliman
```
