### PR TITLE
Revert "Add apa102-pi in 'rosdep/python.yaml'"

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6022,15 +6022,6 @@ python3-anytree-pip:
   ubuntu:
     pip:
       packages: [anytree]
-python3-apa102-pi-pip:
-  debian:
-    pip:
-      depends: [python-rpi.gpio-pip]
-      packages: [apa102-pi]
-  ubuntu:
-    pip:
-      depends: [python-rpi.gpio-pip]
-      packages: [apa102-pi]
 python3-argcomplete:
   alpine: [py3-argcomplete]
   arch: [python-argcomplete]


### PR DESCRIPTION
35045 was merged prematurely.

Reverts ros/rosdistro#36045