### PR TITLE
Stop running tests with nose.

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -30,10 +30,6 @@ jobs:
         python -m pip install -r test/requirements.txt
     - name: Run Tests
       run: pytest -s test
-    - name: Run Nose Tests
-      run: |
-        pip install nose
-        nosetests -s
   yamllint:
     name: Yaml Linting
     runs-on: ubuntu-20.04


### PR DESCRIPTION
After a week or so and a few explicit reviews, we should drop the nose test execution. As of #36201 tests are primarily run with pytest.


<details><summary>I should have called this branch tissues</summary>Because it stops running nose</details>