### PR TITLE
ign_ros2_control: 0.4.3-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1839,6 +1839,24 @@ repositories:
       url: https://github.com/ros2-gbp/ifm3d-release.git
       version: 0.18.0-7
     status: developed
+  ign_ros2_control:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/gz_ros2_control.git
+      version: humble
+    release:
+      packages:
+      - ign_ros2_control
+      - ign_ros2_control_demos
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/ign_ros2_control-release.git
+      version: 0.4.3-2
+    source:
+      type: git
+      url: https://github.com/ros-controls/gz_ros2_control.git
+      version: humble
+    status: developed
   ign_rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ign_ros2_control` to `0.4.3-2`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## ign_ros2_control

```
* Fix example demos in humble branch #118 <https://github.com/ros-controls/gz_ros2_control/issues/118> from iche033/iche033/fix_humble_demos
* Remove URDF dependency (#56 <https://github.com/ros-controls/gz_ros2_control/issues/56>)
* Adapt to ROS 2 Humble
* typo in citadel name (#54 <https://github.com/ros-controls/gz_ros2_control/issues/54>)
* ros2_control is now having usings under its namespace. (#43 <https://github.com/ros-controls/gz_ros2_control/issues/43>)
* Fix default ign gazebo version Rolling (#45 <https://github.com/ros-controls/gz_ros2_control/issues/45>)
* Fix ignition version in package.xml - Rolling (#41 <https://github.com/ros-controls/gz_ros2_control/issues/41>)
* Fixed position control (#29 <https://github.com/ros-controls/gz_ros2_control/issues/29>)
* Add support for initial_values for hardware interfaces when starting simulation. (#27 <https://github.com/ros-controls/gz_ros2_control/issues/27>)
* Contributors: Alejandro Hernández Cordero, Bence Magyar, Denis Štogl, Guillaume Beuzeboc
```

## ign_ros2_control_demos

```
* Add tricycle example to the humble branch #119 <https://github.com/ros-controls/gz_ros2_control/issues/119> from azazdeaz/humble
* Replace ros_ign_gazebo with ros_gz_sim
* Add tricycle demo (#80 <https://github.com/ros-controls/gz_ros2_control/issues/80>)
* Fix example demos in humble branch #118 <https://github.com/ros-controls/gz_ros2_control/issues/118> from iche033/iche033/fix_humble_demos
* use ros_gz_sim
* fix demo launch (#75 <https://github.com/ros-controls/gz_ros2_control/issues/75>)
* Adjust URLs (#65 <https://github.com/ros-controls/gz_ros2_control/issues/65>)
* ign_ros2_control_demos: Install urdf dir (#61 <https://github.com/ros-controls/gz_ros2_control/issues/61>)
* Remove URDF dependency (#56 <https://github.com/ros-controls/gz_ros2_control/issues/56>)
* Use Ubuntu Jammy in CI (#47 <https://github.com/ros-controls/gz_ros2_control/issues/47>)
* Add support for initial_values for hardware interfaces when starting simulation. (#27 <https://github.com/ros-controls/gz_ros2_control/issues/27>)
* Contributors: Alejandro Hernández Cordero, Andrej Orsula, Bence Magyar, Denis Štogl, Ian Chen, Maciej Bednarczyk, Polgár András, Tony Najjar
```
