### PR TITLE
foxglove_bridge: 0.4.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1403,7 +1403,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_bridge` to `0.4.1-1`:

- upstream repository: https://github.com/foxglove/ros-foxglove-bridge.git
- release repository: https://github.com/ros2-gbp/foxglove_bridge-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.0-1`

## foxglove_bridge

```
* Run client handler functions in separate thread (#165 <https://github.com/foxglove/ros-foxglove-bridge/issues/165>)
* Fix compilation error due to mismatched new-delete (#163 <https://github.com/foxglove/ros-foxglove-bridge/issues/163>)
* Decouple server implementation (#156 <https://github.com/foxglove/ros-foxglove-bridge/issues/156>)
* ROS2 parameter fixes (#169 <https://github.com/foxglove/ros-foxglove-bridge/issues/169>)
* Fix program crash due to unhandled exception when creating publisher with invalid topic name (#168 <https://github.com/foxglove/ros-foxglove-bridge/issues/168>)
* Contributors: Hans-Joachim Krauch
```
