### PR TITLE
turtlebot4: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6736,6 +6736,26 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
       version: ros2
     status: maintained
+  turtlebot4:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4.git
+      version: humble
+    release:
+      packages:
+      - turtlebot4_description
+      - turtlebot4_msgs
+      - turtlebot4_navigation
+      - turtlebot4_node
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot4-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4.git
+      version: humble
+    status: developed
   turtlesim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4` to `1.0.0-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4.git
- release repository: https://github.com/ros2-gbp/turtlebot4-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## turtlebot4_description

```
* Updates for new DepthAI node.
* Added tf_static remapping to support namespacing
* Updated oakd link names to match new oakd node
* Added fix for wheeldrop frames not found by Rviz
* Namespacing
* Remap tf topics to not use global namespace
* Contributors: Roni Kreinin
```

## turtlebot4_msgs

- No changes

## turtlebot4_navigation

```
* Namespacing
* Linter fixes
* Nav2, localization, and slam launch and config files
* Contributors: Roni Kreinin
```

## turtlebot4_node

```
* Updates for new DepthAI node.
* Linter fixes
* Separated RPLIDAR Motor function into stop/start
* Added OAKD stop/start function
* Added power saver option
* Update display only when something has changed
* Function calls
* Namespacing
* Flash Comms LED based on high frequency wheel status feedback instead of low frequency battery state
* Move comms_timer() from battery_callback() to wheel_status_callback()
* Updated dock action
* Contributors: Joey Yang, Roni Kreinin
```
