### PR TITLE
ros2_control: 2.23.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4870,7 +4870,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.22.0-1
+      version: 2.23.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.23.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.22.0-1`

## controller_interface

- No changes

## controller_manager

```
* Adds list_hardware_components to CLI #796 <https://github.com/ros-controls/ros2_control/issues/796> - Adds list_hardware_components to CLI (#891 <https://github.com/ros-controls/ros2_control/issues/891>) (#937 <https://github.com/ros-controls/ros2_control/issues/937>)
* Do not use CLI calls but direct API for setting parameters. (backport #910 <https://github.com/ros-controls/ros2_control/issues/910>) (#913 <https://github.com/ros-controls/ros2_control/issues/913>)
* Contributors: Andy McEvoy, Denis Stogl
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Adds list_hardware_components to CLI #796 <https://github.com/ros-controls/ros2_control/issues/796> - Adds list_hardware_components to CLI (#891 <https://github.com/ros-controls/ros2_control/issues/891>) (#937 <https://github.com/ros-controls/ros2_control/issues/937>)
* Do not use CLI calls but direct API for setting parameters. (backport #910 <https://github.com/ros-controls/ros2_control/issues/910>) (#913 <https://github.com/ros-controls/ros2_control/issues/913>)
* Contributors: Andy McEvoy, Denis Stogl
```

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
