### PR TITLE
rviz_satellite: 3.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10017,7 +10017,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/nobleo/rviz_satellite-release.git
-      version: 3.0.3-1
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/nobleo/rviz_satellite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_satellite` to `3.1.0-1`:

- upstream repository: https://github.com/nobleo/rviz_satellite.git
- release repository: https://github.com/nobleo/rviz_satellite-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.3-1`

## rviz_satellite

```
* Add possibility to specify TF frames as position reference in UTM mode.
* Turn map and UTM selection UI into TfFrameProperty.
* Simplify UTM frame mode integration.
* Improved map transform type wording.
* Added UTM frame mode.
* Added option to configure the map frame.
* Added missing header file
```
