### PR TITLE
rviz_satellite: 4.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5961,6 +5961,21 @@ repositories:
       url: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git
       version: main
     status: developed
+  rviz_satellite:
+    doc:
+      type: git
+      url: https://github.com/nobleo/rviz_satellite.git
+      version: ros2
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/nobleo/rviz_satellite-release.git
+      version: 4.0.0-1
+    source:
+      type: git
+      url: https://github.com/nobleo/rviz_satellite.git
+      version: ros2
+    status: maintained
   rviz_visual_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_satellite` to `4.0.0-1`:

- upstream repository: https://github.com/nobleo/rviz_satellite.git
- release repository: https://github.com/nobleo/rviz_satellite-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## rviz_satellite

```
* ROS2 support!
* Contributors: Lee Hicks, Marcel Zeilinger, Tim Clephas, Vitaliy Bondar, ceranit
```
