### PR TITLE
Add rosdep rule for img2pdf python package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7371,7 +7371,9 @@ python3-img2pdf:
   nixos: [python39Packages.img2pdf]
   opensuse: [python3-img2pdf]
   ubuntu: [python3-img2pdf]
-  rhel: [python3-img2pdf]
+  rhel:
+    '*': [python3-img2pdf]
+    '7': null
 python3-importlib-metadata:
   alpine: [py3-importlib-metadata]
   arch: [python-importlib-metadata]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7370,10 +7370,10 @@ python3-img2pdf:
   gentoo: [media-gfx/img2pdf]
   nixos: [python39Packages.img2pdf]
   opensuse: [python3-img2pdf]
-  ubuntu: [python3-img2pdf]
   rhel:
     '*': [python3-img2pdf]
     '7': null
+  ubuntu: [python3-img2pdf]
 python3-importlib-metadata:
   alpine: [py3-importlib-metadata]
   arch: [python-importlib-metadata]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7363,6 +7363,7 @@ python3-imageio:
   openembedded: [python3-imageio@meta-python]
   ubuntu: [python3-imageio]
 python3-img2pdf:
+  alpine: [py3-img2pdf]
   arch: [img2pdf]
   debian: [python3-img2pdf]
   fedora: [python3-img2pdf]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7362,6 +7362,15 @@ python3-imageio:
   nixos: [python3Packages.imageio]
   openembedded: [python3-imageio@meta-python]
   ubuntu: [python3-imageio]
+python3-img2pdf:
+  arch: [img2pdf]
+  debian: [python3-img2pdf]
+  fedora: [python3-img2pdf]
+  gentoo: [media-gfx/img2pdf]
+  nixos: [python39Packages.img2pdf]
+  opensuse: [python3-img2pdf]
+  ubuntu: [python3-img2pdf]
+  rhel: [python3-img2pdf]
 python3-importlib-metadata:
   alpine: [py3-importlib-metadata]
   arch: [python-importlib-metadata]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-img2pdf

## Package Upstream Source:

https://gitlab.mister-muffin.de/josch/img2pdf

## Purpose of using this:

I would like to use this dependency in my [aruco_opencv](https://github.com/fictionlab/ros_aruco_opencv/tree/noetic/aruco_opencv) package for converting ArUco marker/board images to PDF format.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/sid/python3-img2pdf
- Ubuntu: https://packages.ubuntu.com/jammy/img2pdf
- Fedora: https://packages.fedoraproject.org/pkgs/python-img2pdf/python3-img2pdf/
- Arch: https://archlinux.org/packages/community/any/img2pdf/
- Gentoo: https://packages.gentoo.org/packages/media-gfx/img2pdf
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/package/edge/community/x86_64/py3-img2pdf
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=22.11&show=python39Packages.img2pdf
- openSUSE: https://software.opensuse.org/package/python3-img2pdf
