### PR TITLE
Add gz-transport-12 for Ubuntu

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1870,6 +1870,10 @@ gz-transport11:
   ubuntu:
     focal: [libgz-transport11-dev]
     jammy: [libgz-transport11-dev]
+gz-transport12:
+  ubuntu:
+    focal: [libgz-transport12-dev]
+    jammy: [libgz-transport12-dev]
 gz-transport8:
   ubuntu:
     focal: [libgz-transport8-dev]


### PR DESCRIPTION
* https://gazebosim.org/libs/transport
* Fixes https://github.com/gazebosim/gz-transport/issues/385

<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

gz-transport-12

## Package Upstream Source:

[link to source repository](https://gazebosim.org/libs/transport)

## Purpose of using this:

For using gazebo garden with ROS2 humble

Distro packaging links:

## Links to Distribution Packages

I cannot find the listings since it's a private cache. However, the build status shows it's being built. I have tested this on Ubuntu 22.04. 

Doing any other package is out of scope since that's all that is released that I can tell. 




# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
