### PR TITLE
Add requirements.txt and instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -295,10 +295,16 @@ How to submit pull requests
 When submitting pull requests it is expected that they pass the unit tests for formatting.
 The unit tests enforce alphabetization of elements and a consistent formatting to keep merging as clean as possible.
 
+If you want to run the tests before submitting, first install the dependencies. Using `pip` is recommended.
+
+```bash
+python3 -m pip install -r requirements.txt
+```
+
 To run the tests run ``nosetests`` in the root of the repository.
 These tests require several dependencies that can be installed either from the ROS repositories or via pip(list built based on the content of [.travis.yaml](https://github.com/ros/rosdistro/blob/master/.travis.yml):
 
-|   Dependency   |            Ubuntu package         |   Pip package  |
+| Dependency   | Ubuntu package (<=20.04)| Pip package  |
 | :------------: | --------------------------------- | -------------- |
 | catkin_pkg     | python-catkin-pkg                 | catkin-pkg     |
 | github         | python-github                     | PyGithub       |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -298,7 +298,7 @@ The unit tests enforce alphabetization of elements and a consistent formatting t
 If you want to run the tests before submitting, first install the dependencies. Using `pip` is recommended.
 
 ```bash
-python3 -m pip install -r requirements.txt
+python3 -m pip install -r test/requirements.txt
 ```
 
 To run the tests run ``nosetests`` in the root of the repository.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+catkin-pkg
+PyGithub
+nose
+rosdistro
+ros-buildfarm
+unidiff
+yamllint
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-catkin-pkg
-PyGithub
-nose
-rosdistro
-ros-buildfarm
-unidiff
-yamllint
-

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,8 +1,10 @@
+catkin-pkg
+nose
 PyGitHub
-PyYAML
-catkin_pkg
 pytest
-ros_buildfarm
+PyYAML
+ros-buildfarm
 rosdep
 rosdistro
 unidiff
+yamllint


### PR DESCRIPTION
* Update ubuntu packages since those only apply to distros 20.04 and earlier, but break on 22.04
* Use pip to avoid having to maintain two package names


Solves this issue: https://github.com/ros/rosdistro/issues/35109
