### PR TITLE
ros_industrial_cmake_boilerplate: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8809,7 +8809,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release.git
-      version: 0.3.1-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_industrial_cmake_boilerplate` to `0.4.0-1`:

- upstream repository: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git
- release repository: https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.1-1`

## ros_industrial_cmake_boilerplate

- No changes
