### PR TITLE
ros_industrial_cmake_boilerplate: 0.4.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5498,6 +5498,12 @@ repositories:
       url: https://github.com/ignitionrobotics/ros_ign.git
       version: foxy
     status: developed
+  ros_industrial_cmake_boilerplate:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release.git
+      version: 0.4.0-1
   ros_testing:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_industrial_cmake_boilerplate` to `0.4.0-1`:

- upstream repository: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git
- release repository: https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## ros_industrial_cmake_boilerplate

- No changes
