### PR TITLE
graceful_controller: 0.4.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4044,7 +4044,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mikeferguson/graceful_controller-gbp.git
-      version: 0.4.5-1
+      version: 0.4.6-1
     source:
       type: git
       url: https://github.com/mikeferguson/graceful_controller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `graceful_controller` to `0.4.6-1`:

- upstream repository: https://github.com/mikeferguson/graceful_controller.git
- release repository: https://github.com/mikeferguson/graceful_controller-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `0.4.5-1`

## graceful_controller

```
* Added flag for backward motion and renamed limit params (#60 <https://github.com/mikeferguson/graceful_controller/issues/60>)
* Contributors: mkaca
```

## graceful_controller_ros

```
* follow acceleration limits when velocity limit changes (#62 <https://github.com/mikeferguson/graceful_controller/issues/62>)
* add angular velocity limiting control (#61 <https://github.com/mikeferguson/graceful_controller/issues/61>)
  Adds max_x_to_max_theta_scale_factor which can be used to control how the angular velocity changes relative to the linear velocity when use_vel_topic feature is enabled.
* Contributors: Michael Ferguson, TrazCobalt
```
