### PR TITLE
control_toolbox: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -743,7 +743,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 2.1.2-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `2.2.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.2-1`

## control_toolbox

```
* Fix overriding of package (#145 <https://github.com/ros-controls/control_toolbox/issues/145>)
* Various dependabot version bumps
* [CI] Add dependabot configuration to automatically update actions.
* Contributors: Christoph Fröhlich, Dr. Denis, Tyler Weaver, dependabot[bot]
```
