### PR TITLE
generate_parameter_library: 0.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1400,7 +1400,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `generate_parameter_library` to `0.3.1-1`:

- upstream repository: https://github.com/PickNikRobotics/generate_parameter_library.git
- release repository: https://github.com/ros2-gbp/generate_parameter_library-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.0-1`

## generate_parameter_library

```
* Add keyword INTERFACE to fix build error 'ar: no archive members specified' since the generated target is header-only (#93 <https://github.com/PickNikRobotics/generate_parameter_library/issues/93>)
* Make it easy for users to override (#92 <https://github.com/PickNikRobotics/generate_parameter_library/issues/92>)
* Contributors: Tyler Weaver, light-tech
```

## generate_parameter_library_example

```
* Make it easy for users to override (#92 <https://github.com/PickNikRobotics/generate_parameter_library/issues/92>)
* Contributors: Tyler Weaver
```

## generate_parameter_library_py

- No changes

## parameter_traits

```
* Make it easy for users to override (#92 <https://github.com/PickNikRobotics/generate_parameter_library/issues/92>)
* Contributors: Tyler Weaver
```
