### PR TITLE
vision_msgs: 4.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7259,10 +7259,13 @@ repositories:
       url: https://github.com/ros-perception/vision_msgs.git
       version: ros2
     release:
+      packages:
+      - vision_msgs
+      - vision_msgs_rviz_plugins
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/vision_msgs-release.git
-      version: 4.0.0-2
+      version: 4.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_msgs` to `4.1.0-1`:

- upstream repository: https://github.com/ros-perception/vision_msgs.git
- release repository: https://github.com/ros2-gbp/vision_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.0-2`
