### PR TITLE
turtlebot4_robot: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6802,6 +6802,27 @@ repositories:
       url: https://github.com/turtlebot/turtlebot4.git
       version: humble
     status: developed
+  turtlebot4_robot:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4_robot.git
+      version: humble
+    release:
+      packages:
+      - turtlebot4_base
+      - turtlebot4_bringup
+      - turtlebot4_diagnostics
+      - turtlebot4_robot
+      - turtlebot4_tests
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot4_robot-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4_robot.git
+      version: humble
+    status: developed
   turtlesim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4_robot` to `1.0.0-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4_robot.git
- release repository: https://github.com/ros2-gbp/turtlebot4_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## turtlebot4_base

```
* Namespacing
* Minor fixes for Humble
* Contributors: Roni Kreinin
```

## turtlebot4_bringup

```
* Updates for new DepthAI node.
* Updated turtlebot4_node config
* Namespacing
* Flake8 fixes
* Linter fixes
* Enable auto_standby for RPLiDAR.
* Enable or disable diagnostics based on TURTLEBOT4_DIAGNOSTICS environment variable.
* Launch joy_teleop_launch.py in Turtlebot4 Lite.
* Contributors: Joey Yang, Roni Kreinin
```

## turtlebot4_diagnostics

```
* Namespacing
* Minor fixes for Humble
* Contributors: Roni Kreinin
```

## turtlebot4_robot

- No changes

## turtlebot4_tests

```
* Namespacing
* Minor fixes for Humble
* Contributors: Roni Kreinin
```
