### PR TITLE
turtlebot4_desktop: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6802,6 +6802,24 @@ repositories:
       url: https://github.com/turtlebot/turtlebot4.git
       version: humble
     status: developed
+  turtlebot4_desktop:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4_desktop.git
+      version: humble
+    release:
+      packages:
+      - turtlebot4_desktop
+      - turtlebot4_viz
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot4_desktop-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4_desktop.git
+      version: humble
+    status: developed
   turtlesim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4_desktop` to `1.0.0-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4_desktop.git
- release repository: https://github.com/ros2-gbp/turtlebot4_desktop-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## turtlebot4_desktop

- No changes

## turtlebot4_viz

```
* Updated camera topic
* Namespacing
* Updated CI to Humble
* Contributors: Roni Kreinin
```
