### PR TITLE
Update libpoco-dev rule for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5097,8 +5097,8 @@ libpoco-dev:
   openembedded: [poco@meta-oe]
   opensuse: [poco-devel]
   rhel:
-    '*': null
-    '7': [poco-devel]
+    '*': [poco-devel]
+    '8': null
   slackware: [poco]
   ubuntu: [libpoco-dev]
 libpocofoundation9:


### PR DESCRIPTION
It appears that this package is available for RHEL 9. Of the supported RHELs, only RHEL 8 does not have poco.

https://src.fedoraproject.org/rpms/poco#bodhi_updates