### PR TITLE
Add python3-construct rule for RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6481,6 +6481,9 @@ python3-construct:
   fedora: [python3-construct]
   gentoo: [dev-python/construct]
   nixos: [python3Packages.construct]
+  rhel:
+    '*': [python3-construct]
+    '7': null
   ubuntu: [python3-construct]
 python3-cookiecutter:
   debian:


### PR DESCRIPTION
~~This package is available for all supported RHEL releases~~

Though this package is available for all RHEL releases, it is only built for Python 3 in RHEL 8 and newer.

https://src.fedoraproject.org/rpms/python-construct#bodhi_updates