### PR TITLE
Add wget rule for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8525,6 +8525,7 @@ wget:
   osx:
     homebrew:
       packages: [wget]
+  rhel: [wget]
   ubuntu: [wget]
 wireguard:
   debian:


### PR DESCRIPTION
On RHEL 7, this package is part of the `os` repository: http://ziply.mm.fcix.net/centos/7.9.2009/os/x86_64/Packages/wget-1.14-18.el7_6.1.x86_64.rpm
On RHEL 8, this package is part of the `AppStream` repository: http://westus2.azure.repo.almalinux.org/almalinux/8.7/AppStream/x86_64/os/Packages/wget-1.19.5-10.el8.x86_64.rpm