### PR TITLE
Add python3-protobuf rule for RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8410,6 +8410,9 @@ python3-protobuf:
   fedora: [python3-protobuf]
   gentoo: [dev-python/protobuf-python]
   nixos: [python3Packages.protobuf]
+  rhel:
+    '*': [python3-protobuf]
+    '7': null
   ubuntu: [python3-protobuf]
 python3-psutil:
   alpine: [py3-psutil]


### PR DESCRIPTION
On RHEL 8, this package is provided by the `AppStream` repository: http://westus2.azure.repo.almalinux.org/almalinux/8.7/AppStream/x86_64/os/Packages/python3-protobuf-3.5.0-15.el8.noarch.rpm

This package is not available for Python 3 on RHEL 7.