### PR TITLE
Add python3-venv rule for RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10004,6 +10004,7 @@ python3-venv:
   osx:
     pip:
       packages: []
+  rhel: [python3-libs]
   ubuntu: [python3-venv]
 python3-virtualserialports-pip:
   debian:


### PR DESCRIPTION
This module was integrated into Python 3.3 and newer, which means it is part of the core Python libraries package in RHEL (just like Fedora).