### PR TITLE
Add pyqt5-dev-tools rule for RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -453,6 +453,7 @@ pyqt5-dev-tools:
   fedora: [python-qt5-devel]
   gentoo: [dev-python/PyQt5]
   openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
+  rhel: [python3-qt5-devel]
   ubuntu: [pyqt5-dev-tools]
 pyrebase-pip:
   debian:


### PR DESCRIPTION
On RHEL 7, this package is provided by EPEL: https://src.fedoraproject.org/rpms/python-qt5#bodhi_updates
On RHEL 8, this package is part of the `PowerTools` repository: http://westus2.azure.repo.almalinux.org/almalinux/8.7/PowerTools/x86_64/os/Packages/python3-qt5-devel-5.15.0-3.el8.i686.rpm