### PR TITLE
libstatistics_collector: 1.3.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2438,7 +2438,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/libstatistics_collector-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libstatistics_collector` to `1.3.1-1`:

- upstream repository: https://github.com/ros-tooling/libstatistics_collector.git
- release repository: https://github.com/ros2-gbp/libstatistics_collector-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.0-1`

## libstatistics_collector

```
* Check if message has a "header" field with a stamp subfield of type builtin_interfaces::msg::Time (#54 <https://github.com/ros-tooling/libstatistics_collector/issues/54>) (#153 <https://github.com/ros-tooling/libstatistics_collector/issues/153>)
  * Fix for Issue 51. Adds check to HasHeader template to check that the message
  in question has a field called 'header' with a subfield 'stamp' of type builtin_interfaces::msg::Time.
  Added unit test case and DummyCustomHeaderMessage for use with tests.
* Contributors: Tim Clephas
```
