### PR TITLE
simple_launch: 1.7.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6503,7 +6503,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/simple_launch-release.git
-      version: 1.6.2-1
+      version: 1.7.0-1
     source:
       type: git
       url: https://github.com/oKermorgant/simple_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_launch` to `1.7.0-1`:

- upstream repository: https://github.com/oKermorgant/simple_launch.git
- release repository: https://github.com/ros2-gbp/simple_launch-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.6.2-1`

## simple_launch

```
* GazeboBridge creates a camera_info topic for all bridged image topics
* Contributors: Olivier Kermorgant
```
