### PR TITLE
aruco_opencv: 0.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -203,7 +203,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fictionlab-gbp/aruco_opencv-release.git
-      version: 0.2.0-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/fictionlab/aruco_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_opencv` to `0.3.0-1`:

- upstream repository: https://github.com/fictionlab/aruco_opencv.git
- release repository: https://github.com/fictionlab-gbp/aruco_opencv-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.0-1`

## aruco_opencv

```
* Add Board detection (#6 <https://github.com/fictionlab/aruco_opencv/issues/6>)
  * Rename SingleMarkerTracker to ArucoTracker
  * Add BoardPose msg, change MarkerDetection to ArucoDetection
  * Load board descriptions from yaml file
  * Add more boards to example configuration
  * Change default marker dictionary
  * Add board pose estimation
  * Lock camera info for board estimation
* Ignore duplicate image frames
* Add scripts for generating markers and boards
* Fix included headers file extensions
* Port changes from foxy branch
* Simplify filling the camera matrix from camera info
* Contributors: Błażej Sowa
```

## aruco_opencv_msgs

```
* Add Board detection (#6 <https://github.com/fictionlab/aruco_opencv/issues/6>)
  * Add BoardPose msg, change MarkerDetection to ArucoDetection
* Contributors: Błażej Sowa
```
