### PR TITLE
aruco_opencv: 4.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -378,7 +378,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_opencv-release.git
-      version: 4.0.1-1
+      version: 4.1.0-1
     source:
       type: git
       url: https://github.com/fictionlab/ros_aruco_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_opencv` to `4.1.0-1`:

- upstream repository: https://github.com/fictionlab/ros_aruco_opencv.git
- release repository: https://github.com/ros2-gbp/aruco_opencv-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.1-1`

## aruco_opencv

```
* Add python dependencies (#19 <https://github.com/fictionlab/ros_aruco_opencv/issues/19>)
* Add board detection (ROS2) (#16 <https://github.com/fictionlab/ros_aruco_opencv/issues/16>)
  * Rename SingleMarkerTracker to ArucoTracker
  * Add BoardPose msg, change MarkerDetection to ArucoDetection
  * Change default marker dictionary
  * Add board descriptions
  * Add board pose estimation
  * Fix cpplint errors
* Add scripts for generating markers and boards (#13 <https://github.com/fictionlab/ros_aruco_opencv/issues/13>)
* Ignore duplicate image frames (#10 <https://github.com/fictionlab/ros_aruco_opencv/issues/10>)
* Add ament_lint tests to cmakelists instead of github workflows (#7 <https://github.com/fictionlab/ros_aruco_opencv/issues/7>)
* Contributors: Błażej Sowa
```

## aruco_opencv_msgs

```
* Add board detection (ROS2) (#16 <https://github.com/fictionlab/ros_aruco_opencv/issues/16>)
  * Add BoardPose msg, change MarkerDetection to ArucoDetection
* Add ament_lint tests to cmakelists instead of github workflows (#7 <https://github.com/fictionlab/ros_aruco_opencv/issues/7>)
* Contributors: Błażej Sowa
```
