### PR TITLE
aruco_opencv: 2.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -413,7 +413,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_opencv-release.git
-      version: 2.0.1-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/fictionlab/ros_aruco_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_opencv` to `2.1.0-1`:

- upstream repository: https://github.com/fictionlab/ros_aruco_opencv.git
- release repository: https://github.com/ros2-gbp/aruco_opencv-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.1-1`

## aruco_opencv

```
* Add python dependencies (#19 <https://github.com/fictionlab/aruco_opencv/issues/19>) (#21 <https://github.com/fictionlab/aruco_opencv/issues/21>)
* Add board detection (ROS2) (backport #16 <https://github.com/fictionlab/aruco_opencv/issues/16>) (#18 <https://github.com/fictionlab/aruco_opencv/issues/18>)
  * Rename SingleMarkerTracker to ArucoTracker
  * Add BoardPose msg, change MarkerDetection to ArucoDetection
  * Change default marker dictionary
  * Add board descriptions
  * Add board pose estimation
  * Fix cpplint errors
* Add scripts for generating markers and boards (#13 <https://github.com/fictionlab/aruco_opencv/issues/13>) (#15 <https://github.com/fictionlab/aruco_opencv/issues/15>)
* Ignore duplicate image frames (#10 <https://github.com/fictionlab/aruco_opencv/issues/10>) (#12 <https://github.com/fictionlab/aruco_opencv/issues/12>)
* Add ament_lint tests to cmakelists instead of github workflows (backport #7 <https://github.com/fictionlab/aruco_opencv/issues/7>) (#8 <https://github.com/fictionlab/aruco_opencv/issues/8>)
* Contributors: Błażej Sowa
```

## aruco_opencv_msgs

```
* Add board detection (ROS2) (backport #16 <https://github.com/fictionlab/aruco_opencv/issues/16>) (#18 <https://github.com/fictionlab/aruco_opencv/issues/18>)
  * Add BoardPose msg, change MarkerDetection to ArucoDetection
* Add ament_lint tests to cmakelists instead of github workflows (backport #7 <https://github.com/fictionlab/aruco_opencv/issues/7>) (#8 <https://github.com/fictionlab/aruco_opencv/issues/8>)
* Contributors: Błażej Sowa
```
