### PR TITLE
aruco_opencv: 1.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -308,7 +308,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_opencv-release.git
-      version: 1.0.1-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/fictionlab/ros_aruco_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_opencv` to `1.1.0-1`:

- upstream repository: https://github.com/fictionlab/ros_aruco_opencv.git
- release repository: https://github.com/ros2-gbp/aruco_opencv-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.1-1`

## aruco_opencv

```
* Add python dependencies (#19 <https://github.com/fictionlab/aruco_opencv/issues/19>) (#20 <https://github.com/fictionlab/aruco_opencv/issues/20>)
* Add board detection (ROS2) (backport #16 <https://github.com/fictionlab/aruco_opencv/issues/16>) (#17 <https://github.com/fictionlab/aruco_opencv/issues/17>)
  * Rename SingleMarkerTracker to ArucoTracker
  * Add BoardPose msg, change MarkerDetection to ArucoDetection
  * Change default marker dictionary
  * Add board descriptions
  * Add board pose estimation
  * Fix cpplint errors
* Add scripts for generating markers and boards (#13 <https://github.com/fictionlab/aruco_opencv/issues/13>) (#14 <https://github.com/fictionlab/aruco_opencv/issues/14>)
* Ignore duplicate image frames (#10 <https://github.com/fictionlab/aruco_opencv/issues/10>) (#11 <https://github.com/fictionlab/aruco_opencv/issues/11>)
* Add ament_lint tests to cmakelists instead of github workflows (backport #7 <https://github.com/fictionlab/aruco_opencv/issues/7>) (#9 <https://github.com/fictionlab/aruco_opencv/issues/9>)
* Contributors: Błażej Sowa
```

## aruco_opencv_msgs

```
* Add board detection (ROS2) (backport #16 <https://github.com/fictionlab/aruco_opencv/issues/16>) (#17 <https://github.com/fictionlab/aruco_opencv/issues/17>)
  * Add BoardPose msg, change MarkerDetection to ArucoDetection
* Add ament_lint tests to cmakelists instead of github workflows (backport #7 <https://github.com/fictionlab/aruco_opencv/issues/7>) (#9 <https://github.com/fictionlab/aruco_opencv/issues/9>)
* Contributors: Błażej Sowa
```
