### PR TITLE
gtsam: 4.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1607,6 +1607,11 @@ repositories:
       type: git
       url: https://github.com/borglab/gtsam.git
       version: develop
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gtsam-release.git
+      version: 4.2.0-1
     source:
       type: git
       url: https://github.com/borglab/gtsam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gtsam` to `4.2.0-1`:

- upstream repository: https://github.com/borglab/gtsam.git
- release repository: https://github.com/ros2-gbp/gtsam-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
