### PR TITLE
swri_console: 2.0.3-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6361,7 +6361,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/swri_console-release.git
-      version: 2.0.2-1
+      version: 2.0.3-2
     source:
       type: git
       url: https://github.com/swri-robotics/swri_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_console` to `2.0.3-2`:

- upstream repository: https://github.com/swri-robotics/swri_console.git
- release repository: https://github.com/ros2-gbp/swri_console-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.2-1`

## swri_console

```
* Fix QoS on Humble (#55 <https://github.com/swri-robotics/swri_console/issues/55>)
  * Use Humble's Default rosout QoS Settings
  Co-authored-by: David Anthony <mailto:david.anthony@swri.org>
  Co-authored-by: Tony Najjar <mailto:tony.najjar.1997@gmail.com>
* Contributors: David Anthony, Tony Najjar
```
