### PR TITLE
swri_console: 2.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5665,6 +5665,21 @@ repositories:
       url: https://github.com/open-rmf/stubborn_buddies.git
       version: main
     status: developed
+  swri_console:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/swri_console.git
+      version: ros2-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/swri_console-release.git
+      version: 2.0.3-1
+    source:
+      type: git
+      url: https://github.com/swri-robotics/swri_console.git
+      version: ros2-devel
+    status: developed
   system_fingerprint:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_console` to `2.0.3-1`:

- upstream repository: https://github.com/swri-robotics/swri_console.git
- release repository: https://github.com/ros2-gbp/swri_console-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## swri_console

```
* Fix QoS on Humble (#55 <https://github.com/swri-robotics/swri_console/issues/55>)
  * Use Humble's Default rosout QoS Settings
  Co-authored-by: David Anthony <mailto:david.anthony@swri.org>
  Co-authored-by: Tony Najjar <mailto:tony.najjar.1997@gmail.com>
* Contributors: David Anthony, Tony Najjar
```
