### PR TITLE
depthai: 2.20.2-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1758,7 +1758,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/luxonis/depthai-core-release.git
-      version: 2.20.2-1
+      version: 2.20.2-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai` to `2.20.2-2`:

- upstream repository: https://github.com/luxonis/depthai-core.git
- release repository: https://github.com/luxonis/depthai-core-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.20.2-1`

## depthai

```
* Fix for ColorCamera at high resolution while using isp scaling
* Fix for OV9282 SW sync on devices with OV9782 RGB camera
* Fix for IMX378/477/577 on sockets other than CAM_A (RGB)
* Contributors: Alex Bougdan, Szabolcs Gergely, Martin Peterlin
```
