### PR TITLE
moveit_task_constructor: 0.1.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5598,7 +5598,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit_task_constructor-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_task_constructor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_task_constructor` to `0.1.2-1`:

- upstream repository: https://github.com/ros-planning/moveit_task_constructor.git
- release repository: https://github.com/ros-gbp/moveit_task_constructor-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.1-1`

## moveit_task_constructor_capabilities

- No changes

## moveit_task_constructor_core

```
* Remove moveit/__init__.py during .deb builds to avoid installation conflicts
* MultiPlanner solver (#429 <https://github.com/ros-planning/moveit_task_constructor/issues/429>): a planner that tries multiple planners in sequence
  
    * CartesianPath: Deprecate redundant property setters
    * PlannerInterface: provide "timeout" property
    * PlannerInterface: provide setters for properties
  
* JointInterpolation: fix timeout handling
* Contributors: Robert Haschke
```

## moveit_task_constructor_demo

```
* CartesianPath: Deprecate redundant property setters (#429 <https://github.com/ros-planning/moveit_task_constructor/issues/429>)
* Contributors: Robert Haschke
```

## moveit_task_constructor_msgs

- No changes

## moveit_task_constructor_visualization

- No changes

## rviz_marker_tools

```
* Fix marker creation: allow zero scale for geometric shapes (#430 <https://github.com/ros-planning/moveit_task_constructor/issues/430>)
* Contributors: Robert Haschke
```
