### PR TITLE
Remove Debian Buster from the repository checks

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3,8 +3,6 @@
 # see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
-  debian:
-  - buster
   ubuntu:
   - focal
 repositories:

--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -61,7 +61,6 @@ supported_versions:
   arch:
   - ''
   debian:
-  - buster
   - bullseye
   fedora:
   - '36'


### PR DESCRIPTION
Debian Buster is EOL

https://github.com/ros-infrastructure/rep/pull/373


Similar to: https://github.com/ros/rosdistro/pull/30094 and https://github.com/ros/rosdistro/pull/27640