### PR TITLE
executive_smach_visualization: 4.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3046,7 +3046,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/jbohren/executive_smach_visualization-release.git
-      version: 4.0.1-1
+      version: 4.1.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/executive_smach_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `executive_smach_visualization` to `4.1.0-1`:

- upstream repository: https://github.com/ros-visualization/executive_smach_visualization.git
- release repository: https://github.com/jbohren/executive_smach_visualization-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.1-1`

## executive_smach_visualization

- No changes

## smach_viewer

```
* add timestamp in published image (#50 <https://github.com/ros-visualization/executive_smach_visualization/issues/50>)
  
    * some tools, for example jsk_rosbag_tools requries all message have time stamp
  
* [smach_viewer] remove smach image in /tmp when the node is killed (#48 <https://github.com/ros-visualization/executive_smach_visualization/issues/48>)
  
    * remove smach image in /tmp when the node is killed
  
* [smach_viewer] add smach_image_publisher.py for headless environment (#46 <https://github.com/ros-visualization/executive_smach_visualization/issues/46>)
  
    * add time stamp in image topics
    * add compressed image publisher
    * change file name and set constant image size
    * check if file is proper
    * change color in active states
    * import not local file
    * add smach_image_publisher.py
    * split and make SmachViewerBase, utils and text_wrapper
  
* Contributors: Kei Okada, Shingo Kitagawa
```
