### PR TITLE
play_motion2: 0.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3612,6 +3612,24 @@ repositories:
       url: https://github.com/stack-of-tasks/pinocchio.git
       version: devel
     status: developed
+  play_motion2:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/play_motion2.git
+      version: humble-devel
+    release:
+      packages:
+      - play_motion2
+      - play_motion2_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/play_motion2-release.git
+      version: 0.0.4-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/play_motion2.git
+      version: humble-devel
+    status: developed
   plotjuggler:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `play_motion2` to `0.0.4-1`:

- upstream repository: https://github.com/pal-robotics/play_motion2.git
- release repository: https://github.com/pal-gbp/play_motion2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## play_motion2

```
* Merge branch 'fix_test' into 'humble-devel'
  Fix unstable test
  See merge request app-tools/play_motion2!16
* set start timeout in a variable
* use a better assert
* fix gtest header
* remove unused header
* fix loop condition to start play_motion2_node_test
* Contributors: Jordan Palacios, Noel Jimenez
```

## play_motion2_msgs

- No changes
