### PR TITLE
Adding python3-ntplib

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7963,6 +7963,13 @@ python3-nose-yanc:
   debian: [python3-nose-yanc]
   openembedded: [python3-nose-yanc@meta-ros-common]
   ubuntu: [python3-nose-yanc]
+python3-ntplib:
+  debian: [python3-ntplib]
+  fedora: [python3-ntplib]
+  nixos: [python3Packages.ntplib]
+  opensuse: [python3-ntplib]
+  rhel: ['python%{python3_pkgversion}-ntplib']
+  ubuntu: [python3-ntplib]
 python3-numba:
   debian: [python3-numba]
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7968,7 +7968,9 @@ python3-ntplib:
   fedora: [python3-ntplib]
   nixos: [python3Packages.ntplib]
   opensuse: [python3-ntplib]
-  rhel: ['python%{python3_pkgversion}-ntplib']
+  rhel:
+    '*': ['python%{python3_pkgversion}-ntplib']
+    '7': null
   ubuntu: [python3-ntplib]
 python3-numba:
   debian: [python3-numba]


### PR DESCRIPTION
## Package name:

python3-ntplib

## Package Upstream Source:

https://github.com/cf-natali/ntplib

## Purpose of using this:

https://github.com/ros/diagnostics/pull/289

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/stable/python3-ntplib
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=ntplib
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-ntplib/python3-ntplib/
- Arch: https://www.archlinux.org/packages/
  - NOT AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - NOT AVAILABLE
- macOS: https://formulae.brew.sh/
  - NOT AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - NOT AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - NOT AVAILABLE
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python3-ntplib