### PR TITLE
rclpy: 3.9.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3745,7 +3745,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 3.8.0-1
+      version: 3.9.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `3.9.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.8.0-1`

## rclpy

```
* to create a sublogger while getting child of Logger (#1084 <https://github.com/ros2/rclpy/issues/1084>)
* Fix #983 <https://github.com/ros2/rclpy/issues/983> by saving future and checking for + raising any exceptions (#1073 <https://github.com/ros2/rclpy/issues/1073>)
* Contributors: Achille Verheye, Chen Lihui
```
