### PR TITLE
launch: 1.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2103,7 +2103,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 1.4.0-1
+      version: 1.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `1.4.1-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.4.0-1`

## launch

```
* Fixed typos (#692 <https://github.com/ros2/launch/issues/692>)
* Contributors: Alejandro Hernández Cordero
```

## launch_pytest

```
* Fixed typos (#692 <https://github.com/ros2/launch/issues/692>)
* Contributors: Alejandro Hernández Cordero
```

## launch_testing

```
* Fixed typos (#692 <https://github.com/ros2/launch/issues/692>)
* Contributors: Alejandro Hernández Cordero
```

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* Fixed typos (#692 <https://github.com/ros2/launch/issues/692>)
* Contributors: Alejandro Hernández Cordero
```

## launch_yaml

- No changes
