### PR TITLE
demos: 0.24.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -820,7 +820,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.24.0-1
+      version: 0.24.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.24.1-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.24.0-1`

## action_tutorials_cpp

- No changes

## action_tutorials_interfaces

- No changes

## action_tutorials_py

- No changes

## composition

- No changes

## demo_nodes_cpp

```
* Added README.md for demo_cpp_nodes (#599 <https://github.com/ros2/demos/issues/599>)
* Contributors: Gary Bey
```

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

- No changes

## dummy_map_server

- No changes

## dummy_robot_bringup

- No changes

## dummy_sensors

- No changes

## image_tools

- No changes

## intra_process_demo

- No changes

## lifecycle

- No changes

## lifecycle_py

- No changes

## logging_demo

- No changes

## pendulum_control

- No changes

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

- No changes

## quality_of_service_demo_py

- No changes

## topic_monitor

- No changes

## topic_statistics_demo

- No changes
