### PR TITLE
turtlebot4_setup: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6841,6 +6841,21 @@ repositories:
       url: https://github.com/turtlebot/turtlebot4_robot.git
       version: humble
     status: developed
+  turtlebot4_setup:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4_setup.git
+      version: humble
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot4_setup-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4_setup.git
+      version: humble
+    status: developed
   turtlesim:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6897,6 +6897,8 @@ repositories:
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot4_setup.git
+      version: humble
+    status: developed
   turtlebot4_tutorials:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4_setup` to `1.0.0-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4_setup.git
- release repository: https://github.com/ros2-gbp/turtlebot4_setup-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## turtlebot4_setup

```
* turtlebot4_setup tool
* RPI config updates
* Discovery server files
* Contributors: Roni Kreinin
```
