### PR TITLE
rclcpp: 19.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3729,7 +3729,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 19.1.0-1
+      version: 19.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `19.2.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `19.1.0-1`

## rclcpp

```
* to create a sublogger while getting child of Logger (#1717 <https://github.com/ros2/rclcpp/issues/1717>)
* Fix documentation of Context class (#2107 <https://github.com/ros2/rclcpp/issues/2107>)
* fixes for rmw callbacks in qos_event class (#2102 <https://github.com/ros2/rclcpp/issues/2102>)
* Contributors: Alberto Soragna, Chen Lihui, Silvio Traversaro
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
