### PR TITLE
Add several rules for Debian Bookworm

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -528,11 +528,7 @@ clang:
 clang-format:
   alpine: [clang]
   arch: [clang]
-  debian:
-    bookworm: [clang-format]
-    bullseye: [clang-format]
-    buster: [clang-format]
-    stretch: [clang-format]
+  debian: [clang-format]
   fedora: [clang]
   gentoo: [sys-devel/clang]
   nixos: [clang]
@@ -544,11 +540,7 @@ clang-format:
 clang-tidy:
   alpine: [clang-extra-tools]
   arch: [clang]
-  debian:
-    bookworm: [clang-tidy]
-    bullseye: [clang-tidy]
-    buster: [clang-tidy]
-    stretch: [clang-tidy]
+  debian: [clang-tidy]
   fedora: [clang-tools-extra]
   gentoo: [sys-devel/clang]
   nixos: [clang]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -529,6 +529,7 @@ clang-format:
   alpine: [clang]
   arch: [clang]
   debian:
+    bookworm: [clang-format]
     bullseye: [clang-format]
     buster: [clang-format]
     stretch: [clang-format]
@@ -544,6 +545,7 @@ clang-tidy:
   alpine: [clang-extra-tools]
   arch: [clang]
   debian:
+    bookworm: [clang-tidy]
     bullseye: [clang-tidy]
     buster: [clang-tidy]
     stretch: [clang-tidy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -350,6 +350,7 @@ pydocstyle:
   alpine: [py3-pydocstyle]
   arch: [python-pydocstyle]
   debian:
+    bookworm: [pydocstyle]
     bullseye: [pydocstyle]
     buster: [pydocstyle]
     stretch: [pydocstyle]
@@ -6769,6 +6770,7 @@ python3-empy:
   alpine: [py3-empy]
   arch: [python-empy]
   debian:
+    bookworm: [python3-empy]
     bullseye: [python3-empy]
     buster: [python3-empy]
     jessie: [python3-empy]
@@ -6922,6 +6924,7 @@ python3-flake8:
   alpine: [py3-flake8]
   arch: [flake8]
   debian:
+    bookworm: [python3-flake8]
     bullseye: [python3-flake8]
     buster: [python3-flake8]
     jessie: [python3-flake8]
@@ -7600,6 +7603,7 @@ python3-lark-parser:
   alpine: [py3-lark-parser]
   arch: [python-lark-parser]
   debian:
+    bookworm: [python3-lark]
     bullseye: [python3-lark]
     buster: [python3-lark-parser]
     stretch: [python3-lark-parser]
@@ -7874,6 +7878,7 @@ python3-mypy:
   alpine: [py3-mypy]
   arch: [mypy]
   debian:
+    bookworm: [python3-mypy]
     bullseye: [python3-mypy]
     buster: [python3-mypy]
     stretch: [mypy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -349,11 +349,7 @@ pika:
 pydocstyle:
   alpine: [py3-pydocstyle]
   arch: [python-pydocstyle]
-  debian:
-    bookworm: [pydocstyle]
-    bullseye: [pydocstyle]
-    buster: [pydocstyle]
-    stretch: [pydocstyle]
+  debian: [pydocstyle]
   fedora: [python3-pydocstyle]
   gentoo: [dev-python/pydocstyle]
   nixos: [python3Packages.pydocstyle]
@@ -6769,12 +6765,7 @@ python3-emoji:
 python3-empy:
   alpine: [py3-empy]
   arch: [python-empy]
-  debian:
-    bookworm: [python3-empy]
-    bullseye: [python3-empy]
-    buster: [python3-empy]
-    jessie: [python3-empy]
-    stretch: [python3-empy]
+  debian: [python3-empy]
   fedora: [python3-empy]
   gentoo: [dev-python/empy]
   nixos: [python3Packages.empy]
@@ -6923,12 +6914,7 @@ python3-fiona:
 python3-flake8:
   alpine: [py3-flake8]
   arch: [flake8]
-  debian:
-    bookworm: [python3-flake8]
-    bullseye: [python3-flake8]
-    buster: [python3-flake8]
-    jessie: [python3-flake8]
-    stretch: [python3-flake8]
+  debian: [python3-flake8]
   fedora: [python3-flake8]
   gentoo: [dev-python/flake8]
   nixos: [python3Packages.flake8]
@@ -7603,8 +7589,7 @@ python3-lark-parser:
   alpine: [py3-lark-parser]
   arch: [python-lark-parser]
   debian:
-    bookworm: [python3-lark]
-    bullseye: [python3-lark]
+    '*': [python3-lark]
     buster: [python3-lark-parser]
     stretch: [python3-lark-parser]
   fedora: [python3-lark-parser]
@@ -7878,9 +7863,7 @@ python3-mypy:
   alpine: [py3-mypy]
   arch: [mypy]
   debian:
-    bookworm: [python3-mypy]
-    bullseye: [python3-mypy]
-    buster: [python3-mypy]
+    '*': [python3-mypy]
     stretch: [mypy]
   fedora: [python3-mypy]
   gentoo: [dev-python/mypy]


### PR DESCRIPTION
All of these package names are the same in Bookworm as they are in Bullseye.

https://packages.debian.org/bookworm/clang-format
https://packages.debian.org/bookworm/clang-tidy
https://packages.debian.org/bookworm/pydocstyle
https://packages.debian.org/bookworm/python3-empy
https://packages.debian.org/bookworm/python3-flake8
https://packages.debian.org/bookworm/python3-lark
https://packages.debian.org/bookworm/python3-mypy