### PR TITLE
rqt: 1.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4929,7 +4929,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `1.3.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros2-gbp/rqt-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.0-1`

## rqt

```
* fix build of rqt with setuptools>=v61.0.0 (#271 <https://github.com/ros-visualization/rqt/issues/271>)
* Contributors: Daniel Reuter
```

## rqt_gui

- No changes

## rqt_gui_cpp

- No changes

## rqt_gui_py

- No changes

## rqt_py_common

- No changes
