### PR TITLE
Re-add debian buster to Noetic distribution.yaml

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3,6 +3,8 @@
 # see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
+  debian:
+  - buster
   ubuntu:
   - focal
 repositories:


### PR DESCRIPTION
Partially reverts https://github.com/ros/rosdistro/pull/36285 - after talking with @nuclearsandwich I learned I made a mistake. This needs to be restored until after the regressions in Buster are resolved and the last snapshot is made.