### PR TITLE
turtlebot4_tutorials: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6841,6 +6841,25 @@ repositories:
       url: https://github.com/turtlebot/turtlebot4_robot.git
       version: humble
     status: developed
+  turtlebot4_tutorials:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4_tutorials.git
+      version: humble
+    release:
+      packages:
+      - turtlebot4_cpp_tutorials
+      - turtlebot4_python_tutorials
+      - turtlebot4_tutorials
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot4_tutorials-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4_tutorials.git
+      version: humble
+    status: developed
   turtlesim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4_tutorials` to `1.0.0-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4_tutorials.git
- release repository: https://github.com/ros2-gbp/turtlebot4_tutorials-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## turtlebot4_cpp_tutorials

- No changes

## turtlebot4_python_tutorials

- No changes

## turtlebot4_tutorials

- No changes
