### PR TITLE
py_trees_js: 0.6.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3327,7 +3327,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_js-release.git
-      version: 0.6.3-1
+      version: 0.6.4-1
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees_js.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3329,6 +3329,7 @@ repositories:
       url: https://github.com/ros2-gbp/py_trees_js-release.git
       version: 0.6.4-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/splintered-reality/py_trees_js.git
       version: devel


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_js` to `0.6.4-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_js.git
- release repository: https://github.com/ros2-gbp/py_trees_js-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.3-1`

## py_trees_js

```
* [actions] pre-merge and update-cache, #146 <https://github.com/splintered-reality/py_trees_js/pull/146>
* [actions] push containers, #144 <https://github.com/splintered-reality/py_trees_js/pull/144>
* [poetry] update project to use poetry, #143 <https://github.com/splintered-reality/py_trees_js/pull/143>
* [vscode] devcontainer workflows, #143 <https://github.com/splintered-reality/py_trees_js/pull/143>
* [tests] basic tests, formatting, linting, #143 <https://github.com/splintered-reality/py_trees_js/pull/143>
```
