### PR TITLE
Added coinor lib's packages for nixos

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -576,25 +576,30 @@ coinor-libcbc-dev:
   debian: [coinor-libcbc-dev]
   fedora: [coin-or-Cbc-devel]
   gentoo: [sci-libs/coinor-cbc]
+  nixos: [cbc]
   ubuntu: [coinor-libcbc-dev]
 coinor-libcbc3:
   debian: [coinor-libcbc3]
   fedora: [coin-or-Cbc]
+  nixos: [cbc]
   ubuntu: [coinor-libcbc3]
 coinor-libcgl-dev:
   debian: [coinor-libcgl-dev]
   fedora: [coin-or-Cgl-devel]
   gentoo: [sci-libs/coinor-cgl]
+  nixos: [cbc]
   ubuntu: [coinor-libcgl-dev]
 coinor-libclp-dev:
   debian: [coinor-libclp-dev]
   fedora: [coin-or-Clp-devel]
   gentoo: [sci-libs/coinor-clp]
+  nixos: [clp]
   ubuntu: [coinor-libclp-dev]
 coinor-libcoinutils-dev:
   debian: [coinor-libcoinutils-dev]
   fedora: [coin-or-CoinUtils-devel]
   gentoo: [sci-libs/coinor-utils]
+  nixos: [cbc]
   rhel:
     '7': [coin-or-CoinUtils-devel]
   ubuntu: [coinor-libcoinutils-dev]
@@ -603,6 +608,7 @@ coinor-libipopt-dev:
   debian: [coinor-libipopt-dev]
   fedora: [coin-or-Ipopt-devel]
   gentoo: [sci-libs/ipopt]
+  nixos: [ipopt]
   rhel:
     '7': [coin-or-Ipopt-devel]
   ubuntu: [coinor-libipopt-dev]
@@ -610,6 +616,7 @@ coinor-libosi-dev:
   debian: [coinor-libosi-dev]
   fedora: [coin-or-Osi-devel]
   gentoo: [sci-libs/coinor-osi]
+  nixos: [osi]
   ubuntu: [coinor-libosi-dev]
 collada-dom:
   arch: [collada-dom]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependencies for nixos to the rosdep database.

## Package's names:

coinor-libcbc-dev (nixos: [cbc])
coinor-libcbc3 (nixos: [cbc])
coinor-libcgl-dev (nixos: [cbc])
coinor-libclp-dev (nixos: [clp])
coinor-libcoinutils-dev (nixos: [cbc])
coinor-libipopt-dev (nixos: [ipopt])
coinor-libosi-dev (nixos: [osi])

## Package's Upstream Sources:

https://github.com/coin-or/Cbc
https://github.com/coin-or/Clp
https://github.com/coin-or/Ipopt
https://github.com/coin-or/Osi

## Purpose of using this:

It's needed for build ROS2 Planning System (already in a ROS2 distribution) with nix package manager or on NixOS
https://github.com/PlanSys2/ros2_planning_system

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- NixOS/nixpkgs: https://search.nixos.org/packages
  - cbc - https://github.com/NixOS/nixpkgs/blob/nixos-22.11/pkgs/applications/science/math/cbc/default.nix
  - clp - https://github.com/NixOS/nixpkgs/blob/nixos-22.11/pkgs/applications/science/math/clp/default.nix
  - ipopt - https://github.com/NixOS/nixpkgs/blob/nixos-22.11/pkgs/development/libraries/science/math/ipopt/default.nix
  - osi - https://github.com/NixOS/nixpkgs/blob/nixos-22.11/pkgs/development/libraries/science/math/osi/default.nix

