### PR TITLE
neonavigation: 0.12.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7772,7 +7772,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.12.0-1
+      version: 0.12.1-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.12.1-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.12.0-1`

## costmap_cspace

- No changes

## joystick_interrupt

- No changes

## map_organizer

- No changes

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

- No changes

## obj_to_pointcloud

- No changes

## planner_cspace

```
* Improve test logs on timeout (#673 <https://github.com/at-wat/neonavigation/issues/673>)
* planner_cspace: fix map update range (#672 <https://github.com/at-wat/neonavigation/issues/672>)
* planner_cspace: clear velocity of dummy_robot on position set (#669 <https://github.com/at-wat/neonavigation/issues/669>)
* planner_cspace: fix flaky action tests (#665 <https://github.com/at-wat/neonavigation/issues/665>)
* planner_cspace: fix planner_cspace_msgs version constraint (#663 <https://github.com/at-wat/neonavigation/issues/663>)
* Contributors: Atsushi Watanabe
```

## safety_limiter

```
* safety_limiter: update config to stabilize simulation test (#668 <https://github.com/at-wat/neonavigation/issues/668>)
* safety_limiter: fix flaky simulation tests (#664 <https://github.com/at-wat/neonavigation/issues/664>)
* Contributors: Atsushi Watanabe
```

## track_odometry

- No changes

## trajectory_tracker

```
* trajectory_tracker: relax test conditions (#674 <https://github.com/at-wat/neonavigation/issues/674>)
* Improve test logs on timeout (#673 <https://github.com/at-wat/neonavigation/issues/673>)
* trajectory_tracker: throttle tf exception logs (#670 <https://github.com/at-wat/neonavigation/issues/670>)
* trajectory_tracker: improve test stability (#667 <https://github.com/at-wat/neonavigation/issues/667>)
* Contributors: Atsushi Watanabe
```
