### PR TITLE
mvsim: 0.6.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7518,7 +7518,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
-      version: 0.4.3-1
+      version: 0.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.6.0-1`:

- upstream repository: https://github.com/MRPT/mvsim.git
- release repository: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.3-1`

## mvsim

```
* Support for SkyBox rendering (requires MRPT >=2.7.0)
* More camera options in world.xml files (initial azimuth, elevation, etc.)
* Terrain elevation models now support repeated textures (requires MRPT >=2.7.0)
* Faster 3D Lidar rendering (Requires MRPT >=2.7.0)
* Add Ouster OS1 sensor file
* Fix default friction coefficients; draw motor torques too
* More accurate Velodyne simulation based on sensor_rpm parameter
* Clearer code and code style conventions
* Add "<static>" XML tag for large, static world objects
* Support for XML tag <if ...>
* Refactor xml parser as a registry of tag->function
* Examples renamed for conciseness: 'mvsim_demo_*' to 'demo_*'
* Added a "greenhouse" example world
* Wheels: allow linked-yaw-objects in vehicle viz
* Support several <visual> tags in custom visualization models
* pybind11 sources simplification.
  Simplify into one single source tree with conditional compilation for different pybind versions.
* Emit clearer warnings and earlier detection of wrong bounding boxes
* Add reference to (preprint) paper
* Controllers: Made threadsafe
* Contributors: Fernando Cañadas, Jose Luis Blanco-Claraco
* BUGFIX: program did not quit if using a non-existing launch file.
* BUGFIX: unneeded friction coefficient for chassis body
* BUGFIX: bbox for compound vehicle models
* BUGFIX: <for> loops ignored more than one inner tag
* BUGFIX: Add epsilon value for bbox determination in 3D models
```
