### PR TITLE
Revert "qb_hand: 3.0.2-2 in 'melodic/distribution.yaml' [bloom] (#357…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9855,12 +9855,11 @@ repositories:
       - qb_hand
       - qb_hand_control
       - qb_hand_description
-      - qb_hand_gazebo
       - qb_hand_hardware_interface
       tags:
         release: release/melodic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbhand-ros-release.git
-      version: 3.0.2-2
+      version: 2.0.0-1
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbhand-ros.git


### PR DESCRIPTION
…91)"

This reverts commit 576ef8e5df76b00cf2e08e7b15c213ed89e299f1.

This has not built since it was merged in early January: https://build.ros.org/view/Mbin_uB64/job/Msrc_uB__qb_hand__ubuntu_bionic__source/

@umbertofontana93 FYI