### PR TITLE
add openni2_camera source ahead of first release

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2957,6 +2957,12 @@ repositories:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
       version: 1.5.2-2
+  openni2_camera:
+    source:
+      type: git
+      url: https://github.com/ros-drivers/openni2_camera.git
+      version: ros2
+    status: maintained
   opensw:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

Adding openni2_camera here since it is desired to review the package naming before merging https://github.com/ros2-gbp/ros2-gbp-github-org/pull/210

# The source is here:

https://github.com/ros-drivers/openni2_camera/tree/ros2

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro