### PR TITLE
graceful_controller: 0.4.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3216,7 +3216,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mikeferguson/graceful_controller-gbp.git
-      version: 0.4.6-1
+      version: 0.4.7-1
     source:
       type: git
       url: https://github.com/mikeferguson/graceful_controller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `graceful_controller` to `0.4.7-1`:

- upstream repository: https://github.com/mikeferguson/graceful_controller.git
- release repository: https://github.com/mikeferguson/graceful_controller-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.6-1`

## graceful_controller

- No changes

## graceful_controller_ros

```
* generate linear movements if final in-place rotation is infeasible (#67 <https://github.com/mikeferguson/graceful_controller/issues/67>)
* Contributors: Michael Ferguson
```
