### PR TITLE
ros_2cli: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4513,6 +4513,17 @@ repositories:
       url: https://github.com/osrf/ros2launch_security.git
       version: main
     status: maintained
+  ros_2cli:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/christophebedard/ros_2cli-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/christophebedard/ros_2cli.git
+      version: rolling
+    status: developed
   ros_canopen:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_2cli` to `0.2.0-1`:

- upstream repository: https://github.com/christophebedard/ros_2cli.git
- release repository: https://github.com/christophebedard/ros_2cli-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## ros_2cli

```
* Switch to Python implementation based on ros2cli for autocompletion
* Contributors: Christophe Bedard
```
