### PR TITLE
Add python3-ultralytics-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9922,7 +9922,7 @@ python3-ujson:
     '*': [python3-ujson]
     '7': null
   ubuntu: [python3-ujson]
-python3-ultralytics:
+python3-ultralytics-pip:
   debian:
     pip:
       packages: [ultralytics]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9922,6 +9922,13 @@ python3-ujson:
     '*': [python3-ujson]
     '7': null
   ubuntu: [python3-ujson]
+python3-ultralytics:
+  debian:
+    pip:
+      packages: [ultralytics]
+  ubuntu:
+    pip:
+      packages: [ultralytics]
 python3-unidiff:
   arch: [python-unidiff]
   debian: [python3-unidiff]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-ultralytics

## Package Upstream Source:

https://pypi.org/project/ultralytics/
https://github.com/ultralytics/ultralytics

## Purpose of using this:

YOLO (You Only Look Once) is an object detection and image segmentation model developed by [Ultralytics](https://ultralytics.com/). The `YOLOv8` model can be useful for computer-vision based tasks, where it can be easily integrated into a ROS node.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://pypi.org/project/ultralytics/
- Ubuntu: https://packages.ubuntu.com/
   - https://pypi.org/project/ultralytics/
