### PR TITLE
Revert "qb_move: 3.0.0-1 in 'melodic/distribution.yaml' [bloom] (#357…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9875,12 +9875,11 @@ repositories:
       - qb_move
       - qb_move_control
       - qb_move_description
-      - qb_move_gazebo
       - qb_move_hardware_interface
       tags:
         release: release/melodic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbmove-ros-release.git
-      version: 3.0.0-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbmove-ros.git


### PR DESCRIPTION
…92)"

This reverts commit d19a87a538bf8140b3033a78483a9d8bcc0713ef.

This has failed to build since it was merged: https://build.ros.org/view/Mbin_uB64/job/Msrc_uB__qb_move_hardware_interface__ubuntu_bionic__source/ .

@umbertofontana93 FYI