### PR TITLE
Revert "qb_device: 3.0.5-2 in 'melodic/distribution.yaml' [bloom] (#3…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9831,7 +9831,6 @@ repositories:
       - qb_device_control
       - qb_device_description
       - qb_device_driver
-      - qb_device_gazebo
       - qb_device_hardware_interface
       - qb_device_msgs
       - qb_device_srvs
@@ -9839,7 +9838,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
-      version: 3.0.5-2
+      version: 2.0.1-0
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbdevice-ros.git


### PR DESCRIPTION
…5790)"

This reverts commit 1a2da52105c7d080494e51d41da96bb5c5d1f1df.

While this package builds, some of the downstream packages that depend on it do not.  So we revert this back to the last known working version (2.0.1).  @umbertofontana93 FYI.