### PR TITLE
jackal_desktop: 0.4.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3970,6 +3970,24 @@ repositories:
       url: https://github.com/jackal/jackal.git
       version: noetic-devel
     status: maintained
+  jackal_desktop:
+    doc:
+      type: git
+      url: https://github.com/jackal/jackal_desktop.git
+      version: melodic-devel
+    release:
+      packages:
+      - jackal_desktop
+      - jackal_viz
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/jackal_desktop-release.git
+      version: 0.4.1-2
+    source:
+      type: git
+      url: https://github.com/jackal/jackal_desktop.git
+      version: melodic-devel
+    status: maintained
   jackal_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_desktop` to `0.4.1-2`:

- upstream repository: https://github.com/jackal/jackal_desktop.git
- release repository: https://github.com/clearpath-gbp/jackal_desktop-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## jackal_desktop

- No changes

## jackal_viz

```
* Updated jackal_viz (#3 <https://github.com/jackal/jackal_desktop/issues/3>)
  * Add rqt_gui as run_depend
  * Add rqt directory and launch check
* Diagnostic Viewer (#2 <https://github.com/jackal/jackal_desktop/issues/2>)
  * Added 'view_diagnostics.launch' to start rqt with console and robot monitor
  * Added noetic .perspective, now are dependant on ROS_DISTRO
  * Removed distro specific perspectives
* Contributors: luis-camero
```
