### PR TITLE
Drop RHEL 7, add RHEL 9 to rosdep repository checks

### DIFF
--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -24,15 +24,15 @@ package_sources:
   - !rpm_base_url http://download.opensuse.org/update/leap/$releasever/non-oss/
   rhel:
   - !rpm_mirrorlist_url https://mirrors.fedoraproject.org/mirrorlist?repo=epel-$releasever&arch=$basearch
-  - '7':
-    - !rpm_mirrorlist_url http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os
-    - !rpm_mirrorlist_url http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates
-    - !rpm_mirrorlist_url http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras
-    - !rpm_mirrorlist_url http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=sclo-sclo
-    '8':
+  - '8':
     - !rpm_mirrorlist_url https://mirrors.almalinux.org/mirrorlist/$releasever/baseos
     - !rpm_mirrorlist_url https://mirrors.almalinux.org/mirrorlist/$releasever/appstream
     - !rpm_mirrorlist_url https://mirrors.almalinux.org/mirrorlist/$releasever/powertools
+    - !rpm_mirrorlist_url https://mirrors.almalinux.org/mirrorlist/$releasever/extras
+    '9':
+    - !rpm_mirrorlist_url https://mirrors.almalinux.org/mirrorlist/$releasever/baseos
+    - !rpm_mirrorlist_url https://mirrors.almalinux.org/mirrorlist/$releasever/appstream
+    - !rpm_mirrorlist_url https://mirrors.almalinux.org/mirrorlist/$releasever/crb
     - !rpm_mirrorlist_url https://mirrors.almalinux.org/mirrorlist/$releasever/extras
   - !rpm_mirrorlist_url https://mirrors.rpmfusion.org/mirrorlist?repo=free-el-updates-released-$releasever&arch=$basearch
   ubuntu:
@@ -68,8 +68,8 @@ supported_versions:
   opensuse:
   - '15.2'
   rhel:
-  - '7'
   - '8'
+  - '9'
   ubuntu:
   - bionic
   - focal
@@ -98,9 +98,9 @@ name_replacements:
     '37':
       '%{__isa_name}': 'x86'
   rhel:
-    '7':
-      '%{__isa_name}': 'x86'
-      '%{python3_pkgversion}': '36'
     '8':
+      '%{__isa_name}': 'x86'
+      '%{python3_pkgversion}': '3'
+    '9':
       '%{__isa_name}': 'x86'
       '%{python3_pkgversion}': '3'


### PR DESCRIPTION
We don't support any distros on RHEL 7, so I see no reason to keep checking rules against it, especially given the overhead of using the `%{python3_pkgversion}` macro.

While we're 100% clean for RHEL 8, we have some work to do on RHEL 9. We don't need to address these failures now, but here are the rules that are currently unsatisfied:

<details>

```
* The following 33 packages were not found for rhel 9 on x86_64:
- Package GeographicLib for rosdep key geographiclib-tools
- Package GeographicLib-devel for rosdep key geographiclib
- Package assimp-devel for rosdep key assimp
- Package assimp-devel for rosdep key assimp-dev
- Package devilspie2 for rosdep key devilspie2
- Package fcl-devel for rosdep key libfcl-dev
- Package fswebcam for rosdep key fswebcam
- Package log4cxx-devel for rosdep key log4cxx
- Package python3-GeographicLib for rosdep key python3-geographiclib
- Package python3-autobahn for rosdep key python3-autobahn
- Package python3-catkin_lint for rosdep key python3-catkin-lint
- Package python3-django-rest-framework for rosdep key python3-djangorestframework
- Package python3-fiona for rosdep key python3-fiona
- Package python3-flask-cors for rosdep key python3-flask-cors
- Package python3-flask-migrate for rosdep key python3-flask-migrate
- Package python3-flask-sqlalchemy for rosdep key python3-flask-sqlalchemy
- Package python3-google-auth-oauthlib for rosdep key python3-google-auth-oauthlib
- Package python3-ifcfg for rosdep key python3-ifcfg
- Package python3-img2pdf for rosdep key python3-img2pdf
- Package python3-matplotlib for rosdep key python3-matplotlib
- Package python3-mock for rosdep key python3-mock
- Package python3-nose for rosdep key python3-nose
- Package python3-pandas for rosdep key python3-pandas
- Package python3-pika for rosdep key python3-pika
- Package python3-pydbus for rosdep key python3-pydbus
- Package python3-pygraphviz for rosdep key python3-pygraphviz
- Package python3-pysnmp for rosdep key python3-pysnmp
- Package python3-reportlab for rosdep key python3-reportlab
- Package python3-rosinstall_generator for rosdep key python3-rosinstall-generator
- Package python3-segno for rosdep key python3-segno
- Package python3-twisted for rosdep key python3-twisted
- Package python3-whichcraft for rosdep key python3-whichcraft
- Package tesseract-langpack-jpn for rosdep key tesseract-ocr-jpn
```

</details>