### PR TITLE
stomp: 0.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6335,11 +6335,20 @@ repositories:
       version: humble
     status: developed
   stomp:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/stomp.git
+      version: main
     release:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/stomp-release.git
       version: 0.1.2-1
+    source:
+      type: git
+      url: https://github.com/ros-industrial/stomp.git
+      version: main
+    status: maintained
   stubborn_buddies:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6334,6 +6334,12 @@ repositories:
       url: https://github.com/ros2/sros2.git
       version: humble
     status: developed
+  stomp:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/stomp-release.git
+      version: 0.1.2-1
   stubborn_buddies:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `stomp` to `0.1.2-1`:

- upstream repository: https://github.com/ros-industrial/stomp.git
- release repository: https://github.com/ros2-gbp/stomp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## stomp

- No changes
