### PR TITLE
gtsam: 4.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1752,6 +1752,11 @@ repositories:
       type: git
       url: https://github.com/borglab/gtsam.git
       version: develop
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/gtsam-release.git
+      version: 4.2.0-1
     source:
       type: git
       url: https://github.com/borglab/gtsam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gtsam` to `4.2.0-1`:

- upstream repository: https://github.com/borglab/gtsam.git
- release repository: https://github.com/ros2-gbp/gtsam-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
