### PR TITLE
neonavigation: 0.12.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7772,7 +7772,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.12.1-1
+      version: 0.12.2-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.12.2-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.12.1-1`

## costmap_cspace

- No changes

## joystick_interrupt

- No changes

## map_organizer

- No changes

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

- No changes

## obj_to_pointcloud

- No changes

## planner_cspace

```
* planner_cspace: fix planner_2dof_serial_joints status (#682 <https://github.com/at-wat/neonavigation/issues/682>)
* planner_cspace: set timestamp to planner status message (#681 <https://github.com/at-wat/neonavigation/issues/681>)
* planner_cspace: fix uninitialized variables in DistanceMap (#679 <https://github.com/at-wat/neonavigation/issues/679>)
* planner_cspace: add scoped trace to some test cases (#680 <https://github.com/at-wat/neonavigation/issues/680>)
* Contributors: Atsushi Watanabe
```

## safety_limiter

- No changes

## track_odometry

- No changes

## trajectory_tracker

- No changes
