### PR TITLE
ros2_control: 3.9.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4354,7 +4354,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.8.0-1
+      version: 3.9.0-2
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.9.0-2`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.8.0-1`

## controller_interface

- No changes

## controller_manager

```
* fix AttributeError: Parameter object attribute name is read-only (#957 <https://github.com/ros-controls/ros2_control/issues/957>)
* Remove deprecations from CLI and controller_manager (#948 <https://github.com/ros-controls/ros2_control/issues/948>)
* Expose node options to controller manager (#942 <https://github.com/ros-controls/ros2_control/issues/942>)
* Contributors: Christoph Fröhlich, Noel Jiménez García, methylDragon
```

## controller_manager_msgs

```
* Remove deprecations from CLI and controller_manager (#948 <https://github.com/ros-controls/ros2_control/issues/948>)
  Co-authored-by: Bence Magyar <mailto:bence.magyar.robotics@gmail.com>
* Contributors: Christoph Fröhlich
```

## hardware_interface

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Remove deprecations from CLI and controller_manager (#948 <https://github.com/ros-controls/ros2_control/issues/948>)
* [CLI] Fix wrong output of controller states for load_controller command (#947 <https://github.com/ros-controls/ros2_control/issues/947>)
* Contributors: Christoph Fröhlich
```

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
