### PR TITLE
schunk_svh_ros_driver: 2.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6436,6 +6436,25 @@ repositories:
       url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_library.git
       version: main
     status: developed
+  schunk_svh_ros_driver:
+    doc:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_ros_driver.git
+      version: ros2-foxy
+    release:
+      packages:
+      - schunk_svh_description
+      - schunk_svh_driver
+      - schunk_svh_tests
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/schunk_svh_ros_driver-release.git
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_ros_driver.git
+      version: ros2-foxy
+    status: developed
   septentrio_gnss_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_svh_ros_driver` to `2.0.1-1`:

- upstream repository: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_ros_driver.git
- release repository: https://github.com/ros2-gbp/schunk_svh_ros_driver-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## schunk_svh_description

```
* Unify version numbers
  The version convention is as follows:
  0.1.x for ROS1 Melodic and Noetic
  2.0.x for ROS2 Foxy
  2.1.x for ROS2 Humble
  We start with 2.0.0 and bumb that with bloom to 2.0.1 for the first
  release.
* Update maintainer info
  Let's keep the list short for now.
* Merge branch 'update-license-ros2' into 'ros2-foxy-devel'
  Switch license to GPLv3
  See merge request ros/schunk_svh_driver!24
* Update SPDX license indicator in package.xml
  This is according to
  here <https://www.gnu.org/licenses/identify-licenses-clearly.html>
* Add a high-level readme file
  Also add a minimal readme for the description sub package.
* Merge branch 'meta-package' into 'ros2-foxy-devel'
  Make this a meta package
  See merge request ros/schunk_svh_driver!21
* Merge remote-tracking branch 'schunk_svh_description/prepare-inclusion-into-meta-package' into meta-package
* Move everything into a equally named sub package
  We'll merge that into the schunk_svh_ros_driver meta package.
* Contributors: Stefan Scherzinger
```

## schunk_svh_driver

```
* Unify version numbers
  The version convention is as follows:
  0.1.x for ROS1 Melodic and Noetic
  2.0.x for ROS2 Foxy
  2.1.x for ROS2 Humble
  We start with 2.0.0 and bumb that with bloom to 2.0.1 for the first
  release.
* Add missing execution dependencies
  We need those for our current, minimal setup.
* Update maintainer info
  Let's keep the list short for now.
* Merge branch 'update-license-ros2' into 'ros2-foxy-devel'
  Switch license to GPLv3
  See merge request ros/schunk_svh_driver!24
* Add license notice to all development files
  The text is in accordance with the recommendations from
  here <https://www.gnu.org/licenses/gpl-howto.html>
  in the section *The license notices*.
* Update SPDX license indicator in package.xml
  This is according to
  here <https://www.gnu.org/licenses/identify-licenses-clearly.html>
* Add license text for the GPLv3
  The license text is from
  here <https://www.gnu.org/licenses/gpl-3.0.txt> after following the
  recommendations from here <https://www.gnu.org/licenses/gpl-howto.html>
* Remove debug comment from launch file
* Update the driver's sup package readme
* Fix build warnings about unused parameters
* Merge branch 'improve-test-gui' into 'ros2-foxy-devel'
  Improve test gui
  See merge request ros/schunk_svh_driver!22
* Improve the gui layout
  The sliders are now horizontally arranged and labeled.
  Also increase the trajectory speed.
* Add a slider for each individual joint
  This allows to test if each joint behaves as expected.
* Merge branch 'meta-package' into 'ros2-foxy-devel'
  Make this a meta package
  See merge request ros/schunk_svh_driver!21
* Add execution dependency for the description package
* Prepare making this a meta repository
  We'll integrate the schunk_svh_description into this package.
* Contributors: Stefan Scherzinger
```

## schunk_svh_tests

```
* Unify version numbers
  The version convention is as follows:
  0.1.x for ROS1 Melodic and Noetic
  2.0.x for ROS2 Foxy
  2.1.x for ROS2 Humble
  We start with 2.0.0 and bumb that with bloom to 2.0.1 for the first
  release.
* Use default hand type for integration tests
  We normally make the distinction on startup via launch file parameters.
  For integration tests, it's sufficient to test with the right hand only.
* Add pipeline for integration testing
  This is a minimal setup that starts the ROS2-control pipeline.
  The driver will currently fail due to a missing serial interface
  (ttyUSB) but the output might give insights if the installation
  process is successful on a fresh OS install.
* Contributors: Stefan Scherzinger
```
