### PR TITLE
turtlebot4: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6796,7 +6796,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot4.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4` to `1.0.1-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4.git
- release repository: https://github.com/ros2-gbp/turtlebot4-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-1`

## turtlebot4_description

- No changes

## turtlebot4_msgs

- No changes

## turtlebot4_navigation

```
* Navigator fixes
* Contributors: Roni Kreinin
```

## turtlebot4_node

```
* Force 1HZ update on display
* Contributors: Roni Kreinin
```
