### PR TITLE
tiago_robot: 4.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6627,7 +6627,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_robot-release.git
-      version: 4.0.2-1
+      version: 4.0.3-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_robot` to `4.0.3-1`:

- upstream repository: https://github.com/pal-robotics/tiago_robot
- release repository: https://github.com/pal-gbp/tiago_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.2-1`

## tiago_bringup

```
* Merge branch 'play_motion2' into 'humble-devel'
  Launch PlayMotion2 and update motions files
  See merge request robots/tiago_robot!189
* rename play_motion2 launcher
* add exec dependency play_motion2
* launch play_motion2
* regenerate motions files for play_motion2
* enable regen_em_file.py
* Contributors: Jordan Palacios, Noel Jimenez
```

## tiago_controller_configuration

- No changes

## tiago_description

```
* Merge branch 'join_transmissions' into 'humble-devel'
  Join transmissions in a single file
  See merge request robots/tiago_robot!187
* join transmissions definition in a single file
* remove unused includes and duplicated transmissions
* Contributors: Jordan Palacios, Noel Jimenez
```

## tiago_robot

- No changes
