### PR TITLE
tiago_simulation: 4.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6645,7 +6645,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_simulation-release.git
-      version: 4.0.1-1
+      version: 4.0.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_simulation` to `4.0.2-1`:

- upstream repository: https://github.com/pal-robotics/tiago_simulation
- release repository: https://github.com/pal-gbp/tiago_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.1-1`

## tiago_gazebo

```
* Merge branch 'tuck_arm' into 'humble-devel'
  tuck_arm for play_motion2
  See merge request robots/tiago_simulation!103
* comment subprocess to kill gazebo at the end of the test
* remove unused deps and reorder
* reduce sleep time
* log waiting for state
* remove unnecessary const
* tuck arm test
* launch tuck arm
* tuck_arm for play_motion2
* Contributors: Jordan Palacios, Noel Jimenez
```

## tiago_simulation

- No changes
