### PR TITLE
rclcpp: 19.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3741,7 +3741,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 19.2.0-1
+      version: 19.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `19.3.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `19.2.0-1`

## rclcpp

```
* Fix memory leak in tracetools::get_symbol() (#2104 <https://github.com/ros2/rclcpp/issues/2104>)
* Service introspection (#1985 <https://github.com/ros2/rclcpp/issues/1985>)
* Allow publishing borrowed messages with intra-process enabled (#2108 <https://github.com/ros2/rclcpp/issues/2108>)
* to fix flaky test about TestTimeSource.callbacks (#2111 <https://github.com/ros2/rclcpp/issues/2111>)
* Contributors: Brian, Chen Lihui, Christophe Bedard, Miguel Company
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
