### PR TITLE
turtlebot4_setup: 1.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6908,7 +6908,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4_setup-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot4_setup.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4_setup` to `1.0.2-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4_setup.git
- release repository: https://github.com/ros2-gbp/turtlebot4_setup-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.1-1`

## turtlebot4_setup

```
* Fixed Discovery Server IP
* Updated default configs
* Contributors: Roni Kreinin
```
