### PR TITLE
openni2_camera: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2963,6 +2963,15 @@ repositories:
       url: https://github.com/ros2-gbp/ompl-release.git
       version: 1.5.2-2
   openni2_camera:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/openni2_camera.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/openni2_camera-release.git
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_camera` to `2.0.0-1`:

- upstream repository: https://github.com/ros-drivers/openni2_camera.git
- release repository: https://github.com/ros2-gbp/openni2_camera-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## openni2_camera

```
* revive the test wrapper (#127 <https://github.com/ros-drivers/openni2_camera/issues/127>)
  resolves #123 <https://github.com/ros-drivers/openni2_camera/issues/123>
* remove boost and unused files (#122 <https://github.com/ros-drivers/openni2_camera/issues/122>)
  * replace boost functionality by standard C++
  * remove ROS nodelet metadata
  * store parameter callback
  * remove ROS1 node
  * remove unused os import
  Co-authored-by: Christian Rauch <mailto:Rauch.Christian@gmx.de>
* fix build, target only humble and later (#118 <https://github.com/ros-drivers/openni2_camera/issues/118>)
* Capability: [CI] Add GitHub Action (#116 <https://github.com/ros-drivers/openni2_camera/issues/116>)
  * Capability: [CI] Add GitHub Action
  * Maintenance: Update maintaner contact
* initial port to ROS2
* Contributors: Isaac I.Y. Saito, Michael Ferguson
```
