### PR TITLE
openni2_camera: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3332,6 +3332,21 @@ repositories:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
       version: 1.6.0-1
+  openni2_camera:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/openni2_camera.git
+      version: ros2
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/openni2_camera-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/openni2_camera.git
+      version: ros2
+    status: maintained
   orocos_kdl_vendor:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_camera` to `2.0.0-1`:

- upstream repository: https://github.com/ros-drivers/openni2_camera.git
- release repository: https://github.com/ros2-gbp/openni2_camera-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## openni2_camera

```
* revive the test wrapper (#127 <https://github.com/ros-drivers/openni2_camera/issues/127>)
  resolves #123 <https://github.com/ros-drivers/openni2_camera/issues/123>
* remove boost and unused files (#122 <https://github.com/ros-drivers/openni2_camera/issues/122>)
  * replace boost functionality by standard C++
  * remove ROS nodelet metadata
  * store parameter callback
  * remove ROS1 node
  * remove unused os import
  Co-authored-by: Christian Rauch <mailto:Rauch.Christian@gmx.de>
* fix build, target only humble and later (#118 <https://github.com/ros-drivers/openni2_camera/issues/118>)
* Capability: [CI] Add GitHub Action (#116 <https://github.com/ros-drivers/openni2_camera/issues/116>)
  * Capability: [CI] Add GitHub Action
  * Maintenance: Update maintaner contact
* initial port to ROS2
* Contributors: Isaac I.Y. Saito, Michael Ferguson
```
