### PR TITLE
gazebo_ros2_control: 0.4.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1436,7 +1436,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.4.1-1
+      version: 0.4.2-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros2_control` to `0.4.2-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros2_control.git
- release repository: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.1-1`

## gazebo_ros2_control

```
* Export all dependencies (#183 <https://github.com/ros-controls/gazebo_ros2_control/issues/183>)
  The ament_export_dependencies exports dependencies to downstream
  packages. This is necessary so that the user of the library does
  not have to call find_package for those dependencies.
* Contributors: Adrian Zwiener
```

## gazebo_ros2_control_demos

- No changes
