### PR TITLE
phidgets_drivers: 1.0.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6912,7 +6912,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
-      version: 1.0.6-1
+      version: 1.0.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `1.0.7-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.6-1`

## libphidget22

```
* Update to libphidget22 1.13. (#161 <https://github.com/ros-drivers/phidgets_drivers/issues/161>)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: Martin Günther
```

## phidgets_accelerometer

- No changes

## phidgets_analog_inputs

- No changes

## phidgets_analog_outputs

- No changes

## phidgets_api

- No changes

## phidgets_digital_inputs

- No changes

## phidgets_digital_outputs

- No changes

## phidgets_drivers

- No changes

## phidgets_gyroscope

- No changes

## phidgets_high_speed_encoder

```
* BUGFIX: Z-channel index was not observed in reported positions (#158 <https://github.com/ros-drivers/phidgets_drivers/issues/158>)
  * fix doxygen format and ensure initial values
  * BUGFIX: Encoder index was not used
* BUGFIX: Wrong speed conversion factor (#155 <https://github.com/ros-drivers/phidgets_drivers/issues/155>)
  The current code assumed time intervals from the Phidgets API was microseconds, but it's actually milliseconds. Reported speeds are all wrong by a factor of 1e3.
* Contributors: Jose Luis Blanco-Claraco
```

## phidgets_ik

- No changes

## phidgets_magnetometer

- No changes

## phidgets_motors

- No changes

## phidgets_msgs

- No changes

## phidgets_spatial

- No changes

## phidgets_temperature

- No changes
