### PR TITLE
ros2_tracing: 5.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4441,7 +4441,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 5.0.0-1
+      version: 5.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `5.1.0-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `5.0.0-1`

## ros2trace

- No changes

## tracetools

```
* Explicitly link against dl for dladdr() (#48 <https://github.com/ros2/ros2_tracing/issues/48>)
* Fix memory leak in tracetools::get_symbol() (#43 <https://github.com/ros2/ros2_tracing/issues/43>)
* Add TRACEPOINT_ENABLED() and DO_TRACEPOINT() macros (#46 <https://github.com/ros2/ros2_tracing/issues/46>)
* Contributors: Christophe Bedard
```

## tracetools_launch

- No changes

## tracetools_read

- No changes

## tracetools_test

- No changes

## tracetools_trace

- No changes
