### PR TITLE
novatel_oem7_driver: 4.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6252,7 +6252,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
-      version: 4.0.0-1
+      version: 4.1.0-1
     source:
       type: git
       url: https://github.com/novatel/novatel_oem7_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_oem7_driver` to `4.1.0-1`:

- upstream repository: https://github.com/novatel/novatel_oem7_driver.git
- release repository: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.0-1`
