### PR TITLE
openni2_camera: 2.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3341,7 +3341,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/openni2_camera-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_camera` to `2.0.1-1`:

- upstream repository: https://github.com/ros-drivers/openni2_camera.git
- release repository: https://github.com/ros2-gbp/openni2_camera-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-1`

## openni2_camera

```
* fix device time (#129 <https://github.com/ros-drivers/openni2_camera/issues/129>)
* add build depend on pkg-config (#128 <https://github.com/ros-drivers/openni2_camera/issues/128>)
* Contributors: Michael Ferguson
```
