### PR TITLE
tf2_2d: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5865,6 +5865,11 @@ repositories:
       type: git
       url: https://github.com/locusrobotics/tf2_2d.git
       version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/tf2_2d-release.git
+      version: 1.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf2_2d` to `1.0.1-1`:

- upstream repository: https://github.com/locusrobotics/tf2_2d.git
- release repository: https://github.com/ros2-gbp/tf2_2d-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## tf2_2d

```
* Port tf2_2d to ROS 2 (#5 <https://github.com/locusrobotics/tf2_2d/issues/5>)
  * Build sytem changes for ROS 2
  * Code changes for ROS 2
  * Don't need int main(); because linking to GTEST_MAIN_LIBRARIES
  * Skip ament_cmake_copyright
  * Move .h headers to .hpp
  * Add .h headers with warning for backwards compatability
  * Linter fixes: Satisfy Uncrustify
  * Linter fixes: Satisfy cpplint
  * Minimum CMake 3.14.4
  * ${tf2_geometry_msgs_TARGETS} -> tf2_geometry_msgs::tf2_geometry_msgs
  * Bump copywrite date on redirection headers
  * Remove Scalar.h include
* Tailor: Updating Jenkinsfile
* Tailor: Updating Jenkinsfile
* Tailor: Updating Jenkinsfile
* Contributors: Shane Loretz, locus-services
```
