### PR TITLE
phidgets_drivers: 2.3.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3574,6 +3574,7 @@ repositories:
       - libphidget22
       - phidgets_accelerometer
       - phidgets_analog_inputs
+      - phidgets_analog_outputs
       - phidgets_api
       - phidgets_digital_inputs
       - phidgets_digital_outputs
@@ -3589,7 +3590,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/phidgets_drivers-release.git
-      version: 2.3.0-2
+      version: 2.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `2.3.1-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros2-gbp/phidgets_drivers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.0-2`

## libphidget22

```
* Update to libphidget22 1.13. (#160 <https://github.com/ros-drivers/phidgets_drivers/issues/160>)
* Contributors: Chris Lalancette
```

## phidgets_accelerometer

- No changes

## phidgets_analog_inputs

- No changes

## phidgets_analog_outputs

```
* adding support for analog outputs for ROS2 (#145 <https://github.com/ros-drivers/phidgets_drivers/issues/145>)
  * support for analog output
  Co-authored-by: Alexis <mailto:alexis.fetet@capacites.fr>
  Co-authored-by: Chris Lalancette <mailto:clalancette@openrobotics.org>
* Contributors: Alexis Fetet
* adding support for analog outputs for ROS2 (#145 <https://github.com/ros-drivers/phidgets_drivers/issues/145>)
* Contributors: Alexis Fetet
```

## phidgets_api

```
* adding support for analog outputs for ROS2 (#145 <https://github.com/ros-drivers/phidgets_drivers/issues/145>)
* Contributors: Alexis Fetet
```

## phidgets_digital_inputs

- No changes

## phidgets_digital_outputs

- No changes

## phidgets_drivers

- No changes

## phidgets_gyroscope

- No changes

## phidgets_high_speed_encoder

```
* BUGFIX: Z-channel index was not observed in reported positions (#158 <https://github.com/ros-drivers/phidgets_drivers/issues/158>)
  * fix doxygen format and ensure initial values
  * BUGFIX: Encoder index was not used
* BUGFIX: Wrong speed conversion factor (#157 <https://github.com/ros-drivers/phidgets_drivers/issues/157>)
  The current code assumed time intervals from the Phisgets API was microseconds, but it's actually milliseconds. Reported speeds are all wrong by a factor of 1e3.
* Contributors: Jose Luis Blanco-Claraco, Martin Günther
```

## phidgets_ik

- No changes

## phidgets_magnetometer

- No changes

## phidgets_motors

- No changes

## phidgets_msgs

```
* adding support for analog outputs for ROS2 (#145 <https://github.com/ros-drivers/phidgets_drivers/issues/145>)
* Contributors: Alexis Fetet
```

## phidgets_spatial

- No changes

## phidgets_temperature

- No changes
