### PR TITLE
Remove Debian Buster from Noetic distribution.yaml

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3,8 +3,6 @@
 # see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
-  debian:
-  - buster
   ubuntu:
   - focal
 repositories:


### PR DESCRIPTION
Redo the reverted part of https://github.com/ros/rosdistro/pull/36285

https://github.com/ros-infrastructure/rep/pull/373