### PR TITLE
libcamera: 0.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2382,6 +2382,16 @@ repositories:
       type: git
       url: https://github.com/lgsvl/lgsvl_msgs.git
       version: foxy-devel
+  libcamera:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/libcamera-release.git
+      version: 0.0.4-1
+    source:
+      type: git
+      url: https://git.libcamera.org/libcamera/libcamera.git
+      version: master
   libg2o:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `libcamera` to `0.0.4-1`:

- upstream repository: https://git.libcamera.org/libcamera/libcamera.git
- release repository: https://github.com/ros2-gbp/libcamera-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
