### PR TITLE
odom_to_tf_ros2: 1.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3588,6 +3588,21 @@ repositories:
       url: https://github.com/OctoMap/octomap_rviz_plugins.git
       version: ros2
     status: maintained
+  odom_to_tf_ros2:
+    doc:
+      type: git
+      url: https://github.com/gstavrinos/odom_to_tf_ros2.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/gstavrinos/odom_to_tf_ros2-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/gstavrinos/odom_to_tf_ros2.git
+      version: master
+    status: maintained
   ompl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `odom_to_tf_ros2` to `1.0.2-1`:

- upstream repository: https://github.com/gstavrinos/odom_to_tf_ros2.git
- release repository: https://github.com/gstavrinos/odom_to_tf_ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## odom_to_tf_ros2

```
* Now using the timestamp to support both simulated and real time applications
* Added an example config file
* Added the ability to change the odom frame_id and child_frame_id
* First complete version of the node
* Initial commit
* Contributors: George Stavrinos
```
