### PR TITLE
Add base rules for paho-mqtt-c and paho-mqtt-cpp

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7160,6 +7160,14 @@ osmium:
   fedora: [libosmium-devel]
   nixos: [libosmium]
   ubuntu: [libosmium-dev]
+paho-mqtt-c:
+  debian:
+    bullseye: [libpaho-mqtt1.3]
+  ubuntu:
+    jammy: [libpaho-mqtt1.3]
+paho-mqtt-cpp:
+  ubuntu:
+    jammy: [libpaho-mqttpp3-1]
 pandoc:
   debian: [pandoc]
   fedora: [pandoc]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7162,17 +7162,20 @@ osmium:
   ubuntu: [libosmium-dev]
 paho-mqtt-c:
   alpine: [paho-mqtt-c]
-  debian:
-    bullseye: [libpaho-mqtt1.3]
+  debian: [libpaho-mqtt1.3]
   fedora: [paho-c]
   nixos: [paho-mqtt-c]
   opensuse: [libpaho-mqtt1]
   ubuntu:
-    jammy: [libpaho-mqtt1.3]
+    '*': [libpaho-mqtt1.3]
+    focal: null
+    bionic: null
 paho-mqtt-cpp:
   nixos: [paho-mqtt-cpp]
   ubuntu:
-    jammy: [libpaho-mqttpp3-1]
+    '*': [libpaho-mqttpp3-1]
+    focal: null
+    bionic: null
 pandoc:
   debian: [pandoc]
   fedora: [pandoc]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7163,9 +7163,14 @@ osmium:
 paho-mqtt-c:
   debian:
     bullseye: [libpaho-mqtt1.3]
+  fedora: [paho-c]
+  nixos: [paho-mqtt-c]
+  opensuse: [paho-mqtt]
   ubuntu:
     jammy: [libpaho-mqtt1.3]
 paho-mqtt-cpp:
+  nixos: [paho-mqtt-cpp]
+  opensuse: [libpaho-mqttpp3-1]
   ubuntu:
     jammy: [libpaho-mqttpp3-1]
 pandoc:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7161,16 +7161,16 @@ osmium:
   nixos: [libosmium]
   ubuntu: [libosmium-dev]
 paho-mqtt-c:
+  alpine: [paho-mqtt-c]
   debian:
     bullseye: [libpaho-mqtt1.3]
   fedora: [paho-c]
   nixos: [paho-mqtt-c]
-  opensuse: [paho-mqtt]
+  opensuse: [libpaho-mqtt1]
   ubuntu:
     jammy: [libpaho-mqtt1.3]
 paho-mqtt-cpp:
   nixos: [paho-mqtt-cpp]
-  opensuse: [libpaho-mqttpp3-1]
   ubuntu:
     jammy: [libpaho-mqttpp3-1]
 pandoc:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4639,6 +4639,36 @@ libosmesa6-dev:
   fedora: [mesa-libOSMesa-devel]
   gentoo: ['media-libs/mesa[osmesa]']
   ubuntu: [libosmesa6-dev]
+libpaho-mqtt:
+  alpine: [paho-mqtt-c]
+  debian: [libpaho-mqtt1.3]
+  fedora: [paho-c]
+  nixos: [paho-mqtt-c]
+  opensuse: [libpaho-mqtt1]
+  ubuntu:
+    '*': [libpaho-mqtt1.3]
+    bionic: null
+    focal: null
+libpaho-mqtt-dev:
+  alpine: [paho-mqtt-c-dev]
+  debian: [libpaho-mqtt-dev]
+  fedora: [paho-c-devel]
+  opensuse: [libpaho-mqtt-devel]
+  ubuntu:
+    '*': [libpaho-mqtt-dev]
+    bionic: null
+    focal: null
+libpaho-mqttpp:
+  nixos: [paho-mqtt-cpp]
+  ubuntu:
+    '*': [libpaho-mqttpp3-1]
+    bionic: null
+    focal: null
+libpaho-mqttpp-dev:
+  ubuntu:
+    '*': [libpaho-mqttpp-dev]
+    bionic: null
+    focal: null
 libpcap:
   arch:
     pacman:
@@ -7160,36 +7190,6 @@ osmium:
   fedora: [libosmium-devel]
   nixos: [libosmium]
   ubuntu: [libosmium-dev]
-libpaho-mqtt:
-  alpine: [paho-mqtt-c]
-  debian: [libpaho-mqtt1.3]
-  fedora: [paho-c]
-  nixos: [paho-mqtt-c]
-  opensuse: [libpaho-mqtt1]
-  ubuntu:
-    '*': [libpaho-mqtt1.3]
-    focal: null
-    bionic: null
-libpaho-mqtt-dev:
-  alpine: [paho-mqtt-c-dev]
-  debian: [libpaho-mqtt-dev]
-  fedora: [paho-c-devel]
-  opensuse: [libpaho-mqtt-devel]
-  ubuntu:
-    '*': [libpaho-mqtt-dev]
-    focal: null
-    bionic: null
-libpaho-mqttpp:
-  nixos: [paho-mqtt-cpp]
-  ubuntu:
-    '*': [libpaho-mqttpp3-1]
-    focal: null
-    bionic: null
-libpaho-mqttpp-dev:
-  ubuntu:
-    '*': [libpaho-mqttpp-dev]
-    focal: null
-    bionic: null
 pandoc:
   debian: [pandoc]
   fedora: [pandoc]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7160,7 +7160,7 @@ osmium:
   fedora: [libosmium-devel]
   nixos: [libosmium]
   ubuntu: [libosmium-dev]
-paho-mqtt-c:
+libpaho-mqtt:
   alpine: [paho-mqtt-c]
   debian: [libpaho-mqtt1.3]
   fedora: [paho-c]
@@ -7170,10 +7170,24 @@ paho-mqtt-c:
     '*': [libpaho-mqtt1.3]
     focal: null
     bionic: null
-paho-mqtt-cpp:
+libpaho-mqtt-dev:
+  alpine: [paho-mqtt-c-dev]
+  debian: [libpaho-mqtt-dev]
+  fedora: [paho-c-devel]
+  opensuse: [libpaho-mqtt-devel]
+  ubuntu:
+    '*': [libpaho-mqtt-dev]
+    focal: null
+    bionic: null
+libpaho-mqttpp:
   nixos: [paho-mqtt-cpp]
   ubuntu:
     '*': [libpaho-mqttpp3-1]
+    focal: null
+    bionic: null
+libpaho-mqttpp-dev:
+  ubuntu:
+    '*': [libpaho-mqttpp-dev]
     focal: null
     bionic: null
 pandoc:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

- libpaho-mqtt
- libpaho-mqtt-dev
- libpaho-mqttpp
- libpaho-mqttpp-dev

## Package Upstream Source:

- https://github.com/eclipse/paho.mqtt.c
- https://github.com/eclipse/paho.mqtt.cpp

## Purpose of using this:

The Paho MQTT C and C++ client libraries are added. The libraries are dependencies of our ROS package [mqtt_client](https://github.com/ika-rwth-aachen/mqtt_client). ROS1 Noetic and ROS2 Galactic already [include a rule to install the libraries from a dedicated release repository](https://github.com/ros/rosdistro/blob/master/noetic/distribution.yaml#L6759). For ROS2 support I'm adding them as system dependencies since they have been officially released as apt dependencies in Ubuntu Jammy. Related to https://github.com/nobleo/paho.mqtt.cpp-release/issues/1.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/libpaho-mqtt1.3
  - https://packages.debian.org/bullseye/libpaho-mqtt-dev
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/jammy/libpaho-mqtt1.3
   - https://packages.ubuntu.com/jammy/libpaho-mqtt-dev
   - https://packages.ubuntu.com/jammy/libpaho-mqttpp3-1
   - https://packages.ubuntu.com/jammy/libpaho-mqttpp-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/paho-c/paho-c/
  - https://packages.fedoraproject.org/pkgs/paho-c/paho-c-devel/
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/packages?name=paho-mqtt-c
  - https://pkgs.alpinelinux.org/packages?name=paho-mqtt-c-dev
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=22.11&show=paho-mqtt-cpp&from=0&size=50&sort=relevance&type=packages&query=paho
  - https://search.nixos.org/packages?channel=22.11&show=paho-mqtt-cpp&from=0&size=50&sort=relevance&type=packages&query=paho
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/libpaho-mqtt1
  - https://software.opensuse.org/package/libpaho-mqtt-devel
