### PR TITLE
smacc2: 2.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6592,8 +6592,6 @@ repositories:
       version: foxy
     release:
       packages:
-      - ros_timer_client
-      - sm_atomic
       - smacc2
       - smacc2_msgs
       tags:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6592,12 +6592,14 @@ repositories:
       version: foxy
     release:
       packages:
+      - ros_timer_client
+      - sm_atomic
       - smacc2
       - smacc2_msgs
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/robosoft-ai/SMACC2-release.git
-      version: 0.2.0-2
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/robosoft-ai/SMACC2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `smacc2` to `2.1.0-1`:

- upstream repository: https://github.com/robosoft-ai/SMACC2.git
- release repository: https://github.com/robosoft-ai/SMACC2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.0-2`
