### PR TITLE
graceful_controller: 0.4.8-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3214,7 +3214,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mikeferguson/graceful_controller-gbp.git
-      version: 0.4.7-1
+      version: 0.4.8-1
     source:
       type: git
       url: https://github.com/mikeferguson/graceful_controller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `graceful_controller` to `0.4.8-1`:

- upstream repository: https://github.com/mikeferguson/graceful_controller.git
- release repository: https://github.com/mikeferguson/graceful_controller-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.7-1`

## graceful_controller

- No changes

## graceful_controller_ros

```
* fix stutter when robot velocity exceeds max_vel_x (#69 <https://github.com/mikeferguson/graceful_controller/issues/69>)
  a bit of noise on the odometry can cause the robot to overshoot
  the max_vel_x - this would then cause us to decelerate - possibly
  quite hard if the decel_lim_x was high.
* Contributors: Michael Ferguson
```
