### PR TITLE
rmw_gurumdds: 4.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4276,7 +4276,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
-      version: 4.1.2-1
+      version: 4.2.0-1
     source:
       type: git
       url: https://github.com/ros2/rmw_gurumdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_gurumdds` to `4.2.0-1`:

- upstream repository: https://github.com/ros2/rmw_gurumdds.git
- release repository: https://github.com/ros2-gbp/rmw_gurumdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.1.2-1`

## gurumdds_cmake_module

```
* Add maintainer
* Contributors: donghee811
```

## rmw_gurumdds_cpp

```
* Add maintainer
* Add null handling
* Apply loop to take sequence
* Make writer_guid uint8_t[] for consistency with rmw_request_id_t
* Make sure to add semicolons to the RMW_CHECK_TYPE_IDENTIFIERS_MATCH
* Contributors: Youngjin Yun, donghee811
```
