### PR TITLE
rmw_gurumdds: 1.4.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5133,7 +5133,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
-      version: 1.3.1-1
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/ros2/rmw_gurumdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_gurumdds` to `1.4.0-1`:

- upstream repository: https://github.com/ros2/rmw_gurumdds.git
- release repository: https://github.com/ros2-gbp/rmw_gurumdds-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.1-1`

## gurumdds_cmake_module

```
* Add maintainer
* Contributors: Youngjin Yun
```

## rmw_gurumdds_cpp

```
* Add maintainer
* Add null handling
* Apply loop to take sequence
* Contributors: Youngjin Yun
```
