### PR TITLE
Change osrf_testing_tools_cpp branch to humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3426,7 +3426,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/osrf/osrf_testing_tools_cpp.git
-      version: master
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -3436,7 +3436,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/osrf/osrf_testing_tools_cpp.git
-      version: master
+      version: humble
     status: maintained
   ouxt_common:
     doc:


### PR DESCRIPTION
This goes along with previous distributions (foxy, eloquent, dashing, etc), and is more inline with what we do today.