### PR TITLE
foxglove_bridge: 0.5.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2780,7 +2780,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/foxglove/ros_foxglove_bridge-release.git
-      version: 0.4.1-1
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_bridge` to `0.5.0-1`:

- upstream repository: https://github.com/foxglove/ros-foxglove-bridge.git
- release repository: https://github.com/foxglove/ros_foxglove_bridge-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.1-1`

## foxglove_bridge

```
* Add support for schemaEncoding field (#186 <https://github.com/foxglove/ros-foxglove-bridge/issues/186>)
* Use QoS profile of existing publishers (if available) when creating new publishers (#184 <https://github.com/foxglove/ros-foxglove-bridge/issues/184>)
* Make server more independent of given server configurations (#185 <https://github.com/foxglove/ros-foxglove-bridge/issues/185>)
* Add parameter client_topic_whitelist for whitelisting client-published topics (#181 <https://github.com/foxglove/ros-foxglove-bridge/issues/181>)
* Make server capabilities configurable (#182 <https://github.com/foxglove/ros-foxglove-bridge/issues/182>)
* Fix action topic log spam (#179 <https://github.com/foxglove/ros-foxglove-bridge/issues/179>)
* Remove (clang specific) compiler flag -Wmost (#177 <https://github.com/foxglove/ros-foxglove-bridge/issues/177>)
* Improve the way compiler flags are set, use clang as default compiler (#175 <https://github.com/foxglove/ros-foxglove-bridge/issues/175>)
* Avoid re-advertising existing channels when advertising new channels (#172 <https://github.com/foxglove/ros-foxglove-bridge/issues/172>)
* Allow subscribing to connection graph updates (#167 <https://github.com/foxglove/ros-foxglove-bridge/issues/167>)
* Contributors: Hans-Joachim Krauch
```
