### PR TITLE
add package "urdf-from-step" to rosdistro "noetic" for documentation indexing

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -14610,6 +14610,16 @@ repositories:
       url: https://github.com/ros/urdf.git
       version: melodic-devel
     status: maintained
+  urdf_from_step:
+    doc:
+      type: git
+      url: https://github.com/ReconCycle/urdf-from-step
+      version: noetic
+    source:
+      type: git
+      url: https://github.com/ReconCycle/urdf-from-step
+      version: noetic
+     status: maintained
   urdf_geometry_parser:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11405,6 +11405,16 @@ repositories:
       url: https://github.com/ros/urdf.git
       version: melodic-devel
     status: maintained
+  urdf_from_step:
+    doc:
+      type: git
+      url: https://github.com/ReconCycle/urdf-from-step
+      version: noetic
+    source:
+      type: git
+      url: https://github.com/ReconCycle/urdf-from-step
+      version: noetic
+     status: maintained
   urdf_geometry_parser:
     doc:
       type: git


### PR DESCRIPTION

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

noetic

# The source is here:

https://github.com/ReconCycle/urdf-from-step


