### PR TITLE
foxglove_bridge: 0.5.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1403,7 +1403,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 0.5.0-1
+      version: 0.5.1-1
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_bridge` to `0.5.1-1`:

- upstream repository: https://github.com/foxglove/ros-foxglove-bridge.git
- release repository: https://github.com/ros2-gbp/foxglove_bridge-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.5.0-1`

## foxglove_bridge

```
* Add more exception handling (#191 <https://github.com/foxglove/ros-foxglove-bridge/issues/191>)
* [ROS1] Fix exception not being caught when retrieving service type  (#190 <https://github.com/foxglove/ros-foxglove-bridge/issues/190>)
* Devcontainer: Use catkin tools, add build commands for ros1 (#188 <https://github.com/foxglove/ros-foxglove-bridge/issues/188>)
* Contributors: Hans-Joachim Krauch
```
