### PR TITLE
husky: 0.6.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3562,7 +3562,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 0.6.6-3
+      version: 0.6.7-1
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `0.6.7-1`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.6-3`

## husky_control

- No changes

## husky_description

```
* Fixed Realsense URDF
* Update README.md
* Cleared up launch from description variables
* Changed 'true' and '1' to 1
* Switched all enables to true
* Contributors: luis-camero
```

## husky_desktop

- No changes

## husky_gazebo

- No changes

## husky_msgs

- No changes

## husky_navigation

```
* Add a scan_topic argument to the gmapping_demo
  This just exposes the gmapping.launch file's argument to the gmapping_demo.launch to make it easier to use non-standard topics.
* Contributors: Chris Iverach-Brereton
```

## husky_simulator

- No changes

## husky_viz

- No changes
