### PR TITLE
Revert "swri_console: 2.0.3-2 in 'humble/distribution.yaml' [bloom]"

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6484,7 +6484,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/swri_console-release.git
-      version: 2.0.3-2
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/swri-robotics/swri_console.git


### PR DESCRIPTION
Reverts ros/rosdistro#36279

Here's an example of the resulting build failure.
https://build.ros2.org/view/Hbin_uJ64/job/Hbin_uJ64__swri_console__ubuntu_jammy_amd64__binary/25/

FYI @danthony06