### PR TITLE
rc_genicam_api: 2.6.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4449,7 +4449,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rc_genicam_api-release.git
-      version: 2.5.12-1
+      version: 2.6.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_api` to `2.6.1-1`:

- upstream repository: https://github.com/roboception/rc_genicam_api.git
- release repository: https://github.com/ros2-gbp/rc_genicam_api-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.5.12-1`

## rc_genicam_api

```
* Fixed resetting of systems so that setSystemsPath() can be called again
* Report reason if loading of producer fails
* Fixed compiling under Windows
* Fixed reading registers with size that is less than the requested size
* Added convenience functions for loading and storing data on the camera via GenICam file interface
```
