### PR TITLE
rc_genicam_api: 2.6.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3595,7 +3595,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rc_genicam_api-release.git
-      version: 2.5.12-2
+      version: 2.6.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_api` to `2.6.1-1`:

- upstream repository: https://github.com/roboception/rc_genicam_api.git
- release repository: https://github.com/ros2-gbp/rc_genicam_api-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.5.12-2`

## rc_genicam_api

```
* Fixed resetting of systems so that setSystemsPath() can be called again
* Report reason if loading of producer fails
* Fixed compiling under Windows
* Fixed reading registers with size that is less than the requested size
* Added convenience functions for loading and storing data on the camera via GenICam file interface
```
