### PR TITLE
maliput_viz: 0.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2807,7 +2807,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput_viz-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_viz` to `0.1.1-1`:

- upstream repository: https://github.com/maliput/maliput_viz.git
- release repository: https://github.com/ros2-gbp/maliput_viz-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.0-1`

## maliput_viz

```
* Evolves dependency tag to <depend> for the ignition-gui3 package. (#22 <https://github.com/maliput/maliput_viz/issues/22>)
* Contributors: Franco Cipollone
```
