### PR TITLE
maliput_py: 0.1.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2775,7 +2775,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput_py-release.git
-      version: 0.1.4-1
+      version: 0.1.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_py` to `0.1.5-1`:

- upstream repository: https://github.com/maliput/maliput_py.git
- release repository: https://github.com/ros2-gbp/maliput_py-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.4-1`

## maliput_py

```
* Adds missing Vector bindings. (#74 <https://github.com/maliput/maliput_py/issues/74>)
* Adds LaneSRange::GetIntersection binding. (#73 <https://github.com/maliput/maliput_py/issues/73>)
* Contributors: Franco Cipollone
```
