### PR TITLE
Add libtins-dev rule for RHEL 9

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5837,6 +5837,9 @@ libtins-dev:
   debian: [libtins-dev]
   fedora: [libtins-devel]
   opensuse: [libtins-devel]
+  rhel:
+    '*': [libtins-devel]
+    '8': null
   ubuntu: [libtins-dev]
 libtool:
   arch: [libtool]


### PR DESCRIPTION
This package is provided by EPEL for RHEL 9: https://packages.fedoraproject.org/pkgs/libtins/libtins-devel/

It is not available for RHEL 8.