### PR TITLE
proxsuite: 0.3.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3338,6 +3338,21 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
       version: master
     status: maintained
+  proxsuite:
+    doc:
+      type: git
+      url: https://github.com/Simple-Robotics/proxsuite.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/proxsuite-release.git
+      version: 0.3.5-1
+    source:
+      type: git
+      url: https://github.com/Simple-Robotics/proxsuite.git
+      version: devel
+    status: developed
   py_trees:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `proxsuite` to `0.3.5-1`:

- upstream repository: https://github.com/Simple-Robotics/proxsuite.git
- release repository: https://github.com/ros2-gbp/proxsuite-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
