### PR TITLE
tinyspline_vendor: 0.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5913,6 +5913,11 @@ repositories:
       type: git
       url: https://github.com/wep21/tinyspline_vendor.git
       version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/tinyspline_vendor-release.git
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/wep21/tinyspline_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tinyspline_vendor` to `0.6.0-1`:

- upstream repository: https://github.com/wep21/tinyspline_vendor.git
- release repository: https://github.com/ros2-gbp/tinyspline_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## tinyspline_vendor

```
* docs: add readme
* feat: initial commit
* Contributors: Daisuke Nishimatsu
```
