### PR TITLE
mrpt2: Do not build develop branch in melodic anymore

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7350,10 +7350,6 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt2-release.git
       version: 2.7.0-1
-    source:
-      type: git
-      url: https://github.com/mrpt/mrpt.git
-      version: develop
     status: maintained
   mrpt_msgs:
     doc:


### PR DESCRIPTION
A change upstream bumped the minimum cmake version to a newer than available in u18.04, so do not attempt to build the develop branch anymore in Melodic. 

The last package release will keep working ok on Melodic and will be the last one released in that distribution.
