### PR TITLE
rc_genicam_driver: 0.7.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7998,7 +7998,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_genicam_driver_ros-release.git
-      version: 0.6.3-1
+      version: 0.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_driver` to `0.7.0-1`:

- upstream repository: https://github.com/roboception/rc_genicam_driver_ros.git
- release repository: https://github.com/roboception-gbp/rc_genicam_driver_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.3-1`

## rc_genicam_driver

```
* Increased max limits of some parameters so that it works for rc_viscore as well as rc_visard
* Replaced parameter camera_exp_auto by camera_exp_control and added camera_gamma
* check device version before ready
```
