### PR TITLE
rcdiscover: 1.1.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10323,7 +10323,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/roboception-gbp/rcdiscover-release.git
-      version: 1.1.4-1
+      version: 1.1.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcdiscover` to `1.1.6-1`:

- upstream repository: https://github.com/roboception/rcdiscover.git
- release repository: https://github.com/roboception-gbp/rcdiscover-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.4-1`

## rcdiscover

```
* Always wait minimum of 1 seconds for getting responses to discovery request
* CI, also build for jammy
```
