### PR TITLE
rcdiscover: 1.1.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3646,7 +3646,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcdiscover-release.git
-      version: 1.1.4-2
+      version: 1.1.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcdiscover` to `1.1.6-1`:

- upstream repository: https://github.com/roboception/rcdiscover.git
- release repository: https://github.com/ros2-gbp/rcdiscover-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.4-2`

## rcdiscover

```
* Always wait minimum of 1 seconds for getting responses to discovery request
* CI, also build for jammy
```
