### PR TITLE
rc_genicam_driver: 0.3.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4465,7 +4465,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/roboception-gbp/rc_genicam_driver_ros2-release.git
-      version: 0.2.1-1
+      version: 0.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_driver` to `0.3.0-1`:

- upstream repository: https://github.com/roboception/rc_genicam_driver_ros2.git
- release repository: https://github.com/roboception-gbp/rc_genicam_driver_ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.1-1`

## rc_genicam_driver

```
* Replaced parameter camera_exp_auto by camera_exp_control and camera_exp_auto_mode for consistency
* Change parameters camera_exp_max and camera_exp_value so unit seconds for consistency
* Added Gamma parameter
* only publish high/low if the publisher exists
* fix if iocontrol is not available
```
