### PR TITLE
rc_genicam_driver: 0.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3611,7 +3611,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rc_genicam_driver_ros2-release.git
-      version: 0.2.1-2
+      version: 0.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_driver` to `0.3.0-1`:

- upstream repository: https://github.com/roboception/rc_genicam_driver_ros2.git
- release repository: https://github.com/ros2-gbp/rc_genicam_driver_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.1-2`

## rc_genicam_driver

```
* Replaced parameter camera_exp_auto by camera_exp_control and camera_exp_auto_mode for consistency
* Change parameters camera_exp_max and camera_exp_value so unit seconds for consistency
* Added Gamma parameter
* only publish high/low if the publisher exists
* fix if iocontrol is not available
```
