### PR TITLE
Update python-bottle definition for ubuntu focal

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -866,11 +866,6 @@ python-bottle:
   fedora: [python-bottle]
   gentoo: [dev-python/bottle]
   ubuntu: [python-bottle]
-python3-bottle:
-  debian: [python3-bottle]
-  fedora: [python3-bottle]
-  gentoo: [dev-python/bottle]
-  ubuntu: [python3-bottle]
 python-box2d:
   debian: [python-box2d]
   ubuntu: [python-box2d]
@@ -6199,6 +6194,11 @@ python3-boto3:
     '*': ['python%{python3_pkgversion}-boto3']
     '7': null
   ubuntu: [python3-boto3]
+python3-bottle:
+  debian: [python3-bottle]
+  fedora: [python3-bottle]
+  gentoo: [dev-python/bottle]
+  ubuntu: [python3-bottle]
 python3-box:
   debian:
     '*': [python3-box]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -865,7 +865,9 @@ python-bottle:
   debian: [python-bottle]
   fedora: [python-bottle]
   gentoo: [dev-python/bottle]
-  ubuntu: [python-bottle]
+  ubuntu: 
+    '*': [python-bottle]
+    'focal': [python3-bottle]
 python-box2d:
   debian: [python-box2d]
   ubuntu: [python-box2d]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -865,9 +865,12 @@ python-bottle:
   debian: [python-bottle]
   fedora: [python-bottle]
   gentoo: [dev-python/bottle]
-  ubuntu: 
-    '*': [python-bottle]
-    'focal': [python3-bottle]
+  ubuntu: [python-bottle]
+python3-bottle:
+  debian: [python3-bottle]
+  fedora: [python3-bottle]
+  gentoo: [dev-python/bottle]
+  ubuntu: [python3-bottle]
 python-box2d:
   debian: [python-box2d]
   ubuntu: [python-box2d]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please update the following dependency to the rosdep database: python-bottle

## Package name:

python-bottle

## Package Upstream Source:

System package update for ubuntu

## Purpose of using this:

python-bottle key is already defined in the list, but the package it points to is no longer available on ubuntu focal 

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Ubuntu:
   - https://packages.ubuntu.com/kinetic/python3-bottle
- Debian
   - https://packages.debian.org/stretch/python3-bottle
- Gentoo
   - https://packages.gentoo.org/packages/dev-python/bottle
- Fedora
   - https://packages.fedoraproject.org/pkgs/python-bottle/python3-bottle/
   
# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
