### PR TITLE
tinyspline_vendor: 0.6.0-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6721,6 +6721,11 @@ repositories:
       type: git
       url: https://github.com/wep21/tinyspline_vendor.git
       version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/tinyspline_vendor-release.git
+      version: 0.6.0-2
     source:
       type: git
       url: https://github.com/wep21/tinyspline_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tinyspline_vendor` to `0.6.0-2`:

- upstream repository: https://github.com/wep21/tinyspline_vendor.git
- release repository: https://github.com/ros2-gbp/tinyspline_vendor-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.1`
- previous version for package: `null`

## tinyspline_vendor

```
* fix: use install directory
* docs: add readme
* feat: initial commit
* Contributors: Daisuke Nishimatsu
```
