### PR TITLE
Add libvtk9-dev rule

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6208,14 +6208,6 @@ libvtk9-dev:
     '*': [libvtk9-dev]
     bionic: null
     focal: null
-libvtk9.1:
-  debian:
-    '*': [libvtk9.1]
-    bullseye: null
-  ubuntu:
-    '*': [libvtk9.1]
-    bionic: null
-    focal: null
 libvulkan-dev:
   debian: [libvulkan-dev]
   fedora: [vulkan-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6202,6 +6202,20 @@ libvtk-qt:
     xenial: [libvtk6-qt-dev]
     yakkety: [libvtk6-qt-dev]
     zesty: [libvtk6-qt-dev]
+libvtk9-dev:
+  debian: [libvtk9-dev]
+  ubuntu:
+    '*': [libvtk9-dev]
+    bionic: null
+    focal: null
+libvtk9.1:
+  debian:
+    '*': [libvtk9.1]
+    bullseye: null
+  ubuntu:
+    '*': [libvtk9.1]
+    bionic: null
+    focal: null
 libvulkan-dev:
   debian: [libvulkan-dev]
   fedora: [vulkan-devel]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`libvtk9.1` and `libvtk9-dev`

## Package Upstream Source:

https://vtk.org/download/

## Purpose of using this:

This is for https://github.com/robotlocomotion/drake-ros . We must use the same version of vtk as Drake: https://github.com/RobotLocomotion/drake/blob/91e3dccea12c6b5fa73ec215d8af0ff4ee7f1876/setup/ubuntu/binary_distribution/packages-jammy.txt#L41

Distro packaging links:

## Links to Distribution Packages

libvtk9-dev
* debian
  * [bullseye](http://deb.debian.org/debian/pool/main/v/vtk9/libvtk9-dev_9.0.1+dfsg1-8_amd64.deb)
* ubuntu
  * [jammy](http://archive.ubuntu.com/ubuntu/pool/universe/v/vtk9/libvtk9-dev_9.1.0+really9.1.0+dfsg2-3build1_amd64.deb)

libvtk9.1
* debian
  * [bookworm](https://packages.debian.org/bookworm/libvtk9.1)
* ubuntu
  * [jammy](http://archive.ubuntu.com/ubuntu/pool/universe/v/vtk9/libvtk9.1_9.1.0+really9.1.0+dfsg2-3build1_amd64.deb)
