### PR TITLE
Fixed redundant ubuntu os_versions for python3-numba

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7966,9 +7966,7 @@ python3-ntplib:
   ubuntu: [python3-ntplib]
 python3-numba:
   debian: [python3-numba]
-  ubuntu:
-    bionic: [python3-numba]
-    focal: [python3-numba]
+  ubuntu: [python3-numba]
 python3-numpy:
   alpine: [py3-numpy]
   arch: [python-numpy]


### PR DESCRIPTION
Please update the following dependency to the rosdep database.

## Package name:

python3-numba

## Package Upstream Source:

[Ubuntu packages](https://packages.ubuntu.com/)

## Purpose of using this:

Python3-numba has two os_versions listed in the list, but it's the same for all ubuntu versions. I had a "not found key" error on Jammy version.

Distro packaging links:

## Links to Distribution Packages

- Debian:
  - https://packages.debian.org/stable/python/python3-numba
- Ubuntu:
   - https://packages.ubuntu.com/bionic/python/python3-numba
   - https://packages.ubuntu.com/focal/python/python3-numba
   - https://packages.ubuntu.com/jammy/python/python3-numba
   - https://packages.ubuntu.com/kinetic/python/python3-numba
   - https://packages.ubuntu.com/lunar/python/python3-numba