### PR TITLE
mimick_vendor: 0.3.2-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2436,7 +2436,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mimick_vendor-release.git
-      version: 0.3.2-1
+      version: 0.3.2-2
     source:
       type: git
       url: https://github.com/ros2/mimick_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mimick_vendor` to `0.3.2-2`:

- upstream repository: https://github.com/ros2/mimick_vendor.git
- release repository: https://github.com/ros2-gbp/mimick_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.2-1`

## mimick_vendor

```
* [rolling] Update maintainers - 2022-11-07 (#29 <https://github.com/ros2/mimick_vendor/issues/29>)
* Contributors: Audrow Nash
```

This release is needed for: ros2-gbp/mimick_vendor-release#6