### PR TITLE
tesseract: 0.15.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10890,7 +10890,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-industrial-release/tesseract-release.git
-      version: 0.15.1-1
+      version: 0.15.2-1
     source:
       type: git
       url: https://github.com/ros-industrial-consortium/tesseract.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tesseract` to `0.15.2-1`:

- upstream repository: https://github.com/tesseract-robotics/tesseract.git
- release repository: https://github.com/ros-industrial-release/tesseract-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.15.1-1`

## tesseract_collision

```
* Expose Bullet collision pool allocator configuration
* Switch include in tesseract_collision
* Contributors: Levi Armstrong
```

## tesseract_common

- No changes

## tesseract_environment

```
* Switch include in tesseract_collision
* Contributors: Levi Armstrong
```

## tesseract_geometry

```
* Switch include in tesseract_collision
* Contributors: Levi Armstrong
```

## tesseract_kinematics

- No changes

## tesseract_scene_graph

- No changes

## tesseract_srdf

- No changes

## tesseract_state_solver

- No changes

## tesseract_support

- No changes

## tesseract_urdf

- No changes

## tesseract_visualization

- No changes
