### PR TITLE
rqt_action: 1.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5977,7 +5977,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_action-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_action.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_action` to `1.0.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_action.git
- release repository: https://github.com/ros2-gbp/rqt_action-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.1-1`

## rqt_action

```
* revert to 1.0.1, so that new changes are only on rolling
* Merge pull request #9 <https://github.com/ros-visualization/rqt_action/issues/9> from ros-visualization/update_maintainers_crystal
* update Open Robotics maintainer
* Fixed package to run with ros2 run (#8 <https://github.com/ros-visualization/rqt_action/issues/8>)
* Contributors: Alejandro Hernández Cordero, Mabel Zhang, William Woodall
```
