### PR TITLE
orocos_kinematics_dynamics: 3.3.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3650,7 +3650,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/orocos_kinematics_dynamics-release.git
-      version: 3.3.4-1
+      version: 3.3.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_kinematics_dynamics` to `3.3.5-1`:

- upstream repository: https://github.com/ros2/orocos_kinematics_dynamics.git
- release repository: https://github.com/ros2-gbp/orocos_kinematics_dynamics-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.3.4-1`

## orocos_kdl

```
* Add changelog
* Delete manifest.xml (#26 <https://github.com/ros2/orocos_kinematics_dynamics/issues/26>) (#28 <https://github.com/ros2/orocos_kinematics_dynamics/issues/28>)
* Contributors: giusebar, Dharini Dutia, mergify[bot]
```
