### PR TITLE
rviz: 8.2.8-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6395,7 +6395,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 8.2.7-1
+      version: 8.2.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `8.2.8-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `8.2.7-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

- No changes

## rviz_default_plugins

```
* Delete frame_locked_markers when reusing marker (#907 <https://github.com/ros2/rviz/issues/907>) (#912 <https://github.com/ros2/rviz/issues/912>)
* Contributors: mergify[bot], Shane Loretz
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* add test to ensure binary STL files from SOLIDWORKS get imported without a warning (#917 <https://github.com/ros2/rviz/issues/917>) (#933 <https://github.com/ros2/rviz/issues/933>)
* Contributors: mergify[bot]
```

## rviz_rendering_tests

```
* add test to ensure binary STL files from SOLIDWORKS get imported without a warning (#917 <https://github.com/ros2/rviz/issues/917>) (#933 <https://github.com/ros2/rviz/issues/933>)
* Contributors: mergify[bot]
```

## rviz_visual_testing_framework

- No changes
