### PR TITLE
rosidl_python: 0.9.7-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5775,7 +5775,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.9.6-1
+      version: 0.9.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_python` to `0.9.7-1`:

- upstream repository: https://github.com/ros2/rosidl_python.git
- release repository: https://github.com/ros2-gbp/rosidl_python-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.9.6-1`

## rosidl_generator_py

```
* Change decode error mode to replace (#176 <https://github.com/ros2/rosidl_python/issues/176>) (#181 <https://github.com/ros2/rosidl_python/issues/181>)
* Contributors: mergify[bot], Tomoya Fujita
```
