### PR TITLE
rmw: 1.0.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5036,7 +5036,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw` to `1.0.4-1`:

- upstream repository: https://github.com/ros2/rmw.git
- release repository: https://github.com/ros2-gbp/rmw-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.3-1`

## rmw

```
* Correct parameter names to match documentation (#250 <https://github.com/ros2/rmw/issues/250>) (#322 <https://github.com/ros2/rmw/issues/322>)
* Contributors: mergify[bot], Geoffrey Biggs
```

## rmw_implementation_cmake

- No changes
