### PR TITLE
rcutils: 1.1.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4691,7 +4691,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 1.1.4-1
+      version: 1.1.5-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `1.1.5-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.4-1`

## rcutils

```
* Change syntax __VAR_ARGS__ to __VA_ARGS__ (#376 <https://github.com/ros2/rcutils/issues/376>) (#379 <https://github.com/ros2/rcutils/issues/379>)
* Contributors: mergify[bot]
```
