### PR TITLE
rclpy: 1.0.12-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4658,7 +4658,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 1.0.11-1
+      version: 1.0.12-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `1.0.12-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.11-1`

## rclpy

```
* Fix test_publisher linter for pydocstyle 6.2.2 (#1063 <https://github.com/ros2/rclpy/issues/1063>) (#1068 <https://github.com/ros2/rclpy/issues/1068>)
* Waitable should check callback_group if it can be executed. (#1001 <https://github.com/ros2/rclpy/issues/1001>) (#1015 <https://github.com/ros2/rclpy/issues/1015>)
* Contributors: mergify[bot], Cristóbal Arroyo, Tomoya Fujita
```
