### PR TITLE
geometry2: 0.13.14-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1666,7 +1666,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.13.13-1
+      version: 0.13.14-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.13.14-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.13.13-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* Include required header Scalar.h (#559 <https://github.com/ros2/geometry2/issues/559>) (#564 <https://github.com/ros2/geometry2/issues/564>)
* Contributors: mergify[bot], Shane Loretz
```

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

```
* Drop PyKDL dependency in tf2_geometry_msgs (backport #509 <https://github.com/ros2/geometry2/issues/509> to foxy) (#532 <https://github.com/ros2/geometry2/issues/532>)
* Contributors: Charles Dawson, Florian Vahl
```

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

- No changes

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
