### PR TITLE
ur_robot_driver: 2.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6289,7 +6289,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.3.0-1
+      version: 2.3.1-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.3.1-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.0-1`

## ur

- No changes

## ur_bringup

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* Adjust scaled jtc to new publish_state interface
  Until next sync we need to build against upstream ros2_controllers, as
  this is an API-breaking change
* Contributors: Robert Wilbrandt
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

- No changes

## ur_robot_driver

```
* Adjust controller switching to message change
* Controller spawner timeout (#608 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/608>)
  * Simplify controller spawner definitions
  * Ignore flake8 W503 as it clashes with black and goes against PEP8 style
  * Add argument to set controller spawner timeout
  * Use longer controller manager timeout in CI
  The default timeout of 10s is the same as our RTDE retry timeout, which
  means if RTDE does not immediately connect (which happens regularly in
  CI runners) controller spawning would fail.
* Increase timeout for first test service call to driver (#605 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/605>)
* Contributors: Robert Wilbrandt, RobertWilbrandt
```
