### PR TITLE
libstatistics_collector: 1.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2518,7 +2518,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/libstatistics_collector-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libstatistics_collector` to `1.0.2-1`:

- upstream repository: https://github.com/ros-tooling/libstatistics_collector.git
- release repository: https://github.com/ros2-gbp/libstatistics_collector-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.1-1`

## libstatistics_collector

```
* [foxy-devel] Update QD to QL 1 (#69 <https://github.com/quarkytale/libstatistics_collector/issues/69>)
* [Backport Foxy] Update QD (#63 <https://github.com/quarkytale/libstatistics_collector/issues/63>)
* [Backport Foxy] Added benchmark test to libstatistics_collector (#57 <https://github.com/quarkytale/libstatistics_collector/issues/57>) (#59 <https://github.com/quarkytale/libstatistics_collector/issues/59>)
* Contributors: Alejandro Hernández Cordero, Stephen Brawner, Chris Lalancette, Emerson Knapp, Devin Bonnie
```
