### PR TITLE
diagnostics: 3.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1015,7 +1015,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 3.1.0-2
+      version: 3.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `3.1.1-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.1.0-2`

## diagnostic_aggregator

```
* exporting dependency on pluginlib fixes #293 <https://github.com/ros/diagnostics/issues/293> (#294 <https://github.com/ros/diagnostics/issues/294>)
* Secretly supporting galactic (#295 <https://github.com/ros/diagnostics/issues/295>)
* Linting additional package (#268 <https://github.com/ros/diagnostics/issues/268>)
* Fix code-analyser bug
* Maintainer update
* Contributors: Austin, Christian Henkel, Ralph Lange, Tim Clephas
```

## diagnostic_common_diagnostics

```
* Secretly supporting galactic (#295 <https://github.com/ros/diagnostics/issues/295>)
* Linting additional package (#268 <https://github.com/ros/diagnostics/issues/268>)
* Maintainer update
* Contributors: Austin, Christian Henkel, Ralph Lange
```

## diagnostic_updater

```
* Secretly supporting galactic (#295 <https://github.com/ros/diagnostics/issues/295>)
* Linting additional package (#268 <https://github.com/ros/diagnostics/issues/268>)
* Adding unit test for DiagnosticStatusWrapper
* Maintainer update
* Contributors: Austin, Christian Henkel, Jordan Palacios, Ralph Lange
```

## diagnostics

```
* Maintainer update
* Contributors: Austin, Ralph Lange
```

## self_test

```
* Secretly supporting galactic (#295 <https://github.com/ros/diagnostics/issues/295>)
* exporting includes (#292 <https://github.com/ros/diagnostics/issues/292>)
* Maintainer update
* Contributors: Austin, Christian Henkel, Ralph Lange
```
