### PR TITLE
Use PySide/Shiboken for RHEL 9 instead of PyQt/sip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8996,7 +8996,9 @@ python3-qt5-bindings:
   nixos: [python3Packages.pyqt5]
   openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python3-qt5]
-  rhel: ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
+  rhel:
+    '*': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
+    '9': [python3-pyside2-devel, python3-shiboken2-devel]
   slackware: [python3-PyQt5]
   ubuntu:
     '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8997,8 +8997,9 @@ python3-qt5-bindings:
   openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python3-qt5]
   rhel:
-    '*': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
-    '9': [python3-pyside2-devel, python3-shiboken2-devel]
+    '*': [python3-pyside2-devel, python3-shiboken2-devel]
+    '7': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
+    '8': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
   slackware: [python3-PyQt5]
   ubuntu:
     '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2]


### PR DESCRIPTION
The version of PyQt5 supplied in RHEL 9 is incompatible with sip 4. Shiboken works fine, so we should use that instead.

https://packages.fedoraproject.org/pkgs/python-pyside2/python3-pyside2-devel/
https://packages.fedoraproject.org/pkgs/python-pyside2/python3-shiboken2-devel/