### PR TITLE
ros2_control: 3.10.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4379,7 +4379,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.9.0-2
+      version: 3.10.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.10.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.9.0-2`

## controller_interface

- No changes

## controller_manager

```
* add spawner for hardware (#941 <https://github.com/ros-controls/ros2_control/issues/941>)
* Contributors: Manuel Muth
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Split transmission interfaces (#938 <https://github.com/ros-controls/ros2_control/issues/938>)
* Contributors: Noel Jiménez García
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

```
* Split transmission interfaces (#938 <https://github.com/ros-controls/ros2_control/issues/938>)
* Contributors: Noel Jiménez García
```
