### PR TITLE
rosbag2: 0.3.10-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5604,7 +5604,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.3.9-1
+      version: 0.3.10-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.3.10-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.9-1`

## bag_recorder_nodes

```
* Added changelog
* Contributors: Dharini Dutia
```

## ros2bag

```
* Check & create database dirs before writing bags (#1133 <https://github.com/ros2/rosbag2/issues/1133>)
* Contributors: Homalozoa X
```

## rosbag2

- No changes

## rosbag2_compression

```
* Check & create database dirs before writing bags (#1133 <https://github.com/ros2/rosbag2/issues/1133>)
* Contributors: Homalozoa X
```

## rosbag2_converter_default_plugins

- No changes

## rosbag2_cpp

```
* Check & create database dirs before writing bags (#1133 <https://github.com/ros2/rosbag2/issues/1133>)
* Contributors: Homalozoa X
```

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

- No changes

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
