### PR TITLE
pal_gripper: 3.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3499,7 +3499,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_gripper-release.git
-      version: 3.0.2-1
+      version: 3.0.3-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_gripper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_gripper` to `3.0.3-1`:

- upstream repository: https://github.com/pal-robotics/pal_gripper.git
- release repository: https://github.com/pal-gbp/pal_gripper-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.2-1`

## pal_gripper

- No changes

## pal_gripper_controller_configuration

```
* Merge branch 'rm_use_sim_time' into 'humble-devel'
  Remove unecessary use_sim_time
  See merge request robots/pal_gripper!23
* rm unnecessary use_sim_time
* Merge branch 'fix_controllers_config' into 'humble-devel'
  Remove initial / from controllers config
  See merge request robots/pal_gripper!25
* remove initial / from controllers config
* Contributors: Jordan Palacios, Noel Jimenez
```

## pal_gripper_description

- No changes
