### PR TITLE
pmb2_robot: 5.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3775,7 +3775,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_robot-gbp.git
-      version: 5.0.0-1
+      version: 5.0.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_robot` to `5.0.2-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_robot.git
- release repository: https://github.com/pal-gbp/pmb2_robot-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `5.0.0-1`

## pmb2_bringup

- No changes

## pmb2_controller_configuration

```
* Merge branch 'rm_use_sim_time' into 'humble-devel'
  remove use_sim_time parameter
  See merge request robots/pmb2_robot!94
* remove use_sim_time parameter
* Contributors: Jordan Palacios, Noel Jimenez
```

## pmb2_description

- No changes

## pmb2_robot

- No changes
