### PR TITLE
add source entry for simple_grasping

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6242,6 +6242,11 @@ repositories:
       url: https://github.com/DLu/simple_actions.git
       version: main
     status: developed
+  simple_grasping:
+    source:
+      type: git
+      url: https://github.com/mikeferguson/simple_grasping.git
+      version: ros2
   simple_launch:
     doc:
       type: git


### PR DESCRIPTION
This package was released in ROS1, getting ready for ROS2 release - first step is getting name approval before creating ros2-gbp config

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
