### PR TITLE
moveit: 2.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2512,7 +2512,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/moveit/moveit2-release.git
-      version: 2.6.0-1
+      version: 2.7.0-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.7.0-1`:

- upstream repository: https://github.com/ros-planning/moveit2.git
- release repository: https://github.com/moveit/moveit2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.6.0-1`

## chomp_motion_planner

```
* Merge https://github.com/ros-planning/moveit/commit/9225971216885490e933ece25390c63ca14f8a58
* Switch to clang-format-14 (#1877 <https://github.com/ros-planning/moveit2/issues/1877>)
  * Switch to clang-format-14
  * Fix clang-format-14
* Change log level of CHOMP runtime output and change kdl print (#1818 <https://github.com/ros-planning/moveit2/issues/1818>)
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Minimize use of this-> (#1784 <https://github.com/ros-planning/moveit2/issues/1784>)
  It's often unnecessary. MoveIt already avoids this in most cases
  so this PR better cements that existing pattern.
* Add braces around blocks. (#999 <https://github.com/ros-planning/moveit2/issues/999>)
* Used C++ style cast instead of C style cast  (#1628 <https://github.com/ros-planning/moveit2/issues/1628>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Use a stronger source of randomness (#1721 <https://github.com/ros-planning/moveit2/issues/1721>)
  * Remove use of deprecated std::random_shuffle
  * Replace random number generators with rsl::rng
  * Utilize rsl::uniform_real
* Fix segfaults in CHOMP (#3204 <https://github.com/ros-planning/moveit2/issues/3204>)
  * due to missing description_
  * in case of an unspecified input trajectory
* Contributors: Abhijeet Das Gupta, Abishalini, Chris Thrasher, Christian Henkel, Cory Crean, Henning Kayser, Robert Haschke, Sebastian Jahr
```

## moveit

```
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Contributors: Christian Henkel
```

## moveit_chomp_optimizer_adapter

```
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Use a stronger source of randomness (#1721 <https://github.com/ros-planning/moveit2/issues/1721>)
  * Remove use of deprecated std::random_shuffle
  * Replace random number generators with rsl::rng
  * Utilize rsl::uniform_real
* Contributors: Chris Thrasher, Christian Henkel
```

## moveit_common

```
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Enable -Wold-style-cast (#1770 <https://github.com/ros-planning/moveit2/issues/1770>)
* Add -Wunused-parameter (#1756 <https://github.com/ros-planning/moveit2/issues/1756>)
* Add -Wunused-function (#1754 <https://github.com/ros-planning/moveit2/issues/1754>)
* Contributors: Chris Thrasher, Christian Henkel
```

## moveit_configs_utils

```
* feat: adds compatibility to robot_description from topic instead of parameter (#1806 <https://github.com/ros-planning/moveit2/issues/1806>)
* Add support for multiple MoveItConfigBuilder instaces (#1807 <https://github.com/ros-planning/moveit2/issues/1807>)
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Contributors: Christian Henkel, Marco Magri
```

## moveit_core

```
* Merge PR #1712 <https://github.com/ros-planning/moveit2/issues/1712>: fix clang compiler warnings + stricter CI
* Don't use ament_export_targets from package sub folder (#1889 <https://github.com/ros-planning/moveit2/issues/1889>)
* kinematic_constraints: update header frames (#1890 <https://github.com/ros-planning/moveit2/issues/1890>)
* Install collision_detector_bullet_plugin from moveit_core
* Sort exports from moveit_core
* Clean up kinematic_constraints/utils, add update functions (#1875 <https://github.com/ros-planning/moveit2/issues/1875>)
* Merge https://github.com/ros-planning/moveit/commit/9225971216885490e933ece25390c63ca14f8a58
* converted characters from string format to character format (#1881 <https://github.com/ros-planning/moveit2/issues/1881>)
* Switch to clang-format-14 (#1877 <https://github.com/ros-planning/moveit2/issues/1877>)
  * Switch to clang-format-14
  * Fix clang-format-14
* Add velocity and acceleration scaling when using custom limits in Time Parameterization (#1832 <https://github.com/ros-planning/moveit2/issues/1832>)
  * add velocity and accelerations scaling when using custom limits for time parameterization
  * add scaling when passing in vecotor of joint-limits
  * add function descriptions
  * add verifyScalingFactor helper function
  * make map const
  * address feedback
  * add comment
  Co-authored-by: Michael Wiznitzer <mailto:michael.wiznitzer@resquared.com>
* Add default constructors
  ... as they are not implicitly declared anymore
* Add default copy/move constructors/assignment operators
  As a user-declared destructor deletes any implicitly-defined move constructor/assignment operator,
  we need to declared them manually. This in turn requires to declare the copy constructor/assignment as well.
* Fix GoogleTestVerification.UninstantiatedTypeParameterizedTestSuite
* Modernize gtest: TYPED_TEST_CASE -> TYPED_TEST_SUITE
* Fix warning: expression with side effects will be evaluated
* Fix warning: definition of implicit copy assignment operator is deprecated
* Cleanup msg includes: Use C++ instead of C header (#1844 <https://github.com/ros-planning/moveit2/issues/1844>)
* Fix trajectory unwind bug (#1772 <https://github.com/ros-planning/moveit2/issues/1772>)
  * ensure trajectory starting point's position is enforced
  * fix angle jump bug
  * handle bounds enforcement edge case
  * clang tidy
  * Minor renaming, better comment, use .at() over []
  * First shot at a unit test
  * fix other unwind bugs
  * test should succeed now
  * unwind test needs a model with a continuous joint
  * clang tidy
  * add test for unwinding from wound up robot state
  * clang tidy
  * tweak test for special case to show that it will fail without these changes
  Co-authored-by: Michael Wiznitzer <mailto:michael.wiznitzer@resquared.com>
  Co-authored-by: AndyZe <mailto:zelenak@picknik.ai>
* Require velocity and acceleration limits in TOTG (#1794 <https://github.com/ros-planning/moveit2/issues/1794>)
  * Require vel/accel limits for TOTG
  * Comment improvements
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@tuta.io>
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@tuta.io>
* Use adjustable waypoint batch sizes for Ruckig (#1719 <https://github.com/ros-planning/moveit2/issues/1719>)
  * Use adjustable waypoint batch sizes for Ruckig
  * Use std::optional for return value
  * Cleanup
  * Add comment about parameterizing
  * Fix potential segfault
  * Batch size argument
  * Use append()
  * Revert "Use append()"
  This reverts commit 96b86a6c783b05ba57e5a6a20bf901cd92ab74d7.
* Fix moveit_core dependency on tf2_kdl (#1817 <https://github.com/ros-planning/moveit2/issues/1817>)
  This is a proper dependency, and not only a test dependency. It is still
  needed when building moveit_core with -DBUILD_TESTING=OFF.
* Bug fix: RobotTrajectory append() (#1813 <https://github.com/ros-planning/moveit2/issues/1813>)
  * Add a test for append()
  * Don't add to the timestep, rather overwrite it
* Print a warning from TOTG if the robot model mixes revolute/prismatic joints (#1799 <https://github.com/ros-planning/moveit2/issues/1799>)
* Tiny optimizations in enforcePositionBounds() for RevoluteJointModel (#1803 <https://github.com/ros-planning/moveit2/issues/1803>)
* Better TOTG comments (#1779 <https://github.com/ros-planning/moveit2/issues/1779>)
  * Increase understanding of TOTG path_tolerance_
  Tiny readability optimization - makes it a little easier for people to figure out what path_tolerance_ does
  * Update the units of path_tolerance_
  * Comment all 3 versions of computeTimeStamps
  * Add param for num_waypoints
  * More clarity on units
  Co-authored-by: AndyZe <mailto:zelenak@picknik.ai>
  Co-authored-by: Nathan Brooks <mailto:nathan.brooks@picknik.ai>
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Remove unnecessary CMake variables and lists (#1790 <https://github.com/ros-planning/moveit2/issues/1790>)
* Stopping calling MoveIt an alpha-stage project (#1789 <https://github.com/ros-planning/moveit2/issues/1789>)
* Ensure all headers get installed within moveit_core directory (#1786 <https://github.com/ros-planning/moveit2/issues/1786>)
* Set the resample_dt_ member of TOTG back to const (#1776 <https://github.com/ros-planning/moveit2/issues/1776>)
  * Set the resample_dt_ member of TOTG back to const
  * Remove unused TOTG instance in test
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  * Add "totg" to function name
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Remove Iterative Spline and Iterative Parabola time-param algorithms (v2) (#1780 <https://github.com/ros-planning/moveit2/issues/1780>)
  * Iterative parabolic parameterization fails for nonzero initial/final conditions
  * Iterative spline parameterization fails, too
  * Delete Iterative Spline & Iterative Parabola algorithms
* Use target_include_directories (#1785 <https://github.com/ros-planning/moveit2/issues/1785>)
* Minimize use of this-> (#1784 <https://github.com/ros-planning/moveit2/issues/1784>)
  It's often unnecessary. MoveIt already avoids this in most cases
  so this PR better cements that existing pattern.
* Enable -Wold-style-cast (#1770 <https://github.com/ros-planning/moveit2/issues/1770>)
* Add a version of TOTG computeTimeStamps() for a fixed num waypoints (#1771 <https://github.com/ros-planning/moveit2/issues/1771>)
  * Add a version of computeTimeStamps() to yield a fixed num. waypoints
  * Add unit test
  * Prevent an ambiguous function signature
  * Remove debugging stuff
  * Can't have fewer than 2 waypoints
  * Warning about sparse waypoint spacing
  * Doxygen comments
  * Clarify about changing the shape of the path
  * Better comment
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@tuta.io>
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@tuta.io>
* Add -Wunused-function (#1754 <https://github.com/ros-planning/moveit2/issues/1754>)
* Remove MOVEIT_LIB_NAME (#1751 <https://github.com/ros-planning/moveit2/issues/1751>)
  It's more readable and searchable if we just spell out the target
  name.
* Add braces around blocks. (#999 <https://github.com/ros-planning/moveit2/issues/999>)
* Use <> for non-local headers (#1734 <https://github.com/ros-planning/moveit2/issues/1734>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
* Used C++ style cast instead of C style cast  (#1628 <https://github.com/ros-planning/moveit2/issues/1628>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Cleanup lookup of planning pipelines in MoveItCpp (#1710 <https://github.com/ros-planning/moveit2/issues/1710>)
  * Revert "Add planner configurations to CHOMP and PILZ (#1522 <https://github.com/ros-planning/moveit2/issues/1522>)"
  * Cleanup lookup of planning pipelines
  Remove MoveItCpp::getPlanningPipelineNames(), which was obviously intended initially to provide a planning-group-based filter for all available planning pipelines: A pipeline was discarded for a group, if there were no planner_configs defined for that group on the parameter server.
  As pointed out in #1522 <https://github.com/ros-planning/moveit2/issues/1522>, only OMPL actually explicitly declares planner_configs on the parameter server.
  To enable all other pipelines as well (and thus circumventing the original filter mechanism), #1522 <https://github.com/ros-planning/moveit2/issues/1522> introduced empty dummy planner_configs for all other planners as well (CHOMP + Pilz).
  This, obviously, renders the whole filter mechanism useless. Thus, here we just remove the function getPlanningPipelineNames() and the corresponding member groups_pipelines_map_.
* Small optimization in constructGoalConstraints() (#1707 <https://github.com/ros-planning/moveit2/issues/1707>)
  * Small optimization in constructGoalConstraints()
  * Quat defaults to unity
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  * Blindly apply automatic clang-tidy fixes
  * Exemplarily cleanup a few automatic clang-tidy fixes
  * Clang-tidy fixups
  * Missed const-ref fixups
  * Fix unsupported non-const -> const
  * More fixes
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Generate version.h with git branch and commit hash (#2793 <https://github.com/ros-planning/moveit2/issues/2793>)
  * Generate version.h on every build and include git hash and branch/tag name
  * Don't generate "alpha" postfix on buildfarm
  * Show git version via moveit_version
  * Change version postfix: alpha -> devel
  Co-authored-by: Robert Haschke <mailto:rhaschke@techfak.uni-bielefeld.de>
* Contributors: Abhijeet Das Gupta, Abishalini, AndyZe, Captain Yoshi, Chris Thrasher, Christian Henkel, Cory Crean, Henning Kayser, Michael Wiznitzer, Nathan Brooks, Robert Haschke, Sameer Gupta, Scott K Logan, Tyler Weaver
```

## moveit_hybrid_planning

```
* Merge PR #1712 <https://github.com/ros-planning/moveit2/issues/1712>: fix clang compiler warnings + stricter CI
* Add default constructors
  ... as they are not implicitly declared anymore
* Explicitly declare overrides
* Add default copy/move constructors/assignment operators
  As a user-declared destructor deletes any implicitly-defined move constructor/assignment operator,
  we need to declared them manually. This in turn requires to declare the copy constructor/assignment as well.
* Fix more clang warnings
* Fix -Wdelete-non-abstract-non-virtual-dtor
* Cleanup msg includes: Use C++ instead of C header (#1844 <https://github.com/ros-planning/moveit2/issues/1844>)
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Minimize use of this-> (#1784 <https://github.com/ros-planning/moveit2/issues/1784>)
  It's often unnecessary. MoveIt already avoids this in most cases
  so this PR better cements that existing pattern.
* Enable -Wold-style-cast (#1770 <https://github.com/ros-planning/moveit2/issues/1770>)
* Add braces around blocks. (#999 <https://github.com/ros-planning/moveit2/issues/999>)
* Use <> for non-local headers (#1734 <https://github.com/ros-planning/moveit2/issues/1734>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
* Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  * Blindly apply automatic clang-tidy fixes
  * Exemplarily cleanup a few automatic clang-tidy fixes
  * Clang-tidy fixups
  * Missed const-ref fixups
  * Fix unsupported non-const -> const
  * More fixes
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Contributors: Chris Thrasher, Christian Henkel, Cory Crean, Robert Haschke
```

## moveit_kinematics

```
* Merge PR #1712 <https://github.com/ros-planning/moveit2/issues/1712>: fix clang compiler warnings + stricter CI
* converted characters from string format to character format (#1881 <https://github.com/ros-planning/moveit2/issues/1881>)
* Add noexcept specifier to constructors
* Add default copy/move constructors/assignment operators
  As a user-declared destructor deletes any implicitly-defined move constructor/assignment operator,
  we need to declared them manually. This in turn requires to declare the copy constructor/assignment as well.
* Fix IKFAST_TEST (#1850 <https://github.com/ros-planning/moveit2/issues/1850>)
* Change log level of CHOMP runtime output and change kdl print (#1818 <https://github.com/ros-planning/moveit2/issues/1818>)
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Minimize use of this-> (#1784 <https://github.com/ros-planning/moveit2/issues/1784>)
  It's often unnecessary. MoveIt already avoids this in most cases
  so this PR better cements that existing pattern.
* Enable -Wold-style-cast (#1770 <https://github.com/ros-planning/moveit2/issues/1770>)
* Remove MOVEIT_LIB_NAME (#1751 <https://github.com/ros-planning/moveit2/issues/1751>)
  It's more readable and searchable if we just spell out the target
  name.
* Add braces around blocks. (#999 <https://github.com/ros-planning/moveit2/issues/999>)
* Used C++ style cast instead of C style cast  (#1628 <https://github.com/ros-planning/moveit2/issues/1628>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Use a stronger source of randomness (#1721 <https://github.com/ros-planning/moveit2/issues/1721>)
  * Remove use of deprecated std::random_shuffle
  * Replace random number generators with rsl::rng
  * Utilize rsl::uniform_real
* Contributors: Abhijeet Das Gupta, Chris Thrasher, Christian Henkel, Cory Crean, Robert Haschke, Sameer Gupta, Sebastian Jahr
```

## moveit_planners

```
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Contributors: Christian Henkel
```

## moveit_planners_chomp

```
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Remove MOVEIT_LIB_NAME (#1751 <https://github.com/ros-planning/moveit2/issues/1751>)
  It's more readable and searchable if we just spell out the target
  name.
* Use a stronger source of randomness (#1721 <https://github.com/ros-planning/moveit2/issues/1721>)
  * Remove use of deprecated std::random_shuffle
  * Replace random number generators with rsl::rng
  * Utilize rsl::uniform_real
* Cleanup lookup of planning pipelines in MoveItCpp (#1710 <https://github.com/ros-planning/moveit2/issues/1710>)
  * Revert "Add planner configurations to CHOMP and PILZ (#1522 <https://github.com/ros-planning/moveit2/issues/1522>)"
  * Cleanup lookup of planning pipelines
  Remove MoveItCpp::getPlanningPipelineNames(), which was obviously intended initially to provide a planning-group-based filter for all available planning pipelines: A pipeline was discarded for a group, if there were no planner_configs defined for that group on the parameter server.
  As pointed out in #1522 <https://github.com/ros-planning/moveit2/issues/1522>, only OMPL actually explicitly declares planner_configs on the parameter server.
  To enable all other pipelines as well (and thus circumventing the original filter mechanism), #1522 <https://github.com/ros-planning/moveit2/issues/1522> introduced empty dummy planner_configs for all other planners as well (CHOMP + Pilz).
  This, obviously, renders the whole filter mechanism useless. Thus, here we just remove the function getPlanningPipelineNames() and the corresponding member groups_pipelines_map_.
* Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  * Blindly apply automatic clang-tidy fixes
  * Exemplarily cleanup a few automatic clang-tidy fixes
  * Clang-tidy fixups
  * Missed const-ref fixups
  * Fix unsupported non-const -> const
  * More fixes
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Contributors: Chris Thrasher, Christian Henkel, Robert Haschke
```

## moveit_planners_ompl

```
* converted characters from string format to character format (#1881 <https://github.com/ros-planning/moveit2/issues/1881>)
* Cleanup msg includes: Use C++ instead of C header (#1844 <https://github.com/ros-planning/moveit2/issues/1844>)
* Remove ancient OMPL version directives (#1825 <https://github.com/ros-planning/moveit2/issues/1825>)
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Minimize use of this-> (#1784 <https://github.com/ros-planning/moveit2/issues/1784>)
  It's often unnecessary. MoveIt already avoids this in most cases
  so this PR better cements that existing pattern.
* Enable -Wold-style-cast (#1770 <https://github.com/ros-planning/moveit2/issues/1770>)
* Remove MOVEIT_LIB_NAME (#1751 <https://github.com/ros-planning/moveit2/issues/1751>)
  It's more readable and searchable if we just spell out the target
  name.
* Add braces around blocks. (#999 <https://github.com/ros-planning/moveit2/issues/999>)
* Use <> for non-local headers (#1734 <https://github.com/ros-planning/moveit2/issues/1734>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
* Used C++ style cast instead of C style cast  (#1628 <https://github.com/ros-planning/moveit2/issues/1628>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  * Blindly apply automatic clang-tidy fixes
  * Exemplarily cleanup a few automatic clang-tidy fixes
  * Clang-tidy fixups
  * Missed const-ref fixups
  * Fix unsupported non-const -> const
  * More fixes
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Contributors: Abhijeet Das Gupta, Chris Thrasher, Christian Henkel, Cory Crean, Henning Kayser, Robert Haschke, Sameer Gupta
```

## moveit_plugins

```
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Contributors: Christian Henkel
```

## moveit_resources_prbt_ikfast_manipulator_plugin

```
* converted characters from string format to character format (#1881 <https://github.com/ros-planning/moveit2/issues/1881>)
* Used C++ style casting for int type (#1627 <https://github.com/ros-planning/moveit2/issues/1627>)
* Add -Wunused-parameter (#1756 <https://github.com/ros-planning/moveit2/issues/1756>)
* Add braces around blocks. (#999 <https://github.com/ros-planning/moveit2/issues/999>)
* Used C++ style cast instead of C style cast  (#1628 <https://github.com/ros-planning/moveit2/issues/1628>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Contributors: Abhijeet Das Gupta, Chris Thrasher, Cory Crean, Sameer Gupta
```

## moveit_resources_prbt_moveit_config

```
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Contributors: Christian Henkel
```

## moveit_resources_prbt_pg70_support

- No changes

## moveit_resources_prbt_support

- No changes

## moveit_ros

```
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Contributors: Christian Henkel
```

## moveit_ros_benchmarks

```
* converted characters from string format to character format (#1881 <https://github.com/ros-planning/moveit2/issues/1881>)
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Remove MOVEIT_LIB_NAME (#1751 <https://github.com/ros-planning/moveit2/issues/1751>)
  It's more readable and searchable if we just spell out the target
  name.
* Add braces around blocks. (#999 <https://github.com/ros-planning/moveit2/issues/999>)
* Used C++ style cast instead of C style cast  (#1628 <https://github.com/ros-planning/moveit2/issues/1628>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Contributors: Abhijeet Das Gupta, Chris Thrasher, Christian Henkel, Cory Crean, Sameer Gupta
```

## moveit_ros_control_interface

```
* Fix parameters for ros2_control namespaces (#1833 <https://github.com/ros-planning/moveit2/issues/1833>)
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Contributors: Christian Henkel, Pablo Iñigo Blasco
```

## moveit_ros_move_group

```
* move_group: Delete unused execute_trajectory_service_capability (#1836 <https://github.com/ros-planning/moveit2/issues/1836>)
* keep printf color change on same line (#1828 <https://github.com/ros-planning/moveit2/issues/1828>)
  This ensures the color reset is applied because printing the color
  reset after new lines seems to preven the color from actually being reset.
  Co-authored-by: William Wedler <mailto:william.wedler@resquared.com>
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Add braces around blocks. (#999 <https://github.com/ros-planning/moveit2/issues/999>)
* Used C++ style cast instead of C style cast  (#1628 <https://github.com/ros-planning/moveit2/issues/1628>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  * Blindly apply automatic clang-tidy fixes
  * Exemplarily cleanup a few automatic clang-tidy fixes
  * Clang-tidy fixups
  * Missed const-ref fixups
  * Fix unsupported non-const -> const
  * More fixes
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Contributors: Abhijeet Das Gupta, AndyZe, Christian Henkel, Cory Crean, Robert Haschke, Will
```

## moveit_ros_occupancy_map_monitor

```
* converted characters from string format to character format (#1881 <https://github.com/ros-planning/moveit2/issues/1881>)
* Switch to clang-format-14 (#1877 <https://github.com/ros-planning/moveit2/issues/1877>)
  * Switch to clang-format-14
  * Fix clang-format-14
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Enable -Wold-style-cast (#1770 <https://github.com/ros-planning/moveit2/issues/1770>)
* Remove MOVEIT_LIB_NAME (#1751 <https://github.com/ros-planning/moveit2/issues/1751>)
  It's more readable and searchable if we just spell out the target
  name.
* Add braces around blocks. (#999 <https://github.com/ros-planning/moveit2/issues/999>)
* Used C++ style cast instead of C style cast  (#1628 <https://github.com/ros-planning/moveit2/issues/1628>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  * Blindly apply automatic clang-tidy fixes
  * Exemplarily cleanup a few automatic clang-tidy fixes
  * Clang-tidy fixups
  * Missed const-ref fixups
  * Fix unsupported non-const -> const
  * More fixes
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Contributors: Abhijeet Das Gupta, Chris Thrasher, Christian Henkel, Cory Crean, Henning Kayser, Robert Haschke, Sameer Gupta
```

## moveit_ros_perception

```
* converted characters from string format to character format (#1881 <https://github.com/ros-planning/moveit2/issues/1881>)
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Enable -Wold-style-cast (#1770 <https://github.com/ros-planning/moveit2/issues/1770>)
* Use sensor data QOS profile for sensor_msgs::Image and sensor_msgs::PointCloud (#664 <https://github.com/ros-planning/moveit2/issues/664>)
  Co-authored-by: Henry Moore <mailto:henrygerardmoore@gmail.com>
  Co-authored-by: Tyler Weaver <mailto:tyler@picknik.ai>
* Remove MOVEIT_LIB_NAME (#1751 <https://github.com/ros-planning/moveit2/issues/1751>)
  It's more readable and searchable if we just spell out the target
  name.
* Add braces around blocks. (#999 <https://github.com/ros-planning/moveit2/issues/999>)
* Use <> for non-local headers (#1734 <https://github.com/ros-planning/moveit2/issues/1734>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
* Used C++ style cast instead of C style cast  (#1628 <https://github.com/ros-planning/moveit2/issues/1628>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  * Blindly apply automatic clang-tidy fixes
  * Exemplarily cleanup a few automatic clang-tidy fixes
  * Clang-tidy fixups
  * Missed const-ref fixups
  * Fix unsupported non-const -> const
  * More fixes
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Contributors: Abhijeet Das Gupta, Chris Thrasher, Christian Henkel, Cory Crean, Nathan Brooks, Robert Haschke, Sameer Gupta
```

## moveit_ros_planning

```
* converted characters from string format to character format (#1881 <https://github.com/ros-planning/moveit2/issues/1881>)
* Add a default stopping criterion for parallel planning (#1876 <https://github.com/ros-planning/moveit2/issues/1876>)
  * Add a default callback for parallel planning termination
  * Delete long-deprecated "using"
  * A new translation unit for the new callback
  * inline
* Switch to clang-format-14 (#1877 <https://github.com/ros-planning/moveit2/issues/1877>)
  * Switch to clang-format-14
  * Fix clang-format-14
* Do not allow traj execution from PlanningComponent (#1835 <https://github.com/ros-planning/moveit2/issues/1835>)
  * Do not allow traj execution from PlanningComponent
  * Deprecate, don't delete
  * Get the group_name from RobotTrajectory
  * Rebase
* Add optional list of controllers to MoveItCpp::execute() (#1838 <https://github.com/ros-planning/moveit2/issues/1838>)
  * Add optional list of controllers
  * The default is an empty vector
* Cleanup msg includes: Use C++ instead of C header (#1844 <https://github.com/ros-planning/moveit2/issues/1844>)
* Fix trajectory unwind bug (#1772 <https://github.com/ros-planning/moveit2/issues/1772>)
  * ensure trajectory starting point's position is enforced
  * fix angle jump bug
  * handle bounds enforcement edge case
  * clang tidy
  * Minor renaming, better comment, use .at() over []
  * First shot at a unit test
  * fix other unwind bugs
  * test should succeed now
  * unwind test needs a model with a continuous joint
  * clang tidy
  * add test for unwinding from wound up robot state
  * clang tidy
  * tweak test for special case to show that it will fail without these changes
  Co-authored-by: Michael Wiznitzer <mailto:michael.wiznitzer@resquared.com>
  Co-authored-by: AndyZe <mailto:zelenak@picknik.ai>
* No default IK solver (#1816 <https://github.com/ros-planning/moveit2/issues/1816>)
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Remove Iterative Spline and Iterative Parabola time-param algorithms (v2) (#1780 <https://github.com/ros-planning/moveit2/issues/1780>)
  * Iterative parabolic parameterization fails for nonzero initial/final conditions
  * Iterative spline parameterization fails, too
  * Delete Iterative Spline & Iterative Parabola algorithms
* Enable -Wold-style-cast (#1770 <https://github.com/ros-planning/moveit2/issues/1770>)
* Remove MOVEIT_LIB_NAME (#1751 <https://github.com/ros-planning/moveit2/issues/1751>)
  It's more readable and searchable if we just spell out the target
  name.
* Add braces around blocks. (#999 <https://github.com/ros-planning/moveit2/issues/999>)
* Use <> for non-local headers (#1734 <https://github.com/ros-planning/moveit2/issues/1734>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
* Used C++ style cast instead of C style cast  (#1628 <https://github.com/ros-planning/moveit2/issues/1628>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Cleanup lookup of planning pipelines in MoveItCpp (#1710 <https://github.com/ros-planning/moveit2/issues/1710>)
  * Revert "Add planner configurations to CHOMP and PILZ (#1522 <https://github.com/ros-planning/moveit2/issues/1522>)"
  * Cleanup lookup of planning pipelines
  Remove MoveItCpp::getPlanningPipelineNames(), which was obviously intended initially to provide a planning-group-based filter for all available planning pipelines: A pipeline was discarded for a group, if there were no planner_configs defined for that group on the parameter server.
  As pointed out in #1522 <https://github.com/ros-planning/moveit2/issues/1522>, only OMPL actually explicitly declares planner_configs on the parameter server.
  To enable all other pipelines as well (and thus circumventing the original filter mechanism), #1522 <https://github.com/ros-planning/moveit2/issues/1522> introduced empty dummy planner_configs for all other planners as well (CHOMP + Pilz).
  This, obviously, renders the whole filter mechanism useless. Thus, here we just remove the function getPlanningPipelineNames() and the corresponding member groups_pipelines_map_.
* Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  * Blindly apply automatic clang-tidy fixes
  * Exemplarily cleanup a few automatic clang-tidy fixes
  * Clang-tidy fixups
  * Missed const-ref fixups
  * Fix unsupported non-const -> const
  * More fixes
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Contributors: Abhijeet Das Gupta, AndyZe, Chris Thrasher, Christian Henkel, Cory Crean, Henning Kayser, Michael Wiznitzer, Robert Haschke, Sameer Gupta, Tyler Weaver
```

## moveit_ros_planning_interface

```
* Merge https://github.com/ros-planning/moveit/commit/9225971216885490e933ece25390c63ca14f8a58
* converted characters from string format to character format (#1881 <https://github.com/ros-planning/moveit2/issues/1881>)
* 400% speed up to move group interface (#1865 <https://github.com/ros-planning/moveit2/issues/1865>)
* GHA: Build moveit_msgs from source (#1853 <https://github.com/ros-planning/moveit2/issues/1853>)
  * Revert #1739 <https://github.com/ros-planning/moveit2/issues/1739>: moveit_msgs no longer needs to be built from source
  This reverts commit 6e0fce31cfe94ef8c6d5ebccb4d865f0c144b6e1.
  * Remove obsolete include: moveit_msgs/srv/execute_known_trajectory.hpp
  * Cleanup moveit2.repos
* Cleanup msg includes: Use C++ instead of C header (#1844 <https://github.com/ros-planning/moveit2/issues/1844>)
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Minimize use of this-> (#1784 <https://github.com/ros-planning/moveit2/issues/1784>)
  It's often unnecessary. MoveIt already avoids this in most cases
  so this PR better cements that existing pattern.
* Remove MOVEIT_LIB_NAME (#1751 <https://github.com/ros-planning/moveit2/issues/1751>)
  It's more readable and searchable if we just spell out the target
  name.
* Add braces around blocks. (#999 <https://github.com/ros-planning/moveit2/issues/999>)
* Use <> for non-local headers (#1734 <https://github.com/ros-planning/moveit2/issues/1734>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
* Used C++ style cast instead of C style cast  (#1628 <https://github.com/ros-planning/moveit2/issues/1628>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  * Blindly apply automatic clang-tidy fixes
  * Exemplarily cleanup a few automatic clang-tidy fixes
  * Clang-tidy fixups
  * Missed const-ref fixups
  * Fix unsupported non-const -> const
  * More fixes
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Test moveit_commander.set_joint_value_target with JointState argument (#3187 <https://github.com/ros-planning/moveit2/issues/3187>)
  * Test with JointState argument
  * Check size of name and position fields
  Co-authored-by: Robert Haschke <mailto:rhaschke@techfak.uni-bielefeld.de>
* Contributors: Abhijeet Das Gupta, Abishalini, Chris Thrasher, Christian Henkel, Cory Crean, Filip Sund, Robert Haschke, Sameer Gupta, azalutsky
```

## moveit_ros_robot_interaction

```
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Minimize use of this-> (#1784 <https://github.com/ros-planning/moveit2/issues/1784>)
  It's often unnecessary. MoveIt already avoids this in most cases
  so this PR better cements that existing pattern.
* Remove MOVEIT_LIB_NAME (#1751 <https://github.com/ros-planning/moveit2/issues/1751>)
  It's more readable and searchable if we just spell out the target
  name.
* Add braces around blocks. (#999 <https://github.com/ros-planning/moveit2/issues/999>)
* Use <> for non-local headers (#1734 <https://github.com/ros-planning/moveit2/issues/1734>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
* Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  * Blindly apply automatic clang-tidy fixes
  * Exemplarily cleanup a few automatic clang-tidy fixes
  * Clang-tidy fixups
  * Missed const-ref fixups
  * Fix unsupported non-const -> const
  * More fixes
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Contributors: Chris Thrasher, Christian Henkel, Cory Crean, Robert Haschke
```

## moveit_ros_visualization

```
* converted characters from string format to character format (#1881 <https://github.com/ros-planning/moveit2/issues/1881>)
* Delete unported moveit_joy visualization demo (#1541 <https://github.com/ros-planning/moveit2/issues/1541>)
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Minimize use of this-> (#1784 <https://github.com/ros-planning/moveit2/issues/1784>)
  It's often unnecessary. MoveIt already avoids this in most cases
  so this PR better cements that existing pattern.
* Enable -Wold-style-cast (#1770 <https://github.com/ros-planning/moveit2/issues/1770>)
* Migrate to Ogre.h (#1764 <https://github.com/ros-planning/moveit2/issues/1764>)
  * Migrate to Ogre.h
  * Remove includ for OgreQuaternion.h, included in Ogre.h
* Remove MOVEIT_LIB_NAME (#1751 <https://github.com/ros-planning/moveit2/issues/1751>)
  It's more readable and searchable if we just spell out the target
  name.
* Add braces around blocks. (#999 <https://github.com/ros-planning/moveit2/issues/999>)
* Use <> for non-local headers (#1734 <https://github.com/ros-planning/moveit2/issues/1734>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
* Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  * Blindly apply automatic clang-tidy fixes
  * Exemplarily cleanup a few automatic clang-tidy fixes
  * Clang-tidy fixups
  * Missed const-ref fixups
  * Fix unsupported non-const -> const
  * More fixes
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Contributors: AndyZe, Chris Thrasher, Christian Henkel, Cory Crean, Robert Haschke, Sameer Gupta, Stephanie Eng
```

## moveit_ros_warehouse

```
* converted characters from string format to character format (#1881 <https://github.com/ros-planning/moveit2/issues/1881>)
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Enable -Wold-style-cast (#1770 <https://github.com/ros-planning/moveit2/issues/1770>)
* Add braces around blocks. (#999 <https://github.com/ros-planning/moveit2/issues/999>)
* Use <> for non-local headers (#1734 <https://github.com/ros-planning/moveit2/issues/1734>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
* Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  * Blindly apply automatic clang-tidy fixes
  * Exemplarily cleanup a few automatic clang-tidy fixes
  * Clang-tidy fixups
  * Missed const-ref fixups
  * Fix unsupported non-const -> const
  * More fixes
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Contributors: Chris Thrasher, Christian Henkel, Cory Crean, Robert Haschke, Sameer Gupta
```

## moveit_runtime

```
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Contributors: Christian Henkel
```

## moveit_servo

```
* Merge PR #1712 <https://github.com/ros-planning/moveit2/issues/1712>: fix clang compiler warnings + stricter CI
* converted characters from string format to character format (#1881 <https://github.com/ros-planning/moveit2/issues/1881>)
* Update the Servo dependency on realtime_tools (#1791 <https://github.com/ros-planning/moveit2/issues/1791>)
  * Update the Servo dependency on realtime_tools
  * Update .repos
  * Add comment
* Fix more clang warnings
* Fix warning: passing by value
* Cleanup msg includes: Use C++ instead of C header (#1844 <https://github.com/ros-planning/moveit2/issues/1844>)
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Minimize use of this-> (#1784 <https://github.com/ros-planning/moveit2/issues/1784>)
  It's often unnecessary. MoveIt already avoids this in most cases
  so this PR better cements that existing pattern.
* Enable -Wold-style-cast (#1770 <https://github.com/ros-planning/moveit2/issues/1770>)
* Add braces around blocks. (#999 <https://github.com/ros-planning/moveit2/issues/999>)
* Use <> for non-local headers (#1734 <https://github.com/ros-planning/moveit2/issues/1734>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
* Servo: Check frames are known before getting their TFs (#612 <https://github.com/ros-planning/moveit2/issues/612>)
  * Check frames are known before getting their TFs
  * Allow empty command frame - fixes tests
  * Address Jere's feedback
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
* Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  * Blindly apply automatic clang-tidy fixes
  * Exemplarily cleanup a few automatic clang-tidy fixes
  * Clang-tidy fixups
  * Missed const-ref fixups
  * Fix unsupported non-const -> const
  * More fixes
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Remove unused function in Servo (#1709 <https://github.com/ros-planning/moveit2/issues/1709>)
* Contributors: AdamPettinger, AndyZe, Chris Thrasher, Christian Henkel, Cory Crean, Henning Kayser, Robert Haschke, Sameer Gupta
```

## moveit_setup_app_plugins

```
* Merge PR #1712 <https://github.com/ros-planning/moveit2/issues/1712>: fix clang compiler warnings + stricter CI
* Declare selected classes as final
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Minimize use of this-> (#1784 <https://github.com/ros-planning/moveit2/issues/1784>)
  It's often unnecessary. MoveIt already avoids this in most cases
  so this PR better cements that existing pattern.
* Contributors: Chris Thrasher, Christian Henkel, Robert Haschke
```

## moveit_setup_assistant

```
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Minimize use of this-> (#1784 <https://github.com/ros-planning/moveit2/issues/1784>)
  It's often unnecessary. MoveIt already avoids this in most cases
  so this PR better cements that existing pattern.
* Add braces around blocks. (#999 <https://github.com/ros-planning/moveit2/issues/999>)
* Use <> for non-local headers (#1734 <https://github.com/ros-planning/moveit2/issues/1734>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
* Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  * Blindly apply automatic clang-tidy fixes
  * Exemplarily cleanup a few automatic clang-tidy fixes
  * Clang-tidy fixups
  * Missed const-ref fixups
  * Fix unsupported non-const -> const
  * More fixes
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Contributors: Chris Thrasher, Christian Henkel, Cory Crean, Robert Haschke
```

## moveit_setup_controllers

```
* Merge PR #1712 <https://github.com/ros-planning/moveit2/issues/1712>: fix clang compiler warnings + stricter CI
* Add default constructors
  ... as they are not implicitly declared anymore
* Add default copy/move constructors/assignment operators
  As a user-declared destructor deletes any implicitly-defined move constructor/assignment operator,
  we need to declared them manually. This in turn requires to declare the copy constructor/assignment as well.
* Fix -Wdelete-non-abstract-non-virtual-dtor
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Minimize use of this-> (#1784 <https://github.com/ros-planning/moveit2/issues/1784>)
  It's often unnecessary. MoveIt already avoids this in most cases
  so this PR better cements that existing pattern.
* Add braces around blocks. (#999 <https://github.com/ros-planning/moveit2/issues/999>)
* Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  * Blindly apply automatic clang-tidy fixes
  * Exemplarily cleanup a few automatic clang-tidy fixes
  * Clang-tidy fixups
  * Missed const-ref fixups
  * Fix unsupported non-const -> const
  * More fixes
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Contributors: Chris Thrasher, Christian Henkel, Cory Crean, Robert Haschke
```

## moveit_setup_core_plugins

```
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Minimize use of this-> (#1784 <https://github.com/ros-planning/moveit2/issues/1784>)
  It's often unnecessary. MoveIt already avoids this in most cases
  so this PR better cements that existing pattern.
* Add braces around blocks. (#999 <https://github.com/ros-planning/moveit2/issues/999>)
* Use <> for non-local headers (#1734 <https://github.com/ros-planning/moveit2/issues/1734>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
* Contributors: Chris Thrasher, Christian Henkel, Cory Crean
```

## moveit_setup_framework

```
* Merge PR #1712 <https://github.com/ros-planning/moveit2/issues/1712>: fix clang compiler warnings + stricter CI
* Add default constructors
  ... as they are not implicitly declared anymore
* Add default copy/move constructors/assignment operators
  As a user-declared destructor deletes any implicitly-defined move constructor/assignment operator,
  we need to declared them manually. This in turn requires to declare the copy constructor/assignment as well.
* Fix -Wdelete-non-abstract-non-virtual-dtor
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Minimize use of this-> (#1784 <https://github.com/ros-planning/moveit2/issues/1784>)
  It's often unnecessary. MoveIt already avoids this in most cases
  so this PR better cements that existing pattern.
* Add braces around blocks. (#999 <https://github.com/ros-planning/moveit2/issues/999>)
* Use <> for non-local headers (#1734 <https://github.com/ros-planning/moveit2/issues/1734>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
* Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  * Blindly apply automatic clang-tidy fixes
  * Exemplarily cleanup a few automatic clang-tidy fixes
  * Clang-tidy fixups
  * Missed const-ref fixups
  * Fix unsupported non-const -> const
  * More fixes
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Contributors: Chris Thrasher, Christian Henkel, Cory Crean, Robert Haschke
```

## moveit_setup_srdf_plugins

```
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Minimize use of this-> (#1784 <https://github.com/ros-planning/moveit2/issues/1784>)
  It's often unnecessary. MoveIt already avoids this in most cases
  so this PR better cements that existing pattern.
* Enable -Wold-style-cast (#1770 <https://github.com/ros-planning/moveit2/issues/1770>)
* Add braces around blocks. (#999 <https://github.com/ros-planning/moveit2/issues/999>)
* Contributors: Chris Thrasher, Christian Henkel, Cory Crean
```

## moveit_simple_controller_manager

```
* converted characters from string format to character format (#1881 <https://github.com/ros-planning/moveit2/issues/1881>)
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Add braces around blocks. (#999 <https://github.com/ros-planning/moveit2/issues/999>)
* Use emulated time in action-based controller (#899 <https://github.com/ros-planning/moveit2/issues/899>)
* Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  * Blindly apply automatic clang-tidy fixes
  * Exemplarily cleanup a few automatic clang-tidy fixes
  * Clang-tidy fixups
  * Missed const-ref fixups
  * Fix unsupported non-const -> const
  * More fixes
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Contributors: Christian Henkel, Cory Crean, Gaël Écorchard, Robert Haschke, Sameer Gupta
```

## pilz_industrial_motion_planner

```
* Merge PR #1712 <https://github.com/ros-planning/moveit2/issues/1712>: fix clang compiler warnings + stricter CI
* converted characters from string format to character format (#1881 <https://github.com/ros-planning/moveit2/issues/1881>)
* Add default constructors
  ... as they are not implicitly declared anymore
* Add default copy/move constructors/assignment operators
  As a user-declared destructor deletes any implicitly-defined move constructor/assignment operator,
  we need to declared them manually. This in turn requires to declare the copy constructor/assignment as well.
* Fix -Wunused-lambda-capture
* fix: resolve bugs in MoveGroupSequenceAction class (main branch) (#1797 <https://github.com/ros-planning/moveit2/issues/1797>)
  * fix: resolve bugs in MoveGroupSequenceAction class
  * style: adopt .clang-format
  Co-authored-by: Marco Magri <mailto:marco.magri@fraunhofer.it>
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Minimize use of this-> (#1784 <https://github.com/ros-planning/moveit2/issues/1784>)
  It's often unnecessary. MoveIt already avoids this in most cases
  so this PR better cements that existing pattern.
* Add braces around blocks. (#999 <https://github.com/ros-planning/moveit2/issues/999>)
* Use <> for non-local headers (#1734 <https://github.com/ros-planning/moveit2/issues/1734>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
* Cleanup lookup of planning pipelines in MoveItCpp (#1710 <https://github.com/ros-planning/moveit2/issues/1710>)
  * Revert "Add planner configurations to CHOMP and PILZ (#1522 <https://github.com/ros-planning/moveit2/issues/1522>)"
  * Cleanup lookup of planning pipelines
  Remove MoveItCpp::getPlanningPipelineNames(), which was obviously intended initially to provide a planning-group-based filter for all available planning pipelines: A pipeline was discarded for a group, if there were no planner_configs defined for that group on the parameter server.
  As pointed out in #1522 <https://github.com/ros-planning/moveit2/issues/1522>, only OMPL actually explicitly declares planner_configs on the parameter server.
  To enable all other pipelines as well (and thus circumventing the original filter mechanism), #1522 <https://github.com/ros-planning/moveit2/issues/1522> introduced empty dummy planner_configs for all other planners as well (CHOMP + Pilz).
  This, obviously, renders the whole filter mechanism useless. Thus, here we just remove the function getPlanningPipelineNames() and the corresponding member groups_pipelines_map_.
* Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  * Blindly apply automatic clang-tidy fixes
  * Exemplarily cleanup a few automatic clang-tidy fixes
  * Clang-tidy fixups
  * Missed const-ref fixups
  * Fix unsupported non-const -> const
  * More fixes
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Contributors: Chris Thrasher, Christian Henkel, Cory Crean, Marco Magri, Robert Haschke, Sameer Gupta
```

## pilz_industrial_motion_planner_testutils

```
* Merge PR #1712 <https://github.com/ros-planning/moveit2/issues/1712>: fix clang compiler warnings + stricter CI
* converted characters from string format to character format (#1881 <https://github.com/ros-planning/moveit2/issues/1881>)
* Add noexcept specifier to constructors
* Add default constructors
  ... as they are not implicitly declared anymore
* Add default copy/move constructors/assignment operators
  As a user-declared destructor deletes any implicitly-defined move constructor/assignment operator,
  we need to declared them manually. This in turn requires to declare the copy constructor/assignment as well.
* Fix -Wdelete-non-abstract-non-virtual-dtor
* Fix BSD license in package.xml (#1796 <https://github.com/ros-planning/moveit2/issues/1796>)
  * fix BSD license in package.xml
  * this must also be spdx compliant
* Minimize use of this-> (#1784 <https://github.com/ros-planning/moveit2/issues/1784>)
  It's often unnecessary. MoveIt already avoids this in most cases
  so this PR better cements that existing pattern.
* Use <> for non-local headers (#1734 <https://github.com/ros-planning/moveit2/issues/1734>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
* Contributors: Chris Thrasher, Christian Henkel, Robert Haschke, Sameer Gupta
```
