### PR TITLE
Migrate to RHEL 9 in ROS 2 Rolling Ridley

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -14,7 +14,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/robosoft-ai/SMACC2.git
-      version: master
+      version: rolling
     release:
       packages:
       - smacc2
@@ -22,18 +22,18 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/SMACC2-release.git
-      version: 0.4.0-1
+      version: 0.4.0-2
     source:
       type: git
       url: https://github.com/robosoft-ai/SMACC2.git
-      version: master
+      version: rolling
     status: developed
   acado_vendor:
     release:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/acado_vendor-release.git
-      version: 1.0.0-3
+      version: 1.0.0-5
     source:
       type: git
       url: https://gitlab.com/autowarefoundation/autoware.auto/acado_vendor.git
@@ -44,7 +44,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ackermann_msgs-release.git
-      version: 2.0.2-2
+      version: 2.0.2-4
     source:
       type: git
       url: https://github.com/ros-drivers/ackermann_msgs.git
@@ -59,7 +59,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/adaptive_component-release.git
-      version: 0.2.1-1
+      version: 0.2.1-3
     source:
       test_pull_requests: true
       type: git
@@ -75,7 +75,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_acceleration-release.git
-      version: 0.2.0-1
+      version: 0.2.0-3
     source:
       test_pull_requests: true
       type: git
@@ -114,7 +114,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 1.5.3-2
+      version: 1.5.3-4
     source:
       test_pull_requests: true
       type: git
@@ -130,7 +130,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake_catch2-release.git
-      version: 1.2.0-2
+      version: 1.2.0-4
     source:
       type: git
       url: https://github.com/open-rmf/ament_cmake_catch2.git
@@ -148,7 +148,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake_ros-release.git
-      version: 0.11.2-1
+      version: 0.11.2-3
     source:
       test_pull_requests: true
       type: git
@@ -164,7 +164,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_download-release.git
-      version: 0.0.5-2
+      version: 0.0.5-4
     source:
       type: git
       url: https://github.com/samsung-ros/ament_download.git
@@ -182,7 +182,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_index-release.git
-      version: 1.5.2-1
+      version: 1.5.2-3
     source:
       test_pull_requests: true
       type: git
@@ -230,7 +230,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.14.0-1
+      version: 0.14.0-3
     source:
       test_pull_requests: true
       type: git
@@ -242,7 +242,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_nodl-release.git
-      version: 0.1.0-3
+      version: 0.1.0-5
     source:
       type: git
       url: https://github.com/ubuntu-robotics/ament_nodl.git
@@ -257,7 +257,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_package-release.git
-      version: 0.15.2-1
+      version: 0.15.2-3
     source:
       test_pull_requests: true
       type: git
@@ -273,7 +273,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_vitis-release.git
-      version: 0.10.1-1
+      version: 0.10.1-3
     source:
       test_pull_requests: true
       type: git
@@ -289,7 +289,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/angles-release.git
-      version: 1.16.0-1
+      version: 1.16.0-3
     source:
       test_pull_requests: true
       type: git
@@ -305,7 +305,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/apex_containers-release.git
-      version: 0.0.4-2
+      version: 0.0.4-4
     source:
       type: git
       url: https://gitlab.com/ApexAI/apex_containers.git
@@ -323,7 +323,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/apex_test_tools-release.git
-      version: 0.0.2-5
+      version: 0.0.2-7
     source:
       type: git
       url: https://gitlab.com/ApexAI/apex_test_tools.git
@@ -338,7 +338,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag-release.git
-      version: 3.2.0-1
+      version: 3.2.0-3
     source:
       type: git
       url: https://github.com/AprilRobotics/apriltag.git
@@ -349,7 +349,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag_msgs-release.git
-      version: 2.0.1-1
+      version: 2.0.1-3
     source:
       type: git
       url: https://github.com/christianrauch/apriltag_msgs.git
@@ -360,7 +360,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag_ros-release.git
-      version: 3.1.1-1
+      version: 3.1.1-3
     source:
       type: git
       url: https://github.com/christianrauch/apriltag_ros.git
@@ -378,7 +378,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_opencv-release.git
-      version: 4.1.0-1
+      version: 4.1.0-3
     source:
       type: git
       url: https://github.com/fictionlab/ros_aruco_opencv.git
@@ -393,7 +393,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/async_web_server_cpp-release.git
-      version: 2.0.0-2
+      version: 2.0.0-4
     source:
       type: git
       url: https://github.com/fkie/async_web_server_cpp.git
@@ -422,7 +422,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/automotive_autonomy_msgs-release.git
-      version: 3.0.4-2
+      version: 3.0.4-4
     source:
       type: git
       url: https://github.com/astuff/automotive_autonomy_msgs.git
@@ -437,7 +437,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_auto_msgs-release.git
-      version: 1.0.0-3
+      version: 1.0.0-5
     source:
       type: git
       url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
@@ -452,7 +452,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/avt_vimba_camera-release.git
-      version: 2001.1.0-2
+      version: 2001.1.0-4
     source:
       type: git
       url: https://github.com/astuff/avt_vimba_camera.git
@@ -469,7 +469,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/aws_robomaker_small_warehouse_world-release.git
-      version: 1.0.5-2
+      version: 1.0.5-3
     source:
       type: git
       url: https://github.com/aws-robotics/aws-robomaker-small-warehouse-world.git
@@ -484,7 +484,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/backward_ros-release.git
-      version: 1.0.2-2
+      version: 1.0.2-4
     source:
       type: git
       url: https://github.com/pal-robotics/backward_ros.git
@@ -499,7 +499,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/bag2_to_image-release.git
-      version: 0.1.0-1
+      version: 0.1.0-3
     source:
       type: git
       url: https://github.com/wep21/bag2_to_image.git
@@ -514,7 +514,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp-release.git
-      version: 3.8.3-2
+      version: 3.8.3-4
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
@@ -529,7 +529,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/bno055-release.git
-      version: 0.4.1-1
+      version: 0.4.1-3
     source:
       type: git
       url: https://github.com/flynneva/bno055.git
@@ -550,7 +550,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/bond_core-release.git
-      version: 4.0.0-1
+      version: 4.0.0-3
     source:
       test_pull_requests: true
       type: git
@@ -566,7 +566,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/boost_geometry_util-release.git
-      version: 0.0.1-1
+      version: 0.0.1-3
     source:
       type: git
       url: https://github.com/OUXT-Polaris/boost_geometry_util.git
@@ -581,7 +581,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/cartographer-release.git
-      version: 2.0.9002-1
+      version: 2.0.9002-3
     source:
       test_pull_requests: true
       type: git
@@ -601,7 +601,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/cartographer_ros-release.git
-      version: 2.0.9000-1
+      version: 2.0.9000-3
     source:
       test_pull_requests: true
       type: git
@@ -620,7 +620,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/cascade_lifecycle-release.git
-      version: 1.0.3-2
+      version: 1.0.3-4
     source:
       type: git
       url: https://github.com/fmrico/cascade_lifecycle.git
@@ -635,7 +635,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/class_loader-release.git
-      version: 2.5.0-1
+      version: 2.5.0-3
     source:
       test_pull_requests: true
       type: git
@@ -651,7 +651,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/color_names-release.git
-      version: 0.0.3-2
+      version: 0.0.3-4
     source:
       type: git
       url: https://github.com/OUXT-Polaris/color_names-release.git
@@ -680,7 +680,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 4.7.0-1
+      version: 4.7.0-3
     source:
       test_pull_requests: true
       type: git
@@ -696,7 +696,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/console_bridge_vendor-release.git
-      version: 1.6.0-1
+      version: 1.6.0-3
     source:
       test_pull_requests: true
       type: git
@@ -712,7 +712,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/control_box_rst-release.git
-      version: 0.0.7-3
+      version: 0.0.7-4
     source:
       test_pull_requests: true
       type: git
@@ -728,7 +728,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/control_msgs-release.git
-      version: 4.1.0-1
+      version: 4.1.0-3
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git
@@ -743,7 +743,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 2.2.0-1
+      version: 2.2.0-3
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git
@@ -757,7 +757,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/cpp_polyfills-release.git
-      version: 1.0.2-1
+      version: 1.0.2-3
     source:
       type: git
       url: https://github.com/PickNikRobotics/cpp_polyfills.git
@@ -772,7 +772,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/cudnn_cmake_module-release.git
-      version: 0.0.1-2
+      version: 0.0.1-4
     source:
       type: git
       url: https://github.com/tier4/cudnn_cmake_module.git
@@ -783,7 +783,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/cyclonedds-release.git
-      version: 0.9.1-1
+      version: 0.9.1-3
     source:
       type: git
       url: https://github.com/eclipse-cyclonedds/cyclonedds.git
@@ -820,7 +820,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.25.0-1
+      version: 0.25.0-3
     source:
       test_pull_requests: true
       type: git
@@ -836,7 +836,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/depthimage_to_laserscan-release.git
-      version: 2.5.0-2
+      version: 2.5.0-4
     source:
       test_pull_requests: true
       type: git
@@ -858,7 +858,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 3.1.1-1
+      version: 3.1.1-3
     source:
       test_pull_requests: true
       type: git
@@ -879,7 +879,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/dolly-release.git
-      version: 0.4.0-2
+      version: 0.4.0-4
     source:
       test_pull_requests: true
       type: git
@@ -895,7 +895,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/domain_bridge-release.git
-      version: 0.5.0-1
+      version: 0.5.0-3
     source:
       test_pull_requests: true
       type: git
@@ -911,7 +911,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_hardware-release.git
-      version: 0.3.1-1
+      version: 0.3.1-3
     source:
       type: git
       url: https://github.com/dynamixel-community/dynamixel_hardware.git
@@ -930,7 +930,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_sdk-release.git
-      version: 3.7.40-2
+      version: 3.7.40-4
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
@@ -948,7 +948,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_workbench-release.git
-      version: 2.2.3-1
+      version: 2.2.3-3
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
@@ -963,7 +963,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_workbench_msgs-release.git
-      version: 2.0.3-1
+      version: 2.0.3-3
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
@@ -1004,7 +1004,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ecl_core-release.git
-      version: 1.2.1-1
+      version: 1.2.1-3
     source:
       test_pull_requests: true
       type: git
@@ -1029,7 +1029,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ecl_lite-release.git
-      version: 1.2.0-1
+      version: 1.2.0-3
     source:
       test_pull_requests: true
       type: git
@@ -1049,7 +1049,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ecl_tools-release.git
-      version: 1.0.3-1
+      version: 1.0.3-3
     source:
       test_pull_requests: true
       type: git
@@ -1065,7 +1065,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/eigen3_cmake_module-release.git
-      version: 0.2.2-1
+      version: 0.2.2-3
     source:
       type: git
       url: https://github.com/ros2/eigen3_cmake_module.git
@@ -1080,7 +1080,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/eigen_stl_containers-release.git
-      version: 1.0.0-3
+      version: 1.0.0-5
     source:
       test_pull_requests: true
       type: git
@@ -1096,7 +1096,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/eigenpy-release.git
-      version: 2.9.2-1
+      version: 2.9.2-3
     source:
       type: git
       url: https://github.com/stack-of-tasks/eigenpy.git
@@ -1111,7 +1111,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/example_interfaces-release.git
-      version: 0.10.2-1
+      version: 0.10.2-3
     source:
       test_pull_requests: true
       type: git
@@ -1150,7 +1150,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/examples-release.git
-      version: 0.17.1-1
+      version: 0.17.1-3
     source:
       test_pull_requests: true
       type: git
@@ -1162,7 +1162,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fastcdr-release.git
-      version: 1.0.26-1
+      version: 1.0.26-3
     source:
       test_commits: false
       test_pull_requests: false
@@ -1179,7 +1179,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fastrtps-release.git
-      version: 2.9.1-1
+      version: 2.9.1-3
     source:
       test_commits: true
       test_pull_requests: false
@@ -1196,7 +1196,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/filters-release.git
-      version: 2.1.0-2
+      version: 2.1.0-4
     source:
       test_pull_requests: true
       type: git
@@ -1212,7 +1212,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/find_object_2d-release.git
-      version: 0.7.0-2
+      version: 0.7.0-4
     source:
       type: git
       url: https://github.com/introlab/find-object.git
@@ -1227,7 +1227,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fluent_rviz-release.git
-      version: 0.0.3-1
+      version: 0.0.3-3
     source:
       type: git
       url: https://github.com/ForteFibre/FluentRviz.git
@@ -1245,7 +1245,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fmi_adapter-release.git
-      version: 2.1.1-2
+      version: 2.1.1-3
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git
@@ -1256,7 +1256,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fmilibrary_vendor-release.git
-      version: 1.0.1-2
+      version: 1.0.1-3
     source:
       type: git
       url: https://github.com/boschresearch/fmilibrary_vendor.git
@@ -1267,7 +1267,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/foonathan_memory_vendor-release.git
-      version: 1.3.0-1
+      version: 1.3.0-3
     source:
       type: git
       url: https://github.com/eProsima/foonathan_memory_vendor.git
@@ -1278,7 +1278,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/four_wheel_steering_msgs-release.git
-      version: 2.0.1-2
+      version: 2.0.1-4
     source:
       type: git
       url: https://github.com/ros-drivers/four_wheel_steering_msgs.git
@@ -1293,7 +1293,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 0.5.1-1
+      version: 0.5.1-3
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git
@@ -1308,7 +1308,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_foxglove_msgs-release.git
-      version: 2.1.1-1
+      version: 2.1.1-3
     source:
       type: git
       url: https://github.com/foxglove/schemas.git
@@ -1337,7 +1337,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.5.1-1
+      version: 0.5.1-3
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git
@@ -1358,7 +1358,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
-      version: 3.7.0-1
+      version: 3.7.0-2
     source:
       test_pull_requests: true
       type: git
@@ -1380,7 +1380,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gc_spl-release.git
-      version: 3.0.0-1
+      version: 3.0.0-3
     source:
       type: git
       url: https://github.com/ros-sports/gc_spl.git
@@ -1400,7 +1400,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 0.3.1-1
+      version: 0.3.1-3
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git
@@ -1419,7 +1419,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geographic_info-release.git
-      version: 1.0.4-5
+      version: 1.0.4-7
     source:
       test_pull_requests: true
       type: git
@@ -1435,7 +1435,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometric_shapes-release.git
-      version: 2.1.3-1
+      version: 2.1.3-3
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git
@@ -1465,7 +1465,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.30.0-1
+      version: 0.30.0-3
     source:
       test_pull_requests: true
       type: git
@@ -1485,7 +1485,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry_tutorials-release.git
-      version: 0.3.6-1
+      version: 0.3.6-3
     source:
       type: git
       url: https://github.com/ros/geometry_tutorials.git
@@ -1500,7 +1500,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/google_benchmark_vendor-release.git
-      version: 0.3.0-1
+      version: 0.3.0-3
     source:
       test_pull_requests: true
       type: git
@@ -1515,7 +1515,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/googletest-release.git
-      version: 1.10.9004-3
+      version: 1.10.9004-5
     source:
       type: git
       url: https://github.com/ament/googletest.git
@@ -1535,7 +1535,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gps_umd-release.git
-      version: 1.0.4-2
+      version: 1.0.4-4
     source:
       test_pull_requests: true
       type: git
@@ -1551,7 +1551,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/graph_msgs-release.git
-      version: 0.2.0-2
+      version: 0.2.0-4
     source:
       type: git
       url: https://github.com/PickNikRobotics/graph_msgs.git
@@ -1566,7 +1566,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/grbl_msgs-release.git
-      version: 0.0.2-5
+      version: 0.0.2-7
     source:
       type: git
       url: https://github.com/flynneva/grbl_msgs.git
@@ -1581,7 +1581,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/grbl_ros-release.git
-      version: 0.0.16-3
+      version: 0.0.16-5
     source:
       type: git
       url: https://github.com/flynneva/grbl_ros.git
@@ -1596,7 +1596,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gscam-release.git
-      version: 2.0.2-1
+      version: 2.0.2-3
     source:
       type: git
       url: https://github.com/ros-drivers/gscam.git
@@ -1611,7 +1611,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gtsam-release.git
-      version: 4.2.0-1
+      version: 4.2.0-3
     source:
       type: git
       url: https://github.com/borglab/gtsam.git
@@ -1626,7 +1626,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/hash_library_vendor-release.git
-      version: 0.1.1-2
+      version: 0.1.1-4
     source:
       type: git
       url: https://github.com/tier4/hash_library_vendor.git
@@ -1651,7 +1651,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/hls_lfcd_lds_driver-release.git
-      version: 2.0.4-2
+      version: 2.0.4-4
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
@@ -1666,7 +1666,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/hpp_fcl-release.git
-      version: 2.3.0-1
+      version: 2.3.0-3
     source:
       type: git
       url: https://github.com/humanoid-path-planner/hpp-fcl.git
@@ -1681,7 +1681,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/iceoryx-release.git
-      version: 2.0.3-1
+      version: 2.0.3-3
     source:
       type: git
       url: https://github.com/eclipse-iceoryx/iceoryx.git
@@ -1692,7 +1692,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ifm3d-release.git
-      version: 0.18.0-6
+      version: 0.18.0-8
     status: developed
   ign_ros2_control:
     doc:
@@ -1706,7 +1706,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 0.6.1-1
+      version: 0.6.1-2
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git
@@ -1740,7 +1740,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ignition_cmake2_vendor-release.git
-      version: 0.0.2-1
+      version: 0.0.2-2
     source:
       test_pull_requests: true
       type: git
@@ -1756,7 +1756,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ignition_math6_vendor-release.git
-      version: 0.0.2-1
+      version: 0.0.2-2
     source:
       test_pull_requests: true
       type: git
@@ -1777,7 +1777,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 4.2.0-1
+      version: 4.2.0-2
     source:
       test_pull_requests: true
       type: git
@@ -1803,7 +1803,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 3.0.1-1
+      version: 3.0.1-2
     source:
       test_pull_requests: true
       type: git
@@ -1824,7 +1824,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 2.6.0-1
+      version: 2.6.0-2
     source:
       test_pull_requests: true
       type: git
@@ -1845,7 +1845,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/imu_tools-release.git
-      version: 2.1.3-1
+      version: 2.1.3-2
     source:
       test_pull_requests: true
       type: git
@@ -1861,7 +1861,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/interactive_markers-release.git
-      version: 2.4.0-1
+      version: 2.4.0-2
     source:
       test_pull_requests: true
       type: git
@@ -1873,7 +1873,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/irobot_create_msgs-release.git
-      version: 2.1.0-1
+      version: 2.1.0-2
     source:
       type: git
       url: https://github.com/iRobotEducation/irobot_create_msgs.git
@@ -1891,7 +1891,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/joint_state_publisher-release.git
-      version: 2.3.0-1
+      version: 2.3.0-2
     source:
       test_pull_requests: true
       type: git
@@ -1907,7 +1907,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/joy_tester-release.git
-      version: 0.0.2-1
+      version: 0.0.2-2
     source:
       type: git
       url: https://github.com/joshnewans/joy_tester.git
@@ -1929,7 +1929,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/joystick_drivers-release.git
-      version: 3.1.0-2
+      version: 3.1.0-3
     source:
       test_pull_requests: true
       type: git
@@ -1945,7 +1945,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/kdl_parser-release.git
-      version: 2.9.0-1
+      version: 2.9.0-2
     source:
       test_pull_requests: true
       type: git
@@ -1961,7 +1961,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/keyboard_handler-release.git
-      version: 0.1.0-1
+      version: 0.1.0-2
     source:
       test_pull_requests: true
       type: git
@@ -1980,7 +1980,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
-      version: 0.1.0-1
+      version: 0.1.0-2
     source:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git
@@ -1995,7 +1995,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/kobuki_core-release.git
-      version: 1.4.0-1
+      version: 1.4.0-2
     source:
       test_pull_requests: true
       type: git
@@ -2011,7 +2011,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/kobuki_ros_interfaces-release.git
-      version: 1.0.0-2
+      version: 1.0.0-3
     source:
       test_pull_requests: true
       type: git
@@ -2027,7 +2027,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/kobuki_velocity_smoother-release.git
-      version: 0.15.0-1
+      version: 0.15.0-2
     source:
       test_pull_requests: true
       type: git
@@ -2054,7 +2054,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/lanelet2-release.git
-      version: 1.1.1-3
+      version: 1.1.1-4
     source:
       type: git
       url: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git
@@ -2065,7 +2065,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/laser_filters-release.git
-      version: 2.0.6-2
+      version: 2.0.6-3
     source:
       type: git
       url: https://github.com/ros-perception/laser_filters.git
@@ -2080,7 +2080,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/laser_geometry-release.git
-      version: 2.5.0-1
+      version: 2.5.0-2
     source:
       test_pull_requests: true
       type: git
@@ -2096,7 +2096,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/laser_proc-release.git
-      version: 1.0.2-4
+      version: 1.0.2-5
     source:
       test_pull_requests: true
       type: git
@@ -2119,7 +2119,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 1.4.1-1
+      version: 1.4.1-2
     source:
       test_pull_requests: true
       type: git
@@ -2135,7 +2135,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_param_builder-release.git
-      version: 0.1.1-1
+      version: 0.1.1-2
     source:
       type: git
       url: https://github.com/PickNikRobotics/launch_param_builder.git
@@ -2154,7 +2154,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.23.0-1
+      version: 0.23.0-2
     source:
       test_pull_requests: true
       type: git
@@ -2166,7 +2166,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/lgsvl_msgs-release.git
-      version: 0.0.4-2
+      version: 0.0.4-3
     source:
       type: git
       url: https://github.com/lgsvl/lgsvl_msgs.git
@@ -2176,7 +2176,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libg2o-release.git
-      version: 2020.5.29-3
+      version: 2020.5.29-4
     status: maintained
   libnabo:
     doc:
@@ -2187,7 +2187,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libnabo-release.git
-      version: 1.0.7-2
+      version: 1.0.7-3
     source:
       type: git
       url: https://github.com/ethz-asl/libnabo.git
@@ -2202,7 +2202,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libpointmatcher-release.git
-      version: 1.3.1-2
+      version: 1.3.1-3
     source:
       type: git
       url: https://github.com/ethz-asl/libpointmatcher.git
@@ -2217,7 +2217,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libstatistics_collector-release.git
-      version: 1.5.0-2
+      version: 1.5.0-3
     source:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git
@@ -2228,7 +2228,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libyaml_vendor-release.git
-      version: 1.5.0-1
+      version: 1.5.0-2
     source:
       test_pull_requests: true
       type: git
@@ -2243,11 +2243,10 @@ repositories:
     release:
       packages:
       - bosch_locator_bridge
-      - bosch_locator_bridge_utils
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/locator_ros_bridge-release.git
-      version: 2.1.8-1
+      version: 2.1.8-2
     source:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git
@@ -2285,7 +2284,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/marti_common-release.git
-      version: 3.5.0-1
+      version: 3.5.0-2
     source:
       test_pull_requests: true
       type: git
@@ -2311,7 +2310,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/marti_messages-release.git
-      version: 1.3.0-2
+      version: 1.3.0-3
     source:
       test_pull_requests: true
       type: git
@@ -2327,7 +2326,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mavlink-gbp-release.git
-      version: 2022.12.30-1
+      version: 2022.12.30-2
     source:
       type: git
       url: https://github.com/mavlink/mavlink-gbp-release.git
@@ -2347,7 +2346,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mavros-release.git
-      version: 2.4.0-1
+      version: 2.4.0-2
     source:
       type: git
       url: https://github.com/mavlink/mavros.git
@@ -2362,7 +2361,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/menge_vendor-release.git
-      version: 1.0.0-2
+      version: 1.0.0-3
     source:
       type: git
       url: https://github.com/open-rmf/menge_vendor.git
@@ -2377,7 +2376,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_message_filters-release.git
-      version: 4.7.0-1
+      version: 4.7.0-2
     source:
       test_pull_requests: true
       type: git
@@ -2396,7 +2395,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/micro_ros_diagnostics-release.git
-      version: 0.3.0-2
+      version: 0.3.0-4
     source:
       type: git
       url: https://github.com/micro-ROS/micro_ros_diagnostics.git
@@ -2411,7 +2410,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/micro_ros_msgs-release.git
-      version: 1.0.0-2
+      version: 1.0.0-3
     source:
       type: git
       url: https://github.com/micro-ROS/micro_ros_msgs.git
@@ -2431,7 +2430,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/microstrain_inertial-release.git
-      version: 3.0.1-1
+      version: 3.0.1-2
     source:
       test_pull_requests: true
       type: git
@@ -2447,7 +2446,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mimick_vendor-release.git
-      version: 0.3.2-2
+      version: 0.3.2-3
     source:
       type: git
       url: https://github.com/ros2/mimick_vendor.git
@@ -2512,7 +2511,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
-      version: 2.7.0-1
+      version: 2.7.0-2
     source:
       test_commits: false
       test_pull_requests: false
@@ -2529,7 +2528,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_msgs-release.git
-      version: 2.2.1-1
+      version: 2.2.1-2
     source:
       type: git
       url: https://github.com/ros-planning/moveit_msgs.git
@@ -2551,7 +2550,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_resources-release.git
-      version: 2.0.6-1
+      version: 2.0.6-2
     source:
       type: git
       url: https://github.com/ros-planning/moveit_resources.git
@@ -2566,7 +2565,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_visual_tools-release.git
-      version: 4.1.0-1
+      version: 4.1.0-2
     source:
       type: git
       url: https://github.com/ros-planning/moveit_visual_tools.git
@@ -2581,7 +2580,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt2-release.git
-      version: 2.7.0-1
+      version: 2.7.0-2
     source:
       type: git
       url: https://github.com/MRPT/mrpt.git
@@ -2596,7 +2595,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_msgs-release.git
-      version: 0.4.4-1
+      version: 0.4.4-2
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
@@ -2631,7 +2630,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mrt_cmake_modules-release.git
-      version: 1.0.9-2
+      version: 1.0.9-3
     source:
       type: git
       url: https://github.com/KIT-MRT/mrt_cmake_modules.git
@@ -2646,7 +2645,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mvsim-release.git
-      version: 0.6.1-1
+      version: 0.6.1-2
     source:
       type: git
       url: https://github.com/MRPT/mvsim.git
@@ -2661,7 +2660,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nao_button_sim-release.git
-      version: 0.1.1-3
+      version: 0.1.1-4
     source:
       type: git
       url: https://github.com/ijnek/nao_button_sim.git
@@ -2679,7 +2678,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nao_interfaces-release.git
-      version: 0.0.4-2
+      version: 0.0.4-3
     source:
       type: git
       url: https://github.com/ijnek/nao_interfaces.git
@@ -2694,7 +2693,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nao_lola-release.git
-      version: 0.2.0-1
+      version: 0.2.0-2
     source:
       type: git
       url: https://github.com/ros-sports/nao_lola.git
@@ -2711,7 +2710,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/navigation_msgs-release.git
-      version: 2.2.0-1
+      version: 2.2.0-2
     source:
       test_pull_requests: true
       type: git
@@ -2722,16 +2721,16 @@ repositories:
     doc:
       type: git
       url: https://github.com/neobotix/neo_simulation2.git
-      version: main
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/neo_simulation2-release.git
-      version: 1.0.0-2
+      version: 1.0.0-3
     source:
       type: git
       url: https://github.com/neobotix/neo_simulation2.git
-      version: main
+      version: rolling
     status: maintained
   nlohmann_json_schema_validator_vendor:
     doc:
@@ -2742,7 +2741,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nlohmann_json_schema_validator_vendor-release.git
-      version: 0.2.4-1
+      version: 0.2.4-2
     source:
       type: git
       url: https://github.com/open-rmf/nlohmann_json_schema_validator_vendor.git
@@ -2757,7 +2756,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nmea_hardware_interface-release.git
-      version: 0.0.1-2
+      version: 0.0.1-3
     source:
       type: git
       url: https://github.com/OUXT-Polaris/nmea_hardware_interface.git
@@ -2772,7 +2771,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nmea_msgs-release.git
-      version: 2.0.0-3
+      version: 2.0.0-4
     source:
       type: git
       url: https://github.com/ros-drivers/nmea_msgs.git
@@ -2783,7 +2782,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nmea_navsat_driver-release.git
-      version: 2.0.0-1
+      version: 2.0.0-2
     source:
       test_pull_requests: true
       type: git
@@ -2803,7 +2802,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nodl-release.git
-      version: 0.3.1-2
+      version: 0.3.1-3
     source:
       type: git
       url: https://github.com/ubuntu-robotics/nodl.git
@@ -2818,7 +2817,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nodl_to_policy-release.git
-      version: 1.0.0-2
+      version: 1.0.0-3
     source:
       test_pull_requests: true
       type: git
@@ -2837,7 +2836,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/novatel_gps_driver-release.git
-      version: 4.1.0-2
+      version: 4.1.0-3
     source:
       type: git
       url: https://github.com/swri-robotics/novatel_gps_driver.git
@@ -2852,7 +2851,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ntpd_driver-release.git
-      version: 2.2.0-1
+      version: 2.2.0-2
     source:
       type: git
       url: https://github.com/vooon/ntpd_driver.git
@@ -2867,7 +2866,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ntrip_client-release.git
-      version: 1.2.0-1
+      version: 1.2.0-2
     source:
       test_pull_requests: true
       type: git
@@ -2879,7 +2878,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/object_recognition_msgs-release.git
-      version: 2.0.0-2
+      version: 2.0.0-3
     source:
       type: git
       url: https://github.com/wg-perception/object_recognition_msgs.git
@@ -2898,7 +2897,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/octomap-release.git
-      version: 1.9.8-1
+      version: 1.9.8-2
     source:
       type: git
       url: https://github.com/octomap/octomap.git
@@ -2916,7 +2915,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/octomap_mapping-release.git
-      version: 2.0.0-2
+      version: 2.0.0-3
     source:
       type: git
       url: https://github.com/OctoMap/octomap_mapping.git
@@ -2931,7 +2930,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/octomap_msgs-release.git
-      version: 2.0.0-2
+      version: 2.0.0-3
     source:
       type: git
       url: https://github.com/octomap/octomap_msgs.git
@@ -2946,7 +2945,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/octomap_ros-release.git
-      version: 0.4.3-1
+      version: 0.4.3-2
     source:
       type: git
       url: https://github.com/OctoMap/octomap_ros.git
@@ -2961,7 +2960,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/octomap_rviz_plugins-release.git
-      version: 2.0.0-2
+      version: 2.0.0-3
     source:
       type: git
       url: https://github.com/OctoMap/octomap_rviz_plugins.git
@@ -2976,7 +2975,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/odom_to_tf_ros2-release.git
-      version: 1.0.2-1
+      version: 1.0.2-2
     source:
       type: git
       url: https://github.com/gstavrinos/odom_to_tf_ros2.git
@@ -2987,7 +2986,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
-      version: 1.5.2-2
+      version: 1.5.2-3
   openni2_camera:
     doc:
       type: git
@@ -2997,7 +2996,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/openni2_camera-release.git
-      version: 2.0.1-1
+      version: 2.0.1-2
     source:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git
@@ -3031,7 +3030,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
-      version: 0.3.4-1
+      version: 0.3.4-2
     source:
       test_pull_requests: true
       type: git
@@ -3047,7 +3046,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/osqp_vendor-release.git
-      version: 0.2.0-1
+      version: 0.2.0-2
     source:
       type: git
       url: https://github.com/tier4/osqp_vendor.git
@@ -3062,7 +3061,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/osrf_pycommon-release.git
-      version: 2.1.2-1
+      version: 2.1.2-2
     source:
       type: git
       url: https://github.com/osrf/osrf_pycommon.git
@@ -3077,7 +3076,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/osrf_testing_tools_cpp-release.git
-      version: 1.5.1-1
+      version: 1.5.1-2
     source:
       test_pull_requests: true
       type: git
@@ -3096,7 +3095,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ouxt_common-release.git
-      version: 0.0.8-2
+      version: 0.0.8-3
     source:
       type: git
       url: https://github.com/OUXT-Polaris/ouxt_common.git
@@ -3107,7 +3106,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pcl_msgs-release.git
-      version: 1.0.0-6
+      version: 1.0.0-7
     source:
       type: git
       url: https://github.com/ros-perception/pcl_msgs.git
@@ -3120,7 +3119,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/perception_open3d-release.git
-      version: 0.1.2-1
+      version: 0.1.2-2
     source:
       type: git
       url: https://github.com/ros-perception/perception_open3d.git
@@ -3139,7 +3138,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/perception_pcl-release.git
-      version: 2.4.0-3
+      version: 2.4.0-4
     source:
       test_pull_requests: true
       type: git
@@ -3155,7 +3154,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/performance_test-release.git
-      version: 1.2.1-2
+      version: 1.2.1-3
     source:
       type: git
       url: https://gitlab.com/ApexAI/performance_test.git
@@ -3166,7 +3165,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/performance_test_fixture-release.git
-      version: 0.1.0-1
+      version: 0.1.0-2
     source:
       test_pull_requests: true
       type: git
@@ -3199,7 +3198,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/phidgets_drivers-release.git
-      version: 2.3.1-1
+      version: 2.3.1-2
     source:
       test_pull_requests: true
       type: git
@@ -3215,7 +3214,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pick_ik-release.git
-      version: 1.0.0-1
+      version: 1.0.0-2
     source:
       type: git
       url: https://github.com/PickNikRobotics/pick_ik.git
@@ -3226,7 +3225,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/picknik_ament_copyright-release.git
-      version: 0.0.2-2
+      version: 0.0.2-3
   pinocchio:
     doc:
       type: git
@@ -3236,7 +3235,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pinocchio-release.git
-      version: 2.6.17-1
+      version: 2.6.17-2
     source:
       type: git
       url: https://github.com/stack-of-tasks/pinocchio.git
@@ -3251,7 +3250,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.5.1-1
+      version: 3.5.1-2
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git
@@ -3266,7 +3265,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler_msgs-release.git
-      version: 0.2.3-2
+      version: 0.2.3-3
     source:
       type: git
       url: https://github.com/facontidavide/plotjuggler_msgs.git
@@ -3281,7 +3280,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-ros-plugins-release.git
-      version: 1.7.3-4
+      version: 1.7.3-5
     source:
       type: git
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
@@ -3296,7 +3295,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 5.2.2-1
+      version: 5.2.2-2
     source:
       test_pull_requests: true
       type: git
@@ -3312,7 +3311,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_msg_wrapper-release.git
-      version: 1.0.7-2
+      version: 1.0.7-3
     source:
       type: git
       url: https://gitlab.com/ApexAI/point_cloud_msg_wrapper
@@ -3327,7 +3326,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pointcloud_to_laserscan-release.git
-      version: 2.0.1-2
+      version: 2.0.1-3
     source:
       test_pull_requests: true
       type: git
@@ -3343,7 +3342,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pose_cov_ops-release.git
-      version: 0.3.8-1
+      version: 0.3.8-2
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
@@ -3358,7 +3357,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/proxsuite-release.git
-      version: 0.3.5-1
+      version: 0.3.5-2
     source:
       type: git
       url: https://github.com/Simple-Robotics/proxsuite.git
@@ -3373,7 +3372,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees-release.git
-      version: 2.2.1-1
+      version: 2.2.1-2
     source:
       test_pull_requests: true
       type: git
@@ -3389,7 +3388,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_js-release.git
-      version: 0.6.4-1
+      version: 0.6.4-2
     source:
       test_pull_requests: true
       type: git
@@ -3405,7 +3404,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_ros-release.git
-      version: 2.2.2-1
+      version: 2.2.2-2
     source:
       test_pull_requests: true
       type: git
@@ -3421,7 +3420,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_ros_interfaces-release.git
-      version: 2.1.0-1
+      version: 2.1.0-2
     source:
       test_pull_requests: true
       type: git
@@ -3437,7 +3436,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pybind11_json_vendor-release.git
-      version: 0.2.2-1
+      version: 0.2.2-2
     source:
       type: git
       url: https://github.com/open-rmf/pybind11_json_vendor.git
@@ -3452,7 +3451,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pybind11_vendor-release.git
-      version: 3.0.2-1
+      version: 3.0.2-2
     source:
       test_pull_requests: true
       type: git
@@ -3468,7 +3467,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/python_cmake_module-release.git
-      version: 0.10.2-1
+      version: 0.10.2-2
     source:
       type: git
       url: https://github.com/ros2/python_cmake_module.git
@@ -3483,7 +3482,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/python_qt_binding-release.git
-      version: 1.2.2-1
+      version: 1.2.2-2
     source:
       test_pull_requests: true
       type: git
@@ -3495,7 +3494,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/qpoases_vendor-release.git
-      version: 3.2.3-2
+      version: 3.2.3-3
     source:
       type: git
       url: https://github.com/Autoware-AI/qpoases_vendor.git
@@ -3517,7 +3516,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 2.4.0-1
+      version: 2.4.0-2
     source:
       test_pull_requests: true
       type: git
@@ -3528,12 +3527,12 @@ repositories:
     doc:
       type: git
       url: https://github.com/OUXT-Polaris/quaternion_operation.git
-      version: master
+      version: ros2
     release:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/quaternion_operation-release.git
-      version: 0.0.7-2
+      version: 0.0.7-3
     source:
       type: git
       url: https://github.com/OUXT-Polaris/quaternion_operation.git
@@ -3552,7 +3551,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/r2r_spl-release.git
-      version: 3.0.1-1
+      version: 3.0.1-2
     source:
       type: git
       url: https://github.com/ros-sports/r2r_spl.git
@@ -3563,7 +3562,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/radar_msgs-release.git
-      version: 0.2.2-1
+      version: 0.2.2-2
     status: maintained
   random_numbers:
     doc:
@@ -3574,7 +3573,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/random_numbers-release.git
-      version: 2.0.1-2
+      version: 2.0.1-3
     source:
       type: git
       url: https://github.com/ros-planning/random_numbers.git
@@ -3589,7 +3588,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rc_common_msgs_ros2-release.git
-      version: 0.5.3-3
+      version: 0.5.3-4
     source:
       test_pull_requests: true
       type: git
@@ -3605,7 +3604,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rc_dynamics_api-release.git
-      version: 0.10.3-2
+      version: 0.10.3-3
     source:
       test_pull_requests: true
       type: git
@@ -3621,7 +3620,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rc_genicam_api-release.git
-      version: 2.6.1-1
+      version: 2.6.1-2
     source:
       test_pull_requests: true
       type: git
@@ -3637,7 +3636,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rc_genicam_driver_ros2-release.git
-      version: 0.3.0-1
+      version: 0.3.0-2
     source:
       test_pull_requests: true
       type: git
@@ -3656,7 +3655,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rc_reason_clients-release.git
-      version: 0.2.1-3
+      version: 0.2.1-4
     source:
       test_pull_requests: true
       type: git
@@ -3672,7 +3671,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcdiscover-release.git
-      version: 1.1.6-1
+      version: 1.1.6-2
     source:
       test_pull_requests: true
       type: git
@@ -3693,7 +3692,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 5.9.0-1
+      version: 5.9.0-2
     source:
       test_pull_requests: true
       type: git
@@ -3719,7 +3718,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_interfaces-release.git
-      version: 1.4.0-1
+      version: 1.4.0-2
     source:
       test_pull_requests: true
       type: git
@@ -3739,7 +3738,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 2.5.0-1
+      version: 2.5.0-2
     source:
       test_pull_requests: true
       type: git
@@ -3771,7 +3770,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
-      version: 3.0.8-1
+      version: 3.0.8-2
     source:
       test_pull_requests: true
       type: git
@@ -3792,7 +3791,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 19.3.0-1
+      version: 19.3.0-2
     source:
       test_pull_requests: true
       type: git
@@ -3808,7 +3807,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 3.10.0-1
+      version: 3.10.0-2
     source:
       test_pull_requests: true
       type: git
@@ -3824,7 +3823,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 2.6.1-1
+      version: 2.6.1-2
     source:
       test_pull_requests: true
       type: git
@@ -3845,7 +3844,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcss3d_agent-release.git
-      version: 0.4.1-1
+      version: 0.4.1-2
     source:
       type: git
       url: https://github.com/ros-sports/rcss3d_agent.git
@@ -3860,7 +3859,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcss3d_nao-release.git
-      version: 0.1.1-1
+      version: 0.1.1-2
     source:
       type: git
       url: https://github.com/ros-sports/rcss3d_nao.git
@@ -3875,7 +3874,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 6.1.1-1
+      version: 6.1.1-2
     source:
       test_pull_requests: true
       type: git
@@ -3894,7 +3893,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_support-release.git
-      version: 0.15.0-1
+      version: 0.15.0-2
     source:
       test_pull_requests: true
       type: git
@@ -3910,7 +3909,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 2.5.0-1
+      version: 2.5.0-2
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git
@@ -3928,7 +3927,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 3.2.2-1
+      version: 3.2.2-2
     source:
       test_pull_requests: true
       type: git
@@ -3940,7 +3939,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rig_reconfigure-release.git
-      version: 1.0.0-3
+      version: 1.0.0-4
     source:
       test_pull_requests: true
       type: git
@@ -3956,7 +3955,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_api_msgs-release.git
-      version: 0.0.1-4
+      version: 0.0.1-5
     source:
       type: git
       url: https://github.com/open-rmf/rmf_api_msgs.git
@@ -3971,7 +3970,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_battery-release.git
-      version: 0.1.3-1
+      version: 0.1.3-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_battery.git
@@ -3986,7 +3985,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_building_map_msgs-release.git
-      version: 1.2.0-5
+      version: 1.2.0-6
     source:
       type: git
       url: https://github.com/open-rmf/rmf_building_map_msgs.git
@@ -4001,7 +4000,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_cmake_uncrustify-release.git
-      version: 1.2.0-3
+      version: 1.2.0-4
     source:
       type: git
       url: https://github.com/open-rmf/rmf_cmake_uncrustify.git
@@ -4039,7 +4038,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
-      version: 3.0.2-1
+      version: 3.0.2-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_internal_msgs.git
@@ -4060,7 +4059,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 2.1.2-1
+      version: 2.1.2-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git
@@ -4082,7 +4081,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_simulation-release.git
-      version: 2.0.0-1
+      version: 2.0.0-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_simulation.git
@@ -4100,7 +4099,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
-      version: 2.1.2-1
+      version: 2.1.2-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_task.git
@@ -4118,7 +4117,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic-release.git
-      version: 3.0.0-1
+      version: 3.0.0-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic.git
@@ -4138,7 +4137,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
-      version: 1.6.0-1
+      version: 1.6.0-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic_editor.git
@@ -4153,7 +4152,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_utils-release.git
-      version: 1.4.0-1
+      version: 1.4.0-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_utils.git
@@ -4177,7 +4176,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_visualization-release.git
-      version: 2.0.1-1
+      version: 2.0.1-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_visualization.git
@@ -4192,7 +4191,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_visualization_msgs-release.git
-      version: 1.2.0-3
+      version: 1.2.0-4
     source:
       type: git
       url: https://github.com/open-rmf/rmf_visualization_msgs.git
@@ -4210,7 +4209,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 7.0.1-1
+      version: 7.0.1-2
     source:
       test_pull_requests: true
       type: git
@@ -4230,7 +4229,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 0.13.0-1
+      version: 0.13.0-2
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git
@@ -4247,7 +4246,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 1.5.1-1
+      version: 1.5.1-2
     source:
       test_pull_requests: true
       type: git
@@ -4263,7 +4262,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_dds_common-release.git
-      version: 2.0.0-1
+      version: 2.0.0-2
     source:
       test_pull_requests: true
       type: git
@@ -4283,7 +4282,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 7.0.0-1
+      version: 7.0.0-2
     source:
       test_pull_requests: true
       type: git
@@ -4294,7 +4293,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rmw_gurumdds.git
-      version: master
+      version: rolling
     release:
       packages:
       - gurumdds_cmake_module
@@ -4302,11 +4301,11 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
-      version: 4.2.0-1
+      version: 4.2.0-2
     source:
       type: git
       url: https://github.com/ros2/rmw_gurumdds.git
-      version: master
+      version: rolling
     status: developed
   rmw_implementation:
     doc:
@@ -4317,7 +4316,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_implementation-release.git
-      version: 2.11.0-1
+      version: 2.11.0-2
     source:
       test_pull_requests: true
       type: git
@@ -4336,7 +4335,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/robot_calibration-release.git
-      version: 0.8.0-1
+      version: 0.8.0-2
     source:
       type: git
       url: https://github.com/mikeferguson/robot_calibration.git
@@ -4347,7 +4346,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/robot_localization-release.git
-      version: 3.5.0-1
+      version: 3.5.0-2
     source:
       test_pull_requests: true
       type: git
@@ -4363,7 +4362,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/robot_state_publisher-release.git
-      version: 3.1.2-1
+      version: 3.1.2-2
     source:
       test_pull_requests: true
       type: git
@@ -4405,7 +4404,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.10.0-1
+      version: 3.10.0-2
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git
@@ -4436,7 +4435,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 3.3.0-1
+      version: 3.3.0-2
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git
@@ -4454,7 +4453,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_ouster_drivers-release.git
-      version: 0.5.0-1
+      version: 0.5.0-2
     source:
       test_pull_requests: true
       type: git
@@ -4470,7 +4469,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_socketcan-release.git
-      version: 1.1.0-2
+      version: 1.1.0-3
     source:
       type: git
       url: https://github.com/autowarefoundation/ros2_socketcan.git
@@ -4492,7 +4491,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 5.1.0-1
+      version: 5.1.0-2
     source:
       test_pull_requests: true
       type: git
@@ -4508,7 +4507,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2acceleration-release.git
-      version: 0.5.1-1
+      version: 0.5.1-2
     source:
       test_pull_requests: true
       type: git
@@ -4540,7 +4539,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.23.0-1
+      version: 0.23.0-2
     source:
       test_pull_requests: true
       type: git
@@ -4556,7 +4555,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli_common_extensions-release.git
-      version: 0.2.2-1
+      version: 0.2.2-2
     source:
       type: git
       url: https://github.com/ros2/ros2cli_common_extensions.git
@@ -4574,7 +4573,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2launch_security-release.git
-      version: 1.0.0-2
+      version: 1.0.0-3
     source:
       test_pull_requests: true
       type: git
@@ -4588,7 +4587,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_canopen-release.git
-      version: 2.0.0-3
+      version: 2.0.0-4
     source:
       type: git
       url: https://github.com/ros-industrial/ros_canopen.git
@@ -4603,7 +4602,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_environment-release.git
-      version: 4.0.1-1
+      version: 4.0.1-2
     source:
       test_pull_requests: true
       type: git
@@ -4626,7 +4625,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 0.244.3-1
+      version: 0.244.3-2
     source:
       test_pull_requests: true
       type: git
@@ -4642,7 +4641,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_image_to_qimage-release.git
-      version: 0.4.1-1
+      version: 0.4.1-2
     source:
       type: git
       url: https://github.com/ros-sports/ros_image_to_qimage.git
@@ -4653,7 +4652,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_industrial_cmake_boilerplate-release.git
-      version: 0.4.0-1
+      version: 0.4.0-2
   ros_testing:
     doc:
       type: git
@@ -4666,7 +4665,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_testing-release.git
-      version: 0.5.2-1
+      version: 0.5.2-2
     source:
       test_pull_requests: true
       type: git
@@ -4678,7 +4677,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_workspace-release.git
-      version: 1.0.3-1
+      version: 1.0.3-2
     source:
       type: git
       url: https://github.com/ros2/ros_workspace.git
@@ -4716,7 +4715,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.20.0-1
+      version: 0.20.0-2
     source:
       test_pull_requests: true
       type: git
@@ -4758,7 +4757,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 1.3.1-1
+      version: 1.3.1-2
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git
@@ -4786,7 +4785,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 3.4.0-1
+      version: 3.4.0-2
     source:
       test_pull_requests: true
       type: git
@@ -4805,7 +4804,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_core-release.git
-      version: 0.1.1-1
+      version: 0.1.1-2
     source:
       test_pull_requests: true
       type: git
@@ -4823,7 +4822,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_dds-release.git
-      version: 0.10.1-1
+      version: 0.10.1-2
     source:
       test_pull_requests: true
       type: git
@@ -4842,7 +4841,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_defaults-release.git
-      version: 1.5.0-1
+      version: 1.5.0-2
     source:
       test_pull_requests: true
       type: git
@@ -4860,7 +4859,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.17.0-1
+      version: 0.17.0-2
     source:
       test_pull_requests: true
       type: git
@@ -4876,7 +4875,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
-      version: 0.11.1-1
+      version: 0.11.1-2
     source:
       test_pull_requests: true
       type: git
@@ -4895,7 +4894,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-      version: 2.3.1-1
+      version: 2.3.1-2
     source:
       test_pull_requests: true
       type: git
@@ -4915,7 +4914,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-      version: 2.5.0-1
+      version: 2.5.0-2
     source:
       test_pull_requests: true
       type: git
@@ -4934,7 +4933,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rospy_message_converter-release.git
-      version: 2.0.1-1
+      version: 2.0.1-2
     source:
       test_pull_requests: true
       type: git
@@ -4948,7 +4947,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rot_conv_lib-release.git
-      version: 1.0.11-1
+      version: 1.0.11-2
     source:
       type: git
       url: https://github.com/AIS-Bonn/rot_conv_lib.git
@@ -4959,7 +4958,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rplidar_ros-release.git
-      version: 2.1.0-1
+      version: 2.1.0-2
     source:
       test_pull_requests: true
       type: git
@@ -4975,7 +4974,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rpyutils-release.git
-      version: 0.3.2-1
+      version: 0.3.2-2
     source:
       test_pull_requests: true
       type: git
@@ -4997,7 +4996,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
-      version: 1.3.1-1
+      version: 1.3.1-2
     source:
       test_pull_requests: true
       type: git
@@ -5013,7 +5012,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_action-release.git
-      version: 2.1.2-1
+      version: 2.1.2-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_action.git
@@ -5031,7 +5030,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
-      version: 1.3.0-1
+      version: 1.3.0-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git
@@ -5046,7 +5045,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_common_plugins-release.git
-      version: 1.2.0-1
+      version: 1.2.0-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git
@@ -5061,7 +5060,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_console-release.git
-      version: 2.1.1-1
+      version: 2.1.1-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git
@@ -5076,7 +5075,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_graph-release.git
-      version: 1.4.1-1
+      version: 1.4.1-2
     source:
       test_pull_requests: true
       type: git
@@ -5095,7 +5094,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_overlay-release.git
-      version: 0.3.1-1
+      version: 0.3.1-2
     source:
       type: git
       url: https://github.com/ros-sports/rqt_image_overlay.git
@@ -5110,7 +5109,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_view-release.git
-      version: 1.2.0-1
+      version: 1.2.0-2
     source:
       test_pull_requests: true
       type: git
@@ -5126,7 +5125,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_moveit-release.git
-      version: 1.0.1-2
+      version: 1.0.1-3
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_moveit.git
@@ -5141,7 +5140,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_msg-release.git
-      version: 1.3.1-1
+      version: 1.3.1-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_msg.git
@@ -5156,7 +5155,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_plot-release.git
-      version: 1.2.1-1
+      version: 1.2.1-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git
@@ -5171,7 +5170,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_publisher-release.git
-      version: 1.6.2-1
+      version: 1.6.2-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git
@@ -5186,7 +5185,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_py_console-release.git
-      version: 1.1.1-1
+      version: 1.1.1-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_py_console.git
@@ -5201,7 +5200,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_reconfigure-release.git
-      version: 1.3.1-1
+      version: 1.3.1-2
     source:
       test_pull_requests: true
       type: git
@@ -5217,7 +5216,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_robot_dashboard-release.git
-      version: 0.6.1-2
+      version: 0.6.1-3
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_dashboard.git
@@ -5232,7 +5231,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_robot_monitor-release.git
-      version: 1.0.5-1
+      version: 1.0.5-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_monitor.git
@@ -5247,7 +5246,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_robot_steering-release.git
-      version: 1.0.0-3
+      version: 1.0.0-4
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_steering.git
@@ -5262,7 +5261,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_runtime_monitor-release.git
-      version: 1.0.0-2
+      version: 1.0.0-3
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_runtime_monitor.git
@@ -5277,7 +5276,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_service_caller-release.git
-      version: 1.1.1-1
+      version: 1.1.1-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_service_caller.git
@@ -5292,7 +5291,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_shell-release.git
-      version: 1.1.1-1
+      version: 1.1.1-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_shell.git
@@ -5307,7 +5306,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_srv-release.git
-      version: 1.1.1-1
+      version: 1.1.1-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_srv.git
@@ -5322,7 +5321,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_tf_tree-release.git
-      version: 1.0.4-1
+      version: 1.0.4-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_tf_tree.git
@@ -5337,7 +5336,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_topic-release.git
-      version: 1.6.1-1
+      version: 1.6.1-2
     source:
       test_pull_requests: true
       type: git
@@ -5353,7 +5352,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/RSL-release.git
-      version: 0.2.1-1
+      version: 0.2.1-2
     source:
       type: git
       url: https://github.com/PickNikRobotics/RSL.git
@@ -5371,7 +5370,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rt_manipulators_cpp-release.git
-      version: 1.0.0-1
+      version: 1.0.0-2
     source:
       type: git
       url: https://github.com/rt-net/rt_manipulators_cpp.git
@@ -5386,7 +5385,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rtabmap-release.git
-      version: 0.20.23-1
+      version: 0.20.23-2
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -5401,7 +5400,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rtcm_msgs-release.git
-      version: 1.1.6-1
+      version: 1.1.6-2
     source:
       type: git
       url: https://github.com/tilk/rtcm_msgs.git
@@ -5412,7 +5411,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ruckig-release.git
-      version: 0.9.2-2
+      version: 0.9.2-3
     source:
       type: git
       url: https://github.com/pantor/ruckig.git
@@ -5436,7 +5435,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 12.3.1-1
+      version: 12.3.1-2
     source:
       test_pull_requests: true
       type: git
@@ -5455,7 +5454,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz_2d_overlay_plugins-release.git
-      version: 1.2.1-1
+      version: 1.2.1-2
     source:
       type: git
       url: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git
@@ -5470,7 +5469,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz_visual_tools-release.git
-      version: 4.1.4-1
+      version: 4.1.4-2
     source:
       type: git
       url: https://github.com/PickNikRobotics/rviz_visual_tools.git
@@ -5488,7 +5487,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sdformat_urdf-release.git
-      version: 1.0.1-1
+      version: 1.0.1-2
     source:
       test_pull_requests: true
       type: git
@@ -5504,7 +5503,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release.git
-      version: 1.2.3-1
+      version: 1.2.3-2
     source:
       test_pull_requests: true
       type: git
@@ -5520,7 +5519,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/simple_actions-release.git
-      version: 0.2.1-1
+      version: 0.2.1-2
     source:
       test_pull_requests: true
       type: git
@@ -5536,7 +5535,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/simple_launch-release.git
-      version: 1.7.0-1
+      version: 1.7.0-2
     source:
       type: git
       url: https://github.com/oKermorgant/simple_launch.git
@@ -5551,7 +5550,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/slider_publisher-release.git
-      version: 2.2.1-1
+      version: 2.2.1-2
     source:
       type: git
       url: https://github.com/oKermorgant/slider_publisher.git
@@ -5566,7 +5565,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/snowbot_release.git
-      version: 0.1.2-2
+      version: 0.1.2-3
     source:
       type: git
       url: https://github.com/PickNikRobotics/snowbot_operating_system.git
@@ -5586,7 +5585,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/soccer_interfaces-release.git
-      version: 0.2.0-1
+      version: 0.2.0-2
     source:
       type: git
       url: https://github.com/ros-sports/soccer_interfaces.git
@@ -5601,7 +5600,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/soccer_object_msgs-release.git
-      version: 1.1.0-1
+      version: 1.1.0-2
     source:
       type: git
       url: https://github.com/ijnek/soccer_object_msgs.git
@@ -5616,7 +5615,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/soccer_vision_3d_rviz_markers-release.git
-      version: 0.0.1-1
+      version: 0.0.1-2
     source:
       type: git
       url: https://github.com/ros-sports/soccer_vision_3d_rviz_markers.git
@@ -5633,7 +5632,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/soccer_visualization-release.git
-      version: 0.1.0-1
+      version: 0.1.0-2
     source:
       type: git
       url: https://github.com/ijnek/soccer_visualization.git
@@ -5648,7 +5647,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sol_vendor-release.git
-      version: 0.0.3-2
+      version: 0.0.3-3
     source:
       type: git
       url: https://github.com/OUXT-Polaris/sol_vendor.git
@@ -5663,7 +5662,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sophus-release.git
-      version: 1.3.1-1
+      version: 1.3.1-2
     source:
       type: git
       url: https://github.com/stonier/sophus.git
@@ -5674,7 +5673,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/spdlog_vendor-release.git
-      version: 1.4.3-1
+      version: 1.4.3-2
     source:
       test_pull_requests: true
       type: git
@@ -5690,7 +5689,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/srdfdom-release.git
-      version: 2.0.4-1
+      version: 2.0.4-2
     source:
       type: git
       url: https://github.com/ros-planning/srdfdom.git
@@ -5708,7 +5707,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.11.1-1
+      version: 0.11.1-2
     source:
       test_pull_requests: true
       type: git
@@ -5724,7 +5723,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/stomp-release.git
-      version: 0.1.2-1
+      version: 0.1.2-2
     source:
       type: git
       url: https://github.com/ros-industrial/stomp.git
@@ -5742,7 +5741,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/stubborn_buddies-release.git
-      version: 1.0.0-4
+      version: 1.0.0-5
     source:
       type: git
       url: https://github.com/open-rmf/stubborn_buddies.git
@@ -5757,7 +5756,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/swri_console-release.git
-      version: 2.0.3-1
+      version: 2.0.3-2
     source:
       type: git
       url: https://github.com/swri-robotics/swri_console.git
@@ -5772,7 +5771,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_system_fingerprint-release.git
-      version: 0.7.0-1
+      version: 0.7.0-2
     source:
       test_pull_requests: true
       type: git
@@ -5793,7 +5792,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/system_modes-release.git
-      version: 0.9.0-3
+      version: 0.9.0-4
     source:
       test_pull_requests: true
       type: git
@@ -5812,7 +5811,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tango_icons_vendor-release.git
-      version: 0.2.2-1
+      version: 0.2.2-2
     source:
       type: git
       url: https://github.com/ros-visualization/tango_icons_vendor.git
@@ -5833,7 +5832,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_tools-release.git
-      version: 1.3.0-2
+      version: 1.3.0-3
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git
@@ -5848,7 +5847,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_twist_joy-release.git
-      version: 2.4.3-3
+      version: 2.4.3-4
     source:
       test_pull_requests: true
       type: git
@@ -5864,7 +5863,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_twist_keyboard-release.git
-      version: 2.3.2-3
+      version: 2.3.2-4
     source:
       test_pull_requests: true
       type: git
@@ -5880,7 +5879,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tensorrt_cmake_module-release.git
-      version: 0.0.3-1
+      version: 0.0.3-2
     source:
       type: git
       url: https://github.com/tier4/tensorrt_cmake_module.git
@@ -5895,7 +5894,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/test_interface_files-release.git
-      version: 0.10.2-1
+      version: 0.10.2-2
     source:
       test_pull_requests: true
       type: git
@@ -5911,7 +5910,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tf2_2d-release.git
-      version: 1.0.1-1
+      version: 1.0.1-2
     source:
       test_pull_requests: true
       type: git
@@ -5927,7 +5926,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tf_transformations_release.git
-      version: 1.0.1-2
+      version: 1.0.1-3
     source:
       test_pull_requests: true
       type: git
@@ -5943,7 +5942,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tinyspline_vendor-release.git
-      version: 0.6.0-2
+      version: 0.6.0-3
     source:
       type: git
       url: https://github.com/wep21/tinyspline_vendor.git
@@ -5958,7 +5957,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tinyxml2_vendor-release.git
-      version: 0.8.2-1
+      version: 0.8.2-2
     source:
       test_pull_requests: true
       type: git
@@ -5970,7 +5969,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tinyxml_vendor-release.git
-      version: 0.9.2-1
+      version: 0.9.2-2
     source:
       test_pull_requests: true
       type: git
@@ -5986,7 +5985,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tlsf-release.git
-      version: 0.8.2-1
+      version: 0.8.2-2
     source:
       test_pull_requests: true
       type: git
@@ -6005,7 +6004,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/topic_tools-release.git
-      version: 1.0.0-1
+      version: 1.0.0-2
     source:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git
@@ -6020,7 +6019,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tracetools_acceleration-release.git
-      version: 0.4.1-1
+      version: 0.4.1-2
     source:
       test_pull_requests: true
       type: git
@@ -6039,7 +6038,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tracetools_analysis-release.git
-      version: 3.0.0-3
+      version: 3.0.0-4
     source:
       type: git
       url: https://gitlab.com/ros-tracing/tracetools_analysis.git
@@ -6059,7 +6058,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/transport_drivers-release.git
-      version: 1.2.0-1
+      version: 1.2.0-2
     source:
       type: git
       url: https://github.com/ros-drivers/transport_drivers.git
@@ -6074,7 +6073,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/turbojpeg_compressed_image_transport-release.git
-      version: 0.2.1-1
+      version: 0.2.1-2
     source:
       type: git
       url: https://github.com/wep21/turbojpeg_compressed_image_transport.git
@@ -6089,7 +6088,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot3_msgs-release.git
-      version: 2.2.1-2
+      version: 2.2.1-3
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
@@ -6108,7 +6107,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot3_simulations-release.git
-      version: 2.2.5-2
+      version: 2.2.5-3
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
@@ -6123,7 +6122,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_tutorials-release.git
-      version: 1.6.0-1
+      version: 1.6.0-2
     source:
       test_pull_requests: true
       type: git
@@ -6139,7 +6138,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tvm_vendor-release.git
-      version: 0.9.1-1
+      version: 0.9.1-2
     source:
       type: git
       url: https://github.com/autowarefoundation/tvm_vendor.git
@@ -6154,7 +6153,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/twist_mux-release.git
-      version: 4.1.0-2
+      version: 4.1.0-3
     source:
       type: git
       url: https://github.com/ros-teleop/twist_mux.git
@@ -6169,7 +6168,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/twist_stamper-release.git
-      version: 0.0.3-1
+      version: 0.0.3-2
     source:
       type: git
       url: https://github.com/joshnewans/twist_stamper.git
@@ -6189,7 +6188,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ublox-release.git
-      version: 2.3.0-1
+      version: 2.3.0-2
     source:
       test_pull_requests: true
       type: git
@@ -6210,7 +6209,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ublox_dgnss-release.git
-      version: 0.3.5-3
+      version: 0.3.5-4
     source:
       type: git
       url: https://github.com/aussierobots/ublox_dgnss.git
@@ -6225,7 +6224,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/udp_msgs-release.git
-      version: 0.0.3-4
+      version: 0.0.3-5
     source:
       type: git
       url: https://github.com/flynneva/udp_msgs.git
@@ -6236,7 +6235,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/uncrustify_vendor-release.git
-      version: 2.1.2-1
+      version: 2.1.2-2
     source:
       type: git
       url: https://github.com/ament/uncrustify_vendor.git
@@ -6251,7 +6250,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/unique_identifier_msgs-release.git
-      version: 2.3.2-1
+      version: 2.3.2-2
     source:
       test_pull_requests: true
       type: git
@@ -6267,7 +6266,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
-      version: 1.3.1-1
+      version: 1.3.1-2
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git
@@ -6282,7 +6281,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.0.1-1
+      version: 2.0.1-2
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
@@ -6297,7 +6296,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ur_msgs-release.git
-      version: 2.0.0-1
+      version: 2.0.0-2
     source:
       type: git
       url: https://github.com/ros-industrial/ur_msgs.git
@@ -6320,7 +6319,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.3.1-1
+      version: 2.3.1-2
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
@@ -6338,7 +6337,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdf-release.git
-      version: 2.8.2-1
+      version: 2.8.2-2
     source:
       test_pull_requests: true
       type: git
@@ -6356,7 +6355,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom_py-release.git
-      version: 1.2.0-1
+      version: 1.2.0-2
     source:
       test_pull_requests: true
       type: git
@@ -6372,7 +6371,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdf_tutorial-release.git
-      version: 1.0.0-2
+      version: 1.0.0-3
     source:
       test_pull_requests: true
       type: git
@@ -6388,7 +6387,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom-release.git
-      version: 3.1.0-1
+      version: 3.1.0-2
     source:
       test_pull_requests: true
       type: git
@@ -6404,7 +6403,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom_headers-release.git
-      version: 1.1.0-1
+      version: 1.1.0-2
     source:
       type: git
       url: https://github.com/ros/urdfdom_headers.git
@@ -6419,7 +6418,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urg_c-release.git
-      version: 1.0.4001-3
+      version: 1.0.4001-4
     source:
       test_pull_requests: true
       type: git
@@ -6435,7 +6434,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urg_node-release.git
-      version: 1.1.1-1
+      version: 1.1.1-2
     source:
       test_pull_requests: true
       type: git
@@ -6451,7 +6450,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urg_node_msgs-release.git
-      version: 1.0.1-5
+      version: 1.0.1-6
     source:
       type: git
       url: https://github.com/ros-drivers/urg_node_msgs.git
@@ -6466,7 +6465,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/usb_cam-release.git
-      version: 0.5.0-1
+      version: 0.5.0-2
     source:
       type: git
       url: https://github.com/ros-drivers/usb_cam.git
@@ -6481,7 +6480,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_v4l2_camera-release.git
-      version: 0.6.1-1
+      version: 0.6.1-2
     source:
       type: git
       url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
@@ -6503,7 +6502,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/variants-release.git
-      version: 0.10.0-1
+      version: 0.10.0-2
     source:
       test_pull_requests: true
       type: git
@@ -6525,7 +6524,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/velodyne-release.git
-      version: 2.3.0-1
+      version: 2.3.0-2
     source:
       type: git
       url: https://github.com/ros-drivers/velodyne.git
@@ -6544,7 +6543,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/velodyne_simulator-release.git
-      version: 2.0.3-1
+      version: 2.0.3-2
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
@@ -6562,7 +6561,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/vision_msgs-release.git
-      version: 4.1.0-1
+      version: 4.1.0-2
     source:
       test_pull_requests: true
       type: git
@@ -6578,7 +6577,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/vision_msgs_layers-release.git
-      version: 0.2.0-1
+      version: 0.2.0-2
     source:
       type: git
       url: https://github.com/ros-sports/vision_msgs_layers.git
@@ -6597,7 +6596,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 3.4.0-1
+      version: 3.4.0-2
     source:
       test_pull_requests: true
       type: git
@@ -6613,7 +6612,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/visp-release.git
-      version: 3.5.0-1
+      version: 3.5.0-2
     source:
       type: git
       url: https://github.com/lagadic/visp.git
@@ -6628,7 +6627,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/vitis_common-release.git
-      version: 0.4.2-1
+      version: 0.4.2-2
     source:
       test_pull_requests: true
       type: git
@@ -6644,7 +6643,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/vrpn-release.git
-      version: 7.35.0-11
+      version: 7.35.0-12
     source:
       test_commits: false
       test_pull_requests: false
@@ -6661,7 +6660,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/vrpn_mocap-release.git
-      version: 1.0.3-1
+      version: 1.0.3-2
     source:
       type: git
       url: https://github.com/alvinsunyixiao/vrpn_mocap.git
@@ -6676,7 +6675,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/warehouse_ros-release.git
-      version: 2.0.4-2
+      version: 2.0.4-3
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros.git
@@ -6705,7 +6704,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/warehouse_ros_sqlite-release.git
-      version: 1.0.3-1
+      version: 1.0.3-2
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros_sqlite.git
@@ -6733,7 +6732,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/webots_ros2-release.git
-      version: 2023.0.2-1
+      version: 2023.0.2-2
     source:
       test_pull_requests: true
       type: git
@@ -6749,7 +6748,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/xacro-release.git
-      version: 2.0.9-1
+      version: 2.0.9-2
     source:
       type: git
       url: https://github.com/ros/xacro.git
@@ -6760,7 +6759,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
-      version: 8.1.2-1
+      version: 8.1.2-2
     source:
       test_pull_requests: true
       type: git
@@ -6776,7 +6775,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/zbar_ros-release.git
-      version: 0.4.0-1
+      version: 0.4.0-2
     source:
       type: git
       url: https://github.com/ros-drivers/zbar_ros.git
@@ -6791,7 +6790,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/zenoh_bridge_dds-release.git
-      version: 0.5.0-2
+      version: 0.5.0-3
     source:
       type: git
       url: https://github.com/eclipse-zenoh/zenoh-plugin-dds.git
@@ -6806,7 +6805,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/zmqpp_vendor-release.git
-      version: 0.0.2-1
+      version: 0.0.2-2
     source:
       type: git
       url: https://github.com/tier4/zmqpp_vendor.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6,7 +6,7 @@ release_platforms:
   debian:
   - bullseye
   rhel:
-  - '8'
+  - '9'
   ubuntu:
   - jammy
 repositories:


### PR DESCRIPTION
This PR will migrate ROS 2 Rolling Ridley from RHEL 8 to RHEL 9.

I plan to run the migration on Tuesday March 21st 2023, which will populate this PR with the new releases.