### PR TITLE
vesc: 1.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -7502,6 +7502,22 @@ repositories:
       url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
       version: foxy-devel
     status: maintained
+  vesc:
+    release:
+      packages:
+      - vesc
+      - vesc_ackermann
+      - vesc_driver
+      - vesc_msgs
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/f1tenth/vesc-release.git
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://github.com/f1tenth/vesc.git
+      version: ros2
+    status: developed
   vision_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vesc` to `1.2.0-1`:

- upstream repository: https://github.com/f1tenth/vesc.git
- release repository: https://github.com/f1tenth/vesc-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## vesc

```
* Merge pull request #14 <https://github.com/f1tenth/vesc/issues/14> from Triton-AI/ros2
  Pull ros2 experimental vesc driver back into f1tenth
* std::optional -> std::experimental::optional
* force c++17
* Porting vesc meta-package to ROS2.
* Contributors: Haoru Xue, Joshua Whitley
```

## vesc_ackermann

```
* Merge pull request #21 <https://github.com/f1tenth/vesc/issues/21> from Triton-AI/ros2
  Debug vesc_to_odom TF not publishing
* Merge pull request #18 <https://github.com/f1tenth/vesc/issues/18> from jacobjj/ros2_correction
  Corrected error in vesc_to_odom.cpp
* change subscriber msg type to Float
* [vesc_ackermann] Adding some missing include headers and using statements.
* [vesc_ackermann] Porting complete.
* [vesc_ackermann] Starting port.
* Porting all package.xml and CMakeList.txt files to ROS2.
* Contributors: Haoru Xue, Hongrui (Billy) Zheng, Jacob Johnson, Joshua Whitley
```

## vesc_driver

```
* Expose VESC config from VESC driver launch file.
* Fix issue with if statements.
* Merge pull request #20 <https://github.com/f1tenth/vesc/issues/20> from Triton-AI/ros2
  [Bug Fix] Use synchronous serial read
* reduce print severity to debug
* Merge pull request #19 <https://github.com/f1tenth/vesc/issues/19> from anscipione/add_imu_support_rebase_v2
  Add imu support and vesc udev enumeration tools (rebase upstream ros2) v2
* fixed some test issues
* publish sensors_msgs::Imu
* replaced  boost::bind with std::bind
* fix sensor
* fixed timing wait for imu polling
* added imu polling
* fixed test for udev
* added script for udev
* added program to enumerate vesc serial ports based on their uuid
* Fix linter errors
* Merge pull request #14 <https://github.com/f1tenth/vesc/issues/14> from Triton-AI/ros2
  Pull ros2 experimental vesc driver back into f1tenth
* remove serial driver from cmake
* removed debug codes from 654ba11
* update main branch changes
* update cmake
* Merge branch 'ros2' of https://github.com/Triton-AI/vesc into ros2
* node naving convention; removed unused variable
* rebased to upstream
* working ros2 driver
* removed old methods
* fixed test results
* fix test results
* protocol update to FW 5.2
* resolved inbound serial comunication problems
* removed old error handler
* update readme
* modified launch file
* std::optional -> std::experimental::optional
* force c++17
* minor coding practice updates
* Merge pull request #12 <https://github.com/f1tenth/vesc/issues/12> from anscipione/protocol_update_to_FW_5.2
  Protocol update to fw 5.2
* Merge pull request #11 <https://github.com/f1tenth/vesc/issues/11> from anscipione/Ros2_bug_fixing_serial_comunication
  resolved inbound serial comunication problems
* Merge remote-tracking branch 'origin/Ros2_bug_fixing_serial_comunication' into protocol_update_to_FW_5.2
* removed commented-out code
* removed old methods
* fixed test results
* Merge branch 'Ros2_bug_fixing_serial_comunication' into protocol_update_to_FW_5.2
* fix test results
* protocol update to FW 5.2
* resolved inbound serial comunication problems
* working ros2 driver
* [vesc_driver] Optimizing mutex utilization.
* [vesc_driver] Changing default port to F1TENTH symlink name.
* Add mutex and wait in read thread.
* [vesc_driver] Re-adding missing join() for thread.
* [vesc_driver] Adding all optional params to launch.
* [vesc_driver] Set launch file to typical device for F1TENTH.
* [vesc_driver] Node finally starts.
* [vesc_driver] Fixing copyrights and finishing transition to boost::asio.
* [vesc_driver] Finished port - applied uncrustify.
* [vesc_driver] Working on implementation of rclcpp::Node.
* [vesc_driver] Starting port of vesc_driver.
* [vesc_driver] Removing unnecessary files and renaming header files.
* [vesc_driver] Removing nodelet XML and renaming header files.
* Porting all package.xml and CMakeList.txt files to ROS2.
* Contributors: Alessandro Celeste, Andrea Scipione, Haoru, Haoru Xue, Hongrui (Billy) Zheng, Joshua Whitley
```

## vesc_msgs

```
* Merge pull request #19 <https://github.com/f1tenth/vesc/issues/19> from anscipione/add_imu_support_rebase_v2
  Add imu support and vesc udev enumeration tools (rebase upstream ros2) v2
* fixed timing wait for imu polling
* added imu polling
* protocol update to FW 5.2
* Merge pull request #12 <https://github.com/f1tenth/vesc/issues/12> from anscipione/protocol_update_to_FW_5.2
  Protocol update to fw 5.2
* [vesc_msgs] Ported to ROS2.
* Porting all package.xml and CMakeList.txt files to ROS2.
* Contributors: Andrea Scipione, Joshua Whitley
```
