### PR TITLE
urg_node: 1.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7359,7 +7359,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/urg_node-release.git
-      version: 1.1.0-3
+      version: 1.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_node` to `1.1.1-1`:

- upstream repository: https://github.com/ros-drivers/urg_node.git
- release repository: https://github.com/ros2-gbp/urg_node-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-3`

## urg_node

```
* add branch information
* add license file, same as ROS1
* increased delay in diagnostics thread to slow down publish rate (#102 <https://github.com/ros-drivers/urg_node/issues/102>)
  This is just a quick PR to increase the thread sleep in the diagnostics thread. Currently the diagnostics status is updated at ~96hz. Which is way too fast and really messes with the Frequency Status Monitor which jumps between too low and too high
* Added URDF for UST10. (#103 <https://github.com/ros-drivers/urg_node/issues/103>)
* Contributors: Michael Ferguson, Richard, Tony Baltovski
```
