### PR TITLE
laser_filters: 2.0.6-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2213,7 +2213,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/laser_filters-release.git
-      version: 2.0.5-1
+      version: 2.0.6-2
     source:
       type: git
       url: https://github.com/ros-perception/laser_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters` to `2.0.6-2`:

- upstream repository: https://github.com/ros-perception/laser_filters.git
- release repository: https://github.com/ros2-gbp/laser_filters-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.5-1`

## laser_filters

```
* Added declaration of parameters
* Reduce computation cost of ScanShadowsFilter
* Update scan_to_cloud_filter_chain.cpp
  As of Eloquent a timer interface is required for the tf buffer.
  https://docs.ros.org/en/galactic/Releases/Release-Eloquent-Elusor.html#tf2-buffer
* Contributors: Atsushi Watanabe, Jon Binney, Jonathan Binney, Riccardo Tornese, brandonbeggs
```
