### PR TITLE
marker_msgs: 0.0.8-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2559,6 +2559,13 @@ repositories:
       url: https://github.com/swri-robotics/mapviz.git
       version: ros2-devel
     status: developed
+  marker_msgs:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/tuw-robotics/marker_msgs-release.git
+      version: 0.0.8-2
+    status: maintained
   marti_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marker_msgs` to `0.0.8-2`:

- upstream repository: https://github.com/tuw-robotics/marker_msgs.git
- release repository: https://github.com/tuw-robotics/marker_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## marker_msgs

```
* updated for ros2
* Update MarkerDetection.msg
* Update README.md
* Create README.md
* Contributors: Markus Bader
```
