### PR TITLE
marker_msgs: 0.0.8-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2263,6 +2263,13 @@ repositories:
       url: https://github.com/hatchbed/log_view.git
       version: ros2
     status: developed
+  marker_msgs:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/tuw-robotics/marker_msgs-release.git
+      version: 0.0.8-1
+    status: maintained
   marti_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marker_msgs` to `0.0.8-1`:

- upstream repository: https://github.com/tuw-robotics/marker_msgs.git
- release repository: https://github.com/tuw-robotics/marker_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## marker_msgs

```
* updated for ros2
* Update MarkerDetection.msg
* Update README.md
* Create README.md
* Contributors: Markus Bader
```
