### PR TITLE
tuw_geometry: 0.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7039,6 +7039,13 @@ repositories:
       url: https://github.com/ros/ros_tutorials.git
       version: humble
     status: maintained
+  tuw_geometry:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/tuw-robotics/tuw_geometry-release.git
+      version: 0.0.4-1
+    status: maintained
   tvm_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tuw_geometry` to `0.0.4-1`:

- upstream repository: https://github.com/tuw-robotics/tuw_geometry.git
- release repository: https://github.com/tuw-robotics/tuw_geometry-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## tuw_geometry

```
* Error on returnvalue in LayeredMaps::getVal( fixed
* header files renamed to hpp
* figure sample added
* uncrustifyed
* code reformated
* ros2 ready
* CMake version updated
* opencv4 fix in grid_map
* warning fixed
* Contributors: Markus Bader
```
