### PR TITLE
[migration-tools] Update release_repo_url value if the release track has one.

### DIFF
--- a/migration-tools/migrate-rosdistro.py
+++ b/migration-tools/migrate-rosdistro.py
@@ -180,6 +180,9 @@ for repo_name in sorted(new_repositories + repositories_to_retry):
                     config = get_patch_config(newref)
                     config['parent'] = config['parent'].replace(args.source, args.dest)
                     set_patch_config(newref, config)
+            # Check for a release repo url in the track configuration
+            if 'release_repo_url' in dest_track:
+                dest_track['release_repo_url'] = new_release_repo_url
             write_tracks_file(tracks, f'Copy {args.source} track to {args.dest} with migrate-rosdistro.py.')
         else:
             dest_track = tracks['tracks'][args.dest]

--- a/migration-tools/migrate-rosdistro.py
+++ b/migration-tools/migrate-rosdistro.py
@@ -182,7 +182,7 @@ for repo_name in sorted(new_repositories + repositories_to_retry):
                     set_patch_config(newref, config)
             # Check for a release repo url in the track configuration
             if 'release_repo_url' in dest_track:
-                dest_track['release_repo_url'] = new_release_repo_url
+                del dest_track['release_repo_url']
             write_tracks_file(tracks, f'Copy {args.source} track to {args.dest} with migrate-rosdistro.py.')
         else:
             dest_track = tracks['tracks'][args.dest]


### PR DESCRIPTION
This is an optional configuration option for individual release tracks which is terribly common since most projects get and use the release repo url from the ros/rosdistro distribution.yaml file. The earlier versions of the migration tool did not check for this value (at the time I wrote this migration script I did not even know that such a config setting was possible).

This change should help avoid confusion in the future due to discrepancies between the release repo url in tracks.yaml and in the rosdistro distribution.yaml.

I would consider eliminating this value entirely rather than rewriting it as well, which personally I like better.