### PR TITLE
[foxy] Update schunk_svh urls

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6440,7 +6440,7 @@ repositories:
   schunk_svh_library:
     doc:
       type: git
-      url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_library.git
+      url: https://github.com/SCHUNK-GmbH-Co-KG/schunk_svh_library.git
       version: main
     release:
       tags:
@@ -6449,13 +6449,13 @@ repositories:
       version: 1.0.1-1
     source:
       type: git
-      url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_library.git
+      url: https://github.com/SCHUNK-GmbH-Co-KG/schunk_svh_library.git
       version: main
     status: developed
   schunk_svh_ros_driver:
     doc:
       type: git
-      url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_ros_driver.git
+      url: https://github.com/SCHUNK-GmbH-Co-KG/schunk_svh_ros_driver.git
       version: ros2-foxy
     release:
       packages:
@@ -6468,7 +6468,7 @@ repositories:
       version: 2.0.1-1
     source:
       type: git
-      url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_ros_driver.git
+      url: https://github.com/SCHUNK-GmbH-Co-KG/schunk_svh_ros_driver.git
       version: ros2-foxy
     status: developed
   septentrio_gnss_driver:


### PR DESCRIPTION
## Background
We developed these libraries in behalf of [Schunk GmbH & Co. KG](https://schunk.com/) (OEM) and now share maintenance. We agreed that the sources should be hosted at [their github space](https://github.com/SCHUNK-GmbH-Co-KG) from now on.

## Steps
This PR updates the respective URLs for *Foxy*.