### PR TITLE
Update ros_system_fingerprint release repo url.

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6804,7 +6804,7 @@ repositories:
     release:
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/ros2-gbp/ros_system_fingerprint-release.git
+      url: https://github.com/MetroRobots/ros_system_fingerprint-release.git
       version: 0.7.0-1
     source:
       test_pull_requests: true

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6804,7 +6804,7 @@ repositories:
     release:
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/MetroRobots/ros_system_fingerprint-release.git
+      url: https://github.com/ros2-gbp/ros_system_fingerprint-release.git
       version: 0.7.0-1
     source:
       test_pull_requests: true

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6508,7 +6508,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/MetroRobots/ros_system_fingerprint-release.git
+      url: https://github.com/ros2-gbp/ros_system_fingerprint-release.git
       version: 0.7.0-1
     source:
       test_pull_requests: true

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5771,7 +5771,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/MetroRobots/ros_system_fingerprint-release.git
+      url: https://github.com/ros2-gbp/ros_system_fingerprint-release.git
       version: 0.7.0-1
     source:
       test_pull_requests: true


### PR DESCRIPTION
This repository has been mirrored into ros2-gbp.