### PR TITLE
Update release repo urls for ecl_core, ecl_lite, ecl_tools, and sophus.

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1198,7 +1198,7 @@ repositories:
       - ecl_utilities
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/ros2-gbp/ecl_core-release.git
+      url: https://github.com/yujinrobot-release/ecl_core-release.git
       version: 1.2.0-1
     source:
       type: git
@@ -1222,7 +1222,7 @@ repositories:
       - ecl_time_lite
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/ros2-gbp/ecl_lite-release.git
+      url: https://github.com/yujinrobot-release/ecl_lite-release.git
       version: 1.1.0-1
     source:
       type: git
@@ -1241,7 +1241,7 @@ repositories:
       - ecl_tools
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/ros2-gbp/ecl_tools-release.git
+      url: https://github.com/yujinrobot-release/ecl_tools-release.git
       version: 1.0.2-2
     source:
       type: git
@@ -6677,7 +6677,7 @@ repositories:
     release:
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/ros2-gbp/sophus-release.git
+      url: https://github.com/yujinrobot-release/sophus-release.git
       version: 1.2.1-1
     source:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1198,7 +1198,7 @@ repositories:
       - ecl_utilities
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/yujinrobot-release/ecl_core-release.git
+      url: https://github.com/ros2-gbp/ecl_core-release.git
       version: 1.2.0-1
     source:
       type: git
@@ -1222,7 +1222,7 @@ repositories:
       - ecl_time_lite
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/yujinrobot-release/ecl_lite-release.git
+      url: https://github.com/ros2-gbp/ecl_lite-release.git
       version: 1.1.0-1
     source:
       type: git
@@ -1241,7 +1241,7 @@ repositories:
       - ecl_tools
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/yujinrobot-release/ecl_tools-release.git
+      url: https://github.com/ros2-gbp/ecl_tools-release.git
       version: 1.0.2-2
     source:
       type: git
@@ -6677,7 +6677,7 @@ repositories:
     release:
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/yujinrobot-release/sophus-release.git
+      url: https://github.com/ros2-gbp/sophus-release.git
       version: 1.2.1-1
     source:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1133,7 +1133,7 @@ repositories:
       - ecl_tools
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/yujinrobot-release/ecl_tools-release.git
+      url: https://github.com/ros2-gbp/ecl_tools-release.git
       version: 1.0.3-2
     source:
       type: git
@@ -6399,7 +6399,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/yujinrobot-release/sophus-release.git
+      url: https://github.com/ros2-gbp/sophus-release.git
       version: 1.3.1-1
     source:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1003,7 +1003,7 @@ repositories:
       - ecl_utilities
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/yujinrobot-release/ecl_core-release.git
+      url: https://github.com/ros2-gbp/ecl_core-release.git
       version: 1.2.1-1
     source:
       test_pull_requests: true
@@ -1028,7 +1028,7 @@ repositories:
       - ecl_time_lite
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/yujinrobot-release/ecl_lite-release.git
+      url: https://github.com/ros2-gbp/ecl_lite-release.git
       version: 1.2.0-1
     source:
       test_pull_requests: true
@@ -1048,7 +1048,7 @@ repositories:
       - ecl_tools
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/yujinrobot-release/ecl_tools-release.git
+      url: https://github.com/ros2-gbp/ecl_tools-release.git
       version: 1.0.3-1
     source:
       test_pull_requests: true
@@ -5662,7 +5662,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/yujinrobot-release/sophus-release.git
+      url: https://github.com/ros2-gbp/sophus-release.git
       version: 1.3.1-1
     source:
       type: git


### PR DESCRIPTION
These release repositories have been mirrored into ros2-gbp.