### PR TITLE
Update septentrio_gnss_driver_ros2 release repo url.

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6479,7 +6479,7 @@ repositories:
     release:
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/septentrio-users/septentrio_gnss_driver_ros2-release.git
+      url: https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release.git
       version: 1.2.3-1
     source:
       test_pull_requests: true

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6479,7 +6479,7 @@ repositories:
     release:
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release.git
+      url: https://github.com/septentrio-users/septentrio_gnss_driver_ros2-release.git
       version: 1.2.3-1
     source:
       test_pull_requests: true

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6167,7 +6167,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/septentrio-users/septentrio_gnss_driver_ros2-release.git
+      url: https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release.git
       version: 1.2.3-1
     source:
       test_pull_requests: true

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5503,7 +5503,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/septentrio-users/septentrio_gnss_driver_ros2-release.git
+      url: https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release.git
       version: 1.2.3-1
     source:
       test_pull_requests: true


### PR DESCRIPTION
This repository has been mirrored into ros2-gbp.
