### PR TITLE
Update rtcm_msgs release repo url.

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6014,7 +6014,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/nobleo/rtcm_msgs-release.git
+      url: https://github.com/ros2-gbp/rtcm_msgs-release.git
       version: 1.1.6-1
     source:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5400,7 +5400,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/nobleo/rtcm_msgs-release.git
+      url: https://github.com/ros2-gbp/rtcm_msgs-release.git
       version: 1.1.6-1
     source:
       type: git


### PR DESCRIPTION
This repo has been mirrored into ros2-gbp.