### PR TITLE
Update ament_download release url

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -198,7 +198,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/samsung-ros/ament_download-release.git
+      url: https://github.com/ros2-gbp/ament_download-release.git
       version: 0.0.5-1
     source:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -163,7 +163,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/samsung-ros/ament_download-release.git
+      url: https://github.com/ros2-gbp/ament_download-release.git
       version: 0.0.5-2
     source:
       type: git


### PR DESCRIPTION
This repository has been mirrored into ros2-gbp.