### PR TITLE
Update moveit2 release repo url.

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2837,7 +2837,7 @@ repositories:
       - pilz_industrial_motion_planner_testutils
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/moveit/moveit2-release.git
+      url: https://github.com/ros2-gbp/moveit2-release.git
       version: 2.5.4-1
     source:
       test_commits: false

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2511,7 +2511,7 @@ repositories:
       - pilz_industrial_motion_planner_testutils
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/moveit/moveit2-release.git
+      url: https://github.com/ros2-gbp/moveit2-release.git
       version: 2.7.0-1
     source:
       test_commits: false


### PR DESCRIPTION
The ros2-gbp mirror has been synchronized with the external one.
