### PR TITLE
Update ros_industrial_cmake_boilerplate release repo url.

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5259,7 +5259,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release.git
+      url: https://github.com/ros2-gbp/ros_industrial_cmake_boilerplate-release.git
       version: 0.4.0-1
   ros_testing:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4652,7 +4652,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release.git
+      url: https://github.com/ros2-gbp/ros_industrial_cmake_boilerplate-release.git
       version: 0.4.0-1
   ros_testing:
     doc:


### PR DESCRIPTION
The ros2-gbp mirror has been synchronized with the external one.