### PR TITLE
witmotion_ros: 1.2.28-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12084,7 +12084,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/twdragon/witmotion_ros-release.git
-      version: 1.2.27-1
+      version: 1.2.28-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `witmotion_ros` to `1.2.28-1`:

- upstream repository: https://github.com/ElettraSciComp/witmotion_IMU_ros.git
- release repository: https://github.com/twdragon/witmotion_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.27-1`

## witmotion_ros

```
* Updated online documentation
* Updated CMake build scenario to suppress useless Doxygen warning
* Version bump to 1.2.28
* Matched versions for ROS node and underlying library
```
