### PR TITLE
tuw_msgs: 0.0.15-3 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7105,6 +7105,21 @@ repositories:
       url: https://github.com/ros/ros_tutorials.git
       version: humble
     status: maintained
+  tuw_geometry:
+    doc:
+      type: git
+      url: https://github.com/tuw-robotics/tuw_geometry.git
+      version: humble
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/tuw-robotics/tuw_geometry-release.git
+      version: 0.0.7-1
+    source:
+      type: git
+      url: https://github.com/tuw-robotics/tuw_geometry.git
+      version: humble
+    status: maintained
   tuw_msgs:
     doc:
       type: git
@@ -7125,21 +7140,6 @@ repositories:
     source:
       type: git
       url: https://github.com/tuw-robotics/tuw_msgs.git
-      version: humble
-    status: maintained
-  tuw_geometry:
-    doc:
-      type: git
-      url: https://github.com/tuw-robotics/tuw_geometry.git
-      version: humble
-    release:
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/tuw-robotics/tuw_geometry-release.git
-      version: 0.0.7-1
-    source:
-      type: git
-      url: https://github.com/tuw-robotics/tuw_geometry.git
       version: humble
     status: maintained
   tvm_vendor:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7074,6 +7074,28 @@ repositories:
       url: https://github.com/ros/ros_tutorials.git
       version: humble
     status: maintained
+  tuw_msgs:
+    doc:
+      type: git
+      url: https://github.com/tuw-robotics/tuw_msgs.git
+      version: humble
+    release:
+      packages:
+      - tuw_airskin_msgs
+      - tuw_geometry_msgs
+      - tuw_msgs
+      - tuw_multi_robot_msgs
+      - tuw_nav_msgs
+      - tuw_object_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/tuw-robotics/tuw_msgs-release.git
+      version: 0.0.15-3
+    source:
+      type: git
+      url: https://github.com/tuw-robotics/tuw_msgs.git
+      version: humble
+    status: maintained
   tvm_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tuw_msgs` to `0.0.15-3`:

- upstream repository: https://github.com/tuw-robotics/tuw_msgs.git
- release repository: https://github.com/tuw-robotics/tuw_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
