### PR TITLE
locator_ros_bridge: 1.0.9-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4815,7 +4815,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/locator_ros_bridge-release.git
-      version: 1.0.8-1
+      version: 1.0.9-3
     source:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `locator_ros_bridge` to `1.0.9-3`:

- upstream repository: https://github.com/boschglobal/locator_ros_bridge.git
- release repository: https://github.com/ros-gbp/locator_ros_bridge-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.8-1`

## bosch_locator_bridge

```
* Try to stop everything before setting config list (#38 <https://github.com/boschglobal/locator_ros_bridge/issues/38>)
* Add errorFlags and infoFlags fields to ClientLocalizationPose (#32 <https://github.com/boschglobal/locator_ros_bridge/issues/32>)
* Update to ROKIT Locator version 1.6
* Contributors: Sheung Ying Yuen-Wille, Stefan Laible
```
