### PR TITLE
[migration-tools] Catch GitHub errors during migration

### DIFF
--- a/migration-tools/migrate-rosdistro.py
+++ b/migration-tools/migrate-rosdistro.py
@@ -240,7 +240,7 @@ for repo_name in sorted(new_repositories + repositories_to_retry):
         release_spec.version = '-'.join([ver, new_release_track_inc])
         repositories_bloomed.append(repo_name)
         subprocess.check_call(['git', 'push', 'origin', 'master'])
-    except (subprocess.CalledProcessError, ValueError) as e:
+    except (subprocess.CalledProcessError, ValueError, github.GithubException) as e:
         repositories_with_errors.append((repo_name, e))
     os.chdir(workdir)
 


### PR DESCRIPTION
This is desirable because a migration may progress substantially before encountering a repository that needs to be created, and the GitHub key may not have that specific permission. If we don't catch the exception here, the entire migration will need to be started again because the progress will be lost.