### PR TITLE
add skyway

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13201,6 +13201,15 @@ repositories:
       url: https://gitlab.com/InstitutMaupertuis/simple_rviz_plugin.git
       version: melodic
     status: maintained
+  skyway:
+    doc:
+      type: git
+      url: https://github.com/ntt-t3/skyway_for_ros.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/ntt-t3/skyway_for_ros.git
+      version: main
   slam_gmapping:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10363,6 +10363,15 @@ repositories:
       url: https://github.com/mikeferguson/simple_grasping.git
       version: ros1
     status: maintained
+  skyway:
+    doc:
+      type: git
+      url: https://github.com/ntt-t3/skyway_for_ros.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/ntt-t3/skyway_for_ros.git
+      version: main
   slam_gmapping:
     doc:
       type: git


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

skyway

## Package Upstream Source:

https://github.com/ntt-t3/skyway_for_ros.git

## Purpose of using this:

This package is designed to enable WebRTC from ROS using the [SkyWay](https://skyway.ntt.com/ja/) WebRTC Platform.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://github.com/ntt-t3/skyway_for_ros.git
- Ubuntu: https://packages.ubuntu.com/
   - https://github.com/ntt-t3/skyway_for_ros.git
- Fedora: https://packages.fedoraproject.org/
  - not available
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available
- openSUSE: https://software.opensuse.org/package/
  - not available

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
