### PR TITLE
witmotion_ros: 1.2.27-4 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -15515,7 +15515,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/twdragon/witmotion_ros-release.git
-      version: 1.2.27-2
+      version: 1.2.27-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `witmotion_ros` to `1.2.27-4`:

- upstream repository: https://github.com/ElettraSciComp/witmotion_IMU_ros.git
- release repository: https://github.com/twdragon/witmotion_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.27-2`

## witmotion_ros

```
* Merged pull request #12 <https://github.com/ElettraSciComp/witmotion_IMU_ros/issues/12> from fllay/main
  Migration to ROS2 made by @fllay approved. The information about the existence of the ROS2 branch will be added to README.md
* Added ROS2 branch information to README
* ros2 code
  Contributors: Andrei Vukolov, Andrey Vukolov, fllay
* Update .gitmodules
  Updated URLs to proper HTTPS
* Rename the project to witmotion_ros - cancelled
* fixed segmentation fault when Ctrl-C
* fixed polling interval and threading
* Fix link error
* package.xml version bump
```
