### PR TITLE
l3cam_ros: 0.0.3-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4409,6 +4409,22 @@ repositories:
       url: https://github.com/MITRE/kvh_geo_fog_3d.git
       version: noetic-devel
     status: maintained
+  l3cam_ros:
+    doc:
+      type: git
+      url: https://github.com/beamaginelidar/l3cam_ros.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/beamaginelidar/l3cam_ros-release.git
+      version: 0.0.3-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/beamaginelidar/l3cam_ros.git
+      version: master
+    status: developed
   lanelet2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `l3cam_ros` to `0.0.3-2`:

- upstream repository: https://github.com/beamaginelidar/l3cam_ros.git
- release repository: https://github.com/beamaginelidar/l3cam_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## l3cam_ros

```
* Added allied Wide and Narrow cameras
* Implemented default parameters
* Bug fixes
* Disable dynamic network configuration
* Contributors: Adrià Subirana
```
