### PR TITLE
locator_ros_bridge: 2.0.10-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2575,7 +2575,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/locator_ros_bridge-release.git
-      version: 2.0.9-1
+      version: 2.0.10-1
     source:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `locator_ros_bridge` to `2.0.10-1`:

- upstream repository: https://github.com/boschglobal/locator_ros_bridge.git
- release repository: https://github.com/ros2-gbp/locator_ros_bridge-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.9-1`

## bosch_locator_bridge

```
* Try to stop everything before setting config list (#37 <https://github.com/boschglobal/locator_ros_bridge/issues/37>)
* Add errorFlags and infoFlags fields to ClientLocalizationPose (#34 <https://github.com/boschglobal/locator_ros_bridge/issues/34>)
* Update to ROKIT Locator version 1.6
* Contributors: Sheung Ying Yuen-Wille, Stefan Laible
```
