### PR TITLE
color_util: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -657,6 +657,22 @@ repositories:
       url: https://github.com/OUXT-Polaris/color_names-release.git
       version: master
     status: developed
+  color_util:
+    doc:
+      type: git
+      url: https://github.com/MetroRobots/color_util.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/MetroRobots-release/color_util-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/MetroRobots/color_util.git
+      version: main
+    status: developed
   common_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `color_util` to `1.0.0-1`:

- upstream repository: https://github.com/MetroRobots/color_util.git
- release repository: https://github.com/MetroRobots-release/color_util-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
