### PR TITLE
moveit: 2.7.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2482,6 +2482,7 @@ repositories:
       - moveit_planners_chomp
       - moveit_planners_ompl
       - moveit_plugins
+      - moveit_py
       - moveit_resources_prbt_ikfast_manipulator_plugin
       - moveit_resources_prbt_moveit_config
       - moveit_resources_prbt_pg70_support
@@ -2510,8 +2511,8 @@ repositories:
       - pilz_industrial_motion_planner_testutils
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/moveit2-release.git
-      version: 2.7.0-2
+      url: https://github.com/ros2-gbp/moveit2-release
+      version: 2.7.1-1
     source:
       test_commits: false
       test_pull_requests: false

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2511,7 +2511,7 @@ repositories:
       - pilz_industrial_motion_planner_testutils
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/moveit2-release
+      url: https://github.com/ros2-gbp/moveit2-release.git
       version: 2.7.1-1
     source:
       test_commits: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.7.1-1`:

- upstream repository: https://github.com/ros-planning/moveit2.git
- release repository: https://github.com/ros2-gbp/moveit2-release
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.7.0-2`

## chomp_motion_planner

```
* remove underscore from public member in MotionPlanResponse (#1939 <https://github.com/ros-planning/moveit2/issues/1939>)
  * remove underscore from private members
  * fix more uses of the suffix notation
* Contributors: AlexWebb
```

## moveit

- No changes

## moveit_chomp_optimizer_adapter

```
* remove underscore from public member in MotionPlanResponse (#1939 <https://github.com/ros-planning/moveit2/issues/1939>)
  * remove underscore from private members
  * fix more uses of the suffix notation
* Contributors: AlexWebb
```

## moveit_common

- No changes

## moveit_configs_utils

- No changes

## moveit_core

```
* Ruckig-smoothing : reduce number of  duration extensions (#1990 <https://github.com/ros-planning/moveit2/issues/1990>)
  * extend duration only for failed segment
  * update comment
  * Remove trajectory reset before extension
  * readability improvement
  * Remove call to RobotState update
  ---------
  Co-authored-by: ibrahiminfinite <ibrahimjkd@@gmail.com>
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
* Fix mimic joints with TOTG (#1989 <https://github.com/ros-planning/moveit2/issues/1989>)
* changed C style cast to C++ style cast for void type (#2010 <https://github.com/ros-planning/moveit2/issues/2010>)
  (void) -> static_cast<void>
* Fix member naming (#1949 <https://github.com/ros-planning/moveit2/issues/1949>)
  * Update clang-tidy rules for readability-identifier-naming
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Fix Ruckig termination condition (#1963 <https://github.com/ros-planning/moveit2/issues/1963>)
* Fix ci-testing build issues (#1998 <https://github.com/ros-planning/moveit2/issues/1998>)
* Fix invalid case style for private member in RobotTrajectory
* Fix unreachable child logger instance
* Document the Butterworth filter better (#1961 <https://github.com/ros-planning/moveit2/issues/1961>)
* Merge pull request #1546 <https://github.com/ros-planning/moveit2/issues/1546> from peterdavidfagan/moveit_py
  Python Bindings - moveit_py
* remove old python bindings
* remove underscore from public member in MotionPlanResponse (#1939 <https://github.com/ros-planning/moveit2/issues/1939>)
  * remove underscore from private members
  * fix more uses of the suffix notation
* Contributors: AlexWebb, AndyZe, Henning Kayser, Jafar, Robert Haschke, Sebastian Castro, Shobuj Paul, V Mohammed Ibrahim, peterdavidfagan
```

## moveit_hybrid_planning

```
* remove underscore from public member in MotionPlanResponse (#1939 <https://github.com/ros-planning/moveit2/issues/1939>)
  * remove underscore from private members
  * fix more uses of the suffix notation
* Contributors: AlexWebb
```

## moveit_kinematics

```
* Fix member naming (#1949 <https://github.com/ros-planning/moveit2/issues/1949>)
  * Update clang-tidy rules for readability-identifier-naming
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Add ament export (#1887 <https://github.com/ros-planning/moveit2/issues/1887>)
  * Add ament export
  Also sort find_package entries alphabetically.
  * Minor cleanup
  ---------
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
* Contributors: Gaël Écorchard, Robert Haschke
```

## moveit_planners

- No changes

## moveit_planners_chomp

```
* remove underscore from public member in MotionPlanResponse (#1939 <https://github.com/ros-planning/moveit2/issues/1939>)
  * remove underscore from private members
  * fix more uses of the suffix notation
* Contributors: AlexWebb
```

## moveit_planners_ompl

```
* Fix include install destination (#2008 <https://github.com/ros-planning/moveit2/issues/2008>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: Tyler Weaver <mailto:maybe@tylerjw.dev>
* Temporarily disable TestPathConstraints with the Panda robot (#2016 <https://github.com/ros-planning/moveit2/issues/2016>)
  This test has become flaky since it was modified to use the OMPL constrained state space (https://github.com/ros-planning/moveit2/issues/2015).
* Increase priority for constrained planning state space (#1300 <https://github.com/ros-planning/moveit2/issues/1300>)
  * Change priority for the constrained planning state space
  * Fix constrained planning tests
  * Use PRM instead of RRTConnect
  ---------
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* remove underscore from public member in MotionPlanResponse (#1939 <https://github.com/ros-planning/moveit2/issues/1939>)
  * remove underscore from private members
  * fix more uses of the suffix notation
* Contributors: Abhijeet Dasgupta, AlexWebb, Stephanie Eng
```

## moveit_plugins

- No changes

## moveit_resources_prbt_ikfast_manipulator_plugin

```
* Fix include install destination (#2008 <https://github.com/ros-planning/moveit2/issues/2008>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: Tyler Weaver <mailto:maybe@tylerjw.dev>
* Contributors: Abhijeet Dasgupta
```

## moveit_resources_prbt_moveit_config

- No changes

## moveit_resources_prbt_pg70_support

- No changes

## moveit_resources_prbt_support

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

```
* Fix member naming (#1949 <https://github.com/ros-planning/moveit2/issues/1949>)
  * Update clang-tidy rules for readability-identifier-naming
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Benchmark parallel planning pipelines (#1539 <https://github.com/ros-planning/moveit2/issues/1539>)
  * Remove launch and config files (moved to moveit_resources)
* remove underscore from public member in MotionPlanResponse (#1939 <https://github.com/ros-planning/moveit2/issues/1939>)
  * remove underscore from private members
  * fix more uses of the suffix notation
* Contributors: AlexWebb, Robert Haschke, Sebastian Jahr
```

## moveit_ros_control_interface

```
* Add Warning Message for Out of Date Controller Information (#1983 <https://github.com/ros-planning/moveit2/issues/1983>)
  Co-authored-by: Joseph Schornak <mailto:joe.schornak@gmail.com>
  Co-authored-by: Joseph Schornak <mailto:joe.schornak@gmail.com>
* Update SwitchController API usage (#1996 <https://github.com/ros-planning/moveit2/issues/1996>)
  Fixes deprecated and now removed message fields https://github.com/ros-controls/ros2_control/pull/948
* Contributors: Erik Holum, Henning Kayser
```

## moveit_ros_move_group

```
* Fix member naming (#1949 <https://github.com/ros-planning/moveit2/issues/1949>)
  * Update clang-tidy rules for readability-identifier-naming
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* remove underscore from public member in MotionPlanResponse (#1939 <https://github.com/ros-planning/moveit2/issues/1939>)
  * remove underscore from private members
  * fix more uses of the suffix notation
* Contributors: AlexWebb, Robert Haschke
```

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

```
* Fix member naming (#1949 <https://github.com/ros-planning/moveit2/issues/1949>)
  * Update clang-tidy rules for readability-identifier-naming
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Contributors: Robert Haschke
```

## moveit_ros_planning

```
* Fix member naming (#1949 <https://github.com/ros-planning/moveit2/issues/1949>)
  * Update clang-tidy rules for readability-identifier-naming
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Benchmark parallel planning pipelines (#1539 <https://github.com/ros-planning/moveit2/issues/1539>)
  * Remove launch and config files (moved to moveit_resources)
* Merge pull request #1546 <https://github.com/ros-planning/moveit2/issues/1546> from peterdavidfagan/moveit_py
  Python Bindings - moveit_py
* add new python bindings
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: Michael Gorner <mailto:me@v4hn.de>
  Co-authored-by: Robert Haschke <mailto:rhaschke@techfak.uni-bielefeld.de>
  Co-authored-by: AndyZe <mailto:zelenak@picknik.ai>
  Co-authored-by: Peter Mitrano <mailto:mitranopeter@gmail.com>
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  Co-authored-by: Jafar <mailto:jafar.uruc@gmail.com>
  Co-authored-by: Shahwas Khan <mailto:shahwazk@usc.edu>
* moveit_cpp: handle the case where blocking==false (#1834 <https://github.com/ros-planning/moveit2/issues/1834>)
* remove underscore from public member in MotionPlanResponse (#1939 <https://github.com/ros-planning/moveit2/issues/1939>)
  * remove underscore from private members
  * fix more uses of the suffix notation
* Contributors: AlexWebb, AndyZe, Jafar, Robert Haschke, Sebastian Jahr, peterdavidfagan
```

## moveit_ros_planning_interface

```
* Fix member naming (#1949 <https://github.com/ros-planning/moveit2/issues/1949>)
  * Update clang-tidy rules for readability-identifier-naming
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* remove underscore from public member in MotionPlanResponse (#1939 <https://github.com/ros-planning/moveit2/issues/1939>)
  * remove underscore from private members
  * fix more uses of the suffix notation
* Contributors: AlexWebb, Robert Haschke
```

## moveit_ros_robot_interaction

```
* Fix member naming (#1949 <https://github.com/ros-planning/moveit2/issues/1949>)
  * Update clang-tidy rules for readability-identifier-naming
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Contributors: Robert Haschke
```

## moveit_ros_visualization

```
* Doxygen tag (#1955 <https://github.com/ros-planning/moveit2/issues/1955>)
  * Generate Doxygen Tag
  * Install tagfile in output directory
  * Fix problematic override for Doxygen linking
* remove underscore from public member in MotionPlanResponse (#1939 <https://github.com/ros-planning/moveit2/issues/1939>)
  * remove underscore from private members
  * fix more uses of the suffix notation
* Contributors: AlexWebb, Henning Kayser
```

## moveit_ros_warehouse

```
* Fix member naming (#1949 <https://github.com/ros-planning/moveit2/issues/1949>)
  * Update clang-tidy rules for readability-identifier-naming
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Contributors: Robert Haschke
```

## moveit_runtime

- No changes

## moveit_servo

```
* Add callback for velocity scaling override + fix params namespace not being set (#2021 <https://github.com/ros-planning/moveit2/issues/2021>)
* Contributors: Sebastian Castro
```

## moveit_setup_app_plugins

```
* add missing dependencies on config utils (#1962 <https://github.com/ros-planning/moveit2/issues/1962>)
  when installing ros-humble-moveit-setup-assistant from debs,
  the package cannot currently run due to this missing depend
* Contributors: Michael Ferguson
```

## moveit_setup_assistant

- No changes

## moveit_setup_controllers

```
* add missing dependencies on config utils (#1962 <https://github.com/ros-planning/moveit2/issues/1962>)
  when installing ros-humble-moveit-setup-assistant from debs,
  the package cannot currently run due to this missing depend
* Contributors: Michael Ferguson
```

## moveit_setup_core_plugins

- No changes

## moveit_setup_framework

```
* Fix member naming (#1949 <https://github.com/ros-planning/moveit2/issues/1949>)
  * Update clang-tidy rules for readability-identifier-naming
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Contributors: Robert Haschke
```

## moveit_setup_srdf_plugins

```
* Fix member naming (#1949 <https://github.com/ros-planning/moveit2/issues/1949>)
  * Update clang-tidy rules for readability-identifier-naming
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Contributors: Robert Haschke
```

## moveit_simple_controller_manager

```
* Fix member naming (#1949 <https://github.com/ros-planning/moveit2/issues/1949>)
  * Update clang-tidy rules for readability-identifier-naming
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Contributors: Robert Haschke
```

## pilz_industrial_motion_planner

```
* Remove "new" from smart pointer instantiation (#2019 <https://github.com/ros-planning/moveit2/issues/2019>)
* Fix member naming (#1949 <https://github.com/ros-planning/moveit2/issues/1949>)
  * Update clang-tidy rules for readability-identifier-naming
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* remove underscore from public member in MotionPlanResponse (#1939 <https://github.com/ros-planning/moveit2/issues/1939>)
  * remove underscore from private members
  * fix more uses of the suffix notation
* Contributors: AlexWebb, Robert Haschke, Shobuj Paul
```

## pilz_industrial_motion_planner_testutils

- No changes
