### PR TITLE
rsl: 0.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5352,7 +5352,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/RSL-release.git
-      version: 0.2.1-2
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/RSL.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rsl` to `0.2.2-1`:

- upstream repository: https://github.com/PickNikRobotics/RSL.git
- release repository: https://github.com/ros2-gbp/RSL-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.1-2`

## rsl

```
* Deprecate rsl::lower_bounds and rsl::upper_bounds
* Depend on ament_cmake_ros for SHARED default
* Upgrade with new pkgs to fix issue with ROS
* Update Catch2
* Contributors: Chris Thrasher, Tyler Weaver
```
