### PR TITLE
skyway-0.0.1

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13206,10 +13206,16 @@ repositories:
       type: git
       url: https://github.com/ntt-t3/skyway_for_ros.git
       version: main
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ntt-t3/skyway_for_ros.git
+      version: 0.0.1-1
     source:
       type: git
       url: https://github.com/ntt-t3/skyway_for_ros.git
       version: main
+    status: developed
   slam_gmapping:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10368,10 +10368,16 @@ repositories:
       type: git
       url: https://github.com/ntt-t3/skyway_for_ros.git
       version: main
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ntt-t3/skyway_for_ros.git
+      version: 0.0.1-1
     source:
       type: git
       url: https://github.com/ntt-t3/skyway_for_ros.git
       version: main
+    status: developed
   slam_gmapping:
     doc:
       type: git


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

skyway

## Package Upstream Source:

[TODO link to source repository](https://github.com/ntt-t3/skyway_for_ros)

## Purpose of using this:

establish WebRTC connection with SkyWay Platform


## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://github.com/ntt-t3/skyway_for_ros
- Ubuntu: https://packages.ubuntu.com/
  - https://github.com/ntt-t3/skyway_for_ros
- Fedora: https://packages.fedoraproject.org/
  - not available
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available
- openSUSE: https://software.opensuse.org/package/
  - not available

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
