### PR TITLE
[python.yaml] add pip package pypdf

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8734,13 +8734,29 @@ python3-pyparsing:
   openembedded: [python3-pyparsing@meta-python]
   opensuse: [python3-pyparsing]
   ubuntu: [python3-pyparsing]
-python3-pypdf-pip:
+python3-pypdf:
   debian:
-    pip:
-      packages: [pypdf]
+    bookworm: [python3-pypdf]
+    stretch:
+      pip:
+        packages: [pypdf]
+    buster:
+      pip:
+        packages: [pypdf]
+    bullseye:
+      pip:
+        packages: [pypdf]
   ubuntu:
-    pip:
-      packages: [pypdf]
+    lunar: [python3-pypdf]
+    bionic:
+      pip:
+        packages: [pypdf]
+    focal:
+      pip:
+        packages: [pypdf]
+    jammy:
+      pip:
+        packages: [pypdf]
 python3-pypng:
   arch: [python-pypng]
   debian: [python3-png]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8734,6 +8734,10 @@ python3-pyparsing:
   openembedded: [python3-pyparsing@meta-python]
   opensuse: [python3-pyparsing]
   ubuntu: [python3-pyparsing]
+python3-pypdf-pip:
+  ubuntu:
+    pip:
+      packages: [pypdf]
 python3-pypng:
   arch: [python-pypng]
   debian: [python3-png]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8735,6 +8735,9 @@ python3-pyparsing:
   opensuse: [python3-pyparsing]
   ubuntu: [python3-pyparsing]
 python3-pypdf-pip:
+  debian:
+    pip:
+      packages: [pypdf]
   ubuntu:
     pip:
       packages: [pypdf]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8737,17 +8737,16 @@ python3-pyparsing:
 python3-pypdf:
   debian:
     bookworm: [python3-pypdf]
-    stretch:
+    bullseye:
       pip:
         packages: [pypdf]
     buster:
       pip:
         packages: [pypdf]
-    bullseye:
+    stretch:
       pip:
         packages: [pypdf]
   ubuntu:
-    lunar: [python3-pypdf]
     bionic:
       pip:
         packages: [pypdf]
@@ -8757,6 +8756,7 @@ python3-pypdf:
     jammy:
       pip:
         packages: [pypdf]
+    lunar: [python3-pypdf]
 python3-pypng:
   arch: [python-pypng]
   debian: [python3-png]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8746,6 +8746,7 @@ python3-pypdf:
     stretch:
       pip:
         packages: [pypdf]
+  gentoo: [dev-python/pypdf]
   ubuntu:
     bionic:
       pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

pypdf

## Package Upstream Source:

https://github.com/py-pdf/pypdf

## Purpose of using this:

pypdf is a free and open-source pure-python PDF library capable of splitting, [merging](https://pypdf.readthedocs.io/en/stable/user/merging-pdfs.html), [cropping, and transforming](https://pypdf.readthedocs.io/en/stable/user/cropping-and-transforming.html) the pages of PDF files. It can also add custom data, viewing options, and [passwords](https://pypdf.readthedocs.io/en/stable/user/encryption-decryption.html) to PDF files. pypdf can [retrieve text](https://pypdf.readthedocs.io/en/stable/user/extract-text.html) and [metadata](https://pypdf.readthedocs.io/en/stable/user/metadata.html) from PDFs as well.

In our case it is utilized to visualize and save ROS data. 

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - bookworm: https://packages.debian.org/bookworm/python3-pypdf 
  - others: via [pip](https://pypi.org/project/pypdf/)
- Ubuntu: https://packages.ubuntu.com/
  - lunar: https://packages.ubuntu.com/lunar/python3-pypdf 
  - others: via [pip](https://pypi.org/project/pypdf/)
- Fedora: https://packages.fedoraproject.org/
  - NOT AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - NOT AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - AVAILABLE https://packages.gentoo.org/packages/dev-python/pypdf
- macOS: https://formulae.brew.sh/
  - NOT AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - NOT AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - NOT AVAILABLE
- openSUSE: https://software.opensuse.org/package/
  - NOT AVAILABLE