### PR TITLE
Adding python3-ntplib in rhel 8

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7968,6 +7968,7 @@ python3-ntplib:
   rhel:
     '*': ['python%{python3_pkgversion}-ntplib']
     '7': null
+    '8': [python3-ntplib]
   ubuntu: [python3-ntplib]
 python3-numba:
   debian: [python3-numba]


### PR DESCRIPTION
Should be available according to https://centos.pkgs.org/8/centos-appstream-aarch64/python3-ntplib-0.3.3-10.el8.noarch.rpm.html