### PR TITLE
diagnostics: 3.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1061,7 +1061,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 3.1.1-1
+      version: 3.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `3.1.2-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.1.1-1`

## diagnostic_aggregator

- No changes

## diagnostic_common_diagnostics

```
* replacing ntpdate with ntplib (#289 <https://github.com/ros/diagnostics/issues/289>)
* Contributors: Christian Henkel
```

## diagnostic_updater

- No changes

## diagnostics

- No changes

## self_test

- No changes
