### PR TITLE
[migration-tools] Pull all branches prior to changing remote

### DIFF
--- a/migration-tools/migrate-rosdistro.py
+++ b/migration-tools/migrate-rosdistro.py
@@ -8,7 +8,7 @@ import sys
 import tempfile
 
 from bloom.commands.git.patch.common import get_patch_config, set_patch_config
-from bloom.git import inbranch, show
+from bloom.git import inbranch, show, track_branches
 
 import github
 import yaml
@@ -138,6 +138,7 @@ for repo_name in sorted(new_repositories + repositories_to_retry):
         if release_repo.endswith('.git'):
             release_repo = release_repo[:-4]
         subprocess.check_call(['git', 'clone', remote_url])
+        track_branches(None, release_repo)
         os.chdir(release_repo)
         tracks = read_tracks_file()
 


### PR DESCRIPTION
There are two reasons this is probably the right thing to do:
1. When the remote gets modified, it breaks Blooms mechanism for determining when a branch already exists remotely prior to creating a new one, which has previously resulted in obliterating the release and patch branches during same-distro migrations.
2. When the repository is moved from one location to another, we end up mirroring all the tags from the original location but only mirroring the branches from the source and destination distros, which is weird. This way we'll mirror everything.

Marking as draft until I can test that this doesn't regress migration to a different distro.

Fixes #32128