### PR TITLE
Re-migrate repositories which dropped patches

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -114,7 +114,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 1.5.3-4
+      version: 1.5.3-5
     source:
       test_pull_requests: true
       type: git
@@ -338,7 +338,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag-release.git
-      version: 3.2.0-3
+      version: 3.2.0-4
     source:
       type: git
       url: https://github.com/AprilRobotics/apriltag.git
@@ -1179,7 +1179,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fastrtps-release.git
-      version: 2.9.1-3
+      version: 2.9.1-4
     source:
       test_commits: true
       test_pull_requests: false
@@ -2446,7 +2446,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mimick_vendor-release.git
-      version: 0.3.2-3
+      version: 0.3.2-4
     source:
       type: git
       url: https://github.com/ros2/mimick_vendor.git
@@ -4316,7 +4316,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_implementation-release.git
-      version: 2.11.0-2
+      version: 2.11.0-3
     source:
       test_pull_requests: true
       type: git
@@ -4677,7 +4677,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_workspace-release.git
-      version: 1.0.3-2
+      version: 1.0.3-3
     source:
       type: git
       url: https://github.com/ros2/ros_workspace.git


### PR DESCRIPTION
This was another incidence of #32128.

I cherry-picked the missing patches from PRs and Humble branches, re-exported them, and then re-ran the migration tool with #36597 applied to re-release with the patches.