### PR TITLE
ament_cmake: 1.5.3-6 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -114,7 +114,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 1.5.3-5
+      version: 1.5.3-6
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake` to `1.5.3-6`:

- upstream repository: https://github.com/ament/ament_cmake.git
- release repository: https://github.com/ros2-gbp/ament_cmake-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.5.3-5`

## ament_cmake

```
* [rolling] Update maintainers - 2022-11-07 (#411 <https://github.com/ament/ament_cmake/issues/411>)
  * Update maintainers to Michael Jeronimo
* Contributors: Audrow Nash
```

## ament_cmake_auto

```
* Fix ament_auto_add_gtest's parameter passing (#421 <https://github.com/ament/ament_cmake/issues/421>)
* [rolling] Update maintainers - 2022-11-07 (#411 <https://github.com/ament/ament_cmake/issues/411>)
  * Update maintainers to Michael Jeronimo
* Contributors: Audrow Nash, Christopher Wecht
```

## ament_cmake_core

```
* Use file(GENERATE OUTPUT) to create dsv files (#416 <https://github.com/ament/ament_cmake/issues/416>)
  Using file(WRITE) and file(APPEND) causes the modification stamp of the
  file to be changed each time CMake configures, resluting in an
  'Installing' message rather than an 'Up-to-date' message even though the
  file content is identical.
  Using file(GENERATE OUTPUT) updates the timestamp of the file only if
  the content changes.
* Warn when trying to symlink install an INTERFACE_LIBRARY (#417 <https://github.com/ament/ament_cmake/issues/417>)
* Workaround to exclude Clion's cmake folders from colcon test (#410 <https://github.com/ament/ament_cmake/issues/410>)
  - Add AMENT_IGNORE to CMAKE_BINARY_DIR to avoid picking up cmake
  specific folders created by CLion in colcon build and colcon test
  commands
* if (NOT ${UNDEFINED_VAR}) gets evaluated to false, so change to if (NOT UNDEFINED_VAR) so it evaluates to true. (#407 <https://github.com/ament/ament_cmake/issues/407>)
* [rolling] Update maintainers - 2022-11-07 (#411 <https://github.com/ament/ament_cmake/issues/411>)
  * Update maintainers to Michael Jeronimo
* Contributors: Audrow Nash, Kenji Brameld, Michael Orlov, Scott K Logan, Shane Loretz
```

## ament_cmake_export_definitions

```
* [rolling] Update maintainers - 2022-11-07 (#411 <https://github.com/ament/ament_cmake/issues/411>)
  * Update maintainers to Michael Jeronimo
* Contributors: Audrow Nash
```

## ament_cmake_export_dependencies

```
* [rolling] Update maintainers - 2022-11-07 (#411 <https://github.com/ament/ament_cmake/issues/411>)
  * Update maintainers to Michael Jeronimo
* Contributors: Audrow Nash
```

## ament_cmake_export_include_directories

```
* [rolling] Update maintainers - 2022-11-07 (#411 <https://github.com/ament/ament_cmake/issues/411>)
  * Update maintainers to Michael Jeronimo
* Contributors: Audrow Nash
```

## ament_cmake_export_interfaces

```
* [rolling] Update maintainers - 2022-11-07 (#411 <https://github.com/ament/ament_cmake/issues/411>)
  * Update maintainers to Michael Jeronimo
* Contributors: Audrow Nash
```

## ament_cmake_export_libraries

```
* [rolling] Update maintainers - 2022-11-07 (#411 <https://github.com/ament/ament_cmake/issues/411>)
  * Update maintainers to Michael Jeronimo
* Contributors: Audrow Nash
```

## ament_cmake_export_link_flags

```
* [rolling] Update maintainers - 2022-11-07 (#411 <https://github.com/ament/ament_cmake/issues/411>)
  * Update maintainers to Michael Jeronimo
* Contributors: Audrow Nash
```

## ament_cmake_export_targets

```
* [rolling] Update maintainers - 2022-11-07 (#411 <https://github.com/ament/ament_cmake/issues/411>)
  * Update maintainers to Michael Jeronimo
* Contributors: Audrow Nash
```

## ament_cmake_gen_version_h

```
* [rolling] Update maintainers - 2022-11-07 (#411 <https://github.com/ament/ament_cmake/issues/411>)
  * Update maintainers to Michael Jeronimo
* Contributors: Audrow Nash
```

## ament_cmake_gmock

```
* Fix compiler warnings related to gtest/gmock (#408 <https://github.com/ament/ament_cmake/issues/408>)
  * Suppress compiler warnings when building gmock
  definition of implicit copy constructor ... is deprecated because it has a user-declared copy assignment operator [-Wdeprecated-copy]
  * Declare gtest/gmock include dirs as SYSTEM PRIVATE for test targets
* [rolling] Update maintainers - 2022-11-07 (#411 <https://github.com/ament/ament_cmake/issues/411>)
  * Update maintainers to Michael Jeronimo
* Contributors: Audrow Nash, Robert Haschke
```

## ament_cmake_google_benchmark

```
* [rolling] Update maintainers - 2022-11-07 (#411 <https://github.com/ament/ament_cmake/issues/411>)
  * Update maintainers to Michael Jeronimo
* Contributors: Audrow Nash
```

## ament_cmake_gtest

```
* Fix compiler warnings related to gtest/gmock (#408 <https://github.com/ament/ament_cmake/issues/408>)
  * Suppress compiler warnings when building gmock
  definition of implicit copy constructor ... is deprecated because it has a user-declared copy assignment operator [-Wdeprecated-copy]
  * Declare gtest/gmock include dirs as SYSTEM PRIVATE for test targets
* [rolling] Update maintainers - 2022-11-07 (#411 <https://github.com/ament/ament_cmake/issues/411>)
  * Update maintainers to Michael Jeronimo
* Contributors: Audrow Nash, Robert Haschke
```

## ament_cmake_include_directories

```
* [rolling] Update maintainers - 2022-11-07 (#411 <https://github.com/ament/ament_cmake/issues/411>)
  * Update maintainers to Michael Jeronimo
* Contributors: Audrow Nash
```

## ament_cmake_libraries

```
* [rolling] Update maintainers - 2022-11-07 (#411 <https://github.com/ament/ament_cmake/issues/411>)
  * Update maintainers to Michael Jeronimo
* Contributors: Audrow Nash
```

## ament_cmake_nose

```
* Deprecate ament_cmake_nose (#415 <https://github.com/ament/ament_cmake/issues/415>)
* [rolling] Update maintainers - 2022-11-07 (#411 <https://github.com/ament/ament_cmake/issues/411>)
  * Update maintainers to Michael Jeronimo
* Contributors: Audrow Nash, Scott K Logan
```

## ament_cmake_pytest

```
* [rolling] Update maintainers - 2022-11-07 (#411 <https://github.com/ament/ament_cmake/issues/411>)
  * Update maintainers to Michael Jeronimo
* Contributors: Audrow Nash
```

## ament_cmake_python

```
* [rolling] Update maintainers - 2022-11-07 (#411 <https://github.com/ament/ament_cmake/issues/411>)
  * Update maintainers to Michael Jeronimo
* Contributors: Audrow Nash
```

## ament_cmake_target_dependencies

```
* [rolling] Update maintainers - 2022-11-07 (#411 <https://github.com/ament/ament_cmake/issues/411>)
  * Update maintainers to Michael Jeronimo
* Contributors: Audrow Nash
```

## ament_cmake_test

```
* [rolling] Update maintainers - 2022-11-07 (#411 <https://github.com/ament/ament_cmake/issues/411>)
  * Update maintainers to Michael Jeronimo
* Contributors: Audrow Nash
```

## ament_cmake_version

```
* [rolling] Update maintainers - 2022-11-07 (#411 <https://github.com/ament/ament_cmake/issues/411>)
  * Update maintainers to Michael Jeronimo
* Contributors: Audrow Nash
```
