### PR TITLE
tuw_geometry: 0.0.7-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6129,6 +6129,21 @@ repositories:
       url: https://github.com/ros/ros_tutorials.git
       version: rolling
     status: maintained
+  tuw_geometry:
+    doc:
+      type: git
+      url: https://github.com/tuw-robotics/tuw_geometry.git
+      version: humble
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/tuw-robotics/tuw_geometry-release.git
+      version: 0.0.7-2
+    source:
+      type: git
+      url: https://github.com/tuw-robotics/tuw_geometry.git
+      version: humble
+    status: maintained
   tvm_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tuw_geometry` to `0.0.7-2`:

- upstream repository: https://github.com/tuw-robotics/tuw_geometry.git
- release repository: https://github.com/tuw-robotics/tuw_geometry-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## tuw_geometry

```
* lint_cmake error fixed
* uncrustify reformated
* minor
* 2D sample class added
* Merge branch 'humble' into ros2
* quaternion support enhanced
* Contributors: Markus Bader
```
