### PR TITLE
Adding libqwt-qt5-dev key for RHEL 8 and 9

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5543,8 +5543,8 @@ libqwt-qt5-dev:
   nixos: [libsForQt5.qwt]
   openembedded: [qwt-qt5@meta-qt5]
   rhel:
-    '8': [qwt-qt5-devel]
-    '9': [qwt-qt5-devel]
+    '*': [qwt-qt5-devel]
+    '7': null
   ubuntu:
     '*': [libqwt-qt5-dev]
     trusty: null

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5542,6 +5542,9 @@ libqwt-qt5-dev:
   gentoo: ['x11-libs/qwt:6']
   nixos: [libsForQt5.qwt]
   openembedded: [qwt-qt5@meta-qt5]
+  rhel:
+    '8': [qwt-qt5-devel]
+    '9': [qwt-qt5-devel]
   ubuntu:
     '*': [libqwt-qt5-dev]
     trusty: null


### PR DESCRIPTION
Please add the following dependency to the rosdep database. **Please note** that this dependency already exists in the `rosdep` database; I am just adding keys for RHEL 8 and 9.

## Package name:

qwt-qt5-devel

## Package Upstream Source:

https://sourceforge.net/projects/qwt/

## Purpose of using this:

I am just adding the keys for `libqwt-qt5-dev` (which already exists) for RHEL 8 and 9.


