### PR TITLE
Add python3-devel to python3-qt5-bindings rule for RHEL 9

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8997,7 +8997,7 @@ python3-qt5-bindings:
   openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python3-qt5]
   rhel:
-    '*': [python3-pyside2-devel, python3-shiboken2-devel]
+    '*': [python3-devel, python3-pyside2-devel, python3-shiboken2-devel]
     '7': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
     '8': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
   slackware: [python3-PyQt5]


### PR DESCRIPTION
It seems that this isn't an implicit dependency for Shiboken2/PySide2 like it was with sip.

This should resolve the `qt_gui_cpp` failure on the buildfarm after re-releasing `python_qt_binding`.