### PR TITLE
Revert "mrpt2: 2.7.0-1 in 'melodic/distribution.yaml' [bloom] (#36390)"

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7349,7 +7349,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt2-release.git
-      version: 2.7.0-1
+      version: 2.5.7-1
     status: maintained
   mrpt_msgs:
     doc:


### PR DESCRIPTION
This reverts commit 724afcaf43e714129f932f39e580d322cb49c5ec.

It looks like #36390 caused downstream projects like https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__mrpt_ekf_slam_2d__ubuntu_bionic_amd64__binary/ to stop building.  Revert for now.

@jlblancoc FYI