### PR TITLE
python_qt_binding: 1.2.2-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3482,7 +3482,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/python_qt_binding-release.git
-      version: 1.2.2-2
+      version: 1.2.2-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `1.2.2-4`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros2-gbp/python_qt_binding-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.2-2`

## python_qt_binding

```
* Demote missing SIP message from WARNING to STATUS (#122 <https://github.com/ros-visualization/python_qt_binding/issues/122>)
* Contributors: Scott K Logan
```
