### PR TITLE
marker_msgs: 0.0.8-3 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2878,6 +2878,21 @@ repositories:
       url: https://github.com/swri-robotics/mapviz.git
       version: dashing-devel
     status: developed
+  marker_msgs:
+    doc:
+      type: git
+      url: https://github.com/tuw-robotics/marker_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/tuw-robotics/marker_msgs-release.git
+      version: 0.0.8-3
+    source:
+      type: git
+      url: https://github.com/tuw-robotics/marker_msgs.git
+      version: ros2
+    status: maintained
   marti_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marker_msgs` to `0.0.8-3`:

- upstream repository: https://github.com/tuw-robotics/marker_msgs.git
- release repository: https://github.com/tuw-robotics/marker_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## marker_msgs

```
* updated for ros2
* Update MarkerDetection.msg
* Update README.md
* Create README.md
* Contributors: Markus Bader
```
