### PR TITLE
tuw_geometry: 0.0.7-3 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -7134,6 +7134,21 @@ repositories:
       url: https://github.com/ros/ros_tutorials.git
       version: foxy-devel
     status: maintained
+  tuw_geometry:
+    doc:
+      type: git
+      url: https://github.com/tuw-robotics/tuw_geometry.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/tuw-robotics/tuw_geometry-release.git
+      version: 0.0.7-3
+    source:
+      type: git
+      url: https://github.com/tuw-robotics/tuw_geometry.git
+      version: ros2
+    status: maintained
   tvm_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tuw_geometry` to `0.0.7-3`:

- upstream repository: https://github.com/tuw-robotics/tuw_geometry.git
- release repository: https://github.com/tuw-robotics/tuw_geometry-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## tuw_geometry

```
* lint_cmake error fixed
* uncrustify reformated
* minor
* 2D sample class added
* Merge branch 'humble' into ros2
* quaternion support enhanced
* Contributors: Markus Bader
```
