### PR TITLE
Add clang to python3-qt5-bindings rule for RHEL 9

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8997,7 +8997,7 @@ python3-qt5-bindings:
   openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python3-qt5]
   rhel:
-    '*': [python3-devel, python3-pyside2-devel, python3-shiboken2-devel]
+    '*': [clang, python3-devel, python3-pyside2-devel, python3-shiboken2-devel]
     '7': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
     '8': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
   slackware: [python3-PyQt5]


### PR DESCRIPTION
It appears that shiboken2 embeds the compiler when it's built, and the RHEL 9 package was built using clang. There's an argument that this is a packaging bug, but this is the best thing we can do to unblock builds for now.