### PR TITLE
vrpn: 7.35.0-13 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6643,7 +6643,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/vrpn-release.git
-      version: 7.35.0-12
+      version: 7.35.0-13
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn` to `7.35.0-13`:

- upstream repository: https://github.com/vrpn/vrpn.git
- release repository: https://github.com/ros2-gbp/vrpn-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `7.35.0-12`
