### PR TITLE
mrpt_navigation: 1.0.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5748,7 +5748,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `1.0.4-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.3-1`

## mrpt_local_obstacles

```
* Fix demo launch files for newer MVSIM
* Fix build against mrpt >=2.7.0
* Contributors: Jose Luis Blanco Claraco
```

## mrpt_localization

```
* Fix build against mrpt >=2.7.0
* add initial pose for localization as param
* Contributors: Jose Luis Blanco-Claraco, SRai22
```

## mrpt_map

```
* mrpt_map: new param to load from ROS map-YAML file
  (Closes #73 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/73>)
* Contributors: Jose Luis Blanco Claraco
```

## mrpt_msgs_bridge

- No changes

## mrpt_navigation

- No changes

## mrpt_rawlog

- No changes

## mrpt_reactivenav2d

```
* Fix demo launch files for newer MVSIM
* Contributors: Jose Luis Blanco Claraco
```

## mrpt_tutorials

- No changes
