### PR TITLE
locator_ros_bridge: 2.1.9-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2246,7 +2246,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/locator_ros_bridge-release.git
-      version: 2.1.8-2
+      version: 2.1.9-2
     source:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `locator_ros_bridge` to `2.1.9-2`:

- upstream repository: https://github.com/boschglobal/locator_ros_bridge.git
- release repository: https://github.com/ros2-gbp/locator_ros_bridge-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.8-2`

## bosch_locator_bridge

```
* Try to stop everything before setting config list (#35 <https://github.com/boschglobal/locator_ros_bridge/issues/35>)
* Add errorFlags and infoFlags fields to ClientLocalizationPose (#33 <https://github.com/boschglobal/locator_ros_bridge/issues/33>)
* Update to ROKIT Locator version 1.6
* Contributors: Stefan Laible
```
