### PR TITLE
ign_ros2_control: 0.4.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1902,7 +1902,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 0.4.3-2
+      version: 0.4.4-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ign_ros2_control` to `0.4.4-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.3-2`

## ign_ros2_control

```
* Context and Namespace Handling for Multi-Robot Sim (#92 <https://github.com/ros-controls/gz_ros2_control/issues/92>)
* Various bug fixes (#114 <https://github.com/ros-controls/gz_ros2_control/issues/114>)
* Force setting use_sim_time parameter when using plugin. (#100 <https://github.com/ros-controls/gz_ros2_control/issues/100>)
* Enable loading params from multiple yaml files (#94 <https://github.com/ros-controls/gz_ros2_control/issues/94>)
* Add support for mimic joints. (#33 <https://github.com/ros-controls/gz_ros2_control/issues/33>)
* Set right initial velocity (#81 <https://github.com/ros-controls/gz_ros2_control/issues/81>)
* Fix setting initial values if command interfaces are not defined. (#73 <https://github.com/ros-controls/gz_ros2_control/issues/73>)
* activated all hardware by default and improved variable naming (#74 <https://github.com/ros-controls/gz_ros2_control/issues/74>)
* Implemented perform_command_mode_switch override in GazeboSystem (#76 <https://github.com/ros-controls/gz_ros2_control/issues/76>)
* Remove warnings (#72 <https://github.com/ros-controls/gz_ros2_control/issues/72>)
* change component name for ignition (#69 <https://github.com/ros-controls/gz_ros2_control/issues/69>)
* Added logic for activating hardware interfaces (#68 <https://github.com/ros-controls/gz_ros2_control/issues/68>)
* Force setting use_sim_time parameter when using plugin. (#100 <https://github.com/ros-controls/gz_ros2_control/issues/100>) (#102 <https://github.com/ros-controls/gz_ros2_control/issues/102>)
* Contributors: Alejandro Hernández Cordero, Andy Zelenak, Bence Magyar, Denis Štogl, Lovro, Tianyu Li, sp-sophia-labs
```

## ign_ros2_control_demos

```
* Merge pull request #121 <https://github.com/ros-controls/gz_ros2_control/issues/121> from livanov93/port-master-to-humble
* Fix gripper mimic joint example.
* Pre-commit fix for tricycle configuration.
* Replace ros_ign_gazebo with ros_gz_sim
* use ros_gz_sim
* Fix Docker entrypoint and add launch CLI to dependencites (#84 <https://github.com/ros-controls/gz_ros2_control/issues/84>)
* Add support for mimic joints. (#33 <https://github.com/ros-controls/gz_ros2_control/issues/33>)
* Add tricycle demo (#80 <https://github.com/ros-controls/gz_ros2_control/issues/80>)
* Fix setting initial values if command interfaces are not defined. (#73 <https://github.com/ros-controls/gz_ros2_control/issues/73>)
* fix demo launch (#75 <https://github.com/ros-controls/gz_ros2_control/issues/75>)
* Contributors: Alejandro Hernández Cordero, Andrej Orsula, Bence Magyar, Denis Štogl, Ian Chen, Krzysztof Wojciechowski, Lovro Ivanov, Maciej Bednarczyk, Polgár András, Tony Najjar
```
