### PR TITLE
pick_ik: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3707,7 +3707,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pick_ik-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/pick_ik.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pick_ik` to `1.0.1-1`:

- upstream repository: https://github.com/PickNikRobotics/pick_ik.git
- release repository: https://github.com/ros2-gbp/pick_ik-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-1`

## pick_ik

```
* Set Werror through CMake presets (#39 <https://github.com/PickNikRobotics/pick_ik/issues/39>)
* Replace lower_bounds with gt_eq (#37 <https://github.com/PickNikRobotics/pick_ik/issues/37>)
* Upgrade with new pkgs to fix issue with ROS
* Target include subdirectory
* Update Catch2 version to 3.3.0
* Fix overriding of package
* Fix orientation calculation in cost function and frame tests (#31 <https://github.com/PickNikRobotics/pick_ik/issues/31>)
  * Fix orientation calculation
  * Update plugin return values
  * Remove redundant (and incorrect) joints bounds check
  * Use Eigen angular distance calculation
* Small grammar fixes (#28 <https://github.com/PickNikRobotics/pick_ik/issues/28>)
* Contributors: Sebastian Castro, Stephanie Eng, Tyler Weaver
```
