### PR TITLE
ros2_control: 3.11.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4404,7 +4404,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.10.0-2
+      version: 3.11.0-2
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.11.0-2`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.10.0-2`

## controller_interface

```
* [ControllerManager] Add Class for Async Controllers and Lifecycle Management (#932 <https://github.com/ros-controls/ros2_control/issues/932>)
* Contributors: Márk Szitanics
```

## controller_manager

```
* [ControllerManager] Add Class for Async Controllers and Lifecycle Management (#932 <https://github.com/ros-controls/ros2_control/issues/932>)
* Consistent use of colors for warning and error msgs in spawner (#974 <https://github.com/ros-controls/ros2_control/issues/974>)
* Fix wrong warning messages (#973 <https://github.com/ros-controls/ros2_control/issues/973>)
* Add log level support to spawner node (#972 <https://github.com/ros-controls/ros2_control/issues/972>)
* Contributors: Dr. Denis, Márk Szitanics, Bijou Abraham
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Check for missing hardware interfaces that use the gpio tag. (#975 <https://github.com/ros-controls/ros2_control/issues/975>)
* Contributors: Ryan Sandzimier
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
