### PR TITLE
skyway: 0.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10368,10 +10368,16 @@ repositories:
       type: git
       url: https://github.com/ntt-t3/skyway_for_ros.git
       version: main
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ntt-t3/skyway_for_ros-release.git
+      version: 0.0.1-1
     source:
       type: git
       url: https://github.com/ntt-t3/skyway_for_ros.git
       version: main
+    status: developed
   slam_gmapping:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `skyway` to `0.0.1-1`:

- upstream repository: https://github.com/ntt-t3/skyway_for_ros.git
- release repository: https://github.com/ntt-t3/skyway_for_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## skyway

- No changes
