### PR TITLE
skyway: 0.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13206,10 +13206,16 @@ repositories:
       type: git
       url: https://github.com/ntt-t3/skyway_for_ros.git
       version: main
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ntt-t3/skyway_for_ros-release.git
+      version: 0.0.1-1
     source:
       type: git
       url: https://github.com/ntt-t3/skyway_for_ros.git
       version: main
+    status: developed
   slam_gmapping:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `skyway` to `0.0.1-1`:

- upstream repository: https://github.com/ntt-t3/skyway_for_ros.git
- release repository: https://github.com/ntt-t3/skyway_for_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## skyway

- No changes
