### PR TITLE
polygon_ros: 1.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4083,7 +4083,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/MetroRobots-release/polygon_ros-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `polygon_ros` to `1.0.1-1`:

- upstream repository: https://github.com/MetroRobots/polygon_ros
- release repository: https://github.com/MetroRobots-release/polygon_ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-1`
