### PR TITLE
simple_actions: 0.2.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6615,7 +6615,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/DLu/simple_actions-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_actions` to `0.2.2-1`:

- upstream repository: https://github.com/DLu/simple_actions.git
- release repository: https://github.com/DLu/simple_actions-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.1-1`
