### PR TITLE
Add 'lttng-tools' rosdep rule for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6622,6 +6622,7 @@ lttng-tools:
   fedora: [lttng-tools]
   gentoo: [dev-util/lttng-tools]
   nixos: [lttng-tools]
+  rhel: [lttng-tools]
   ubuntu: [lttng-tools]
 lua-dev:
   arch: [lua]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`lttng-tools`

## Package Upstream Source:

https://github.com/lttng/lttng-tools

## Purpose of using this:

To be used by `tracetools`, see: https://github.com/ros2/ros2_tracing/pull/31

See also https://github.com/ros2/ros2/issues/1177

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

RHEL: https://pkgs.org/search/?q=lttng-tools