### PR TITLE
polygon_ros: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3900,6 +3900,27 @@ repositories:
       url: https://github.com/ros-perception/pointcloud_to_laserscan.git
       version: humble
     status: maintained
+  polygon_ros:
+    doc:
+      type: git
+      url: https://github.com/MetroRobots/polygon_ros.git
+      version: main
+    release:
+      packages:
+      - polygon_demos
+      - polygon_msgs
+      - polygon_rviz_plugins
+      - polygon_utils
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/MetroRobots-release/polygon_ros-release.git
+      version: 1.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/MetroRobots/polygon_ros.git
+      version: main
+    status: developed
   popf:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `polygon_ros` to `1.0.1-1`:

- upstream repository: https://github.com/MetroRobots/polygon_ros
- release repository: https://github.com/MetroRobots-release/polygon_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
