### PR TITLE
foxglove_bridge: 0.5.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3576,7 +3576,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/foxglove/ros_foxglove_bridge-release.git
-      version: 0.5.1-1
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_bridge` to `0.5.2-1`:

- upstream repository: https://github.com/foxglove/ros-foxglove-bridge.git
- release repository: https://github.com/foxglove/ros_foxglove_bridge-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.5.1-1`

## foxglove_bridge

```
* Notify client when Server's send buffer limit has been reached (#201 <https://github.com/foxglove/ros-foxglove-bridge/issues/201>)
* Add support for byte array params (#199 <https://github.com/foxglove/ros-foxglove-bridge/issues/199>)
* Do not allow connection output buffer to exceed configured limit (#196 <https://github.com/foxglove/ros-foxglove-bridge/issues/196>)
* Fix exception parameter not being used (#194 <https://github.com/foxglove/ros-foxglove-bridge/issues/194>)
* Contributors: Hans-Joachim Krauch
```
