### PR TITLE
libpointmatcher: 1.3.1-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2202,7 +2202,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libpointmatcher-release.git
-      version: 1.3.1-3
+      version: 1.3.1-4
     source:
       type: git
       url: https://github.com/ethz-asl/libpointmatcher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libpointmatcher` to `1.3.1-4`:

- upstream repository: https://github.com/ethz-asl/libpointmatcher.git
- release repository: https://github.com/ros2-gbp/libpointmatcher-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.1-3`

## libpointmatcher

```
* Added documentation for people using ROS.
* Increased libnabo minimal version to 1.0.7.
* Added interface to inform if maximum number of iterations was reached.
* Fixed portability issue of the FileLogger.
* Fixed unit tests on Windows.
* Fixed parameter-less modules having 'unknown' as class name.
* Updated Windows compilation tutorial.
* Fixed compilation problems on Windows.
* Fixed PointToPlan error residual.
* Changed DOI resolver link in documentation.
* Added validation for the input transformation matrix in ICP.cpp.
* Removed duplication of PointToPoint compute in PointToPointWithCov.
* Added the RemoveSensorBias filter.
* Splitted ErrorMinimizersImpl.cpp into multiple files.
```
