### PR TITLE
rviz: 1.14.20-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10003,7 +10003,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.14.19-1
+      version: 1.14.20-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.14.20-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.14.19-1`

## rviz

```
* Improvements to TF display (#1789 <https://github.com/ros-visualization/rviz/issues/1789>)
  
    * Add regex filters (white+black list) to TF Display (#1744 <https://github.com/ros-visualization/rviz/issues/1744>)
    * Reparent children to root tree node when deleting a frame
    * Insert frame properties sorted
    * Create tree nodes also if the frame is not connected to rviz' global frame
  
* RobotModel: Fix orientation of joint axis arrow (#1788 <https://github.com/ros-visualization/rviz/issues/1788>)
* Use static QCoreApplication::processEvents() w/o QApplication instance (#1772 <https://github.com/ros-visualization/rviz/issues/1772>)
* Contributors: Blaz Potokar, Robert Haschke, Yannis Gerlach
```
