### PR TITLE
generic_transform: 1.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2939,6 +2939,17 @@ repositories:
       url: https://github.com/ros/gencpp.git
       version: kinetic-devel
     status: maintained
+  generic_transform:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ika-rwth-aachen/generic_transform-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ika-rwth-aachen/generic_transform.git
+      version: main
+    status: maintained
   geneus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `generic_transform` to `1.0.0-1`:

- upstream repository: https://github.com/ika-rwth-aachen/generic_transform.git
- release repository: https://github.com/ika-rwth-aachen/generic_transform-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
