### PR TITLE
generic_transform: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1441,6 +1441,17 @@ repositories:
       url: https://github.com/PickNikRobotics/generate_parameter_library.git
       version: main
     status: developed
+  generic_transform:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ika-rwth-aachen/generic_transform-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ika-rwth-aachen/generic_transform.git
+      version: main
+    status: maintained
   geographic_info:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `generic_transform` to `1.0.0-1`:

- upstream repository: https://github.com/ika-rwth-aachen/generic_transform.git
- release repository: https://github.com/ika-rwth-aachen/generic_transform-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
