### PR TITLE
cras_msgs: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2061,6 +2061,21 @@ repositories:
       url: https://github.com/rt-net/crane_x7_ros.git
       version: master
     status: developed
+  cras_msgs:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/cras_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/cras_msgs
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ctu-vras/cras_msgs.git
+      version: master
+    status: developed
   cras_ros_utils:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_msgs` to `1.0.1-1`:

- upstream repository: https://github.com/ctu-vras/cras_msgs
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/cras_msgs
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## cras_msgs

```
* Prepared package for release.
* Contributors: Martin Pecka
```
