### PR TITLE
grepros: 0.6.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3273,7 +3273,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/suurjaak/grepros-release.git
-      version: 0.5.0-1
+      version: 0.6.0-2
     source:
       type: git
       url: https://github.com/suurjaak/grepros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grepros` to `0.6.0-2`:

- upstream repository: https://github.com/suurjaak/grepros.git
- release repository: https://github.com/suurjaak/grepros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.5.0-1`

## grepros

```
* add nesting=array|all to --write Parquet options
* add idgenerator=callable to --write Parquet options
* add rosapi.canonical()
* match bounded array fields to configured output types properly
  in Parquet/Postgres/SQL/SQLite output, like "uint8[10]" for "BYTEA" in Postgres
* workaround for ROS1 time/duration fields defined as int32 while actually being uint32
* fix date formatting in HTML output
```
