### PR TITLE
fastrtps: 2.10.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1195,7 +1195,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fastrtps-release.git
-      version: 2.9.1-4
+      version: 2.10.0-1
     source:
       test_commits: true
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `fastrtps` to `2.10.0-1`:

- upstream repository: https://github.com/eProsima/Fast-DDS.git
- release repository: https://github.com/ros2-gbp/fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.9.1-4`
