### PR TITLE
geometric_shapes: 0.6.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3911,7 +3911,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/geometric_shapes-release.git
-      version: 0.6.4-1
+      version: 0.6.5-1
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.6.5-1`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/ros-gbp/geometric_shapes-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.4-1`

## geometric_shapes

```
* Add bodies::Body::computeBoundingBox (oriented box version) (#210 <https://github.com/ros-planning/geometric_shapes/issues/210>)This adds the dependency on FCL, provide support for FCL 0.6 if available
* Add body operations constructShapeFromBody() and constructMarkerFromBody() (#209 <https://github.com/ros-planning/geometric_shapes/issues/209>)
* Eigen < 3.3.0 needs explicit cast (#224 <https://github.com/ros-planning/geometric_shapes/issues/224>)
* Contributors: Kei Okada, Martin Pecka, Robert Haschke
```
