### PR TITLE
geometric_shapes: 0.7.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3071,7 +3071,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/geometric_shapes-release.git
-      version: 0.7.3-1
+      version: 0.7.4-1
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.7.4-1`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/ros-gbp/geometric_shapes-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.3-1`

## geometric_shapes

```
* Body::getScaledDimensions(): avoid vtable lookup (#225 <https://github.com/ros-planning/geometric_shapes/issues/225>)
* Add Body::computeBoundingBox (oriented box version) (#210 <https://github.com/ros-planning/geometric_shapes/issues/210>)This adds the dependency on FCL, provide support for FCL 0.6 if available
* Contributors: Martin Pecka, Robert Haschke
```
