### PR TITLE
rclc: 1.1.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4683,7 +4683,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclc` to `1.1.2-1`:

- upstream repository: https://github.com/ros2/rclc.git
- release repository: https://github.com/ros2-gbp/rclc-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.1-1`

## rclc

```
* Added build status of bloom-releases for Humble distribution (backport #291) (#294)
* [rolling] updated ros-tooling versions (backport #289) (#299)
* added documentation (#301) (#304)
* Drop build dependency on std_msgs (backport #314) (#317)
* Updated ros-tooling versions (backport #318) (#319)
* removed build status for Galactic distribution in README (backport #321) (#323)
* Update documentation about number_of_handles (#326) (#328)
```

## rclc_examples

```
* Example real-time concurreny timer and subscription (backport #329) (#331)
* updated rclc_examples (backport #332) (#333)
* Updated README in rclc_examples (backport #335) (#337)
```

## rclc_lifecycle

```
* Fix rclc lifecyle header (#279) (#280)
* added documentation (#301) (#304)
```

## rclc_parameter

```
* Fix parameter tests timeout (backport #283) (#284)
* rclc_parameter: Fix rcl return values (backport #270) (#276)
* added documentation (#301) (#304)
```
