### PR TITLE
Revert "Revert "rsl: 0.2.2-1 in 'humble/distribution.yaml' [bloom]""

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6036,7 +6036,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/RSL-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/RSL.git


### PR DESCRIPTION
Reverts ros/rosdistro#36613

@ChrisThrasher, the Humble sync just went out. We can see if this breaks any downstream packages and try to fix them before the next Humble sync in 2-3 weeks.