### PR TITLE
pose_cov_ops: 0.3.9-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9282,7 +9282,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release.git
-      version: 0.3.8-1
+      version: 0.3.9-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pose_cov_ops` to `0.3.9-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
- release repository: https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.8-1`

## pose_cov_ops

```
* Merge pull request #12 <https://github.com/mrpt-ros-pkg/pose_cov_ops/issues/12> from roncapat/patch-1
  Fix build issues with ROS2
* Update README.md: fix badge table
* Contributors: Jose Luis Blanco-Claraco, Patrick Roncagliolo
```
