### PR TITLE
pose_cov_ops: 0.3.9-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3378,7 +3378,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pose_cov_ops-release.git
-      version: 0.3.8-2
+      version: 0.3.9-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pose_cov_ops` to `0.3.9-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
- release repository: https://github.com/ros2-gbp/pose_cov_ops-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.8-2`

## pose_cov_ops

```
* Merge pull request #12 <https://github.com/mrpt-ros-pkg/pose_cov_ops/issues/12> from roncapat/patch-1
  Fix build issues with ROS2
* Update README.md: fix badge table
* Contributors: Jose Luis Blanco-Claraco, Patrick Roncagliolo
```
