### PR TITLE
camera_ros: 0.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -645,6 +645,18 @@ repositories:
       url: https://github.com/OUXT-Polaris/boost_geometry_util.git
       version: master
     status: developed
+  camera_ros:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/camera_ros-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/christianrauch/camera_ros.git
+      version: main
+    status: developed
   cartographer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_ros` to `0.1.0-1`:

- upstream repository: https://github.com/christianrauch/camera_ros.git
- release repository: https://github.com/ros2-gbp/camera_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
