### PR TITLE
control_msgs: 4.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -744,7 +744,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/control_msgs-release.git
-      version: 4.2.0-2
+      version: 4.3.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `4.3.0-1`:

- upstream repository: https://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros2-gbp/control_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.2.0-2`

## control_msgs

```
* Add generic messages for commanding and getting states from controllers. (#69 <https://github.com/ros-controls/control_msgs/issues/69>)
* Contributors: Dr. Denis
```
