### PR TITLE
ros2_control: 3.12.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4440,7 +4440,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.11.0-2
+      version: 3.12.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.12.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.11.0-2`

## controller_interface

```
* [Controller Interface] Add time and period paramters to update_reference_from_subscribers() (#846 <https://github.com/ros-controls/ros2_control/issues/846>) #API-break
* Contributors: Robotgir, Denis Štogl
```

## controller_manager

```
* [Controller Interface] Add time and period paramters to update_reference_from_subscribers() (#846 <https://github.com/ros-controls/ros2_control/issues/846>) #API-break
* Contributors: Robotgir
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## joint_limits

```
* Extend joint limits structure with deceleration limits. (#977 <https://github.com/ros-controls/ros2_control/issues/977>)
* Contributors: Dr. Denis
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
