### PR TITLE
ros2_controllers: 3.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4471,7 +4471,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 3.3.0-2
+      version: 3.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `3.4.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.3.0-2`

## admittance_controller

```
* [AdmittanceController] Addintional argument in methods of ControllerInterface (#553 <https://github.com/ros-controls/ros2_controllers/issues/553>)
* Removed auto param decl (#546 <https://github.com/ros-controls/ros2_controllers/issues/546>)
* Contributors: Dr. Denis, GuiHome
```

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

```
* Fix broken links (#554 <https://github.com/ros-controls/ros2_controllers/issues/554>)
* Update docs (#552 <https://github.com/ros-controls/ros2_controllers/issues/552>)
* Contributors: Christoph Fröhlich
```

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* Update JTC documentation (#541 <https://github.com/ros-controls/ros2_controllers/issues/541>)
* Contributors: Christoph Fröhlich
```

## position_controllers

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## tricycle_controller

- No changes

## velocity_controllers

- No changes
