### PR TITLE
ros2_control: 2.25.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5078,7 +5078,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.24.1-1
+      version: 2.25.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.25.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.24.1-1`

## controller_interface

- No changes

## controller_manager

- No changes

## controller_manager_msgs

- No changes

## hardware_interface

```
* Check for missing hardware interfaces that use the gpio tag. (#953 <https://github.com/ros-controls/ros2_control/issues/953>)
* Split transmission interfaces (backport #938 <https://github.com/ros-controls/ros2_control/issues/938>) (#968 <https://github.com/ros-controls/ros2_control/issues/968>)
* Contributors: Ryan Sandzimier, Noel Jiménez García, Bence Magyar
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

```
* Split transmission interfaces (backport #938 <https://github.com/ros-controls/ros2_control/issues/938>) (#968 <https://github.com/ros-controls/ros2_control/issues/968>)
* Contributors: Noel Jiménez García, Bence Magyar
```
