### PR TITLE
libcamera: 0.0.4-4 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2450,11 +2450,12 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/libcamera-release.git
-      version: 0.0.4-3
+      version: 0.0.4-4
     source:
       type: git
       url: https://git.libcamera.org/libcamera/libcamera.git
       version: master
+    status: developed
   libg2o:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `libcamera` to `0.0.4-4`:

- upstream repository: https://git.libcamera.org/libcamera/libcamera.git
- release repository: https://github.com/ros2-gbp/libcamera-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.4-3`
