### PR TITLE
usb_cam: 0.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6516,7 +6516,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/usb_cam-release.git
-      version: 0.5.0-2
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/ros-drivers/usb_cam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `usb_cam` to `0.6.0-1`:

- upstream repository: https://github.com/ros-drivers/usb_cam.git
- release repository: https://github.com/ros2-gbp/usb_cam-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.5.0-2`

## usb_cam

```
* If auto exposure is true, set it
* Migrate previous pixel formats to new approach
  - Add M4202RGB pixel format (aka YUV420 to RGB8)
  - Add Y102MONO8 pixel format (aka MONO10 to MONO8)
* Update documentation related to supported formats
  - update doc strings in new pixel format base class
* Fix linter errors, clean up tests
  - fix humble and rolling build
* Implement new pixel_format class structure
  - implement virtual convert method for new pixel format class
  - fix MJPEG2RGB conversion logic using new pixel format class
* Fix typo in workspace path in README
* fix whitespace around comments
* fix unused variable error
* possible fix for timestamp jumping
* fix code style
* dont change brightness with default config
* use v4l2  for "brightness", "contrast", "saturation", "sharpness", "gain", "auto_white_balance",
  "white_balance", "autoexposure", "exposure", "autofocus", "focus"
* Contributors: Evan Flynn, john
```
