### PR TITLE
pal_navigation_cfg_public: 3.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3578,6 +3578,25 @@ repositories:
       url: https://github.com/pal-robotics/pal_gripper.git
       version: humble-devel
     status: developed
+  pal_navigation_cfg_public:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pal_navigation_cfg_public.git
+      version: humble-devel
+    release:
+      packages:
+      - pal_navigation_cfg
+      - pal_navigation_cfg_bringup
+      - pal_navigation_cfg_params
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/pal_navigation_cfg_public-release.git
+      version: 3.0.1-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pal_navigation_cfg_public.git
+      version: humble-devel
+    status: developed
   pal_statistics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_navigation_cfg_public` to `3.0.1-1`:

- upstream repository: https://github.com/pal-robotics/pal_navigation_cfg_public.git
- release repository: https://github.com/pal-gbp/pal_navigation_cfg_public-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## pal_navigation_cfg

```
* init ROS2 migration
* Contributors: antoniobrandi
```

## pal_navigation_cfg_bringup

```
* Merge branch 'fix/unify-nav' into 'humble-devel'
  unify nav launch files
  See merge request navigation/pal_navigation_cfg_public!45
* unify nav launch files
* added default parameters and launch files
* init ROS2 migration
* Contributors: antoniobrandi
```

## pal_navigation_cfg_params

```
* added default parameters and launch files
* init ROS2 migration
* Contributors: antoniobrandi
```
