### PR TITLE
swri_console: 1.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10749,7 +10749,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/swri_console-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_console` to `1.1.1-1`:

- upstream repository: https://github.com/swri-robotics/swri_console.git
- release repository: https://github.com/swri-robotics-gbp/swri_console-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-1`

## swri_console

```
* feat: human readable time formatting (#57 <https://github.com/swri-robotics/swri_console/issues/57>)
  Adds option to make the date and time easier to read for humans
* Added options to be displayed in each log line: logger name and function name. (#38 <https://github.com/swri-robotics/swri_console/issues/38>)
  Co-authored-by: Rasmus Skovgaard Andersen <mailto:Rasmus.Andersen@marel.com>
* Switching to GitHub actions (#47 <https://github.com/swri-robotics/swri_console/issues/47>)
* Merge pull request #40 <https://github.com/swri-robotics/swri_console/issues/40> from cellumation/master
  Enable closing via Ctrl-C from a terminal
* Merge pull request #39 <https://github.com/swri-robotics/swri_console/issues/39> from jarvisschultz/rosout_agg_bag_support
  Add ability to read either /rosout or /rosout_agg from bag files
* Do not use the ros signal handlers. Thus, it is now possible to close the swri_console via Ctrl-C from the console
* Add ability to read either /rosout or /rosout_agg from bag files
  Prefer /rosout if it exists, if not, fall back to /rosout_agg. Also, if no log messages are found in a bag emit a
  warning to indicate to user the reason why log messages did not change.
  Tested this with bag files containing only /rosout, only /rosout_agg, both /rosout and /rosout_agg, and neither
  /rosout nor /rosout_agg.
* Update documentation
  Add some feature bullet points and point out ROS 2 support
* Update package maintainers (#29 <https://github.com/swri-robotics/swri_console/issues/29>)
* Contributors: Alexis Tsogias, David Anthony, Jarvis Schultz, Mart Moerdijk, Matthew, P. J. Reed
```
