### PR TITLE
gps_umd: 1.0.8-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1748,7 +1748,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/swri-robotics-gbp/gps_umd-release.git
-      version: 1.0.6-1
+      version: 1.0.8-1
     source:
       test_pull_requests: true
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1747,7 +1747,7 @@ repositories:
       - gpsd_client
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/swri-robotics-gbp/gps_umd-release.git
+      url: https://github.com/ros2-gbp/gps_umd-release.git
       version: 1.0.8-1
     source:
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_umd` to `1.0.8-1`:

- upstream repository: https://github.com/swri-robotics/gps_umd.git
- release repository: https://github.com/swri-robotics-gbp/gps_umd-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.6-1`
