### PR TITLE
Add more dependencies of ceres-solver for Fedora/RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3031,11 +3031,13 @@ libcereal-dev:
   ubuntu: [libcereal-dev]
 libceres-dev:
   debian: [libceres-dev]
-  fedora: [ceres-solver-devel]
+  fedora: [ceres-solver-devel, suitesparse-devel, flexiblas-devel]
   gentoo: ['sci-libs/ceres-solver[sparse,lapack]']
   nixos: [ceres-solver]
   openembedded: [ceres-solver@meta-oe]
-  rhel: [ceres-solver-devel]
+  rhel:
+    '*': [ceres-solver-devel, suitesparse-devel, flexiblas-devel]
+    '8': [ceres-solver-devel]
   ubuntu: [libceres-dev]
 libcgroup-dev:
   debian: [libcgroup-dev]


### PR DESCRIPTION
Newer versions of ceres-solver seem to have different implicit dependencies which are needed to find_package(Ceres).

https://packages.fedoraproject.org/pkgs/ceres-solver/ceres-solver-devel/
https://packages.fedoraproject.org/pkgs/suitesparse/suitesparse-devel/
https://packages.fedoraproject.org/pkgs/flexiblas/flexiblas-devel/

http://or-mirror.iwebfusion.net/almalinux/9.1/CRB/x86_64/os/Packages/suitesparse-devel-5.4.0-10.el9.i686.rpm
http://or-mirror.iwebfusion.net/almalinux/9.1/CRB/x86_64/os/Packages/flexiblas-devel-3.0.4-8.el9.i686.rpm

Motivation is to get the `cartographer` builds working for RHEL 9.