### PR TITLE
control_toolbox: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -759,7 +759,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 2.2.0-3
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `3.0.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.0-3`

## control_toolbox

```
* [PidROS] Enable interpreting prefix as param prefix. (#129 <https://github.com/ros-controls/control_toolbox/issues/129>)
* Use std::clamp (#140 <https://github.com/ros-controls/control_toolbox/issues/140>)
* [CI] Fixes and update for branch out (#155 <https://github.com/ros-controls/control_toolbox/issues/155>)
* Enable subclassing of PID implementation. (#148 <https://github.com/ros-controls/control_toolbox/issues/148>)
* [CI] Add Humble job (#147 <https://github.com/ros-controls/control_toolbox/issues/147>)
* Finally update formatting to other repositories convention. (#131 <https://github.com/ros-controls/control_toolbox/issues/131>)
* [CI] 🔧 Update pre-commit hooks and sync actions to other repositories. (#130 <https://github.com/ros-controls/control_toolbox/issues/130>)
* Contributors: Bence Magyar, Christoph Fröhlich, Dr. Denis, dependabot[bot]
```
