### PR TITLE
Update the Fast-DDS branches in Rolling to 2.10.x.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1190,7 +1190,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/eProsima/Fast-RTPS.git
-      version: master
+      version: 2.10.x
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1201,7 +1201,7 @@ repositories:
       test_pull_requests: false
       type: git
       url: https://github.com/eProsima/Fast-DDS.git
-      version: 2.7.x
+      version: 2.10.x
     status: maintained
   filters:
     doc:


### PR DESCRIPTION
This matches what the release is, and what we will be using in ros2.repos soon.

@Yadunund @cottsay FYI