### PR TITLE
depthai: 2.21.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1771,7 +1771,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/luxonis/depthai-core-release.git
-      version: 2.21.0-1
+      version: 2.21.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai` to `2.21.2-1`:

- upstream repository: https://github.com/luxonis/depthai-core.git
- release repository: https://github.com/luxonis/depthai-core-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.21.0-1`

## depthai

```
* UPDATE: Use v2.21.2 due to issues this version carries
* Contributors: Alex Bougdan, Szabolcs Gergely, Martin Peterlin
```
