### PR TITLE
Add debian bookworm packages

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1844,8 +1844,8 @@ ignition-citadel:
     focal: [ignition-citadel]
 ignition-cmake2:
   debian:
-    buster: [libignition-cmake2-dev]
     bookworm: [libignition-cmake-dev]
+    buster: [libignition-cmake2-dev]
   nixos: [ignition.cmake2]
   ubuntu:
     focal: [libignition-cmake2-dev]
@@ -1951,8 +1951,8 @@ ignition-launch5:
     jammy: [libignition-launch5-dev]
 ignition-math6:
   debian:
-    buster: [libignition-math6-dev]
     bookworm: [libignition-math-dev]
+    buster: [libignition-math6-dev]
   nixos: [ignition.math6]
   ubuntu:
     focal: [libignition-math6-dev]
@@ -2473,9 +2473,9 @@ libboost-coroutine-dev:
   ubuntu: [libboost-coroutine-dev]
 libboost-date-time:
   debian:
+    bookworm: [libboost-date-time1.81.0]
     bullseye: [libboost-date-time1.74.0]
     buster: [libboost-date-time1.67.0]
-    bookworm: [libboost-date-time1.81.0]
   fedora: [boost-date-time]
   gentoo: [dev-libs/boost]
   nixos: [boost]
@@ -2506,9 +2506,9 @@ libboost-dev:
   ubuntu: [libboost-dev]
 libboost-filesystem:
   debian:
+    bookworm: [libboost-filesystem-dev]
     bullseye: [libboost-filesystem1.74.0]
     buster: [libboost-filesystem1.67.0]
-    bookworm: [libboost-filesystem-dev]
   fedora: [boost-filesystem]
   gentoo: [dev-libs/boost]
   nixos: [boost]
@@ -2606,9 +2606,9 @@ libboost-program-options-dev:
 libboost-python:
   alpine: [boost-python2]
   debian:
+    bookworm: [libboost-python1.81.0]
     bullseye: [libboost-python1.74.0]
     buster: [libboost-python1.67.0]
-    bookworm: [libboost-python1.81.0]
   fedora: [boost-python3]
   gentoo: ['dev-libs/boost[python]']
   nixos: [boost]
@@ -2635,9 +2635,9 @@ libboost-python-dev:
   ubuntu: [libboost-python-dev]
 libboost-random:
   debian:
+    bookworm: [libboost-random1.81.0]
     bullseye: [libboost-random1.74.0]
     buster: [libboost-random1.67.0]
-    bookworm: [libboost-random1.81.0]
   fedora: [boost-random]
   gentoo: [dev-libs/boost]
   nixos: [boost]
@@ -2728,9 +2728,9 @@ libboost-system-dev:
   ubuntu: [libboost-system-dev]
 libboost-thread:
   debian:
+    bookworm: [libboost-thread1.81.0]
     bullseye: [libboost-thread1.74.0]
     buster: [libboost-thread1.67.0]
-    bookworm: [libboost-thread1.81.0]
   fedora: [boost-thread]
   gentoo: ['dev-libs/boost[threads]']
   nixos: [boost]
@@ -4145,10 +4145,10 @@ libogg:
 libogre:
   arch: [ogre-1.9]
   debian:
+    bookworm: [libogre-1.12-dev]
     buster: [libogre-1.9.0v5]
     stretch: [libogre-1.9.0v5]
     wheezy: [libogre-dev]
-    bookworm: [libogre-1.12-dev]
   fedora: [ogre-devel]
   freebsd: [ogre3d]
   gentoo: [dev-games/ogre]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2665,7 +2665,7 @@ libboost-filesystem:
   debian:
     bullseye: [libboost-filesystem1.74.0]
     buster: [libboost-filesystem1.67.0]
-    bookworm:[libboost-filesystem-dev]
+    bookworm: [libboost-filesystem-dev]
   fedora: [boost-filesystem]
   gentoo: [dev-libs/boost]
   nixos: [boost]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4412,7 +4412,6 @@ libogre:
 libogre-1.12-dev:
   debian:
     bullseye: [libogre-1.12-dev]
-    bookworm: [libogre-1.12-dev]
   ubuntu:
     focal: [libogre-1.12-dev]
     jammy: [libogre-1.12-dev]
@@ -4423,6 +4422,7 @@ libogre-dev:
     jessie: [libogre-1.9-dev]
     stretch: [libogre-1.9-dev]
     wheezy: [libogre-dev]
+    bookworm: [libogre-1.12-dev]
   fedora: [ogre-devel]
   freebsd: [ogre3d]
   gentoo: [dev-games/ogre]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4399,6 +4399,7 @@ libogre:
     jessie: [libogre-1.9.0]
     stretch: [libogre-1.9.0v5]
     wheezy: [libogre-dev]
+    
   fedora: [ogre-devel]
   freebsd: [ogre3d]
   gentoo: [dev-games/ogre]
@@ -4411,6 +4412,7 @@ libogre:
 libogre-1.12-dev:
   debian:
     bullseye: [libogre-1.12-dev]
+    bookworm: [libogre-1.12-dev]
   ubuntu:
     focal: [libogre-1.12-dev]
     jammy: [libogre-1.12-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2631,7 +2631,7 @@ libboost-date-time:
   debian:
     bullseye: [libboost-date-time1.74.0]
     buster: [libboost-date-time1.67.0]
-    bookworm: [libboost-date-time-dev]
+    bookworm: [libboost-date-time1.81.0]
   fedora: [boost-date-time]
   gentoo: [dev-libs/boost]
   nixos: [boost]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4408,7 +4408,6 @@ libogre:
     stretch: [libogre-1.9.0v5]
     wheezy: [libogre-dev]
     bookworm: [libogre-1.12-dev]
-    
   fedora: [ogre-devel]
   freebsd: [ogre3d]
   gentoo: [dev-games/ogre]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2775,6 +2775,7 @@ libboost-python:
   debian:
     bullseye: [libboost-python1.74.0]
     buster: [libboost-python1.67.0]
+    bookworm: [libboost-python1.81.0]
   fedora: [boost-python3]
   gentoo: ['dev-libs/boost[python]']
   nixos: [boost]
@@ -2806,6 +2807,7 @@ libboost-random:
   debian:
     bullseye: [libboost-random1.74.0]
     buster: [libboost-random1.67.0]
+    bookworm: [libboost-random1.81.0]
   fedora: [boost-random]
   gentoo: [dev-libs/boost]
   nixos: [boost]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2665,6 +2665,7 @@ libboost-filesystem:
   debian:
     bullseye: [libboost-filesystem1.74.0]
     buster: [libboost-filesystem1.67.0]
+    bookworm:[libboost-filesystem-dev]
   fedora: [boost-filesystem]
   gentoo: [dev-libs/boost]
   nixos: [boost]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1966,6 +1966,7 @@ ignition-citadel:
 ignition-cmake2:
   debian:
     buster: [libignition-cmake2-dev]
+    bookworm: [libignition-cmake-dev]
   nixos: [ignition.cmake2]
   ubuntu:
     focal: [libignition-cmake2-dev]
@@ -2072,6 +2073,7 @@ ignition-launch5:
 ignition-math6:
   debian:
     buster: [libignition-math6-dev]
+    bookworm: [libignition-math-dev]
   nixos: [ignition.math6]
   ubuntu:
     focal: [libignition-math6-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2908,6 +2908,7 @@ libboost-thread:
   debian:
     bullseye: [libboost-thread1.74.0]
     buster: [libboost-thread1.67.0]
+    bookworm: [libboost-thread1.81.0]
   fedora: [boost-thread]
   gentoo: ['dev-libs/boost[threads]']
   nixos: [boost]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2631,6 +2631,7 @@ libboost-date-time:
   debian:
     bullseye: [libboost-date-time1.74.0]
     buster: [libboost-date-time1.67.0]
+    bookworm: [libboost-date-time-dev]
   fedora: [boost-date-time]
   gentoo: [dev-libs/boost]
   nixos: [boost]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4399,6 +4399,7 @@ libogre:
     jessie: [libogre-1.9.0]
     stretch: [libogre-1.9.0v5]
     wheezy: [libogre-dev]
+    bookworm: [libogre-1.12-dev]
     
   fedora: [ogre-devel]
   freebsd: [ogre3d]
@@ -4422,7 +4423,6 @@ libogre-dev:
     jessie: [libogre-1.9-dev]
     stretch: [libogre-1.9-dev]
     wheezy: [libogre-dev]
-    bookworm: [libogre-1.12-dev]
   fedora: [ogre-devel]
   freebsd: [ogre3d]
   gentoo: [dev-games/ogre]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

* libignition-cmake-dev
* libignition-math-dev
* libboost-date-time1.81.0
* libboost-python1.81.0
* libboost-random1.81.0
* libboost-thread1.81.0
* libogre-1.12-dev

## Purpose of using this:

The added dependencies are needed to compile ROS 2 on Debian "bookworm".

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/libignition-cmake-dev
  - https://packages.debian.org/bookworm/libignition-math-dev
  - https://packages.debian.org/bookworm/libboost-date-time1.81.0
  - https://packages.debian.org/bookworm/libboost-python1.81.0
  - https://packages.debian.org/bookworm/libboost-random1.81.0
  - https://packages.debian.org/bookworm/libboost-thread1.81.0
  - https://packages.debian.org/bookworm/libogre-1.12-dev

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->
