### PR TITLE
skyway: 0.0.2-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13225,7 +13225,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ntt-t3/skyway_for_ros-release.git
-      version: 0.0.1-1
+      version: 0.0.2-3
     source:
       type: git
       url: https://github.com/ntt-t3/skyway_for_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `skyway` to `0.0.2-3`:

- upstream repository: https://github.com/ntt-t3/skyway_for_ros.git
- release repository: https://github.com/ntt-t3/skyway_for_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.1-1`

## skyway

```
* Output logs when loading and unloading plugins
```
