### PR TITLE
actuator_msgs: 0.0.1-1 in rolling/distribution.yaml

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -50,6 +50,12 @@ repositories:
       url: https://github.com/ros-drivers/ackermann_msgs.git
       version: ros2
     status: maintained
+  actuator_msgs:
+    source:
+      type: git
+      url: https://github.com/rudislabs/actuator_msgs.git
+      version: main
+    status: maintained
   adaptive_component:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

Rolling

# The source is here:

https://github.com/rudislabs/actuator_msgs.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
