### PR TITLE
cartographer: 2.0.9002-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -581,7 +581,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/cartographer-release.git
-      version: 2.0.9002-3
+      version: 2.0.9002-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cartographer` to `2.0.9002-4`:

- upstream repository: https://github.com/ros2/cartographer.git
- release repository: https://github.com/ros2-gbp/cartographer-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.9002-3`
