### PR TITLE
mrpt_slam: 0.1.13-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7439,7 +7439,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_slam-release.git
-      version: 0.1.12-1
+      version: 0.1.13-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_slam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_slam` to `0.1.13-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_slam.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_slam-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.12-1`

## mrpt_ekf_slam_2d

```
* Fix build against last mrpt 2.7.x
* Contributors: Jose Luis Blanco Claraco
```

## mrpt_ekf_slam_3d

```
* Fix build against last mrpt 2.7.x
* Contributors: Jose Luis Blanco Claraco
```

## mrpt_icp_slam_2d

- No changes

## mrpt_rbpf_slam

```
* Fix build against last mrpt 2.7.x
* Contributors: Jose Luis Blanco Claraco
```

## mrpt_slam

- No changes
