### PR TITLE
Add libclang-dev rule for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3051,6 +3051,7 @@ libclang-dev:
   debian: [libclang-dev]
   fedora: [clang-devel]
   nixos: [clang]
+  rhel: [clang-devel]
   ubuntu: [libclang-dev]
 libcoin60-dev:
   arch: [coin]


### PR DESCRIPTION
In both RHEL 8 and RHEL 9, this package is provided by `AppStream`:
http://ziply.mm.fcix.net/almalinux/8.7/AppStream/x86_64/os/Packages/clang-devel-14.0.6-1.module_el8.7.0+3277+b822483f.i686.rpm
http://ziply.mm.fcix.net/almalinux/9.1/AppStream/x86_64/os/Packages/clang-devel-14.0.6-1.el9.i686.rpm