### PR TITLE
genmypy: 0.3.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3010,7 +3010,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/rospypi/genmypy-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/rospypi/genmypy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `genmypy` to `0.3.2-1`:

- upstream repository: https://github.com/rospypi/genmypy.git
- release repository: https://github.com/rospypi/genmypy-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.1-1`

## genmypy

```
* Need genpy init file to be generated before generating mypy module init file (#45 <https://github.com/rospypi/genmypy/issues/45>, thanks @mikaelarguedas!)
* Upgrade dev dependencies (#46 <https://github.com/rospypi/genmypy/issues/46>)
```
