### PR TITLE
cras_ros_utils: 2.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1527,7 +1527,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
-      version: 2.1.2-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/ctu-vras/ros-utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_ros_utils` to `2.2.0-1`:

- upstream repository: https://github.com/ctu-vras/ros-utils
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.2-1`

## cras_cpp_common

```
* Fixed parseFloat()/parseDouble() tests to reflect the behavior change in fast_float library.
* Update fast_float to v4.0.
* Update fast_float to v3.10.0.
* Update tl/expected.
* Update tl/optional to v1.1.0.
* string_utils: Added toLower/toUpper.
* Added std::span shim.
* Contributors: Martin Pecka
```

## cras_docs_common

```
* Fixed sphinx docs build on Noetic.
* Added support for custom themes.
* Improved readme
* Fixed wrong cross-references created for :ivar: fields by Sphinx.
* Fix providing the custom sphinx theme to packages from this stack on ROS buildfarm.
* Contributors: Martin Pecka
```

## cras_py_common

- No changes

## cras_topic_tools

```
* Added heartbeat.
* Simplified lazy subscriber classes and nodelet code. Added ~tcp_no_delay param to most nodelets. API breaks included, but hopefully nothing will be affected.
  API breaks:
  - LazySubscriberBase->ConditionalSubscriber
  - LazySubscriber: callback is now passed as parameter instead of being a virtual member function
  - GenericLazyPubSub: callback is now passed as parameter instead of being a virtual member function
  - the nodelets no longer have a dedicated PubSub object that would be reusable elsewhere (the minimum probability of reuse does not outweigh the code complications it brings)
* Contributors: Martin Pecka
```

## image_transport_codecs

```
* Fixed getCompressedImageContent() for JPEGs in CompressedCodec.
* Swap the order of image and topic arguments in encode/decode to make the Python and C++ APIs consistent.
* Generalized getCompressedImageContent() to all codecs.
* Added getCompressedImageContent() to compressedDepth codec.
* Added guessAnyCompressedImageTransportFormat().
* Contributors: Martin Pecka
```
