### PR TITLE
rtabmap_ros: 0.21.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9978,10 +9978,26 @@ repositories:
       url: https://github.com/introlab/rtabmap_ros.git
       version: noetic-devel
     release:
+      packages:
+      - rtabmap_conversions
+      - rtabmap_costmap_plugins
+      - rtabmap_demos
+      - rtabmap_examples
+      - rtabmap_launch
+      - rtabmap_legacy
+      - rtabmap_msgs
+      - rtabmap_odom
+      - rtabmap_python
+      - rtabmap_ros
+      - rtabmap_rviz_plugins
+      - rtabmap_slam
+      - rtabmap_sync
+      - rtabmap_util
+      - rtabmap_viz
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.20.23-1
+      version: 0.21.1-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap_ros` to `0.21.1-1`:

- upstream repository: https://github.com/introlab/rtabmap_ros.git
- release repository: https://github.com/introlab/rtabmap_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.20.23-1`
