### PR TITLE
polygon_ros: 1.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3935,7 +3935,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/MetroRobots-release/polygon_ros-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `polygon_ros` to `1.0.2-1`:

- upstream repository: https://github.com/MetroRobots/polygon_ros
- release repository: https://github.com/MetroRobots-release/polygon_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.1-1`
