### PR TITLE
polygon_ros: 1.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3369,6 +3369,27 @@ repositories:
       url: https://github.com/ros-perception/pointcloud_to_laserscan.git
       version: rolling
     status: maintained
+  polygon_ros:
+    doc:
+      type: git
+      url: https://github.com/MetroRobots/polygon_ros.git
+      version: main
+    release:
+      packages:
+      - polygon_demos
+      - polygon_msgs
+      - polygon_rviz_plugins
+      - polygon_utils
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/MetroRobots-release/polygon_ros-release.git
+      version: 1.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/MetroRobots/polygon_ros.git
+      version: main
+    status: developed
   pose_cov_ops:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `polygon_ros` to `1.0.2-1`:

- upstream repository: https://github.com/MetroRobots/polygon_ros
- release repository: https://github.com/MetroRobots-release/polygon_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
