### PR TITLE
Added libomp-dev for osx

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -283,6 +283,10 @@ libogre-dev:
   osx:
     homebrew:
       packages: [ogre]
+libomp-dev:
+  osx:
+    homebrew:
+      packages: [libomp]
 libopencv-dev:
   osx:
     homebrew:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

This pull request is meant to add the libomp-dev definition for osx because it is required by some packages such as moveit_planners_ompl. It isn't needed on Ubuntu because it is already required in its distribution.

## Package name: 

libomp-dev

## Package Upstream Source:

https://openmp.llvm.org/

## Purpose of using this:

The libomp-dev definition is needed on osx because it is required by some packages such as moveit_planners_ompl and moveit_ros_perception, but it isn't defined on osx although there is already a homebrew package.


<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- macOS: https://formulae.brew.sh/formula/libomp#default
