### PR TITLE
Adding Python3 to OSX

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -283,6 +283,10 @@ libogre-dev:
   osx:
     homebrew:
       packages: [ogre]
+libomp-dev:
+  osx:
+    homebrew:
+      packages: [libomp]
 libopencv-dev:
   osx:
     homebrew:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -283,10 +283,6 @@ libogre-dev:
   osx:
     homebrew:
       packages: [ogre]
-libomp-dev:
-  osx:
-    homebrew:
-      packages: [libomp]
 libopencv-dev:
   osx:
     homebrew:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -650,7 +650,7 @@ protobuf-dev:
 python:
   osx:
     homebrew:
-      packages: []
+      packages: [python, python3]
 python-cairo:
   osx:
     homebrew:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -650,7 +650,7 @@ protobuf-dev:
 python:
   osx:
     homebrew:
-      packages: [python, python3]
+      packages: []
 python-cairo:
   osx:
     homebrew:
@@ -694,7 +694,7 @@ python-vtk:
 python3:
   osx:
     homebrew:
-      packages: []
+      packages: [python3]
 python3-pygments:
   osx:
     homebrew:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -695,6 +695,10 @@ python-vtk:
   osx:
     homebrew:
       depends: [libvtk]
+python3:
+  osx:
+    homebrew:
+      packages: []
 python3-pygments:
   osx:
     homebrew:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -647,10 +647,6 @@ protobuf-dev:
   osx:
     homebrew:
       packages: [protobuf]
-python:
-  osx:
-    homebrew:
-      packages: []
 python-cairo:
   osx:
     homebrew:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1565,6 +1565,9 @@ python-dlib:
   fedora:
     pip: [dlib]
   nixos: [pythonPackages.dlib]
+  osx:
+    pip:
+      packages: [dlib]
   ubuntu:
     pip: [dlib]
 python-docker:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Adding the Python3 package to the OSX version of rosdistro, as it is already required with the ubuntu version and there is a homebrew package.

## Package name:

python3

## Package Upstream Source:

https://www.python.org/

## Purpose of using this:

There are libraries like moveit_ros_planning_interface that utilize python3 as part of rosdep, but it currently doesn't have access. Although the package has a different name it is already on homebrew which makes this simple to add.


<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- macOS: https://formulae.brew.sh/formula/python@3.11#default