### PR TITLE
Fix libturbojpeg rules for Fedora and RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5892,13 +5892,13 @@ libturbojpeg:
   debian:
     '*': [libturbojpeg0-dev]
     jessie: [libturbojpeg1-dev]
-  fedora: [turbojpeg-devel]
+  fedora: [libjpeg-turbo-devel, turbojpeg-devel]
   freebsd: [libjpeg-turbo]
   gentoo: [media-libs/libjpeg-turbo]
   nixos: [libjpeg_turbo]
   openembedded: [libjpeg-turbo@openembedded-core]
   opensuse: [libturbojpeg0, libjpeg8-devel]
-  rhel: [turbojpeg-devel]
+  rhel: [libjpeg-turbo-devel, turbojpeg-devel]
   ubuntu:
     '*': [libturbojpeg0-dev]
     precise: [libturbojpeg, libjpeg-turbo8-dev]


### PR DESCRIPTION
The debian packages listed here seem to have an implicit dependency that the RPM packages do not have, so we need to explicitly list the other package so that the rules behave the same way.

https://packages.fedoraproject.org/pkgs/libjpeg-turbo/libjpeg-turbo-devel/

http://ziply.mm.fcix.net/almalinux/8.7/AppStream/x86_64/os/Packages/libjpeg-turbo-devel-1.5.3-12.el8.x86_64.rpm
http://mirrors.cat.pdx.edu/alma/9.1/AppStream/x86_64/os/Packages/libjpeg-turbo-devel-2.0.90-5.el9.x86_64.rpm

Should resolve RPM build failures for `turbojpeg_compressed_image_transport` on the buildfarm: https://build.ros2.org/view/Rbin_rhel_el964/job/Rbin_rhel_el964__turbojpeg_compressed_image_transport__rhel_9_x86_64__binary/