### PR TITLE
Adding fmt on osx

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1109,6 +1109,9 @@ fmt:
   gentoo: [dev-libs/libfmt]
   nixos: [fmt]
   openembedded: [fmt@meta-oe]
+  osx:
+    homebrew:
+      packages: [fmt]
   rhel: [fmt-devel]
   ubuntu: [libfmt-dev]
 fonts-noto:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -111,10 +111,6 @@ fluid:
   osx:
     homebrew:
       packages: [fltk]
-fmt:
-  osx:
-    homebrew:
-      packages: []
 freeimage:
   osx:
     homebrew:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -99,6 +99,10 @@ ffmpeg:
   osx:
     homebrew:
       packages: [ffmpeg]
+fmt:
+  osx:
+    homebrew:
+      packages: []
 flex:
   osx:
     homebrew:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -99,10 +99,6 @@ ffmpeg:
   osx:
     homebrew:
       packages: [ffmpeg]
-fmt:
-  osx:
-    homebrew:
-      packages: []
 flex:
   osx:
     homebrew:
@@ -115,6 +111,10 @@ fluid:
   osx:
     homebrew:
       packages: [fltk]
+fmt:
+  osx:
+    homebrew:
+      packages: []
 freeimage:
   osx:
     homebrew:


### PR DESCRIPTION
Adding fmt to the osx homebrew base of rosdep because ubuntu already has access to this, while osx still needs it.

## Package name:

fmt

## Package Upstream Source:

[TODO link to source repository](https://fmt.dev/latest/index.html)

## Purpose of using this:

fmt is required by many packages such as parameter_traits and ubuntu already uses it in their distribution, so since there's already a homebrew package it should be added.

- macOS: https://formulae.brew.sh/formula/fmt#default
