### PR TITLE
Added range-v3 to OSX

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7653,6 +7653,9 @@ range-v3:
     stretch: null
   fedora: [range-v3-devel]
   gentoo: [dev-cpp/range-v3]
+  osx:
+    homebrew:
+      packages: [range-v3]
   rhel:
     '*': [range-v3-devel]
     '7': null

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -703,10 +703,6 @@ qtbase5-dev:
   osx:
     homebrew:
       packages: [qt5]
-range-v3:
-  osx:
-    homebrew:
-      packages: []
 rake:
   osx:
     homebrew:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -703,6 +703,10 @@ qtbase5-dev:
   osx:
     homebrew:
       packages: [qt5]
+range-v3:
+  osx:
+    homebrew:
+      packages: []
 rake:
   osx:
     homebrew:


### PR DESCRIPTION
This PR looks to add the range-v3 homebrew formula to OSX

## Package name:

range-v3

## Package Upstream Source:

https://ericniebler.github.io/range-v3/

## Purpose of using this:

There are other packages that need this package as there is already a section for it in Ubuntu and others, since there was a homebrew package already, this can be added.

- macOS: https://formulae.brew.sh/formula/range-v3#default