### PR TITLE
Adding libdw to osx

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3206,7 +3206,7 @@ libdw-dev:
   opensuse: [libdw-devel]
   osx:
     homebrew:
-      packages: [libdw]
+      packages: [elfutils]
   rhel: [elfutils-devel]
   ubuntu: [libdw-dev]
 libdxflib-dev:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3204,6 +3204,9 @@ libdw-dev:
   nixos: [elfutils]
   openembedded: [elfutils@openembedded-core]
   opensuse: [libdw-devel]
+  osx:
+    homebrew:
+      packages: [libdw]
   rhel: [elfutils-devel]
   ubuntu: [libdw-dev]
 libdxflib-dev:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -199,10 +199,6 @@ libdmtx-dev:
   osx:
     homebrew:
       packages: [libdmtx]
-libdw-dev:
-  osx:
-    homebrew:
-      packages: [elfutils]
 libedit:
   osx:
     homebrew:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -199,6 +199,10 @@ libdmtx-dev:
   osx:
     homebrew:
       packages: [libdmtx]
+libdw-dev:
+  osx:
+    homebrew:
+      packages: [elfutils]
 libedit:
   osx:
     homebrew:


### PR DESCRIPTION
This PR aims to add the libdw dependency to osx via homebrew

## Package name:

libdw

## Package Upstream Source:

https://sourceware.org/elfutils/

## Purpose of using this:

This dependency is already needed in packages like backward_ros and is being used on other OS like ubuntu. While it at first seems misleading that it brews with the entire elfutils library instead of just libdw, ubuntu currently uses the exact same tar.bz file via apt that macos would use the homebrew. If needing reference [osx](https://github.com/Homebrew/homebrew-core/blob/b3e60b5e8ef82db4e226184552568c6820a26e14/Formula/elfutils.rb) and [ubuntu](https://packages.ubuntu.com/kinetic/libdw-dev)


- macOS: https://formulae.brew.sh/formula/elfutils#default