### PR TITLE
Cleanup rosdep rules for long EOL Ubuntu and Debian distros

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,6 +135,8 @@ Guidelines for rosdep rules
     * If specific versions are called out, there should be coverage of all versions currently targeted by supported ROS distros.
      * If there's a new distro in prerelease adding a rule for it is fine.
        However please don't target 'sid' as it's a rolling target and when the keys change our database gets out of date.
+    * Rules for EOL Distros will be pruned periodically.
+      * If you are trying to use an EOL platform for historical purposes, you can access the old rules from tags of the rosdistro when that platform was supported, but there will not be any support or changes. [example](https://github.com/ros/rosdistro/issues/31569#issuecomment-1003974561)
   * Keep everything in alphabetical order for better merging.
   * No trailing whitespace.
   * No blank lines.

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -178,7 +178,6 @@ assimp:
   slackware: [assimp]
   ubuntu:
     '*': [libassimp-dev]
-    oneiric: [assimp-dev]
 assimp-dev:
   alpine: [assimp-dev]
   arch: [assimp]
@@ -193,7 +192,6 @@ assimp-dev:
   slackware: [assimp]
   ubuntu:
     '*': [libassimp-dev]
-    oneiric: [assimp-dev]
 at-spi2-core:
   arch: [at-spi2-core]
   debian: [at-spi2-core]
@@ -620,7 +618,6 @@ collada-dom:
   slackware: [collada-dom]
   ubuntu:
     '*': [libcollada-dom2.4-dp-dev]
-    oneiric: [collada-dom-dev]
     precise: [collada-dom-dev]
     quantal: [collada-dom-dev]
     raring: [collada-dom-dev]
@@ -866,7 +863,6 @@ eclipse:
   gentoo: [dev-java/ant-eclipse-ecj, dev-java/eclipse-ecj]
   ubuntu:
     karmic: [eclipse, eclipse-platform, eclipse-rcp, eclipse-pde]
-    oneiric: [eclipse, eclipse-platform, eclipse-rcp, eclipse-emf, eclipse-xsd, eclipse-pde]
     precise: [eclipse, eclipse-platform, eclipse-rcp, eclipse-emf, eclipse-xsd, eclipse-pde]
     quantal: [eclipse, eclipse-platform, eclipse-rcp, eclipse-emf, eclipse-xsd, eclipse-pde]
     raring: [eclipse, eclipse-platform, eclipse-rcp, eclipse-emf, eclipse-xsd, eclipse-pde]
@@ -1066,7 +1062,6 @@ fltk:  # Consider using the libfltk-dev and fluid (fltk runtime) keys instead.
     artful: [fluid, libfltk1.3-dev]
     bionic: [fluid, libfltk1.3-dev]
     focal: [fluid, libfltk1.3-dev]
-    oneiric: [fluid, libfltk1.1-dev]
     precise: [fluid, libfltk1.1-dev]
     quantal: [fluid, libfltk1.1-dev]
     raring: [fluid, libfltk1.1-dev]
@@ -1573,7 +1568,6 @@ gstreamer0.10-plugins-ugly:
     wheezy: [gstreamer0.10-plugins-ugly]
   gentoo: ['media-libs/gst-plugins-ugly:0.10']
   ubuntu:
-    oneiric: [gstreamer0.10-plugins-ugly]
     precise: [gstreamer0.10-plugins-ugly]
     quantal: [gstreamer0.10-plugins-ugly]
     raring: [gstreamer0.10-plugins-ugly]
@@ -2259,7 +2253,6 @@ jasper:
     slackpkg:
       packages: [jasper]
   ubuntu:
-    oneiric: [libjasper-dev]
     precise: [libjasper-dev]
     quantal: [libjasper-dev]
     raring: [libjasper-dev]
@@ -3660,7 +3653,6 @@ libgpgme-dev:
   rhel: [gpgme-devel]
   ubuntu:
     '*': [libgpgme-dev]
-    oneiric: [libgpgme11-dev]
     precise: [libgpgme11-dev]
     quantal: [libgpgme11-dev]
     raring: [libgpgme11-dev]
@@ -4502,7 +4494,6 @@ libopenni-nite-dev:
   debian: [libopenni-nite-dev]
   fedora: [openni-nite-devel]
   ubuntu:
-    oneiric: [libopenni-nite-dev]
     precise: [libopenni-nite-dev]
     quantal: [libopenni-nite-dev]
 libopenni-sensor-primesense-dev:
@@ -5108,7 +5099,6 @@ libpqxx:
     artful: [libpqxx-4.0v5]
     bionic: [libpqxx-4.0v5]
     focal: [libpqxx-6.4]
-    oneiric: [libpqxx-3.0]
     precise: [libpqxx-3.1]
     quantal: [libpqxx-3.1]
     raring: [libpqxx-3.1]
@@ -5187,7 +5177,6 @@ libqglviewer-qt4:
   ubuntu:
     artful: [libqglviewer2-qt4]
     bionic: [libqglviewer2-qt4]
-    oneiric: [libqglviewer-qt4-2]
     precise: [libqglviewer-qt4-2]
     quantal: [libqglviewer-qt4-2]
     raring: [libqglviewer-qt4-2]
@@ -5211,7 +5200,6 @@ libqglviewer-qt4-dev:
   ubuntu:
     artful: [libqglviewer-dev-qt4]
     bionic: [libqglviewer-dev-qt4]
-    oneiric: [libqglviewer-qt4-dev]
     precise: [libqglviewer-qt4-dev]
     quantal: [libqglviewer-qt4-dev]
     raring: [libqglviewer-qt4-dev]
@@ -5833,7 +5821,6 @@ libtool:
     bionic: [libtool, libltdl-dev, libtool-bin]
     focal: [libtool, libltdl-dev, libtool-bin]
     jammy: [libtool, libltdl-dev, libtool-bin]
-    oneiric: [libtool, libltdl-dev]
     precise: [libtool, libltdl-dev]
     quantal: [libtool, libltdl-dev]
     raring: [libtool, libltdl-dev]
@@ -6093,7 +6080,6 @@ libvtk:
     '*': [libvtk7-dev]
     artful: [libvtk6-dev]
     bionic: [libvtk6-dev]
-    oneiric: [libvtk5-dev, default-jre-headless, openjdk-6-jdk]
     precise: [libvtk5-dev]
     quantal: [libvtk5-dev]
     raring: [libvtk5-dev]
@@ -6149,7 +6135,6 @@ libvtk-qt:
     '*': [libvtk7-qt-dev]
     artful: [libvtk6-qt-dev]
     bionic: [libvtk6-qt-dev]
-    oneiric: [libvtk5-qt4-dev]
     precise: [libvtk5-qt4-dev]
     quantal: [libvtk5-qt4-dev]
     raring: [libvtk5-qt4-dev]
@@ -6559,7 +6544,6 @@ log4cxx:
   slackware: [apache-log4cxx]
   ubuntu:
     '*': [liblog4cxx-dev]
-    oneiric: [liblog4cxx10-dev]
     precise: [liblog4cxx10-dev]
     quantal: [liblog4cxx10-dev]
     raring: [liblog4cxx10-dev]
@@ -7646,7 +7630,6 @@ robotino-api2:
   ubuntu: [robotino-api2]
 rosemacs-el:
   ubuntu:
-    oneiric: [rosemacs-el]
     precise: [rosemacs-el]
 rsync:
   arch: [rsync]
@@ -8028,7 +8011,6 @@ swi-prolog-clib:
     woody: [swi-prolog-clib]
   fedora: [pl-devel]
   ubuntu:
-    oneiric: [swi-prolog]
     precise: [swi-prolog]
     quantal: [swi-prolog]
     raring: [swi-prolog]
@@ -8038,7 +8020,6 @@ swi-prolog-http:
     lenny: [swi-prolog-http]
   fedora: [pl]
   ubuntu:
-    oneiric: [swi-prolog]
     precise: [swi-prolog]
     quantal: [swi-prolog]
     raring: [swi-prolog]
@@ -8057,7 +8038,6 @@ swi-prolog-semweb:
   arch: [swi-prolog]
   fedora: [pl]
   ubuntu:
-    oneiric: [swi-prolog]
     precise: [swi-prolog]
     quantal: [swi-prolog]
     raring: [swi-prolog]
@@ -8067,7 +8047,6 @@ swi-prolog-sgml:
     lenny: [swi-prolog-sgml]
   fedora: [pl]
   ubuntu:
-    oneiric: [swi-prolog]
     precise: [swi-prolog]
     quantal: [swi-prolog]
     raring: [swi-prolog]
@@ -8077,7 +8056,6 @@ swi-prolog-xpce:
     woody: [swi-prolog-xpce]
   fedora: [pl-xpce]
   ubuntu:
-    oneiric: [swi-prolog]
     precise: [swi-prolog]
     quantal: [swi-prolog]
     raring: [swi-prolog]
@@ -8682,7 +8660,6 @@ xulrunner-1.9.2:
   debian: []
   ubuntu:
     karmic: [xulrunner-1.9.2]
-    oneiric: []
     precise: []
     quantal: []
     raring: []

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -178,7 +178,6 @@ assimp:
   slackware: [assimp]
   ubuntu:
     '*': [libassimp-dev]
-    maverick: [assimp-dev]
     oneiric: [assimp-dev]
 assimp-dev:
   alpine: [assimp-dev]
@@ -194,7 +193,6 @@ assimp-dev:
   slackware: [assimp]
   ubuntu:
     '*': [libassimp-dev]
-    maverick: [assimp-dev]
     oneiric: [assimp-dev]
 at-spi2-core:
   arch: [at-spi2-core]
@@ -622,7 +620,6 @@ collada-dom:
   slackware: [collada-dom]
   ubuntu:
     '*': [libcollada-dom2.4-dp-dev]
-    maverick: [collada-dom-dev]
     natty: [collada-dom-dev]
     oneiric: [collada-dom-dev]
     precise: [collada-dom-dev]
@@ -870,7 +867,6 @@ eclipse:
   gentoo: [dev-java/ant-eclipse-ecj, dev-java/eclipse-ecj]
   ubuntu:
     karmic: [eclipse, eclipse-platform, eclipse-rcp, eclipse-pde]
-    maverick: [eclipse, eclipse-platform, eclipse-rcp, eclipse-emf, eclipse-xsd, eclipse-pde]
     natty: [eclipse, eclipse-platform, eclipse-rcp, eclipse-emf, eclipse-xsd, eclipse-pde]
     oneiric: [eclipse, eclipse-platform, eclipse-rcp, eclipse-emf, eclipse-xsd, eclipse-pde]
     precise: [eclipse, eclipse-platform, eclipse-rcp, eclipse-emf, eclipse-xsd, eclipse-pde]
@@ -1072,7 +1068,6 @@ fltk:  # Consider using the libfltk-dev and fluid (fltk runtime) keys instead.
     artful: [fluid, libfltk1.3-dev]
     bionic: [fluid, libfltk1.3-dev]
     focal: [fluid, libfltk1.3-dev]
-    maverick: [fluid, libfltk1.1-dev]
     natty: [fluid, libfltk1.1-dev]
     oneiric: [fluid, libfltk1.1-dev]
     precise: [fluid, libfltk1.1-dev]
@@ -1581,7 +1576,6 @@ gstreamer0.10-plugins-ugly:
     wheezy: [gstreamer0.10-plugins-ugly]
   gentoo: ['media-libs/gst-plugins-ugly:0.10']
   ubuntu:
-    maverick: [gstreamer0.10-plugins-ugly-multiverse]
     natty: [gstreamer0.10-plugins-ugly]
     oneiric: [gstreamer0.10-plugins-ugly]
     precise: [gstreamer0.10-plugins-ugly]
@@ -2269,7 +2263,6 @@ jasper:
     slackpkg:
       packages: [jasper]
   ubuntu:
-    maverick: [libjasper-dev]
     natty: [libjasper-dev]
     oneiric: [libjasper-dev]
     precise: [libjasper-dev]
@@ -3672,7 +3665,6 @@ libgpgme-dev:
   rhel: [gpgme-devel]
   ubuntu:
     '*': [libgpgme-dev]
-    maverick: [libgpgme11-dev]
     oneiric: [libgpgme11-dev]
     precise: [libgpgme11-dev]
     quantal: [libgpgme11-dev]
@@ -4515,7 +4507,6 @@ libopenni-nite-dev:
   debian: [libopenni-nite-dev]
   fedora: [openni-nite-devel]
   ubuntu:
-    maverick: [libopenni-nite-dev]
     natty: [libopenni-nite-dev]
     oneiric: [libopenni-nite-dev]
     precise: [libopenni-nite-dev]
@@ -5123,7 +5114,6 @@ libpqxx:
     artful: [libpqxx-4.0v5]
     bionic: [libpqxx-4.0v5]
     focal: [libpqxx-6.4]
-    maverick: [libpqxx-3.0]
     natty: [libpqxx-3.0]
     oneiric: [libpqxx-3.0]
     precise: [libpqxx-3.1]
@@ -5204,7 +5194,6 @@ libqglviewer-qt4:
   ubuntu:
     artful: [libqglviewer2-qt4]
     bionic: [libqglviewer2-qt4]
-    maverick: [libqglviewer-qt4-2]
     natty: [libqglviewer-qt4-2]
     oneiric: [libqglviewer-qt4-2]
     precise: [libqglviewer-qt4-2]
@@ -5230,7 +5219,6 @@ libqglviewer-qt4-dev:
   ubuntu:
     artful: [libqglviewer-dev-qt4]
     bionic: [libqglviewer-dev-qt4]
-    maverick: [libqglviewer-qt4-dev]
     natty: [libqglviewer-qt4-dev]
     oneiric: [libqglviewer-qt4-dev]
     precise: [libqglviewer-qt4-dev]
@@ -5854,7 +5842,6 @@ libtool:
     bionic: [libtool, libltdl-dev, libtool-bin]
     focal: [libtool, libltdl-dev, libtool-bin]
     jammy: [libtool, libltdl-dev, libtool-bin]
-    maverick: [libtool, libltdl-dev]
     natty: [libtool, libltdl-dev]
     oneiric: [libtool, libltdl-dev]
     precise: [libtool, libltdl-dev]
@@ -6116,7 +6103,6 @@ libvtk:
     '*': [libvtk7-dev]
     artful: [libvtk6-dev]
     bionic: [libvtk6-dev]
-    maverick: [libvtk5-dev]
     natty: [libvtk5-dev]
     oneiric: [libvtk5-dev, default-jre-headless, openjdk-6-jdk]
     precise: [libvtk5-dev]
@@ -6174,7 +6160,6 @@ libvtk-qt:
     '*': [libvtk7-qt-dev]
     artful: [libvtk6-qt-dev]
     bionic: [libvtk6-qt-dev]
-    maverick: [libvtk5-qt4-dev]
     natty: [libvtk5-qt4-dev]
     oneiric: [libvtk5-qt4-dev]
     precise: [libvtk5-qt4-dev]
@@ -6586,7 +6571,6 @@ log4cxx:
   slackware: [apache-log4cxx]
   ubuntu:
     '*': [liblog4cxx-dev]
-    maverick: [liblog4cxx10-dev]
     natty: [liblog4cxx10-dev]
     oneiric: [liblog4cxx10-dev]
     precise: [liblog4cxx10-dev]
@@ -8057,7 +8041,6 @@ swi-prolog-clib:
     woody: [swi-prolog-clib]
   fedora: [pl-devel]
   ubuntu:
-    maverick: [swi-prolog]
     natty: [swi-prolog]
     oneiric: [swi-prolog]
     precise: [swi-prolog]
@@ -8069,7 +8052,6 @@ swi-prolog-http:
     lenny: [swi-prolog-http]
   fedora: [pl]
   ubuntu:
-    maverick: [swi-prolog]
     natty: [swi-prolog]
     oneiric: [swi-prolog]
     precise: [swi-prolog]
@@ -8090,7 +8072,6 @@ swi-prolog-semweb:
   arch: [swi-prolog]
   fedora: [pl]
   ubuntu:
-    maverick: [swi-prolog]
     natty: [swi-prolog]
     oneiric: [swi-prolog]
     precise: [swi-prolog]
@@ -8102,7 +8083,6 @@ swi-prolog-sgml:
     lenny: [swi-prolog-sgml]
   fedora: [pl]
   ubuntu:
-    maverick: [swi-prolog]
     natty: [swi-prolog]
     oneiric: [swi-prolog]
     precise: [swi-prolog]
@@ -8114,7 +8094,6 @@ swi-prolog-xpce:
     woody: [swi-prolog-xpce]
   fedora: [pl-xpce]
   ubuntu:
-    maverick: [swi-prolog]
     natty: [swi-prolog]
     oneiric: [swi-prolog]
     precise: [swi-prolog]
@@ -8721,7 +8700,6 @@ xulrunner-1.9.2:
   debian: []
   ubuntu:
     karmic: [xulrunner-1.9.2]
-    maverick: [xulrunner-1.9.2]
     natty: [xulrunner-1.9.2]
     oneiric: []
     precise: []

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1141,7 +1141,6 @@ gazebo:
   slackware: [gazebo]
   ubuntu:
     bionic: [gazebo9]
-    eoan: [gazebo9]
     focal: [gazebo11]
     jammy: [gazebo]
 gazebo11:
@@ -1174,7 +1173,6 @@ gazebo9:
   openembedded: []
   ubuntu:
     bionic: [gazebo9]
-    eoan: [gazebo9]
 gcc-arm-none-eabi:
   arch: [gcc-arm-none-eabi]
   debian: [gcc-arm-none-eabi]
@@ -2422,7 +2420,6 @@ libboost-atomic:
   rhel: [boost-atomic]
   ubuntu:
     bionic: [libboost-atomic1.65.1]
-    eoan: [libboost-atomic1.67.0]
     focal: [libboost-atomic1.71.0]
     jammy: [libboost-atomic1.74.0]
 libboost-atomic-dev:
@@ -2446,7 +2443,6 @@ libboost-chrono:
   rhel: [boost-chrono]
   ubuntu:
     bionic: [libboost-chrono1.65.1]
-    eoan: [libboost-chrono1.67.0]
     focal: [libboost-chrono1.71.0]
     jammy: [libboost-chrono1.74.0]
 libboost-chrono-dev:
@@ -2473,7 +2469,6 @@ libboost-coroutine:
     '7': null
   ubuntu:
     bionic: [libboost-coroutine1.65.1]
-    eoan: [libboost-coroutine1.67.0]
     focal: [libboost-coroutine1.71.0]
     jammy: [libboost-coroutine1.74.0]
 libboost-coroutine-dev:
@@ -2498,7 +2493,6 @@ libboost-date-time:
   rhel: [boost-date-time]
   ubuntu:
     bionic: [libboost-date-time1.65.1]
-    eoan: [libboost-date-time1.67.0]
     focal: [libboost-date-time1.71.0]
     jammy: [libboost-date-time1.74.0]
 libboost-date-time-dev:
@@ -2531,7 +2525,6 @@ libboost-filesystem:
   rhel: [boost-filesystem]
   ubuntu:
     bionic: [libboost-filesystem1.65.1]
-    eoan: [libboost-filesystem1.67.0]
     focal: [libboost-filesystem1.71.0]
     jammy: [libboost-filesystem1.74.0]
 libboost-filesystem-dev:
@@ -2555,7 +2548,6 @@ libboost-iostreams:
   rhel: [boost-iostreams]
   ubuntu:
     bionic: [libboost-iostreams1.65.1]
-    eoan: [libboost-iostreams1.67.0]
     focal: [libboost-iostreams1.71.0]
     jammy: [libboost-iostreams1.74.0]
 libboost-iostreams-dev:
@@ -2578,7 +2570,6 @@ libboost-math:
   rhel: [boost-math]
   ubuntu:
     bionic: [libboost-math1.65.1]
-    eoan: [libboost-math1.67.0]
     focal: [libboost-math1.71.0]
     jammy: [libboost-math1.74.0]
 libboost-math-dev:
@@ -2609,7 +2600,6 @@ libboost-program-options:
   rhel: [boost-program-options]
   ubuntu:
     bionic: [libboost-program-options1.65.1]
-    eoan: [libboost-program-options1.67.0]
     focal: [libboost-program-options1.71.0]
     jammy: [libboost-program-options1.74.0]
 libboost-program-options-dev:
@@ -2636,7 +2626,6 @@ libboost-python:
     '7': [boost-python, 'boost-python%{python3_pkgversion}']
   ubuntu:
     bionic: [libboost-python1.65.1]
-    eoan: [libboost-python1.67.0]
     focal: [libboost-python1.71.0]
     jammy: [libboost-python1.74.0]
 libboost-python-dev:
@@ -2663,7 +2652,6 @@ libboost-random:
   rhel: [boost-random]
   ubuntu:
     bionic: [libboost-random1.65.1]
-    eoan: [libboost-random1.67.0]
     focal: [libboost-random1.71.0]
     jammy: [libboost-random1.74.0]
 libboost-random-dev:
@@ -2687,7 +2675,6 @@ libboost-regex:
   rhel: [boost-regex]
   ubuntu:
     bionic: [libboost-regex1.65.1]
-    eoan: [libboost-regex1.67.0]
     focal: [libboost-regex1.71.0]
     jammy: [libboost-regex1.74.0]
 libboost-regex-dev:
@@ -2711,7 +2698,6 @@ libboost-serialization:
   rhel: [boost-serialization]
   ubuntu:
     bionic: [libboost-serialization1.65.1]
-    eoan: [libboost-serialization1.67.0]
     focal: [libboost-serialization1.71.0]
     jammy: [libboost-serialization1.74.0]
 libboost-serialization-dev:
@@ -2735,7 +2721,6 @@ libboost-system:
   rhel: [boost-system]
   ubuntu:
     bionic: [libboost-system1.65.1]
-    eoan: [libboost-system1.67.0]
     focal: [libboost-system1.71.0]
     jammy: [libboost-system1.74.0]
 libboost-system-dev:
@@ -2759,7 +2744,6 @@ libboost-thread:
   rhel: [boost-thread]
   ubuntu:
     bionic: [libboost-thread1.65.1]
-    eoan: [libboost-thread1.67.0]
     focal: [libboost-thread1.71.0]
     jammy: [libboost-thread1.74.0]
 libboost-thread-dev:
@@ -2782,7 +2766,6 @@ libboost-timer:
   rhel: [boost-timer]
   ubuntu:
     bionic: [libboost-timer1.65.1]
-    eoan: [libboost-timer1.67.0]
     focal: [libboost-timer1.71.0]
     jammy: [libboost-timer1.74.0]
 libboost-timer-dev:
@@ -3335,7 +3318,6 @@ libgazebo9-dev:
   nixos: [gazebo_9]
   ubuntu:
     bionic: [libgazebo9-dev]
-    eoan: [libgazebo9-dev]
 libgconf2:
   arch: [gconf]
   debian: [libgconf-2-4]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1141,7 +1141,6 @@ gazebo:
   slackware: [gazebo]
   ubuntu:
     bionic: [gazebo9]
-    disco: [gazebo9]
     eoan: [gazebo9]
     focal: [gazebo11]
     jammy: [gazebo]
@@ -1175,7 +1174,6 @@ gazebo9:
   openembedded: []
   ubuntu:
     bionic: [gazebo9]
-    disco: [gazebo9]
     eoan: [gazebo9]
 gcc-arm-none-eabi:
   arch: [gcc-arm-none-eabi]
@@ -2611,7 +2609,6 @@ libboost-program-options:
   rhel: [boost-program-options]
   ubuntu:
     bionic: [libboost-program-options1.65.1]
-    disco: [libboost-program-options1.67.0]
     eoan: [libboost-program-options1.67.0]
     focal: [libboost-program-options1.71.0]
     jammy: [libboost-program-options1.74.0]
@@ -2639,7 +2636,6 @@ libboost-python:
     '7': [boost-python, 'boost-python%{python3_pkgversion}']
   ubuntu:
     bionic: [libboost-python1.65.1]
-    disco: [libboost-python1.67.0]
     eoan: [libboost-python1.67.0]
     focal: [libboost-python1.71.0]
     jammy: [libboost-python1.74.0]
@@ -2667,7 +2663,6 @@ libboost-random:
   rhel: [boost-random]
   ubuntu:
     bionic: [libboost-random1.65.1]
-    disco: [libboost-random1.67.0]
     eoan: [libboost-random1.67.0]
     focal: [libboost-random1.71.0]
     jammy: [libboost-random1.74.0]
@@ -2740,7 +2735,6 @@ libboost-system:
   rhel: [boost-system]
   ubuntu:
     bionic: [libboost-system1.65.1]
-    disco: [libboost-system1.67.0]
     eoan: [libboost-system1.67.0]
     focal: [libboost-system1.71.0]
     jammy: [libboost-system1.74.0]
@@ -2765,7 +2759,6 @@ libboost-thread:
   rhel: [boost-thread]
   ubuntu:
     bionic: [libboost-thread1.65.1]
-    disco: [libboost-thread1.67.0]
     eoan: [libboost-thread1.67.0]
     focal: [libboost-thread1.71.0]
     jammy: [libboost-thread1.74.0]
@@ -3342,7 +3335,6 @@ libgazebo9-dev:
   nixos: [gazebo_9]
   ubuntu:
     bionic: [libgazebo9-dev]
-    disco: [libgazebo9-dev]
     eoan: [libgazebo9-dev]
 libgconf2:
   arch: [gconf]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -41,7 +41,6 @@ acpitool:
   nixos: [acpitool]
   ubuntu:
     trusty: [acpitool]
-    vivid: [acpitool]
     wily: [acpitool]
     xenial: [acpitool]
 alsa-oss:
@@ -617,7 +616,6 @@ collada-dom:
   ubuntu:
     '*': [libcollada-dom2.4-dp-dev]
     trusty: [collada-dom-dev]
-    vivid: [collada-dom-dev]
     wily: [collada-dom-dev]
 collectd:
   debian: [collectd]
@@ -982,7 +980,6 @@ ffmpeg:
   ubuntu:
     '*': [ffmpeg, libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev]
     trusty: [libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev]
-    vivid: [libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev]
 ffmpeg2theora:
   arch: [ffmpeg2theora]
   debian: [ffmpeg2theora]
@@ -1052,7 +1049,6 @@ fltk:  # Consider using the libfltk-dev and fluid (fltk runtime) keys instead.
     bionic: [fluid, libfltk1.3-dev]
     focal: [fluid, libfltk1.3-dev]
     trusty: [fluid, libfltk1.1-dev]
-    vivid: [fluid, libfltk1.3-dev]
     wily: [fluid, libfltk1.3-dev]
     xenial: [fluid, libfltk1.3-dev]
 fluid:
@@ -1529,7 +1525,6 @@ gstreamer0.10-gconf:
     jessie: [gstreamer0.10-gconf]
   ubuntu:
     trusty: [gstreamer0.10-gconf]
-    vivid: [gstreamer0.10-gconf]
     wily: [gstreamer0.10-gconf]
     xenial: [gstreamer0.10-gconf]
 gstreamer0.10-plugins-good:
@@ -1547,7 +1542,6 @@ gstreamer0.10-plugins-ugly:
   gentoo: ['media-libs/gst-plugins-ugly:0.10']
   ubuntu:
     trusty: [gstreamer0.10-plugins-ugly]
-    vivid: [gstreamer0.10-plugins-ugly]
     wily: [gstreamer0.10-plugins-ugly]
 gstreamer0.10-pocketsphinx:
   debian:
@@ -2227,7 +2221,6 @@ jasper:
       packages: [jasper]
   ubuntu:
     trusty: [libjasper-dev]
-    vivid: [libjasper-dev]
     wily: [libjasper-dev]
     xenial: [libjasper-dev]
     yakkety: [libjasper-dev]
@@ -2455,7 +2448,6 @@ libbison-dev:
   rhel: [bison-devel]
   ubuntu:
     trusty: [libbison-dev]
-    vivid: [libbison-dev]
     wily: [libbison-dev]
     xenial: [libbison-dev]
 libblas-dev:
@@ -3196,7 +3188,6 @@ libestools-dev:
   ubuntu:
     '*': [libestools-dev]
     trusty: [libestools2.1-dev]
-    vivid: [libestools2.1-dev]
 libev-dev:
   arch: [libev]
   debian: [libev-dev]
@@ -3274,7 +3265,6 @@ libflann:
   ubuntu:
     '*': [libflann1.9]
     trusty: [libflann1.8]
-    vivid: [libflann1.8]
     wily: [libflann1.8]
     xenial: [libflann1.8]
 libflann-dev:
@@ -3399,7 +3389,6 @@ libftdipp-dev:
   ubuntu:
     bionic: [libftdipp1-dev]
     trusty: [libftdipp-dev]
-    vivid: [libftdipp-dev]
     wily: [libftdipp-dev]
     xenial: [libftdipp1-dev]
 libftgl-dev:
@@ -3611,7 +3600,6 @@ libgpgme-dev:
   ubuntu:
     '*': [libgpgme-dev]
     trusty: [libgpgme11-dev]
-    vivid: [libgpgme11-dev]
     wily: [libgpgme11-dev]
     xenial: [libgpgme11-dev]
 libgphoto-dev:
@@ -3658,7 +3646,6 @@ libgsl:
   ubuntu:
     '*': [libgsl-dev]
     trusty: [libgsl0-dev]
-    vivid: [libgsl0-dev]
     wily: [libgsl0-dev]
 libgstreamer-plugins-base0.10-0:
   arch: [gstreamer0.10-base-plugins]
@@ -3921,7 +3908,6 @@ libjaxp1.3-java:
   debian: [libjaxp1.3-java]
   ubuntu:
     trusty: [libjaxp1.3-java]
-    vivid: [libjaxp1.3-java]
     wily: [libjaxp1.3-java]
     xenial: [libjaxp1.3-java]
 libjpeg:
@@ -4491,7 +4477,6 @@ libopenvdb:
     focal: [libopenvdb6.2]
     jammy: [libopenvdb8.1]
     trusty: [libopenvdb2.1]
-    vivid: [libopenvdb2.3]
     wily: [libopenvdb3.0]
     xenial: [libopenvdb3.1]
     yakkety: [libopenvdb3.1]
@@ -4973,7 +4958,6 @@ libpng-dev:
   ubuntu:
     '*': [libpng-dev]
     trusty: [libpng12-dev]
-    vivid: [libpng12-dev]
     wily: [libpng12-dev]
     xenial: [libpng12-dev]
 libpng12-dev:
@@ -5035,7 +5019,6 @@ libpqxx:
     bionic: [libpqxx-4.0v5]
     focal: [libpqxx-6.4]
     trusty: [libpqxx-4.0]
-    vivid: [libpqxx-4.0]
     wily: [libpqxx-4.0]
     xenial: [libpqxx-4.0]
     yakkety: [libpqxx-4.0v5]
@@ -5108,7 +5091,6 @@ libqglviewer-qt4:
     artful: [libqglviewer2-qt4]
     bionic: [libqglviewer2-qt4]
     trusty: [libqglviewer2]
-    vivid: [libqglviewer2]
     wily: [libqglviewer2-qt4]
     xenial: [libqglviewer2-qt4]
     yakkety: [libqglviewer2-qt4]
@@ -5126,7 +5108,6 @@ libqglviewer-qt4-dev:
     artful: [libqglviewer-dev-qt4]
     bionic: [libqglviewer-dev-qt4]
     trusty: [libqglviewer-dev]
-    vivid: [libqglviewer-dev]
     wily: [libqglviewer-dev-qt4]
     xenial: [libqglviewer-dev-qt4]
     yakkety: [libqglviewer-dev-qt4]
@@ -5742,7 +5723,6 @@ libtool:
     focal: [libtool, libltdl-dev, libtool-bin]
     jammy: [libtool, libltdl-dev, libtool-bin]
     trusty: [libtool, libltdl-dev]
-    vivid: [libtool, libltdl-dev, libtool-bin]
     wily: [libtool, libltdl-dev, libtool-bin]
     xenial: [libtool, libltdl-dev, libtool-bin]
     yakkety: [libtool, libltdl-dev, libtool-bin]
@@ -5765,7 +5745,6 @@ libturbojpeg:
   ubuntu:
     '*': [libturbojpeg0-dev]
     trusty: [libturbojpeg, libjpeg-turbo8-dev]
-    vivid: [libturbojpeg, libjpeg-turbo8-dev]
     wily: [libturbojpeg, libjpeg-turbo8-dev]
     xenial: [libturbojpeg, libjpeg-turbo8-dev]
     yakkety: [libturbojpeg, libjpeg-turbo8-dev]
@@ -5889,7 +5868,6 @@ libuv-dev:
   ubuntu:
     bionic: [libuv0.10-dev]
     trusty: [libuv-dev]
-    vivid: [libuv0.10-dev]
     wily: [libuv0.10-dev]
     xenial: [libuv0.10-dev]
     yakkety: [libuv0.10-dev]
@@ -5938,7 +5916,6 @@ libvlc:
   ubuntu:
     '*': [libvlc5, vlc-bin]
     trusty: [libvlc5, vlc-nox]
-    vivid: [libvlc5, vlc-nox]
     wily: [libvlc5, vlc-nox]
     xenial: [libvlc5, vlc-nox]
     yakkety: [libvlc5, vlc-nox]
@@ -5980,7 +5957,6 @@ libvtk:
     artful: [libvtk6-dev]
     bionic: [libvtk6-dev]
     trusty: [libvtk5-dev]
-    vivid: [libvtk5-dev]
     wily: [libvtk5-dev]
     xenial: [libvtk6-dev]
     yakkety: [libvtk6-dev]
@@ -6002,7 +5978,6 @@ libvtk-java:
     artful: [libvtk6-java]
     bionic: [libvtk6-java]
     trusty: [libvtk-java]
-    vivid: [libvtk-java]
     wily: [libvtk-java]
     xenial: [libvtk-java]
     yakkety: [libvtk6-java]
@@ -6025,7 +6000,6 @@ libvtk-qt:
     artful: [libvtk6-qt-dev]
     bionic: [libvtk6-qt-dev]
     trusty: [libvtk5-qt4-dev]
-    vivid: [libvtk5-qt4-dev]
     wily: [libvtk5-qt4-dev]
     xenial: [libvtk6-qt-dev]
     yakkety: [libvtk6-qt-dev]
@@ -6429,7 +6403,6 @@ log4cxx:
   ubuntu:
     '*': [liblog4cxx-dev]
     trusty: [liblog4cxx10-dev]
-    vivid: [liblog4cxx10-dev]
     wily: [liblog4cxx10-dev]
     xenial: [liblog4cxx10-dev]
     yakkety: [liblog4cxx10-dev]
@@ -7047,7 +7020,6 @@ php:
   nixos: [php]
   ubuntu:
     trusty: [php5]
-    vivid: [php5]
     wily: [php5]
     xenial: [php7.0]
     yakkety: [php7.0]
@@ -7092,7 +7064,6 @@ pocketsphinx-bin:
   nixos: [pocketsphinx]
   ubuntu:
     trusty: [libsphinxbase1]
-    vivid: [libsphinxbase1]
     wily: [libsphinxbase1]
     xenial: [pocketsphinx]
     yakkety: [pocketsphinx]
@@ -7148,7 +7119,6 @@ postgresql-9.x-postgis:
   gentoo: [dev-db/postgis, =dev-db/postgresql-9*]
   ubuntu:
     trusty: [postgresql-9.3-postgis-2.1, postgresql-contrib-9.3, postgresql-server-dev-9.3]
-    vivid: [postgresql-9.4-postgis-2.1, postgresql-contrib-9.4, postgresql-server-dev-9.4]
     wily: [postgresql-9.4-postgis-2.1, postgresql-contrib-9.4, postgresql-server-dev-9.4]
     xenial: [postgresql-9.5-postgis-2.2, postgresql-contrib-9.5, postgresql-server-dev-9.5]
 postgresql-client:
@@ -7767,7 +7737,6 @@ speex:
   nixos: [speex]
   ubuntu:
     trusty: [speex]
-    vivid: [speex]
     wily: [speex]
     xenial: [speex]
 spirv-headers:
@@ -7950,7 +7919,6 @@ tap-plugins:
   gentoo: [media-plugins/tap-plugins]
   ubuntu:
     trusty: [tap-plugins]
-    vivid: [tap-plugins]
     wily: [tap-plugins]
     xenial: [tap-plugins]
 tar:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -41,7 +41,6 @@ acpitool:
   nixos: [acpitool]
   ubuntu:
     trusty: [acpitool]
-    wily: [acpitool]
     xenial: [acpitool]
 alsa-oss:
   arch: [alsa-oss]
@@ -359,7 +358,6 @@ bluez-hcidump:
   gentoo: [net-wireless/bluez-hcidump]
   ubuntu:
     trusty: [bluez-hcidump]
-    wily: [bluez-hcidump]
     xenial: [bluez-hcidump]
 boost:
   alpine: [boost-dev]
@@ -616,7 +614,6 @@ collada-dom:
   ubuntu:
     '*': [libcollada-dom2.4-dp-dev]
     trusty: [collada-dom-dev]
-    wily: [collada-dom-dev]
 collectd:
   debian: [collectd]
   fedora: [collectd]
@@ -1049,7 +1046,6 @@ fltk:  # Consider using the libfltk-dev and fluid (fltk runtime) keys instead.
     bionic: [fluid, libfltk1.3-dev]
     focal: [fluid, libfltk1.3-dev]
     trusty: [fluid, libfltk1.1-dev]
-    wily: [fluid, libfltk1.3-dev]
     xenial: [fluid, libfltk1.3-dev]
 fluid:
   arch: [fltk]
@@ -1174,7 +1170,6 @@ gazebo:
     focal: [gazebo11]
     jammy: [gazebo]
     trusty: [gazebo2]
-    wily: [gazebo7]
     xenial: [gazebo7]
     yakkety: [gazebo7]
     zesty: [gazebo7]
@@ -1525,7 +1520,6 @@ gstreamer0.10-gconf:
     jessie: [gstreamer0.10-gconf]
   ubuntu:
     trusty: [gstreamer0.10-gconf]
-    wily: [gstreamer0.10-gconf]
     xenial: [gstreamer0.10-gconf]
 gstreamer0.10-plugins-good:
   arch: [gstreamer0.10-good-plugins]
@@ -1542,7 +1536,6 @@ gstreamer0.10-plugins-ugly:
   gentoo: ['media-libs/gst-plugins-ugly:0.10']
   ubuntu:
     trusty: [gstreamer0.10-plugins-ugly]
-    wily: [gstreamer0.10-plugins-ugly]
 gstreamer0.10-pocketsphinx:
   debian:
     jessie: [gstreamer0.10-pocketsphinx]
@@ -2221,7 +2214,6 @@ jasper:
       packages: [jasper]
   ubuntu:
     trusty: [libjasper-dev]
-    wily: [libjasper-dev]
     xenial: [libjasper-dev]
     yakkety: [libjasper-dev]
 java:
@@ -2448,7 +2440,6 @@ libbison-dev:
   rhel: [bison-devel]
   ubuntu:
     trusty: [libbison-dev]
-    wily: [libbison-dev]
     xenial: [libbison-dev]
 libblas-dev:
   arch: [cblas]
@@ -3228,7 +3219,6 @@ libfcl-dev:
     '7': null
   ubuntu:
     '*': [libfcl-dev]
-    wily: [libfcl-0.5-dev]
     xenial: [libfcl-0.5-dev]
 libffi-dev:
   debian: [libffi-dev]
@@ -3265,7 +3255,6 @@ libflann:
   ubuntu:
     '*': [libflann1.9]
     trusty: [libflann1.8]
-    wily: [libflann1.8]
     xenial: [libflann1.8]
 libflann-dev:
   arch: [flann]
@@ -3389,7 +3378,6 @@ libftdipp-dev:
   ubuntu:
     bionic: [libftdipp1-dev]
     trusty: [libftdipp-dev]
-    wily: [libftdipp-dev]
     xenial: [libftdipp1-dev]
 libftgl-dev:
   arch: [ftgl]
@@ -3600,7 +3588,6 @@ libgpgme-dev:
   ubuntu:
     '*': [libgpgme-dev]
     trusty: [libgpgme11-dev]
-    wily: [libgpgme11-dev]
     xenial: [libgpgme11-dev]
 libgphoto-dev:
   arch: [libgphoto2]
@@ -3646,7 +3633,6 @@ libgsl:
   ubuntu:
     '*': [libgsl-dev]
     trusty: [libgsl0-dev]
-    wily: [libgsl0-dev]
 libgstreamer-plugins-base0.10-0:
   arch: [gstreamer0.10-base-plugins]
   debian:
@@ -3908,7 +3894,6 @@ libjaxp1.3-java:
   debian: [libjaxp1.3-java]
   ubuntu:
     trusty: [libjaxp1.3-java]
-    wily: [libjaxp1.3-java]
     xenial: [libjaxp1.3-java]
 libjpeg:
   arch: [libjpeg-turbo]
@@ -4477,7 +4462,6 @@ libopenvdb:
     focal: [libopenvdb6.2]
     jammy: [libopenvdb8.1]
     trusty: [libopenvdb2.1]
-    wily: [libopenvdb3.0]
     xenial: [libopenvdb3.1]
     yakkety: [libopenvdb3.1]
     zesty: [libopenvdb3.2]
@@ -4958,7 +4942,6 @@ libpng-dev:
   ubuntu:
     '*': [libpng-dev]
     trusty: [libpng12-dev]
-    wily: [libpng12-dev]
     xenial: [libpng12-dev]
 libpng12-dev:
   arch: [libpng]
@@ -5019,7 +5002,6 @@ libpqxx:
     bionic: [libpqxx-4.0v5]
     focal: [libpqxx-6.4]
     trusty: [libpqxx-4.0]
-    wily: [libpqxx-4.0]
     xenial: [libpqxx-4.0]
     yakkety: [libpqxx-4.0v5]
     zesty: [libpqxx-4.0v5]
@@ -5091,7 +5073,6 @@ libqglviewer-qt4:
     artful: [libqglviewer2-qt4]
     bionic: [libqglviewer2-qt4]
     trusty: [libqglviewer2]
-    wily: [libqglviewer2-qt4]
     xenial: [libqglviewer2-qt4]
     yakkety: [libqglviewer2-qt4]
     zesty: [libqglviewer2-qt4]
@@ -5108,7 +5089,6 @@ libqglviewer-qt4-dev:
     artful: [libqglviewer-dev-qt4]
     bionic: [libqglviewer-dev-qt4]
     trusty: [libqglviewer-dev]
-    wily: [libqglviewer-dev-qt4]
     xenial: [libqglviewer-dev-qt4]
     yakkety: [libqglviewer-dev-qt4]
     zesty: [libqglviewer-dev-qt4]
@@ -5723,7 +5703,6 @@ libtool:
     focal: [libtool, libltdl-dev, libtool-bin]
     jammy: [libtool, libltdl-dev, libtool-bin]
     trusty: [libtool, libltdl-dev]
-    wily: [libtool, libltdl-dev, libtool-bin]
     xenial: [libtool, libltdl-dev, libtool-bin]
     yakkety: [libtool, libltdl-dev, libtool-bin]
     zesty: [libtool, libltdl-dev, libtool-bin]
@@ -5745,7 +5724,6 @@ libturbojpeg:
   ubuntu:
     '*': [libturbojpeg0-dev]
     trusty: [libturbojpeg, libjpeg-turbo8-dev]
-    wily: [libturbojpeg, libjpeg-turbo8-dev]
     xenial: [libturbojpeg, libjpeg-turbo8-dev]
     yakkety: [libturbojpeg, libjpeg-turbo8-dev]
     zesty: [libturbojpeg, libjpeg-turbo8-dev]
@@ -5868,7 +5846,6 @@ libuv-dev:
   ubuntu:
     bionic: [libuv0.10-dev]
     trusty: [libuv-dev]
-    wily: [libuv0.10-dev]
     xenial: [libuv0.10-dev]
     yakkety: [libuv0.10-dev]
     zesty: [libuv0.10-dev]
@@ -5916,7 +5893,6 @@ libvlc:
   ubuntu:
     '*': [libvlc5, vlc-bin]
     trusty: [libvlc5, vlc-nox]
-    wily: [libvlc5, vlc-nox]
     xenial: [libvlc5, vlc-nox]
     yakkety: [libvlc5, vlc-nox]
 libvlc-dev:
@@ -5957,7 +5933,6 @@ libvtk:
     artful: [libvtk6-dev]
     bionic: [libvtk6-dev]
     trusty: [libvtk5-dev]
-    wily: [libvtk5-dev]
     xenial: [libvtk6-dev]
     yakkety: [libvtk6-dev]
     zesty: [libvtk6-dev]
@@ -5978,7 +5953,6 @@ libvtk-java:
     artful: [libvtk6-java]
     bionic: [libvtk6-java]
     trusty: [libvtk-java]
-    wily: [libvtk-java]
     xenial: [libvtk-java]
     yakkety: [libvtk6-java]
     zesty: [libvtk6-java]
@@ -6000,7 +5974,6 @@ libvtk-qt:
     artful: [libvtk6-qt-dev]
     bionic: [libvtk6-qt-dev]
     trusty: [libvtk5-qt4-dev]
-    wily: [libvtk5-qt4-dev]
     xenial: [libvtk6-qt-dev]
     yakkety: [libvtk6-qt-dev]
     zesty: [libvtk6-qt-dev]
@@ -6403,7 +6376,6 @@ log4cxx:
   ubuntu:
     '*': [liblog4cxx-dev]
     trusty: [liblog4cxx10-dev]
-    wily: [liblog4cxx10-dev]
     xenial: [liblog4cxx10-dev]
     yakkety: [liblog4cxx10-dev]
     zesty: [liblog4cxx10-dev]
@@ -6539,7 +6511,6 @@ mkdocs:
         packages: [mkdocs]
       pip:
         packages: [mkdocs]
-    wily: [mkdocs]
     xenial: [mkdocs]
     yakkety: [mkdocs]
     zesty: [mkdocs]
@@ -6563,7 +6534,6 @@ mkdocs-bootstrap:
         packages: [mkdocs-bootstrap]
       pip:
         packages: [mkdocs-bootswatch]
-    wily:
       pip:
         packages: [mkdocs-bootswatch]
     xenial:
@@ -6591,7 +6561,6 @@ mkdocs-bootswatch:
         packages: [mkdocs-bootswatch]
       pip:
         packages: [mkdocs-bootswatch]
-    wily:
       pip:
         packages: [mkdocs-bootswatch]
     xenial:
@@ -7020,7 +6989,6 @@ php:
   nixos: [php]
   ubuntu:
     trusty: [php5]
-    wily: [php5]
     xenial: [php7.0]
     yakkety: [php7.0]
     zesty: [php7.0]
@@ -7064,7 +7032,6 @@ pocketsphinx-bin:
   nixos: [pocketsphinx]
   ubuntu:
     trusty: [libsphinxbase1]
-    wily: [libsphinxbase1]
     xenial: [pocketsphinx]
     yakkety: [pocketsphinx]
     zesty: [pocketsphinx]
@@ -7119,7 +7086,6 @@ postgresql-9.x-postgis:
   gentoo: [dev-db/postgis, =dev-db/postgresql-9*]
   ubuntu:
     trusty: [postgresql-9.3-postgis-2.1, postgresql-contrib-9.3, postgresql-server-dev-9.3]
-    wily: [postgresql-9.4-postgis-2.1, postgresql-contrib-9.4, postgresql-server-dev-9.4]
     xenial: [postgresql-9.5-postgis-2.2, postgresql-contrib-9.5, postgresql-server-dev-9.5]
 postgresql-client:
   debian: [postgresql-client]
@@ -7737,7 +7703,6 @@ speex:
   nixos: [speex]
   ubuntu:
     trusty: [speex]
-    wily: [speex]
     xenial: [speex]
 spirv-headers:
   arch: [spirv-headers]
@@ -7919,7 +7884,6 @@ tap-plugins:
   gentoo: [media-plugins/tap-plugins]
   ubuntu:
     trusty: [tap-plugins]
-    wily: [tap-plugins]
     xenial: [tap-plugins]
 tar:
   arch: [libtar]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -79,7 +79,6 @@ apache2:
   ubuntu: [apache2]
 apache2-mpm-prefork:
   debian:
-    jessie: [apache2-mpm-prefork]
     wheezy: [apache2-mpm-prefork]
   gentoo: ['www-servers/apache[apache2_mpms_prefork]']
   ubuntu: [apache2-mpm-prefork]
@@ -132,7 +131,6 @@ arduino-core:
 arista:
   arch: [arista-transcoder]
   debian:
-    jessie: [arista]
     wheezy: [arista]
   ubuntu: [arista]
 armadillo:
@@ -593,7 +591,6 @@ collada-dom:
   arch: [collada-dom]
   debian:
     buster: [libcollada-dom2.4-dp-dev]
-    jessie: [libcollada-dom2.4-dp-dev]
     stretch: [libcollada-dom2.4-dp-dev]
   fedora: [collada-dom-devel]
   freebsd: [collada-dom]
@@ -787,7 +784,6 @@ docker-compose:
 docker.io:
   debian:
     '*': [docker.io]
-    jessie: null
     stretch: null
     wheezy: null
   fedora: [docker]
@@ -865,7 +861,6 @@ eigen:
 eigen2:
   arch: [eigen2]
   debian:
-    jessie: [libeigen2-dev]
     wheezy: [libeigen2-dev]
   freebsd: [eigen2]
   gentoo: ['dev-cpp/eigen:2']
@@ -954,7 +949,6 @@ ffmpeg:
   arch: [ffmpeg]
   debian:
     '*': [ffmpeg, libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev]
-    jessie: [libav-tools, libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev]
   fedora: [ffmpeg-devel]
   freebsd: [ffmpeg]
   gentoo: [virtual/ffmpeg]
@@ -1141,7 +1135,6 @@ gazebo:
   arch: [gazebo]
   debian:
     buster: [gazebo11]
-    jessie: [gazebo7]
     stretch: [gazebo9]
   fedora: [gazebo]
   gentoo: [sci-electronics/gazebo]
@@ -1171,7 +1164,6 @@ gazebo7:
   arch: [gazebo]
   debian:
     buster: [gazebo7]
-    jessie: [gazebo7]
     stretch: [gazebo7]
   gentoo: [=sci-electronics/gazebo-7*]
   nixos: [gazebo_7]
@@ -1433,7 +1425,6 @@ gperftools:
 gpg-agent:
   debian:
     '*': [gpg-agent]
-    jessie: [gnupg-agent]
   ubuntu:
     '*': [gpg-agent]
 gphoto2:
@@ -1457,7 +1448,6 @@ gradle:
   arch: [gradle]
   debian:
     buster: [gradle]
-    jessie: [gradle]
     stretch: [gradle]
   gentoo: [dev-java/gradle-bin]
   nixos: [gradle]
@@ -1498,25 +1488,21 @@ gringo:
   ubuntu: [gringo]
 gstreamer0.10-gconf:
   debian:
-    jessie: [gstreamer0.10-gconf]
   ubuntu:
 gstreamer0.10-plugins-good:
   arch: [gstreamer0.10-good-plugins]
   debian:
-    jessie: [gstreamer0.10-plugins-good]
     wheezy: [gstreamer0.10-plugins-good]
   gentoo: ['media-libs/gst-plugins-good:0.10']
   ubuntu: [gstreamer0.10-plugins-good]
 gstreamer0.10-plugins-ugly:
   arch: [gstreamer0.10-ugly-plugins]
   debian:
-    jessie: [gstreamer0.10-plugins-ugly]
     wheezy: [gstreamer0.10-plugins-ugly]
   gentoo: ['media-libs/gst-plugins-ugly:0.10']
   ubuntu:
 gstreamer0.10-pocketsphinx:
   debian:
-    jessie: [gstreamer0.10-pocketsphinx]
   fedora: [pocketsphinx-plugin]
   gentoo: [app-accessibility/pocketsphinx]
   ubuntu: [gstreamer0.10-pocketsphinx]
@@ -2174,7 +2160,6 @@ jack:
 jasper:
   arch: [jasper]
   debian:
-    jessie: [libjasper-dev]
     wheezy: [libjasper-dev]
   fedora: [jasper-devel]
   freebsd: [jasper]
@@ -2192,7 +2177,6 @@ java:
   arch: [jdk7-openjdk]
   debian:
     '*': [default-jdk]
-    jessie: [openjdk-7-jdk]
     wheezy: [openjdk-7-jdk]
   fedora: [java]
   freebsd: [openjdk6]
@@ -2935,7 +2919,6 @@ libcoin60-dev:
 libcoin80-dev:
   debian:
     '*': [libcoin-dev]
-    jessie: [libcoin80-dev]
     stretch: [libcoin80-dev]
   fedora: [Coin2-devel]
   ubuntu:
@@ -3121,7 +3104,6 @@ libespeak-ng1:
 libestools-dev:
   debian:
     buster: [libestools-dev]
-    jessie: [libestools2.1-dev]
     stretch: [libestools-dev]
     wheezy: [libestools2.1-dev]
   fedora: [speech-tools-libs-devel]
@@ -3192,7 +3174,6 @@ libflann:
   arch: [flann]
   debian:
     '*': [libflann1.9]
-    jessie: [libflann1.8]
     wheezy: [libflann1.7]
   fedora: [flann]
   gentoo: [sci-libs/flann]
@@ -3216,7 +3197,6 @@ libfltk-dev:
   arch: [fltk]
   debian:
     buster: [libfltk1.3-dev]
-    jessie: [libfltk1.1-dev]
     stretch: [libfltk1.3-dev]
     wheezy: [libfltk1.1-dev]
   fedora: [fltk-devel]
@@ -3315,7 +3295,6 @@ libftdi1-dev:
 libftdipp-dev:
   debian:
     buster: [libftdipp1-dev]
-    jessie: [libftdipp-dev]
     stretch: [libftdipp1-dev]
     wheezy: [libftdipp-dev]
   fedora: [libftdi-c++-devel]
@@ -3354,7 +3333,6 @@ libgazebo7-dev:
   arch: [gazebo]
   debian:
     buster: [libgazebo7-dev]
-    jessie: [libgazebo7-dev]
     stretch: [libgazebo7-dev]
   gentoo: [=sci-electronics/gazebo-7*]
   nixos: [gazebo_7]
@@ -3563,7 +3541,6 @@ libgsl:
   arch: [gsl]
   debian:
     buster: [libgsl-dev]
-    jessie: [libgsl0-dev]
     stretch: [libgsl-dev]
     wheezy: [libgsl0-dev]
   fedora: [gsl-devel]
@@ -3576,14 +3553,12 @@ libgsl:
 libgstreamer-plugins-base0.10-0:
   arch: [gstreamer0.10-base-plugins]
   debian:
-    jessie: [libgstreamer-plugins-base0.10-0]
     wheezy: [libgstreamer-plugins-base0.10-0]
   gentoo: ['media-libs/gst-plugins-base:0.10']
   ubuntu: [libgstreamer-plugins-base0.10-0]
 libgstreamer-plugins-base0.10-dev:
   arch: [gstreamer0.10-base-plugins]
   debian:
-    jessie: [libgstreamer-plugins-base0.10-dev]
     wheezy: [libgstreamer-plugins-base0.10-dev]
   gentoo: ['media-libs/gst-plugins-base:0.10']
   ubuntu: [libgstreamer-plugins-base0.10-dev]
@@ -3600,14 +3575,12 @@ libgstreamer-plugins-base1.0-dev:
 libgstreamer0.10-0:
   arch: [gstreamer0.10]
   debian:
-    jessie: [libgstreamer0.10-0]
     wheezy: [libgstreamer0.10-0]
   gentoo: ['media-libs/gstreamer:0.10']
   ubuntu: [libgstreamer0.10-0]
 libgstreamer0.10-dev:
   arch: [gstreamer0.10]
   debian:
-    jessie: [libgstreamer0.10-dev]
     wheezy: [libgstreamer0.10-dev]
   gentoo: ['media-libs/gstreamer:0.10']
   ubuntu: [libgstreamer0.10-dev]
@@ -4212,7 +4185,6 @@ libogre:
   arch: [ogre-1.9]
   debian:
     buster: [libogre-1.9.0v5]
-    jessie: [libogre-1.9.0]
     stretch: [libogre-1.9.0v5]
     wheezy: [libogre-dev]
   fedora: [ogre-devel]
@@ -4234,7 +4206,6 @@ libogre-dev:
   arch: [ogre-1.9]
   debian:
     buster: [libogre-1.9-dev]
-    jessie: [libogre-1.9-dev]
     stretch: [libogre-1.9-dev]
     wheezy: [libogre-dev]
   fedora: [ogre-devel]
@@ -4379,7 +4350,6 @@ libopenvdb:
   debian:
     bullseye: [libopenvdb7.1]
     buster: [libopenvdb5.2]
-    jessie: [libopenvdb2.3]
     stretch: [libopenvdb3.2]
   fedora: [openvdb]
   gentoo: [media-gfx/openvdb]
@@ -4913,7 +4883,6 @@ libpq-dev:
 libpqxx:
   debian:
     buster: [libpqxx-6.2]
-    jessie: [libpqxx-4.0]
     stretch: [libpqxx-4.0v5]
     wheezy: [libpqxx-3.1]
   fedora: [libpqxx]
@@ -4957,7 +4926,6 @@ libpulse-dev:
 libqcustomplot-dev:
   debian:
     buster: [libqcustomplot-dev]
-    jessie: [libqcustomplot-dev]
     stretch: [libqcustomplot-dev]
   fedora: [qcustomplot-devel]
   gentoo: [dev-libs/qcustomplot]
@@ -4981,7 +4949,6 @@ libqglviewer-qt4:
   arch: [libqglviewer-qt4]
   debian:
     buster: [libqglviewer2-qt4]
-    jessie: [libqglviewer2]
     stretch: [libqglviewer2-qt4]
     wheezy: [libqglviewer-qt4-2]
   fedora: [libQGLViewer]
@@ -4994,7 +4961,6 @@ libqglviewer-qt4-dev:
   arch: [libqglviewer-qt4]
   debian:
     buster: [libqglviewer-dev-qt4]
-    jessie: [libqglviewer-dev]
     stretch: [libqglviewer-dev-qt4]
     wheezy: [libqglviewer-qt4-dev]
   fedora: [libQGLViewer-devel]
@@ -5204,7 +5170,6 @@ libqt5-sql:
   arch: [qt5-base]
   debian:
     buster: [libqt5sql5]
-    jessie: [libqt5sql5]
     stretch: [libqt5sql5]
   fedora: [qt5-qtbase]
   freebsd: [qt5-sql]
@@ -5424,7 +5389,6 @@ libspatialite:
   arch: [libspatialite]
   debian:
     '*': [libsqlite3-mod-spatialite]
-    jessie: [libspatialite5]
   fedora: [libspatialite]
   gentoo: ['dev-db/spatialite:0']
   nixos: [libspatialite]
@@ -5590,7 +5554,6 @@ libtool:
   arch: [libtool]
   debian:
     buster: [libtool, libltdl-dev, libtool-bin]
-    jessie: [libtool, libltdl-dev, libtool-bin]
     lenny: [libtool, libltdl3-dev]
     squeeze: [libtool, libltdl-dev]
     stretch: [libtool, libltdl-dev, libtool-bin]
@@ -5616,8 +5579,7 @@ libturbojpeg:
   arch: [libjpeg-turbo]
   debian:
     '*': [libturbojpeg0-dev]
-    jessie: [libturbojpeg1-dev]
-  fedora: [libjpeg-turbo-devel, turbojpeg-devel]
+  fedora: [turbojpeg-devel]
   freebsd: [libjpeg-turbo]
   gentoo: [media-libs/libjpeg-turbo]
   nixos: [libjpeg_turbo]
@@ -5655,7 +5617,6 @@ libunwind:
 libunwind-dev:
   debian:
     buster: [libunwind8-dev]
-    jessie: [libunwind8-dev]
     stretch: [libunwind8-dev]
     wheezy: [libunwind7-dev]
   fedora: [libunwind-devel]
@@ -5740,14 +5701,12 @@ libusb-dev:
   ubuntu: [libusb-dev]
 libuv-dev:
   debian:
-    jessie: [libuv0.10-dev]
   ubuntu:
     bionic: [libuv0.10-dev]
 libuv1-dev:
   arch: [libuv]
   debian:
     '*': [libuv1-dev]
-    jessie: null
   fedora: [libuv-devel]
   gentoo: [dev-libs/libuv]
   nixos: [libuv]
@@ -5777,7 +5736,6 @@ libv4l-dev:
 libvlc:
   debian:
     '*': [libvlc5, vlc-bin]
-    jessie: [libvlc5, vlc-nox]
   fedora: [vlc-core]
   gentoo: [media-video/vlc]
   nixos: [vlc]
@@ -5809,7 +5767,6 @@ libvtk:
   arch: [vtk]
   debian:
     buster: [libvtk7-dev]
-    jessie: [libvtk5-dev]
     stretch: [libvtk6-dev]
     wheezy: [libvtk5-dev]
   fedora: [vtk-devel]
@@ -5826,7 +5783,6 @@ libvtk-java:
   arch: [vtk]
   debian:
     buster: [libvtk7-java]
-    jessie: [libvtk-java]
     stretch: [libvtk6-java]
     wheezy: [libvtk-java]
   fedora: [vtk-java]
@@ -5842,7 +5798,6 @@ libvtk-qt:
   arch: [vtk]
   debian:
     buster: [libvtk7-qt-dev]
-    jessie: [libvtk5-qt4-dev]
     stretch: [libvtk6-qt-dev]
     wheezy: [libvtk5-qt4-dev]
   fedora: [vtk-qt]
@@ -5947,7 +5902,6 @@ libxcursor-dev:
   ubuntu: [libxcursor-dev]
 libxenomai-dev:
   debian:
-    jessie: [libxenomai-dev]
     wheezy: [libxenomai-dev]
   ubuntu: [libxenomai-dev]
 libxext:
@@ -6162,7 +6116,6 @@ linphone:
 linux-headers-generic:
   arch: [linux-headers]
   debian:
-    jessie: [linux-headers-3.16.0-4-all]
     stretch: [linux-headers-4.9.0-11-all]
     wheezy: [linux-headers-3.2.0-4-all]
   fedora: [kernel-headers, kernel-devel]
@@ -6236,7 +6189,6 @@ log4cxx:
   debian:
     bullseye: [liblog4cxx-dev]
     buster: [liblog4cxx-dev]
-    jessie: [liblog4cxx10-dev]
     squeeze: [liblog4cxx10-dev]
     stretch: [liblog4cxx-dev]
     wheezy: [liblog4cxx10-dev]
@@ -6365,7 +6317,6 @@ meshlab:
 mkdocs:
   debian:
     buster: [mkdocs]
-    jessie:
       pip:
         packages: [mkdocs]
     stretch: [mkdocs]
@@ -6385,7 +6336,6 @@ mkdocs:
 mkdocs-bootstrap:
   debian:
     buster: [mkdocs-bootstrap]
-    jessie:
       pip:
         packages: [mkdocs-bootstrap]
     stretch: [mkdocs-bootstrap]
@@ -6408,7 +6358,6 @@ mkdocs-bootstrap:
 mkdocs-bootswatch:
   debian:
     buster: [mkdocs-bootswatch]
-    jessie:
       pip:
         packages: [mkdocs-bootswatch]
     stretch: [mkdocs-bootswatch]
@@ -6604,7 +6553,6 @@ nlohmann-json-dev:
   debian:
     bullseye: [nlohmann-json3-dev]
     buster: [nlohmann-json3-dev]
-    jessie: null
     sid: [nlohmann-json3-dev]
     stretch: [nlohmann-json-dev]
   fedora: [json-devel]
@@ -6839,7 +6787,6 @@ php:
   arch: [php]
   debian:
     buster: [php7.1]
-    jessie: [php5]
     stretch: [php7.0]
   fedora: [php]
   gentoo: [dev-lang/php]
@@ -6878,7 +6825,6 @@ pmount:
 pocketsphinx-bin:
   debian:
     buster: [pocketsphinx]
-    jessie: [pocketsphinx]
     stretch: [pocketsphinx]
   fedora: [pocketsphinx]
   gentoo: [app-accessibility/pocketsphinx]
@@ -6887,7 +6833,6 @@ pocketsphinx-bin:
 polyclipping-dev:
   debian:
     buster: [libpolyclipping-dev]
-    jessie: [libpolyclipping-dev]
     stretch: [libpolyclipping-dev]
   fedora: [polyclipping-devel]
   ubuntu: [libpolyclipping-dev]
@@ -6928,7 +6873,6 @@ postgresql:
 postgresql-9.x-postgis:
   debian:
     buster: [postgresql-9.6-postgis-2.3, postgresql-contrib, postgresql-server-dev-all]
-    jessie: [postgresql-9.4-postgis-2.1, postgresql-contrib, postgresql-server-dev-all]
     stretch: [postgresql-9.6-postgis-2.3, postgresql-contrib, postgresql-server-dev-all]
     wheezy: [postgresql-9.4-postgis-2.1, postgresql-contrib, postgresql-server-dev-all]
   fedora: [postgis]
@@ -6942,7 +6886,6 @@ postgresql-client:
 postgresql-postgis:
   debian:
     buster: [postgresql-11-postgis-2.5, postgresql-contrib, postgresql-server-dev-all]
-    jessie: [postgresql-9.4-postgis-2.1, postgresql-contrib, postgresql-server-dev-all]
     stretch: [postgresql-9.6-postgis-2.3, postgresql-contrib, postgresql-server-dev-all]
   fedora: [postgis]
   gentoo: [dev-db/postgis, =dev-db/postgresql-9*]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -11,7 +11,6 @@ ack:
   rhel: [ack]
   ubuntu:
     '*': [ack]
-    xenial: null
 ack-grep:
   arch: [ack]
   debian: [ack-grep]
@@ -40,7 +39,6 @@ acpitool:
   gentoo: [sys-power/acpitool]
   nixos: [acpitool]
   ubuntu:
-    xenial: [acpitool]
 alsa-oss:
   arch: [alsa-oss]
   debian: [alsa-oss]
@@ -118,7 +116,6 @@ aravis:
     '*': [libaravis-0.8-0, aravis-tools]
     bionic: null
     focal: [libaravis-0.6-0, aravis-tools]
-    xenial: null
 aravis-dev:
   debian: [libaravis-dev]
   gentoo: [media-video/aravis]
@@ -126,7 +123,6 @@ aravis-dev:
   ubuntu:
     '*': [libaravis-dev]
     bionic: null
-    xenial: null
 arduino-core:
   arch: [arduino]
   debian: [arduino-core]
@@ -314,7 +310,6 @@ benchmark:
   rhel: [google-benchmark-devel]
   ubuntu:
     '*': [libbenchmark-dev]
-    xenial: null
 binutils:
   arch: [binutils]
   debian: [binutils-dev]
@@ -356,7 +351,6 @@ bluez-hcidump:
   fedora: [bluez-hcidump]
   gentoo: [net-wireless/bluez-hcidump]
   ubuntu:
-    xenial: [bluez-hcidump]
 boost:
   alpine: [boost-dev]
   arch: [boost]
@@ -896,7 +890,6 @@ embree:
   ubuntu:
     '*': [libembree-dev]
     bionic: null
-    xenial: null
 enblend:
   debian: [enblend]
   fedora: [enblend]
@@ -1040,7 +1033,6 @@ fltk:  # Consider using the libfltk-dev and fluid (fltk runtime) keys instead.
     artful: [fluid, libfltk1.3-dev]
     bionic: [fluid, libfltk1.3-dev]
     focal: [fluid, libfltk1.3-dev]
-    xenial: [fluid, libfltk1.3-dev]
 fluid:
   arch: [fltk]
   debian: [libfltk1.1-dev]
@@ -1163,7 +1155,6 @@ gazebo:
     eoan: [gazebo9]
     focal: [gazebo11]
     jammy: [gazebo]
-    xenial: [gazebo7]
 gazebo11:
   debian:
     buster: [gazebo11]
@@ -1445,7 +1436,6 @@ gpg-agent:
     jessie: [gnupg-agent]
   ubuntu:
     '*': [gpg-agent]
-    xenial: [gnupg-agent]
 gphoto2:
   arch: [gphoto2]
   debian: [gphoto2]
@@ -1510,7 +1500,6 @@ gstreamer0.10-gconf:
   debian:
     jessie: [gstreamer0.10-gconf]
   ubuntu:
-    xenial: [gstreamer0.10-gconf]
 gstreamer0.10-plugins-good:
   arch: [gstreamer0.10-good-plugins]
   debian:
@@ -1558,7 +1547,6 @@ gstreamer1.0-gl:
   rhel: [gstreamer1-plugins-base]
   ubuntu:
     '*': [gstreamer1.0-gl]
-    xenial: null
 gstreamer1.0-libav:
   arch: [gst-libav]
   debian: [gstreamer1.0-libav]
@@ -1678,18 +1666,15 @@ gurumdds-2.6:
   ubuntu:
     bionic: [gurumdds-2.6]
     focal: [gurumdds-2.6]
-    xenial: [gurumdds-2.6]
 gurumdds-2.7:
   ubuntu:
     bionic: [gurumdds-2.7]
     focal: [gurumdds-2.7]
-    xenial: [gurumdds-2.7]
 gurumdds-2.8:
   ubuntu:
     bionic: [gurumdds-2.8]
     focal: [gurumdds-2.8]
     jammy: [gurumdds-2.8]
-    xenial: [gurumdds-2.8]
 gv:
   arch: [gv]
   debian: [gv]
@@ -2202,7 +2187,6 @@ jasper:
     slackpkg:
       packages: [jasper]
   ubuntu:
-    xenial: [libjasper-dev]
 java:
   alpine: [openjdk8-jre]
   arch: [jdk7-openjdk]
@@ -2385,7 +2369,6 @@ libav:
   nixos: [libav]
   ubuntu:
     '*': null
-    xenial: [libav-tools]
 libavahi-client-dev:
   arch: [avahi]
   debian: [libavahi-client-dev]
@@ -2418,7 +2401,6 @@ libbackward-cpp-dev:
   ubuntu:
     '*': [libbackward-cpp-dev]
     bionic: null
-    xenial: null
 libbison-dev:
   debian: [libbison-dev]
   fedora: [bison-devel]
@@ -2426,7 +2408,6 @@ libbison-dev:
   nixos: [bison]
   rhel: [bison-devel]
   ubuntu:
-    xenial: [libbison-dev]
 libblas-dev:
   arch: [cblas]
   debian: [libblas-dev]
@@ -2467,7 +2448,6 @@ libboost-atomic:
     eoan: [libboost-atomic1.67.0]
     focal: [libboost-atomic1.71.0]
     jammy: [libboost-atomic1.74.0]
-    xenial: [libboost-atomic1.58.0]
 libboost-atomic-dev:
   debian: [libboost-atomic-dev]
   fedora: [boost-devel]
@@ -2492,7 +2472,6 @@ libboost-chrono:
     eoan: [libboost-chrono1.67.0]
     focal: [libboost-chrono1.71.0]
     jammy: [libboost-chrono1.74.0]
-    xenial: [libboost-chrono1.58.0]
 libboost-chrono-dev:
   debian: [libboost-chrono-dev]
   fedora: [boost-devel]
@@ -2520,7 +2499,6 @@ libboost-coroutine:
     eoan: [libboost-coroutine1.67.0]
     focal: [libboost-coroutine1.71.0]
     jammy: [libboost-coroutine1.74.0]
-    xenial: [libboost-coroutine1.58.0]
 libboost-coroutine-dev:
   alpine: [boost-dev]
   debian: [libboost-coroutine-dev]
@@ -2546,7 +2524,6 @@ libboost-date-time:
     eoan: [libboost-date-time1.67.0]
     focal: [libboost-date-time1.71.0]
     jammy: [libboost-date-time1.74.0]
-    xenial: [libboost-date-time1.58.0]
 libboost-date-time-dev:
   debian: [libboost-date-time-dev]
   fedora: [boost-devel]
@@ -2580,7 +2557,6 @@ libboost-filesystem:
     eoan: [libboost-filesystem1.67.0]
     focal: [libboost-filesystem1.71.0]
     jammy: [libboost-filesystem1.74.0]
-    xenial: [libboost-filesystem1.58.0]
 libboost-filesystem-dev:
   debian: [libboost-filesystem-dev]
   fedora: [boost-devel]
@@ -2605,7 +2581,6 @@ libboost-iostreams:
     eoan: [libboost-iostreams1.67.0]
     focal: [libboost-iostreams1.71.0]
     jammy: [libboost-iostreams1.74.0]
-    xenial: [libboost-iostreams1.58.0]
 libboost-iostreams-dev:
   debian: [libboost-iostreams-dev]
   fedora: [boost-devel]
@@ -2629,7 +2604,6 @@ libboost-math:
     eoan: [libboost-math1.67.0]
     focal: [libboost-math1.71.0]
     jammy: [libboost-math1.74.0]
-    xenial: [libboost-math1.58.0]
 libboost-math-dev:
   debian: [libboost-math-dev]
   fedora: [boost-devel]
@@ -2662,7 +2636,6 @@ libboost-program-options:
     eoan: [libboost-program-options1.67.0]
     focal: [libboost-program-options1.71.0]
     jammy: [libboost-program-options1.74.0]
-    xenial: [libboost-program-options1.58.0]
 libboost-program-options-dev:
   debian: [libboost-program-options-dev]
   fedora: [boost-devel]
@@ -2691,7 +2664,6 @@ libboost-python:
     eoan: [libboost-python1.67.0]
     focal: [libboost-python1.71.0]
     jammy: [libboost-python1.74.0]
-    xenial: [libboost-python1.58.0]
 libboost-python-dev:
   alpine: [boost-python2]
   debian: [libboost-python-dev]
@@ -2720,7 +2692,6 @@ libboost-random:
     eoan: [libboost-random1.67.0]
     focal: [libboost-random1.71.0]
     jammy: [libboost-random1.74.0]
-    xenial: [libboost-random1.58.0]
 libboost-random-dev:
   debian: [libboost-random-dev]
   fedora: [boost-devel]
@@ -2745,7 +2716,6 @@ libboost-regex:
     eoan: [libboost-regex1.67.0]
     focal: [libboost-regex1.71.0]
     jammy: [libboost-regex1.74.0]
-    xenial: [libboost-regex1.58.0]
 libboost-regex-dev:
   debian: [libboost-regex-dev]
   fedora: [boost-devel]
@@ -2770,7 +2740,6 @@ libboost-serialization:
     eoan: [libboost-serialization1.67.0]
     focal: [libboost-serialization1.71.0]
     jammy: [libboost-serialization1.74.0]
-    xenial: [libboost-serialization1.58.0]
 libboost-serialization-dev:
   debian: [libboost-serialization-dev]
   fedora: [boost-devel]
@@ -2796,7 +2765,6 @@ libboost-system:
     eoan: [libboost-system1.67.0]
     focal: [libboost-system1.71.0]
     jammy: [libboost-system1.74.0]
-    xenial: [libboost-system1.58.0]
 libboost-system-dev:
   debian: [libboost-system-dev]
   fedora: [boost-devel]
@@ -2822,7 +2790,6 @@ libboost-thread:
     eoan: [libboost-thread1.67.0]
     focal: [libboost-thread1.71.0]
     jammy: [libboost-thread1.74.0]
-    xenial: [libboost-thread1.58.0]
 libboost-thread-dev:
   debian: [libboost-thread-dev]
   fedora: [boost-devel]
@@ -2846,7 +2813,6 @@ libboost-timer:
     eoan: [libboost-timer1.67.0]
     focal: [libboost-timer1.71.0]
     jammy: [libboost-timer1.74.0]
-    xenial: [libboost-timer1.58.0]
 libboost-timer-dev:
   debian: [libboost-timer-dev]
   fedora: [boost-devel]
@@ -2975,7 +2941,6 @@ libcoin80-dev:
   ubuntu:
     '*': [libcoin-dev]
     bionic: [libcoin80-dev]
-    xenial: [libcoin80-dev]
 libconfig++-dev:
   debian: [libconfig++-dev]
   fedora: [libconfig-devel]
@@ -3203,7 +3168,6 @@ libfcl-dev:
     '7': null
   ubuntu:
     '*': [libfcl-dev]
-    xenial: [libfcl-0.5-dev]
 libffi-dev:
   debian: [libffi-dev]
   fedora: [libffi-devel]
@@ -3238,7 +3202,6 @@ libflann:
   rhel: [flann]
   ubuntu:
     '*': [libflann1.9]
-    xenial: [libflann1.8]
 libflann-dev:
   arch: [flann]
   debian: [libflann-dev]
@@ -3360,7 +3323,6 @@ libftdipp-dev:
   openembedded: [libftdi@meta-oe]
   ubuntu:
     bionic: [libftdipp1-dev]
-    xenial: [libftdipp1-dev]
 libftgl-dev:
   arch: [ftgl]
   debian: [libftgl-dev]
@@ -3568,7 +3530,6 @@ libgpgme-dev:
   rhel: [gpgme-devel]
   ubuntu:
     '*': [libgpgme-dev]
-    xenial: [libgpgme11-dev]
 libgphoto-dev:
   arch: [libgphoto2]
   debian: [libgphoto2-dev]
@@ -3872,7 +3833,6 @@ libjansson-dev:
 libjaxp1.3-java:
   debian: [libjaxp1.3-java]
   ubuntu:
-    xenial: [libjaxp1.3-java]
 libjpeg:
   arch: [libjpeg-turbo]
   debian: [libjpeg-dev]
@@ -3917,7 +3877,6 @@ libjsoncpp:
     '*': [libjsoncpp25]
     bionic: [libjsoncpp1]
     focal: [libjsoncpp1]
-    xenial: [libjsoncpp1]
 libjsoncpp-dev:
   arch: [jsoncpp]
   debian: [libjsoncpp-dev]
@@ -3977,12 +3936,10 @@ liblcm:
   debian: [liblcm1]
   ubuntu:
     '*': [liblcm1]
-    xenial: null
 liblcm-dev:
   debian: [liblcm-dev]
   ubuntu:
     '*': [liblcm-dev]
-    xenial: null
 libleptonica-dev:
   arch: [leptonica]
   debian: [libleptonica-dev]
@@ -4214,7 +4171,6 @@ libnlopt-cxx-dev:
   ubuntu:
     '*': [libnlopt-cxx-dev]
     bionic: null
-    xenial: null
 libnlopt-dev:
   debian: [libnlopt-dev]
   fedora: [NLopt-devel]
@@ -4413,13 +4369,11 @@ libopensplice67:
   gentoo: [=sci-libs/opensplice-6.7.*]
   ubuntu:
     bionic: [libopensplice67]
-    xenial: [libopensplice67]
 libopensplice69:
   gentoo: [=sci-libs/opensplice-6.9.*]
   nixos: [opensplice_6_9]
   ubuntu:
     bionic: [libopensplice69]
-    xenial: [libopensplice69]
 libopenvdb:
   arch: [openvdb]
   debian:
@@ -4438,7 +4392,6 @@ libopenvdb:
     bionic: [libopenvdb5.0]
     focal: [libopenvdb6.2]
     jammy: [libopenvdb8.1]
-    xenial: [libopenvdb3.1]
 libopenvdb-dev:
   arch: [openvdb]
   debian: [libopenvdb-dev, libilmbase-dev]
@@ -4457,7 +4410,6 @@ liborocos-bfl:
   ubuntu:
     '*': [liborocos-bfl0.8]
     bionic: null
-    xenial: null
 liborocos-bfl-dev:
   debian: [liborocos-bfl-dev]
   fedora: [orocos-bfl-devel]
@@ -4478,7 +4430,6 @@ liborocos-kdl:
     bionic: [liborocos-kdl1.3]
     focal: [liborocos-kdl1.4]
     impish: [liborocos-kdl1.4]
-    xenial: [liborocos-kdl1.3]
 liborocos-kdl-dev:
   debian: [liborocos-kdl-dev]
   fedora: [orocos-kdl-devel]
@@ -4525,7 +4476,6 @@ libpcl-all:
     bionic: [libpcl-apps1.8, libpcl-common1.8, libpcl-features1.8, libpcl-filters1.8, libpcl-io1.8, libpcl-kdtree1.8, libpcl-keypoints1.8, libpcl-ml1.8, libpcl-octree1.8, libpcl-outofcore1.8, libpcl-people1.8, libpcl-recognition1.8, libpcl-registration1.8, libpcl-sample-consensus1.8, libpcl-search1.8, libpcl-segmentation1.8, libpcl-stereo1.8, libpcl-surface1.8, libpcl-tracking1.8, libpcl-visualization1.8]
     focal: [libpcl-apps1.10, libpcl-common1.10, libpcl-features1.10, libpcl-filters1.10, libpcl-io1.10, libpcl-kdtree1.10, libpcl-keypoints1.10, libpcl-ml1.10, libpcl-octree1.10, libpcl-outofcore1.10, libpcl-people1.10, libpcl-recognition1.10, libpcl-registration1.10, libpcl-sample-consensus1.10, libpcl-search1.10, libpcl-segmentation1.10, libpcl-stereo1.10, libpcl-surface1.10, libpcl-tracking1.10, libpcl-visualization1.10]
     jammy: [libpcl-apps1.12, libpcl-common1.12, libpcl-features1.12, libpcl-filters1.12, libpcl-io1.12, libpcl-kdtree1.12, libpcl-keypoints1.12, libpcl-ml1.12, libpcl-octree1.12, libpcl-outofcore1.12, libpcl-people1.12, libpcl-recognition1.12, libpcl-registration1.12, libpcl-sample-consensus1.12, libpcl-search1.12, libpcl-segmentation1.12, libpcl-stereo1.12, libpcl-surface1.12, libpcl-tracking1.12, libpcl-visualization1.12]
-    xenial: [libpcl1.7]
 libpcl-all-dev:
   arch: [pcl]
   debian: [libpcl-dev]
@@ -4915,7 +4865,6 @@ libpng-dev:
   slackware: [libpng]
   ubuntu:
     '*': [libpng-dev]
-    xenial: [libpng12-dev]
 libpng12-dev:
   arch: [libpng]
   debian: [libpng12-dev]
@@ -4974,7 +4923,6 @@ libpqxx:
     artful: [libpqxx-4.0v5]
     bionic: [libpqxx-4.0v5]
     focal: [libpqxx-6.4]
-    xenial: [libpqxx-4.0]
 libpqxx-dev:
   debian: [libpqxx-dev]
   fedora: [libpqxx-devel]
@@ -5042,7 +4990,6 @@ libqglviewer-qt4:
   ubuntu:
     artful: [libqglviewer2-qt4]
     bionic: [libqglviewer2-qt4]
-    xenial: [libqglviewer2-qt4]
 libqglviewer-qt4-dev:
   arch: [libqglviewer-qt4]
   debian:
@@ -5055,7 +5002,6 @@ libqglviewer-qt4-dev:
   ubuntu:
     artful: [libqglviewer-dev-qt4]
     bionic: [libqglviewer-dev-qt4]
-    xenial: [libqglviewer-dev-qt4]
 libqglviewer2-qt5:
   debian: [libqglviewer2-qt5]
   fedora: [libQGLViewer-qt5]
@@ -5663,7 +5609,6 @@ libtool:
     bionic: [libtool, libltdl-dev, libtool-bin]
     focal: [libtool, libltdl-dev, libtool-bin]
     jammy: [libtool, libltdl-dev, libtool-bin]
-    xenial: [libtool, libltdl-dev, libtool-bin]
 libttspico:
   debian: [libttspico-dev, libttspico-data, libttspico-utils, libttspico0]
   ubuntu: [libttspico-dev, libttspico-data, libttspico-utils, libttspico0]
@@ -5681,7 +5626,6 @@ libturbojpeg:
   rhel: [libjpeg-turbo-devel, turbojpeg-devel]
   ubuntu:
     '*': [libturbojpeg0-dev]
-    xenial: [libturbojpeg, libjpeg-turbo8-dev]
 libudev-dev:
   arch: [systemd]
   debian: [libudev-dev]
@@ -5799,7 +5743,6 @@ libuv-dev:
     jessie: [libuv0.10-dev]
   ubuntu:
     bionic: [libuv0.10-dev]
-    xenial: [libuv0.10-dev]
 libuv1-dev:
   arch: [libuv]
   debian:
@@ -5817,7 +5760,6 @@ libuvc-dev:
   nixos: [libuvc]
   ubuntu:
     '*': [libuvc-dev]
-    xenial: null
 libv4l-dev:
   arch: [v4l-utils]
   debian: [libv4l-dev]
@@ -5843,7 +5785,6 @@ libvlc:
   opensuse: [libvlc5, vlc-noX]
   ubuntu:
     '*': [libvlc5, vlc-bin]
-    xenial: [libvlc5, vlc-nox]
 libvlc-dev:
   debian: [libvlc-dev]
   fedora: [vlc-devel]
@@ -5881,7 +5822,6 @@ libvtk:
     '*': [libvtk7-dev]
     artful: [libvtk6-dev]
     bionic: [libvtk6-dev]
-    xenial: [libvtk6-dev]
 libvtk-java:
   arch: [vtk]
   debian:
@@ -5898,7 +5838,6 @@ libvtk-java:
     '*': [libvtk7-java]
     artful: [libvtk6-java]
     bionic: [libvtk6-java]
-    xenial: [libvtk-java]
 libvtk-qt:
   arch: [vtk]
   debian:
@@ -5916,7 +5855,6 @@ libvtk-qt:
     '*': [libvtk7-qt-dev]
     artful: [libvtk6-qt-dev]
     bionic: [libvtk6-qt-dev]
-    xenial: [libvtk6-qt-dev]
 libvtk9-dev:
   debian: [libvtk9-dev]
   ubuntu:
@@ -6200,7 +6138,6 @@ libzstd-dev:
   rhel: [libzstd-devel]
   ubuntu:
     '*': [libzstd-dev]
-    xenial: [libzstd1-dev]
 light-locker:
   debian: [light-locker]
   fedora: [light-locker]
@@ -6314,7 +6251,6 @@ log4cxx:
   slackware: [apache-log4cxx]
   ubuntu:
     '*': [liblog4cxx-dev]
-    xenial: [liblog4cxx10-dev]
 lttng-modules:
   arch: [lttng-modules]
   debian: [lttng-modules-dkms]
@@ -6446,7 +6382,6 @@ mkdocs:
         packages: [mkdocs]
       pip:
         packages: [mkdocs]
-    xenial: [mkdocs]
 mkdocs-bootstrap:
   debian:
     buster: [mkdocs-bootstrap]
@@ -6468,7 +6403,6 @@ mkdocs-bootstrap:
         packages: [mkdocs-bootswatch]
       pip:
         packages: [mkdocs-bootswatch]
-    xenial:
       pip:
         packages: [mkdocs-bootstrap]
 mkdocs-bootswatch:
@@ -6492,7 +6426,6 @@ mkdocs-bootswatch:
         packages: [mkdocs-bootswatch]
       pip:
         packages: [mkdocs-bootswatch]
-    xenial:
       pip:
         packages: [mkdocs-bootswatch]
       pip:
@@ -6504,7 +6437,6 @@ mongodb:
   ubuntu:
     bionic: [mongodb]
     focal: [mongodb]
-    xenial: [mongodb]
 mongodb-dev:
   debian: [libmongoclient-dev]
   gentoo: [dev-db/mongodb]
@@ -6685,7 +6617,6 @@ nlohmann-json-dev:
     focal: [nlohmann-json3-dev]
     groovy: [nlohmann-json3-dev]
     jammy: [nlohmann-json3-dev]
-    xenial: null
 nmap:
   archlinux: [nmap]
   debian: [nmap]
@@ -6914,7 +6845,6 @@ php:
   gentoo: [dev-lang/php]
   nixos: [php]
   ubuntu:
-    xenial: [php7.0]
 pigz:
   debian: [pigz]
   fedora: [pigz]
@@ -6954,7 +6884,6 @@ pocketsphinx-bin:
   gentoo: [app-accessibility/pocketsphinx]
   nixos: [pocketsphinx]
   ubuntu:
-    xenial: [pocketsphinx]
 polyclipping-dev:
   debian:
     buster: [libpolyclipping-dev]
@@ -7005,7 +6934,6 @@ postgresql-9.x-postgis:
   fedora: [postgis]
   gentoo: [dev-db/postgis, =dev-db/postgresql-9*]
   ubuntu:
-    xenial: [postgresql-9.5-postgis-2.2, postgresql-contrib-9.5, postgresql-server-dev-9.5]
 postgresql-client:
   debian: [postgresql-client]
   fedora: [postgresql]
@@ -7022,7 +6950,6 @@ postgresql-postgis:
     artful: [postgresql-9.6-postgis-2.3, postgresql-contrib, postgresql-server-dev-all]
     bionic: [postgresql-10-postgis-2.4, postgresql-contrib, postgresql-server-dev-all]
     focal: [postgresql-12-postgis-3, postgresql-contrib, postgresql-server-dev-all]
-    xenial: [postgresql-9.5-postgis-2.2, postgresql-contrib, postgresql-server-dev-all]
 potrace:
   debian: [potrace]
   fedora: [potrace]
@@ -7072,7 +6999,6 @@ protobuf:
     bionic: [libprotobuf10]
     focal: [libprotobuf17]
     jammy: [libprotobuf23]
-    xenial: [libprotobuf9v5]
 protobuf-dev:
   arch: [protobuf]
   debian: [libprotobuf-dev, protobuf-compiler, libprotoc-dev]
@@ -7200,7 +7126,6 @@ qt4-linguist-tools:
   ubuntu:
     '*': null
     bionic: [qt4-linguist-tools]
-    xenial: [qt4-linguist-tools]
 qt4-qmake:
   arch: [qt4]
   debian: [qt4-qmake]
@@ -7310,7 +7235,6 @@ range-v3:
     '7': null
   ubuntu:
     '*': [librange-v3-dev]
-    xenial: null
 rapidjson-dev:
   debian: [rapidjson-dev]
   fedora: [rapidjson]
@@ -7365,7 +7289,6 @@ rti-connext-dds-5.3.1:
   ubuntu:
     bionic: [rti-connext-dds-5.3.1]
     focal: [rti-connext-dds-5.3.1]
-    xenial: [rti-connext-dds-5.3.1]
 rti-connext-dds-6.0.1:
   nixos: []
   ubuntu:
@@ -7430,7 +7353,6 @@ sdformat:
     cosmic: [libsdformat6-dev]
     focal: [libsdformat9-dev]
     jammy: [libsdformat-dev]
-    xenial: [libsdformat4-dev]
 sdformat11:
   debian:
     buster: [libsdformat11-dev]
@@ -7619,7 +7541,6 @@ speex:
   gentoo: [media-libs/speex]
   nixos: [speex]
   ubuntu:
-    xenial: [speex]
 spirv-headers:
   arch: [spirv-headers]
   debian: [spirv-headers]
@@ -7631,7 +7552,6 @@ spirv-headers:
   ubuntu:
     '*': [spirv-headers]
     bionic: null
-    xenial: null
 spirv-tools:
   arch: [spirv-tools]
   debian: [spirv-tools]
@@ -7643,7 +7563,6 @@ spirv-tools:
   ubuntu:
     '*': [spirv-tools]
     bionic: null
-    xenial: null
 sqlite3:
   arch: [sqlite]
   debian: [sqlite3]
@@ -7799,7 +7718,6 @@ tap-plugins:
   fedora: [ladspa-tap-plugins]
   gentoo: [media-plugins/tap-plugins]
   ubuntu:
-    xenial: [tap-plugins]
 tar:
   arch: [libtar]
   debian: [libtar-dev]
@@ -8232,7 +8150,6 @@ wxwidgets:
   ubuntu:
     '*': [libwxgtk3.0-gtk3-dev]
     bionic: [libwxgtk3.0-dev]
-    xenial: [libwxgtk3.0-dev]
 x11proto-dri2-dev:
   arch: [dri2proto]
   debian: [x11proto-dri2-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1789,7 +1789,6 @@ hddtemp:
     '*': null
     bionic: [hddtemp]
     focal: [hddtemp]
-    impish: [hddtemp]
 hdf5:
   arch: [hdf5-cpp-fortran]
   debian: [libhdf5-dev]
@@ -4365,7 +4364,6 @@ liborocos-kdl:
     '*': [liborocos-kdl1.5]
     bionic: [liborocos-kdl1.3]
     focal: [liborocos-kdl1.4]
-    impish: [liborocos-kdl1.4]
 liborocos-kdl-dev:
   debian: [liborocos-kdl-dev]
   fedora: [orocos-kdl-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1171,7 +1171,6 @@ gazebo:
     jammy: [gazebo]
     trusty: [gazebo2]
     xenial: [gazebo7]
-    yakkety: [gazebo7]
     zesty: [gazebo7]
 gazebo11:
   debian:
@@ -2215,7 +2214,6 @@ jasper:
   ubuntu:
     trusty: [libjasper-dev]
     xenial: [libjasper-dev]
-    yakkety: [libjasper-dev]
 java:
   alpine: [openjdk8-jre]
   arch: [jdk7-openjdk]
@@ -4463,7 +4461,6 @@ libopenvdb:
     jammy: [libopenvdb8.1]
     trusty: [libopenvdb2.1]
     xenial: [libopenvdb3.1]
-    yakkety: [libopenvdb3.1]
     zesty: [libopenvdb3.2]
 libopenvdb-dev:
   arch: [openvdb]
@@ -5003,7 +5000,6 @@ libpqxx:
     focal: [libpqxx-6.4]
     trusty: [libpqxx-4.0]
     xenial: [libpqxx-4.0]
-    yakkety: [libpqxx-4.0v5]
     zesty: [libpqxx-4.0v5]
 libpqxx-dev:
   debian: [libpqxx-dev]
@@ -5074,7 +5070,6 @@ libqglviewer-qt4:
     bionic: [libqglviewer2-qt4]
     trusty: [libqglviewer2]
     xenial: [libqglviewer2-qt4]
-    yakkety: [libqglviewer2-qt4]
     zesty: [libqglviewer2-qt4]
 libqglviewer-qt4-dev:
   arch: [libqglviewer-qt4]
@@ -5090,7 +5085,6 @@ libqglviewer-qt4-dev:
     bionic: [libqglviewer-dev-qt4]
     trusty: [libqglviewer-dev]
     xenial: [libqglviewer-dev-qt4]
-    yakkety: [libqglviewer-dev-qt4]
     zesty: [libqglviewer-dev-qt4]
 libqglviewer2-qt5:
   debian: [libqglviewer2-qt5]
@@ -5704,7 +5698,6 @@ libtool:
     jammy: [libtool, libltdl-dev, libtool-bin]
     trusty: [libtool, libltdl-dev]
     xenial: [libtool, libltdl-dev, libtool-bin]
-    yakkety: [libtool, libltdl-dev, libtool-bin]
     zesty: [libtool, libltdl-dev, libtool-bin]
 libttspico:
   debian: [libttspico-dev, libttspico-data, libttspico-utils, libttspico0]
@@ -5725,7 +5718,6 @@ libturbojpeg:
     '*': [libturbojpeg0-dev]
     trusty: [libturbojpeg, libjpeg-turbo8-dev]
     xenial: [libturbojpeg, libjpeg-turbo8-dev]
-    yakkety: [libturbojpeg, libjpeg-turbo8-dev]
     zesty: [libturbojpeg, libjpeg-turbo8-dev]
 libudev-dev:
   arch: [systemd]
@@ -5847,7 +5839,6 @@ libuv-dev:
     bionic: [libuv0.10-dev]
     trusty: [libuv-dev]
     xenial: [libuv0.10-dev]
-    yakkety: [libuv0.10-dev]
     zesty: [libuv0.10-dev]
 libuv1-dev:
   arch: [libuv]
@@ -5894,7 +5885,6 @@ libvlc:
     '*': [libvlc5, vlc-bin]
     trusty: [libvlc5, vlc-nox]
     xenial: [libvlc5, vlc-nox]
-    yakkety: [libvlc5, vlc-nox]
 libvlc-dev:
   debian: [libvlc-dev]
   fedora: [vlc-devel]
@@ -5934,7 +5924,6 @@ libvtk:
     bionic: [libvtk6-dev]
     trusty: [libvtk5-dev]
     xenial: [libvtk6-dev]
-    yakkety: [libvtk6-dev]
     zesty: [libvtk6-dev]
 libvtk-java:
   arch: [vtk]
@@ -5954,7 +5943,6 @@ libvtk-java:
     bionic: [libvtk6-java]
     trusty: [libvtk-java]
     xenial: [libvtk-java]
-    yakkety: [libvtk6-java]
     zesty: [libvtk6-java]
 libvtk-qt:
   arch: [vtk]
@@ -5975,7 +5963,6 @@ libvtk-qt:
     bionic: [libvtk6-qt-dev]
     trusty: [libvtk5-qt4-dev]
     xenial: [libvtk6-qt-dev]
-    yakkety: [libvtk6-qt-dev]
     zesty: [libvtk6-qt-dev]
 libvtk9-dev:
   debian: [libvtk9-dev]
@@ -6377,7 +6364,6 @@ log4cxx:
     '*': [liblog4cxx-dev]
     trusty: [liblog4cxx10-dev]
     xenial: [liblog4cxx10-dev]
-    yakkety: [liblog4cxx10-dev]
     zesty: [liblog4cxx10-dev]
 lttng-modules:
   arch: [lttng-modules]
@@ -6512,7 +6498,6 @@ mkdocs:
       pip:
         packages: [mkdocs]
     xenial: [mkdocs]
-    yakkety: [mkdocs]
     zesty: [mkdocs]
 mkdocs-bootstrap:
   debian:
@@ -6539,7 +6524,6 @@ mkdocs-bootstrap:
     xenial:
       pip:
         packages: [mkdocs-bootstrap]
-    yakkety: [mkdocs-bootstrap]
     zesty: [mkdocs-bootstrap]
 mkdocs-bootswatch:
   debian:
@@ -6566,7 +6550,6 @@ mkdocs-bootswatch:
     xenial:
       pip:
         packages: [mkdocs-bootswatch]
-    yakkety:
       pip:
         packages: [mkdocs-bootswatch]
     zesty: [mkdocs-bootswatch]
@@ -6990,7 +6973,6 @@ php:
   ubuntu:
     trusty: [php5]
     xenial: [php7.0]
-    yakkety: [php7.0]
     zesty: [php7.0]
 pigz:
   debian: [pigz]
@@ -7033,7 +7015,6 @@ pocketsphinx-bin:
   ubuntu:
     trusty: [libsphinxbase1]
     xenial: [pocketsphinx]
-    yakkety: [pocketsphinx]
     zesty: [pocketsphinx]
 polyclipping-dev:
   debian:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1024,7 +1024,6 @@ fltk:  # Consider using the libfltk-dev and fluid (fltk runtime) keys instead.
   opensuse: [fltk-devel]
   slackware: [fltk]
   ubuntu:
-    artful: [fluid, libfltk1.3-dev]
     bionic: [fluid, libfltk1.3-dev]
     focal: [fluid, libfltk1.3-dev]
 fluid:
@@ -1141,7 +1140,6 @@ gazebo:
   nixos: [gazebo]
   slackware: [gazebo]
   ubuntu:
-    artful: [gazebo9]
     bionic: [gazebo9]
     cosmic: [gazebo9]
     disco: [gazebo9]
@@ -1177,7 +1175,6 @@ gazebo9:
   nixos: [gazebo_9]
   openembedded: []
   ubuntu:
-    artful: [gazebo9]
     bionic: [gazebo9]
     cosmic: [gazebo9]
     disco: [gazebo9]
@@ -3346,7 +3343,6 @@ libgazebo9-dev:
   gentoo: [sci-electronics/gazebo]
   nixos: [gazebo_9]
   ubuntu:
-    artful: [libgazebo9-dev]
     bionic: [libgazebo9-dev]
     cosmic: [libgazebo9-dev]
     disco: [libgazebo9-dev]
@@ -4358,7 +4354,6 @@ libopenvdb:
     '*': [openvdb]
     '7': null
   ubuntu:
-    artful: [libopenvdb3.2]
     bionic: [libopenvdb5.0]
     focal: [libopenvdb6.2]
     jammy: [libopenvdb8.1]
@@ -4889,7 +4884,6 @@ libpqxx:
   gentoo: [dev-libs/libpqxx]
   nixos: [libpqxx]
   ubuntu:
-    artful: [libpqxx-4.0v5]
     bionic: [libpqxx-4.0v5]
     focal: [libpqxx-6.4]
 libpqxx-dev:
@@ -4955,7 +4949,6 @@ libqglviewer-qt4:
   gentoo: ['x11-libs/libQGLViewer:0/qt4-2']
   macports: [libQGLViewer]
   ubuntu:
-    artful: [libqglviewer2-qt4]
     bionic: [libqglviewer2-qt4]
 libqglviewer-qt4-dev:
   arch: [libqglviewer-qt4]
@@ -4966,7 +4959,6 @@ libqglviewer-qt4-dev:
   fedora: [libQGLViewer-devel]
   gentoo: ['x11-libs/libQGLViewer:0/qt4-2']
   ubuntu:
-    artful: [libqglviewer-dev-qt4]
     bionic: [libqglviewer-dev-qt4]
 libqglviewer2-qt5:
   debian: [libqglviewer2-qt5]
@@ -5568,7 +5560,6 @@ libtool:
   rhel: [libtool, libtool-ltdl-devel]
   slackware: [libtool]
   ubuntu:
-    artful: [libtool, libltdl-dev, libtool-bin]
     bionic: [libtool, libltdl-dev, libtool-bin]
     focal: [libtool, libltdl-dev, libtool-bin]
     jammy: [libtool, libltdl-dev, libtool-bin]
@@ -5777,7 +5768,6 @@ libvtk:
   opensuse: [vtk-devel]
   ubuntu:
     '*': [libvtk7-dev]
-    artful: [libvtk6-dev]
     bionic: [libvtk6-dev]
 libvtk-java:
   arch: [vtk]
@@ -5792,7 +5782,6 @@ libvtk-java:
   slackware: [VTK]
   ubuntu:
     '*': [libvtk7-java]
-    artful: [libvtk6-java]
     bionic: [libvtk6-java]
 libvtk-qt:
   arch: [vtk]
@@ -5808,7 +5797,6 @@ libvtk-qt:
   slackware: [VTK]
   ubuntu:
     '*': [libvtk7-qt-dev]
-    artful: [libvtk6-qt-dev]
     bionic: [libvtk6-qt-dev]
 libvtk9-dev:
   debian: [libvtk9-dev]
@@ -6327,7 +6315,6 @@ mkdocs:
   gentoo: [dev-python/mkdocs]
   nixos: [mkdocs]
   ubuntu:
-    artful: [mkdocs]
     bionic: [mkdocs]
       pip:
         packages: [mkdocs]
@@ -6345,7 +6332,6 @@ mkdocs-bootstrap:
   fedora: [mkdocs-bootstrap]
   gentoo: [dev-python/mkdocs-bootstrap]
   ubuntu:
-    artful: [mkdocs-bootstrap]
     bionic: [mkdocs-bootstrap]
       pip:
         packages: [mkdocs-bootstrap]
@@ -6367,7 +6353,6 @@ mkdocs-bootswatch:
   fedora: [mkdocs-bootswatch]
   gentoo: [dev-python/mkdocs-bootswatch]
   ubuntu:
-    artful: [mkdocs-bootswatch]
     bionic: [mkdocs-bootswatch]
       pip:
         packages: [mkdocs-bootswatch]
@@ -6890,7 +6875,6 @@ postgresql-postgis:
   fedora: [postgis]
   gentoo: [dev-db/postgis, =dev-db/postgresql-9*]
   ubuntu:
-    artful: [postgresql-9.6-postgis-2.3, postgresql-contrib, postgresql-server-dev-all]
     bionic: [postgresql-10-postgis-2.4, postgresql-contrib, postgresql-server-dev-all]
     focal: [postgresql-12-postgis-3, postgresql-contrib, postgresql-server-dev-all]
 potrace:
@@ -7291,7 +7275,6 @@ sdformat:
   rhel:
     '7': [sdformat-devel]
   ubuntu:
-    artful: [libsdformat6-dev]
     bionic: [libsdformat6-dev]
     cosmic: [libsdformat6-dev]
     focal: [libsdformat9-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -616,7 +616,6 @@ collada-dom:
   slackware: [collada-dom]
   ubuntu:
     '*': [libcollada-dom2.4-dp-dev]
-    raring: [collada-dom-dev]
     saucy: [collada-dom-dev]
     trusty: [collada-dom-dev]
     utopic: [collada-dom-dev]
@@ -859,7 +858,6 @@ eclipse:
   gentoo: [dev-java/ant-eclipse-ecj, dev-java/eclipse-ecj]
   ubuntu:
     karmic: [eclipse, eclipse-platform, eclipse-rcp, eclipse-pde]
-    raring: [eclipse, eclipse-platform, eclipse-rcp, eclipse-emf, eclipse-xsd, eclipse-pde]
 ed:
   debian: [ed]
   fedora: [ed]
@@ -1056,7 +1054,6 @@ fltk:  # Consider using the libfltk-dev and fluid (fltk runtime) keys instead.
     artful: [fluid, libfltk1.3-dev]
     bionic: [fluid, libfltk1.3-dev]
     focal: [fluid, libfltk1.3-dev]
-    raring: [fluid, libfltk1.1-dev]
     saucy: [fluid, libfltk1.1-dev]
     trusty: [fluid, libfltk1.1-dev]
     utopic: [fluid, libfltk1.3-dev]
@@ -1185,7 +1182,6 @@ gazebo:
     eoan: [gazebo9]
     focal: [gazebo11]
     jammy: [gazebo]
-    raring: [gazebo]
     saucy: [gazebo2]
     trusty: [gazebo2]
     wily: [gazebo7]
@@ -1557,7 +1553,6 @@ gstreamer0.10-plugins-ugly:
     wheezy: [gstreamer0.10-plugins-ugly]
   gentoo: ['media-libs/gst-plugins-ugly:0.10']
   ubuntu:
-    raring: [gstreamer0.10-plugins-ugly]
     saucy: [gstreamer0.10-plugins-ugly]
     trusty: [gstreamer0.10-plugins-ugly]
     utopic: [gstreamer0.10-plugins-ugly]
@@ -2240,7 +2235,6 @@ jasper:
     slackpkg:
       packages: [jasper]
   ubuntu:
-    raring: [libjasper-dev]
     saucy: [libjasper-dev]
     trusty: [libjasper-dev]
     utopic: [libjasper-dev]
@@ -3292,7 +3286,6 @@ libflann:
   rhel: [flann]
   ubuntu:
     '*': [libflann1.9]
-    raring: [libflann1.7]
     saucy: [libflann1.8]
     trusty: [libflann1.8]
     utopic: [libflann1.8]
@@ -3633,7 +3626,6 @@ libgpgme-dev:
   rhel: [gpgme-devel]
   ubuntu:
     '*': [libgpgme-dev]
-    raring: [libgpgme11-dev]
     saucy: [libgpgme11-dev]
     trusty: [libgpgme11-dev]
     utopic: [libgpgme11-dev]
@@ -3650,7 +3642,6 @@ libgphoto-dev:
   rhel: [libgphoto2-devel]
   ubuntu:
     '*': [libgphoto2-dev]
-    raring: [libgphoto2-2-dev]
     saucy: [libgphoto2-6-dev]
 libgpiod-dev:
   debian: [libgpiod-dev]
@@ -3685,7 +3676,6 @@ libgsl:
   openembedded: [gsl@meta-oe]
   ubuntu:
     '*': [libgsl-dev]
-    raring: [libgsl0-dev]
     saucy: [libgsl0-dev]
     trusty: [libgsl0-dev]
     utopic: [libgsl0-dev]
@@ -5005,7 +4995,6 @@ libpng-dev:
   slackware: [libpng]
   ubuntu:
     '*': [libpng-dev]
-    raring: [libpng12-dev]
     saucy: [libpng12-dev]
     trusty: [libpng12-dev]
     utopic: [libpng12-dev]
@@ -5070,7 +5059,6 @@ libpqxx:
     artful: [libpqxx-4.0v5]
     bionic: [libpqxx-4.0v5]
     focal: [libpqxx-6.4]
-    raring: [libpqxx-3.1]
     saucy: [libpqxx-3.1]
     trusty: [libpqxx-4.0]
     utopic: [libpqxx-4.0]
@@ -5146,7 +5134,6 @@ libqglviewer-qt4:
   ubuntu:
     artful: [libqglviewer2-qt4]
     bionic: [libqglviewer2-qt4]
-    raring: [libqglviewer-qt4-2]
     saucy: [libqglviewer2]
     trusty: [libqglviewer2]
     utopic: [libqglviewer2]
@@ -5167,7 +5154,6 @@ libqglviewer-qt4-dev:
   ubuntu:
     artful: [libqglviewer-dev-qt4]
     bionic: [libqglviewer-dev-qt4]
-    raring: [libqglviewer-qt4-dev]
     saucy: [libqglviewer-dev]
     trusty: [libqglviewer-dev]
     utopic: [libqglviewer-dev]
@@ -5786,7 +5772,6 @@ libtool:
     bionic: [libtool, libltdl-dev, libtool-bin]
     focal: [libtool, libltdl-dev, libtool-bin]
     jammy: [libtool, libltdl-dev, libtool-bin]
-    raring: [libtool, libltdl-dev]
     saucy: [libtool, libltdl-dev]
     trusty: [libtool, libltdl-dev]
     utopic: [libtool, libltdl-dev, libtool-bin]
@@ -5812,7 +5797,6 @@ libturbojpeg:
   rhel: [libjpeg-turbo-devel, turbojpeg-devel]
   ubuntu:
     '*': [libturbojpeg0-dev]
-    raring: [libturbojpeg, libjpeg-turbo8-dev]
     saucy: [libturbojpeg, libjpeg-turbo8-dev]
     trusty: [libturbojpeg, libjpeg-turbo8-dev]
     utopic: [libturbojpeg, libjpeg-turbo8-dev]
@@ -5858,7 +5842,6 @@ libunwind-dev:
   nixos: [libunwind]
   ubuntu:
     '*': [libunwind-dev]
-    raring: [libunwind8-dev]
     saucy: [libunwind8-dev]
     trusty: [libunwind8-dev]
 liburdfdom-dev:
@@ -6036,7 +6019,6 @@ libvtk:
     '*': [libvtk7-dev]
     artful: [libvtk6-dev]
     bionic: [libvtk6-dev]
-    raring: [libvtk5-dev]
     saucy: [libvtk5-dev]
     trusty: [libvtk5-dev]
     utopic: [libvtk5-dev]
@@ -6061,7 +6043,6 @@ libvtk-java:
     '*': [libvtk7-java]
     artful: [libvtk6-java]
     bionic: [libvtk6-java]
-    raring: [libvtk-java]
     saucy: [libvtk-java]
     trusty: [libvtk-java]
     utopic: [libvtk-java]
@@ -6087,7 +6068,6 @@ libvtk-qt:
     '*': [libvtk7-qt-dev]
     artful: [libvtk6-qt-dev]
     bionic: [libvtk6-qt-dev]
-    raring: [libvtk5-qt4-dev]
     saucy: [libvtk5-qt4-dev]
     trusty: [libvtk5-qt4-dev]
     utopic: [libvtk5-qt4-dev]
@@ -6494,7 +6474,6 @@ log4cxx:
   slackware: [apache-log4cxx]
   ubuntu:
     '*': [liblog4cxx-dev]
-    raring: [liblog4cxx10-dev]
     saucy: [liblog4cxx10-dev]
     trusty: [liblog4cxx10-dev]
     utopic: [liblog4cxx10-dev]
@@ -7118,7 +7097,6 @@ php:
   gentoo: [dev-lang/php]
   nixos: [php]
   ubuntu:
-    raring: [php5]
     saucy: [php5]
     trusty: [php5]
     utopic: [php5]
@@ -7166,7 +7144,6 @@ pocketsphinx-bin:
   gentoo: [app-accessibility/pocketsphinx]
   nixos: [pocketsphinx]
   ubuntu:
-    raring: [libsphinxbase1]
     saucy: [libsphinxbase1]
     trusty: [libsphinxbase1]
     utopic: [libsphinxbase1]
@@ -7225,7 +7202,6 @@ postgresql-9.x-postgis:
   fedora: [postgis]
   gentoo: [dev-db/postgis, =dev-db/postgresql-9*]
   ubuntu:
-    raring: [postgresql-9.1-postgis, postgresql-contrib-9.1, postgresql-server-dev-9.1]
     saucy: [postgresql-9.1-postgis, postgresql-contrib-9.1, postgresql-server-dev-9.1]
     trusty: [postgresql-9.3-postgis-2.1, postgresql-contrib-9.3, postgresql-server-dev-9.3]
     utopic: [postgresql-9.4-postgis-2.1, postgresql-contrib-9.4, postgresql-server-dev-9.4]
@@ -7657,7 +7633,6 @@ sdformat:
     cosmic: [libsdformat6-dev]
     focal: [libsdformat9-dev]
     jammy: [libsdformat-dev]
-    raring: [sdformat]
     saucy: [libsdformat-dev]
     trusty: [libsdformat-dev]
     xenial: [libsdformat4-dev]
@@ -7951,14 +7926,12 @@ swi-prolog-clib:
     woody: [swi-prolog-clib]
   fedora: [pl-devel]
   ubuntu:
-    raring: [swi-prolog]
 swi-prolog-http:
   arch: [swi-prolog]
   debian:
     lenny: [swi-prolog-http]
   fedora: [pl]
   ubuntu:
-    raring: [swi-prolog]
 swi-prolog-java:
   debian: [swi-prolog-java]
   fedora: [pl-jpl]
@@ -7974,21 +7947,18 @@ swi-prolog-semweb:
   arch: [swi-prolog]
   fedora: [pl]
   ubuntu:
-    raring: [swi-prolog]
 swi-prolog-sgml:
   arch: [swi-prolog]
   debian:
     lenny: [swi-prolog-sgml]
   fedora: [pl]
   ubuntu:
-    raring: [swi-prolog]
 swi-prolog-xpce:
   arch: [swi-prolog]
   debian:
     woody: [swi-prolog-xpce]
   fedora: [pl-xpce]
   ubuntu:
-    raring: [swi-prolog]
 swig:
   debian: [swig]
   fedora: [swig]
@@ -8588,7 +8558,6 @@ xulrunner-1.9.2:
   debian: []
   ubuntu:
     karmic: [xulrunner-1.9.2]
-    raring: []
 xulrunner-dev:
   arch: [xulrunner]
   debian: [libv8-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -40,7 +40,6 @@ acpitool:
   gentoo: [sys-power/acpitool]
   nixos: [acpitool]
   ubuntu:
-    trusty: [acpitool]
     xenial: [acpitool]
 alsa-oss:
   arch: [alsa-oss]
@@ -357,7 +356,6 @@ bluez-hcidump:
   fedora: [bluez-hcidump]
   gentoo: [net-wireless/bluez-hcidump]
   ubuntu:
-    trusty: [bluez-hcidump]
     xenial: [bluez-hcidump]
 boost:
   alpine: [boost-dev]
@@ -535,7 +533,6 @@ clang-tidy:
     '7': null
   ubuntu:
     '*': [clang-tidy]
-    trusty: null
 cmake:
   alpine: [cmake]
   arch: [cmake]
@@ -613,7 +610,6 @@ collada-dom:
   slackware: [collada-dom]
   ubuntu:
     '*': [libcollada-dom2.4-dp-dev]
-    trusty: [collada-dom-dev]
 collectd:
   debian: [collectd]
   fedora: [collectd]
@@ -976,7 +972,6 @@ ffmpeg:
   slackware: [ffmpeg]
   ubuntu:
     '*': [ffmpeg, libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev]
-    trusty: [libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev]
 ffmpeg2theora:
   arch: [ffmpeg2theora]
   debian: [ffmpeg2theora]
@@ -1045,7 +1040,6 @@ fltk:  # Consider using the libfltk-dev and fluid (fltk runtime) keys instead.
     artful: [fluid, libfltk1.3-dev]
     bionic: [fluid, libfltk1.3-dev]
     focal: [fluid, libfltk1.3-dev]
-    trusty: [fluid, libfltk1.1-dev]
     xenial: [fluid, libfltk1.3-dev]
 fluid:
   arch: [fltk]
@@ -1169,7 +1163,6 @@ gazebo:
     eoan: [gazebo9]
     focal: [gazebo11]
     jammy: [gazebo]
-    trusty: [gazebo2]
     xenial: [gazebo7]
 gazebo11:
   debian:
@@ -1517,7 +1510,6 @@ gstreamer0.10-gconf:
   debian:
     jessie: [gstreamer0.10-gconf]
   ubuntu:
-    trusty: [gstreamer0.10-gconf]
     xenial: [gstreamer0.10-gconf]
 gstreamer0.10-plugins-good:
   arch: [gstreamer0.10-good-plugins]
@@ -1533,7 +1525,6 @@ gstreamer0.10-plugins-ugly:
     wheezy: [gstreamer0.10-plugins-ugly]
   gentoo: ['media-libs/gst-plugins-ugly:0.10']
   ubuntu:
-    trusty: [gstreamer0.10-plugins-ugly]
 gstreamer0.10-pocketsphinx:
   debian:
     jessie: [gstreamer0.10-pocketsphinx]
@@ -2211,7 +2202,6 @@ jasper:
     slackpkg:
       packages: [jasper]
   ubuntu:
-    trusty: [libjasper-dev]
     xenial: [libjasper-dev]
 java:
   alpine: [openjdk8-jre]
@@ -2436,7 +2426,6 @@ libbison-dev:
   nixos: [bison]
   rhel: [bison-devel]
   ubuntu:
-    trusty: [libbison-dev]
     xenial: [libbison-dev]
 libblas-dev:
   arch: [cblas]
@@ -3093,7 +3082,6 @@ libdlib-dev:
   nixos: [dlib]
   ubuntu:
     '*': [libdlib-dev]
-    trusty: null
 libdmtx-dev:
   arch: [libdmtx]
   debian: [libdmtx-dev]
@@ -3175,7 +3163,6 @@ libestools-dev:
   gentoo: [app-accessibility/festival]
   ubuntu:
     '*': [libestools-dev]
-    trusty: [libestools2.1-dev]
 libev-dev:
   arch: [libev]
   debian: [libev-dev]
@@ -3251,7 +3238,6 @@ libflann:
   rhel: [flann]
   ubuntu:
     '*': [libflann1.9]
-    trusty: [libflann1.8]
     xenial: [libflann1.8]
 libflann-dev:
   arch: [flann]
@@ -3374,7 +3360,6 @@ libftdipp-dev:
   openembedded: [libftdi@meta-oe]
   ubuntu:
     bionic: [libftdipp1-dev]
-    trusty: [libftdipp-dev]
     xenial: [libftdipp1-dev]
 libftgl-dev:
   arch: [ftgl]
@@ -3503,7 +3488,6 @@ libglfw3-dev:
   rhel: [glfw-devel]
   ubuntu:
     '*': [libglfw3-dev]
-    trusty: null
 libglib-dev:
   arch: [glib2]
   debian: [libglib2.0-dev]
@@ -3584,7 +3568,6 @@ libgpgme-dev:
   rhel: [gpgme-devel]
   ubuntu:
     '*': [libgpgme-dev]
-    trusty: [libgpgme11-dev]
     xenial: [libgpgme11-dev]
 libgphoto-dev:
   arch: [libgphoto2]
@@ -3629,7 +3612,6 @@ libgsl:
   openembedded: [gsl@meta-oe]
   ubuntu:
     '*': [libgsl-dev]
-    trusty: [libgsl0-dev]
 libgstreamer-plugins-base0.10-0:
   arch: [gstreamer0.10-base-plugins]
   debian:
@@ -3890,7 +3872,6 @@ libjansson-dev:
 libjaxp1.3-java:
   debian: [libjaxp1.3-java]
   ubuntu:
-    trusty: [libjaxp1.3-java]
     xenial: [libjaxp1.3-java]
 libjpeg:
   arch: [libjpeg-turbo]
@@ -3936,7 +3917,6 @@ libjsoncpp:
     '*': [libjsoncpp25]
     bionic: [libjsoncpp1]
     focal: [libjsoncpp1]
-    trusty: [libjsoncpp0]
     xenial: [libjsoncpp1]
 libjsoncpp-dev:
   arch: [jsoncpp]
@@ -4458,7 +4438,6 @@ libopenvdb:
     bionic: [libopenvdb5.0]
     focal: [libopenvdb6.2]
     jammy: [libopenvdb8.1]
-    trusty: [libopenvdb2.1]
     xenial: [libopenvdb3.1]
 libopenvdb-dev:
   arch: [openvdb]
@@ -4936,7 +4915,6 @@ libpng-dev:
   slackware: [libpng]
   ubuntu:
     '*': [libpng-dev]
-    trusty: [libpng12-dev]
     xenial: [libpng12-dev]
 libpng12-dev:
   arch: [libpng]
@@ -4996,7 +4974,6 @@ libpqxx:
     artful: [libpqxx-4.0v5]
     bionic: [libpqxx-4.0v5]
     focal: [libpqxx-6.4]
-    trusty: [libpqxx-4.0]
     xenial: [libpqxx-4.0]
 libpqxx-dev:
   debian: [libpqxx-dev]
@@ -5065,7 +5042,6 @@ libqglviewer-qt4:
   ubuntu:
     artful: [libqglviewer2-qt4]
     bionic: [libqglviewer2-qt4]
-    trusty: [libqglviewer2]
     xenial: [libqglviewer2-qt4]
 libqglviewer-qt4-dev:
   arch: [libqglviewer-qt4]
@@ -5079,7 +5055,6 @@ libqglviewer-qt4-dev:
   ubuntu:
     artful: [libqglviewer-dev-qt4]
     bionic: [libqglviewer-dev-qt4]
-    trusty: [libqglviewer-dev]
     xenial: [libqglviewer-dev-qt4]
 libqglviewer2-qt5:
   debian: [libqglviewer2-qt5]
@@ -5371,7 +5346,6 @@ libqwt-qt5-dev:
     '7': null
   ubuntu:
     '*': [libqwt-qt5-dev]
-    trusty: null
 libqwt5-qt4-dev:
   arch: [qwt5]
   debian: [libqwt5-qt4-dev]
@@ -5510,7 +5484,6 @@ libspatialite:
   nixos: [libspatialite]
   ubuntu:
     '*': [libsqlite3-mod-spatialite]
-    trusty: [libspatialite5]
 libspnav-dev:
   arch: [libspnav]
   debian: [libspnav-dev, libx11-dev]
@@ -5607,7 +5580,6 @@ libsystemd-dev:
   fedora: [systemd-devel]
   ubuntu:
     '*': [libsystemd-dev]
-    trusty: null
 libtclap-dev:
   arch: [tclap]
   debian: [libtclap-dev]
@@ -5691,7 +5663,6 @@ libtool:
     bionic: [libtool, libltdl-dev, libtool-bin]
     focal: [libtool, libltdl-dev, libtool-bin]
     jammy: [libtool, libltdl-dev, libtool-bin]
-    trusty: [libtool, libltdl-dev]
     xenial: [libtool, libltdl-dev, libtool-bin]
 libttspico:
   debian: [libttspico-dev, libttspico-data, libttspico-utils, libttspico0]
@@ -5710,7 +5681,6 @@ libturbojpeg:
   rhel: [libjpeg-turbo-devel, turbojpeg-devel]
   ubuntu:
     '*': [libturbojpeg0-dev]
-    trusty: [libturbojpeg, libjpeg-turbo8-dev]
     xenial: [libturbojpeg, libjpeg-turbo8-dev]
 libudev-dev:
   arch: [systemd]
@@ -5749,7 +5719,6 @@ libunwind-dev:
   nixos: [libunwind]
   ubuntu:
     '*': [libunwind-dev]
-    trusty: [libunwind8-dev]
 liburdfdom-dev:
   arch: [urdfdom]
   debian: [liburdfdom-dev]
@@ -5830,7 +5799,6 @@ libuv-dev:
     jessie: [libuv0.10-dev]
   ubuntu:
     bionic: [libuv0.10-dev]
-    trusty: [libuv-dev]
     xenial: [libuv0.10-dev]
 libuv1-dev:
   arch: [libuv]
@@ -5875,7 +5843,6 @@ libvlc:
   opensuse: [libvlc5, vlc-noX]
   ubuntu:
     '*': [libvlc5, vlc-bin]
-    trusty: [libvlc5, vlc-nox]
     xenial: [libvlc5, vlc-nox]
 libvlc-dev:
   debian: [libvlc-dev]
@@ -5914,7 +5881,6 @@ libvtk:
     '*': [libvtk7-dev]
     artful: [libvtk6-dev]
     bionic: [libvtk6-dev]
-    trusty: [libvtk5-dev]
     xenial: [libvtk6-dev]
 libvtk-java:
   arch: [vtk]
@@ -5932,7 +5898,6 @@ libvtk-java:
     '*': [libvtk7-java]
     artful: [libvtk6-java]
     bionic: [libvtk6-java]
-    trusty: [libvtk-java]
     xenial: [libvtk-java]
 libvtk-qt:
   arch: [vtk]
@@ -5951,7 +5916,6 @@ libvtk-qt:
     '*': [libvtk7-qt-dev]
     artful: [libvtk6-qt-dev]
     bionic: [libvtk6-qt-dev]
-    trusty: [libvtk5-qt4-dev]
     xenial: [libvtk6-qt-dev]
 libvtk9-dev:
   debian: [libvtk9-dev]
@@ -5970,7 +5934,6 @@ libvulkan-dev:
     '7': [vulkan-devel]
   ubuntu:
     '*': [libvulkan-dev]
-    trusty: null
 libwebp-dev:
   debian: [libwebp-dev]
   fedora: [libwebp-devel]
@@ -6351,7 +6314,6 @@ log4cxx:
   slackware: [apache-log4cxx]
   ubuntu:
     '*': [liblog4cxx-dev]
-    trusty: [liblog4cxx10-dev]
     xenial: [liblog4cxx10-dev]
 lttng-modules:
   arch: [lttng-modules]
@@ -6480,7 +6442,6 @@ mkdocs:
   ubuntu:
     artful: [mkdocs]
     bionic: [mkdocs]
-    trusty:
       pip:
         packages: [mkdocs]
       pip:
@@ -6501,7 +6462,6 @@ mkdocs-bootstrap:
   ubuntu:
     artful: [mkdocs-bootstrap]
     bionic: [mkdocs-bootstrap]
-    trusty:
       pip:
         packages: [mkdocs-bootstrap]
       pip:
@@ -6526,7 +6486,6 @@ mkdocs-bootswatch:
   ubuntu:
     artful: [mkdocs-bootswatch]
     bionic: [mkdocs-bootswatch]
-    trusty:
       pip:
         packages: [mkdocs-bootswatch]
       pip:
@@ -6788,7 +6747,6 @@ odb:
   debian: [odb]
   ubuntu:
     '*': [odb]
-    trusty: null
 omniidl:
   arch: [omniorb]
   debian: [omniidl, omniorb-idl]
@@ -6956,7 +6914,6 @@ php:
   gentoo: [dev-lang/php]
   nixos: [php]
   ubuntu:
-    trusty: [php5]
     xenial: [php7.0]
 pigz:
   debian: [pigz]
@@ -6997,7 +6954,6 @@ pocketsphinx-bin:
   gentoo: [app-accessibility/pocketsphinx]
   nixos: [pocketsphinx]
   ubuntu:
-    trusty: [libsphinxbase1]
     xenial: [pocketsphinx]
 polyclipping-dev:
   debian:
@@ -7049,7 +7005,6 @@ postgresql-9.x-postgis:
   fedora: [postgis]
   gentoo: [dev-db/postgis, =dev-db/postgresql-9*]
   ubuntu:
-    trusty: [postgresql-9.3-postgis-2.1, postgresql-contrib-9.3, postgresql-server-dev-9.3]
     xenial: [postgresql-9.5-postgis-2.2, postgresql-contrib-9.5, postgresql-server-dev-9.5]
 postgresql-client:
   debian: [postgresql-client]
@@ -7067,7 +7022,6 @@ postgresql-postgis:
     artful: [postgresql-9.6-postgis-2.3, postgresql-contrib, postgresql-server-dev-all]
     bionic: [postgresql-10-postgis-2.4, postgresql-contrib, postgresql-server-dev-all]
     focal: [postgresql-12-postgis-3, postgresql-contrib, postgresql-server-dev-all]
-    trusty: [postgresql-9.3-postgis-2.1, postgresql-contrib, postgresql-server-dev-all]
     xenial: [postgresql-9.5-postgis-2.2, postgresql-contrib, postgresql-server-dev-all]
 potrace:
   debian: [potrace]
@@ -7476,7 +7430,6 @@ sdformat:
     cosmic: [libsdformat6-dev]
     focal: [libsdformat9-dev]
     jammy: [libsdformat-dev]
-    trusty: [libsdformat-dev]
     xenial: [libsdformat4-dev]
 sdformat11:
   debian:
@@ -7666,7 +7619,6 @@ speex:
   gentoo: [media-libs/speex]
   nixos: [speex]
   ubuntu:
-    trusty: [speex]
     xenial: [speex]
 spirv-headers:
   arch: [spirv-headers]
@@ -7847,7 +7799,6 @@ tap-plugins:
   fedora: [ladspa-tap-plugins]
   gentoo: [media-plugins/tap-plugins]
   ubuntu:
-    trusty: [tap-plugins]
     xenial: [tap-plugins]
 tar:
   arch: [libtar]
@@ -8188,7 +8139,6 @@ vorbis-tools:
   ubuntu: [vorbis-tools]
 vrep:
   ubuntu:
-    trusty:
       source:
         uri: https://raw.githubusercontent.com/peci1/vrep_ros_bridge/rdmanifest/vrep.rdmanifest
 wget:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1171,7 +1171,6 @@ gazebo:
     jammy: [gazebo]
     trusty: [gazebo2]
     xenial: [gazebo7]
-    zesty: [gazebo7]
 gazebo11:
   debian:
     buster: [gazebo11]
@@ -4461,7 +4460,6 @@ libopenvdb:
     jammy: [libopenvdb8.1]
     trusty: [libopenvdb2.1]
     xenial: [libopenvdb3.1]
-    zesty: [libopenvdb3.2]
 libopenvdb-dev:
   arch: [openvdb]
   debian: [libopenvdb-dev, libilmbase-dev]
@@ -5000,7 +4998,6 @@ libpqxx:
     focal: [libpqxx-6.4]
     trusty: [libpqxx-4.0]
     xenial: [libpqxx-4.0]
-    zesty: [libpqxx-4.0v5]
 libpqxx-dev:
   debian: [libpqxx-dev]
   fedora: [libpqxx-devel]
@@ -5070,7 +5067,6 @@ libqglviewer-qt4:
     bionic: [libqglviewer2-qt4]
     trusty: [libqglviewer2]
     xenial: [libqglviewer2-qt4]
-    zesty: [libqglviewer2-qt4]
 libqglviewer-qt4-dev:
   arch: [libqglviewer-qt4]
   debian:
@@ -5085,7 +5081,6 @@ libqglviewer-qt4-dev:
     bionic: [libqglviewer-dev-qt4]
     trusty: [libqglviewer-dev]
     xenial: [libqglviewer-dev-qt4]
-    zesty: [libqglviewer-dev-qt4]
 libqglviewer2-qt5:
   debian: [libqglviewer2-qt5]
   fedora: [libQGLViewer-qt5]
@@ -5698,7 +5693,6 @@ libtool:
     jammy: [libtool, libltdl-dev, libtool-bin]
     trusty: [libtool, libltdl-dev]
     xenial: [libtool, libltdl-dev, libtool-bin]
-    zesty: [libtool, libltdl-dev, libtool-bin]
 libttspico:
   debian: [libttspico-dev, libttspico-data, libttspico-utils, libttspico0]
   ubuntu: [libttspico-dev, libttspico-data, libttspico-utils, libttspico0]
@@ -5718,7 +5712,6 @@ libturbojpeg:
     '*': [libturbojpeg0-dev]
     trusty: [libturbojpeg, libjpeg-turbo8-dev]
     xenial: [libturbojpeg, libjpeg-turbo8-dev]
-    zesty: [libturbojpeg, libjpeg-turbo8-dev]
 libudev-dev:
   arch: [systemd]
   debian: [libudev-dev]
@@ -5839,7 +5832,6 @@ libuv-dev:
     bionic: [libuv0.10-dev]
     trusty: [libuv-dev]
     xenial: [libuv0.10-dev]
-    zesty: [libuv0.10-dev]
 libuv1-dev:
   arch: [libuv]
   debian:
@@ -5924,7 +5916,6 @@ libvtk:
     bionic: [libvtk6-dev]
     trusty: [libvtk5-dev]
     xenial: [libvtk6-dev]
-    zesty: [libvtk6-dev]
 libvtk-java:
   arch: [vtk]
   debian:
@@ -5943,7 +5934,6 @@ libvtk-java:
     bionic: [libvtk6-java]
     trusty: [libvtk-java]
     xenial: [libvtk-java]
-    zesty: [libvtk6-java]
 libvtk-qt:
   arch: [vtk]
   debian:
@@ -5963,7 +5953,6 @@ libvtk-qt:
     bionic: [libvtk6-qt-dev]
     trusty: [libvtk5-qt4-dev]
     xenial: [libvtk6-qt-dev]
-    zesty: [libvtk6-qt-dev]
 libvtk9-dev:
   debian: [libvtk9-dev]
   ubuntu:
@@ -6364,7 +6353,6 @@ log4cxx:
     '*': [liblog4cxx-dev]
     trusty: [liblog4cxx10-dev]
     xenial: [liblog4cxx10-dev]
-    zesty: [liblog4cxx10-dev]
 lttng-modules:
   arch: [lttng-modules]
   debian: [lttng-modules-dkms]
@@ -6498,7 +6486,6 @@ mkdocs:
       pip:
         packages: [mkdocs]
     xenial: [mkdocs]
-    zesty: [mkdocs]
 mkdocs-bootstrap:
   debian:
     buster: [mkdocs-bootstrap]
@@ -6524,7 +6511,6 @@ mkdocs-bootstrap:
     xenial:
       pip:
         packages: [mkdocs-bootstrap]
-    zesty: [mkdocs-bootstrap]
 mkdocs-bootswatch:
   debian:
     buster: [mkdocs-bootswatch]
@@ -6552,7 +6538,6 @@ mkdocs-bootswatch:
         packages: [mkdocs-bootswatch]
       pip:
         packages: [mkdocs-bootswatch]
-    zesty: [mkdocs-bootswatch]
 mongodb:
   gentoo: [dev-db/mongodb]
   nixos: [mongodb]
@@ -6973,7 +6958,6 @@ php:
   ubuntu:
     trusty: [php5]
     xenial: [php7.0]
-    zesty: [php7.0]
 pigz:
   debian: [pigz]
   fedora: [pigz]
@@ -7015,7 +6999,6 @@ pocketsphinx-bin:
   ubuntu:
     trusty: [libsphinxbase1]
     xenial: [pocketsphinx]
-    zesty: [pocketsphinx]
 polyclipping-dev:
   debian:
     buster: [libpolyclipping-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -40,7 +40,6 @@ acpitool:
   gentoo: [sys-power/acpitool]
   nixos: [acpitool]
   ubuntu:
-    precise: [acpitool]
     trusty: [acpitool]
     vivid: [acpitool]
     wily: [acpitool]
@@ -360,7 +359,6 @@ bluez-hcidump:
   fedora: [bluez-hcidump]
   gentoo: [net-wireless/bluez-hcidump]
   ubuntu:
-    precise: [bluez-hcidump]
     trusty: [bluez-hcidump]
     wily: [bluez-hcidump]
     xenial: [bluez-hcidump]
@@ -618,7 +616,6 @@ collada-dom:
   slackware: [collada-dom]
   ubuntu:
     '*': [libcollada-dom2.4-dp-dev]
-    precise: [collada-dom-dev]
     quantal: [collada-dom-dev]
     raring: [collada-dom-dev]
     saucy: [collada-dom-dev]
@@ -863,7 +860,6 @@ eclipse:
   gentoo: [dev-java/ant-eclipse-ecj, dev-java/eclipse-ecj]
   ubuntu:
     karmic: [eclipse, eclipse-platform, eclipse-rcp, eclipse-pde]
-    precise: [eclipse, eclipse-platform, eclipse-rcp, eclipse-emf, eclipse-xsd, eclipse-pde]
     quantal: [eclipse, eclipse-platform, eclipse-rcp, eclipse-emf, eclipse-xsd, eclipse-pde]
     raring: [eclipse, eclipse-platform, eclipse-rcp, eclipse-emf, eclipse-xsd, eclipse-pde]
 ed:
@@ -1062,7 +1058,6 @@ fltk:  # Consider using the libfltk-dev and fluid (fltk runtime) keys instead.
     artful: [fluid, libfltk1.3-dev]
     bionic: [fluid, libfltk1.3-dev]
     focal: [fluid, libfltk1.3-dev]
-    precise: [fluid, libfltk1.1-dev]
     quantal: [fluid, libfltk1.1-dev]
     raring: [fluid, libfltk1.1-dev]
     saucy: [fluid, libfltk1.1-dev]
@@ -1193,7 +1188,6 @@ gazebo:
     eoan: [gazebo9]
     focal: [gazebo11]
     jammy: [gazebo]
-    precise: [gazebo]
     quantal: [gazebo]
     raring: [gazebo]
     saucy: [gazebo2]
@@ -1548,7 +1542,6 @@ gstreamer0.10-gconf:
   debian:
     jessie: [gstreamer0.10-gconf]
   ubuntu:
-    precise: [gstreamer0.10-gconf]
     trusty: [gstreamer0.10-gconf]
     utopic: [gstreamer0.10-gconf]
     vivid: [gstreamer0.10-gconf]
@@ -1568,7 +1561,6 @@ gstreamer0.10-plugins-ugly:
     wheezy: [gstreamer0.10-plugins-ugly]
   gentoo: ['media-libs/gst-plugins-ugly:0.10']
   ubuntu:
-    precise: [gstreamer0.10-plugins-ugly]
     quantal: [gstreamer0.10-plugins-ugly]
     raring: [gstreamer0.10-plugins-ugly]
     saucy: [gstreamer0.10-plugins-ugly]
@@ -2253,7 +2245,6 @@ jasper:
     slackpkg:
       packages: [jasper]
   ubuntu:
-    precise: [libjasper-dev]
     quantal: [libjasper-dev]
     raring: [libjasper-dev]
     saucy: [libjasper-dev]
@@ -2416,7 +2407,6 @@ libaria:
         uri: https://raw.github.com/amor-ros-pkg/rosaria/master/libaria.rdmanifest
   ubuntu:
     '*': [libaria-dev]
-    precise:
       source:
         md5sum: 589c387995beb951edd9c77f33cb2286
         uri: https://raw.github.com/amor-ros-pkg/rosaria/master/libaria.rdmanifest
@@ -2487,7 +2477,6 @@ libbison-dev:
   nixos: [bison]
   rhel: [bison-devel]
   ubuntu:
-    precise: [libbison-dev]
     trusty: [libbison-dev]
     vivid: [libbison-dev]
     wily: [libbison-dev]
@@ -3309,7 +3298,6 @@ libflann:
   rhel: [flann]
   ubuntu:
     '*': [libflann1.9]
-    precise: [libflann1]
     quantal: [libflann1.7]
     raring: [libflann1.7]
     saucy: [libflann1.8]
@@ -3439,7 +3427,6 @@ libftdipp-dev:
   openembedded: [libftdi@meta-oe]
   ubuntu:
     bionic: [libftdipp1-dev]
-    precise: [libftdipp-dev]
     saucy: [libftdipp-dev]
     trusty: [libftdipp-dev]
     vivid: [libftdipp-dev]
@@ -3653,7 +3640,6 @@ libgpgme-dev:
   rhel: [gpgme-devel]
   ubuntu:
     '*': [libgpgme-dev]
-    precise: [libgpgme11-dev]
     quantal: [libgpgme11-dev]
     raring: [libgpgme11-dev]
     saucy: [libgpgme11-dev]
@@ -3672,7 +3658,6 @@ libgphoto-dev:
   rhel: [libgphoto2-devel]
   ubuntu:
     '*': [libgphoto2-dev]
-    precise: [libgphoto2-2-dev]
     raring: [libgphoto2-2-dev]
     saucy: [libgphoto2-6-dev]
 libgpiod-dev:
@@ -3708,7 +3693,6 @@ libgsl:
   openembedded: [gsl@meta-oe]
   ubuntu:
     '*': [libgsl-dev]
-    precise: [libgsl0-dev]
     raring: [libgsl0-dev]
     saucy: [libgsl0-dev]
     trusty: [libgsl0-dev]
@@ -3975,7 +3959,6 @@ libjansson-dev:
 libjaxp1.3-java:
   debian: [libjaxp1.3-java]
   ubuntu:
-    precise: [libjaxp1.3-java]
     trusty: [libjaxp1.3-java]
     vivid: [libjaxp1.3-java]
     wily: [libjaxp1.3-java]
@@ -4494,7 +4477,6 @@ libopenni-nite-dev:
   debian: [libopenni-nite-dev]
   fedora: [openni-nite-devel]
   ubuntu:
-    precise: [libopenni-nite-dev]
     quantal: [libopenni-nite-dev]
 libopenni-sensor-primesense-dev:
   arch: [sensorkinect]
@@ -5032,7 +5014,6 @@ libpng-dev:
   slackware: [libpng]
   ubuntu:
     '*': [libpng-dev]
-    precise: [libpng12-dev]
     quantal: [libpng12-dev]
     raring: [libpng12-dev]
     saucy: [libpng12-dev]
@@ -5099,7 +5080,6 @@ libpqxx:
     artful: [libpqxx-4.0v5]
     bionic: [libpqxx-4.0v5]
     focal: [libpqxx-6.4]
-    precise: [libpqxx-3.1]
     quantal: [libpqxx-3.1]
     raring: [libpqxx-3.1]
     saucy: [libpqxx-3.1]
@@ -5177,7 +5157,6 @@ libqglviewer-qt4:
   ubuntu:
     artful: [libqglviewer2-qt4]
     bionic: [libqglviewer2-qt4]
-    precise: [libqglviewer-qt4-2]
     quantal: [libqglviewer-qt4-2]
     raring: [libqglviewer-qt4-2]
     saucy: [libqglviewer2]
@@ -5200,7 +5179,6 @@ libqglviewer-qt4-dev:
   ubuntu:
     artful: [libqglviewer-dev-qt4]
     bionic: [libqglviewer-dev-qt4]
-    precise: [libqglviewer-qt4-dev]
     quantal: [libqglviewer-qt4-dev]
     raring: [libqglviewer-qt4-dev]
     saucy: [libqglviewer-dev]
@@ -5821,7 +5799,6 @@ libtool:
     bionic: [libtool, libltdl-dev, libtool-bin]
     focal: [libtool, libltdl-dev, libtool-bin]
     jammy: [libtool, libltdl-dev, libtool-bin]
-    precise: [libtool, libltdl-dev]
     quantal: [libtool, libltdl-dev]
     raring: [libtool, libltdl-dev]
     saucy: [libtool, libltdl-dev]
@@ -5849,7 +5826,6 @@ libturbojpeg:
   rhel: [libjpeg-turbo-devel, turbojpeg-devel]
   ubuntu:
     '*': [libturbojpeg0-dev]
-    precise: [libturbojpeg, libjpeg-turbo8-dev]
     quantal: [libturbojpeg, libjpeg-turbo8-dev]
     raring: [libturbojpeg, libjpeg-turbo8-dev]
     saucy: [libturbojpeg, libjpeg-turbo8-dev]
@@ -5886,7 +5862,6 @@ libunwind:
   nixos: [libunwind]
   ubuntu:
     '*': [libunwind8]
-    precise: [libunwind7]
 libunwind-dev:
   debian:
     buster: [libunwind8-dev]
@@ -5898,7 +5873,6 @@ libunwind-dev:
   nixos: [libunwind]
   ubuntu:
     '*': [libunwind-dev]
-    precise: [libunwind7-dev]
     quantal: [libunwind8-dev]
     raring: [libunwind8-dev]
     saucy: [libunwind8-dev]
@@ -5983,7 +5957,6 @@ libuv-dev:
     jessie: [libuv0.10-dev]
   ubuntu:
     bionic: [libuv0.10-dev]
-    precise: [libuv-dev]
     saucy: [libuv-dev]
     trusty: [libuv-dev]
     utopic: [libuv-dev]
@@ -6035,7 +6008,6 @@ libvlc:
   opensuse: [libvlc5, vlc-noX]
   ubuntu:
     '*': [libvlc5, vlc-bin]
-    precise: [libvlc5, vlc-nox]
     saucy: [libvlc5, vlc-nox]
     trusty: [libvlc5, vlc-nox]
     utopic: [libvlc5, vlc-nox]
@@ -6080,7 +6052,6 @@ libvtk:
     '*': [libvtk7-dev]
     artful: [libvtk6-dev]
     bionic: [libvtk6-dev]
-    precise: [libvtk5-dev]
     quantal: [libvtk5-dev]
     raring: [libvtk5-dev]
     saucy: [libvtk5-dev]
@@ -6107,7 +6078,6 @@ libvtk-java:
     '*': [libvtk7-java]
     artful: [libvtk6-java]
     bionic: [libvtk6-java]
-    precise: [libvtk-java]
     quantal: [libvtk-java]
     raring: [libvtk-java]
     saucy: [libvtk-java]
@@ -6135,7 +6105,6 @@ libvtk-qt:
     '*': [libvtk7-qt-dev]
     artful: [libvtk6-qt-dev]
     bionic: [libvtk6-qt-dev]
-    precise: [libvtk5-qt4-dev]
     quantal: [libvtk5-qt4-dev]
     raring: [libvtk5-qt4-dev]
     saucy: [libvtk5-qt4-dev]
@@ -6544,7 +6513,6 @@ log4cxx:
   slackware: [apache-log4cxx]
   ubuntu:
     '*': [liblog4cxx-dev]
-    precise: [liblog4cxx10-dev]
     quantal: [liblog4cxx10-dev]
     raring: [liblog4cxx10-dev]
     saucy: [liblog4cxx10-dev]
@@ -7170,7 +7138,6 @@ php:
   gentoo: [dev-lang/php]
   nixos: [php]
   ubuntu:
-    precise: [php5]
     raring: [php5]
     saucy: [php5]
     trusty: [php5]
@@ -7219,7 +7186,6 @@ pocketsphinx-bin:
   gentoo: [app-accessibility/pocketsphinx]
   nixos: [pocketsphinx]
   ubuntu:
-    precise: [libsphinxbase1]
     quantal: [libsphinxbase1]
     raring: [libsphinxbase1]
     saucy: [libsphinxbase1]
@@ -7280,7 +7246,6 @@ postgresql-9.x-postgis:
   fedora: [postgis]
   gentoo: [dev-db/postgis, =dev-db/postgresql-9*]
   ubuntu:
-    precise: [postgresql-9.1-postgis, postgresql-contrib-9.1, postgresql-server-dev-9.1]
     raring: [postgresql-9.1-postgis, postgresql-contrib-9.1, postgresql-server-dev-9.1]
     saucy: [postgresql-9.1-postgis, postgresql-contrib-9.1, postgresql-server-dev-9.1]
     trusty: [postgresql-9.3-postgis-2.1, postgresql-contrib-9.3, postgresql-server-dev-9.3]
@@ -7630,7 +7595,6 @@ robotino-api2:
   ubuntu: [robotino-api2]
 rosemacs-el:
   ubuntu:
-    precise: [rosemacs-el]
 rsync:
   arch: [rsync]
   debian: [rsync]
@@ -7714,7 +7678,6 @@ sdformat:
     cosmic: [libsdformat6-dev]
     focal: [libsdformat9-dev]
     jammy: [libsdformat-dev]
-    precise: [sdformat]
     quantal: [sdformat]
     raring: [sdformat]
     saucy: [libsdformat-dev]
@@ -7908,7 +7871,6 @@ speex:
   gentoo: [media-libs/speex]
   nixos: [speex]
   ubuntu:
-    precise: [speex]
     trusty: [speex]
     vivid: [speex]
     wily: [speex]
@@ -8011,7 +7973,6 @@ swi-prolog-clib:
     woody: [swi-prolog-clib]
   fedora: [pl-devel]
   ubuntu:
-    precise: [swi-prolog]
     quantal: [swi-prolog]
     raring: [swi-prolog]
 swi-prolog-http:
@@ -8020,7 +7981,6 @@ swi-prolog-http:
     lenny: [swi-prolog-http]
   fedora: [pl]
   ubuntu:
-    precise: [swi-prolog]
     quantal: [swi-prolog]
     raring: [swi-prolog]
 swi-prolog-java:
@@ -8038,7 +7998,6 @@ swi-prolog-semweb:
   arch: [swi-prolog]
   fedora: [pl]
   ubuntu:
-    precise: [swi-prolog]
     quantal: [swi-prolog]
     raring: [swi-prolog]
 swi-prolog-sgml:
@@ -8047,7 +8006,6 @@ swi-prolog-sgml:
     lenny: [swi-prolog-sgml]
   fedora: [pl]
   ubuntu:
-    precise: [swi-prolog]
     quantal: [swi-prolog]
     raring: [swi-prolog]
 swi-prolog-xpce:
@@ -8056,7 +8014,6 @@ swi-prolog-xpce:
     woody: [swi-prolog-xpce]
   fedora: [pl-xpce]
   ubuntu:
-    precise: [swi-prolog]
     quantal: [swi-prolog]
     raring: [swi-prolog]
 swig:
@@ -8107,7 +8064,6 @@ tap-plugins:
   fedora: [ladspa-tap-plugins]
   gentoo: [media-plugins/tap-plugins]
   ubuntu:
-    precise: [tap-plugins]
     trusty: [tap-plugins]
     vivid: [tap-plugins]
     wily: [tap-plugins]
@@ -8600,7 +8556,6 @@ xfont-server:
   fedora: [libXfont]
   gentoo: [x11-libs/libXfont]
   ubuntu:
-    precise: [xfs]
 xfonts-100dpi:
   debian: [xfonts-100dpi]
   fedora: [xorg-x11-fonts-100dpi]
@@ -8660,7 +8615,6 @@ xulrunner-1.9.2:
   debian: []
   ubuntu:
     karmic: [xulrunner-1.9.2]
-    precise: []
     quantal: []
     raring: []
 xulrunner-dev:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1141,7 +1141,6 @@ gazebo:
   slackware: [gazebo]
   ubuntu:
     bionic: [gazebo9]
-    cosmic: [gazebo9]
     disco: [gazebo9]
     eoan: [gazebo9]
     focal: [gazebo11]
@@ -1176,7 +1175,6 @@ gazebo9:
   openembedded: []
   ubuntu:
     bionic: [gazebo9]
-    cosmic: [gazebo9]
     disco: [gazebo9]
     eoan: [gazebo9]
 gcc-arm-none-eabi:
@@ -3344,7 +3342,6 @@ libgazebo9-dev:
   nixos: [gazebo_9]
   ubuntu:
     bionic: [libgazebo9-dev]
-    cosmic: [libgazebo9-dev]
     disco: [libgazebo9-dev]
     eoan: [libgazebo9-dev]
 libgconf2:
@@ -7276,7 +7273,6 @@ sdformat:
     '7': [sdformat-devel]
   ubuntu:
     bionic: [libsdformat6-dev]
-    cosmic: [libsdformat6-dev]
     focal: [libsdformat9-dev]
     jammy: [libsdformat-dev]
 sdformat11:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -181,7 +181,6 @@ assimp:
     lucid: [assimp-dev]
     maverick: [assimp-dev]
     oneiric: [assimp-dev]
-    trusty_python3: [libassimp-dev]
 assimp-dev:
   alpine: [assimp-dev]
   arch: [assimp]
@@ -199,7 +198,6 @@ assimp-dev:
     lucid: [assimp-dev]
     maverick: [assimp-dev]
     oneiric: [assimp-dev]
-    trusty_python3: [libassimp-dev]
 at-spi2-core:
   arch: [at-spi2-core]
   debian: [at-spi2-core]
@@ -408,7 +406,6 @@ bullet:
   rhel: [bullet-devel]
   ubuntu:
     '*': [libbullet-dev]
-    trusty_python3: [libbullet-dev]
 bullet-extras:
   arch: [bullet]
   debian: [libbullet-extras-dev]
@@ -3690,7 +3687,6 @@ libgpgme-dev:
     raring: [libgpgme11-dev]
     saucy: [libgpgme11-dev]
     trusty: [libgpgme11-dev]
-    trusty_python3: [libgpgme11-dev]
     utopic: [libgpgme11-dev]
     vivid: [libgpgme11-dev]
     wily: [libgpgme11-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -616,7 +616,6 @@ collada-dom:
   slackware: [collada-dom]
   ubuntu:
     '*': [libcollada-dom2.4-dp-dev]
-    saucy: [collada-dom-dev]
     trusty: [collada-dom-dev]
     utopic: [collada-dom-dev]
     vivid: [collada-dom-dev]
@@ -1054,7 +1053,6 @@ fltk:  # Consider using the libfltk-dev and fluid (fltk runtime) keys instead.
     artful: [fluid, libfltk1.3-dev]
     bionic: [fluid, libfltk1.3-dev]
     focal: [fluid, libfltk1.3-dev]
-    saucy: [fluid, libfltk1.1-dev]
     trusty: [fluid, libfltk1.1-dev]
     utopic: [fluid, libfltk1.3-dev]
     vivid: [fluid, libfltk1.3-dev]
@@ -1182,7 +1180,6 @@ gazebo:
     eoan: [gazebo9]
     focal: [gazebo11]
     jammy: [gazebo]
-    saucy: [gazebo2]
     trusty: [gazebo2]
     wily: [gazebo7]
     xenial: [gazebo7]
@@ -1553,7 +1550,6 @@ gstreamer0.10-plugins-ugly:
     wheezy: [gstreamer0.10-plugins-ugly]
   gentoo: ['media-libs/gst-plugins-ugly:0.10']
   ubuntu:
-    saucy: [gstreamer0.10-plugins-ugly]
     trusty: [gstreamer0.10-plugins-ugly]
     utopic: [gstreamer0.10-plugins-ugly]
     vivid: [gstreamer0.10-plugins-ugly]
@@ -2235,7 +2231,6 @@ jasper:
     slackpkg:
       packages: [jasper]
   ubuntu:
-    saucy: [libjasper-dev]
     trusty: [libjasper-dev]
     utopic: [libjasper-dev]
     vivid: [libjasper-dev]
@@ -3206,7 +3201,6 @@ libestools-dev:
   gentoo: [app-accessibility/festival]
   ubuntu:
     '*': [libestools-dev]
-    saucy: [libestools2.1-dev]
     trusty: [libestools2.1-dev]
     utopic: [libestools2.1-dev]
     vivid: [libestools2.1-dev]
@@ -3286,7 +3280,6 @@ libflann:
   rhel: [flann]
   ubuntu:
     '*': [libflann1.9]
-    saucy: [libflann1.8]
     trusty: [libflann1.8]
     utopic: [libflann1.8]
     vivid: [libflann1.8]
@@ -3413,7 +3406,6 @@ libftdipp-dev:
   openembedded: [libftdi@meta-oe]
   ubuntu:
     bionic: [libftdipp1-dev]
-    saucy: [libftdipp-dev]
     trusty: [libftdipp-dev]
     vivid: [libftdipp-dev]
     wily: [libftdipp-dev]
@@ -3626,7 +3618,6 @@ libgpgme-dev:
   rhel: [gpgme-devel]
   ubuntu:
     '*': [libgpgme-dev]
-    saucy: [libgpgme11-dev]
     trusty: [libgpgme11-dev]
     utopic: [libgpgme11-dev]
     vivid: [libgpgme11-dev]
@@ -3642,7 +3633,6 @@ libgphoto-dev:
   rhel: [libgphoto2-devel]
   ubuntu:
     '*': [libgphoto2-dev]
-    saucy: [libgphoto2-6-dev]
 libgpiod-dev:
   debian: [libgpiod-dev]
   fedora: [libgpiod-devel]
@@ -3676,7 +3666,6 @@ libgsl:
   openembedded: [gsl@meta-oe]
   ubuntu:
     '*': [libgsl-dev]
-    saucy: [libgsl0-dev]
     trusty: [libgsl0-dev]
     utopic: [libgsl0-dev]
     vivid: [libgsl0-dev]
@@ -4511,7 +4500,6 @@ libopenvdb:
     bionic: [libopenvdb5.0]
     focal: [libopenvdb6.2]
     jammy: [libopenvdb8.1]
-    saucy: [libopenvdb1.1]
     trusty: [libopenvdb2.1]
     utopic: [libopenvdb2.3]
     vivid: [libopenvdb2.3]
@@ -4995,7 +4983,6 @@ libpng-dev:
   slackware: [libpng]
   ubuntu:
     '*': [libpng-dev]
-    saucy: [libpng12-dev]
     trusty: [libpng12-dev]
     utopic: [libpng12-dev]
     vivid: [libpng12-dev]
@@ -5059,7 +5046,6 @@ libpqxx:
     artful: [libpqxx-4.0v5]
     bionic: [libpqxx-4.0v5]
     focal: [libpqxx-6.4]
-    saucy: [libpqxx-3.1]
     trusty: [libpqxx-4.0]
     utopic: [libpqxx-4.0]
     vivid: [libpqxx-4.0]
@@ -5134,7 +5120,6 @@ libqglviewer-qt4:
   ubuntu:
     artful: [libqglviewer2-qt4]
     bionic: [libqglviewer2-qt4]
-    saucy: [libqglviewer2]
     trusty: [libqglviewer2]
     utopic: [libqglviewer2]
     vivid: [libqglviewer2]
@@ -5154,7 +5139,6 @@ libqglviewer-qt4-dev:
   ubuntu:
     artful: [libqglviewer-dev-qt4]
     bionic: [libqglviewer-dev-qt4]
-    saucy: [libqglviewer-dev]
     trusty: [libqglviewer-dev]
     utopic: [libqglviewer-dev]
     vivid: [libqglviewer-dev]
@@ -5772,7 +5756,6 @@ libtool:
     bionic: [libtool, libltdl-dev, libtool-bin]
     focal: [libtool, libltdl-dev, libtool-bin]
     jammy: [libtool, libltdl-dev, libtool-bin]
-    saucy: [libtool, libltdl-dev]
     trusty: [libtool, libltdl-dev]
     utopic: [libtool, libltdl-dev, libtool-bin]
     vivid: [libtool, libltdl-dev, libtool-bin]
@@ -5797,7 +5780,6 @@ libturbojpeg:
   rhel: [libjpeg-turbo-devel, turbojpeg-devel]
   ubuntu:
     '*': [libturbojpeg0-dev]
-    saucy: [libturbojpeg, libjpeg-turbo8-dev]
     trusty: [libturbojpeg, libjpeg-turbo8-dev]
     utopic: [libturbojpeg, libjpeg-turbo8-dev]
     vivid: [libturbojpeg, libjpeg-turbo8-dev]
@@ -5842,7 +5824,6 @@ libunwind-dev:
   nixos: [libunwind]
   ubuntu:
     '*': [libunwind-dev]
-    saucy: [libunwind8-dev]
     trusty: [libunwind8-dev]
 liburdfdom-dev:
   arch: [urdfdom]
@@ -5924,7 +5905,6 @@ libuv-dev:
     jessie: [libuv0.10-dev]
   ubuntu:
     bionic: [libuv0.10-dev]
-    saucy: [libuv-dev]
     trusty: [libuv-dev]
     utopic: [libuv-dev]
     vivid: [libuv0.10-dev]
@@ -5975,7 +5955,6 @@ libvlc:
   opensuse: [libvlc5, vlc-noX]
   ubuntu:
     '*': [libvlc5, vlc-bin]
-    saucy: [libvlc5, vlc-nox]
     trusty: [libvlc5, vlc-nox]
     utopic: [libvlc5, vlc-nox]
     vivid: [libvlc5, vlc-nox]
@@ -6019,7 +5998,6 @@ libvtk:
     '*': [libvtk7-dev]
     artful: [libvtk6-dev]
     bionic: [libvtk6-dev]
-    saucy: [libvtk5-dev]
     trusty: [libvtk5-dev]
     utopic: [libvtk5-dev]
     vivid: [libvtk5-dev]
@@ -6043,7 +6021,6 @@ libvtk-java:
     '*': [libvtk7-java]
     artful: [libvtk6-java]
     bionic: [libvtk6-java]
-    saucy: [libvtk-java]
     trusty: [libvtk-java]
     utopic: [libvtk-java]
     vivid: [libvtk-java]
@@ -6068,7 +6045,6 @@ libvtk-qt:
     '*': [libvtk7-qt-dev]
     artful: [libvtk6-qt-dev]
     bionic: [libvtk6-qt-dev]
-    saucy: [libvtk5-qt4-dev]
     trusty: [libvtk5-qt4-dev]
     utopic: [libvtk5-qt4-dev]
     vivid: [libvtk5-qt4-dev]
@@ -6474,7 +6450,6 @@ log4cxx:
   slackware: [apache-log4cxx]
   ubuntu:
     '*': [liblog4cxx-dev]
-    saucy: [liblog4cxx10-dev]
     trusty: [liblog4cxx10-dev]
     utopic: [liblog4cxx10-dev]
     vivid: [liblog4cxx10-dev]
@@ -7097,7 +7072,6 @@ php:
   gentoo: [dev-lang/php]
   nixos: [php]
   ubuntu:
-    saucy: [php5]
     trusty: [php5]
     utopic: [php5]
     vivid: [php5]
@@ -7144,7 +7118,6 @@ pocketsphinx-bin:
   gentoo: [app-accessibility/pocketsphinx]
   nixos: [pocketsphinx]
   ubuntu:
-    saucy: [libsphinxbase1]
     trusty: [libsphinxbase1]
     utopic: [libsphinxbase1]
     vivid: [libsphinxbase1]
@@ -7202,7 +7175,6 @@ postgresql-9.x-postgis:
   fedora: [postgis]
   gentoo: [dev-db/postgis, =dev-db/postgresql-9*]
   ubuntu:
-    saucy: [postgresql-9.1-postgis, postgresql-contrib-9.1, postgresql-server-dev-9.1]
     trusty: [postgresql-9.3-postgis-2.1, postgresql-contrib-9.3, postgresql-server-dev-9.3]
     utopic: [postgresql-9.4-postgis-2.1, postgresql-contrib-9.4, postgresql-server-dev-9.4]
     vivid: [postgresql-9.4-postgis-2.1, postgresql-contrib-9.4, postgresql-server-dev-9.4]
@@ -7633,7 +7605,6 @@ sdformat:
     cosmic: [libsdformat6-dev]
     focal: [libsdformat9-dev]
     jammy: [libsdformat-dev]
-    saucy: [libsdformat-dev]
     trusty: [libsdformat-dev]
     xenial: [libsdformat4-dev]
 sdformat11:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -178,7 +178,6 @@ assimp:
   slackware: [assimp]
   ubuntu:
     '*': [libassimp-dev]
-    lucid: [assimp-dev]
     maverick: [assimp-dev]
     oneiric: [assimp-dev]
 assimp-dev:
@@ -195,7 +194,6 @@ assimp-dev:
   slackware: [assimp]
   ubuntu:
     '*': [libassimp-dev]
-    lucid: [assimp-dev]
     maverick: [assimp-dev]
     oneiric: [assimp-dev]
 at-spi2-core:
@@ -624,7 +622,6 @@ collada-dom:
   slackware: [collada-dom]
   ubuntu:
     '*': [libcollada-dom2.4-dp-dev]
-    lucid: [collada-dom-dev]
     maverick: [collada-dom-dev]
     natty: [collada-dom-dev]
     oneiric: [collada-dom-dev]
@@ -873,7 +870,6 @@ eclipse:
   gentoo: [dev-java/ant-eclipse-ecj, dev-java/eclipse-ecj]
   ubuntu:
     karmic: [eclipse, eclipse-platform, eclipse-rcp, eclipse-pde]
-    lucid: [eclipse, eclipse-platform, eclipse-rcp, eclipse-pde]
     maverick: [eclipse, eclipse-platform, eclipse-rcp, eclipse-emf, eclipse-xsd, eclipse-pde]
     natty: [eclipse, eclipse-platform, eclipse-rcp, eclipse-emf, eclipse-xsd, eclipse-pde]
     oneiric: [eclipse, eclipse-platform, eclipse-rcp, eclipse-emf, eclipse-xsd, eclipse-pde]
@@ -1076,7 +1072,6 @@ fltk:  # Consider using the libfltk-dev and fluid (fltk runtime) keys instead.
     artful: [fluid, libfltk1.3-dev]
     bionic: [fluid, libfltk1.3-dev]
     focal: [fluid, libfltk1.3-dev]
-    lucid: [fluid, libfltk1.1-dev]
     maverick: [fluid, libfltk1.1-dev]
     natty: [fluid, libfltk1.1-dev]
     oneiric: [fluid, libfltk1.1-dev]
@@ -1586,7 +1581,6 @@ gstreamer0.10-plugins-ugly:
     wheezy: [gstreamer0.10-plugins-ugly]
   gentoo: ['media-libs/gst-plugins-ugly:0.10']
   ubuntu:
-    lucid: [gstreamer0.10-plugins-ugly-multiverse]
     maverick: [gstreamer0.10-plugins-ugly-multiverse]
     natty: [gstreamer0.10-plugins-ugly]
     oneiric: [gstreamer0.10-plugins-ugly]
@@ -2275,7 +2269,6 @@ jasper:
     slackpkg:
       packages: [jasper]
   ubuntu:
-    lucid: [libjasper-dev]
     maverick: [libjasper-dev]
     natty: [libjasper-dev]
     oneiric: [libjasper-dev]
@@ -3679,7 +3672,6 @@ libgpgme-dev:
   rhel: [gpgme-devel]
   ubuntu:
     '*': [libgpgme-dev]
-    lucid: [libgpgme11-dev]
     maverick: [libgpgme11-dev]
     oneiric: [libgpgme11-dev]
     precise: [libgpgme11-dev]
@@ -4523,7 +4515,6 @@ libopenni-nite-dev:
   debian: [libopenni-nite-dev]
   fedora: [openni-nite-devel]
   ubuntu:
-    lucid: [libopenni-nite-dev]
     maverick: [libopenni-nite-dev]
     natty: [libopenni-nite-dev]
     oneiric: [libopenni-nite-dev]
@@ -5132,7 +5123,6 @@ libpqxx:
     artful: [libpqxx-4.0v5]
     bionic: [libpqxx-4.0v5]
     focal: [libpqxx-6.4]
-    lucid: [libpqxx-3.0]
     maverick: [libpqxx-3.0]
     natty: [libpqxx-3.0]
     oneiric: [libpqxx-3.0]
@@ -5214,7 +5204,6 @@ libqglviewer-qt4:
   ubuntu:
     artful: [libqglviewer2-qt4]
     bionic: [libqglviewer2-qt4]
-    lucid: [libqglviewer-qt4-2]
     maverick: [libqglviewer-qt4-2]
     natty: [libqglviewer-qt4-2]
     oneiric: [libqglviewer-qt4-2]
@@ -5241,7 +5230,6 @@ libqglviewer-qt4-dev:
   ubuntu:
     artful: [libqglviewer-dev-qt4]
     bionic: [libqglviewer-dev-qt4]
-    lucid: [libqglviewer-qt4-dev]
     maverick: [libqglviewer-qt4-dev]
     natty: [libqglviewer-qt4-dev]
     oneiric: [libqglviewer-qt4-dev]
@@ -5866,7 +5854,6 @@ libtool:
     bionic: [libtool, libltdl-dev, libtool-bin]
     focal: [libtool, libltdl-dev, libtool-bin]
     jammy: [libtool, libltdl-dev, libtool-bin]
-    lucid: [libtool, libltdl-dev]
     maverick: [libtool, libltdl-dev]
     natty: [libtool, libltdl-dev]
     oneiric: [libtool, libltdl-dev]
@@ -6129,7 +6116,6 @@ libvtk:
     '*': [libvtk7-dev]
     artful: [libvtk6-dev]
     bionic: [libvtk6-dev]
-    lucid: [libvtk5-dev]
     maverick: [libvtk5-dev]
     natty: [libvtk5-dev]
     oneiric: [libvtk5-dev, default-jre-headless, openjdk-6-jdk]
@@ -6160,7 +6146,6 @@ libvtk-java:
     '*': [libvtk7-java]
     artful: [libvtk6-java]
     bionic: [libvtk6-java]
-    lucid: [libvtk-java]
     precise: [libvtk-java]
     quantal: [libvtk-java]
     raring: [libvtk-java]
@@ -6189,7 +6174,6 @@ libvtk-qt:
     '*': [libvtk7-qt-dev]
     artful: [libvtk6-qt-dev]
     bionic: [libvtk6-qt-dev]
-    lucid: [libvtk5-qt4-dev]
     maverick: [libvtk5-qt4-dev]
     natty: [libvtk5-qt4-dev]
     oneiric: [libvtk5-qt4-dev]
@@ -6602,7 +6586,6 @@ log4cxx:
   slackware: [apache-log4cxx]
   ubuntu:
     '*': [liblog4cxx-dev]
-    lucid: [liblog4cxx10-dev]
     maverick: [liblog4cxx10-dev]
     natty: [liblog4cxx10-dev]
     oneiric: [liblog4cxx10-dev]
@@ -7692,7 +7675,6 @@ robotino-api2:
   ubuntu: [robotino-api2]
 rosemacs-el:
   ubuntu:
-    lucid: [rosemacs-el]
     oneiric: [rosemacs-el]
     precise: [rosemacs-el]
 rsync:
@@ -8075,7 +8057,6 @@ swi-prolog-clib:
     woody: [swi-prolog-clib]
   fedora: [pl-devel]
   ubuntu:
-    lucid: [swi-prolog-clib]
     maverick: [swi-prolog]
     natty: [swi-prolog]
     oneiric: [swi-prolog]
@@ -8088,7 +8069,6 @@ swi-prolog-http:
     lenny: [swi-prolog-http]
   fedora: [pl]
   ubuntu:
-    lucid: [swi-prolog-http]
     maverick: [swi-prolog]
     natty: [swi-prolog]
     oneiric: [swi-prolog]
@@ -8110,7 +8090,6 @@ swi-prolog-semweb:
   arch: [swi-prolog]
   fedora: [pl]
   ubuntu:
-    lucid: [swi-prolog-semweb]
     maverick: [swi-prolog]
     natty: [swi-prolog]
     oneiric: [swi-prolog]
@@ -8123,7 +8102,6 @@ swi-prolog-sgml:
     lenny: [swi-prolog-sgml]
   fedora: [pl]
   ubuntu:
-    lucid: [swi-prolog-sgml]
     maverick: [swi-prolog]
     natty: [swi-prolog]
     oneiric: [swi-prolog]
@@ -8136,7 +8114,6 @@ swi-prolog-xpce:
     woody: [swi-prolog-xpce]
   fedora: [pl-xpce]
   ubuntu:
-    lucid: [swi-prolog-xpce]
     maverick: [swi-prolog]
     natty: [swi-prolog]
     oneiric: [swi-prolog]
@@ -8684,7 +8661,6 @@ xfont-server:
   fedora: [libXfont]
   gentoo: [x11-libs/libXfont]
   ubuntu:
-    lucid: [xfs]
     precise: [xfs]
 xfonts-100dpi:
   debian: [xfonts-100dpi]
@@ -8745,7 +8721,6 @@ xulrunner-1.9.2:
   debian: []
   ubuntu:
     karmic: [xulrunner-1.9.2]
-    lucid: [xulrunner-1.9.2]
     maverick: [xulrunner-1.9.2]
     natty: [xulrunner-1.9.2]
     oneiric: []

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2307,9 +2307,6 @@ libaria:
         uri: https://raw.github.com/amor-ros-pkg/rosaria/master/libaria.rdmanifest
   ubuntu:
     '*': [libaria-dev]
-      source:
-        md5sum: 589c387995beb951edd9c77f33cb2286
-        uri: https://raw.github.com/amor-ros-pkg/rosaria/master/libaria.rdmanifest
 libasound2-dev:
   arch: [alsa-lib]
   debian: [libasound2-dev]
@@ -6264,8 +6261,6 @@ meshlab:
 mkdocs:
   debian:
     buster: [mkdocs]
-      pip:
-        packages: [mkdocs]
     stretch: [mkdocs]
     wheezy:
       pip:
@@ -6275,54 +6270,22 @@ mkdocs:
   nixos: [mkdocs]
   ubuntu:
     bionic: [mkdocs]
-      pip:
-        packages: [mkdocs]
-      pip:
-        packages: [mkdocs]
 mkdocs-bootstrap:
   debian:
     buster: [mkdocs-bootstrap]
-      pip:
-        packages: [mkdocs-bootstrap]
     stretch: [mkdocs-bootstrap]
-    wheezy:
-      pip:
-        packages: [mkdocs-bootstrap]
   fedora: [mkdocs-bootstrap]
   gentoo: [dev-python/mkdocs-bootstrap]
   ubuntu:
     bionic: [mkdocs-bootstrap]
-      pip:
-        packages: [mkdocs-bootstrap]
-      pip:
-        packages: [mkdocs-bootswatch]
-      pip:
-        packages: [mkdocs-bootswatch]
-      pip:
-        packages: [mkdocs-bootstrap]
 mkdocs-bootswatch:
   debian:
     buster: [mkdocs-bootswatch]
-      pip:
-        packages: [mkdocs-bootswatch]
     stretch: [mkdocs-bootswatch]
-    wheezy:
-      pip:
-        packages: [mkdocs-bootswatch]
   fedora: [mkdocs-bootswatch]
   gentoo: [dev-python/mkdocs-bootswatch]
   ubuntu:
     bionic: [mkdocs-bootswatch]
-      pip:
-        packages: [mkdocs-bootswatch]
-      pip:
-        packages: [mkdocs-bootswatch]
-      pip:
-        packages: [mkdocs-bootswatch]
-      pip:
-        packages: [mkdocs-bootswatch]
-      pip:
-        packages: [mkdocs-bootswatch]
 mongodb:
   gentoo: [dev-db/mongodb]
   nixos: [mongodb]
@@ -7513,12 +7476,12 @@ swi-prolog-clib:
     lenny: [swi-prolog-clib]
     woody: [swi-prolog-clib]
   fedora: [pl-devel]
-wi-prolog-http:
+swi-prolog-http:
   arch: [swi-prolog]
   debian:
     lenny: [swi-prolog-http]
   fedora: [pl]
-wi-prolog-java:
+swi-prolog-java:
   debian: [swi-prolog-java]
   fedora: [pl-jpl]
   gentoo: ['dev-lang/swi-prolog[java]']
@@ -7537,7 +7500,7 @@ swi-prolog-sgml:
   debian:
     lenny: [swi-prolog-sgml]
   fedora: [pl]
-wi-prolog-xpce:
+swi-prolog-xpce:
   arch: [swi-prolog]
   debian:
     woody: [swi-prolog-xpce]
@@ -8070,7 +8033,7 @@ xfont-server:
   debian: [xfs]
   fedora: [libXfont]
   gentoo: [x11-libs/libXfont]
-fonts-100dpi:
+xfonts-100dpi:
   debian: [xfonts-100dpi]
   fedora: [xorg-x11-fonts-100dpi]
   gentoo: [media-fonts/font-adobe-100dpi, media-fonts/font-bh-100dpi, media-fonts/font-bh-lucidatypewriter-100dpi, media-fonts/font-bitstream-100dpi]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -38,7 +38,6 @@ acpitool:
   fedora: [acpitool]
   gentoo: [sys-power/acpitool]
   nixos: [acpitool]
-  ubuntu:
 alsa-oss:
   arch: [alsa-oss]
   debian: [alsa-oss]
@@ -348,7 +347,6 @@ bluez-hcidump:
   debian: [bluez-hcidump]
   fedora: [bluez-hcidump]
   gentoo: [net-wireless/bluez-hcidump]
-  ubuntu:
 boost:
   alpine: [boost-dev]
   arch: [boost]
@@ -1477,9 +1475,6 @@ gringo:
   debian: [gringo]
   nixos: [gringo]
   ubuntu: [gringo]
-gstreamer0.10-gconf:
-  debian:
-  ubuntu:
 gstreamer0.10-plugins-good:
   arch: [gstreamer0.10-good-plugins]
   debian:
@@ -1491,7 +1486,6 @@ gstreamer0.10-plugins-ugly:
   debian:
     wheezy: [gstreamer0.10-plugins-ugly]
   gentoo: ['media-libs/gst-plugins-ugly:0.10']
-  ubuntu:
 gstreamer0.10-pocketsphinx:
   debian:
   fedora: [pocketsphinx-plugin]
@@ -2161,7 +2155,6 @@ jasper:
   slackware:
     slackpkg:
       packages: [jasper]
-  ubuntu:
 java:
   alpine: [openjdk8-jre]
   arch: [jdk7-openjdk]
@@ -2381,7 +2374,6 @@ libbison-dev:
   gentoo: [sys-devel/bison]
   nixos: [bison]
   rhel: [bison-devel]
-  ubuntu:
 libblas-dev:
   arch: [cblas]
   debian: [libblas-dev]
@@ -3771,7 +3763,6 @@ libjansson-dev:
   ubuntu: [libjansson-dev]
 libjaxp1.3-java:
   debian: [libjaxp1.3-java]
-  ubuntu:
 libjpeg:
   arch: [libjpeg-turbo]
   debian: [libjpeg-dev]
@@ -4278,7 +4269,6 @@ libopenni-nite-dev:
   arch: [primesense-nite]
   debian: [libopenni-nite-dev]
   fedora: [openni-nite-devel]
-  ubuntu:
 libopenni-sensor-primesense-dev:
   arch: [sensorkinect]
   debian: [libopenni-sensor-primesense-dev]
@@ -6744,7 +6734,6 @@ php:
   fedora: [php]
   gentoo: [dev-lang/php]
   nixos: [php]
-  ubuntu:
 pigz:
   debian: [pigz]
   fedora: [pigz]
@@ -6782,7 +6771,6 @@ pocketsphinx-bin:
   fedora: [pocketsphinx]
   gentoo: [app-accessibility/pocketsphinx]
   nixos: [pocketsphinx]
-  ubuntu:
 polyclipping-dev:
   debian:
     buster: [libpolyclipping-dev]
@@ -6830,7 +6818,6 @@ postgresql-9.x-postgis:
     wheezy: [postgresql-9.4-postgis-2.1, postgresql-contrib, postgresql-server-dev-all]
   fedora: [postgis]
   gentoo: [dev-db/postgis, =dev-db/postgresql-9*]
-  ubuntu:
 postgresql-client:
   debian: [postgresql-client]
   fedora: [postgresql]
@@ -7164,8 +7151,6 @@ redis-server:
   ubuntu: [redis-server]
 robotino-api2:
   ubuntu: [robotino-api2]
-rosemacs-el:
-  ubuntu:
 rsync:
   arch: [rsync]
   debian: [rsync]
@@ -7433,7 +7418,6 @@ speex:
   fedora: [speex, speex-tools, speexdsp]
   gentoo: [media-libs/speex]
   nixos: [speex]
-  ubuntu:
 spirv-headers:
   arch: [spirv-headers]
   debian: [spirv-headers]
@@ -7529,14 +7513,12 @@ swi-prolog-clib:
     lenny: [swi-prolog-clib]
     woody: [swi-prolog-clib]
   fedora: [pl-devel]
-  ubuntu:
-swi-prolog-http:
+wi-prolog-http:
   arch: [swi-prolog]
   debian:
     lenny: [swi-prolog-http]
   fedora: [pl]
-  ubuntu:
-swi-prolog-java:
+wi-prolog-java:
   debian: [swi-prolog-java]
   fedora: [pl-jpl]
   gentoo: ['dev-lang/swi-prolog[java]']
@@ -7550,19 +7532,16 @@ swi-prolog-odbc:
 swi-prolog-semweb:
   arch: [swi-prolog]
   fedora: [pl]
-  ubuntu:
 swi-prolog-sgml:
   arch: [swi-prolog]
   debian:
     lenny: [swi-prolog-sgml]
   fedora: [pl]
-  ubuntu:
-swi-prolog-xpce:
+wi-prolog-xpce:
   arch: [swi-prolog]
   debian:
     woody: [swi-prolog-xpce]
   fedora: [pl-xpce]
-  ubuntu:
 swig:
   debian: [swig]
   fedora: [swig]
@@ -7610,7 +7589,6 @@ tap-plugins:
   debian: [tap-plugins]
   fedora: [ladspa-tap-plugins]
   gentoo: [media-plugins/tap-plugins]
-  ubuntu:
 tar:
   arch: [libtar]
   debian: [libtar-dev]
@@ -7948,10 +7926,6 @@ vorbis-tools:
   gentoo: [media-sound/vorbis-tools]
   nixos: [vorbis-tools]
   ubuntu: [vorbis-tools]
-vrep:
-  ubuntu:
-      source:
-        uri: https://raw.githubusercontent.com/peci1/vrep_ros_bridge/rdmanifest/vrep.rdmanifest
 wget:
   arch: [wget]
   debian: [wget]
@@ -8096,8 +8070,7 @@ xfont-server:
   debian: [xfs]
   fedora: [libXfont]
   gentoo: [x11-libs/libXfont]
-  ubuntu:
-xfonts-100dpi:
+fonts-100dpi:
   debian: [xfonts-100dpi]
   fedora: [xorg-x11-fonts-100dpi]
   gentoo: [media-fonts/font-adobe-100dpi, media-fonts/font-bh-100dpi, media-fonts/font-bh-lucidatypewriter-100dpi, media-fonts/font-bitstream-100dpi]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -620,7 +620,6 @@ collada-dom:
   slackware: [collada-dom]
   ubuntu:
     '*': [libcollada-dom2.4-dp-dev]
-    natty: [collada-dom-dev]
     oneiric: [collada-dom-dev]
     precise: [collada-dom-dev]
     quantal: [collada-dom-dev]
@@ -867,7 +866,6 @@ eclipse:
   gentoo: [dev-java/ant-eclipse-ecj, dev-java/eclipse-ecj]
   ubuntu:
     karmic: [eclipse, eclipse-platform, eclipse-rcp, eclipse-pde]
-    natty: [eclipse, eclipse-platform, eclipse-rcp, eclipse-emf, eclipse-xsd, eclipse-pde]
     oneiric: [eclipse, eclipse-platform, eclipse-rcp, eclipse-emf, eclipse-xsd, eclipse-pde]
     precise: [eclipse, eclipse-platform, eclipse-rcp, eclipse-emf, eclipse-xsd, eclipse-pde]
     quantal: [eclipse, eclipse-platform, eclipse-rcp, eclipse-emf, eclipse-xsd, eclipse-pde]
@@ -1068,7 +1066,6 @@ fltk:  # Consider using the libfltk-dev and fluid (fltk runtime) keys instead.
     artful: [fluid, libfltk1.3-dev]
     bionic: [fluid, libfltk1.3-dev]
     focal: [fluid, libfltk1.3-dev]
-    natty: [fluid, libfltk1.1-dev]
     oneiric: [fluid, libfltk1.1-dev]
     precise: [fluid, libfltk1.1-dev]
     quantal: [fluid, libfltk1.1-dev]
@@ -1576,7 +1573,6 @@ gstreamer0.10-plugins-ugly:
     wheezy: [gstreamer0.10-plugins-ugly]
   gentoo: ['media-libs/gst-plugins-ugly:0.10']
   ubuntu:
-    natty: [gstreamer0.10-plugins-ugly]
     oneiric: [gstreamer0.10-plugins-ugly]
     precise: [gstreamer0.10-plugins-ugly]
     quantal: [gstreamer0.10-plugins-ugly]
@@ -2263,7 +2259,6 @@ jasper:
     slackpkg:
       packages: [jasper]
   ubuntu:
-    natty: [libjasper-dev]
     oneiric: [libjasper-dev]
     precise: [libjasper-dev]
     quantal: [libjasper-dev]
@@ -4507,7 +4502,6 @@ libopenni-nite-dev:
   debian: [libopenni-nite-dev]
   fedora: [openni-nite-devel]
   ubuntu:
-    natty: [libopenni-nite-dev]
     oneiric: [libopenni-nite-dev]
     precise: [libopenni-nite-dev]
     quantal: [libopenni-nite-dev]
@@ -5114,7 +5108,6 @@ libpqxx:
     artful: [libpqxx-4.0v5]
     bionic: [libpqxx-4.0v5]
     focal: [libpqxx-6.4]
-    natty: [libpqxx-3.0]
     oneiric: [libpqxx-3.0]
     precise: [libpqxx-3.1]
     quantal: [libpqxx-3.1]
@@ -5194,7 +5187,6 @@ libqglviewer-qt4:
   ubuntu:
     artful: [libqglviewer2-qt4]
     bionic: [libqglviewer2-qt4]
-    natty: [libqglviewer-qt4-2]
     oneiric: [libqglviewer-qt4-2]
     precise: [libqglviewer-qt4-2]
     quantal: [libqglviewer-qt4-2]
@@ -5219,7 +5211,6 @@ libqglviewer-qt4-dev:
   ubuntu:
     artful: [libqglviewer-dev-qt4]
     bionic: [libqglviewer-dev-qt4]
-    natty: [libqglviewer-qt4-dev]
     oneiric: [libqglviewer-qt4-dev]
     precise: [libqglviewer-qt4-dev]
     quantal: [libqglviewer-qt4-dev]
@@ -5842,7 +5833,6 @@ libtool:
     bionic: [libtool, libltdl-dev, libtool-bin]
     focal: [libtool, libltdl-dev, libtool-bin]
     jammy: [libtool, libltdl-dev, libtool-bin]
-    natty: [libtool, libltdl-dev]
     oneiric: [libtool, libltdl-dev]
     precise: [libtool, libltdl-dev]
     quantal: [libtool, libltdl-dev]
@@ -6103,7 +6093,6 @@ libvtk:
     '*': [libvtk7-dev]
     artful: [libvtk6-dev]
     bionic: [libvtk6-dev]
-    natty: [libvtk5-dev]
     oneiric: [libvtk5-dev, default-jre-headless, openjdk-6-jdk]
     precise: [libvtk5-dev]
     quantal: [libvtk5-dev]
@@ -6160,7 +6149,6 @@ libvtk-qt:
     '*': [libvtk7-qt-dev]
     artful: [libvtk6-qt-dev]
     bionic: [libvtk6-qt-dev]
-    natty: [libvtk5-qt4-dev]
     oneiric: [libvtk5-qt4-dev]
     precise: [libvtk5-qt4-dev]
     quantal: [libvtk5-qt4-dev]
@@ -6571,7 +6559,6 @@ log4cxx:
   slackware: [apache-log4cxx]
   ubuntu:
     '*': [liblog4cxx-dev]
-    natty: [liblog4cxx10-dev]
     oneiric: [liblog4cxx10-dev]
     precise: [liblog4cxx10-dev]
     quantal: [liblog4cxx10-dev]
@@ -8041,7 +8028,6 @@ swi-prolog-clib:
     woody: [swi-prolog-clib]
   fedora: [pl-devel]
   ubuntu:
-    natty: [swi-prolog]
     oneiric: [swi-prolog]
     precise: [swi-prolog]
     quantal: [swi-prolog]
@@ -8052,7 +8038,6 @@ swi-prolog-http:
     lenny: [swi-prolog-http]
   fedora: [pl]
   ubuntu:
-    natty: [swi-prolog]
     oneiric: [swi-prolog]
     precise: [swi-prolog]
     quantal: [swi-prolog]
@@ -8072,7 +8057,6 @@ swi-prolog-semweb:
   arch: [swi-prolog]
   fedora: [pl]
   ubuntu:
-    natty: [swi-prolog]
     oneiric: [swi-prolog]
     precise: [swi-prolog]
     quantal: [swi-prolog]
@@ -8083,7 +8067,6 @@ swi-prolog-sgml:
     lenny: [swi-prolog-sgml]
   fedora: [pl]
   ubuntu:
-    natty: [swi-prolog]
     oneiric: [swi-prolog]
     precise: [swi-prolog]
     quantal: [swi-prolog]
@@ -8094,7 +8077,6 @@ swi-prolog-xpce:
     woody: [swi-prolog-xpce]
   fedora: [pl-xpce]
   ubuntu:
-    natty: [swi-prolog]
     oneiric: [swi-prolog]
     precise: [swi-prolog]
     quantal: [swi-prolog]
@@ -8700,7 +8682,6 @@ xulrunner-1.9.2:
   debian: []
   ubuntu:
     karmic: [xulrunner-1.9.2]
-    natty: [xulrunner-1.9.2]
     oneiric: []
     precise: []
     quantal: []

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6519,7 +6519,6 @@ nlohmann-json-dev:
   ubuntu:
     bionic: [nlohmann-json-dev]
     focal: [nlohmann-json3-dev]
-    groovy: [nlohmann-json3-dev]
     jammy: [nlohmann-json3-dev]
 nmap:
   archlinux: [nmap]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -616,7 +616,6 @@ collada-dom:
   slackware: [collada-dom]
   ubuntu:
     '*': [libcollada-dom2.4-dp-dev]
-    quantal: [collada-dom-dev]
     raring: [collada-dom-dev]
     saucy: [collada-dom-dev]
     trusty: [collada-dom-dev]
@@ -860,7 +859,6 @@ eclipse:
   gentoo: [dev-java/ant-eclipse-ecj, dev-java/eclipse-ecj]
   ubuntu:
     karmic: [eclipse, eclipse-platform, eclipse-rcp, eclipse-pde]
-    quantal: [eclipse, eclipse-platform, eclipse-rcp, eclipse-emf, eclipse-xsd, eclipse-pde]
     raring: [eclipse, eclipse-platform, eclipse-rcp, eclipse-emf, eclipse-xsd, eclipse-pde]
 ed:
   debian: [ed]
@@ -1058,7 +1056,6 @@ fltk:  # Consider using the libfltk-dev and fluid (fltk runtime) keys instead.
     artful: [fluid, libfltk1.3-dev]
     bionic: [fluid, libfltk1.3-dev]
     focal: [fluid, libfltk1.3-dev]
-    quantal: [fluid, libfltk1.1-dev]
     raring: [fluid, libfltk1.1-dev]
     saucy: [fluid, libfltk1.1-dev]
     trusty: [fluid, libfltk1.1-dev]
@@ -1188,7 +1185,6 @@ gazebo:
     eoan: [gazebo9]
     focal: [gazebo11]
     jammy: [gazebo]
-    quantal: [gazebo]
     raring: [gazebo]
     saucy: [gazebo2]
     trusty: [gazebo2]
@@ -1561,7 +1557,6 @@ gstreamer0.10-plugins-ugly:
     wheezy: [gstreamer0.10-plugins-ugly]
   gentoo: ['media-libs/gst-plugins-ugly:0.10']
   ubuntu:
-    quantal: [gstreamer0.10-plugins-ugly]
     raring: [gstreamer0.10-plugins-ugly]
     saucy: [gstreamer0.10-plugins-ugly]
     trusty: [gstreamer0.10-plugins-ugly]
@@ -2245,7 +2240,6 @@ jasper:
     slackpkg:
       packages: [jasper]
   ubuntu:
-    quantal: [libjasper-dev]
     raring: [libjasper-dev]
     saucy: [libjasper-dev]
     trusty: [libjasper-dev]
@@ -3298,7 +3292,6 @@ libflann:
   rhel: [flann]
   ubuntu:
     '*': [libflann1.9]
-    quantal: [libflann1.7]
     raring: [libflann1.7]
     saucy: [libflann1.8]
     trusty: [libflann1.8]
@@ -3640,7 +3633,6 @@ libgpgme-dev:
   rhel: [gpgme-devel]
   ubuntu:
     '*': [libgpgme-dev]
-    quantal: [libgpgme11-dev]
     raring: [libgpgme11-dev]
     saucy: [libgpgme11-dev]
     trusty: [libgpgme11-dev]
@@ -4477,7 +4469,6 @@ libopenni-nite-dev:
   debian: [libopenni-nite-dev]
   fedora: [openni-nite-devel]
   ubuntu:
-    quantal: [libopenni-nite-dev]
 libopenni-sensor-primesense-dev:
   arch: [sensorkinect]
   debian: [libopenni-sensor-primesense-dev]
@@ -5014,7 +5005,6 @@ libpng-dev:
   slackware: [libpng]
   ubuntu:
     '*': [libpng-dev]
-    quantal: [libpng12-dev]
     raring: [libpng12-dev]
     saucy: [libpng12-dev]
     trusty: [libpng12-dev]
@@ -5080,7 +5070,6 @@ libpqxx:
     artful: [libpqxx-4.0v5]
     bionic: [libpqxx-4.0v5]
     focal: [libpqxx-6.4]
-    quantal: [libpqxx-3.1]
     raring: [libpqxx-3.1]
     saucy: [libpqxx-3.1]
     trusty: [libpqxx-4.0]
@@ -5157,7 +5146,6 @@ libqglviewer-qt4:
   ubuntu:
     artful: [libqglviewer2-qt4]
     bionic: [libqglviewer2-qt4]
-    quantal: [libqglviewer-qt4-2]
     raring: [libqglviewer-qt4-2]
     saucy: [libqglviewer2]
     trusty: [libqglviewer2]
@@ -5179,7 +5167,6 @@ libqglviewer-qt4-dev:
   ubuntu:
     artful: [libqglviewer-dev-qt4]
     bionic: [libqglviewer-dev-qt4]
-    quantal: [libqglviewer-qt4-dev]
     raring: [libqglviewer-qt4-dev]
     saucy: [libqglviewer-dev]
     trusty: [libqglviewer-dev]
@@ -5799,7 +5786,6 @@ libtool:
     bionic: [libtool, libltdl-dev, libtool-bin]
     focal: [libtool, libltdl-dev, libtool-bin]
     jammy: [libtool, libltdl-dev, libtool-bin]
-    quantal: [libtool, libltdl-dev]
     raring: [libtool, libltdl-dev]
     saucy: [libtool, libltdl-dev]
     trusty: [libtool, libltdl-dev]
@@ -5826,7 +5812,6 @@ libturbojpeg:
   rhel: [libjpeg-turbo-devel, turbojpeg-devel]
   ubuntu:
     '*': [libturbojpeg0-dev]
-    quantal: [libturbojpeg, libjpeg-turbo8-dev]
     raring: [libturbojpeg, libjpeg-turbo8-dev]
     saucy: [libturbojpeg, libjpeg-turbo8-dev]
     trusty: [libturbojpeg, libjpeg-turbo8-dev]
@@ -5873,7 +5858,6 @@ libunwind-dev:
   nixos: [libunwind]
   ubuntu:
     '*': [libunwind-dev]
-    quantal: [libunwind8-dev]
     raring: [libunwind8-dev]
     saucy: [libunwind8-dev]
     trusty: [libunwind8-dev]
@@ -6052,7 +6036,6 @@ libvtk:
     '*': [libvtk7-dev]
     artful: [libvtk6-dev]
     bionic: [libvtk6-dev]
-    quantal: [libvtk5-dev]
     raring: [libvtk5-dev]
     saucy: [libvtk5-dev]
     trusty: [libvtk5-dev]
@@ -6078,7 +6061,6 @@ libvtk-java:
     '*': [libvtk7-java]
     artful: [libvtk6-java]
     bionic: [libvtk6-java]
-    quantal: [libvtk-java]
     raring: [libvtk-java]
     saucy: [libvtk-java]
     trusty: [libvtk-java]
@@ -6105,7 +6087,6 @@ libvtk-qt:
     '*': [libvtk7-qt-dev]
     artful: [libvtk6-qt-dev]
     bionic: [libvtk6-qt-dev]
-    quantal: [libvtk5-qt4-dev]
     raring: [libvtk5-qt4-dev]
     saucy: [libvtk5-qt4-dev]
     trusty: [libvtk5-qt4-dev]
@@ -6513,7 +6494,6 @@ log4cxx:
   slackware: [apache-log4cxx]
   ubuntu:
     '*': [liblog4cxx-dev]
-    quantal: [liblog4cxx10-dev]
     raring: [liblog4cxx10-dev]
     saucy: [liblog4cxx10-dev]
     trusty: [liblog4cxx10-dev]
@@ -7186,7 +7166,6 @@ pocketsphinx-bin:
   gentoo: [app-accessibility/pocketsphinx]
   nixos: [pocketsphinx]
   ubuntu:
-    quantal: [libsphinxbase1]
     raring: [libsphinxbase1]
     saucy: [libsphinxbase1]
     trusty: [libsphinxbase1]
@@ -7678,7 +7657,6 @@ sdformat:
     cosmic: [libsdformat6-dev]
     focal: [libsdformat9-dev]
     jammy: [libsdformat-dev]
-    quantal: [sdformat]
     raring: [sdformat]
     saucy: [libsdformat-dev]
     trusty: [libsdformat-dev]
@@ -7973,7 +7951,6 @@ swi-prolog-clib:
     woody: [swi-prolog-clib]
   fedora: [pl-devel]
   ubuntu:
-    quantal: [swi-prolog]
     raring: [swi-prolog]
 swi-prolog-http:
   arch: [swi-prolog]
@@ -7981,7 +7958,6 @@ swi-prolog-http:
     lenny: [swi-prolog-http]
   fedora: [pl]
   ubuntu:
-    quantal: [swi-prolog]
     raring: [swi-prolog]
 swi-prolog-java:
   debian: [swi-prolog-java]
@@ -7998,7 +7974,6 @@ swi-prolog-semweb:
   arch: [swi-prolog]
   fedora: [pl]
   ubuntu:
-    quantal: [swi-prolog]
     raring: [swi-prolog]
 swi-prolog-sgml:
   arch: [swi-prolog]
@@ -8006,7 +7981,6 @@ swi-prolog-sgml:
     lenny: [swi-prolog-sgml]
   fedora: [pl]
   ubuntu:
-    quantal: [swi-prolog]
     raring: [swi-prolog]
 swi-prolog-xpce:
   arch: [swi-prolog]
@@ -8014,7 +7988,6 @@ swi-prolog-xpce:
     woody: [swi-prolog-xpce]
   fedora: [pl-xpce]
   ubuntu:
-    quantal: [swi-prolog]
     raring: [swi-prolog]
 swig:
   debian: [swig]
@@ -8615,7 +8588,6 @@ xulrunner-1.9.2:
   debian: []
   ubuntu:
     karmic: [xulrunner-1.9.2]
-    quantal: []
     raring: []
 xulrunner-dev:
   arch: [xulrunner]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -617,7 +617,6 @@ collada-dom:
   ubuntu:
     '*': [libcollada-dom2.4-dp-dev]
     trusty: [collada-dom-dev]
-    utopic: [collada-dom-dev]
     vivid: [collada-dom-dev]
     wily: [collada-dom-dev]
 collectd:
@@ -983,7 +982,6 @@ ffmpeg:
   ubuntu:
     '*': [ffmpeg, libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev]
     trusty: [libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev]
-    utopic: [libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev]
     vivid: [libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev]
 ffmpeg2theora:
   arch: [ffmpeg2theora]
@@ -1054,7 +1052,6 @@ fltk:  # Consider using the libfltk-dev and fluid (fltk runtime) keys instead.
     bionic: [fluid, libfltk1.3-dev]
     focal: [fluid, libfltk1.3-dev]
     trusty: [fluid, libfltk1.1-dev]
-    utopic: [fluid, libfltk1.3-dev]
     vivid: [fluid, libfltk1.3-dev]
     wily: [fluid, libfltk1.3-dev]
     xenial: [fluid, libfltk1.3-dev]
@@ -1532,7 +1529,6 @@ gstreamer0.10-gconf:
     jessie: [gstreamer0.10-gconf]
   ubuntu:
     trusty: [gstreamer0.10-gconf]
-    utopic: [gstreamer0.10-gconf]
     vivid: [gstreamer0.10-gconf]
     wily: [gstreamer0.10-gconf]
     xenial: [gstreamer0.10-gconf]
@@ -1551,7 +1547,6 @@ gstreamer0.10-plugins-ugly:
   gentoo: ['media-libs/gst-plugins-ugly:0.10']
   ubuntu:
     trusty: [gstreamer0.10-plugins-ugly]
-    utopic: [gstreamer0.10-plugins-ugly]
     vivid: [gstreamer0.10-plugins-ugly]
     wily: [gstreamer0.10-plugins-ugly]
 gstreamer0.10-pocketsphinx:
@@ -2232,7 +2227,6 @@ jasper:
       packages: [jasper]
   ubuntu:
     trusty: [libjasper-dev]
-    utopic: [libjasper-dev]
     vivid: [libjasper-dev]
     wily: [libjasper-dev]
     xenial: [libjasper-dev]
@@ -3202,7 +3196,6 @@ libestools-dev:
   ubuntu:
     '*': [libestools-dev]
     trusty: [libestools2.1-dev]
-    utopic: [libestools2.1-dev]
     vivid: [libestools2.1-dev]
 libev-dev:
   arch: [libev]
@@ -3281,7 +3274,6 @@ libflann:
   ubuntu:
     '*': [libflann1.9]
     trusty: [libflann1.8]
-    utopic: [libflann1.8]
     vivid: [libflann1.8]
     wily: [libflann1.8]
     xenial: [libflann1.8]
@@ -3619,7 +3611,6 @@ libgpgme-dev:
   ubuntu:
     '*': [libgpgme-dev]
     trusty: [libgpgme11-dev]
-    utopic: [libgpgme11-dev]
     vivid: [libgpgme11-dev]
     wily: [libgpgme11-dev]
     xenial: [libgpgme11-dev]
@@ -3667,7 +3658,6 @@ libgsl:
   ubuntu:
     '*': [libgsl-dev]
     trusty: [libgsl0-dev]
-    utopic: [libgsl0-dev]
     vivid: [libgsl0-dev]
     wily: [libgsl0-dev]
 libgstreamer-plugins-base0.10-0:
@@ -4501,7 +4491,6 @@ libopenvdb:
     focal: [libopenvdb6.2]
     jammy: [libopenvdb8.1]
     trusty: [libopenvdb2.1]
-    utopic: [libopenvdb2.3]
     vivid: [libopenvdb2.3]
     wily: [libopenvdb3.0]
     xenial: [libopenvdb3.1]
@@ -4984,7 +4973,6 @@ libpng-dev:
   ubuntu:
     '*': [libpng-dev]
     trusty: [libpng12-dev]
-    utopic: [libpng12-dev]
     vivid: [libpng12-dev]
     wily: [libpng12-dev]
     xenial: [libpng12-dev]
@@ -5047,7 +5035,6 @@ libpqxx:
     bionic: [libpqxx-4.0v5]
     focal: [libpqxx-6.4]
     trusty: [libpqxx-4.0]
-    utopic: [libpqxx-4.0]
     vivid: [libpqxx-4.0]
     wily: [libpqxx-4.0]
     xenial: [libpqxx-4.0]
@@ -5121,7 +5108,6 @@ libqglviewer-qt4:
     artful: [libqglviewer2-qt4]
     bionic: [libqglviewer2-qt4]
     trusty: [libqglviewer2]
-    utopic: [libqglviewer2]
     vivid: [libqglviewer2]
     wily: [libqglviewer2-qt4]
     xenial: [libqglviewer2-qt4]
@@ -5140,7 +5126,6 @@ libqglviewer-qt4-dev:
     artful: [libqglviewer-dev-qt4]
     bionic: [libqglviewer-dev-qt4]
     trusty: [libqglviewer-dev]
-    utopic: [libqglviewer-dev]
     vivid: [libqglviewer-dev]
     wily: [libqglviewer-dev-qt4]
     xenial: [libqglviewer-dev-qt4]
@@ -5757,7 +5742,6 @@ libtool:
     focal: [libtool, libltdl-dev, libtool-bin]
     jammy: [libtool, libltdl-dev, libtool-bin]
     trusty: [libtool, libltdl-dev]
-    utopic: [libtool, libltdl-dev, libtool-bin]
     vivid: [libtool, libltdl-dev, libtool-bin]
     wily: [libtool, libltdl-dev, libtool-bin]
     xenial: [libtool, libltdl-dev, libtool-bin]
@@ -5781,7 +5765,6 @@ libturbojpeg:
   ubuntu:
     '*': [libturbojpeg0-dev]
     trusty: [libturbojpeg, libjpeg-turbo8-dev]
-    utopic: [libturbojpeg, libjpeg-turbo8-dev]
     vivid: [libturbojpeg, libjpeg-turbo8-dev]
     wily: [libturbojpeg, libjpeg-turbo8-dev]
     xenial: [libturbojpeg, libjpeg-turbo8-dev]
@@ -5906,7 +5889,6 @@ libuv-dev:
   ubuntu:
     bionic: [libuv0.10-dev]
     trusty: [libuv-dev]
-    utopic: [libuv-dev]
     vivid: [libuv0.10-dev]
     wily: [libuv0.10-dev]
     xenial: [libuv0.10-dev]
@@ -5956,7 +5938,6 @@ libvlc:
   ubuntu:
     '*': [libvlc5, vlc-bin]
     trusty: [libvlc5, vlc-nox]
-    utopic: [libvlc5, vlc-nox]
     vivid: [libvlc5, vlc-nox]
     wily: [libvlc5, vlc-nox]
     xenial: [libvlc5, vlc-nox]
@@ -5999,7 +5980,6 @@ libvtk:
     artful: [libvtk6-dev]
     bionic: [libvtk6-dev]
     trusty: [libvtk5-dev]
-    utopic: [libvtk5-dev]
     vivid: [libvtk5-dev]
     wily: [libvtk5-dev]
     xenial: [libvtk6-dev]
@@ -6022,7 +6002,6 @@ libvtk-java:
     artful: [libvtk6-java]
     bionic: [libvtk6-java]
     trusty: [libvtk-java]
-    utopic: [libvtk-java]
     vivid: [libvtk-java]
     wily: [libvtk-java]
     xenial: [libvtk-java]
@@ -6046,7 +6025,6 @@ libvtk-qt:
     artful: [libvtk6-qt-dev]
     bionic: [libvtk6-qt-dev]
     trusty: [libvtk5-qt4-dev]
-    utopic: [libvtk5-qt4-dev]
     vivid: [libvtk5-qt4-dev]
     wily: [libvtk5-qt4-dev]
     xenial: [libvtk6-qt-dev]
@@ -6451,7 +6429,6 @@ log4cxx:
   ubuntu:
     '*': [liblog4cxx-dev]
     trusty: [liblog4cxx10-dev]
-    utopic: [liblog4cxx10-dev]
     vivid: [liblog4cxx10-dev]
     wily: [liblog4cxx10-dev]
     xenial: [liblog4cxx10-dev]
@@ -6587,7 +6564,6 @@ mkdocs:
     trusty:
       pip:
         packages: [mkdocs]
-    utopic:
       pip:
         packages: [mkdocs]
     wily: [mkdocs]
@@ -6612,7 +6588,6 @@ mkdocs-bootstrap:
     trusty:
       pip:
         packages: [mkdocs-bootstrap]
-    utopic:
       pip:
         packages: [mkdocs-bootswatch]
     wily:
@@ -6641,7 +6616,6 @@ mkdocs-bootswatch:
     trusty:
       pip:
         packages: [mkdocs-bootswatch]
-    utopic:
       pip:
         packages: [mkdocs-bootswatch]
     wily:
@@ -7073,7 +7047,6 @@ php:
   nixos: [php]
   ubuntu:
     trusty: [php5]
-    utopic: [php5]
     vivid: [php5]
     wily: [php5]
     xenial: [php7.0]
@@ -7119,7 +7092,6 @@ pocketsphinx-bin:
   nixos: [pocketsphinx]
   ubuntu:
     trusty: [libsphinxbase1]
-    utopic: [libsphinxbase1]
     vivid: [libsphinxbase1]
     wily: [libsphinxbase1]
     xenial: [pocketsphinx]
@@ -7176,7 +7148,6 @@ postgresql-9.x-postgis:
   gentoo: [dev-db/postgis, =dev-db/postgresql-9*]
   ubuntu:
     trusty: [postgresql-9.3-postgis-2.1, postgresql-contrib-9.3, postgresql-server-dev-9.3]
-    utopic: [postgresql-9.4-postgis-2.1, postgresql-contrib-9.4, postgresql-server-dev-9.4]
     vivid: [postgresql-9.4-postgis-2.1, postgresql-contrib-9.4, postgresql-server-dev-9.4]
     wily: [postgresql-9.4-postgis-2.1, postgresql-contrib-9.4, postgresql-server-dev-9.4]
     xenial: [postgresql-9.5-postgis-2.2, postgresql-contrib-9.5, postgresql-server-dev-9.5]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -622,9 +622,6 @@ python-attrs-pip:
   fedora:
     pip:
       packages: [attrs]
-  ubuntu:
-    pip:
-      packages: [attrs]
 python-autobahn:
   debian: [python-autobahn]
   fedora:
@@ -638,22 +635,6 @@ python-autobahn:
       packages: [autobahn]
   ubuntu:
     '*': [python-autobahn]
-      pip:
-        packages: [autobahn]
-      pip:
-        packages: [autobahn]
-      pip:
-        packages: [autobahn]
-      pip:
-        packages: [autobahn]
-      pip:
-        packages: [autobahn]
-      pip:
-        packages: [autobahn]
-      pip:
-        packages: [autobahn]
-      pip:
-        packages: [autobahn]
 python-avahi:
   arch: [avahi]
   debian: [python-avahi]
@@ -693,10 +674,6 @@ python-backports.ssl-match-hostname:
   openembedded: ['${PYTHON_PN}-backports-ssl@meta-python']
   ubuntu:
     bionic: [python-backports.ssl-match-hostname]
-      pip:
-        packages: [backports.ssl_match_hostname]
-      pip:
-        packages: [backports.ssl_match_hostname]
 python-bcrypt:
   arch: [python2-bcrypt]
   debian: [python-bcrypt]
@@ -763,8 +740,6 @@ python-bokeh-pip:
 python-boltons:
   debian:
     '*': [python-boltons]
-      pip:
-        packages: [boltons]
     wheezy:
       pip:
         packages: [boltons]
@@ -776,16 +751,6 @@ python-boltons:
       packages: [boltons]
   ubuntu:
     '*': [python-boltons]
-      pip:
-        packages: [boltons]
-      pip:
-        packages: [boltons]
-      pip:
-        packages: [boltons]
-      pip:
-        packages: [boltons]
-      pip:
-        packages: [boltons]
 python-boto3:
   arch: [python-boto3]
   debian: [python-boto3]
@@ -853,52 +818,14 @@ python-can:
   arch:
     pip:
       packages: [python-can]
-  debian:
-    '*': [python-can]
-      pip:
-        packages: [python-can]
-    squeeze:
-      pip:
-        packages: [python-can]
-    wheezy:
-      pip:
-        packages: [python-can]
+  debian: [python-can]
   fedora:
     pip:
       packages: [python-can]
   osx:
     pip:
       packages: [python-can]
-  ubuntu:
-    '*': [python-can]
-      pip:
-        packages: [python-can]
-      pip:
-        packages: [python-can]
-      pip:
-        packages: [python-can]
-      pip:
-        packages: [python-can]
-      pip:
-        packages: [python-can]
-      pip:
-        packages: [python-can]
-      pip:
-        packages: [python-can]
-      pip:
-        packages: [python-can]
-      pip:
-        packages: [python-can]
-      pip:
-        packages: [python-can]
-      pip:
-        packages: [python-can]
-      pip:
-        packages: [python-can]
-      pip:
-        packages: [python-can]
-      pip:
-        packages: [python-can]
+  ubuntu: [python-can]
 python-cantools-pip:
   debian:
     pip:
@@ -1071,13 +998,7 @@ python-clearsilver:
     '7': [python-clearsilver]
   ubuntu: [python-clearsilver]
 python-click:
-  debian:
-    '*': [python-click]
-      pip:
-        packages: [python-click]
-    wheezy:
-      pip:
-        packages: [python-click]
+  debian:  [python-click]
   fedora: [python-click]
   gentoo: [dev-python/click]
   nixos: [pythonPackages.click]
@@ -1085,18 +1006,7 @@ python-click:
   osx:
     pip:
       packages: [click]
-  ubuntu:
-    '*': [python-click]
-      pip:
-        packages: [click]
-      pip:
-        packages: [click]
-      pip:
-        packages: [click]
-      pip:
-        packages: [click]
-      pip:
-        packages: [click]
+  ubuntu: [python-click]
 python-cobs-pip:
   debian:
     pip:
@@ -1588,8 +1498,7 @@ python-flake8:
   gentoo: [dev-python/flake8]
   nixos: [python3Packages.flake8]
   openembedded: ['${PYTHON_PN}-flake8@meta-ros-common']
-  ubuntu:
-    '*': [python-flake8]
+  ubuntu: [python-flake8]
 python-flask:
   arch: [python-flask]
   debian: [python-flask]
@@ -1623,15 +1532,6 @@ python-flask-restful:
   fedora: [python-flask-restful]
   gentoo: [dev-python/flask-restful]
   nixos: [pythonPackages.flask-restful]
-  ubuntu:
-      pip:
-        packages: [flask-restful]
-      pip:
-        packages: [flask-restful]
-      pip:
-        packages: [flask-restful]
-      pip:
-        packages: [flask-restful]
 python-flatdict-pip:
   ubuntu:
     pip:
@@ -1678,14 +1578,7 @@ python-future:
   osx:
     pip:
       packages: [future]
-  ubuntu:
-    bionic: [python-future]
-      pip:
-        packages: [future]
-      pip:
-        packages: [future]
-      pip:
-        packages: [future]
+  ubuntu: [python-future]
 python-fuzzywuzzy-pip:
   debian:
     pip:
@@ -1793,21 +1686,8 @@ python-github-pip:
     pip:
       packages: [PyGithub]
 python-gitlab:
-  debian:
-    '*': [python-gitlab]
-      pip:
-        packages: [python-gitlab]
-    stretch:
-      pip:
-        packages: [python-gitlab]
-  ubuntu:
-    '*': [python-gitlab]
-      pip:
-        packages: [python-gitlab]
-      pip:
-        packages: [python-gitlab]
-      pip:
-        packages: [python-gitlab]
+  debian: [python-gitlab]
+  ubuntu: [python-gitlab]
 python-gitpython-pip:
   ubuntu:
     pip:
@@ -1905,25 +1785,8 @@ python-googleapi:
 python-gpiozero:
   debian:
     buster: [python-gpiozero]
-      pip:
-        packages: [gpiozero]
-    stretch:
-      pip:
-        packages: [gpiozero]
   ubuntu:
     bionic: [python-gpiozero]
-      pip:
-        packages: [gpiozero]
-      pip:
-        packages: [gpiozero]
-      pip:
-        packages: [gpiozero]
-      pip:
-        packages: [gpiozero]
-      pip:
-        packages: [gpiozero]
-      pip:
-        packages: [gpiozero]
 python-gputil-pip:
   debian:
     pip:
@@ -1940,26 +1803,10 @@ python-gputil-pip:
 python-gpxpy:
   debian:
     buster: [python-gpxpy]
-      pip:
-        packages: [gpxpy]
     stretch: [python-gpxpy]
   gentoo: [sci-geosciences/gpxpy]
   ubuntu:
     bionic: [python-gpxpy]
-      pip:
-        packages: [gpxpy]
-      pip:
-        packages: [gpxpy]
-      pip:
-        packages: [gpxpy]
-      pip:
-        packages: [gpxpy]
-      pip:
-        packages: [gpxpy]
-      pip:
-        packages: [gpxpy]
-      pip:
-        packages: [gpxpy]
 python-graphitesend-pip:
   debian:
     pip:
@@ -1983,7 +1830,6 @@ python-gridfs:
 python-grpc-tools:
   debian:
     '*': [python-grpc-tools]
-      pip: [grpcio-tools]
     stretch:
       pip: [grpcio-tools]
   nixos: [pythonPackages.grpcio-tools]
@@ -1991,34 +1837,15 @@ python-grpc-tools:
     '*': [python-grpc-tools]
     bionic:
       pip: [grpcio-tools]
-      pip: [grpcio-tools]
-      pip: [grpcio-tools]
 python-grpcio:
   debian:
     '*': [python-grpcio]
-      pip: [grpcio]
     stretch:
       pip: [grpcio]
   ubuntu:
     '*': [python-grpcio]
     bionic:
       pip: [grpcio]
-      pip: [grpcio]
-      pip: [grpcio]
-python-grpcio-reflection-pip:
-  debian:
-    pip:
-      packages: [grpcio-reflection]
-  ubuntu:
-    pip:
-      packages: [grpcio-reflection]
-python-grpcio-testing-pip:
-  debian:
-    pip:
-      packages: [grpcio-testing]
-  ubuntu:
-    pip:
-      packages: [grpcio-testing]
 python-gst:
   arch: [gstreamer0.10-python]
   debian:
@@ -2083,12 +1910,7 @@ python-hypothesis:
 python-imageio:
   debian:
     '*': [python-imageio]
-      pip:
-        packages: [imageio]
     stretch:
-      pip:
-        packages: [imageio]
-    wheezy:
       pip:
         packages: [imageio]
   fedora:
@@ -2097,12 +1919,7 @@ python-imageio:
   gentoo: [dev-python/imageio]
   nixos: [pythonPackages.imageio]
   opensuse: [python2-imageio]
-  ubuntu:
-    '*': [python-imageio]
-      pip:
-        packages: [imageio]
-      pip:
-        packages: [imageio]
+  ubuntu: [python-imageio]
 python-imaging:
   alpine: [py-imaging]
   arch: [python2-pillow]
@@ -2514,28 +2331,6 @@ python-more-itertools:
   fedora: [python-more-itertools]
   ubuntu:
     '*': [python-more-itertools]
-python-more-itertools-pip:
-  arch:
-    pip:
-      packages: [more-itertools]
-  debian:
-    pip:
-      packages: [more-itertools]
-  fedora:
-    pip:
-      packages: [more-itertools]
-  ubuntu:
-      pip: [more-itertools]
-python-moviepy-pip:
-  debian:
-    pip:
-      packages: [moviepy]
-  fedora:
-    pip:
-      packages: [moviepy]
-  ubuntu:
-    pip:
-      packages: [moviepy]
 python-msgpack:
   arch: [python2-msgpack]
   debian: [python-msgpack]
@@ -2600,20 +2395,7 @@ python-netaddr:
   osx:
     pip:
       packages: [netaddr]
-  ubuntu:
-    bionic: [python-netaddr]
-      pip:
-        packages: [netaddr]
-      pip:
-        packages: [netaddr]
-      pip:
-        packages: [netaddr]
-      pip:
-        packages: [netaddr]
-      pip:
-        packages: [netaddr]
-      pip:
-        packages: [netaddr]
+  ubuntu: [python-netaddr]
 python-netcdf4:
   arch: [python-netcdf4]
   debian: [python-netcdf4]
@@ -2828,8 +2610,6 @@ python-pandas:
 python-parameterized:
   debian:
     '*': [python-parameterized]
-      pip:
-        packages: [parameterized]
     stretch:
       pip:
         packages: [parameterized]
@@ -2837,20 +2617,7 @@ python-parameterized:
   osx:
     pip:
       packages: [parameterized]
-  ubuntu:
-    '*': [python-parameterized]
-      pip:
-        packages: [parameterized]
-      pip:
-        packages: [parameterized]
-      pip:
-        packages: [parameterized]
-      pip:
-        packages: [parameterized]
-      pip:
-        packages: [parameterized]
-      pip:
-        packages: [parameterized]
+  ubuntu: [python-parameterized]
 python-paramiko:
   alpine: [py-paramiko]
   arch: [python2-paramiko]
@@ -2880,8 +2647,6 @@ python-parso:
         packages: [parso]
   ubuntu:
     bionic: [python-parso]
-      pip:
-        packages: [parso]
 python-passlib:
   debian: [python-passlib]
   fedora: [python-passlib]
@@ -3186,12 +2951,6 @@ python-pycurl:
 python-pydbus:
   ubuntu:
     bionic: [python-pydbus]
-      pip:
-        depends: [python-gi]
-        packages: [pydbus]
-      pip:
-        depends: [python-gi]
-        packages: [pydbus]
 python-pydot:
   arch: [python2-pydot]
   debian: [python-pydot]
@@ -3367,19 +3126,12 @@ python-pypng:
       packages: [pypng]
   debian:
     buster: [python-png]
-      pip:
-        packages: [pypng]
     stretch:
       pip:
         packages: [pypng]
   fedora: [python-pypng]
   gentoo: [dev-python/pypng]
-  ubuntu:
-    '*': [python-png]
-      pip:
-        packages: [pypng]
-      pip:
-        packages: [pypng]
+  ubuntu: [python-png]
 python-pypozyx-pip:
   ubuntu:
     pip:
@@ -3400,18 +3152,11 @@ python-pyqrcode:
   arch: [python2-qrcode]
   debian:
     buster: [python-pyqrcode]
-      pip:
-        packages: [PyQRCode]
     stretch:
       pip:
         packages: [PyQRCode]
   gentoo: [dev-python/pyqrcode]
-  ubuntu:
-    '*': [python-pyqrcode]
-      pip:
-        packages: [PyQRCode]
-      pip:
-        packages: [PyQRCode]
+  ubuntu: [python-pyqrcode]
 python-pyqtgraph:
   debian: [python-pyqtgraph]
   fedora:
@@ -3853,35 +3598,11 @@ python-rospkg-modules:
 python-rpi.gpio:
   debian:
     buster: [python-rpi.gpio]
-      pip:
-        packages: [RPi.GPIO]
     stretch:
       pip:
         packages: [RPi.GPIO]
   ubuntu:
     bionic: [python-rpi.gpio]
-      pip:
-        packages: [RPi.GPIO]
-      pip:
-        packages: [RPi.GPIO]
-      pip:
-        packages: [RPi.GPIO]
-      pip:
-        packages: [RPi.GPIO]
-      pip:
-        packages: [RPi.GPIO]
-      pip:
-        packages: [RPi.GPIO]
-python-rpi.gpio-pip:
-  debian:
-    pip:
-      packages: [RPi.GPIO]
-  fedora:
-    pip:
-      packages: [RPi.GPIO]
-  ubuntu:
-    pip:
-      packages: [RPi.GPIO]
 python-rrdtool:
   debian: [python-rrdtool]
   gentoo: [net-analyzer/rrdtool]
@@ -3947,10 +3668,7 @@ python-seaborn:
     pip:
       packages: [seaborn]
   gentoo: [dev-python/seaborn]
-  ubuntu:
-    '*': [python-seaborn]
-      pip:
-        packages: [seaborn]
+  ubuntu: [python-seaborn]
 python-selectors2-pip:
   arch:
     pip:
@@ -4019,8 +3737,6 @@ python-setuptools:
 python-sexpdata:
   debian:
     '*': [python-sexpdata]
-      pip:
-        packages: [sexpdata]
     stretch:
       pip:
         packages: [sexpdata]
@@ -4029,16 +3745,11 @@ python-sexpdata:
     bionic:
       pip:
         packages: [sexpdata]
-      pip:
-        packages: [sexpdata]
 python-sh:
   debian: [python-sh]
   fedora: [python-sh]
   gentoo: [dev-python/sh]
-  ubuntu:
-    '*': [python-sh]
-      pip:
-        packages: [sh]
+  ubuntu: [python-sh]
 python-shapely:
   debian: [python-shapely]
   fedora: [python-shapely]
@@ -4098,18 +3809,7 @@ python-skimage:
   osx:
     pip:
       packages: [scikit-image]
-  ubuntu:
-    '*': [python-skimage]
-      pip:
-        packages: [scikit-image]
-      pip:
-        packages: [scikit-image]
-      pip:
-        packages: [scikit-image]
-      pip:
-        packages: [scikit-image]
-      pip:
-        packages: [scikit-image]
+  ubuntu: [python-skimage]
 python-skimage-pip:
   osx:
     pip:
@@ -4256,15 +3956,9 @@ python-support:
       packages: []
   ubuntu: [python-support]
 python-svg.path:
-  debian:
-    '*': [python-svg.path]
-      pip:
-        packages: [svg.path]
+  debian: [python-svg.path]
   fedora: [python-svg-path]
-  ubuntu:
-    '*': [python-svg.path]
-      pip:
-        packages: [svg.path]
+  ubuntu: [python-svg.path]
 python-svn:
   debian: [python-svn]
   gentoo: [dev-python/pysvn]
@@ -4444,12 +4138,7 @@ python-texttable:
   osx:
     pip:
       packages: [texttable]
-  ubuntu:
-    '*': [python-texttable]
-      pip:
-        packages: [texttable]
-      pip:
-        packages: [texttable]
+  ubuntu: [python-texttable]
 python-tftpy:
   debian: [python-tftpy]
   fedora: [python-tftpy]
@@ -4458,41 +4147,17 @@ python-theano:
   arch: [python-theano]
   debian:
     buster: [python-theano]
-      pip:
-        packages: [Theano]
     stretch: [python-theano]
   fedora: [python-theano]
   gentoo: [dev-python/theano]
   osx:
     pip:
       packages: [Theano]
-  ubuntu:
-      pip:
-        packages: [Theano]
-      pip:
-        packages: [Theano]
-      pip:
-        packages: [Theano]
-      pip:
-        packages: [Theano]
-      pip:
-        packages: [Theano]
-      pip:
-        packages: [Theano]
-      pip:
-        packages: [Theano]
 python-tilestache:
   debian: [tilestache]
   fedora: [python-tilestache]
   nixos: [pythonPackages.tilestache]
   ubuntu: [tilestache]
-python-tinydb-pip:
-  debian:
-    pip:
-      packages: [tinydb]
-  ubuntu:
-    pip:
-      packages: [tinydb]
 python-tk:
   arch: [python2, tk]
   debian: [python-tk]
@@ -4542,20 +4207,7 @@ python-tqdm:
     buster: [python-tqdm]
     stretch: [python-tqdm]
   fedora: [python-tqdm]
-  ubuntu:
-    '*': [python-tqdm]
-      pip:
-        packages: [tqdm]
-      pip:
-        packages: [tqdm]
-      pip:
-        packages: [tqdm]
-      pip:
-        packages: [tqdm]
-      pip:
-        packages: [tqdm]
-      pip:
-        packages: [tqdm]
+  ubuntu: [python-tqdm]
 python-transforms3d-pip:
   debian:
     pip:
@@ -4579,10 +4231,6 @@ python-transitions:
         packages: [transitions]
   ubuntu:
     bionic: [python-transitions]
-      pip:
-        packages: [transitions]
-      pip:
-        packages: [transitions]
 python-trep:
   debian:
     pip:
@@ -4680,10 +4328,7 @@ python-tzlocal-pip:
       packages: [tzlocal]
 python-ubjson:
   debian: [python-ubjson]
-  ubuntu:
-    '*': [python-ubjson]
-      pip:
-        packages: [py-ubjson]
+  ubuntu: [python-ubjson]
 python-ujson:
   debian:
     buster: [python-ujson]
@@ -4694,16 +4339,7 @@ python-ujson:
   osx:
     pip:
       packages: [ujson]
-  ubuntu:
-    '*': [python-ujson]
-      pip:
-        packages: [ujson]
-      pip:
-        packages: [ujson]
-      pip:
-        packages: [ujson]
-      pip:
-        packages: [ujson]
+  ubuntu: [python-ujson]
 python-unittest2:
   debian: [python-unittest2]
   nixos: [pythonPackages.unittest2]
@@ -4874,16 +4510,6 @@ python-websocket:
   opensuse: [python2-websocket-client]
   ubuntu:
     bionic: [python-websocket]
-      pip:
-        packages: [websocket-client]
-      pip:
-        packages: [websocket-client]
-      pip:
-        packages: [websocket-client]
-      pip:
-        packages: [websocket-client]
-      pip:
-        packages: [websocket-client]
 python-webtest:
   debian: [python-webtest]
   fedora: [python-webtest]
@@ -6316,8 +5942,6 @@ python3-github:
 python3-gitlab:
   debian:
     '*': [python3-gitlab]
-      pip:
-        packages: [python-gitlab]
     stretch:
       pip:
         packages: [python-gitlab]
@@ -6326,14 +5950,7 @@ python3-gitlab:
   rhel:
     '*': [python3-gitlab]
     '7': null
-  ubuntu:
-    '*': [python3-gitlab]
-      pip:
-        packages: [python-gitlab]
-      pip:
-        packages: [python-gitlab]
-      pip:
-        packages: [python-gitlab]
+  ubuntu: [python3-gitlab]
 python3-glpk-pip: *migrate_eol_2025_04_30_python3_glpk_pip
 python3-gnupg:
   debian: [python3-gnupg]
@@ -8456,8 +8073,6 @@ python3-setuptools:
 python3-sexpdata:
   debian:
     '*': [python3-sexpdata]
-      pip:
-        packages: [sexpdata]
     stretch:
       pip:
         packages: [sexpdata]
@@ -8466,8 +8081,6 @@ python3-sexpdata:
   ubuntu:
     '*': [python3-sexpdata]
     bionic:
-      pip:
-        packages: [sexpdata]
       pip:
         packages: [sexpdata]
 python3-sh:
@@ -8844,10 +8457,7 @@ python3-thop-pip:
       packages: [thop]
 python3-thriftpy:
   debian: [python3-thriftpy]
-  ubuntu:
-    '*': [python3-thriftpy]
-      pip:
-        packages: [thriftpy]
+  ubuntu: [python3-thriftpy]
 python3-tilestache-pip:
   debian:
     pip:
@@ -8931,12 +8541,7 @@ python3-transitions:
     stretch:
       pip:
         packages: [transitions]
-  ubuntu:
-    '*': [python3-transitions]
-      pip:
-        packages: [transitions]
-      pip:
-        packages: [transitions]
+  ubuntu: [python3-transitions]
 python3-triangle-pip:
   debian:
     pip:
@@ -9424,27 +9029,10 @@ wxpython:
     '*': [python-wxgtk3.0]
 yapf:
   arch: [yapf]
-  debian:
-    buster: [yapf]
-    stretch: [yapf]
+  debian: [yapf]
   nixos: [python3Packages.yapf]
   opensuse: [python2-yapf]
-  ubuntu:
-    '*': [yapf]
-      pip:
-        packages: [yapf]
-      pip:
-        packages: [yapf]
-      pip:
-        packages: [yapf]
-      pip:
-        packages: [yapf]
-      pip:
-        packages: [yapf]
-      pip:
-        packages: [yapf]
-      pip:
-        packages: [yapf]
+  ubuntu: [yapf]
 yapf3:
   debian: [yapf3]
   fedora: [python3-yapf]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -501,7 +501,6 @@ python:
     artful: [python-dev]
     bionic: [python-dev]
     trusty: [python-dev]
-    vivid: [python-dev]
     wily: [python-dev]
     xenial: [python-dev]
     yakkety: [python-dev]
@@ -720,7 +719,6 @@ python-backports.ssl-match-hostname:
     trusty:
       pip:
         packages: [backports.ssl_match_hostname]
-    vivid: [backports.ssl_match_hostname]
     wily: [python-backports.ssl-match-hostname]
     xenial: [python-backports.ssl-match-hostname]
     yakkety: [python-backports.ssl-match-hostname]
@@ -931,7 +929,6 @@ python-can:
         packages: [python-can]
       pip:
         packages: [python-can]
-    vivid:
       pip:
         packages: [python-can]
     wily:
@@ -981,7 +978,6 @@ python-catkin-pkg:
     artful: [python-catkin-pkg]
     bionic: [python-catkin-pkg]
     trusty: [python-catkin-pkg]
-    vivid: [python-catkin-pkg]
     wily: [python-catkin-pkg]
     xenial: [python-catkin-pkg]
     yakkety: [python-catkin-pkg]
@@ -1150,7 +1146,6 @@ python-click:
         packages: [click]
       pip:
         packages: [click]
-    vivid:
       pip:
         packages: [click]
     wily:
@@ -1260,7 +1255,6 @@ python-coverage:
     artful: [python-coverage]
     bionic: [python-coverage]
     trusty: [python-coverage]
-    vivid: [python-coverage]
     wily: [python-coverage]
     xenial: [python-coverage]
     yakkety: [python-coverage]
@@ -1320,7 +1314,6 @@ python-crypto:
     artful: [python-crypto]
     bionic: [python-crypto]
     trusty: [python-crypto]
-    vivid: [python-crypto]
     wily: [python-crypto]
     xenial: [python-crypto]
     yakkety: [python-crypto]
@@ -1398,7 +1391,6 @@ python-debian:
     artful: [python-debian]
     bionic: [python-debian]
     trusty: [python-debian]
-    vivid: [python-debian]
     wily: [python-debian]
     xenial: [python-debian]
     yakkety: [python-debian]
@@ -1502,7 +1494,6 @@ python-docutils:
     artful: [python-docutils]
     bionic: [python-docutils]
     trusty: [python-docutils]
-    vivid: [python-docutils]
     wily: [python-docutils]
     xenial: [python-docutils]
 python-docx:
@@ -1721,7 +1712,6 @@ python-flask-restful:
         packages: [flask-restful]
       pip:
         packages: [flask-restful]
-    vivid:
       pip:
         packages: [flask-restful]
     wily:
@@ -1783,7 +1773,6 @@ python-future:
         packages: [future]
       pip:
         packages: [future]
-    vivid:
       pip:
         packages: [future]
     wily: [python-future]
@@ -2013,7 +2002,6 @@ python-googleapi:
   ubuntu:
     bionic: [python-googleapi]
     trusty: [python-googleapi]
-    vivid: [python-googleapi]
     wily: [python-googleapi]
     xenial: [python-googleapi]
 python-gpiozero:
@@ -2033,7 +2021,6 @@ python-gpiozero:
         packages: [gpiozero]
       pip:
         packages: [gpiozero]
-    vivid:
       pip:
         packages: [gpiozero]
     wily:
@@ -2075,7 +2062,6 @@ python-gpxpy:
         packages: [gpxpy]
       pip:
         packages: [gpxpy]
-    vivid:
       pip:
         packages: [gpxpy]
     wily:
@@ -2165,7 +2151,6 @@ python-gst:
   gentoo: [dev-python/gst-python]
   ubuntu:
     trusty: [python-gst0.10]
-    vivid: [python-gst0.10]
 python-gst-1.0:
   debian:
     buster: [python-gst-1.0]
@@ -2275,7 +2260,6 @@ python-imaging:
     '*': [python-pil]
     artful: [python-imaging]
     trusty: [python-imaging]
-    vivid: [python-imaging]
     wily: [python-imaging]
     xenial: [python-imaging]
     yakkety: [python-imaging]
@@ -2630,7 +2614,6 @@ python-matplotlib:
     artful: [python-matplotlib]
     bionic: [python-matplotlib]
     trusty: [python-matplotlib]
-    vivid: [python-matplotlib]
     wily: [python-matplotlib]
     xenial: [python-matplotlib]
     yakkety: [python-matplotlib]
@@ -2671,7 +2654,6 @@ python-mock:
     artful: [python-mock]
     bionic: [python-mock]
     trusty: [python-mock]
-    vivid: [python-mock]
     wily: [python-mock]
     xenial: [python-mock]
     yakkety: [python-mock]
@@ -2793,7 +2775,6 @@ python-netaddr:
       pip:
         packages: [netaddr]
     trusty: [python-netaddr]
-    vivid: [python-netaddr]
     xenial: [python-netaddr]
     yakkety: [python-netaddr]
     zesty: [python-netaddr]
@@ -2827,7 +2808,6 @@ python-netifaces:
     artful: [python-netifaces]
     bionic: [python-netifaces]
     trusty: [python-netifaces]
-    vivid: [python-netifaces]
     wily: [python-netifaces]
     xenial: [python-netifaces]
     yakkety: [python-netifaces]
@@ -2926,7 +2906,6 @@ python-oauth2:
   gentoo: [dev-python/oauth2]
   ubuntu:
     trusty: [python-oauth2]
-    vivid: [python-oauth2]
 python-oauth2client:
   debian: [python-oauth2client]
   fedora: [python-oauth2client]
@@ -2983,7 +2962,6 @@ python-opengl:
     artful: [python-opengl]
     bionic: [python-opengl]
     trusty: [python-opengl]
-    vivid: [python-opengl]
     wily: [python-opengl]
     xenial: [python-opengl]
     yakkety: [python-opengl]
@@ -3171,7 +3149,6 @@ python-pep8:
   ubuntu:
     '*': [python-pep8]
     trusty: [pep8]
-    vivid: [pep8]
     wily: [pep8]
 python-percol:
   debian:
@@ -3295,7 +3272,6 @@ python-progressbar:
     bionic: [python-progressbar]
     cosmic: [python-progressbar]
     trusty: [python-progressbar]
-    vivid: [python-progressbar]
     wily: [python-progressbar]
     xenial: [python-progressbar]
 python-progressbar2-pip:
@@ -3361,7 +3337,6 @@ python-pyassimp:
     artful: [python-pyassimp]
     bionic: [python-pyassimp]
     trusty: [python-pyassimp]
-    vivid: [python-pyassimp]
     wily: [python-pyassimp]
     xenial: [python-pyassimp]
     yakkety: [python-pyassimp]
@@ -3692,12 +3667,10 @@ python-pyside:
   gentoo: [dev-python/pyside]
   ubuntu:
     trusty: [python-pyside]
-    vivid: [python-pyside]
 python-pyside.qtuitools:
   debian: [python-pyside.qtuitools]
   ubuntu:
     trusty: [python-pyside.qtuitools]
-    vivid: [python-pyside.qtuitools]
 python-pysimplegui27-pip:
   debian:
     pip:
@@ -4017,7 +3990,6 @@ python-rosdep:
     artful: [python-rosdep]
     bionic: [python-rosdep]
     trusty: [python-rosdep]
-    vivid: [python-rosdep]
     wily: [python-rosdep]
     xenial: [python-rosdep]
     yakkety: [python-rosdep]
@@ -4058,7 +4030,6 @@ python-rosdistro:
   ubuntu:
     artful: [python-rosdistro]
     trusty: [python-rosdistro]
-    vivid: [python-rosdistro]
     wily: [python-rosdistro]
     xenial: [python-rosdistro]
     yakkety: [python-rosdistro]
@@ -4149,7 +4120,6 @@ python-rpi.gpio:
         packages: [RPi.GPIO]
       pip:
         packages: [RPi.GPIO]
-    vivid:
       pip:
         packages: [RPi.GPIO]
     wily:
@@ -4297,7 +4267,6 @@ python-serial:
     artful: [python-serial]
     bionic: [python-serial]
     trusty: [python-serial]
-    vivid: [python-serial]
     wily: [python-serial]
     xenial: [python-serial]
     yakkety: [python-serial]
@@ -4324,7 +4293,6 @@ python-setuptools:
     artful: [python-setuptools]
     bionic: [python-setuptools]
     trusty: [python-setuptools]
-    vivid: [python-setuptools]
     wily: [python-setuptools]
     xenial: [python-setuptools]
     yakkety: [python-setuptools]
@@ -4555,7 +4523,6 @@ python-sqlalchemy:
     artful: [python-sqlalchemy]
     bionic: [python-sqlalchemy]
     trusty: [python-sqlalchemy]
-    vivid: [python-sqlalchemy]
     wily: [python-sqlalchemy]
     xenial: [python-sqlalchemy]
 python-sqlite:
@@ -4823,7 +4790,6 @@ python-theano:
         packages: [Theano]
       pip:
         packages: [Theano]
-    vivid:
       pip:
         packages: [Theano]
     wily:
@@ -4904,7 +4870,6 @@ python-tqdm:
         packages: [tqdm]
       pip:
         packages: [tqdm]
-    vivid:
       pip:
         packages: [tqdm]
     wily:
@@ -5066,7 +5031,6 @@ python-ujson:
         packages: [ujson]
       pip:
         packages: [ujson]
-    vivid:
       pip:
         packages: [ujson]
 python-unittest2:
@@ -5185,7 +5149,6 @@ python-vtk:
   ubuntu:
     bionic: [python-vtk6]
     trusty: [python-vtk]
-    vivid: [python-vtk]
     wily: [python-vtk]
     xenial: [python-vtk6]
 python-w1thermsensor-pip:
@@ -5259,7 +5222,6 @@ python-websocket:
         packages: [websocket-client]
       pip:
         packages: [websocket-client]
-    vivid: [python-websocket]
     wily: [python-websocket]
     xenial: [python-websocket]
 python-webtest:
@@ -5389,7 +5351,6 @@ python-yaml:
     bionic: [python-yaml]
     focal: [python-yaml]
     trusty: [python-yaml]
-    vivid: [python-yaml]
     wily: [python-yaml]
     xenial: [python-yaml]
     yakkety: [python-yaml]
@@ -9868,7 +9829,6 @@ wxpython:
   ubuntu:
     '*': [python-wxgtk3.0]
     trusty: [python-wxgtk2.8]
-    vivid: [python-wxgtk2.8]
     wily: [python-wxgtk2.8]
 yapf:
   arch: [yapf]
@@ -9886,7 +9846,6 @@ yapf:
         packages: [yapf]
       pip:
         packages: [yapf]
-    vivid:
       pip:
         packages: [yapf]
     wily:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -500,7 +500,6 @@ python:
   ubuntu:
     artful: [python-dev]
     bionic: [python-dev]
-    quantal: [python-dev]
     raring: [python-dev]
     saucy: [python-dev]
     trusty: [python-dev]
@@ -673,7 +672,6 @@ python-autobahn:
         packages: [autobahn]
       pip:
         packages: [autobahn]
-    quantal:
       pip:
         packages: [autobahn]
     raring:
@@ -928,7 +926,6 @@ python-can:
         packages: [python-can]
       pip:
         packages: [python-can]
-    quantal:
       pip:
         packages: [python-can]
     raring:
@@ -992,7 +989,6 @@ python-catkin-pkg:
   ubuntu:
     artful: [python-catkin-pkg]
     bionic: [python-catkin-pkg]
-    quantal: [python-catkin-pkg]
     raring: [python-catkin-pkg]
     saucy: [python-catkin-pkg]
     trusty: [python-catkin-pkg]
@@ -1277,7 +1273,6 @@ python-coverage:
   ubuntu:
     artful: [python-coverage]
     bionic: [python-coverage]
-    quantal: [python-coverage]
     raring: [python-coverage]
     saucy: [python-coverage]
     trusty: [python-coverage]
@@ -1341,7 +1336,6 @@ python-crypto:
   ubuntu:
     artful: [python-crypto]
     bionic: [python-crypto]
-    quantal: [python-crypto]
     raring: [python-crypto]
     saucy: [python-crypto]
     trusty: [python-crypto]
@@ -1528,7 +1522,6 @@ python-docutils:
   ubuntu:
     artful: [python-docutils]
     bionic: [python-docutils]
-    quantal: [python-docutils]
     raring: [python-docutils]
     saucy: [python-docutils]
     trusty: [python-docutils]
@@ -1606,7 +1599,6 @@ python-enum34-pip:
 python-espeak:
   debian: [python-espeak]
   ubuntu:
-    quantal: [python-espeak]
     raring: [python-espeak]
     saucy: [python-espeak]
     trusty: [python-espeak]
@@ -2151,7 +2143,6 @@ python-gridfs:
   debian: [python-gridfs]
   fedora: [python-pymongo-gridfs]
   ubuntu:
-    quantal: [python-gridfs]
     raring: [python-gridfs]
     saucy: [python-gridfs]
     trusty: [python-gridfs]
@@ -2207,7 +2198,6 @@ python-gst:
     wheezy: [python-gst0.10]
   gentoo: [dev-python/gst-python]
   ubuntu:
-    quantal: [python-gst0.10]
     raring: [python-gst0.10]
     saucy: [python-gst0.10]
     trusty: [python-gst0.10]
@@ -2321,7 +2311,6 @@ python-imaging:
   ubuntu:
     '*': [python-pil]
     artful: [python-imaging]
-    quantal: [python-imaging]
     raring: [python-imaging]
     saucy: [python-imaging]
     trusty: [python-imaging]
@@ -2680,7 +2669,6 @@ python-matplotlib:
   ubuntu:
     artful: [python-matplotlib]
     bionic: [python-matplotlib]
-    quantal: [python-matplotlib]
     raring: [python-matplotlib]
     saucy: [python-matplotlib]
     trusty: [python-matplotlib]
@@ -2725,7 +2713,6 @@ python-mock:
   ubuntu:
     artful: [python-mock]
     bionic: [python-mock]
-    quantal: [python-mock]
     raring: [python-mock]
     saucy: [python-mock]
     trusty: [python-mock]
@@ -2845,7 +2832,6 @@ python-netaddr:
         packages: [netaddr]
       pip:
         packages: [netaddr]
-    quantal:
       pip:
         packages: [netaddr]
     raring:
@@ -2889,7 +2875,6 @@ python-netifaces:
   ubuntu:
     artful: [python-netifaces]
     bionic: [python-netifaces]
-    quantal: [python-netifaces]
     raring: [python-netifaces]
     saucy: [python-netifaces]
     trusty: [python-netifaces]
@@ -2992,7 +2977,6 @@ python-oauth2:
   fedora: [python-oauth2]
   gentoo: [dev-python/oauth2]
   ubuntu:
-    quantal: [python-oauth2]
     raring: [python-oauth2]
     saucy: [python-oauth2]
     trusty: [python-oauth2]
@@ -3053,7 +3037,6 @@ python-opengl:
   ubuntu:
     artful: [python-opengl]
     bionic: [python-opengl]
-    quantal: [python-opengl]
     raring: [python-opengl]
     saucy: [python-opengl]
     trusty: [python-opengl]
@@ -3245,7 +3228,6 @@ python-pep8:
       packages: [pep8]
   ubuntu:
     '*': [python-pep8]
-    quantal: [pep8]
     raring: [pep8]
     saucy: [pep8]
     trusty: [pep8]
@@ -3373,7 +3355,6 @@ python-progressbar:
     artful: [python-progressbar]
     bionic: [python-progressbar]
     cosmic: [python-progressbar]
-    quantal: [python-progressbar]
     raring: [python-progressbar]
     saucy: [python-progressbar]
     trusty: [python-progressbar]
@@ -3443,7 +3424,6 @@ python-pyassimp:
   ubuntu:
     artful: [python-pyassimp]
     bionic: [python-pyassimp]
-    quantal: [python-pyassimp]
     raring: [python-pyassimp]
     saucy: [python-pyassimp]
     trusty: [python-pyassimp]
@@ -3778,7 +3758,6 @@ python-pyside:
   debian: [python-pyside]
   gentoo: [dev-python/pyside]
   ubuntu:
-    quantal: [python-pyside]
     raring: [python-pyside]
     saucy: [python-pyside]
     trusty: [python-pyside]
@@ -3787,7 +3766,6 @@ python-pyside:
 python-pyside.qtuitools:
   debian: [python-pyside.qtuitools]
   ubuntu:
-    quantal: [python-pyside.qtuitools]
     raring: [python-pyside.qtuitools]
     saucy: [python-pyside.qtuitools]
     trusty: [python-pyside.qtuitools]
@@ -4111,7 +4089,6 @@ python-rosdep:
   ubuntu:
     artful: [python-rosdep]
     bionic: [python-rosdep]
-    quantal: [python-rosdep]
     raring: [python-rosdep]
     saucy: [python-rosdep]
     trusty: [python-rosdep]
@@ -4156,7 +4133,6 @@ python-rosdistro:
     '7': [python2-rosdistro]
   ubuntu:
     artful: [python-rosdistro]
-    quantal: [python-rosdistro]
     raring: [python-rosdistro]
     saucy: [python-rosdistro]
     trusty: [python-rosdistro]
@@ -4280,7 +4256,6 @@ python-rrdtool:
   debian: [python-rrdtool]
   gentoo: [net-analyzer/rrdtool]
   ubuntu:
-    quantal: [python-rrdtool]
     raring: [python-rrdtool]
     saucy: [python-rrdtool]
     trusty: [python-rrdtool]
@@ -4403,7 +4378,6 @@ python-serial:
   ubuntu:
     artful: [python-serial]
     bionic: [python-serial]
-    quantal: [python-serial]
     raring: [python-serial]
     saucy: [python-serial]
     trusty: [python-serial]
@@ -4434,7 +4408,6 @@ python-setuptools:
   ubuntu:
     artful: [python-setuptools]
     bionic: [python-setuptools]
-    quantal: [python-setuptools]
     raring: [python-setuptools]
     saucy: [python-setuptools]
     trusty: [python-setuptools]
@@ -4669,7 +4642,6 @@ python-sqlalchemy:
   ubuntu:
     artful: [python-sqlalchemy]
     bionic: [python-sqlalchemy]
-    quantal: [python-sqlalchemy]
     raring: [python-sqlalchemy]
     saucy: [python-sqlalchemy]
     trusty: [python-sqlalchemy]
@@ -4730,7 +4702,6 @@ python-sympy:
     artful: [python-sympy]
     bionic: [python-sympy]
     cosmic: [python-sympy]
-    quantal: [python-sympy]
     raring: [python-sympy]
     saucy: [python-sympy]
     trusty: [python-sympy]
@@ -5381,7 +5352,6 @@ python-websocket:
     bionic: [python-websocket]
       pip:
         packages: [websocket-client]
-    quantal:
       pip:
         packages: [websocket-client]
     raring:
@@ -5523,7 +5493,6 @@ python-yaml:
     artful: [python-yaml]
     bionic: [python-yaml]
     focal: [python-yaml]
-    quantal: [python-yaml]
     raring: [python-yaml]
     saucy: [python-yaml]
     trusty: [python-yaml]
@@ -10006,7 +9975,6 @@ wxpython:
     '7': [wxPython-devel]
   ubuntu:
     '*': [python-wxgtk3.0]
-    quantal: [python-wxgtk2.8]
     raring: [python-wxgtk2.8]
     saucy: [python-wxgtk2.8]
     trusty: [python-wxgtk2.8]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -500,7 +500,6 @@ python:
   ubuntu:
     artful: [python-dev]
     bionic: [python-dev]
-    natty: [python-dev]
     oneiric: [python-dev]
     precise: [python-dev]
     quantal: [python-dev]
@@ -620,7 +619,6 @@ python-argparse:
       packages: [argparse]
   ubuntu:
     '*': []
-    natty: [python-argparse]
     oneiric: [python-argparse]
 python-astor-pip:
   debian:
@@ -672,7 +670,6 @@ python-autobahn:
         packages: [autobahn]
       pip:
         packages: [autobahn]
-    natty:
       pip:
         packages: [autobahn]
     oneiric:
@@ -930,7 +927,6 @@ python-can:
         packages: [python-can]
       pip:
         packages: [python-can]
-    natty:
       pip:
         packages: [python-can]
     oneiric:
@@ -1003,7 +999,6 @@ python-catkin-pkg:
   ubuntu:
     artful: [python-catkin-pkg]
     bionic: [python-catkin-pkg]
-    natty: [python-catkin-pkg]
     oneiric: [python-catkin-pkg]
     precise: [python-catkin-pkg]
     quantal: [python-catkin-pkg]
@@ -1291,7 +1286,6 @@ python-coverage:
   ubuntu:
     artful: [python-coverage]
     bionic: [python-coverage]
-    natty: [python-coverage]
     oneiric: [python-coverage]
     precise: [python-coverage]
     quantal: [python-coverage]
@@ -1358,7 +1352,6 @@ python-crypto:
   ubuntu:
     artful: [python-crypto]
     bionic: [python-crypto]
-    natty: [python-crypto]
     oneiric: [python-crypto]
     precise: [python-crypto]
     quantal: [python-crypto]
@@ -1548,7 +1541,6 @@ python-docutils:
   ubuntu:
     artful: [python-docutils]
     bionic: [python-docutils]
-    natty: [python-docutils]
     oneiric: [python-docutils]
     precise: [python-docutils]
     quantal: [python-docutils]
@@ -1629,7 +1621,6 @@ python-enum34-pip:
 python-espeak:
   debian: [python-espeak]
   ubuntu:
-    natty: [python-espeak]
     oneiric: [python-espeak]
     precise: [python-espeak]
     quantal: [python-espeak]
@@ -2177,7 +2168,6 @@ python-gridfs:
   debian: [python-gridfs]
   fedora: [python-pymongo-gridfs]
   ubuntu:
-    natty: [python-gridfs]
     oneiric: [python-gridfs]
     precise: [python-gridfs]
     quantal: [python-gridfs]
@@ -2236,7 +2226,6 @@ python-gst:
     wheezy: [python-gst0.10]
   gentoo: [dev-python/gst-python]
   ubuntu:
-    natty: [python-gst0.10]
     oneiric: [python-gst0.10]
     precise: [python-gst0.10]
     quantal: [python-gst0.10]
@@ -2353,7 +2342,6 @@ python-imaging:
   ubuntu:
     '*': [python-pil]
     artful: [python-imaging]
-    natty: [python-imaging]
     oneiric: [python-imaging]
     precise: [python-imaging]
     quantal: [python-imaging]
@@ -2715,7 +2703,6 @@ python-matplotlib:
   ubuntu:
     artful: [python-matplotlib]
     bionic: [python-matplotlib]
-    natty: [python-matplotlib]
     oneiric: [python-matplotlib]
     precise: [python-matplotlib]
     quantal: [python-matplotlib]
@@ -2763,7 +2750,6 @@ python-mock:
   ubuntu:
     artful: [python-mock]
     bionic: [python-mock]
-    natty: [python-mock]
     oneiric: [python-mock]
     precise: [python-mock]
     quantal: [python-mock]
@@ -2882,7 +2868,6 @@ python-netaddr:
     bionic: [python-netaddr]
       pip:
         packages: [netaddr]
-    natty:
       pip:
         packages: [netaddr]
     oneiric:
@@ -2933,7 +2918,6 @@ python-netifaces:
   ubuntu:
     artful: [python-netifaces]
     bionic: [python-netifaces]
-    natty: [python-netifaces]
     oneiric: [python-netifaces]
     precise: [python-netifaces]
     quantal: [python-netifaces]
@@ -3101,7 +3085,6 @@ python-opengl:
   ubuntu:
     artful: [python-opengl]
     bionic: [python-opengl]
-    natty: [python-opengl]
     oneiric: [python-opengl]
     precise: [python-opengl]
     quantal: [python-opengl]
@@ -3425,7 +3408,6 @@ python-progressbar:
     artful: [python-progressbar]
     bionic: [python-progressbar]
     cosmic: [python-progressbar]
-    natty: [python-progressbar]
     oneiric: [python-progressbar]
     precise: [python-progressbar]
     quantal: [python-progressbar]
@@ -3835,7 +3817,6 @@ python-pyside:
   debian: [python-pyside]
   gentoo: [dev-python/pyside]
   ubuntu:
-    natty: [python-pyside]
     oneiric: [python-pyside]
     precise: [python-pyside]
     quantal: [python-pyside]
@@ -3847,7 +3828,6 @@ python-pyside:
 python-pyside.qtuitools:
   debian: [python-pyside.qtuitools]
   ubuntu:
-    natty: [python-pyside.qtuitools]
     oneiric: [python-pyside.qtuitools]
     precise: [python-pyside.qtuitools]
     quantal: [python-pyside.qtuitools]
@@ -4174,7 +4154,6 @@ python-rosdep:
   ubuntu:
     artful: [python-rosdep]
     bionic: [python-rosdep]
-    natty: [python-rosdep]
     oneiric: [python-rosdep]
     precise: [python-rosdep]
     quantal: [python-rosdep]
@@ -4222,7 +4201,6 @@ python-rosdistro:
     '7': [python2-rosdistro]
   ubuntu:
     artful: [python-rosdistro]
-    natty: [python-rosdistro]
     oneiric: [python-rosdistro]
     precise: [python-rosdistro]
     quantal: [python-rosdistro]
@@ -4349,7 +4327,6 @@ python-rrdtool:
   debian: [python-rrdtool]
   gentoo: [net-analyzer/rrdtool]
   ubuntu:
-    natty: [python-rrdtool]
     oneiric: [python-rrdtool]
     precise: [python-rrdtool]
     quantal: [python-rrdtool]
@@ -4475,7 +4452,6 @@ python-serial:
   ubuntu:
     artful: [python-serial]
     bionic: [python-serial]
-    natty: [python-serial]
     oneiric: [python-serial]
     precise: [python-serial]
     quantal: [python-serial]
@@ -4509,7 +4485,6 @@ python-setuptools:
   ubuntu:
     artful: [python-setuptools]
     bionic: [python-setuptools]
-    natty: [python-setuptools]
     oneiric: [python-setuptools]
     precise: [python-setuptools]
     quantal: [python-setuptools]
@@ -4613,7 +4588,6 @@ python-skimage:
         packages: [scikit-image]
       pip:
         packages: [scikit-image]
-    natty:
       pip:
         packages: [scikit-image]
     oneiric:
@@ -4640,7 +4614,6 @@ python-sklearn:
       packages: [scikit-learn]
   ubuntu:
     '*': [python-sklearn]
-    natty: []
     oneiric: []
 python-slackclient-pip:
   debian:
@@ -4814,7 +4787,6 @@ python-sympy:
     artful: [python-sympy]
     bionic: [python-sympy]
     cosmic: [python-sympy]
-    natty: [python-sympy]
     oneiric: [python-sympy]
     precise: [python-sympy]
     quantal: [python-sympy]
@@ -5613,7 +5585,6 @@ python-yaml:
     artful: [python-yaml]
     bionic: [python-yaml]
     focal: [python-yaml]
-    natty: [python-yaml]
     oneiric: [python-yaml]
     precise: [python-yaml]
     quantal: [python-yaml]
@@ -10099,7 +10070,6 @@ wxpython:
     '7': [wxPython-devel]
   ubuntu:
     '*': [python-wxgtk3.0]
-    natty: [python-wxgtk2.8]
     oneiric: [python-wxgtk2.8]
     precise: [python-wxgtk2.8]
     quantal: [python-wxgtk2.8]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -502,7 +502,6 @@ python:
     bionic: [python-dev]
     trusty: [python-dev]
     xenial: [python-dev]
-    zesty: [python-dev]
 python-absl-py-pip:
   debian:
     pip:
@@ -550,7 +549,6 @@ python-aniso8601:
     artful: [python-aniso8601]
     bionic: [python-aniso8601]
     xenial: [python-aniso8601]
-    zesty: [python-aniso8601]
 python-annoy-pip:
   debian:
     pip:
@@ -744,7 +742,6 @@ python-bitstring:
     artful: [python-bitstring]
     bionic: [python-bitstring]
     xenial: [python-bitstring]
-    zesty: [python-bitstring]
 python-bitstring-pip:
   debian:
     pip:
@@ -810,7 +807,6 @@ python-boltons:
         packages: [boltons]
       pip:
         packages: [boltons]
-    zesty:
       pip:
         packages: [boltons]
 python-boto3:
@@ -969,7 +965,6 @@ python-catkin-pkg:
     bionic: [python-catkin-pkg]
     trusty: [python-catkin-pkg]
     xenial: [python-catkin-pkg]
-    zesty: [python-catkin-pkg]
 python-catkin-pkg-modules:
   alpine:
     pip:
@@ -1037,7 +1032,6 @@ python-certifi:
     artful: [python-certifi]
     bionic: [python-certifi]
     xenial: [python-certifi]
-    zesty: [python-certifi]
 python-chainer-mask-rcnn-pip:
   debian:
     pip:
@@ -1242,7 +1236,6 @@ python-coverage:
     bionic: [python-coverage]
     trusty: [python-coverage]
     xenial: [python-coverage]
-    zesty: [python-coverage]
 python-cpplint:
   debian:
     pip:
@@ -1299,7 +1292,6 @@ python-crypto:
     bionic: [python-crypto]
     trusty: [python-crypto]
     xenial: [python-crypto]
-    zesty: [python-crypto]
 python-cryptography:
   debian: [python-cryptography]
   gentoo: [dev-python/cryptography]
@@ -1374,7 +1366,6 @@ python-debian:
     bionic: [python-debian]
     trusty: [python-debian]
     xenial: [python-debian]
-    zesty: [python-debian]
 python-decorator:
   debian: [python-decorator]
   gentoo: [dev-python/decorator]
@@ -1753,7 +1744,6 @@ python-future:
       pip:
         packages: [future]
     xenial: [python-future]
-    zesty: [python-future]
 python-fuzzywuzzy-pip:
   debian:
     pip:
@@ -2004,7 +1994,6 @@ python-gpiozero:
         packages: [gpiozero]
       pip:
         packages: [gpiozero]
-    zesty: [python-gpiozero]
 python-gputil-pip:
   debian:
     pip:
@@ -2043,7 +2032,6 @@ python-gpxpy:
         packages: [gpxpy]
       pip:
         packages: [gpxpy]
-    zesty:
       pip:
         packages: [gpxpy]
 python-graphitesend-pip:
@@ -2231,7 +2219,6 @@ python-imaging:
     artful: [python-imaging]
     trusty: [python-imaging]
     xenial: [python-imaging]
-    zesty: [python-imaging]
 python-imaging-imagetk:
   debian: [python-pil.imagetk]
   ubuntu: [python-pil.imagetk]
@@ -2583,7 +2570,6 @@ python-matplotlib:
     bionic: [python-matplotlib]
     trusty: [python-matplotlib]
     xenial: [python-matplotlib]
-    zesty: [python-matplotlib]
 python-mechanize:
   arch: [python2-mechanize]
   debian: [python-mechanize]
@@ -2621,7 +2607,6 @@ python-mock:
     bionic: [python-mock]
     trusty: [python-mock]
     xenial: [python-mock]
-    zesty: [python-mock]
 python-monotonic:
   arch: [python-monotonic]
   debian: [python-monotonic]
@@ -2740,7 +2725,6 @@ python-netaddr:
         packages: [netaddr]
     trusty: [python-netaddr]
     xenial: [python-netaddr]
-    zesty: [python-netaddr]
 python-netcdf4:
   arch: [python-netcdf4]
   debian: [python-netcdf4]
@@ -2772,7 +2756,6 @@ python-netifaces:
     bionic: [python-netifaces]
     trusty: [python-netifaces]
     xenial: [python-netifaces]
-    zesty: [python-netifaces]
 python-networkmanager:
   debian:
     buster: [python-networkmanager]
@@ -2924,7 +2907,6 @@ python-opengl:
     bionic: [python-opengl]
     trusty: [python-opengl]
     xenial: [python-opengl]
-    zesty: [python-opengl]
 python-openssl:
   debian: [python-openssl]
   gentoo: [dev-python/pyopenssl]
@@ -2992,7 +2974,6 @@ python-parameterized:
         packages: [parameterized]
       pip:
         packages: [parameterized]
-    zesty:
       pip:
         packages: [parameterized]
 python-paramiko:
@@ -3072,7 +3053,6 @@ python-pathtools:
   ubuntu:
     artful: [python-pathtools]
     xenial: [python-pathtools]
-    zesty: [python-pathtools]
 python-pbr:
   debian: [python-pbr]
   fedora: [python-pbr]
@@ -3292,7 +3272,6 @@ python-pyassimp:
     bionic: [python-pyassimp]
     trusty: [python-pyassimp]
     xenial: [python-pyassimp]
-    zesty: [python-pyassimp]
 python-pyaudio:
   debian: [python-pyaudio]
   gentoo: [dev-python/pyaudio]
@@ -3816,7 +3795,6 @@ python-qt5-bindings:
     artful: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev]
     bionic: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev]
     xenial: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-pyside2, python-sip-dev, shiboken2]
-    zesty: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev]
 python-qt5-bindings-gl:
   arch: [python2-pyqt5]
   debian:
@@ -3834,7 +3812,6 @@ python-qt5-bindings-gl:
     artful: [python-pyqt5.qtopengl]
     bionic: [python-pyqt5.qtopengl]
     xenial: [python-pyqt5.qtopengl]
-    zesty: [python-pyqt5.qtopengl]
 python-qt5-bindings-qsci:
   debian: [python-pyqt5.qsci]
   openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
@@ -3858,7 +3835,6 @@ python-qt5-bindings-webkit:
     artful: [python-pyqt5.qtwebkit]
     bionic: [python-pyqt5.qtwebkit]
     xenial: [python-pyqt5.qtwebkit]
-    zesty: [python-pyqt5.qtwebkit]
 python-qtpy:
   arch: [python-qtpy]
   debian: [python-qtpy]
@@ -3937,7 +3913,6 @@ python-rosdep:
     bionic: [python-rosdep]
     trusty: [python-rosdep]
     xenial: [python-rosdep]
-    zesty: [python-rosdep]
 python-rosdep-modules:
   alpine:
     pip:
@@ -3975,7 +3950,6 @@ python-rosdistro:
     artful: [python-rosdistro]
     trusty: [python-rosdistro]
     xenial: [python-rosdistro]
-    zesty: [python-rosdistro]
 python-rosinstall:
   arch: [python2-rosinstall]
   debian: [python-rosinstall]
@@ -4071,7 +4045,6 @@ python-rpi.gpio:
         packages: [RPi.GPIO]
       pip:
         packages: [RPi.GPIO]
-    zesty: [python-rpi.gpio]
 python-rpi.gpio-pip:
   debian:
     pip:
@@ -4101,7 +4074,6 @@ python-ruamel.yaml:
     artful: [python-ruamel.yaml]
     bionic: [python-ruamel.yaml]
     xenial: [python-ruamel.yaml]
-    zesty: [python-ruamel.yaml]
 python-rx-pip:
   debian:
     pip:
@@ -4207,7 +4179,6 @@ python-serial:
     bionic: [python-serial]
     trusty: [python-serial]
     xenial: [python-serial]
-    zesty: [python-serial]
 python-setproctitle:
   debian: [python-setproctitle]
   ubuntu: [python-setproctitle]
@@ -4231,7 +4202,6 @@ python-setuptools:
     bionic: [python-setuptools]
     trusty: [python-setuptools]
     xenial: [python-setuptools]
-    zesty: [python-setuptools]
 python-sexpdata:
   debian:
     '*': [python-sexpdata]
@@ -4429,7 +4399,6 @@ python-sphinx-argparse:
     artful: [python-sphinx-argparse]
     bionic: [python-sphinx-argparse]
     xenial: [python-sphinx-argparse]
-    zesty: [python-sphinx-argparse]
 python-sphinx-rtd-theme:
   debian:
     buster: [python-sphinx-rtd-theme]
@@ -4440,7 +4409,6 @@ python-sphinx-rtd-theme:
     artful: [python-sphinx-rtd-theme]
     bionic: [python-sphinx-rtd-theme]
     xenial: [python-sphinx-rtd-theme]
-    zesty: [python-sphinx-rtd-theme]
 python-spidev-pip: &migrate_eol_2025_04_30_python3_spidev_pip
   debian:
     pip:
@@ -4547,7 +4515,6 @@ python-tabulate:
     artful: [python-tabulate]
     bionic: [python-tabulate]
     xenial: [python-tabulate]
-    zesty: [python-tabulate]
 python-tabulate-pip:
   debian:
     pip:
@@ -4727,7 +4694,6 @@ python-theano:
     xenial:
       pip:
         packages: [Theano]
-    zesty: [python-theano]
 python-tilestache:
   debian: [tilestache]
   fedora: [python-tilestache]
@@ -5100,7 +5066,6 @@ python-watchdog:
     artful: [python-watchdog]
     bionic: [python-watchdog]
     xenial: [python-watchdog]
-    zesty: [python-watchdog]
 python-webob:
   debian: [python-webob]
   fedora: [python-webob]
@@ -5240,7 +5205,6 @@ python-xmltodict:
     artful: [python-xmltodict]
     bionic: [python-xmltodict]
     xenial: [python-xmltodict]
-    zesty: [python-xmltodict]
 python-yamale-pip:
   debian:
     pip:
@@ -5275,7 +5239,6 @@ python-yaml:
     focal: [python-yaml]
     trusty: [python-yaml]
     xenial: [python-yaml]
-    zesty: [python-yaml]
 python-zbar:
   debian: [python-zbar]
   gentoo: ['media-gfx/zbar[python]']
@@ -8427,7 +8390,6 @@ python3-qt5-bindings:
     disco: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
     eoan: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
     xenial: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
-    zesty: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
 python3-qt5-bindings-gl:
   debian: [python3-pyqt5.qtopengl]
   fedora: [python3-qt5]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3079,7 +3079,6 @@ python-progressbar:
       packages: [progressbar]
   ubuntu:
     bionic: [python-progressbar]
-    cosmic: [python-progressbar]
 python-progressbar2-pip:
   debian:
     pip:
@@ -4286,7 +4285,6 @@ python-sympy:
   nixos: [pythonPackages.sympy]
   ubuntu:
     bionic: [python-sympy]
-    cosmic: [python-sympy]
 python-systemd:
   debian:
     buster: [python-systemd]
@@ -8124,7 +8122,6 @@ python3-qt5-bindings:
   ubuntu:
     '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2]
     bionic: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
-    cosmic: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
     disco: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
     eoan: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
 python3-qt5-bindings-gl:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -263,7 +263,6 @@ jupyter-nbconvert:
   nixos: [python3Packages.nbconvert]
   ubuntu:
     '*': [jupyter-nbconvert]
-    xenial: null
 jupyter-notebook:
   debian:
     '*': [jupyter-notebook]
@@ -272,7 +271,6 @@ jupyter-notebook:
   nixos: [jupyter]
   ubuntu:
     '*': [jupyter-notebook]
-    xenial: [ipython-notebook]
 libgv-python:
   debian: [libgv-python]
   ubuntu: [libgv-python]
@@ -499,7 +497,6 @@ python:
   ubuntu:
     artful: [python-dev]
     bionic: [python-dev]
-    xenial: [python-dev]
 python-absl-py-pip:
   debian:
     pip:
@@ -545,7 +542,6 @@ python-aniso8601:
   ubuntu:
     artful: [python-aniso8601]
     bionic: [python-aniso8601]
-    xenial: [python-aniso8601]
 python-annoy-pip:
   debian:
     pip:
@@ -709,7 +705,6 @@ python-backports.ssl-match-hostname:
         packages: [backports.ssl_match_hostname]
       pip:
         packages: [backports.ssl_match_hostname]
-    xenial: [python-backports.ssl-match-hostname]
 python-bcrypt:
   arch: [python2-bcrypt]
   debian: [python-bcrypt]
@@ -736,7 +731,6 @@ python-bitstring:
   ubuntu:
     artful: [python-bitstring]
     bionic: [python-bitstring]
-    xenial: [python-bitstring]
 python-bitstring-pip:
   debian:
     pip:
@@ -796,7 +790,6 @@ python-boltons:
         packages: [boltons]
       pip:
         packages: [boltons]
-    xenial:
       pip:
         packages: [boltons]
       pip:
@@ -913,7 +906,6 @@ python-can:
         packages: [python-can]
       pip:
         packages: [python-can]
-    xenial:
       pip:
         packages: [python-can]
       pip:
@@ -955,7 +947,6 @@ python-catkin-pkg:
   ubuntu:
     artful: [python-catkin-pkg]
     bionic: [python-catkin-pkg]
-    xenial: [python-catkin-pkg]
 python-catkin-pkg-modules:
   alpine:
     pip:
@@ -1022,7 +1013,6 @@ python-certifi:
   ubuntu:
     artful: [python-certifi]
     bionic: [python-certifi]
-    xenial: [python-certifi]
 python-chainer-mask-rcnn-pip:
   debian:
     pip:
@@ -1159,7 +1149,6 @@ python-construct:
   gentoo: [dev-python/construct]
   ubuntu:
     bionic: [python-construct]
-    xenial: [python-construct]
 python-construct-pip:
   debian:
     pip:
@@ -1224,7 +1213,6 @@ python-coverage:
   ubuntu:
     artful: [python-coverage]
     bionic: [python-coverage]
-    xenial: [python-coverage]
 python-cpplint:
   debian:
     pip:
@@ -1262,7 +1250,6 @@ python-crcmod:
       packages: [crcmod]
   ubuntu:
     bionic: [python-crcmod]
-    xenial: [python-crcmod]
 python-crypto:
   alpine: [py-crypto]
   arch: [python2-crypto]
@@ -1279,7 +1266,6 @@ python-crypto:
   ubuntu:
     artful: [python-crypto]
     bionic: [python-crypto]
-    xenial: [python-crypto]
 python-cryptography:
   debian: [python-cryptography]
   gentoo: [dev-python/cryptography]
@@ -1297,7 +1283,6 @@ python-cvxopt:
   ubuntu:
     '*': null
     bionic: [python-cvxopt]
-    xenial: [python-cvxopt]
 python-cvxpy-pip: &migrate_eol_2025_04_30_python3_cvxpy_pip
   debian:
     pip:
@@ -1352,7 +1337,6 @@ python-debian:
   ubuntu:
     artful: [python-debian]
     bionic: [python-debian]
-    xenial: [python-debian]
 python-decorator:
   debian: [python-decorator]
   gentoo: [dev-python/decorator]
@@ -1451,7 +1435,6 @@ python-docutils:
   ubuntu:
     artful: [python-docutils]
     bionic: [python-docutils]
-    xenial: [python-docutils]
 python-docx:
   fedora: [python-docx]
   ubuntu:
@@ -1671,7 +1654,6 @@ python-flask-restful:
         packages: [flask-restful]
       pip:
         packages: [flask-restful]
-    xenial: [python-flask-restful]
 python-flatdict-pip:
   ubuntu:
     pip:
@@ -1727,7 +1709,6 @@ python-future:
         packages: [future]
       pip:
         packages: [future]
-    xenial: [python-future]
 python-fuzzywuzzy-pip:
   debian:
     pip:
@@ -1773,7 +1754,6 @@ python-gdal:
   gentoo: ['sci-libs/gdal[python]']
   ubuntu:
     bionic: [python-gdal]
-    xenial: [python-gdal]
 python-gdown-pip: &migrate_eol_2025_04_30_python3_gdown_pip
   debian:
     pip:
@@ -1852,7 +1832,6 @@ python-gitlab:
         packages: [python-gitlab]
       pip:
         packages: [python-gitlab]
-    xenial:
       pip:
         packages: [python-gitlab]
 python-gitpython-pip:
@@ -1949,7 +1928,6 @@ python-googleapi:
   gentoo: [dev-python/google-api-python-client]
   ubuntu:
     bionic: [python-googleapi]
-    xenial: [python-googleapi]
 python-gpiozero:
   debian:
     buster: [python-gpiozero]
@@ -1970,7 +1948,6 @@ python-gpiozero:
         packages: [gpiozero]
       pip:
         packages: [gpiozero]
-    xenial:
       pip:
         packages: [gpiozero]
       pip:
@@ -2007,7 +1984,6 @@ python-gpxpy:
         packages: [gpxpy]
       pip:
         packages: [gpxpy]
-    xenial:
       pip:
         packages: [gpxpy]
       pip:
@@ -2048,7 +2024,6 @@ python-grpc-tools:
     bionic:
       pip: [grpcio-tools]
       pip: [grpcio-tools]
-    xenial:
       pip: [grpcio-tools]
 python-grpcio:
   debian:
@@ -2062,7 +2037,6 @@ python-grpcio:
     bionic:
       pip: [grpcio]
       pip: [grpcio]
-    xenial:
       pip: [grpcio]
 python-grpcio-reflection-pip:
   debian:
@@ -2164,7 +2138,6 @@ python-imageio:
     '*': [python-imageio]
       pip:
         packages: [imageio]
-    xenial:
       pip:
         packages: [imageio]
 python-imaging:
@@ -2192,7 +2165,6 @@ python-imaging:
   ubuntu:
     '*': [python-pil]
     artful: [python-imaging]
-    xenial: [python-imaging]
 python-imaging-imagetk:
   debian: [python-pil.imagetk]
   ubuntu: [python-pil.imagetk]
@@ -2209,7 +2181,6 @@ python-influxdb:
   ubuntu:
     bionic: [python-influxdb]
     disco: [python-influxdb]
-    xenial: [python-influxdb]
 python-inject-pip: &migrate_eol_2025_04_30_python3_inject_pip
   ubuntu:
     pip:
@@ -2248,7 +2219,6 @@ python-is-python3:
   ubuntu:
     '*': [python-is-python3]
     bionic: null
-    xenial: null
 python-itsdangerous:
   debian:
     buster: [python-itsdangerous]
@@ -2480,7 +2450,6 @@ python-lxml:
   ubuntu:
     bionic: [python-lxml]
     focal: [python-lxml]
-    xenial: [python-lxml]
 python-lzf-pip:
   debian:
     pip:
@@ -2542,7 +2511,6 @@ python-matplotlib:
   ubuntu:
     artful: [python-matplotlib]
     bionic: [python-matplotlib]
-    xenial: [python-matplotlib]
 python-mechanize:
   arch: [python2-mechanize]
   debian: [python-mechanize]
@@ -2578,7 +2546,6 @@ python-mock:
   ubuntu:
     artful: [python-mock]
     bionic: [python-mock]
-    xenial: [python-mock]
 python-monotonic:
   arch: [python-monotonic]
   debian: [python-monotonic]
@@ -2592,7 +2559,6 @@ python-more-itertools:
   fedora: [python-more-itertools]
   ubuntu:
     '*': [python-more-itertools]
-    xenial: null
 python-more-itertools-pip:
   arch:
     pip:
@@ -2604,7 +2570,6 @@ python-more-itertools-pip:
     pip:
       packages: [more-itertools]
   ubuntu:
-    xenial:
       pip: [more-itertools]
 python-moviepy-pip:
   debian:
@@ -2695,7 +2660,6 @@ python-netaddr:
         packages: [netaddr]
       pip:
         packages: [netaddr]
-    xenial: [python-netaddr]
 python-netcdf4:
   arch: [python-netcdf4]
   debian: [python-netcdf4]
@@ -2725,7 +2689,6 @@ python-netifaces:
   ubuntu:
     artful: [python-netifaces]
     bionic: [python-netifaces]
-    xenial: [python-netifaces]
 python-networkmanager:
   debian:
     buster: [python-networkmanager]
@@ -2785,7 +2748,6 @@ python-numpy:
   ubuntu:
     bionic: [python-numpy]
     focal: [python-numpy]
-    xenial: [python-numpy]
 python-numpy-quaternion-pip:
   debian:
     pip:
@@ -2874,7 +2836,6 @@ python-opengl:
   ubuntu:
     artful: [python-opengl]
     bionic: [python-opengl]
-    xenial: [python-opengl]
 python-openssl:
   debian: [python-openssl]
   gentoo: [dev-python/pyopenssl]
@@ -2936,7 +2897,6 @@ python-parameterized:
         packages: [parameterized]
       pip:
         packages: [parameterized]
-    xenial:
       pip:
         packages: [parameterized]
       pip:
@@ -2972,7 +2932,6 @@ python-parso:
         packages: [parso]
   ubuntu:
     bionic: [python-parso]
-    xenial:
       pip:
         packages: [parso]
 python-passlib:
@@ -3007,7 +2966,6 @@ python-pathlib2:
   nixos: [pythonPackages.pathlib2]
   ubuntu:
     '*': [python-pathlib2]
-    xenial: null
 python-pathos-pip:
   debian:
     pip:
@@ -3019,7 +2977,6 @@ python-pathtools:
   debian: [python-pathtools]
   ubuntu:
     artful: [python-pathtools]
-    xenial: [python-pathtools]
 python-pbr:
   debian: [python-pbr]
   fedora: [python-pbr]
@@ -3172,7 +3129,6 @@ python-progressbar:
     artful: [python-progressbar]
     bionic: [python-progressbar]
     cosmic: [python-progressbar]
-    xenial: [python-progressbar]
 python-progressbar2-pip:
   debian:
     pip:
@@ -3235,7 +3191,6 @@ python-pyassimp:
   ubuntu:
     artful: [python-pyassimp]
     bionic: [python-pyassimp]
-    xenial: [python-pyassimp]
 python-pyaudio:
   debian: [python-pyaudio]
   gentoo: [dev-python/pyaudio]
@@ -3292,7 +3247,6 @@ python-pydbus:
       pip:
         depends: [python-gi]
         packages: [pydbus]
-    xenial:
       pip:
         depends: [python-gi]
         packages: [pydbus]
@@ -3483,7 +3437,6 @@ python-pypng:
     '*': [python-png]
       pip:
         packages: [pypng]
-    xenial:
       pip:
         packages: [pypng]
 python-pypozyx-pip:
@@ -3517,7 +3470,6 @@ python-pyqrcode:
     '*': [python-pyqrcode]
       pip:
         packages: [PyQRCode]
-    xenial:
       pip:
         packages: [PyQRCode]
 python-pyqtgraph:
@@ -3528,7 +3480,6 @@ python-pyqtgraph:
   nixos: [pythonPackages.pyqtgraph]
   ubuntu:
     bionic: [python-pyqtgraph]
-    xenial: [python-pyqtgraph]
 python-pyquery:
   debian: [python-pyquery]
   fedora: [python-pyquery]
@@ -3753,7 +3704,6 @@ python-qt5-bindings:
   ubuntu:
     artful: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev]
     bionic: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev]
-    xenial: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-pyside2, python-sip-dev, shiboken2]
 python-qt5-bindings-gl:
   arch: [python2-pyqt5]
   debian:
@@ -3770,7 +3720,6 @@ python-qt5-bindings-gl:
   ubuntu:
     artful: [python-pyqt5.qtopengl]
     bionic: [python-pyqt5.qtopengl]
-    xenial: [python-pyqt5.qtopengl]
 python-qt5-bindings-qsci:
   debian: [python-pyqt5.qsci]
   openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
@@ -3793,7 +3742,6 @@ python-qt5-bindings-webkit:
   ubuntu:
     artful: [python-pyqt5.qtwebkit]
     bionic: [python-pyqt5.qtwebkit]
-    xenial: [python-pyqt5.qtwebkit]
 python-qtpy:
   arch: [python-qtpy]
   debian: [python-qtpy]
@@ -3870,7 +3818,6 @@ python-rosdep:
   ubuntu:
     artful: [python-rosdep]
     bionic: [python-rosdep]
-    xenial: [python-rosdep]
 python-rosdep-modules:
   alpine:
     pip:
@@ -3906,7 +3853,6 @@ python-rosdistro:
     '7': [python2-rosdistro]
   ubuntu:
     artful: [python-rosdistro]
-    xenial: [python-rosdistro]
 python-rosinstall:
   arch: [python2-rosinstall]
   debian: [python-rosinstall]
@@ -3996,7 +3942,6 @@ python-rpi.gpio:
         packages: [RPi.GPIO]
       pip:
         packages: [RPi.GPIO]
-    xenial:
       pip:
         packages: [RPi.GPIO]
       pip:
@@ -4028,7 +3973,6 @@ python-ruamel.yaml:
   ubuntu:
     artful: [python-ruamel.yaml]
     bionic: [python-ruamel.yaml]
-    xenial: [python-ruamel.yaml]
 python-rx-pip:
   debian:
     pip:
@@ -4116,7 +4060,6 @@ python-semantic-version:
   nixos: [pythonPackages.semantic-version]
   ubuntu:
     bionic: [python-semantic-version]
-    xenial: [python-semantic-version]
 python-semver:
   debian: [python-semver]
   fedora: [python-semver]
@@ -4131,7 +4074,6 @@ python-serial:
   ubuntu:
     artful: [python-serial]
     bionic: [python-serial]
-    xenial: [python-serial]
 python-setproctitle:
   debian: [python-setproctitle]
   ubuntu: [python-setproctitle]
@@ -4153,7 +4095,6 @@ python-setuptools:
   ubuntu:
     artful: [python-setuptools]
     bionic: [python-setuptools]
-    xenial: [python-setuptools]
 python-sexpdata:
   debian:
     '*': [python-sexpdata]
@@ -4168,7 +4109,6 @@ python-sexpdata:
     bionic:
       pip:
         packages: [sexpdata]
-    xenial:
       pip:
         packages: [sexpdata]
 python-sh:
@@ -4349,7 +4289,6 @@ python-sphinx-argparse:
   ubuntu:
     artful: [python-sphinx-argparse]
     bionic: [python-sphinx-argparse]
-    xenial: [python-sphinx-argparse]
 python-sphinx-rtd-theme:
   debian:
     buster: [python-sphinx-rtd-theme]
@@ -4359,7 +4298,6 @@ python-sphinx-rtd-theme:
   ubuntu:
     artful: [python-sphinx-rtd-theme]
     bionic: [python-sphinx-rtd-theme]
-    xenial: [python-sphinx-rtd-theme]
 python-spidev-pip: &migrate_eol_2025_04_30_python3_spidev_pip
   debian:
     pip:
@@ -4374,7 +4312,6 @@ python-sqlalchemy:
   ubuntu:
     artful: [python-sqlalchemy]
     bionic: [python-sqlalchemy]
-    xenial: [python-sqlalchemy]
 python-sqlite:
   debian: [python-sqlite]
   ubuntu: [python-sqlite]
@@ -4426,7 +4363,6 @@ python-sympy:
     artful: [python-sympy]
     bionic: [python-sympy]
     cosmic: [python-sympy]
-    xenial: [python-sympy]
 python-systemd:
   debian:
     buster: [python-systemd]
@@ -4434,7 +4370,6 @@ python-systemd:
   nixos: [pythonPackages.systemd]
   ubuntu:
     bionic: [python-systemd]
-    xenial: [python-systemd]
 python-sysv-ipc:
   debian: [python-sysv-ipc]
   ubuntu: [python-sysv-ipc]
@@ -4461,7 +4396,6 @@ python-tabulate:
   ubuntu:
     artful: [python-tabulate]
     bionic: [python-tabulate]
-    xenial: [python-tabulate]
 python-tabulate-pip:
   debian:
     pip:
@@ -4637,7 +4571,6 @@ python-theano:
         packages: [Theano]
       pip:
         packages: [Theano]
-    xenial:
       pip:
         packages: [Theano]
 python-tilestache:
@@ -4713,7 +4646,6 @@ python-tqdm:
         packages: [tqdm]
       pip:
         packages: [tqdm]
-    xenial:
       pip:
         packages: [tqdm]
 python-transforms3d-pip:
@@ -4741,7 +4673,6 @@ python-transitions:
     bionic: [python-transitions]
       pip:
         packages: [transitions]
-    xenial:
       pip:
         packages: [transitions]
 python-trep:
@@ -4822,7 +4753,6 @@ python-typing:
   nixos: [pythonPackages.typing]
   ubuntu:
     '*': [python-typing]
-    xenial: null
 python-typing-pip:
   debian:
     pip:
@@ -4845,7 +4775,6 @@ python-ubjson:
   debian: [python-ubjson]
   ubuntu:
     '*': [python-ubjson]
-    xenial:
       pip:
         packages: [py-ubjson]
 python-ujson:
@@ -4983,7 +4912,6 @@ python-vtk:
   gentoo: [dev-python/pyvtk]
   ubuntu:
     bionic: [python-vtk6]
-    xenial: [python-vtk6]
 python-w1thermsensor-pip:
   debian:
     pip:
@@ -5006,7 +4934,6 @@ python-watchdog:
   ubuntu:
     artful: [python-watchdog]
     bionic: [python-watchdog]
-    xenial: [python-watchdog]
 python-webob:
   debian: [python-webob]
   fedora: [python-webob]
@@ -5052,7 +4979,6 @@ python-websocket:
         packages: [websocket-client]
       pip:
         packages: [websocket-client]
-    xenial: [python-websocket]
 python-webtest:
   debian: [python-webtest]
   fedora: [python-webtest]
@@ -5144,7 +5070,6 @@ python-xmltodict:
   ubuntu:
     artful: [python-xmltodict]
     bionic: [python-xmltodict]
-    xenial: [python-xmltodict]
 python-yamale-pip:
   debian:
     pip:
@@ -5177,7 +5102,6 @@ python-yaml:
     artful: [python-yaml]
     bionic: [python-yaml]
     focal: [python-yaml]
-    xenial: [python-yaml]
 python-zbar:
   debian: [python-zbar]
   gentoo: ['media-gfx/zbar[python]']
@@ -5444,7 +5368,6 @@ python3-bluez:
   ubuntu:
     '*': [python3-bluez]
     bionic: null
-    xenial: null
 python3-bokeh-pip:
   debian:
     pip:
@@ -5562,7 +5485,6 @@ python3-can:
   fedora: [python3-can]
   ubuntu:
     '*': [python3-can]
-    xenial: null
 python3-can-j1939-pip:
   debian:
     pip:
@@ -5591,7 +5513,6 @@ python3-catkin-lint:
   ubuntu:
     '*': [python3-catkin-lint]
     bionic: null
-    xenial: null
 python3-catkin-pkg:
   alpine: [py3-catkin-pkg]
   arch:
@@ -5720,7 +5641,6 @@ python3-collada:
   ubuntu:
     '*': [python3-collada]
     bionic: null
-    xenial: null
 python3-collada-pip:
   debian:
     pip:
@@ -5940,7 +5860,6 @@ python3-distutils:
   nixos: [python3]
   ubuntu:
     '*': [python3-distutils]
-    xenial: null
 python3-django:
   debian: [python3-django]
   fedora: [python3-django]
@@ -6515,7 +6434,6 @@ python3-gitlab:
         packages: [python-gitlab]
       pip:
         packages: [python-gitlab]
-    xenial:
       pip:
         packages: [python-gitlab]
 python3-glpk-pip: *migrate_eol_2025_04_30_python3_glpk_pip
@@ -6612,7 +6530,6 @@ python3-grpc-tools:
   ubuntu:
     '*': [python3-grpc-tools]
     bionic: null
-    xenial: null
 python3-grpcio:
   debian:
     '*': [python3-grpcio]
@@ -6623,7 +6540,6 @@ python3-grpcio:
   ubuntu:
     '*': [python3-grpcio]
     bionic: null
-    xenial: null
 python3-gurobipy-pip: *migrate_eol_2025_04_30_python3_gurobipy_pip
 python3-gz-math6:
   ubuntu:
@@ -6714,7 +6630,6 @@ python3-importlib-metadata:
     bionic:
       pip:
         packages: [importlib-metadata]
-    xenial:
       pip:
         packages: [importlib-metadata]
 python3-importlib-resources:
@@ -6743,7 +6658,6 @@ python3-importlib-resources:
     bionic:
       pip:
         packages: [importlib-resources]
-    xenial:
       pip:
         packages: [importlib-resources]
 python3-inflection-pip:
@@ -6835,7 +6749,6 @@ python3-junitparser:
   ubuntu:
     '*': [python3-junitparser]
     bionic: null
-    xenial: null
 python3-jupyros-pip:
   debian:
     pip:
@@ -6857,7 +6770,6 @@ python3-kitchen:
       packages: [kitchen]
   ubuntu:
     '*': [python3-kitchen]
-    xenial: null
 python3-kivy:
   debian:
     '*': [python3-kivy]
@@ -6904,7 +6816,6 @@ python3-lark-parser:
   ubuntu:
     '*': [python3-lark]
     bionic: [python3-lark-parser]
-    xenial: [python3-lark-parser]
 python3-libgpiod:
   alpine: [py3-libgpiod]
   arch: [libgpiod]
@@ -7038,7 +6949,6 @@ python3-mechanize:
   ubuntu:
     '*': [python3-mechanize]
     bionic: null
-    xenial: null
 python3-mediapipe-pip:
   debian:
     pip:
@@ -7234,7 +7144,6 @@ python3-nlopt:
   ubuntu:
     '*': [python3-nlopt]
     bionic: null
-    xenial: null
 python3-nose:
   arch: [python-nose]
   debian: [python3-nose]
@@ -7284,7 +7193,6 @@ python3-numpy-stl:
   nixos: [python3Packages.numpy-stl]
   ubuntu:
     '*': [python3-numpy-stl]
-    xenial: null
 python3-nuscenes-devkit-pip:
   arch:
     pip:
@@ -7462,7 +7370,6 @@ python3-paho-mqtt:
     '7': null
   ubuntu:
     '*': [python3-paho-mqtt]
-    xenial: null
 python3-pandas:
   debian: [python3-pandas]
   fedora: [python3-pandas]
@@ -7750,7 +7657,6 @@ python3-pyassimp:
   openembedded: [python3-pyassimp@meta-ros-common]
   ubuntu:
     '*': [python3-pyassimp]
-    xenial: null
 python3-pyaudio:
   arch: [python-pyaudio]
   debian: [python3-pyaudio]
@@ -7824,7 +7730,6 @@ python3-pydantic:
     '*': [python3-pydantic]
     bionic:
       pip: [pydantic]
-    xenial:
       pip: [pydantic]
 python3-pydbus:
   debian: [python3-pydbus]
@@ -7876,7 +7781,6 @@ python3-pygame:
     '*': [python3-pygame]
     bionic:
       pip: [pygame]
-    xenial:
       pip: [pygame]
 python3-pygit2:
   alpine: [py3-pygit2]
@@ -7933,7 +7837,6 @@ python3-pykdl:
   ubuntu:
     '*': [python3-pykdl]
     bionic: null
-    xenial: null
 python3-pylatexenc:
   debian:
     '*': [python3-pylatexenc]
@@ -7999,7 +7902,6 @@ python3-pymodbus:
   fedora: [python3-pymodbus]
   ubuntu:
     '*': [python3-pymodbus]
-    xenial: null
 python3-pymodbus-pip: *migrate_eol_2027_04_30_python3_pymodbus_pip
 python3-pymongo:
   arch: [python-pymongo]
@@ -8060,7 +7962,6 @@ python3-pypng:
   gentoo: [dev-python/pypng]
   ubuntu:
     '*': [python3-png]
-    xenial: null
 python3-pyproj:
   arch: [python-pyproj]
   debian: [python3-pyproj]
@@ -8132,7 +8033,6 @@ python3-pyside2.qtopengl:
   ubuntu:
     '*': [python3-pyside2.qtopengl]
     bionic: null
-    xenial: null
 python3-pyside2.qtquick:
   arch: [pyside2]
   debian: [python3-pyside2.qtquick]
@@ -8141,13 +8041,11 @@ python3-pyside2.qtquick:
   ubuntu:
     '*': [python3-pyside2.qtquick]
     bionic: null
-    xenial: null
 python3-pyside2.qtuitools:
   debian: [python3-pyside2.qtuitools]
   ubuntu:
     '*': [python3-pyside2.qtuitools]
     bionic: null
-    xenial: null
 python3-pysnmp:
   debian: [python3-pysnmp4]
   fedora: [python3-pysnmp]
@@ -8171,7 +8069,6 @@ python3-pystemd:
     bionic:
       pip:
         packages: [pystemd]
-    xenial:
       pip:
         packages: [pystemd]
 python3-pyswarms-pip:
@@ -8327,7 +8224,6 @@ python3-qt5-bindings:
     cosmic: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
     disco: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
     eoan: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
-    xenial: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
 python3-qt5-bindings-gl:
   debian: [python3-pyqt5.qtopengl]
   fedora: [python3-qt5]
@@ -8686,7 +8582,6 @@ python3-sexpdata:
     bionic:
       pip:
         packages: [sexpdata]
-    xenial:
       pip:
         packages: [sexpdata]
 python3-sh:
@@ -9065,7 +8960,6 @@ python3-thriftpy:
   debian: [python3-thriftpy]
   ubuntu:
     '*': [python3-thriftpy]
-    xenial:
       pip:
         packages: [thriftpy]
 python3-tilestache-pip:
@@ -9122,7 +9016,6 @@ python3-tqdm:
       packages: [tqdm]
   ubuntu:
     '*': [python3-tqdm]
-    xenial: null
 python3-transformers-pip:
   debian:
     pip:
@@ -9156,7 +9049,6 @@ python3-transitions:
     '*': [python3-transitions]
       pip:
         packages: [transitions]
-    xenial:
       pip:
         packages: [transitions]
 python3-triangle-pip:
@@ -9251,7 +9143,6 @@ python3-ubjson:
   debian: [python3-ubjson]
   ubuntu:
     '*': [python3-ubjson]
-    xenial: null
 python3-ujson:
   debian: [python3-ujson]
   fedora: [python3-ujson]
@@ -9516,7 +9407,6 @@ python3-yappi:
   ubuntu:
     '*': [python3-yappi]
     bionic: null
-    xenial: null
 python3-yolov5:
   debian:
     pip:
@@ -9666,7 +9556,6 @@ yapf:
         packages: [yapf]
       pip:
         packages: [yapf]
-    xenial:
       pip:
         packages: [yapf]
       pip:
@@ -9677,7 +9566,6 @@ yapf3:
   nixos: [python3Packages.yapf]
   ubuntu:
     '*': [yapf3]
-    xenial: null
 zulip-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -500,7 +500,6 @@ python:
   ubuntu:
     artful: [python-dev]
     bionic: [python-dev]
-    maverick: [python-dev]
     natty: [python-dev]
     oneiric: [python-dev]
     precise: [python-dev]
@@ -621,7 +620,6 @@ python-argparse:
       packages: [argparse]
   ubuntu:
     '*': []
-    maverick: [python-argparse]
     natty: [python-argparse]
     oneiric: [python-argparse]
 python-astor-pip:
@@ -672,7 +670,6 @@ python-autobahn:
     '*': [python-autobahn]
       pip:
         packages: [autobahn]
-    maverick:
       pip:
         packages: [autobahn]
     natty:
@@ -931,7 +928,6 @@ python-can:
     '*': [python-can]
       pip:
         packages: [python-can]
-    maverick:
       pip:
         packages: [python-can]
     natty:
@@ -1007,7 +1003,6 @@ python-catkin-pkg:
   ubuntu:
     artful: [python-catkin-pkg]
     bionic: [python-catkin-pkg]
-    maverick: [python-catkin-pkg]
     natty: [python-catkin-pkg]
     oneiric: [python-catkin-pkg]
     precise: [python-catkin-pkg]
@@ -1296,7 +1291,6 @@ python-coverage:
   ubuntu:
     artful: [python-coverage]
     bionic: [python-coverage]
-    maverick: [python-coverage]
     natty: [python-coverage]
     oneiric: [python-coverage]
     precise: [python-coverage]
@@ -1364,7 +1358,6 @@ python-crypto:
   ubuntu:
     artful: [python-crypto]
     bionic: [python-crypto]
-    maverick: [python-crypto]
     natty: [python-crypto]
     oneiric: [python-crypto]
     precise: [python-crypto]
@@ -1555,7 +1548,6 @@ python-docutils:
   ubuntu:
     artful: [python-docutils]
     bionic: [python-docutils]
-    maverick: [python-docutils]
     natty: [python-docutils]
     oneiric: [python-docutils]
     precise: [python-docutils]
@@ -1637,7 +1629,6 @@ python-enum34-pip:
 python-espeak:
   debian: [python-espeak]
   ubuntu:
-    maverick: [python-espeak]
     natty: [python-espeak]
     oneiric: [python-espeak]
     precise: [python-espeak]
@@ -2186,7 +2177,6 @@ python-gridfs:
   debian: [python-gridfs]
   fedora: [python-pymongo-gridfs]
   ubuntu:
-    maverick: [python-gridfs]
     natty: [python-gridfs]
     oneiric: [python-gridfs]
     precise: [python-gridfs]
@@ -2246,7 +2236,6 @@ python-gst:
     wheezy: [python-gst0.10]
   gentoo: [dev-python/gst-python]
   ubuntu:
-    maverick: [python-gst0.10]
     natty: [python-gst0.10]
     oneiric: [python-gst0.10]
     precise: [python-gst0.10]
@@ -2364,7 +2353,6 @@ python-imaging:
   ubuntu:
     '*': [python-pil]
     artful: [python-imaging]
-    maverick: [python-imaging]
     natty: [python-imaging]
     oneiric: [python-imaging]
     precise: [python-imaging]
@@ -2727,7 +2715,6 @@ python-matplotlib:
   ubuntu:
     artful: [python-matplotlib]
     bionic: [python-matplotlib]
-    maverick: [python-matplotlib]
     natty: [python-matplotlib]
     oneiric: [python-matplotlib]
     precise: [python-matplotlib]
@@ -2776,7 +2763,6 @@ python-mock:
   ubuntu:
     artful: [python-mock]
     bionic: [python-mock]
-    maverick: [python-mock]
     natty: [python-mock]
     oneiric: [python-mock]
     precise: [python-mock]
@@ -2894,7 +2880,6 @@ python-netaddr:
   ubuntu:
     artful: [python-netaddr]
     bionic: [python-netaddr]
-    maverick:
       pip:
         packages: [netaddr]
     natty:
@@ -2948,7 +2933,6 @@ python-netifaces:
   ubuntu:
     artful: [python-netifaces]
     bionic: [python-netifaces]
-    maverick: [python-netifaces]
     natty: [python-netifaces]
     oneiric: [python-netifaces]
     precise: [python-netifaces]
@@ -3117,7 +3101,6 @@ python-opengl:
   ubuntu:
     artful: [python-opengl]
     bionic: [python-opengl]
-    maverick: [python-opengl]
     natty: [python-opengl]
     oneiric: [python-opengl]
     precise: [python-opengl]
@@ -3442,7 +3425,6 @@ python-progressbar:
     artful: [python-progressbar]
     bionic: [python-progressbar]
     cosmic: [python-progressbar]
-    maverick: [python-progressbar]
     natty: [python-progressbar]
     oneiric: [python-progressbar]
     precise: [python-progressbar]
@@ -3853,7 +3835,6 @@ python-pyside:
   debian: [python-pyside]
   gentoo: [dev-python/pyside]
   ubuntu:
-    maverick: [python-pyside]
     natty: [python-pyside]
     oneiric: [python-pyside]
     precise: [python-pyside]
@@ -3866,7 +3847,6 @@ python-pyside:
 python-pyside.qtuitools:
   debian: [python-pyside.qtuitools]
   ubuntu:
-    maverick: [python-pyside.qtuitools]
     natty: [python-pyside.qtuitools]
     oneiric: [python-pyside.qtuitools]
     precise: [python-pyside.qtuitools]
@@ -4194,7 +4174,6 @@ python-rosdep:
   ubuntu:
     artful: [python-rosdep]
     bionic: [python-rosdep]
-    maverick: [python-rosdep]
     natty: [python-rosdep]
     oneiric: [python-rosdep]
     precise: [python-rosdep]
@@ -4243,7 +4222,6 @@ python-rosdistro:
     '7': [python2-rosdistro]
   ubuntu:
     artful: [python-rosdistro]
-    maverick: [python-rosdistro]
     natty: [python-rosdistro]
     oneiric: [python-rosdistro]
     precise: [python-rosdistro]
@@ -4371,7 +4349,6 @@ python-rrdtool:
   debian: [python-rrdtool]
   gentoo: [net-analyzer/rrdtool]
   ubuntu:
-    maverick: [python-rrdtool]
     natty: [python-rrdtool]
     oneiric: [python-rrdtool]
     precise: [python-rrdtool]
@@ -4498,7 +4475,6 @@ python-serial:
   ubuntu:
     artful: [python-serial]
     bionic: [python-serial]
-    maverick: [python-serial]
     natty: [python-serial]
     oneiric: [python-serial]
     precise: [python-serial]
@@ -4533,7 +4509,6 @@ python-setuptools:
   ubuntu:
     artful: [python-setuptools]
     bionic: [python-setuptools]
-    maverick: [python-setuptools]
     natty: [python-setuptools]
     oneiric: [python-setuptools]
     precise: [python-setuptools]
@@ -4636,7 +4611,6 @@ python-skimage:
     '*': [python-skimage]
       pip:
         packages: [scikit-image]
-    maverick:
       pip:
         packages: [scikit-image]
     natty:
@@ -4666,7 +4640,6 @@ python-sklearn:
       packages: [scikit-learn]
   ubuntu:
     '*': [python-sklearn]
-    maverick: []
     natty: []
     oneiric: []
 python-slackclient-pip:
@@ -4841,7 +4814,6 @@ python-sympy:
     artful: [python-sympy]
     bionic: [python-sympy]
     cosmic: [python-sympy]
-    maverick: [python-sympy]
     natty: [python-sympy]
     oneiric: [python-sympy]
     precise: [python-sympy]
@@ -5641,7 +5613,6 @@ python-yaml:
     artful: [python-yaml]
     bionic: [python-yaml]
     focal: [python-yaml]
-    maverick: [python-yaml]
     natty: [python-yaml]
     oneiric: [python-yaml]
     precise: [python-yaml]
@@ -10128,7 +10099,6 @@ wxpython:
     '7': [wxPython-devel]
   ubuntu:
     '*': [python-wxgtk3.0]
-    maverick: [python-wxgtk2.8]
     natty: [python-wxgtk2.8]
     oneiric: [python-wxgtk2.8]
     precise: [python-wxgtk2.8]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -500,7 +500,6 @@ python:
   ubuntu:
     artful: [python-dev]
     bionic: [python-dev]
-    precise: [python-dev]
     quantal: [python-dev]
     raring: [python-dev]
     saucy: [python-dev]
@@ -672,7 +671,6 @@ python-autobahn:
         packages: [autobahn]
       pip:
         packages: [autobahn]
-    precise:
       pip:
         packages: [autobahn]
     quantal:
@@ -928,7 +926,6 @@ python-can:
         packages: [python-can]
       pip:
         packages: [python-can]
-    precise:
       pip:
         packages: [python-can]
     quantal:
@@ -995,7 +992,6 @@ python-catkin-pkg:
   ubuntu:
     artful: [python-catkin-pkg]
     bionic: [python-catkin-pkg]
-    precise: [python-catkin-pkg]
     quantal: [python-catkin-pkg]
     raring: [python-catkin-pkg]
     saucy: [python-catkin-pkg]
@@ -1281,7 +1277,6 @@ python-coverage:
   ubuntu:
     artful: [python-coverage]
     bionic: [python-coverage]
-    precise: [python-coverage]
     quantal: [python-coverage]
     raring: [python-coverage]
     saucy: [python-coverage]
@@ -1346,7 +1341,6 @@ python-crypto:
   ubuntu:
     artful: [python-crypto]
     bionic: [python-crypto]
-    precise: [python-crypto]
     quantal: [python-crypto]
     raring: [python-crypto]
     saucy: [python-crypto]
@@ -1534,7 +1528,6 @@ python-docutils:
   ubuntu:
     artful: [python-docutils]
     bionic: [python-docutils]
-    precise: [python-docutils]
     quantal: [python-docutils]
     raring: [python-docutils]
     saucy: [python-docutils]
@@ -1613,7 +1606,6 @@ python-enum34-pip:
 python-espeak:
   debian: [python-espeak]
   ubuntu:
-    precise: [python-espeak]
     quantal: [python-espeak]
     raring: [python-espeak]
     saucy: [python-espeak]
@@ -2159,7 +2151,6 @@ python-gridfs:
   debian: [python-gridfs]
   fedora: [python-pymongo-gridfs]
   ubuntu:
-    precise: [python-gridfs]
     quantal: [python-gridfs]
     raring: [python-gridfs]
     saucy: [python-gridfs]
@@ -2216,7 +2207,6 @@ python-gst:
     wheezy: [python-gst0.10]
   gentoo: [dev-python/gst-python]
   ubuntu:
-    precise: [python-gst0.10]
     quantal: [python-gst0.10]
     raring: [python-gst0.10]
     saucy: [python-gst0.10]
@@ -2331,7 +2321,6 @@ python-imaging:
   ubuntu:
     '*': [python-pil]
     artful: [python-imaging]
-    precise: [python-imaging]
     quantal: [python-imaging]
     raring: [python-imaging]
     saucy: [python-imaging]
@@ -2691,7 +2680,6 @@ python-matplotlib:
   ubuntu:
     artful: [python-matplotlib]
     bionic: [python-matplotlib]
-    precise: [python-matplotlib]
     quantal: [python-matplotlib]
     raring: [python-matplotlib]
     saucy: [python-matplotlib]
@@ -2737,7 +2725,6 @@ python-mock:
   ubuntu:
     artful: [python-mock]
     bionic: [python-mock]
-    precise: [python-mock]
     quantal: [python-mock]
     raring: [python-mock]
     saucy: [python-mock]
@@ -2858,7 +2845,6 @@ python-netaddr:
         packages: [netaddr]
       pip:
         packages: [netaddr]
-    precise: [python-netaddr]
     quantal:
       pip:
         packages: [netaddr]
@@ -2903,7 +2889,6 @@ python-netifaces:
   ubuntu:
     artful: [python-netifaces]
     bionic: [python-netifaces]
-    precise: [python-netifaces]
     quantal: [python-netifaces]
     raring: [python-netifaces]
     saucy: [python-netifaces]
@@ -3007,7 +2992,6 @@ python-oauth2:
   fedora: [python-oauth2]
   gentoo: [dev-python/oauth2]
   ubuntu:
-    precise: [python-oauth2]
     quantal: [python-oauth2]
     raring: [python-oauth2]
     saucy: [python-oauth2]
@@ -3069,7 +3053,6 @@ python-opengl:
   ubuntu:
     artful: [python-opengl]
     bionic: [python-opengl]
-    precise: [python-opengl]
     quantal: [python-opengl]
     raring: [python-opengl]
     saucy: [python-opengl]
@@ -3262,7 +3245,6 @@ python-pep8:
       packages: [pep8]
   ubuntu:
     '*': [python-pep8]
-    precise: [pep8]
     quantal: [pep8]
     raring: [pep8]
     saucy: [pep8]
@@ -3391,7 +3373,6 @@ python-progressbar:
     artful: [python-progressbar]
     bionic: [python-progressbar]
     cosmic: [python-progressbar]
-    precise: [python-progressbar]
     quantal: [python-progressbar]
     raring: [python-progressbar]
     saucy: [python-progressbar]
@@ -3462,7 +3443,6 @@ python-pyassimp:
   ubuntu:
     artful: [python-pyassimp]
     bionic: [python-pyassimp]
-    precise: [python-pyassimp]
     quantal: [python-pyassimp]
     raring: [python-pyassimp]
     saucy: [python-pyassimp]
@@ -3798,7 +3778,6 @@ python-pyside:
   debian: [python-pyside]
   gentoo: [dev-python/pyside]
   ubuntu:
-    precise: [python-pyside]
     quantal: [python-pyside]
     raring: [python-pyside]
     saucy: [python-pyside]
@@ -3808,7 +3787,6 @@ python-pyside:
 python-pyside.qtuitools:
   debian: [python-pyside.qtuitools]
   ubuntu:
-    precise: [python-pyside.qtuitools]
     quantal: [python-pyside.qtuitools]
     raring: [python-pyside.qtuitools]
     saucy: [python-pyside.qtuitools]
@@ -4133,7 +4111,6 @@ python-rosdep:
   ubuntu:
     artful: [python-rosdep]
     bionic: [python-rosdep]
-    precise: [python-rosdep]
     quantal: [python-rosdep]
     raring: [python-rosdep]
     saucy: [python-rosdep]
@@ -4179,7 +4156,6 @@ python-rosdistro:
     '7': [python2-rosdistro]
   ubuntu:
     artful: [python-rosdistro]
-    precise: [python-rosdistro]
     quantal: [python-rosdistro]
     raring: [python-rosdistro]
     saucy: [python-rosdistro]
@@ -4304,7 +4280,6 @@ python-rrdtool:
   debian: [python-rrdtool]
   gentoo: [net-analyzer/rrdtool]
   ubuntu:
-    precise: [python-rrdtool]
     quantal: [python-rrdtool]
     raring: [python-rrdtool]
     saucy: [python-rrdtool]
@@ -4428,7 +4403,6 @@ python-serial:
   ubuntu:
     artful: [python-serial]
     bionic: [python-serial]
-    precise: [python-serial]
     quantal: [python-serial]
     raring: [python-serial]
     saucy: [python-serial]
@@ -4460,7 +4434,6 @@ python-setuptools:
   ubuntu:
     artful: [python-setuptools]
     bionic: [python-setuptools]
-    precise: [python-setuptools]
     quantal: [python-setuptools]
     raring: [python-setuptools]
     saucy: [python-setuptools]
@@ -4566,7 +4539,6 @@ python-skimage:
         packages: [scikit-image]
       pip:
         packages: [scikit-image]
-    precise:
       pip:
         packages: [scikit-image]
 python-skimage-pip:
@@ -4697,7 +4669,6 @@ python-sqlalchemy:
   ubuntu:
     artful: [python-sqlalchemy]
     bionic: [python-sqlalchemy]
-    precise: [python-sqlalchemy]
     quantal: [python-sqlalchemy]
     raring: [python-sqlalchemy]
     saucy: [python-sqlalchemy]
@@ -4759,7 +4730,6 @@ python-sympy:
     artful: [python-sympy]
     bionic: [python-sympy]
     cosmic: [python-sympy]
-    precise: [python-sympy]
     quantal: [python-sympy]
     raring: [python-sympy]
     saucy: [python-sympy]
@@ -4944,7 +4914,6 @@ python-texttable:
       packages: [texttable]
   ubuntu:
     '*': [python-texttable]
-    precise:
       pip:
         packages: [texttable]
     saucy:
@@ -4968,7 +4937,6 @@ python-theano:
     pip:
       packages: [Theano]
   ubuntu:
-    precise:
       pip:
         packages: [Theano]
     saucy:
@@ -5411,7 +5379,6 @@ python-websocket:
   ubuntu:
     artful: [python-websocket]
     bionic: [python-websocket]
-    precise:
       pip:
         packages: [websocket-client]
     quantal:
@@ -5556,7 +5523,6 @@ python-yaml:
     artful: [python-yaml]
     bionic: [python-yaml]
     focal: [python-yaml]
-    precise: [python-yaml]
     quantal: [python-yaml]
     raring: [python-yaml]
     saucy: [python-yaml]
@@ -10040,7 +10006,6 @@ wxpython:
     '7': [wxPython-devel]
   ubuntu:
     '*': [python-wxgtk3.0]
-    precise: [python-wxgtk2.8]
     quantal: [python-wxgtk2.8]
     raring: [python-wxgtk2.8]
     saucy: [python-wxgtk2.8]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -500,7 +500,6 @@ python:
   ubuntu:
     artful: [python-dev]
     bionic: [python-dev]
-    lucid: [python-dev]
     maverick: [python-dev]
     natty: [python-dev]
     oneiric: [python-dev]
@@ -622,7 +621,6 @@ python-argparse:
       packages: [argparse]
   ubuntu:
     '*': []
-    lucid: [python-argparse]
     maverick: [python-argparse]
     natty: [python-argparse]
     oneiric: [python-argparse]
@@ -672,7 +670,6 @@ python-autobahn:
       packages: [autobahn]
   ubuntu:
     '*': [python-autobahn]
-    lucid:
       pip:
         packages: [autobahn]
     maverick:
@@ -932,7 +929,6 @@ python-can:
       packages: [python-can]
   ubuntu:
     '*': [python-can]
-    lucid:
       pip:
         packages: [python-can]
     maverick:
@@ -1011,7 +1007,6 @@ python-catkin-pkg:
   ubuntu:
     artful: [python-catkin-pkg]
     bionic: [python-catkin-pkg]
-    lucid: [python-catkin-pkg]
     maverick: [python-catkin-pkg]
     natty: [python-catkin-pkg]
     oneiric: [python-catkin-pkg]
@@ -1301,7 +1296,6 @@ python-coverage:
   ubuntu:
     artful: [python-coverage]
     bionic: [python-coverage]
-    lucid: [python-coverage]
     maverick: [python-coverage]
     natty: [python-coverage]
     oneiric: [python-coverage]
@@ -1370,7 +1364,6 @@ python-crypto:
   ubuntu:
     artful: [python-crypto]
     bionic: [python-crypto]
-    lucid: [python-crypto]
     maverick: [python-crypto]
     natty: [python-crypto]
     oneiric: [python-crypto]
@@ -1562,7 +1555,6 @@ python-docutils:
   ubuntu:
     artful: [python-docutils]
     bionic: [python-docutils]
-    lucid: [python-docutils]
     maverick: [python-docutils]
     natty: [python-docutils]
     oneiric: [python-docutils]
@@ -1645,7 +1637,6 @@ python-enum34-pip:
 python-espeak:
   debian: [python-espeak]
   ubuntu:
-    lucid: [python-espeak]
     maverick: [python-espeak]
     natty: [python-espeak]
     oneiric: [python-espeak]
@@ -2195,7 +2186,6 @@ python-gridfs:
   debian: [python-gridfs]
   fedora: [python-pymongo-gridfs]
   ubuntu:
-    lucid: [python-gridfs]
     maverick: [python-gridfs]
     natty: [python-gridfs]
     oneiric: [python-gridfs]
@@ -2256,7 +2246,6 @@ python-gst:
     wheezy: [python-gst0.10]
   gentoo: [dev-python/gst-python]
   ubuntu:
-    lucid: [python-gst0.10]
     maverick: [python-gst0.10]
     natty: [python-gst0.10]
     oneiric: [python-gst0.10]
@@ -2375,7 +2364,6 @@ python-imaging:
   ubuntu:
     '*': [python-pil]
     artful: [python-imaging]
-    lucid: [python-imaging]
     maverick: [python-imaging]
     natty: [python-imaging]
     oneiric: [python-imaging]
@@ -2739,7 +2727,6 @@ python-matplotlib:
   ubuntu:
     artful: [python-matplotlib]
     bionic: [python-matplotlib]
-    lucid: [python-matplotlib]
     maverick: [python-matplotlib]
     natty: [python-matplotlib]
     oneiric: [python-matplotlib]
@@ -2789,7 +2776,6 @@ python-mock:
   ubuntu:
     artful: [python-mock]
     bionic: [python-mock]
-    lucid: [python-mock]
     maverick: [python-mock]
     natty: [python-mock]
     oneiric: [python-mock]
@@ -2908,7 +2894,6 @@ python-netaddr:
   ubuntu:
     artful: [python-netaddr]
     bionic: [python-netaddr]
-    lucid: [python-netaddr]
     maverick:
       pip:
         packages: [netaddr]
@@ -2963,7 +2948,6 @@ python-netifaces:
   ubuntu:
     artful: [python-netifaces]
     bionic: [python-netifaces]
-    lucid: [python-netifaces]
     maverick: [python-netifaces]
     natty: [python-netifaces]
     oneiric: [python-netifaces]
@@ -3094,7 +3078,6 @@ python-omniorb:
   gentoo: ['net-misc/omniORB[python]']
   ubuntu:
     '*': [python-omniorb, python-omniorb-omg, omniidl-python]
-    lucid: [python-omniorb2, python-omniorb2-omg, omniidl4-python]
 python-open3d-pip:
   debian:
     pip:
@@ -3134,7 +3117,6 @@ python-opengl:
   ubuntu:
     artful: [python-opengl]
     bionic: [python-opengl]
-    lucid: [python-opengl]
     maverick: [python-opengl]
     natty: [python-opengl]
     oneiric: [python-opengl]
@@ -3460,7 +3442,6 @@ python-progressbar:
     artful: [python-progressbar]
     bionic: [python-progressbar]
     cosmic: [python-progressbar]
-    lucid: [python-progressbar]
     maverick: [python-progressbar]
     natty: [python-progressbar]
     oneiric: [python-progressbar]
@@ -3535,7 +3516,6 @@ python-pyassimp:
   ubuntu:
     artful: [python-pyassimp]
     bionic: [python-pyassimp]
-    lucid: []
     oneiric: []
     precise: [python-pyassimp]
     quantal: [python-pyassimp]
@@ -3873,7 +3853,6 @@ python-pyside:
   debian: [python-pyside]
   gentoo: [dev-python/pyside]
   ubuntu:
-    lucid: [python-pyside]
     maverick: [python-pyside]
     natty: [python-pyside]
     oneiric: [python-pyside]
@@ -3887,7 +3866,6 @@ python-pyside:
 python-pyside.qtuitools:
   debian: [python-pyside.qtuitools]
   ubuntu:
-    lucid: [python-pyside.qtuitools]
     maverick: [python-pyside.qtuitools]
     natty: [python-pyside.qtuitools]
     oneiric: [python-pyside.qtuitools]
@@ -4054,7 +4032,6 @@ python-qt-bindings:
     '7': [PyQt4, PyQt4-devel, sip-devel]
   ubuntu:
     '*': [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
-    lucid: [python-qt4, python-qt4-dev, python-sip-dev]
 python-qt-bindings-gl:
   arch: [python2-pyqt4]
   debian: [python-qt4-gl]
@@ -4217,7 +4194,6 @@ python-rosdep:
   ubuntu:
     artful: [python-rosdep]
     bionic: [python-rosdep]
-    lucid: [python-rosdep]
     maverick: [python-rosdep]
     natty: [python-rosdep]
     oneiric: [python-rosdep]
@@ -4267,7 +4243,6 @@ python-rosdistro:
     '7': [python2-rosdistro]
   ubuntu:
     artful: [python-rosdistro]
-    lucid: [python-rosdistro]
     maverick: [python-rosdistro]
     natty: [python-rosdistro]
     oneiric: [python-rosdistro]
@@ -4396,7 +4371,6 @@ python-rrdtool:
   debian: [python-rrdtool]
   gentoo: [net-analyzer/rrdtool]
   ubuntu:
-    lucid: [python-rrdtool]
     maverick: [python-rrdtool]
     natty: [python-rrdtool]
     oneiric: [python-rrdtool]
@@ -4524,7 +4498,6 @@ python-serial:
   ubuntu:
     artful: [python-serial]
     bionic: [python-serial]
-    lucid: [python-serial]
     maverick: [python-serial]
     natty: [python-serial]
     oneiric: [python-serial]
@@ -4560,7 +4533,6 @@ python-setuptools:
   ubuntu:
     artful: [python-setuptools]
     bionic: [python-setuptools]
-    lucid: [python-setuptools]
     maverick: [python-setuptools]
     natty: [python-setuptools]
     oneiric: [python-setuptools]
@@ -4662,7 +4634,6 @@ python-skimage:
       packages: [scikit-image]
   ubuntu:
     '*': [python-skimage]
-    lucid:
       pip:
         packages: [scikit-image]
     maverick:
@@ -4695,7 +4666,6 @@ python-sklearn:
       packages: [scikit-learn]
   ubuntu:
     '*': [python-sklearn]
-    lucid: []
     maverick: []
     natty: []
     oneiric: []
@@ -4871,7 +4841,6 @@ python-sympy:
     artful: [python-sympy]
     bionic: [python-sympy]
     cosmic: [python-sympy]
-    lucid: [python-sympy]
     maverick: [python-sympy]
     natty: [python-sympy]
     oneiric: [python-sympy]
@@ -5672,7 +5641,6 @@ python-yaml:
     artful: [python-yaml]
     bionic: [python-yaml]
     focal: [python-yaml]
-    lucid: [python-yaml]
     maverick: [python-yaml]
     natty: [python-yaml]
     oneiric: [python-yaml]
@@ -10160,7 +10128,6 @@ wxpython:
     '7': [wxPython-devel]
   ubuntu:
     '*': [python-wxgtk3.0]
-    lucid: [python-wxgtk2.8]
     maverick: [python-wxgtk2.8]
     natty: [python-wxgtk2.8]
     oneiric: [python-wxgtk2.8]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -500,7 +500,6 @@ python:
   ubuntu:
     artful: [python-dev]
     bionic: [python-dev]
-    oneiric: [python-dev]
     precise: [python-dev]
     quantal: [python-dev]
     raring: [python-dev]
@@ -619,7 +618,6 @@ python-argparse:
       packages: [argparse]
   ubuntu:
     '*': []
-    oneiric: [python-argparse]
 python-astor-pip:
   debian:
     pip:
@@ -672,7 +670,6 @@ python-autobahn:
         packages: [autobahn]
       pip:
         packages: [autobahn]
-    oneiric:
       pip:
         packages: [autobahn]
     precise:
@@ -929,7 +926,6 @@ python-can:
         packages: [python-can]
       pip:
         packages: [python-can]
-    oneiric:
       pip:
         packages: [python-can]
     precise:
@@ -999,7 +995,6 @@ python-catkin-pkg:
   ubuntu:
     artful: [python-catkin-pkg]
     bionic: [python-catkin-pkg]
-    oneiric: [python-catkin-pkg]
     precise: [python-catkin-pkg]
     quantal: [python-catkin-pkg]
     raring: [python-catkin-pkg]
@@ -1286,7 +1281,6 @@ python-coverage:
   ubuntu:
     artful: [python-coverage]
     bionic: [python-coverage]
-    oneiric: [python-coverage]
     precise: [python-coverage]
     quantal: [python-coverage]
     raring: [python-coverage]
@@ -1352,7 +1346,6 @@ python-crypto:
   ubuntu:
     artful: [python-crypto]
     bionic: [python-crypto]
-    oneiric: [python-crypto]
     precise: [python-crypto]
     quantal: [python-crypto]
     raring: [python-crypto]
@@ -1541,7 +1534,6 @@ python-docutils:
   ubuntu:
     artful: [python-docutils]
     bionic: [python-docutils]
-    oneiric: [python-docutils]
     precise: [python-docutils]
     quantal: [python-docutils]
     raring: [python-docutils]
@@ -1621,7 +1613,6 @@ python-enum34-pip:
 python-espeak:
   debian: [python-espeak]
   ubuntu:
-    oneiric: [python-espeak]
     precise: [python-espeak]
     quantal: [python-espeak]
     raring: [python-espeak]
@@ -2168,7 +2159,6 @@ python-gridfs:
   debian: [python-gridfs]
   fedora: [python-pymongo-gridfs]
   ubuntu:
-    oneiric: [python-gridfs]
     precise: [python-gridfs]
     quantal: [python-gridfs]
     raring: [python-gridfs]
@@ -2226,7 +2216,6 @@ python-gst:
     wheezy: [python-gst0.10]
   gentoo: [dev-python/gst-python]
   ubuntu:
-    oneiric: [python-gst0.10]
     precise: [python-gst0.10]
     quantal: [python-gst0.10]
     raring: [python-gst0.10]
@@ -2342,7 +2331,6 @@ python-imaging:
   ubuntu:
     '*': [python-pil]
     artful: [python-imaging]
-    oneiric: [python-imaging]
     precise: [python-imaging]
     quantal: [python-imaging]
     raring: [python-imaging]
@@ -2703,7 +2691,6 @@ python-matplotlib:
   ubuntu:
     artful: [python-matplotlib]
     bionic: [python-matplotlib]
-    oneiric: [python-matplotlib]
     precise: [python-matplotlib]
     quantal: [python-matplotlib]
     raring: [python-matplotlib]
@@ -2750,7 +2737,6 @@ python-mock:
   ubuntu:
     artful: [python-mock]
     bionic: [python-mock]
-    oneiric: [python-mock]
     precise: [python-mock]
     quantal: [python-mock]
     raring: [python-mock]
@@ -2870,7 +2856,6 @@ python-netaddr:
         packages: [netaddr]
       pip:
         packages: [netaddr]
-    oneiric:
       pip:
         packages: [netaddr]
     precise: [python-netaddr]
@@ -2918,7 +2903,6 @@ python-netifaces:
   ubuntu:
     artful: [python-netifaces]
     bionic: [python-netifaces]
-    oneiric: [python-netifaces]
     precise: [python-netifaces]
     quantal: [python-netifaces]
     raring: [python-netifaces]
@@ -3085,7 +3069,6 @@ python-opengl:
   ubuntu:
     artful: [python-opengl]
     bionic: [python-opengl]
-    oneiric: [python-opengl]
     precise: [python-opengl]
     quantal: [python-opengl]
     raring: [python-opengl]
@@ -3408,7 +3391,6 @@ python-progressbar:
     artful: [python-progressbar]
     bionic: [python-progressbar]
     cosmic: [python-progressbar]
-    oneiric: [python-progressbar]
     precise: [python-progressbar]
     quantal: [python-progressbar]
     raring: [python-progressbar]
@@ -3480,7 +3462,6 @@ python-pyassimp:
   ubuntu:
     artful: [python-pyassimp]
     bionic: [python-pyassimp]
-    oneiric: []
     precise: [python-pyassimp]
     quantal: [python-pyassimp]
     raring: [python-pyassimp]
@@ -3817,7 +3798,6 @@ python-pyside:
   debian: [python-pyside]
   gentoo: [dev-python/pyside]
   ubuntu:
-    oneiric: [python-pyside]
     precise: [python-pyside]
     quantal: [python-pyside]
     raring: [python-pyside]
@@ -3828,7 +3808,6 @@ python-pyside:
 python-pyside.qtuitools:
   debian: [python-pyside.qtuitools]
   ubuntu:
-    oneiric: [python-pyside.qtuitools]
     precise: [python-pyside.qtuitools]
     quantal: [python-pyside.qtuitools]
     raring: [python-pyside.qtuitools]
@@ -4154,7 +4133,6 @@ python-rosdep:
   ubuntu:
     artful: [python-rosdep]
     bionic: [python-rosdep]
-    oneiric: [python-rosdep]
     precise: [python-rosdep]
     quantal: [python-rosdep]
     raring: [python-rosdep]
@@ -4201,7 +4179,6 @@ python-rosdistro:
     '7': [python2-rosdistro]
   ubuntu:
     artful: [python-rosdistro]
-    oneiric: [python-rosdistro]
     precise: [python-rosdistro]
     quantal: [python-rosdistro]
     raring: [python-rosdistro]
@@ -4327,7 +4304,6 @@ python-rrdtool:
   debian: [python-rrdtool]
   gentoo: [net-analyzer/rrdtool]
   ubuntu:
-    oneiric: [python-rrdtool]
     precise: [python-rrdtool]
     quantal: [python-rrdtool]
     raring: [python-rrdtool]
@@ -4452,7 +4428,6 @@ python-serial:
   ubuntu:
     artful: [python-serial]
     bionic: [python-serial]
-    oneiric: [python-serial]
     precise: [python-serial]
     quantal: [python-serial]
     raring: [python-serial]
@@ -4485,7 +4460,6 @@ python-setuptools:
   ubuntu:
     artful: [python-setuptools]
     bionic: [python-setuptools]
-    oneiric: [python-setuptools]
     precise: [python-setuptools]
     quantal: [python-setuptools]
     raring: [python-setuptools]
@@ -4590,7 +4564,6 @@ python-skimage:
         packages: [scikit-image]
       pip:
         packages: [scikit-image]
-    oneiric:
       pip:
         packages: [scikit-image]
     precise:
@@ -4614,7 +4587,6 @@ python-sklearn:
       packages: [scikit-learn]
   ubuntu:
     '*': [python-sklearn]
-    oneiric: []
 python-slackclient-pip:
   debian:
     pip:
@@ -4787,7 +4759,6 @@ python-sympy:
     artful: [python-sympy]
     bionic: [python-sympy]
     cosmic: [python-sympy]
-    oneiric: [python-sympy]
     precise: [python-sympy]
     quantal: [python-sympy]
     raring: [python-sympy]
@@ -5585,7 +5556,6 @@ python-yaml:
     artful: [python-yaml]
     bionic: [python-yaml]
     focal: [python-yaml]
-    oneiric: [python-yaml]
     precise: [python-yaml]
     quantal: [python-yaml]
     raring: [python-yaml]
@@ -10070,7 +10040,6 @@ wxpython:
     '7': [wxPython-devel]
   ubuntu:
     '*': [python-wxgtk3.0]
-    oneiric: [python-wxgtk2.8]
     precise: [python-wxgtk2.8]
     quantal: [python-wxgtk2.8]
     raring: [python-wxgtk2.8]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -502,7 +502,6 @@ python:
     bionic: [python-dev]
     trusty: [python-dev]
     xenial: [python-dev]
-    yakkety: [python-dev]
     zesty: [python-dev]
 python-absl-py-pip:
   debian:
@@ -551,7 +550,6 @@ python-aniso8601:
     artful: [python-aniso8601]
     bionic: [python-aniso8601]
     xenial: [python-aniso8601]
-    yakkety: [python-aniso8601]
     zesty: [python-aniso8601]
 python-annoy-pip:
   debian:
@@ -719,7 +717,6 @@ python-backports.ssl-match-hostname:
       pip:
         packages: [backports.ssl_match_hostname]
     xenial: [python-backports.ssl-match-hostname]
-    yakkety: [python-backports.ssl-match-hostname]
 python-bcrypt:
   arch: [python2-bcrypt]
   debian: [python-bcrypt]
@@ -811,7 +808,6 @@ python-boltons:
     xenial:
       pip:
         packages: [boltons]
-    yakkety:
       pip:
         packages: [boltons]
     zesty:
@@ -932,7 +928,6 @@ python-can:
     xenial:
       pip:
         packages: [python-can]
-    yakkety:
       pip:
         packages: [python-can]
 python-cantools-pip:
@@ -974,7 +969,6 @@ python-catkin-pkg:
     bionic: [python-catkin-pkg]
     trusty: [python-catkin-pkg]
     xenial: [python-catkin-pkg]
-    yakkety: [python-catkin-pkg]
     zesty: [python-catkin-pkg]
 python-catkin-pkg-modules:
   alpine:
@@ -1043,7 +1037,6 @@ python-certifi:
     artful: [python-certifi]
     bionic: [python-certifi]
     xenial: [python-certifi]
-    yakkety: [python-certifi]
     zesty: [python-certifi]
 python-chainer-mask-rcnn-pip:
   debian:
@@ -1249,7 +1242,6 @@ python-coverage:
     bionic: [python-coverage]
     trusty: [python-coverage]
     xenial: [python-coverage]
-    yakkety: [python-coverage]
     zesty: [python-coverage]
 python-cpplint:
   debian:
@@ -1307,7 +1299,6 @@ python-crypto:
     bionic: [python-crypto]
     trusty: [python-crypto]
     xenial: [python-crypto]
-    yakkety: [python-crypto]
     zesty: [python-crypto]
 python-cryptography:
   debian: [python-cryptography]
@@ -1383,7 +1374,6 @@ python-debian:
     bionic: [python-debian]
     trusty: [python-debian]
     xenial: [python-debian]
-    yakkety: [python-debian]
     zesty: [python-debian]
 python-decorator:
   debian: [python-decorator]
@@ -1706,7 +1696,6 @@ python-flask-restful:
       pip:
         packages: [flask-restful]
     xenial: [python-flask-restful]
-    yakkety: [python-flask-restful]
 python-flatdict-pip:
   ubuntu:
     pip:
@@ -1764,7 +1753,6 @@ python-future:
       pip:
         packages: [future]
     xenial: [python-future]
-    yakkety: [python-future]
     zesty: [python-future]
 python-fuzzywuzzy-pip:
   debian:
@@ -2014,7 +2002,6 @@ python-gpiozero:
     xenial:
       pip:
         packages: [gpiozero]
-    yakkety:
       pip:
         packages: [gpiozero]
     zesty: [python-gpiozero]
@@ -2054,7 +2041,6 @@ python-gpxpy:
     xenial:
       pip:
         packages: [gpxpy]
-    yakkety:
       pip:
         packages: [gpxpy]
     zesty:
@@ -2245,7 +2231,6 @@ python-imaging:
     artful: [python-imaging]
     trusty: [python-imaging]
     xenial: [python-imaging]
-    yakkety: [python-imaging]
     zesty: [python-imaging]
 python-imaging-imagetk:
   debian: [python-pil.imagetk]
@@ -2598,7 +2583,6 @@ python-matplotlib:
     bionic: [python-matplotlib]
     trusty: [python-matplotlib]
     xenial: [python-matplotlib]
-    yakkety: [python-matplotlib]
     zesty: [python-matplotlib]
 python-mechanize:
   arch: [python2-mechanize]
@@ -2637,7 +2621,6 @@ python-mock:
     bionic: [python-mock]
     trusty: [python-mock]
     xenial: [python-mock]
-    yakkety: [python-mock]
     zesty: [python-mock]
 python-monotonic:
   arch: [python-monotonic]
@@ -2757,7 +2740,6 @@ python-netaddr:
         packages: [netaddr]
     trusty: [python-netaddr]
     xenial: [python-netaddr]
-    yakkety: [python-netaddr]
     zesty: [python-netaddr]
 python-netcdf4:
   arch: [python-netcdf4]
@@ -2790,7 +2772,6 @@ python-netifaces:
     bionic: [python-netifaces]
     trusty: [python-netifaces]
     xenial: [python-netifaces]
-    yakkety: [python-netifaces]
     zesty: [python-netifaces]
 python-networkmanager:
   debian:
@@ -2943,7 +2924,6 @@ python-opengl:
     bionic: [python-opengl]
     trusty: [python-opengl]
     xenial: [python-opengl]
-    yakkety: [python-opengl]
     zesty: [python-opengl]
 python-openssl:
   debian: [python-openssl]
@@ -3010,7 +2990,6 @@ python-parameterized:
     xenial:
       pip:
         packages: [parameterized]
-    yakkety:
       pip:
         packages: [parameterized]
     zesty:
@@ -3093,7 +3072,6 @@ python-pathtools:
   ubuntu:
     artful: [python-pathtools]
     xenial: [python-pathtools]
-    yakkety: [python-pathtools]
     zesty: [python-pathtools]
 python-pbr:
   debian: [python-pbr]
@@ -3314,7 +3292,6 @@ python-pyassimp:
     bionic: [python-pyassimp]
     trusty: [python-pyassimp]
     xenial: [python-pyassimp]
-    yakkety: [python-pyassimp]
     zesty: [python-pyassimp]
 python-pyaudio:
   debian: [python-pyaudio]
@@ -3839,7 +3816,6 @@ python-qt5-bindings:
     artful: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev]
     bionic: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev]
     xenial: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-pyside2, python-sip-dev, shiboken2]
-    yakkety: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-pyside2, python-sip-dev, shiboken2]
     zesty: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev]
 python-qt5-bindings-gl:
   arch: [python2-pyqt5]
@@ -3858,7 +3834,6 @@ python-qt5-bindings-gl:
     artful: [python-pyqt5.qtopengl]
     bionic: [python-pyqt5.qtopengl]
     xenial: [python-pyqt5.qtopengl]
-    yakkety: [python-pyqt5.qtopengl]
     zesty: [python-pyqt5.qtopengl]
 python-qt5-bindings-qsci:
   debian: [python-pyqt5.qsci]
@@ -3883,7 +3858,6 @@ python-qt5-bindings-webkit:
     artful: [python-pyqt5.qtwebkit]
     bionic: [python-pyqt5.qtwebkit]
     xenial: [python-pyqt5.qtwebkit]
-    yakkety: [python-pyqt5.qtwebkit]
     zesty: [python-pyqt5.qtwebkit]
 python-qtpy:
   arch: [python-qtpy]
@@ -3963,7 +3937,6 @@ python-rosdep:
     bionic: [python-rosdep]
     trusty: [python-rosdep]
     xenial: [python-rosdep]
-    yakkety: [python-rosdep]
     zesty: [python-rosdep]
 python-rosdep-modules:
   alpine:
@@ -4002,7 +3975,6 @@ python-rosdistro:
     artful: [python-rosdistro]
     trusty: [python-rosdistro]
     xenial: [python-rosdistro]
-    yakkety: [python-rosdistro]
     zesty: [python-rosdistro]
 python-rosinstall:
   arch: [python2-rosinstall]
@@ -4097,7 +4069,6 @@ python-rpi.gpio:
     xenial:
       pip:
         packages: [RPi.GPIO]
-    yakkety:
       pip:
         packages: [RPi.GPIO]
     zesty: [python-rpi.gpio]
@@ -4130,7 +4101,6 @@ python-ruamel.yaml:
     artful: [python-ruamel.yaml]
     bionic: [python-ruamel.yaml]
     xenial: [python-ruamel.yaml]
-    yakkety: [python-ruamel.yaml]
     zesty: [python-ruamel.yaml]
 python-rx-pip:
   debian:
@@ -4237,7 +4207,6 @@ python-serial:
     bionic: [python-serial]
     trusty: [python-serial]
     xenial: [python-serial]
-    yakkety: [python-serial]
     zesty: [python-serial]
 python-setproctitle:
   debian: [python-setproctitle]
@@ -4262,7 +4231,6 @@ python-setuptools:
     bionic: [python-setuptools]
     trusty: [python-setuptools]
     xenial: [python-setuptools]
-    yakkety: [python-setuptools]
     zesty: [python-setuptools]
 python-sexpdata:
   debian:
@@ -4461,7 +4429,6 @@ python-sphinx-argparse:
     artful: [python-sphinx-argparse]
     bionic: [python-sphinx-argparse]
     xenial: [python-sphinx-argparse]
-    yakkety: [python-sphinx-argparse]
     zesty: [python-sphinx-argparse]
 python-sphinx-rtd-theme:
   debian:
@@ -4473,7 +4440,6 @@ python-sphinx-rtd-theme:
     artful: [python-sphinx-rtd-theme]
     bionic: [python-sphinx-rtd-theme]
     xenial: [python-sphinx-rtd-theme]
-    yakkety: [python-sphinx-rtd-theme]
     zesty: [python-sphinx-rtd-theme]
 python-spidev-pip: &migrate_eol_2025_04_30_python3_spidev_pip
   debian:
@@ -4761,7 +4727,6 @@ python-theano:
     xenial:
       pip:
         packages: [Theano]
-    yakkety: [python-theano]
     zesty: [python-theano]
 python-tilestache:
   debian: [tilestache]
@@ -5135,7 +5100,6 @@ python-watchdog:
     artful: [python-watchdog]
     bionic: [python-watchdog]
     xenial: [python-watchdog]
-    yakkety: [python-watchdog]
     zesty: [python-watchdog]
 python-webob:
   debian: [python-webob]
@@ -5276,7 +5240,6 @@ python-xmltodict:
     artful: [python-xmltodict]
     bionic: [python-xmltodict]
     xenial: [python-xmltodict]
-    yakkety: [python-xmltodict]
     zesty: [python-xmltodict]
 python-yamale-pip:
   debian:
@@ -5312,7 +5275,6 @@ python-yaml:
     focal: [python-yaml]
     trusty: [python-yaml]
     xenial: [python-yaml]
-    yakkety: [python-yaml]
     zesty: [python-yaml]
 python-zbar:
   debian: [python-zbar]
@@ -8465,7 +8427,6 @@ python3-qt5-bindings:
     disco: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
     eoan: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
     xenial: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
-    yakkety: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
     zesty: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
 python3-qt5-bindings-gl:
   debian: [python3-pyqt5.qtopengl]
@@ -9811,7 +9772,6 @@ yapf:
     xenial:
       pip:
         packages: [yapf]
-    yakkety:
       pip:
         packages: [yapf]
 yapf3:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -501,7 +501,6 @@ python:
     artful: [python-dev]
     bionic: [python-dev]
     trusty: [python-dev]
-    wily: [python-dev]
     xenial: [python-dev]
     yakkety: [python-dev]
     zesty: [python-dev]
@@ -719,7 +718,6 @@ python-backports.ssl-match-hostname:
     trusty:
       pip:
         packages: [backports.ssl_match_hostname]
-    wily: [python-backports.ssl-match-hostname]
     xenial: [python-backports.ssl-match-hostname]
     yakkety: [python-backports.ssl-match-hostname]
 python-bcrypt:
@@ -748,7 +746,6 @@ python-bitstring:
   ubuntu:
     artful: [python-bitstring]
     bionic: [python-bitstring]
-    wily: [python-bitstring]
     xenial: [python-bitstring]
     zesty: [python-bitstring]
 python-bitstring-pip:
@@ -809,7 +806,6 @@ python-boltons:
     trusty:
       pip:
         packages: [boltons]
-    wily:
       pip:
         packages: [boltons]
     xenial:
@@ -931,7 +927,6 @@ python-can:
         packages: [python-can]
       pip:
         packages: [python-can]
-    wily:
       pip:
         packages: [python-can]
     xenial:
@@ -978,7 +973,6 @@ python-catkin-pkg:
     artful: [python-catkin-pkg]
     bionic: [python-catkin-pkg]
     trusty: [python-catkin-pkg]
-    wily: [python-catkin-pkg]
     xenial: [python-catkin-pkg]
     yakkety: [python-catkin-pkg]
     zesty: [python-catkin-pkg]
@@ -1148,7 +1142,6 @@ python-click:
         packages: [click]
       pip:
         packages: [click]
-    wily:
       pip:
         packages: [click]
 python-cobs-pip:
@@ -1255,7 +1248,6 @@ python-coverage:
     artful: [python-coverage]
     bionic: [python-coverage]
     trusty: [python-coverage]
-    wily: [python-coverage]
     xenial: [python-coverage]
     yakkety: [python-coverage]
     zesty: [python-coverage]
@@ -1314,7 +1306,6 @@ python-crypto:
     artful: [python-crypto]
     bionic: [python-crypto]
     trusty: [python-crypto]
-    wily: [python-crypto]
     xenial: [python-crypto]
     yakkety: [python-crypto]
     zesty: [python-crypto]
@@ -1391,7 +1382,6 @@ python-debian:
     artful: [python-debian]
     bionic: [python-debian]
     trusty: [python-debian]
-    wily: [python-debian]
     xenial: [python-debian]
     yakkety: [python-debian]
     zesty: [python-debian]
@@ -1494,7 +1484,6 @@ python-docutils:
     artful: [python-docutils]
     bionic: [python-docutils]
     trusty: [python-docutils]
-    wily: [python-docutils]
     xenial: [python-docutils]
 python-docx:
   fedora: [python-docx]
@@ -1714,7 +1703,6 @@ python-flask-restful:
         packages: [flask-restful]
       pip:
         packages: [flask-restful]
-    wily:
       pip:
         packages: [flask-restful]
     xenial: [python-flask-restful]
@@ -1775,7 +1763,6 @@ python-future:
         packages: [future]
       pip:
         packages: [future]
-    wily: [python-future]
     xenial: [python-future]
     yakkety: [python-future]
     zesty: [python-future]
@@ -2002,7 +1989,6 @@ python-googleapi:
   ubuntu:
     bionic: [python-googleapi]
     trusty: [python-googleapi]
-    wily: [python-googleapi]
     xenial: [python-googleapi]
 python-gpiozero:
   debian:
@@ -2023,7 +2009,6 @@ python-gpiozero:
         packages: [gpiozero]
       pip:
         packages: [gpiozero]
-    wily:
       pip:
         packages: [gpiozero]
     xenial:
@@ -2064,7 +2049,6 @@ python-gpxpy:
         packages: [gpxpy]
       pip:
         packages: [gpxpy]
-    wily:
       pip:
         packages: [gpxpy]
     xenial:
@@ -2260,7 +2244,6 @@ python-imaging:
     '*': [python-pil]
     artful: [python-imaging]
     trusty: [python-imaging]
-    wily: [python-imaging]
     xenial: [python-imaging]
     yakkety: [python-imaging]
     zesty: [python-imaging]
@@ -2614,7 +2597,6 @@ python-matplotlib:
     artful: [python-matplotlib]
     bionic: [python-matplotlib]
     trusty: [python-matplotlib]
-    wily: [python-matplotlib]
     xenial: [python-matplotlib]
     yakkety: [python-matplotlib]
     zesty: [python-matplotlib]
@@ -2654,7 +2636,6 @@ python-mock:
     artful: [python-mock]
     bionic: [python-mock]
     trusty: [python-mock]
-    wily: [python-mock]
     xenial: [python-mock]
     yakkety: [python-mock]
     zesty: [python-mock]
@@ -2808,7 +2789,6 @@ python-netifaces:
     artful: [python-netifaces]
     bionic: [python-netifaces]
     trusty: [python-netifaces]
-    wily: [python-netifaces]
     xenial: [python-netifaces]
     yakkety: [python-netifaces]
     zesty: [python-netifaces]
@@ -2962,7 +2942,6 @@ python-opengl:
     artful: [python-opengl]
     bionic: [python-opengl]
     trusty: [python-opengl]
-    wily: [python-opengl]
     xenial: [python-opengl]
     yakkety: [python-opengl]
     zesty: [python-opengl]
@@ -3026,7 +3005,6 @@ python-parameterized:
     trusty:
       pip:
         packages: [parameterized]
-    wily:
       pip:
         packages: [parameterized]
     xenial:
@@ -3149,7 +3127,6 @@ python-pep8:
   ubuntu:
     '*': [python-pep8]
     trusty: [pep8]
-    wily: [pep8]
 python-percol:
   debian:
     pip:
@@ -3272,7 +3249,6 @@ python-progressbar:
     bionic: [python-progressbar]
     cosmic: [python-progressbar]
     trusty: [python-progressbar]
-    wily: [python-progressbar]
     xenial: [python-progressbar]
 python-progressbar2-pip:
   debian:
@@ -3337,7 +3313,6 @@ python-pyassimp:
     artful: [python-pyassimp]
     bionic: [python-pyassimp]
     trusty: [python-pyassimp]
-    wily: [python-pyassimp]
     xenial: [python-pyassimp]
     yakkety: [python-pyassimp]
     zesty: [python-pyassimp]
@@ -3863,7 +3838,6 @@ python-qt5-bindings:
   ubuntu:
     artful: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev]
     bionic: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev]
-    wily: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-pyside2, python-sip-dev, shiboken2]
     xenial: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-pyside2, python-sip-dev, shiboken2]
     yakkety: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-pyside2, python-sip-dev, shiboken2]
     zesty: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev]
@@ -3883,7 +3857,6 @@ python-qt5-bindings-gl:
   ubuntu:
     artful: [python-pyqt5.qtopengl]
     bionic: [python-pyqt5.qtopengl]
-    wily: [python-pyqt5.qtopengl]
     xenial: [python-pyqt5.qtopengl]
     yakkety: [python-pyqt5.qtopengl]
     zesty: [python-pyqt5.qtopengl]
@@ -3909,7 +3882,6 @@ python-qt5-bindings-webkit:
   ubuntu:
     artful: [python-pyqt5.qtwebkit]
     bionic: [python-pyqt5.qtwebkit]
-    wily: [python-pyqt5.qtwebkit]
     xenial: [python-pyqt5.qtwebkit]
     yakkety: [python-pyqt5.qtwebkit]
     zesty: [python-pyqt5.qtwebkit]
@@ -3990,7 +3962,6 @@ python-rosdep:
     artful: [python-rosdep]
     bionic: [python-rosdep]
     trusty: [python-rosdep]
-    wily: [python-rosdep]
     xenial: [python-rosdep]
     yakkety: [python-rosdep]
     zesty: [python-rosdep]
@@ -4030,7 +4001,6 @@ python-rosdistro:
   ubuntu:
     artful: [python-rosdistro]
     trusty: [python-rosdistro]
-    wily: [python-rosdistro]
     xenial: [python-rosdistro]
     yakkety: [python-rosdistro]
     zesty: [python-rosdistro]
@@ -4122,7 +4092,6 @@ python-rpi.gpio:
         packages: [RPi.GPIO]
       pip:
         packages: [RPi.GPIO]
-    wily:
       pip:
         packages: [RPi.GPIO]
     xenial:
@@ -4267,7 +4236,6 @@ python-serial:
     artful: [python-serial]
     bionic: [python-serial]
     trusty: [python-serial]
-    wily: [python-serial]
     xenial: [python-serial]
     yakkety: [python-serial]
     zesty: [python-serial]
@@ -4293,7 +4261,6 @@ python-setuptools:
     artful: [python-setuptools]
     bionic: [python-setuptools]
     trusty: [python-setuptools]
-    wily: [python-setuptools]
     xenial: [python-setuptools]
     yakkety: [python-setuptools]
     zesty: [python-setuptools]
@@ -4523,7 +4490,6 @@ python-sqlalchemy:
     artful: [python-sqlalchemy]
     bionic: [python-sqlalchemy]
     trusty: [python-sqlalchemy]
-    wily: [python-sqlalchemy]
     xenial: [python-sqlalchemy]
 python-sqlite:
   debian: [python-sqlite]
@@ -4579,7 +4545,6 @@ python-sympy:
     bionic: [python-sympy]
     cosmic: [python-sympy]
     trusty: [python-sympy]
-    wily: [python-sympy]
     xenial: [python-sympy]
 python-systemd:
   debian:
@@ -4615,7 +4580,6 @@ python-tabulate:
   ubuntu:
     artful: [python-tabulate]
     bionic: [python-tabulate]
-    wily: [python-tabulate]
     xenial: [python-tabulate]
     zesty: [python-tabulate]
 python-tabulate-pip:
@@ -4792,7 +4756,6 @@ python-theano:
         packages: [Theano]
       pip:
         packages: [Theano]
-    wily:
       pip:
         packages: [Theano]
     xenial:
@@ -4872,7 +4835,6 @@ python-tqdm:
         packages: [tqdm]
       pip:
         packages: [tqdm]
-    wily:
       pip:
         packages: [tqdm]
     xenial:
@@ -5149,7 +5111,6 @@ python-vtk:
   ubuntu:
     bionic: [python-vtk6]
     trusty: [python-vtk]
-    wily: [python-vtk]
     xenial: [python-vtk6]
 python-w1thermsensor-pip:
   debian:
@@ -5222,7 +5183,6 @@ python-websocket:
         packages: [websocket-client]
       pip:
         packages: [websocket-client]
-    wily: [python-websocket]
     xenial: [python-websocket]
 python-webtest:
   debian: [python-webtest]
@@ -5351,7 +5311,6 @@ python-yaml:
     bionic: [python-yaml]
     focal: [python-yaml]
     trusty: [python-yaml]
-    wily: [python-yaml]
     xenial: [python-yaml]
     yakkety: [python-yaml]
     zesty: [python-yaml]
@@ -9829,7 +9788,6 @@ wxpython:
   ubuntu:
     '*': [python-wxgtk3.0]
     trusty: [python-wxgtk2.8]
-    wily: [python-wxgtk2.8]
 yapf:
   arch: [yapf]
   debian:
@@ -9848,7 +9806,6 @@ yapf:
         packages: [yapf]
       pip:
         packages: [yapf]
-    wily:
       pip:
         packages: [yapf]
     xenial:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -493,7 +493,6 @@ python:
     slackpkg:
       packages: [python]
   ubuntu:
-    artful: [python-dev]
     bionic: [python-dev]
 python-absl-py-pip:
   debian:
@@ -536,7 +535,6 @@ python-aniso8601:
   rhel:
     '7': [python-aniso8601]
   ubuntu:
-    artful: [python-aniso8601]
     bionic: [python-aniso8601]
 python-annoy-pip:
   debian:
@@ -694,7 +692,6 @@ python-backports.ssl-match-hostname:
   nixos: [pythonPackages.backports_ssl_match_hostname]
   openembedded: ['${PYTHON_PN}-backports-ssl@meta-python']
   ubuntu:
-    artful: [python-backports.ssl-match-hostname]
     bionic: [python-backports.ssl-match-hostname]
       pip:
         packages: [backports.ssl_match_hostname]
@@ -724,7 +721,6 @@ python-bitstring:
   gentoo: [dev-python/bitstring]
   nixos: [pythonPackages.bitstring]
   ubuntu:
-    artful: [python-bitstring]
     bionic: [python-bitstring]
 python-bitstring-pip:
   debian:
@@ -938,7 +934,6 @@ python-catkin-pkg:
     pip:
       packages: [catkin-pkg]
   ubuntu:
-    artful: [python-catkin-pkg]
     bionic: [python-catkin-pkg]
 python-catkin-pkg-modules:
   alpine:
@@ -1004,7 +999,6 @@ python-certifi:
   fedora: [python-certifi]
   gentoo: [dev-python/certifi]
   ubuntu:
-    artful: [python-certifi]
     bionic: [python-certifi]
 python-chainer-mask-rcnn-pip:
   debian:
@@ -1202,7 +1196,6 @@ python-coverage:
     '8': [python2-coverage]
   slackware: [coverage]
   ubuntu:
-    artful: [python-coverage]
     bionic: [python-coverage]
 python-cpplint:
   debian:
@@ -1255,7 +1248,6 @@ python-crypto:
     pip:
       packages: [pycrypto]
   ubuntu:
-    artful: [python-crypto]
     bionic: [python-crypto]
 python-cryptography:
   debian: [python-cryptography]
@@ -1326,7 +1318,6 @@ python-debian:
   fedora: [python-debian]
   gentoo: [dev-python/python-debian]
   ubuntu:
-    artful: [python-debian]
     bionic: [python-debian]
 python-decorator:
   debian: [python-decorator]
@@ -1424,7 +1415,6 @@ python-docutils:
   nixos: [pythonPackages.docutils]
   opensuse: [python2-docutils]
   ubuntu:
-    artful: [python-docutils]
     bionic: [python-docutils]
 python-docx:
   fedora: [python-docx]
@@ -1690,7 +1680,6 @@ python-future:
     pip:
       packages: [future]
   ubuntu:
-    artful: [python-future]
     bionic: [python-future]
       pip:
         packages: [future]
@@ -1814,7 +1803,6 @@ python-gitlab:
         packages: [python-gitlab]
   ubuntu:
     '*': [python-gitlab]
-    artful:
       pip:
         packages: [python-gitlab]
       pip:
@@ -1924,7 +1912,6 @@ python-gpiozero:
       pip:
         packages: [gpiozero]
   ubuntu:
-    artful: [python-gpiozero]
     bionic: [python-gpiozero]
       pip:
         packages: [gpiozero]
@@ -1959,7 +1946,6 @@ python-gpxpy:
     stretch: [python-gpxpy]
   gentoo: [sci-geosciences/gpxpy]
   ubuntu:
-    artful: [python-gpxpy]
     bionic: [python-gpxpy]
       pip:
         packages: [gpxpy]
@@ -2143,7 +2129,6 @@ python-imaging:
       packages: [python-pillow]
   ubuntu:
     '*': [python-pil]
-    artful: [python-imaging]
 python-imaging-imagetk:
   debian: [python-pil.imagetk]
   ubuntu: [python-pil.imagetk]
@@ -2485,7 +2470,6 @@ python-matplotlib:
     '7': [python-matplotlib]
   slackware: [matplotlib]
   ubuntu:
-    artful: [python-matplotlib]
     bionic: [python-matplotlib]
 python-mechanize:
   arch: [python2-mechanize]
@@ -2520,7 +2504,6 @@ python-mock:
     '8': [python2-mock]
   slackware: [mock]
   ubuntu:
-    artful: [python-mock]
     bionic: [python-mock]
 python-monotonic:
   arch: [python-monotonic]
@@ -2622,7 +2605,6 @@ python-netaddr:
     pip:
       packages: [netaddr]
   ubuntu:
-    artful: [python-netaddr]
     bionic: [python-netaddr]
       pip:
         packages: [netaddr]
@@ -2663,7 +2645,6 @@ python-netifaces:
     '7': [python-netifaces]
   slackware: [netifaces]
   ubuntu:
-    artful: [python-netifaces]
     bionic: [python-netifaces]
 python-networkmanager:
   debian:
@@ -2809,7 +2790,6 @@ python-opengl:
     '7': [PyOpenGL]
   slackware: [PyOpenGL]
   ubuntu:
-    artful: [python-opengl]
     bionic: [python-opengl]
 python-openssl:
   debian: [python-openssl]
@@ -2864,7 +2844,6 @@ python-parameterized:
       packages: [parameterized]
   ubuntu:
     '*': [python-parameterized]
-    artful:
       pip:
         packages: [parameterized]
       pip:
@@ -2950,7 +2929,6 @@ python-pathos-pip:
 python-pathtools:
   debian: [python-pathtools]
   ubuntu:
-    artful: [python-pathtools]
 python-pbr:
   debian: [python-pbr]
   fedora: [python-pbr]
@@ -3100,7 +3078,6 @@ python-progressbar:
     pip:
       packages: [progressbar]
   ubuntu:
-    artful: [python-progressbar]
     bionic: [python-progressbar]
     cosmic: [python-progressbar]
 python-progressbar2-pip:
@@ -3163,7 +3140,6 @@ python-pyassimp:
       homebrew:
         packages: [pyassimp]
   ubuntu:
-    artful: [python-pyassimp]
     bionic: [python-pyassimp]
 python-pyaudio:
   debian: [python-pyaudio]
@@ -3216,7 +3192,6 @@ python-pycurl:
   ubuntu: [python-pycurl]
 python-pydbus:
   ubuntu:
-    artful: [python-pydbus]
     bionic: [python-pydbus]
       pip:
         depends: [python-gi]
@@ -3672,7 +3647,6 @@ python-qt5-bindings:
   opensuse: [python2-qt5-devel, python2-sip-devel]
   slackware: [PyQt5]
   ubuntu:
-    artful: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev]
     bionic: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev]
 python-qt5-bindings-gl:
   arch: [python2-pyqt5]
@@ -3687,7 +3661,6 @@ python-qt5-bindings-gl:
   opensuse: [python2-qt5]
   slackware: [PyQt5]
   ubuntu:
-    artful: [python-pyqt5.qtopengl]
     bionic: [python-pyqt5.qtopengl]
 python-qt5-bindings-qsci:
   debian: [python-pyqt5.qsci]
@@ -3708,7 +3681,6 @@ python-qt5-bindings-webkit:
   openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
   opensuse: [python2-qt5]
   ubuntu:
-    artful: [python-pyqt5.qtwebkit]
     bionic: [python-pyqt5.qtwebkit]
 python-qtpy:
   arch: [python-qtpy]
@@ -3784,7 +3756,6 @@ python-rosdep:
     pip:
       packages: [rosdep]
   ubuntu:
-    artful: [python-rosdep]
     bionic: [python-rosdep]
 python-rosdep-modules:
   alpine:
@@ -3820,7 +3791,6 @@ python-rosdistro:
   rhel:
     '7': [python2-rosdistro]
   ubuntu:
-    artful: [python-rosdistro]
 python-rosinstall:
   arch: [python2-rosinstall]
   debian: [python-rosinstall]
@@ -3899,7 +3869,6 @@ python-rpi.gpio:
       pip:
         packages: [RPi.GPIO]
   ubuntu:
-    artful: [python-rpi.gpio]
     bionic: [python-rpi.gpio]
       pip:
         packages: [RPi.GPIO]
@@ -3937,7 +3906,6 @@ python-ruamel.yaml:
   fedora: [python-ruamel-yaml]
   nixos: [pythonPackages.ruamel_yaml]
   ubuntu:
-    artful: [python-ruamel.yaml]
     bionic: [python-ruamel.yaml]
 python-rx-pip:
   debian:
@@ -4038,7 +4006,6 @@ python-serial:
   openembedded: ['${PYTHON_PN}-pyserial@meta-python']
   opensuse: [python2-pyserial]
   ubuntu:
-    artful: [python-serial]
     bionic: [python-serial]
 python-setproctitle:
   debian: [python-setproctitle]
@@ -4059,7 +4026,6 @@ python-setuptools:
     '7': [python2-setuptools]
     '8': [python2-setuptools]
   ubuntu:
-    artful: [python-setuptools]
     bionic: [python-setuptools]
 python-sexpdata:
   debian:
@@ -4252,7 +4218,6 @@ python-sphinx-argparse:
     buster: [python-sphinx-argparse]
     stretch: [python-sphinx-argparse]
   ubuntu:
-    artful: [python-sphinx-argparse]
     bionic: [python-sphinx-argparse]
 python-sphinx-rtd-theme:
   debian:
@@ -4260,7 +4225,6 @@ python-sphinx-rtd-theme:
     stretch: [python-sphinx-rtd-theme]
   opensuse: [python2-sphinx_rtd_theme]
   ubuntu:
-    artful: [python-sphinx-rtd-theme]
     bionic: [python-sphinx-rtd-theme]
 python-spidev-pip: &migrate_eol_2025_04_30_python3_spidev_pip
   debian:
@@ -4274,7 +4238,6 @@ python-sqlalchemy:
   fedora: [python-sqlalchemy]
   gentoo: [dev-python/sqlalchemy]
   ubuntu:
-    artful: [python-sqlalchemy]
     bionic: [python-sqlalchemy]
 python-sqlite:
   debian: [python-sqlite]
@@ -4322,7 +4285,6 @@ python-sympy:
   gentoo: [dev-python/sympy]
   nixos: [pythonPackages.sympy]
   ubuntu:
-    artful: [python-sympy]
     bionic: [python-sympy]
     cosmic: [python-sympy]
 python-systemd:
@@ -4356,7 +4318,6 @@ python-tabulate:
   gentoo: [dev-python/tabulate]
   nixos: [pythonPackages.tabulate]
   ubuntu:
-    artful: [python-tabulate]
     bionic: [python-tabulate]
 python-tabulate-pip:
   debian:
@@ -4890,7 +4851,6 @@ python-walrus-pip:
 python-watchdog:
   debian: [python-watchdog]
   ubuntu:
-    artful: [python-watchdog]
     bionic: [python-watchdog]
 python-webob:
   debian: [python-webob]
@@ -4925,7 +4885,6 @@ python-websocket:
   openembedded: ['${PYTHON_PN}-websocket-client@meta-python']
   opensuse: [python2-websocket-client]
   ubuntu:
-    artful: [python-websocket]
     bionic: [python-websocket]
       pip:
         packages: [websocket-client]
@@ -5025,7 +4984,6 @@ python-xmltodict:
   fedora: [python-xmltodict]
   gentoo: [dev-python/xmltodict]
   ubuntu:
-    artful: [python-xmltodict]
     bionic: [python-xmltodict]
 python-yamale-pip:
   debian:
@@ -5056,7 +5014,6 @@ python-yaml:
     '8': [python2-pyyaml]
   slackware: [PyYAML]
   ubuntu:
-    artful: [python-yaml]
     bionic: [python-yaml]
     focal: [python-yaml]
 python-zbar:
@@ -6383,7 +6340,6 @@ python3-gitlab:
     '7': null
   ubuntu:
     '*': [python3-gitlab]
-    artful:
       pip:
         packages: [python-gitlab]
       pip:
@@ -7229,7 +7185,6 @@ python3-open3d:
     stretch: null
   ubuntu:
     '*': [python3-open3d]
-    artful: null
     bionic: null
     focal: null
 python3-open3d-pip:
@@ -8168,7 +8123,6 @@ python3-qt5-bindings:
   slackware: [python3-PyQt5]
   ubuntu:
     '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2]
-    artful: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
     bionic: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
     cosmic: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
     disco: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -500,7 +500,6 @@ python:
   ubuntu:
     artful: [python-dev]
     bionic: [python-dev]
-    saucy: [python-dev]
     trusty: [python-dev]
     utopic: [python-dev]
     vivid: [python-dev]
@@ -675,7 +674,6 @@ python-autobahn:
         packages: [autobahn]
       pip:
         packages: [autobahn]
-    saucy:
       pip:
         packages: [autobahn]
 python-avahi:
@@ -718,7 +716,6 @@ python-backports.ssl-match-hostname:
   ubuntu:
     artful: [python-backports.ssl-match-hostname]
     bionic: [python-backports.ssl-match-hostname]
-    saucy:
       pip:
         packages: [backports.ssl_match_hostname]
     trusty:
@@ -928,7 +925,6 @@ python-can:
         packages: [python-can]
       pip:
         packages: [python-can]
-    saucy:
       pip:
         packages: [python-can]
     trusty:
@@ -986,7 +982,6 @@ python-catkin-pkg:
   ubuntu:
     artful: [python-catkin-pkg]
     bionic: [python-catkin-pkg]
-    saucy: [python-catkin-pkg]
     trusty: [python-catkin-pkg]
     utopic: [python-catkin-pkg]
     vivid: [python-catkin-pkg]
@@ -1151,7 +1146,6 @@ python-click:
       packages: [click]
   ubuntu:
     '*': [python-click]
-    saucy:
       pip:
         packages: [click]
     trusty:
@@ -1269,7 +1263,6 @@ python-coverage:
   ubuntu:
     artful: [python-coverage]
     bionic: [python-coverage]
-    saucy: [python-coverage]
     trusty: [python-coverage]
     utopic: [python-coverage]
     vivid: [python-coverage]
@@ -1331,7 +1324,6 @@ python-crypto:
   ubuntu:
     artful: [python-crypto]
     bionic: [python-crypto]
-    saucy: [python-crypto]
     trusty: [python-crypto]
     utopic: [python-crypto]
     vivid: [python-crypto]
@@ -1516,7 +1508,6 @@ python-docutils:
   ubuntu:
     artful: [python-docutils]
     bionic: [python-docutils]
-    saucy: [python-docutils]
     trusty: [python-docutils]
     utopic: [python-docutils]
     vivid: [python-docutils]
@@ -1592,7 +1583,6 @@ python-enum34-pip:
 python-espeak:
   debian: [python-espeak]
   ubuntu:
-    saucy: [python-espeak]
     trusty: [python-espeak]
 python-evdev:
   gentoo: [dev-python/python-evdev]
@@ -1735,7 +1725,6 @@ python-flask-restful:
   gentoo: [dev-python/flask-restful]
   nixos: [pythonPackages.flask-restful]
   ubuntu:
-    saucy:
       pip:
         packages: [flask-restful]
     utopic:
@@ -2135,7 +2124,6 @@ python-gridfs:
   debian: [python-gridfs]
   fedora: [python-pymongo-gridfs]
   ubuntu:
-    saucy: [python-gridfs]
     trusty: [python-gridfs]
 python-grpc-tools:
   debian:
@@ -2189,7 +2177,6 @@ python-gst:
     wheezy: [python-gst0.10]
   gentoo: [dev-python/gst-python]
   ubuntu:
-    saucy: [python-gst0.10]
     trusty: [python-gst0.10]
     utopic: [python-gst0.10]
     vivid: [python-gst0.10]
@@ -2301,7 +2288,6 @@ python-imaging:
   ubuntu:
     '*': [python-pil]
     artful: [python-imaging]
-    saucy: [python-imaging]
     trusty: [python-imaging]
     utopic: [python-imaging]
     vivid: [python-imaging]
@@ -2658,7 +2644,6 @@ python-matplotlib:
   ubuntu:
     artful: [python-matplotlib]
     bionic: [python-matplotlib]
-    saucy: [python-matplotlib]
     trusty: [python-matplotlib]
     utopic: [python-matplotlib]
     vivid: [python-matplotlib]
@@ -2701,7 +2686,6 @@ python-mock:
   ubuntu:
     artful: [python-mock]
     bionic: [python-mock]
-    saucy: [python-mock]
     trusty: [python-mock]
     utopic: [python-mock]
     vivid: [python-mock]
@@ -2823,7 +2807,6 @@ python-netaddr:
         packages: [netaddr]
       pip:
         packages: [netaddr]
-    saucy:
       pip:
         packages: [netaddr]
     trusty: [python-netaddr]
@@ -2861,7 +2844,6 @@ python-netifaces:
   ubuntu:
     artful: [python-netifaces]
     bionic: [python-netifaces]
-    saucy: [python-netifaces]
     trusty: [python-netifaces]
     utopic: [python-netifaces]
     vivid: [python-netifaces]
@@ -2962,7 +2944,6 @@ python-oauth2:
   fedora: [python-oauth2]
   gentoo: [dev-python/oauth2]
   ubuntu:
-    saucy: [python-oauth2]
     trusty: [python-oauth2]
     utopic: [python-oauth2]
     vivid: [python-oauth2]
@@ -3021,7 +3002,6 @@ python-opengl:
   ubuntu:
     artful: [python-opengl]
     bionic: [python-opengl]
-    saucy: [python-opengl]
     trusty: [python-opengl]
     utopic: [python-opengl]
     vivid: [python-opengl]
@@ -3211,7 +3191,6 @@ python-pep8:
       packages: [pep8]
   ubuntu:
     '*': [python-pep8]
-    saucy: [pep8]
     trusty: [pep8]
     utopic: [pep8]
     vivid: [pep8]
@@ -3337,7 +3316,6 @@ python-progressbar:
     artful: [python-progressbar]
     bionic: [python-progressbar]
     cosmic: [python-progressbar]
-    saucy: [python-progressbar]
     trusty: [python-progressbar]
     utopic: [python-progressbar]
     vivid: [python-progressbar]
@@ -3405,7 +3383,6 @@ python-pyassimp:
   ubuntu:
     artful: [python-pyassimp]
     bionic: [python-pyassimp]
-    saucy: [python-pyassimp]
     trusty: [python-pyassimp]
     utopic: [python-pyassimp]
     vivid: [python-pyassimp]
@@ -3738,14 +3715,12 @@ python-pyside:
   debian: [python-pyside]
   gentoo: [dev-python/pyside]
   ubuntu:
-    saucy: [python-pyside]
     trusty: [python-pyside]
     utopic: [python-pyside]
     vivid: [python-pyside]
 python-pyside.qtuitools:
   debian: [python-pyside.qtuitools]
   ubuntu:
-    saucy: [python-pyside.qtuitools]
     trusty: [python-pyside.qtuitools]
     utopic: [python-pyside.qtuitools]
     vivid: [python-pyside.qtuitools]
@@ -4067,7 +4042,6 @@ python-rosdep:
   ubuntu:
     artful: [python-rosdep]
     bionic: [python-rosdep]
-    saucy: [python-rosdep]
     trusty: [python-rosdep]
     utopic: [python-rosdep]
     vivid: [python-rosdep]
@@ -4110,7 +4084,6 @@ python-rosdistro:
     '7': [python2-rosdistro]
   ubuntu:
     artful: [python-rosdistro]
-    saucy: [python-rosdistro]
     trusty: [python-rosdistro]
     utopic: [python-rosdistro]
     vivid: [python-rosdistro]
@@ -4232,7 +4205,6 @@ python-rrdtool:
   debian: [python-rrdtool]
   gentoo: [net-analyzer/rrdtool]
   ubuntu:
-    saucy: [python-rrdtool]
     trusty: [python-rrdtool]
 python-rtree:
   debian: [python-rtree]
@@ -4353,7 +4325,6 @@ python-serial:
   ubuntu:
     artful: [python-serial]
     bionic: [python-serial]
-    saucy: [python-serial]
     trusty: [python-serial]
     utopic: [python-serial]
     vivid: [python-serial]
@@ -4382,7 +4353,6 @@ python-setuptools:
   ubuntu:
     artful: [python-setuptools]
     bionic: [python-setuptools]
-    saucy: [python-setuptools]
     trusty: [python-setuptools]
     utopic: [python-setuptools]
     vivid: [python-setuptools]
@@ -4615,7 +4585,6 @@ python-sqlalchemy:
   ubuntu:
     artful: [python-sqlalchemy]
     bionic: [python-sqlalchemy]
-    saucy: [python-sqlalchemy]
     trusty: [python-sqlalchemy]
     utopic: [python-sqlalchemy]
     vivid: [python-sqlalchemy]
@@ -4674,7 +4643,6 @@ python-sympy:
     artful: [python-sympy]
     bionic: [python-sympy]
     cosmic: [python-sympy]
-    saucy: [python-sympy]
     trusty: [python-sympy]
     wily: [python-sympy]
     xenial: [python-sympy]
@@ -4858,7 +4826,6 @@ python-texttable:
     '*': [python-texttable]
       pip:
         packages: [texttable]
-    saucy:
       pip:
         packages: [texttable]
 python-tftpy:
@@ -4881,7 +4848,6 @@ python-theano:
   ubuntu:
       pip:
         packages: [Theano]
-    saucy:
       pip:
         packages: [Theano]
     trusty:
@@ -4964,7 +4930,6 @@ python-tqdm:
   fedora: [python-tqdm]
   ubuntu:
     '*': [python-tqdm]
-    saucy:
       pip:
         packages: [tqdm]
     trusty:
@@ -5128,7 +5093,6 @@ python-ujson:
       packages: [ujson]
   ubuntu:
     '*': [python-ujson]
-    saucy:
       pip:
         packages: [ujson]
     trusty:
@@ -5255,7 +5219,6 @@ python-vtk:
   gentoo: [dev-python/pyvtk]
   ubuntu:
     bionic: [python-vtk6]
-    saucy: [python-vtk]
     trusty: [python-vtk]
     utopic: [python-vtk]
     vivid: [python-vtk]
@@ -5327,7 +5290,6 @@ python-websocket:
         packages: [websocket-client]
       pip:
         packages: [websocket-client]
-    saucy: [python-websocket-client]
     trusty: [python-websocket]
       pip:
         packages: [websocket-client]
@@ -5463,7 +5425,6 @@ python-yaml:
     artful: [python-yaml]
     bionic: [python-yaml]
     focal: [python-yaml]
-    saucy: [python-yaml]
     trusty: [python-yaml]
     utopic: [python-yaml]
     vivid: [python-yaml]
@@ -9944,7 +9905,6 @@ wxpython:
     '7': [wxPython-devel]
   ubuntu:
     '*': [python-wxgtk3.0]
-    saucy: [python-wxgtk2.8]
     trusty: [python-wxgtk2.8]
     utopic: [python-wxgtk2.8]
     vivid: [python-wxgtk2.8]
@@ -9958,7 +9918,6 @@ yapf:
   opensuse: [python2-yapf]
   ubuntu:
     '*': [yapf]
-    saucy:
       pip:
         packages: [yapf]
     trusty:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -272,7 +272,6 @@ jupyter-notebook:
   nixos: [jupyter]
   ubuntu:
     '*': [jupyter-notebook]
-    trusty: [ipython-notebook]
     xenial: [ipython-notebook]
 libgv-python:
   debian: [libgv-python]
@@ -500,7 +499,6 @@ python:
   ubuntu:
     artful: [python-dev]
     bionic: [python-dev]
-    trusty: [python-dev]
     xenial: [python-dev]
 python-absl-py-pip:
   debian:
@@ -531,7 +529,6 @@ python-alembic:
   gentoo: [dev-python/alembic]
   ubuntu:
     '*': [python-alembic]
-    trusty: [alembic]
 python-amqp:
   debian:
     buster: [python-amqp]
@@ -627,7 +624,6 @@ python-attrs:
   ubuntu:
     '*':
       packages: [python-attr]
-    trusty:
       pip:
         packages: [attrs]
 python-attrs-pip:
@@ -711,7 +707,6 @@ python-backports.ssl-match-hostname:
     bionic: [python-backports.ssl-match-hostname]
       pip:
         packages: [backports.ssl_match_hostname]
-    trusty:
       pip:
         packages: [backports.ssl_match_hostname]
     xenial: [python-backports.ssl-match-hostname]
@@ -797,7 +792,6 @@ python-boltons:
       packages: [boltons]
   ubuntu:
     '*': [python-boltons]
-    trusty:
       pip:
         packages: [boltons]
       pip:
@@ -818,7 +812,6 @@ python-boto3:
   opensuse: [python-boto3]
   ubuntu:
     '*': [python-boto3]
-    trusty: null
 python-bottle:
   debian: [python-bottle]
   fedora: [python-bottle]
@@ -912,7 +905,6 @@ python-can:
         packages: [python-can]
       pip:
         packages: [python-can]
-    trusty:
       pip:
         packages: [python-can]
       pip:
@@ -963,7 +955,6 @@ python-catkin-pkg:
   ubuntu:
     artful: [python-catkin-pkg]
     bionic: [python-catkin-pkg]
-    trusty: [python-catkin-pkg]
     xenial: [python-catkin-pkg]
 python-catkin-pkg-modules:
   alpine:
@@ -1122,7 +1113,6 @@ python-click:
     '*': [python-click]
       pip:
         packages: [click]
-    trusty:
       pip:
         packages: [click]
       pip:
@@ -1234,7 +1224,6 @@ python-coverage:
   ubuntu:
     artful: [python-coverage]
     bionic: [python-coverage]
-    trusty: [python-coverage]
     xenial: [python-coverage]
 python-cpplint:
   debian:
@@ -1290,7 +1279,6 @@ python-crypto:
   ubuntu:
     artful: [python-crypto]
     bionic: [python-crypto]
-    trusty: [python-crypto]
     xenial: [python-crypto]
 python-cryptography:
   debian: [python-cryptography]
@@ -1364,7 +1352,6 @@ python-debian:
   ubuntu:
     artful: [python-debian]
     bionic: [python-debian]
-    trusty: [python-debian]
     xenial: [python-debian]
 python-decorator:
   debian: [python-decorator]
@@ -1464,7 +1451,6 @@ python-docutils:
   ubuntu:
     artful: [python-docutils]
     bionic: [python-docutils]
-    trusty: [python-docutils]
     xenial: [python-docutils]
 python-docx:
   fedora: [python-docx]
@@ -1536,7 +1522,6 @@ python-enum34-pip:
 python-espeak:
   debian: [python-espeak]
   ubuntu:
-    trusty: [python-espeak]
 python-evdev:
   gentoo: [dev-python/python-evdev]
   ubuntu: [python-evdev]
@@ -1736,7 +1721,6 @@ python-future:
   ubuntu:
     artful: [python-future]
     bionic: [python-future]
-    trusty:
       pip:
         packages: [future]
       pip:
@@ -1866,7 +1850,6 @@ python-gitlab:
     artful:
       pip:
         packages: [python-gitlab]
-    trusty:
       pip:
         packages: [python-gitlab]
     xenial:
@@ -1966,7 +1949,6 @@ python-googleapi:
   gentoo: [dev-python/google-api-python-client]
   ubuntu:
     bionic: [python-googleapi]
-    trusty: [python-googleapi]
     xenial: [python-googleapi]
 python-gpiozero:
   debian:
@@ -1980,7 +1962,6 @@ python-gpiozero:
   ubuntu:
     artful: [python-gpiozero]
     bionic: [python-gpiozero]
-    trusty:
       pip:
         packages: [gpiozero]
       pip:
@@ -2018,7 +1999,6 @@ python-gpxpy:
   ubuntu:
     artful: [python-gpxpy]
     bionic: [python-gpxpy]
-    trusty:
       pip:
         packages: [gpxpy]
       pip:
@@ -2055,7 +2035,6 @@ python-gridfs:
   debian: [python-gridfs]
   fedora: [python-pymongo-gridfs]
   ubuntu:
-    trusty: [python-gridfs]
 python-grpc-tools:
   debian:
     '*': [python-grpc-tools]
@@ -2068,7 +2047,6 @@ python-grpc-tools:
     '*': [python-grpc-tools]
     bionic:
       pip: [grpcio-tools]
-    trusty:
       pip: [grpcio-tools]
     xenial:
       pip: [grpcio-tools]
@@ -2083,7 +2061,6 @@ python-grpcio:
     '*': [python-grpcio]
     bionic:
       pip: [grpcio]
-    trusty:
       pip: [grpcio]
     xenial:
       pip: [grpcio]
@@ -2108,7 +2085,6 @@ python-gst:
     wheezy: [python-gst0.10]
   gentoo: [dev-python/gst-python]
   ubuntu:
-    trusty: [python-gst0.10]
 python-gst-1.0:
   debian:
     buster: [python-gst-1.0]
@@ -2186,7 +2162,6 @@ python-imageio:
   opensuse: [python2-imageio]
   ubuntu:
     '*': [python-imageio]
-    trusty:
       pip:
         packages: [imageio]
     xenial:
@@ -2217,7 +2192,6 @@ python-imaging:
   ubuntu:
     '*': [python-pil]
     artful: [python-imaging]
-    trusty: [python-imaging]
     xenial: [python-imaging]
 python-imaging-imagetk:
   debian: [python-pil.imagetk]
@@ -2568,7 +2542,6 @@ python-matplotlib:
   ubuntu:
     artful: [python-matplotlib]
     bionic: [python-matplotlib]
-    trusty: [python-matplotlib]
     xenial: [python-matplotlib]
 python-mechanize:
   arch: [python2-mechanize]
@@ -2605,7 +2578,6 @@ python-mock:
   ubuntu:
     artful: [python-mock]
     bionic: [python-mock]
-    trusty: [python-mock]
     xenial: [python-mock]
 python-monotonic:
   arch: [python-monotonic]
@@ -2723,7 +2695,6 @@ python-netaddr:
         packages: [netaddr]
       pip:
         packages: [netaddr]
-    trusty: [python-netaddr]
     xenial: [python-netaddr]
 python-netcdf4:
   arch: [python-netcdf4]
@@ -2754,7 +2725,6 @@ python-netifaces:
   ubuntu:
     artful: [python-netifaces]
     bionic: [python-netifaces]
-    trusty: [python-netifaces]
     xenial: [python-netifaces]
 python-networkmanager:
   debian:
@@ -2849,7 +2819,6 @@ python-oauth2:
   fedora: [python-oauth2]
   gentoo: [dev-python/oauth2]
   ubuntu:
-    trusty: [python-oauth2]
 python-oauth2client:
   debian: [python-oauth2client]
   fedora: [python-oauth2client]
@@ -2905,7 +2874,6 @@ python-opengl:
   ubuntu:
     artful: [python-opengl]
     bionic: [python-opengl]
-    trusty: [python-opengl]
     xenial: [python-opengl]
 python-openssl:
   debian: [python-openssl]
@@ -2964,7 +2932,6 @@ python-parameterized:
     artful:
       pip:
         packages: [parameterized]
-    trusty:
       pip:
         packages: [parameterized]
       pip:
@@ -3084,7 +3051,6 @@ python-pep8:
       packages: [pep8]
   ubuntu:
     '*': [python-pep8]
-    trusty: [pep8]
 python-percol:
   debian:
     pip:
@@ -3206,7 +3172,6 @@ python-progressbar:
     artful: [python-progressbar]
     bionic: [python-progressbar]
     cosmic: [python-progressbar]
-    trusty: [python-progressbar]
     xenial: [python-progressbar]
 python-progressbar2-pip:
   debian:
@@ -3270,7 +3235,6 @@ python-pyassimp:
   ubuntu:
     artful: [python-pyassimp]
     bionic: [python-pyassimp]
-    trusty: [python-pyassimp]
     xenial: [python-pyassimp]
 python-pyaudio:
   debian: [python-pyaudio]
@@ -3325,7 +3289,6 @@ python-pydbus:
   ubuntu:
     artful: [python-pydbus]
     bionic: [python-pydbus]
-    trusty:
       pip:
         depends: [python-gi]
         packages: [pydbus]
@@ -3518,7 +3481,6 @@ python-pypng:
   gentoo: [dev-python/pypng]
   ubuntu:
     '*': [python-png]
-    trusty:
       pip:
         packages: [pypng]
     xenial:
@@ -3553,7 +3515,6 @@ python-pyqrcode:
   gentoo: [dev-python/pyqrcode]
   ubuntu:
     '*': [python-pyqrcode]
-    trusty:
       pip:
         packages: [PyQRCode]
     xenial:
@@ -3597,11 +3558,9 @@ python-pyside:
   debian: [python-pyside]
   gentoo: [dev-python/pyside]
   ubuntu:
-    trusty: [python-pyside]
 python-pyside.qtuitools:
   debian: [python-pyside.qtuitools]
   ubuntu:
-    trusty: [python-pyside.qtuitools]
 python-pysimplegui27-pip:
   debian:
     pip:
@@ -3911,7 +3870,6 @@ python-rosdep:
   ubuntu:
     artful: [python-rosdep]
     bionic: [python-rosdep]
-    trusty: [python-rosdep]
     xenial: [python-rosdep]
 python-rosdep-modules:
   alpine:
@@ -3948,7 +3906,6 @@ python-rosdistro:
     '7': [python2-rosdistro]
   ubuntu:
     artful: [python-rosdistro]
-    trusty: [python-rosdistro]
     xenial: [python-rosdistro]
 python-rosinstall:
   arch: [python2-rosinstall]
@@ -4031,7 +3988,6 @@ python-rpi.gpio:
   ubuntu:
     artful: [python-rpi.gpio]
     bionic: [python-rpi.gpio]
-    trusty:
       pip:
         packages: [RPi.GPIO]
       pip:
@@ -4059,7 +4015,6 @@ python-rrdtool:
   debian: [python-rrdtool]
   gentoo: [net-analyzer/rrdtool]
   ubuntu:
-    trusty: [python-rrdtool]
 python-rtree:
   debian: [python-rtree]
   ubuntu: [python-rtree]
@@ -4127,7 +4082,6 @@ python-seaborn:
   gentoo: [dev-python/seaborn]
   ubuntu:
     '*': [python-seaborn]
-    trusty:
       pip:
         packages: [seaborn]
 python-selectors2-pip:
@@ -4177,7 +4131,6 @@ python-serial:
   ubuntu:
     artful: [python-serial]
     bionic: [python-serial]
-    trusty: [python-serial]
     xenial: [python-serial]
 python-setproctitle:
   debian: [python-setproctitle]
@@ -4200,7 +4153,6 @@ python-setuptools:
   ubuntu:
     artful: [python-setuptools]
     bionic: [python-setuptools]
-    trusty: [python-setuptools]
     xenial: [python-setuptools]
 python-sexpdata:
   debian:
@@ -4225,7 +4177,6 @@ python-sh:
   gentoo: [dev-python/sh]
   ubuntu:
     '*': [python-sh]
-    trusty:
       pip:
         packages: [sh]
 python-shapely:
@@ -4423,7 +4374,6 @@ python-sqlalchemy:
   ubuntu:
     artful: [python-sqlalchemy]
     bionic: [python-sqlalchemy]
-    trusty: [python-sqlalchemy]
     xenial: [python-sqlalchemy]
 python-sqlite:
   debian: [python-sqlite]
@@ -4446,7 +4396,6 @@ python-subprocess32:
   gentoo: [dev-python/subprocess32]
   ubuntu:
     '*': [python-subprocess32]
-    trusty: null
 python-support:
   debian: [python-support]
   fedora: [python]
@@ -4463,7 +4412,6 @@ python-svg.path:
   fedora: [python-svg-path]
   ubuntu:
     '*': [python-svg.path]
-    trusty:
       pip:
         packages: [svg.path]
 python-svn:
@@ -4478,7 +4426,6 @@ python-sympy:
     artful: [python-sympy]
     bionic: [python-sympy]
     cosmic: [python-sympy]
-    trusty: [python-sympy]
     xenial: [python-sympy]
 python-systemd:
   debian:
@@ -4682,7 +4629,6 @@ python-theano:
         packages: [Theano]
       pip:
         packages: [Theano]
-    trusty:
       pip:
         packages: [Theano]
       pip:
@@ -4759,7 +4705,6 @@ python-tqdm:
     '*': [python-tqdm]
       pip:
         packages: [tqdm]
-    trusty:
       pip:
         packages: [tqdm]
       pip:
@@ -4794,7 +4739,6 @@ python-transitions:
         packages: [transitions]
   ubuntu:
     bionic: [python-transitions]
-    trusty:
       pip:
         packages: [transitions]
     xenial:
@@ -4878,7 +4822,6 @@ python-typing:
   nixos: [pythonPackages.typing]
   ubuntu:
     '*': [python-typing]
-    trusty: null
     xenial: null
 python-typing-pip:
   debian:
@@ -4919,7 +4862,6 @@ python-ujson:
     '*': [python-ujson]
       pip:
         packages: [ujson]
-    trusty:
       pip:
         packages: [ujson]
       pip:
@@ -5041,7 +4983,6 @@ python-vtk:
   gentoo: [dev-python/pyvtk]
   ubuntu:
     bionic: [python-vtk6]
-    trusty: [python-vtk]
     xenial: [python-vtk6]
 python-w1thermsensor-pip:
   debian:
@@ -5107,7 +5048,6 @@ python-websocket:
         packages: [websocket-client]
       pip:
         packages: [websocket-client]
-    trusty: [python-websocket]
       pip:
         packages: [websocket-client]
       pip:
@@ -5237,7 +5177,6 @@ python-yaml:
     artful: [python-yaml]
     bionic: [python-yaml]
     focal: [python-yaml]
-    trusty: [python-yaml]
     xenial: [python-yaml]
 python-zbar:
   debian: [python-zbar]
@@ -6574,7 +6513,6 @@ python3-gitlab:
     artful:
       pip:
         packages: [python-gitlab]
-    trusty:
       pip:
         packages: [python-gitlab]
     xenial:
@@ -9216,7 +9154,6 @@ python3-transitions:
         packages: [transitions]
   ubuntu:
     '*': [python3-transitions]
-    trusty:
       pip:
         packages: [transitions]
     xenial:
@@ -9710,7 +9647,6 @@ wxpython:
     '7': [wxPython-devel]
   ubuntu:
     '*': [python-wxgtk3.0]
-    trusty: [python-wxgtk2.8]
 yapf:
   arch: [yapf]
   debian:
@@ -9722,7 +9658,6 @@ yapf:
     '*': [yapf]
       pip:
         packages: [yapf]
-    trusty:
       pip:
         packages: [yapf]
       pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2143,7 +2143,6 @@ python-influxdb:
   nixos: [pythonPackages.influxdb]
   ubuntu:
     bionic: [python-influxdb]
-    disco: [python-influxdb]
 python-inject-pip: &migrate_eol_2025_04_30_python3_inject_pip
   ubuntu:
     pip:
@@ -8122,7 +8121,6 @@ python3-qt5-bindings:
   ubuntu:
     '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2]
     bionic: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
-    disco: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
     eoan: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
 python3-qt5-bindings-gl:
   debian: [python3-pyqt5.qtopengl]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -500,7 +500,6 @@ python:
   ubuntu:
     artful: [python-dev]
     bionic: [python-dev]
-    raring: [python-dev]
     saucy: [python-dev]
     trusty: [python-dev]
     utopic: [python-dev]
@@ -674,7 +673,6 @@ python-autobahn:
         packages: [autobahn]
       pip:
         packages: [autobahn]
-    raring:
       pip:
         packages: [autobahn]
     saucy:
@@ -928,7 +926,6 @@ python-can:
         packages: [python-can]
       pip:
         packages: [python-can]
-    raring:
       pip:
         packages: [python-can]
     saucy:
@@ -989,7 +986,6 @@ python-catkin-pkg:
   ubuntu:
     artful: [python-catkin-pkg]
     bionic: [python-catkin-pkg]
-    raring: [python-catkin-pkg]
     saucy: [python-catkin-pkg]
     trusty: [python-catkin-pkg]
     utopic: [python-catkin-pkg]
@@ -1273,7 +1269,6 @@ python-coverage:
   ubuntu:
     artful: [python-coverage]
     bionic: [python-coverage]
-    raring: [python-coverage]
     saucy: [python-coverage]
     trusty: [python-coverage]
     utopic: [python-coverage]
@@ -1336,7 +1331,6 @@ python-crypto:
   ubuntu:
     artful: [python-crypto]
     bionic: [python-crypto]
-    raring: [python-crypto]
     saucy: [python-crypto]
     trusty: [python-crypto]
     utopic: [python-crypto]
@@ -1522,7 +1516,6 @@ python-docutils:
   ubuntu:
     artful: [python-docutils]
     bionic: [python-docutils]
-    raring: [python-docutils]
     saucy: [python-docutils]
     trusty: [python-docutils]
     utopic: [python-docutils]
@@ -1599,7 +1592,6 @@ python-enum34-pip:
 python-espeak:
   debian: [python-espeak]
   ubuntu:
-    raring: [python-espeak]
     saucy: [python-espeak]
     trusty: [python-espeak]
 python-evdev:
@@ -2143,7 +2135,6 @@ python-gridfs:
   debian: [python-gridfs]
   fedora: [python-pymongo-gridfs]
   ubuntu:
-    raring: [python-gridfs]
     saucy: [python-gridfs]
     trusty: [python-gridfs]
 python-grpc-tools:
@@ -2198,7 +2189,6 @@ python-gst:
     wheezy: [python-gst0.10]
   gentoo: [dev-python/gst-python]
   ubuntu:
-    raring: [python-gst0.10]
     saucy: [python-gst0.10]
     trusty: [python-gst0.10]
     utopic: [python-gst0.10]
@@ -2311,7 +2301,6 @@ python-imaging:
   ubuntu:
     '*': [python-pil]
     artful: [python-imaging]
-    raring: [python-imaging]
     saucy: [python-imaging]
     trusty: [python-imaging]
     utopic: [python-imaging]
@@ -2669,7 +2658,6 @@ python-matplotlib:
   ubuntu:
     artful: [python-matplotlib]
     bionic: [python-matplotlib]
-    raring: [python-matplotlib]
     saucy: [python-matplotlib]
     trusty: [python-matplotlib]
     utopic: [python-matplotlib]
@@ -2713,7 +2701,6 @@ python-mock:
   ubuntu:
     artful: [python-mock]
     bionic: [python-mock]
-    raring: [python-mock]
     saucy: [python-mock]
     trusty: [python-mock]
     utopic: [python-mock]
@@ -2834,7 +2821,6 @@ python-netaddr:
         packages: [netaddr]
       pip:
         packages: [netaddr]
-    raring:
       pip:
         packages: [netaddr]
     saucy:
@@ -2875,7 +2861,6 @@ python-netifaces:
   ubuntu:
     artful: [python-netifaces]
     bionic: [python-netifaces]
-    raring: [python-netifaces]
     saucy: [python-netifaces]
     trusty: [python-netifaces]
     utopic: [python-netifaces]
@@ -2977,7 +2962,6 @@ python-oauth2:
   fedora: [python-oauth2]
   gentoo: [dev-python/oauth2]
   ubuntu:
-    raring: [python-oauth2]
     saucy: [python-oauth2]
     trusty: [python-oauth2]
     utopic: [python-oauth2]
@@ -3037,7 +3021,6 @@ python-opengl:
   ubuntu:
     artful: [python-opengl]
     bionic: [python-opengl]
-    raring: [python-opengl]
     saucy: [python-opengl]
     trusty: [python-opengl]
     utopic: [python-opengl]
@@ -3228,7 +3211,6 @@ python-pep8:
       packages: [pep8]
   ubuntu:
     '*': [python-pep8]
-    raring: [pep8]
     saucy: [pep8]
     trusty: [pep8]
     utopic: [pep8]
@@ -3355,7 +3337,6 @@ python-progressbar:
     artful: [python-progressbar]
     bionic: [python-progressbar]
     cosmic: [python-progressbar]
-    raring: [python-progressbar]
     saucy: [python-progressbar]
     trusty: [python-progressbar]
     utopic: [python-progressbar]
@@ -3424,7 +3405,6 @@ python-pyassimp:
   ubuntu:
     artful: [python-pyassimp]
     bionic: [python-pyassimp]
-    raring: [python-pyassimp]
     saucy: [python-pyassimp]
     trusty: [python-pyassimp]
     utopic: [python-pyassimp]
@@ -3758,7 +3738,6 @@ python-pyside:
   debian: [python-pyside]
   gentoo: [dev-python/pyside]
   ubuntu:
-    raring: [python-pyside]
     saucy: [python-pyside]
     trusty: [python-pyside]
     utopic: [python-pyside]
@@ -3766,7 +3745,6 @@ python-pyside:
 python-pyside.qtuitools:
   debian: [python-pyside.qtuitools]
   ubuntu:
-    raring: [python-pyside.qtuitools]
     saucy: [python-pyside.qtuitools]
     trusty: [python-pyside.qtuitools]
     utopic: [python-pyside.qtuitools]
@@ -4089,7 +4067,6 @@ python-rosdep:
   ubuntu:
     artful: [python-rosdep]
     bionic: [python-rosdep]
-    raring: [python-rosdep]
     saucy: [python-rosdep]
     trusty: [python-rosdep]
     utopic: [python-rosdep]
@@ -4133,7 +4110,6 @@ python-rosdistro:
     '7': [python2-rosdistro]
   ubuntu:
     artful: [python-rosdistro]
-    raring: [python-rosdistro]
     saucy: [python-rosdistro]
     trusty: [python-rosdistro]
     utopic: [python-rosdistro]
@@ -4256,7 +4232,6 @@ python-rrdtool:
   debian: [python-rrdtool]
   gentoo: [net-analyzer/rrdtool]
   ubuntu:
-    raring: [python-rrdtool]
     saucy: [python-rrdtool]
     trusty: [python-rrdtool]
 python-rtree:
@@ -4378,7 +4353,6 @@ python-serial:
   ubuntu:
     artful: [python-serial]
     bionic: [python-serial]
-    raring: [python-serial]
     saucy: [python-serial]
     trusty: [python-serial]
     utopic: [python-serial]
@@ -4408,7 +4382,6 @@ python-setuptools:
   ubuntu:
     artful: [python-setuptools]
     bionic: [python-setuptools]
-    raring: [python-setuptools]
     saucy: [python-setuptools]
     trusty: [python-setuptools]
     utopic: [python-setuptools]
@@ -4642,7 +4615,6 @@ python-sqlalchemy:
   ubuntu:
     artful: [python-sqlalchemy]
     bionic: [python-sqlalchemy]
-    raring: [python-sqlalchemy]
     saucy: [python-sqlalchemy]
     trusty: [python-sqlalchemy]
     utopic: [python-sqlalchemy]
@@ -4702,7 +4674,6 @@ python-sympy:
     artful: [python-sympy]
     bionic: [python-sympy]
     cosmic: [python-sympy]
-    raring: [python-sympy]
     saucy: [python-sympy]
     trusty: [python-sympy]
     wily: [python-sympy]
@@ -5354,7 +5325,6 @@ python-websocket:
         packages: [websocket-client]
       pip:
         packages: [websocket-client]
-    raring:
       pip:
         packages: [websocket-client]
     saucy: [python-websocket-client]
@@ -5493,7 +5463,6 @@ python-yaml:
     artful: [python-yaml]
     bionic: [python-yaml]
     focal: [python-yaml]
-    raring: [python-yaml]
     saucy: [python-yaml]
     trusty: [python-yaml]
     utopic: [python-yaml]
@@ -9975,7 +9944,6 @@ wxpython:
     '7': [wxPython-devel]
   ubuntu:
     '*': [python-wxgtk3.0]
-    raring: [python-wxgtk2.8]
     saucy: [python-wxgtk2.8]
     trusty: [python-wxgtk2.8]
     utopic: [python-wxgtk2.8]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -501,7 +501,6 @@ python:
     artful: [python-dev]
     bionic: [python-dev]
     trusty: [python-dev]
-    utopic: [python-dev]
     vivid: [python-dev]
     wily: [python-dev]
     xenial: [python-dev]
@@ -930,7 +929,6 @@ python-can:
     trusty:
       pip:
         packages: [python-can]
-    utopic:
       pip:
         packages: [python-can]
     vivid:
@@ -983,7 +981,6 @@ python-catkin-pkg:
     artful: [python-catkin-pkg]
     bionic: [python-catkin-pkg]
     trusty: [python-catkin-pkg]
-    utopic: [python-catkin-pkg]
     vivid: [python-catkin-pkg]
     wily: [python-catkin-pkg]
     xenial: [python-catkin-pkg]
@@ -1151,7 +1148,6 @@ python-click:
     trusty:
       pip:
         packages: [click]
-    utopic:
       pip:
         packages: [click]
     vivid:
@@ -1264,7 +1260,6 @@ python-coverage:
     artful: [python-coverage]
     bionic: [python-coverage]
     trusty: [python-coverage]
-    utopic: [python-coverage]
     vivid: [python-coverage]
     wily: [python-coverage]
     xenial: [python-coverage]
@@ -1325,7 +1320,6 @@ python-crypto:
     artful: [python-crypto]
     bionic: [python-crypto]
     trusty: [python-crypto]
-    utopic: [python-crypto]
     vivid: [python-crypto]
     wily: [python-crypto]
     xenial: [python-crypto]
@@ -1404,7 +1398,6 @@ python-debian:
     artful: [python-debian]
     bionic: [python-debian]
     trusty: [python-debian]
-    utopic: [python-debian]
     vivid: [python-debian]
     wily: [python-debian]
     xenial: [python-debian]
@@ -1509,7 +1502,6 @@ python-docutils:
     artful: [python-docutils]
     bionic: [python-docutils]
     trusty: [python-docutils]
-    utopic: [python-docutils]
     vivid: [python-docutils]
     wily: [python-docutils]
     xenial: [python-docutils]
@@ -1727,7 +1719,6 @@ python-flask-restful:
   ubuntu:
       pip:
         packages: [flask-restful]
-    utopic:
       pip:
         packages: [flask-restful]
     vivid:
@@ -1790,7 +1781,6 @@ python-future:
     trusty:
       pip:
         packages: [future]
-    utopic:
       pip:
         packages: [future]
     vivid:
@@ -2023,7 +2013,6 @@ python-googleapi:
   ubuntu:
     bionic: [python-googleapi]
     trusty: [python-googleapi]
-    utopic: [python-googleapi]
     vivid: [python-googleapi]
     wily: [python-googleapi]
     xenial: [python-googleapi]
@@ -2042,7 +2031,6 @@ python-gpiozero:
     trusty:
       pip:
         packages: [gpiozero]
-    utopic:
       pip:
         packages: [gpiozero]
     vivid:
@@ -2085,7 +2073,6 @@ python-gpxpy:
     trusty:
       pip:
         packages: [gpxpy]
-    utopic:
       pip:
         packages: [gpxpy]
     vivid:
@@ -2178,7 +2165,6 @@ python-gst:
   gentoo: [dev-python/gst-python]
   ubuntu:
     trusty: [python-gst0.10]
-    utopic: [python-gst0.10]
     vivid: [python-gst0.10]
 python-gst-1.0:
   debian:
@@ -2289,7 +2275,6 @@ python-imaging:
     '*': [python-pil]
     artful: [python-imaging]
     trusty: [python-imaging]
-    utopic: [python-imaging]
     vivid: [python-imaging]
     wily: [python-imaging]
     xenial: [python-imaging]
@@ -2645,7 +2630,6 @@ python-matplotlib:
     artful: [python-matplotlib]
     bionic: [python-matplotlib]
     trusty: [python-matplotlib]
-    utopic: [python-matplotlib]
     vivid: [python-matplotlib]
     wily: [python-matplotlib]
     xenial: [python-matplotlib]
@@ -2687,7 +2671,6 @@ python-mock:
     artful: [python-mock]
     bionic: [python-mock]
     trusty: [python-mock]
-    utopic: [python-mock]
     vivid: [python-mock]
     wily: [python-mock]
     xenial: [python-mock]
@@ -2810,7 +2793,6 @@ python-netaddr:
       pip:
         packages: [netaddr]
     trusty: [python-netaddr]
-    utopic: [python-netaddr]
     vivid: [python-netaddr]
     xenial: [python-netaddr]
     yakkety: [python-netaddr]
@@ -2845,7 +2827,6 @@ python-netifaces:
     artful: [python-netifaces]
     bionic: [python-netifaces]
     trusty: [python-netifaces]
-    utopic: [python-netifaces]
     vivid: [python-netifaces]
     wily: [python-netifaces]
     xenial: [python-netifaces]
@@ -2945,7 +2926,6 @@ python-oauth2:
   gentoo: [dev-python/oauth2]
   ubuntu:
     trusty: [python-oauth2]
-    utopic: [python-oauth2]
     vivid: [python-oauth2]
 python-oauth2client:
   debian: [python-oauth2client]
@@ -3003,7 +2983,6 @@ python-opengl:
     artful: [python-opengl]
     bionic: [python-opengl]
     trusty: [python-opengl]
-    utopic: [python-opengl]
     vivid: [python-opengl]
     wily: [python-opengl]
     xenial: [python-opengl]
@@ -3192,7 +3171,6 @@ python-pep8:
   ubuntu:
     '*': [python-pep8]
     trusty: [pep8]
-    utopic: [pep8]
     vivid: [pep8]
     wily: [pep8]
 python-percol:
@@ -3317,7 +3295,6 @@ python-progressbar:
     bionic: [python-progressbar]
     cosmic: [python-progressbar]
     trusty: [python-progressbar]
-    utopic: [python-progressbar]
     vivid: [python-progressbar]
     wily: [python-progressbar]
     xenial: [python-progressbar]
@@ -3384,7 +3361,6 @@ python-pyassimp:
     artful: [python-pyassimp]
     bionic: [python-pyassimp]
     trusty: [python-pyassimp]
-    utopic: [python-pyassimp]
     vivid: [python-pyassimp]
     wily: [python-pyassimp]
     xenial: [python-pyassimp]
@@ -3716,13 +3692,11 @@ python-pyside:
   gentoo: [dev-python/pyside]
   ubuntu:
     trusty: [python-pyside]
-    utopic: [python-pyside]
     vivid: [python-pyside]
 python-pyside.qtuitools:
   debian: [python-pyside.qtuitools]
   ubuntu:
     trusty: [python-pyside.qtuitools]
-    utopic: [python-pyside.qtuitools]
     vivid: [python-pyside.qtuitools]
 python-pysimplegui27-pip:
   debian:
@@ -4043,7 +4017,6 @@ python-rosdep:
     artful: [python-rosdep]
     bionic: [python-rosdep]
     trusty: [python-rosdep]
-    utopic: [python-rosdep]
     vivid: [python-rosdep]
     wily: [python-rosdep]
     xenial: [python-rosdep]
@@ -4085,7 +4058,6 @@ python-rosdistro:
   ubuntu:
     artful: [python-rosdistro]
     trusty: [python-rosdistro]
-    utopic: [python-rosdistro]
     vivid: [python-rosdistro]
     wily: [python-rosdistro]
     xenial: [python-rosdistro]
@@ -4175,7 +4147,6 @@ python-rpi.gpio:
     trusty:
       pip:
         packages: [RPi.GPIO]
-    utopic:
       pip:
         packages: [RPi.GPIO]
     vivid:
@@ -4326,7 +4297,6 @@ python-serial:
     artful: [python-serial]
     bionic: [python-serial]
     trusty: [python-serial]
-    utopic: [python-serial]
     vivid: [python-serial]
     wily: [python-serial]
     xenial: [python-serial]
@@ -4354,7 +4324,6 @@ python-setuptools:
     artful: [python-setuptools]
     bionic: [python-setuptools]
     trusty: [python-setuptools]
-    utopic: [python-setuptools]
     vivid: [python-setuptools]
     wily: [python-setuptools]
     xenial: [python-setuptools]
@@ -4586,7 +4555,6 @@ python-sqlalchemy:
     artful: [python-sqlalchemy]
     bionic: [python-sqlalchemy]
     trusty: [python-sqlalchemy]
-    utopic: [python-sqlalchemy]
     vivid: [python-sqlalchemy]
     wily: [python-sqlalchemy]
     xenial: [python-sqlalchemy]
@@ -4853,7 +4821,6 @@ python-theano:
     trusty:
       pip:
         packages: [Theano]
-    utopic:
       pip:
         packages: [Theano]
     vivid:
@@ -4935,7 +4902,6 @@ python-tqdm:
     trusty:
       pip:
         packages: [tqdm]
-    utopic:
       pip:
         packages: [tqdm]
     vivid:
@@ -5098,7 +5064,6 @@ python-ujson:
     trusty:
       pip:
         packages: [ujson]
-    utopic:
       pip:
         packages: [ujson]
     vivid:
@@ -5220,7 +5185,6 @@ python-vtk:
   ubuntu:
     bionic: [python-vtk6]
     trusty: [python-vtk]
-    utopic: [python-vtk]
     vivid: [python-vtk]
     wily: [python-vtk]
     xenial: [python-vtk6]
@@ -5293,7 +5257,6 @@ python-websocket:
     trusty: [python-websocket]
       pip:
         packages: [websocket-client]
-    utopic: [python-websocket]
       pip:
         packages: [websocket-client]
     vivid: [python-websocket]
@@ -5426,7 +5389,6 @@ python-yaml:
     bionic: [python-yaml]
     focal: [python-yaml]
     trusty: [python-yaml]
-    utopic: [python-yaml]
     vivid: [python-yaml]
     wily: [python-yaml]
     xenial: [python-yaml]
@@ -9906,7 +9868,6 @@ wxpython:
   ubuntu:
     '*': [python-wxgtk3.0]
     trusty: [python-wxgtk2.8]
-    utopic: [python-wxgtk2.8]
     vivid: [python-wxgtk2.8]
     wily: [python-wxgtk2.8]
 yapf:
@@ -9923,7 +9884,6 @@ yapf:
     trusty:
       pip:
         packages: [yapf]
-    utopic:
       pip:
         packages: [yapf]
     vivid:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -389,8 +389,6 @@ pymap3d-pip:
     buster:
       pip:
         packages: [pymap3d]
-      pip:
-        packages: [pymap3d]
     stretch:
       pip:
         packages: [pymap3d]
@@ -6181,8 +6179,6 @@ python3-importlib-metadata:
     bionic:
       pip:
         packages: [importlib-metadata]
-      pip:
-        packages: [importlib-metadata]
 python3-importlib-resources:
   arch: [python-importlib_resources]
   debian:
@@ -6207,8 +6203,6 @@ python3-importlib-resources:
   ubuntu:
     '*': [python3-minimal]
     bionic:
-      pip:
-        packages: [importlib-resources]
       pip:
         packages: [importlib-resources]
 python3-inflection-pip:
@@ -7268,7 +7262,6 @@ python3-pydantic:
     '*': [python3-pydantic]
     buster:
       pip: [pydantic]
-      pip: [pydantic]
     stretch:
       pip: [pydantic]
   fedora: [python3-pydantic]
@@ -7276,7 +7269,6 @@ python3-pydantic:
   ubuntu:
     '*': [python3-pydantic]
     bionic:
-      pip: [pydantic]
       pip: [pydantic]
 python3-pydbus:
   debian: [python3-pydbus]
@@ -7327,7 +7319,6 @@ python3-pygame:
   ubuntu:
     '*': [python3-pygame]
     bionic:
-      pip: [pygame]
       pip: [pygame]
 python3-pygit2:
   alpine: [py3-pygit2]
@@ -7613,8 +7604,6 @@ python3-pystemd:
   ubuntu:
     '*': [python3-pystemd]
     bionic:
-      pip:
-        packages: [pystemd]
       pip:
         packages: [pystemd]
 python3-pyswarms-pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -266,7 +266,6 @@ jupyter-nbconvert:
 jupyter-notebook:
   debian:
     '*': [jupyter-notebook]
-    jessie: [ipython-notebook]
   fedora: [python3-notebook]
   nixos: [jupyter]
   ubuntu:
@@ -390,7 +389,6 @@ pymap3d-pip:
     buster:
       pip:
         packages: [pymap3d]
-    jessie:
       pip:
         packages: [pymap3d]
     stretch:
@@ -520,7 +518,6 @@ python-adafruit-bno055-pip:
 python-alembic:
   debian:
     buster: [python-alembic]
-    jessie: [python-alembic]
     stretch: [python-alembic]
   fedora: [python-alembic]
   gentoo: [dev-python/alembic]
@@ -529,7 +526,6 @@ python-alembic:
 python-amqp:
   debian:
     buster: [python-amqp]
-    jessie: [python-amqp]
     stretch: [python-amqp]
   fedora: [python-amqp]
   gentoo: [dev-python/py-amqp]
@@ -578,7 +574,6 @@ python-argparse:
   arch: [python2]
   debian:
     buster: [libpython2.7-stdlib]
-    jessie: [libpython2.7-stdlib]
     squeeze: [python-argparse]
     stretch: [libpython2.7-stdlib]
     wheezy: [python-argparse]
@@ -772,7 +767,6 @@ python-bokeh-pip:
 python-boltons:
   debian:
     '*': [python-boltons]
-    jessie:
       pip:
         packages: [boltons]
     wheezy:
@@ -865,7 +859,6 @@ python-can:
       packages: [python-can]
   debian:
     '*': [python-can]
-    jessie:
       pip:
         packages: [python-can]
     squeeze:
@@ -1086,7 +1079,6 @@ python-clearsilver:
 python-click:
   debian:
     '*': [python-click]
-    jessie:
       pip:
         packages: [python-click]
     wheezy:
@@ -1166,7 +1158,6 @@ python-control-pip:
 python-cookiecutter:
   debian:
     buster: [python-cookiecutter]
-    jessie: [python-cookiecutter]
     stretch: [python-cookiecutter]
   fedora:
     pip:
@@ -1485,13 +1476,11 @@ python-empy:
   ubuntu: [python-empy]
 python-enum:
   debian:
-    jessie: [python-enum]
     wheezy: [python-enum]
   ubuntu: [python-enum]
 python-enum34:
   debian:
     buster: [python-enum34]
-    jessie: [python-enum34]
     stretch: [python-enum34]
   gentoo: [virtual/python-enum34]
   nixos: [pythonPackages.enum34]
@@ -1722,7 +1711,6 @@ python-fuzzywuzzy-pip:
 python-fysom:
   debian:
     buster: [python-fysom]
-    jessie: [python-fysom]
     stretch: [python-fysom]
   fedora:
     pip:
@@ -1819,7 +1807,6 @@ python-github-pip:
 python-gitlab:
   debian:
     '*': [python-gitlab]
-    jessie:
       pip:
         packages: [python-gitlab]
     stretch:
@@ -1931,7 +1918,6 @@ python-googleapi:
 python-gpiozero:
   debian:
     buster: [python-gpiozero]
-    jessie:
       pip:
         packages: [gpiozero]
     stretch:
@@ -1968,7 +1954,6 @@ python-gputil-pip:
 python-gpxpy:
   debian:
     buster: [python-gpxpy]
-    jessie:
       pip:
         packages: [gpxpy]
     stretch: [python-gpxpy]
@@ -2014,7 +1999,6 @@ python-gridfs:
 python-grpc-tools:
   debian:
     '*': [python-grpc-tools]
-    jessie:
       pip: [grpcio-tools]
     stretch:
       pip: [grpcio-tools]
@@ -2028,7 +2012,6 @@ python-grpc-tools:
 python-grpcio:
   debian:
     '*': [python-grpcio]
-    jessie:
       pip: [grpcio]
     stretch:
       pip: [grpcio]
@@ -2055,14 +2038,12 @@ python-grpcio-testing-pip:
 python-gst:
   arch: [gstreamer0.10-python]
   debian:
-    jessie: [python-gst0.10]
     wheezy: [python-gst0.10]
   gentoo: [dev-python/gst-python]
   ubuntu:
 python-gst-1.0:
   debian:
     buster: [python-gst-1.0]
-    jessie: [python-gst-1.0]
     stretch: [python-gst-1.0]
   gentoo: ['dev-python/gst-python:1.0']
   openembedded: [gstreamer1.0-python@openembedded-core]
@@ -2119,7 +2100,6 @@ python-hypothesis:
 python-imageio:
   debian:
     '*': [python-imageio]
-    jessie:
       pip:
         packages: [imageio]
     stretch:
@@ -2145,7 +2125,6 @@ python-imaging:
   arch: [python2-pillow]
   debian:
     '*': [python-pil]
-    jessie: [python-imaging]
     stretch: [python-imaging]
   fedora: [python-pillow, python-pillow-qt]
   freebsd: [py27-pillow]
@@ -2176,7 +2155,6 @@ python-impacket:
 python-influxdb:
   debian:
     buster: [python-influxdb]
-    jessie: [python-influxdb]
   nixos: [pythonPackages.influxdb]
   ubuntu:
     bionic: [python-influxdb]
@@ -2222,7 +2200,6 @@ python-is-python3:
 python-itsdangerous:
   debian:
     buster: [python-itsdangerous]
-    jessie: [python-itsdangerous]
     stretch: [python-itsdangerous]
   fedora: [python-itsdangerous]
   gentoo: [dev-python/itsdangerous]
@@ -2308,7 +2285,6 @@ python-jwt:
 python-kdtree:
   debian:
     buster: [python-kdtree]
-    jessie: [python-kdtree]
     stretch: [python-kdtree]
   ubuntu:
     pip:
@@ -2692,7 +2668,6 @@ python-netifaces:
 python-networkmanager:
   debian:
     buster: [python-networkmanager]
-    jessie: [python-networkmanager]
     stretch: [python-networkmanager]
   ubuntu: [python-networkmanager]
 python-networkx:
@@ -2878,7 +2853,6 @@ python-pandas:
 python-parameterized:
   debian:
     '*': [python-parameterized]
-    jessie:
       pip:
         packages: [parameterized]
     stretch:
@@ -3425,7 +3399,6 @@ python-pypng:
       packages: [pypng]
   debian:
     buster: [python-png]
-    jessie:
       pip:
         packages: [pypng]
     stretch:
@@ -3459,7 +3432,6 @@ python-pyqrcode:
   arch: [python2-qrcode]
   debian:
     buster: [python-pyqrcode]
-    jessie:
       pip:
         packages: [PyQRCode]
     stretch:
@@ -3657,7 +3629,6 @@ python-qt-bindings:
   arch: [python2-pyqt4]
   debian:
     buster: [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
-    jessie: [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
     squeeze: [python-qt4, python-qt4-dev, python-sip-dev]
     stretch: [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
     wheezy: [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
@@ -3692,7 +3663,6 @@ python-qt5-bindings:
   arch: [python2-pyqt5]
   debian:
     buster: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev, qtbase5-dev]
-    jessie: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev, qtbase5-dev]
     stretch: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev, qtbase5-dev]
   fedora: [python-qt5-devel, sip]
   freebsd: [py27-qt5]
@@ -3708,7 +3678,6 @@ python-qt5-bindings-gl:
   arch: [python2-pyqt5]
   debian:
     buster: [python-pyqt5.qtopengl]
-    jessie: [python-pyqt5.qtopengl]
     stretch: [python-pyqt5.qtopengl]
   fedora: [python-qt5]
   freebsd: [py27-qt5-opengl]
@@ -3731,7 +3700,6 @@ python-qt5-bindings-webkit:
   arch: [python2-pyqt5]
   debian:
     buster: [python-pyqt5.qtwebkit]
-    jessie: [python-pyqt5.qtwebkit]
     stretch: [python-pyqt5.qtwebkit]
   fedora: [python-qt5]
   freebsd: [py27-qt5-webkit]
@@ -3925,7 +3893,6 @@ python-rospkg-modules:
 python-rpi.gpio:
   debian:
     buster: [python-rpi.gpio]
-    jessie:
       pip:
         packages: [RPi.GPIO]
     stretch:
@@ -3966,7 +3933,6 @@ python-rtree:
 python-ruamel.yaml:
   debian:
     buster: [python-ruamel.yaml]
-    jessie: [python-ruamel.yaml]
     stretch: [python-ruamel.yaml]
   fedora: [python-ruamel-yaml]
   nixos: [pythonPackages.ruamel_yaml]
@@ -4098,7 +4064,6 @@ python-setuptools:
 python-sexpdata:
   debian:
     '*': [python-sexpdata]
-    jessie:
       pip:
         packages: [sexpdata]
     stretch:
@@ -4292,7 +4257,6 @@ python-sphinx-argparse:
 python-sphinx-rtd-theme:
   debian:
     buster: [python-sphinx-rtd-theme]
-    jessie: [python-sphinx-rtd-theme]
     stretch: [python-sphinx-rtd-theme]
   opensuse: [python2-sphinx_rtd_theme]
   ubuntu:
@@ -4329,7 +4293,6 @@ python-statsd:
 python-subprocess32:
   debian:
     '*': [python-subprocess32]
-    jessie: null
   gentoo: [dev-python/subprocess32]
   ubuntu:
     '*': [python-subprocess32]
@@ -4343,7 +4306,6 @@ python-support:
 python-svg.path:
   debian:
     '*': [python-svg.path]
-    jessie:
       pip:
         packages: [svg.path]
   fedora: [python-svg-path]
@@ -4499,7 +4461,6 @@ python-tensorflow-serving-api-pip:
 python-termcolor:
   debian:
     buster: [python-termcolor]
-    jessie: [python-termcolor]
     stretch: [python-termcolor]
     wheezy:
       pip:
@@ -4527,7 +4488,6 @@ python-texttable:
   arch: [python2-texttable]
   debian:
     buster: [python-texttable]
-    jessie: [python-texttable]
     stretch: [python-texttable]
   fedora: [python-texttable]
   gentoo: [dev-python/texttable]
@@ -4549,7 +4509,6 @@ python-theano:
   arch: [python-theano]
   debian:
     buster: [python-theano]
-    jessie:
       pip:
         packages: [Theano]
     stretch: [python-theano]
@@ -4741,7 +4700,6 @@ python-twisted-web:
 python-twitter:
   debian:
     buster: [python-twitter]
-    jessie: [python-twitter]
     stretch: [python-twitter]
   fedora: [python-twitter]
   gentoo: [dev-python/python-twitter]
@@ -5063,7 +5021,6 @@ python-xmlplain-pip:
 python-xmltodict:
   debian:
     buster: [python-xmltodict]
-    jessie: [python-xmltodict]
     stretch: [python-xmltodict]
   fedora: [python-xmltodict]
   gentoo: [dev-python/xmltodict]
@@ -5505,7 +5462,6 @@ python3-cantools-pip:
 python3-catkin-lint:
   debian:
     '*': [python3-catkin-lint]
-    jessie: null
     stretch: null
   fedora: [python3-catkin_lint]
   openembedded: [python3-catkin-lint@meta-ros-common]
@@ -6008,7 +5964,6 @@ python3-evdev:
   arch: [python-evdev]
   debian:
     '*': [python3-evdev]
-    jessie: null
     stretch: null
   fedora: [python3-evdev]
   gentoo: [dev-python/python-evdev]
@@ -6416,7 +6371,6 @@ python3-github:
 python3-gitlab:
   debian:
     '*': [python3-gitlab]
-    jessie:
       pip:
         packages: [python-gitlab]
     stretch:
@@ -7125,7 +7079,6 @@ python3-netifaces:
 python3-networkmanager:
   debian:
     buster: [python3-networkmanager]
-    jessie: [python3-networkmanager]
   fedora: [python3-networkmanager]
   ubuntu: [python3-networkmanager]
 python3-networkx:
@@ -7429,7 +7382,6 @@ python3-pep8:
   alpine: [py3-pycodestyle]
   debian:
     buster: [python3-pep8]
-    jessie: [python3-pep8]
     stretch: [python3-pep8]
   gentoo: [dev-python/pep8]
   nixos: [python3Packages.pep8]
@@ -7720,7 +7672,6 @@ python3-pydantic:
     '*': [python3-pydantic]
     buster:
       pip: [pydantic]
-    jessie:
       pip: [pydantic]
     stretch:
       pip: [pydantic]
@@ -7878,7 +7829,6 @@ python3-pymap3d:
   debian:
     '*': [python3-pymap3d]
     buster: null
-    jessie: null
     stretch: null
   gentoo: [sci-geosciences/pymap3d]
   ubuntu:
@@ -8205,7 +8155,6 @@ python3-qt5-bindings:
   arch: [python-pyqt5]
   debian:
     '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2]
-    jessie: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
     stretch: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
   fedora: [python3-qt5-devel, python3-sip-devel, libXext-devel]
   gentoo: [dev-python/PyQt5]
@@ -8432,7 +8381,6 @@ python3-rtree:
 python3-ruamel.yaml:
   debian:
     buster: [python3-ruamel.yaml]
-    jessie: [python3-ruamel.yaml]
     stretch: [python3-ruamel.yaml]
   fedora: [python3-ruamel-yaml]
   nixos: [python3Packages.ruamel_yaml]
@@ -8569,7 +8517,6 @@ python3-setuptools:
 python3-sexpdata:
   debian:
     '*': [python3-sexpdata]
-    jessie:
       pip:
         packages: [sexpdata]
     stretch:
@@ -9523,7 +9470,6 @@ wxpython:
   arch: [wxpython]
   debian:
     buster: [python-wxgtk3.0]
-    jessie: [python-wxgtk3.0]
     squeeze: [python-wxgtk2.8]
     stretch: [python-wxgtk3.0]
     wheezy: [python-wxgtk2.8]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -818,14 +818,17 @@ python-can:
   arch:
     pip:
       packages: [python-can]
-  debian: [python-can]
+  debian:
+    buster: [python-can]
+    stretch: [python-can]
   fedora:
     pip:
       packages: [python-can]
   osx:
     pip:
       packages: [python-can]
-  ubuntu: [python-can]
+  ubuntu:
+    bionic: [python-can]
 python-cantools-pip:
   debian:
     pip:
@@ -998,7 +1001,9 @@ python-clearsilver:
     '7': [python-clearsilver]
   ubuntu: [python-clearsilver]
 python-click:
-  debian:  [python-click]
+  debian:
+    buster: [python-click]
+    stretch: [python-click]
   fedora: [python-click]
   gentoo: [dev-python/click]
   nixos: [pythonPackages.click]
@@ -1006,7 +1011,8 @@ python-click:
   osx:
     pip:
       packages: [click]
-  ubuntu: [python-click]
+  ubuntu:
+    bionic: [python-click]
 python-cobs-pip:
   debian:
     pip:
@@ -1493,12 +1499,15 @@ python-fixtures:
   gentoo: [dev-python/fixtures]
   ubuntu: [python-fixtures]
 python-flake8:
-  debian: [python-flake8]
+  debian:
+    buster: [python-flake8]
+    stretch: [python-flake8]
   fedora: [python-flake8]
   gentoo: [dev-python/flake8]
   nixos: [python3Packages.flake8]
   openembedded: ['${PYTHON_PN}-flake8@meta-ros-common']
-  ubuntu: [python-flake8]
+  ubuntu:
+    bionic: [python-flake8]
 python-flask:
   arch: [python-flask]
   debian: [python-flask]
@@ -1578,7 +1587,8 @@ python-future:
   osx:
     pip:
       packages: [future]
-  ubuntu: [python-future]
+  ubuntu:
+    bionic: [python-future]
 python-fuzzywuzzy-pip:
   debian:
     pip:
@@ -1686,8 +1696,11 @@ python-github-pip:
     pip:
       packages: [PyGithub]
 python-gitlab:
-  debian: [python-gitlab]
-  ubuntu: [python-gitlab]
+  debian:
+    buster: [python-gitlab]
+    stretch: [python-gitlab]
+  ubuntu:
+    bionic: [python-gitlab]
 python-gitpython-pip:
   ubuntu:
     pip:
@@ -1909,7 +1922,7 @@ python-hypothesis:
     '*': [python-hypothesis]
 python-imageio:
   debian:
-    '*': [python-imageio]
+    buster: [python-imageio]
     stretch:
       pip:
         packages: [imageio]
@@ -1919,7 +1932,8 @@ python-imageio:
   gentoo: [dev-python/imageio]
   nixos: [pythonPackages.imageio]
   opensuse: [python2-imageio]
-  ubuntu: [python-imageio]
+  ubuntu:
+    bionic: [python-imageio]
 python-imaging:
   alpine: [py-imaging]
   arch: [python2-pillow]
@@ -2387,7 +2401,9 @@ python-nclib-pip:
     pip:
       packages: [nclib]
 python-netaddr:
-  debian: [python-netaddr]
+  debian:
+    buster: [python-netaddr]
+    stretch: [python-netaddr]
   fedora:
     pip:
       packages: [netaddr]
@@ -2395,7 +2411,8 @@ python-netaddr:
   osx:
     pip:
       packages: [netaddr]
-  ubuntu: [python-netaddr]
+  ubuntu:
+    bionic: [python-netaddr]
 python-netcdf4:
   arch: [python-netcdf4]
   debian: [python-netcdf4]
@@ -2617,7 +2634,8 @@ python-parameterized:
   osx:
     pip:
       packages: [parameterized]
-  ubuntu: [python-parameterized]
+  ubuntu:
+    bionic: [python-parameterized]
 python-paramiko:
   alpine: [py-paramiko]
   arch: [python2-paramiko]
@@ -3131,7 +3149,8 @@ python-pypng:
         packages: [pypng]
   fedora: [python-pypng]
   gentoo: [dev-python/pypng]
-  ubuntu: [python-png]
+  ubuntu:
+    bionic: [python-png]
 python-pypozyx-pip:
   ubuntu:
     pip:
@@ -3156,7 +3175,8 @@ python-pyqrcode:
       pip:
         packages: [PyQRCode]
   gentoo: [dev-python/pyqrcode]
-  ubuntu: [python-pyqrcode]
+  ubuntu:
+    bionic: [python-pyqrcode]
 python-pyqtgraph:
   debian: [python-pyqtgraph]
   fedora:
@@ -3668,7 +3688,8 @@ python-seaborn:
     pip:
       packages: [seaborn]
   gentoo: [dev-python/seaborn]
-  ubuntu: [python-seaborn]
+  ubuntu:
+    bionic: [python-seaborn]
 python-selectors2-pip:
   arch:
     pip:
@@ -3746,10 +3767,13 @@ python-sexpdata:
       pip:
         packages: [sexpdata]
 python-sh:
-  debian: [python-sh]
+  debian:
+    buster: [python-sh]
+    stretch: [python-sh]
   fedora: [python-sh]
   gentoo: [dev-python/sh]
-  ubuntu: [python-sh]
+  ubuntu:
+    bionic: [python-sh]
 python-shapely:
   debian: [python-shapely]
   fedora: [python-shapely]
@@ -3802,14 +3826,17 @@ python-six:
   openembedded: ['${PYTHON_PN}-six@openembedded-core']
   ubuntu: [python-six]
 python-skimage:
-  debian: [python-skimage]
+  debian:
+    buster: [python-skimage]
+    stretch: [python-skimage]
   fedora: [python-scikit-image]
   gentoo: [sci-libs/scikits_image]
   nixos: [pythonPackages.scikitimage]
   osx:
     pip:
       packages: [scikit-image]
-  ubuntu: [python-skimage]
+  ubuntu:
+    bionic: [python-skimage]
 python-skimage-pip:
   osx:
     pip:
@@ -3956,9 +3983,12 @@ python-support:
       packages: []
   ubuntu: [python-support]
 python-svg.path:
-  debian: [python-svg.path]
+  debian:
+    buster: [python-svg.path]
+    stretch: [python-svg.path]
   fedora: [python-svg-path]
-  ubuntu: [python-svg.path]
+  ubuntu:
+    bionic: [python-svg.path]
 python-svn:
   debian: [python-svn]
   gentoo: [dev-python/pysvn]
@@ -4138,7 +4168,8 @@ python-texttable:
   osx:
     pip:
       packages: [texttable]
-  ubuntu: [python-texttable]
+  ubuntu:
+    bionic: [python-texttable]
 python-tftpy:
   debian: [python-tftpy]
   fedora: [python-tftpy]
@@ -4207,7 +4238,8 @@ python-tqdm:
     buster: [python-tqdm]
     stretch: [python-tqdm]
   fedora: [python-tqdm]
-  ubuntu: [python-tqdm]
+  ubuntu:
+    bionic: [python-tqdm]
 python-transforms3d-pip:
   debian:
     pip:
@@ -4327,8 +4359,11 @@ python-tzlocal-pip:
     pip:
       packages: [tzlocal]
 python-ubjson:
-  debian: [python-ubjson]
-  ubuntu: [python-ubjson]
+  debian:
+    buster: [python-ubjson]
+    stretch: [python-ubjson]
+  ubuntu:
+    bionic: [python-ubjson]
 python-ujson:
   debian:
     buster: [python-ujson]
@@ -4339,7 +4374,8 @@ python-ujson:
   osx:
     pip:
       packages: [ujson]
-  ubuntu: [python-ujson]
+  ubuntu:
+    bionic: [python-ujson]
 python-unittest2:
   debian: [python-unittest2]
   nixos: [pythonPackages.unittest2]
@@ -9029,10 +9065,13 @@ wxpython:
     '*': [python-wxgtk3.0]
 yapf:
   arch: [yapf]
-  debian: [yapf]
+  debian:
+    buster: [yapf]
+    stretch: [yapf]
   nixos: [python3Packages.yapf]
   opensuse: [python2-yapf]
-  ubuntu: [yapf]
+  ubuntu:
+    bionic: [yapf]
 yapf3:
   debian: [yapf3]
   fedora: [python3-yapf]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -509,17 +509,12 @@ python:
     raring: [python-dev]
     saucy: [python-dev]
     trusty: [python-dev]
-    trusty_python3: [python3-dev]
     utopic: [python-dev]
     vivid: [python-dev]
     wily: [python-dev]
-    wily_python3: [python3-dev]
     xenial: [python-dev]
-    xenial_python3: [python3-dev]
     yakkety: [python-dev]
-    yakkety_python3: [python3-dev]
     zesty: [python-dev]
-    zesty_python3: [python3-dev]
 python-absl-py-pip:
   debian:
     pip:
@@ -804,7 +799,6 @@ python-bloom:
   gentoo: [dev-python/bloom]
   ubuntu:
     '*': [python-bloom]
-    trusty_python3: [python3-bloom]
 python-bluez:
   arch: [python2-pybluez]
   debian: [python-bluez]
@@ -1026,13 +1020,10 @@ python-catkin-pkg:
     raring: [python-catkin-pkg]
     saucy: [python-catkin-pkg]
     trusty: [python-catkin-pkg]
-    trusty_python3: [python3-catkin-pkg]
     utopic: [python-catkin-pkg]
     vivid: [python-catkin-pkg]
     wily: [python-catkin-pkg]
-    wily_python3: [python3-catkin-pkg]
     xenial: [python-catkin-pkg]
-    xenial_python3: [python3-catkin-pkg]
     yakkety: [python-catkin-pkg]
     zesty: [python-catkin-pkg]
 python-catkin-pkg-modules:
@@ -1319,7 +1310,6 @@ python-coverage:
     raring: [python-coverage]
     saucy: [python-coverage]
     trusty: [python-coverage]
-    trusty_python3: [python3-coverage]
     utopic: [python-coverage]
     vivid: [python-coverage]
     wily: [python-coverage]
@@ -1379,9 +1369,7 @@ python-crypto:
       packages: [pycrypto]
   ubuntu:
     artful: [python-crypto]
-    artful_python3: [python3-crypto]
     bionic: [python-crypto]
-    bionic_python3: [python3-crypto]
     lucid: [python-crypto]
     maverick: [python-crypto]
     natty: [python-crypto]
@@ -1392,17 +1380,11 @@ python-crypto:
     saucy: [python-crypto]
     trusty: [python-crypto]
     utopic: [python-crypto]
-    utopic_python3: [python3-crypto]
     vivid: [python-crypto]
-    vivid_python3: [python3-crypto]
     wily: [python-crypto]
-    wily_python3: [python3-crypto]
     xenial: [python-crypto]
-    xenial_python3: [python3-crypto]
     yakkety: [python-crypto]
-    yakkety_python3: [python3-crypto]
     zesty: [python-crypto]
-    zesty_python3: [python3-crypto]
 python-cryptography:
   debian: [python-cryptography]
   gentoo: [dev-python/cryptography]
@@ -1474,23 +1456,14 @@ python-debian:
   gentoo: [dev-python/python-debian]
   ubuntu:
     artful: [python-debian]
-    artful_python3: [python3-debian]
     bionic: [python-debian]
-    bionic_python3: [python3-debian]
     trusty: [python-debian]
-    trusty_python3: [python3-debian]
     utopic: [python-debian]
-    utopic_python3: [python3-debian]
     vivid: [python-debian]
-    vivid_python3: [python3-debian]
     wily: [python-debian]
-    wily_python3: [python3-debian]
     xenial: [python-debian]
-    xenial_python3: [python3-debian]
     yakkety: [python-debian]
-    yakkety_python3: [python3-debian]
     zesty: [python-debian]
-    zesty_python3: [python3-debian]
 python-decorator:
   debian: [python-decorator]
   gentoo: [dev-python/decorator]
@@ -1598,11 +1571,8 @@ python-docutils:
     raring: [python-docutils]
     saucy: [python-docutils]
     trusty: [python-docutils]
-    trusty_python3: [python3-docutils]
     utopic: [python-docutils]
-    utopic_python3: [python3-docutils]
     vivid: [python-docutils]
-    vivid_python3: [python3-docutils]
     wily: [python-docutils]
     xenial: [python-docutils]
 python-docx:
@@ -1684,7 +1654,6 @@ python-espeak:
     raring: [python-espeak]
     saucy: [python-espeak]
     trusty: [python-espeak]
-    trusty_python3: [python3-espeak]
 python-evdev:
   gentoo: [dev-python/python-evdev]
   ubuntu: [python-evdev]
@@ -1792,7 +1761,6 @@ python-flake8:
   openembedded: ['${PYTHON_PN}-flake8@meta-ros-common']
   ubuntu:
     '*': [python-flake8]
-    trusty_python3: [python3-flake8]
 python-flask:
   arch: [python-flask]
   debian: [python-flask]
@@ -1801,7 +1769,6 @@ python-flask:
   nixos: [pythonPackages.flask]
   ubuntu:
     '*': [python-flask]
-    trusty_python3: [python3-flask]
 python-flask-appbuilder-pip:
   debian:
     pip:
@@ -2237,7 +2204,6 @@ python-gridfs:
     raring: [python-gridfs]
     saucy: [python-gridfs]
     trusty: [python-gridfs]
-    trusty_python3: [python3-gridfs]
 python-grpc-tools:
   debian:
     '*': [python-grpc-tools]
@@ -2346,23 +2312,18 @@ python-h5py:
   opensuse: [python2-h5py]
   ubuntu:
     '*': [python-h5py]
-    trusty_python3: [python3-h5py]
 python-httplib2:
   debian: [python-httplib2]
   fedora: [python-httplib2]
   gentoo: [dev-python/httplib2]
   ubuntu:
     '*': [python-httplib2]
-    trusty_python3: [python3-httplib2]
 python-hypothesis:
   debian: [python-hypothesis]
   fedora: [python-hypothesis]
   gentoo: [dev-python/hypothesis]
   ubuntu:
     '*': [python-hypothesis]
-    xenial_python3: [python3-hypothesis]
-    yakkety_python3: [python3-hypothesis]
-    zesty_python3: [python3-hypothesis]
 python-imageio:
   debian:
     '*': [python-imageio]
@@ -2423,17 +2384,12 @@ python-imaging:
     raring: [python-imaging]
     saucy: [python-imaging]
     trusty: [python-imaging]
-    trusty_python3: [python3-imaging]
     utopic: [python-imaging]
     vivid: [python-imaging]
     wily: [python-imaging]
-    wily_python3: [python3-imaging]
     xenial: [python-imaging]
-    xenial_python3: [python3-imaging]
     yakkety: [python-imaging]
-    yakkety_python3: [python3-imaging]
     zesty: [python-imaging]
-    zesty_python3: [python3-imaging]
 python-imaging-imagetk:
   debian: [python-pil.imagetk]
   ubuntu: [python-pil.imagetk]
@@ -2792,19 +2748,12 @@ python-matplotlib:
     raring: [python-matplotlib]
     saucy: [python-matplotlib]
     trusty: [python-matplotlib]
-    trusty_python3: [python3-matplotlib]
     utopic: [python-matplotlib]
-    utopic_python3: [python3-matplotlib]
     vivid: [python-matplotlib]
-    vivid_python3: [python3-matplotlib]
     wily: [python-matplotlib]
-    wily_python3: [python3-matplotlib]
     xenial: [python-matplotlib]
-    xenial_python3: [python3-matplotlib]
     yakkety: [python-matplotlib]
-    yakkety_python3: [python3-matplotlib]
     zesty: [python-matplotlib]
-    zesty_python3: [python3-matplotlib]
 python-mechanize:
   arch: [python2-mechanize]
   debian: [python-mechanize]
@@ -2849,13 +2798,10 @@ python-mock:
     raring: [python-mock]
     saucy: [python-mock]
     trusty: [python-mock]
-    trusty_python3: [python3-mock]
     utopic: [python-mock]
     vivid: [python-mock]
     wily: [python-mock]
-    wily_python3: [python3-mock]
     xenial: [python-mock]
-    xenial_python3: [python3-mock]
     yakkety: [python-mock]
     zesty: [python-mock]
 python-monotonic:
@@ -2983,7 +2929,6 @@ python-netaddr:
       pip:
         packages: [netaddr]
     trusty: [python-netaddr]
-    trusty_python3: [python3-netaddr]
     utopic: [python-netaddr]
     vivid: [python-netaddr]
     xenial: [python-netaddr]
@@ -3027,17 +2972,12 @@ python-netifaces:
     raring: [python-netifaces]
     saucy: [python-netifaces]
     trusty: [python-netifaces]
-    trusty_python3: [python3-netifaces]
     utopic: [python-netifaces]
     vivid: [python-netifaces]
     wily: [python-netifaces]
-    wily_python3: [python3-netifaces]
     xenial: [python-netifaces]
-    xenial_python3: [python3-netifaces]
     yakkety: [python-netifaces]
-    yakkety_python3: [python3-netifaces]
     zesty: [python-netifaces]
-    zesty_python3: [python3-netifaces]
 python-networkmanager:
   debian:
     buster: [python-networkmanager]
@@ -3051,11 +2991,6 @@ python-networkx:
   gentoo: [dev-python/networkx]
   ubuntu:
     '*': [python-networkx]
-    trusty_python3: [python3-networkx]
-    wily_python3: [python3-networkx]
-    xenial_python3: [python3-networkx]
-    yakkety_python3: [python3-networkx]
-    zesty_python3: [python3-networkx]
 python-nose:
   alpine: [py-nose]
   arch: [python2-nose]
@@ -3076,9 +3011,6 @@ python-nose:
   slackware: [nose]
   ubuntu:
     '*': [python-nose]
-    trusty_python3: [python3-nose]
-    wily_python3: [python3-nose]
-    xenial_python3: [python3-nose]
 python-ntplib:
   debian: [python-ntplib]
   fedora: [python-ntplib]
@@ -3211,7 +3143,6 @@ python-opengl:
     raring: [python-opengl]
     saucy: [python-opengl]
     trusty: [python-opengl]
-    trusty_python3: [python3-opengl]
     utopic: [python-opengl]
     vivid: [python-opengl]
     wily: [python-opengl]
@@ -3400,21 +3331,14 @@ python-pep8:
       packages: [pep8]
   ubuntu:
     '*': [python-pep8]
-    artful_python3: [python3-pep8]
-    bionic_python3: [python3-pep8]
-    cosmic_python3: [python3-pep8]
     precise: [pep8]
     quantal: [pep8]
     raring: [pep8]
     saucy: [pep8]
     trusty: [pep8]
-    trusty_python3: [python3-pep8]
     utopic: [pep8]
     vivid: [pep8]
     wily: [pep8]
-    xenial_python3: [python3-pep8]
-    yakkety_python3: [python3-pep8]
-    zesty_python3: [python3-pep8]
 python-percol:
   debian:
     pip:
@@ -3545,7 +3469,6 @@ python-progressbar:
     raring: [python-progressbar]
     saucy: [python-progressbar]
     trusty: [python-progressbar]
-    trusty_python3: [python3-progressbar]
     utopic: [python-progressbar]
     vivid: [python-progressbar]
     wily: [python-progressbar]
@@ -3583,7 +3506,6 @@ python-psutil:
   slackware: [psutil]
   ubuntu:
     '*': [python-psutil]
-    trusty_python3: [python3-psutil]
 python-psycopg2:
   debian: [python-psycopg2]
   fedora: [python-psycopg2]
@@ -3591,8 +3513,6 @@ python-psycopg2:
   ubuntu:
     '*': [python-psycopg2]
     focal: [python3-psycopg2]
-    trusty_python3: [python3-psycopg2]
-    xenial_python3: [python3-psycopg2]
 python-pulsectl-pip:
   debian:
     pip:
@@ -3834,11 +3754,6 @@ python-pymongo:
       packages: [pymongo]
   ubuntu:
     '*': [python-pymongo]
-    trusty_python3: [python3-pymongo]
-    utopic_python3: [python3-pymongo]
-    vivid_python3: [python3-pymongo]
-    wily_python3: [python3-pymongo]
-    xenial_python3: [python3-pymongo]
 python-pymouse:
   debian:
     pip:
@@ -3967,11 +3882,8 @@ python-pyside:
     raring: [python-pyside]
     saucy: [python-pyside]
     trusty: [python-pyside]
-    trusty_python3: [python3-pyside]
     utopic: [python-pyside]
-    utopic_python3: [python3-pyside]
     vivid: [python-pyside]
-    vivid_python3: [python3-pyside]
 python-pyside.qtuitools:
   debian: [python-pyside.qtuitools]
   ubuntu:
@@ -3984,11 +3896,8 @@ python-pyside.qtuitools:
     raring: [python-pyside.qtuitools]
     saucy: [python-pyside.qtuitools]
     trusty: [python-pyside.qtuitools]
-    trusty_python3: [python3-pyside.qtuitools]
     utopic: [python-pyside.qtuitools]
-    utopic_python3: [python3-pyside.qtuitools]
     vivid: [python-pyside.qtuitools]
-    vivid_python3: [python3-pyside.qtuitools]
 python-pysimplegui27-pip:
   debian:
     pip:
@@ -4087,12 +3996,6 @@ python-pyudev:
   openembedded: ['${PYTHON_PN}-pyudev@meta-python']
   ubuntu:
     '*': [python-pyudev]
-    artful_python3: [python3-pyudev]
-    bionic_python3: [python3-pyudev]
-    cosmic_python3: [python3-pyudev]
-    trusty_python3: [python3-pyudev]
-    xenial_python3: [python3-pyudev]
-    zesty_python3: [python3-pyudev]
 python-pyusb-pip:
   debian:
     pip: [pyusb]
@@ -4152,7 +4055,6 @@ python-qt-bindings:
   ubuntu:
     '*': [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
     lucid: [python-qt4, python-qt4-dev, python-sip-dev]
-    trusty_python3: [python3-pyside, libpyside-dev, libshiboken-dev, shiboken, python3-pyqt4, python3-sip-dev]
 python-qt-bindings-gl:
   arch: [python2-pyqt4]
   debian: [python-qt4-gl]
@@ -4278,13 +4180,6 @@ python-requests:
       packages: [requests]
   ubuntu:
     '*': [python-requests]
-    trusty_python3: [python3-requests]
-    utopic_python3: [python3-requests]
-    vivid_python3: [python3-requests]
-    wily_python3: [python3-requests]
-    xenial_python3: [python3-requests]
-    yakkety_python3: [python3-requests]
-    zesty_python3: [python3-requests]
 python-requests-oauthlib:
   debian: [python-requests-oauthlib]
   fedora: [python-requests-oauthlib]
@@ -4331,17 +4226,12 @@ python-rosdep:
     raring: [python-rosdep]
     saucy: [python-rosdep]
     trusty: [python-rosdep]
-    trusty_python3: [python3-rosdep]
     utopic: [python-rosdep]
     vivid: [python-rosdep]
     wily: [python-rosdep]
-    wily_python3: [python3-rosdep]
     xenial: [python-rosdep]
-    xenial_python3: [python3-rosdep]
     yakkety: [python-rosdep]
-    yakkety_python3: [python3-rosdep]
     zesty: [python-rosdep]
-    zesty_python3: [python3-rosdep]
 python-rosdep-modules:
   alpine:
     pip:
@@ -4386,17 +4276,12 @@ python-rosdistro:
     raring: [python-rosdistro]
     saucy: [python-rosdistro]
     trusty: [python-rosdistro]
-    trusty_python3: [python3-rosdistro]
     utopic: [python-rosdistro]
     vivid: [python-rosdistro]
     wily: [python-rosdistro]
-    wily_python3: [python3-rosdistro]
     xenial: [python-rosdistro]
-    xenial_python3: [python3-rosdistro]
     yakkety: [python-rosdistro]
-    yakkety_python3: [python3-rosdistro]
     zesty: [python-rosdistro]
-    zesty_python3: [python3-rosdistro]
 python-rosinstall:
   arch: [python2-rosinstall]
   debian: [python-rosinstall]
@@ -4407,7 +4292,6 @@ python-rosinstall:
     '7': [python-rosinstall]
   ubuntu:
     '*': [python-rosinstall]
-    trusty_python3: [python3-rosinstall]
 python-rosinstall-generator:
   arch: [python2-rosinstall-generator]
   debian:
@@ -4444,13 +4328,6 @@ python-rospkg:
       packages: [rospkg]
   ubuntu:
     '*': [python-rospkg]
-    trusty_python3: [python3-rospkg]
-    utopic_python3: [python3-rospkg]
-    vivid_python3: [python3-rospkg]
-    wily_python3: [python3-rospkg]
-    xenial_python3: [python3-rospkg]
-    yakkety_python3: [python3-rospkg]
-    zesty_python3: [python3-rospkg]
 python-rospkg-modules:
   alpine:
     pip:
@@ -4584,15 +4461,6 @@ python-scipy:
       packages: [scipy]
   ubuntu:
     '*': [python-scipy]
-    artful_python3: [python3-scipy]
-    bionic_python3: [python3-scipy]
-    trusty_python3: [python3-scipy]
-    utopic_python3: [python3-scipy]
-    vivid_python3: [python3-scipy]
-    wily_python3: [python3-scipy]
-    xenial_python3: [python3-scipy]
-    yakkety_python3: [python3-scipy]
-    zesty_python3: [python3-scipy]
 python-scp:
   debian: [python-scp]
   fedora: [python-scp]
@@ -4655,9 +4523,7 @@ python-serial:
   opensuse: [python2-pyserial]
   ubuntu:
     artful: [python-serial]
-    artful_python3: [python3-serial]
     bionic: [python-serial]
-    bionic_python3: [python3-serial]
     lucid: [python-serial]
     maverick: [python-serial]
     natty: [python-serial]
@@ -4667,19 +4533,12 @@ python-serial:
     raring: [python-serial]
     saucy: [python-serial]
     trusty: [python-serial]
-    trusty_python3: [python3-serial]
     utopic: [python-serial]
-    utopic_python3: [python3-serial]
     vivid: [python-serial]
-    vivid_python3: [python3-serial]
     wily: [python-serial]
-    wily_python3: [python3-serial]
     xenial: [python-serial]
-    xenial_python3: [python3-serial]
     yakkety: [python-serial]
-    yakkety_python3: [python3-serial]
     zesty: [python-serial]
-    zesty_python3: [python3-serial]
 python-setproctitle:
   debian: [python-setproctitle]
   ubuntu: [python-setproctitle]
@@ -4710,15 +4569,10 @@ python-setuptools:
     raring: [python-setuptools]
     saucy: [python-setuptools]
     trusty: [python-setuptools]
-    trusty_python3: [python3-setuptools]
     utopic: [python-setuptools]
-    utopic_python3: [python3-setuptools]
     vivid: [python-setuptools]
-    vivid_python3: [python3-setuptools]
     wily: [python-setuptools]
-    wily_python3: [python3-setuptools]
     xenial: [python-setuptools]
-    xenial_python3: [python3-setuptools]
     yakkety: [python-setuptools]
     zesty: [python-setuptools]
 python-sexpdata:
@@ -4756,12 +4610,6 @@ python-shapely:
       packages: [shapely]
   ubuntu:
     '*': [python-shapely]
-    trusty_python3: [python3-shapely]
-    utopic_python3: [python3-shapely]
-    vivid_python3: [python3-shapely]
-    wily_python3: [python3-shapely]
-    xenial_python3: [python3-shapely]
-    yakkety_python3: [python3-shapely]
 python-simplejson:
   arch: [python2-simplejson]
   debian: [python-simplejson]
@@ -4791,8 +4639,6 @@ python-sip:
       packages: [sip]
   ubuntu:
     '*': [python-sip-dev]
-    bionic_python3: [python3-sip-dev]
-    xenial_python3: [python3-sip-dev]
 python-sip4:
   debian: [python-sip-dev]
   fedora: [sip]
@@ -4927,23 +4773,16 @@ python-sphinx:
     '7': [python-sphinx]
   ubuntu:
     '*': [python-sphinx]
-    trusty_python3: [python3-sphinx]
-    xenial_python3: [python3-sphinx]
 python-sphinx-argparse:
   debian:
     buster: [python-sphinx-argparse]
     stretch: [python-sphinx-argparse]
   ubuntu:
     artful: [python-sphinx-argparse]
-    artful_python3: [python3-sphinx-argparse]
     bionic: [python-sphinx-argparse]
-    bionic_python3: [python3-sphinx-argparse]
     xenial: [python-sphinx-argparse]
-    xenial_python3: [python3-sphinx-argparse]
     yakkety: [python-sphinx-argparse]
-    yakkety_python3: [python3-sphinx-argparse]
     zesty: [python-sphinx-argparse]
-    zesty_python3: [python3-sphinx-argparse]
 python-sphinx-rtd-theme:
   debian:
     buster: [python-sphinx-rtd-theme]
@@ -4952,15 +4791,10 @@ python-sphinx-rtd-theme:
   opensuse: [python2-sphinx_rtd_theme]
   ubuntu:
     artful: [python-sphinx-rtd-theme]
-    artful_python3: [python3-sphinx-rtd-theme]
     bionic: [python-sphinx-rtd-theme]
-    bionic_python3: [python3-sphinx-rtd-theme]
     xenial: [python-sphinx-rtd-theme]
-    xenial_python3: [python3-sphinx-rtd-theme]
     yakkety: [python-sphinx-rtd-theme]
-    yakkety_python3: [python3-sphinx-rtd-theme]
     zesty: [python-sphinx-rtd-theme]
-    zesty_python3: [python3-sphinx-rtd-theme]
 python-spidev-pip: &migrate_eol_2025_04_30_python3_spidev_pip
   debian:
     pip:
@@ -4980,12 +4814,10 @@ python-sqlalchemy:
     raring: [python-sqlalchemy]
     saucy: [python-sqlalchemy]
     trusty: [python-sqlalchemy]
-    trusty_python3: [python3-sqlalchemy]
     utopic: [python-sqlalchemy]
     vivid: [python-sqlalchemy]
     wily: [python-sqlalchemy]
     xenial: [python-sqlalchemy]
-    xenial_python3: [python3-sqlalchemy]
 python-sqlite:
   debian: [python-sqlite]
   ubuntu: [python-sqlite]
@@ -5049,9 +4881,7 @@ python-sympy:
     saucy: [python-sympy]
     trusty: [python-sympy]
     wily: [python-sympy]
-    wily_python3: [python3-sympy]
     xenial: [python-sympy]
-    xenial_python3: [python3-sympy]
 python-systemd:
   debian:
     buster: [python-systemd]
@@ -5206,12 +5036,6 @@ python-termcolor:
       packages: [termcolor]
   ubuntu:
     '*': [python-termcolor]
-    artful_python3: [python3-termcolor]
-    bionic_python3: [python3-termcolor]
-    cosmic_python3: [python3-termcolor]
-    trusty_python3: [python3-termcolor]
-    xenial_python3: [python3-termcolor]
-    zesty_python3: [python3-termcolor]
 python-testscenarios:
   debian: [python-testscenarios]
   fedora: [python-testscenarios]
@@ -5307,12 +5131,6 @@ python-tk:
     '8': [python2-tkinter]
   ubuntu:
     '*': [python-tk]
-    bionic_python3: [python3-tk]
-    trusty_python3: [python3-tk]
-    utopic_python3: [python3-tk]
-    vivid_python3: [python3-tk]
-    wily_python3: [python3-tk]
-    xenial_python3: [python3-tk]
 python-toml:
   debian: [python-toml]
   fedora: [python-toml]
@@ -5708,9 +5526,7 @@ python-websocket:
   opensuse: [python2-websocket-client]
   ubuntu:
     artful: [python-websocket]
-    artful_python3: [python3-websocket]
     bionic: [python-websocket]
-    bionic_python3: [python3-websocket]
     precise:
       pip:
         packages: [websocket-client]
@@ -5722,19 +5538,14 @@ python-websocket:
         packages: [websocket-client]
     saucy: [python-websocket-client]
     trusty: [python-websocket]
-    trusty_python3:
       pip:
         packages: [websocket-client]
     utopic: [python-websocket]
-    utopic_python3:
       pip:
         packages: [websocket-client]
     vivid: [python-websocket]
-    vivid_python3: [python3-websocket]
     wily: [python-websocket]
-    wily_python3: [python3-websocket]
     xenial: [python-websocket]
-    xenial_python3: [python3-websocket]
 python-webtest:
   debian: [python-webtest]
   fedora: [python-webtest]
@@ -5870,17 +5681,12 @@ python-yaml:
     raring: [python-yaml]
     saucy: [python-yaml]
     trusty: [python-yaml]
-    trusty_python3: [python3-yaml]
     utopic: [python-yaml]
     vivid: [python-yaml]
     wily: [python-yaml]
-    wily_python3: [python3-yaml]
     xenial: [python-yaml]
-    xenial_python3: [python3-yaml]
     yakkety: [python-yaml]
-    yakkety_python3: [python3-yaml]
     zesty: [python-yaml]
-    zesty_python3: [python3-yaml]
 python-zbar:
   debian: [python-zbar]
   gentoo: ['media-gfx/zbar[python]']
@@ -5893,7 +5699,6 @@ python-zmq:
   nixos: [pythonPackages.pyzmq]
   ubuntu:
     '*': [python-zmq]
-    trusty_python3: [python3-zmq]
 python3:
   alpine: [python3]
   arch: [python]
@@ -10364,7 +10169,6 @@ wxpython:
     raring: [python-wxgtk2.8]
     saucy: [python-wxgtk2.8]
     trusty: [python-wxgtk2.8]
-    trusty_python3: [python-wxgtk2.8]
     utopic: [python-wxgtk2.8]
     vivid: [python-wxgtk2.8]
     wily: [python-wxgtk2.8]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1483,7 +1483,6 @@ python-enum34-pip:
       packages: [enum34]
 python-espeak:
   debian: [python-espeak]
-  ubuntu:
 python-evdev:
   gentoo: [dev-python/python-evdev]
   ubuntu: [python-evdev]
@@ -1981,7 +1980,6 @@ python-graphviz-pip:
 python-gridfs:
   debian: [python-gridfs]
   fedora: [python-pymongo-gridfs]
-  ubuntu:
 python-grpc-tools:
   debian:
     '*': [python-grpc-tools]
@@ -2026,7 +2024,6 @@ python-gst:
   debian:
     wheezy: [python-gst0.10]
   gentoo: [dev-python/gst-python]
-  ubuntu:
 python-gst-1.0:
   debian:
     buster: [python-gst-1.0]
@@ -2735,7 +2732,6 @@ python-oauth2:
     wheezy: [python-oauth2]
   fedora: [python-oauth2]
   gentoo: [dev-python/oauth2]
-  ubuntu:
 python-oauth2client:
   debian: [python-oauth2client]
   fedora: [python-oauth2client]
@@ -2927,7 +2923,6 @@ python-pathos-pip:
       packages: [pathos]
 python-pathtools:
   debian: [python-pathtools]
-  ubuntu:
 python-pbr:
   debian: [python-pbr]
   fedora: [python-pbr]
@@ -3453,10 +3448,8 @@ python-pyside:
   arch: [python2-pyside]
   debian: [python-pyside]
   gentoo: [dev-python/pyside]
-  ubuntu:
 python-pyside.qtuitools:
   debian: [python-pyside.qtuitools]
-  ubuntu:
 python-pysimplegui27-pip:
   debian:
     pip:
@@ -3788,7 +3781,6 @@ python-rosdistro:
       packages: [rosdistro]
   rhel:
     '7': [python2-rosdistro]
-  ubuntu:
 python-rosinstall:
   arch: [python2-rosinstall]
   debian: [python-rosinstall]
@@ -3893,7 +3885,6 @@ python-rpi.gpio-pip:
 python-rrdtool:
   debian: [python-rrdtool]
   gentoo: [net-analyzer/rrdtool]
-  ubuntu:
 python-rtree:
   debian: [python-rtree]
   ubuntu: [python-rtree]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8121,7 +8121,6 @@ python3-qt5-bindings:
   ubuntu:
     '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2]
     bionic: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
-    eoan: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
 python3-qt5-bindings-gl:
   debian: [python3-pyqt5.qtopengl]
   fedora: [python3-qt5]

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -80,7 +80,6 @@ ruby:
   nixos: [ruby]
   ubuntu:
     '*': [ruby]
-    raring: [ruby, ruby-dev]
     saucy: [ruby, ruby-dev]
     trusty: [ruby, ruby-dev]
     utopic: [ruby, ruby-dev]

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -33,7 +33,6 @@ jekyll:
   debian: [jekyll]
   gentoo: [www-apps/jekyll]
   ubuntu:
-    precise:
       gem:
         depends: [ruby1.9.3]
         packages: [jekyll]
@@ -81,7 +80,6 @@ ruby:
   nixos: [ruby]
   ubuntu:
     '*': [ruby]
-    precise: [ruby1.8-dev, libruby1.8, rubygems1.8]
     quantal: [ruby, ruby-dev]
     raring: [ruby, ruby-dev]
     saucy: [ruby, ruby-dev]
@@ -118,7 +116,6 @@ ruby-sass:
   ubuntu: [ruby-sass]
 ruby1.9.3:
   ubuntu:
-    precise: [ruby1.9.3]
 utilrb:
   debian:
     gem: [utilrb]

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -82,7 +82,6 @@ ruby:
     '*': [ruby]
     trusty: [ruby, ruby-dev]
     xenial: [ruby, ruby-dev]
-    zesty: [ruby, ruby-dev]
 ruby-backports:
   debian: [ruby-backports]
   gentoo: [dev-ruby/backports]

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -81,7 +81,6 @@ ruby:
   nixos: [ruby]
   ubuntu:
     '*': [ruby]
-    maverick: [ruby1.8-dev, libruby1.8, rubygems1.8]
     natty: [ruby1.8-dev, libruby1.8, rubygems1.8]
     oneiric: [ruby1.8-dev, libruby1.8, rubygems1.8]
     precise: [ruby1.8-dev, libruby1.8, rubygems1.8]

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -81,7 +81,6 @@ ruby:
   ubuntu:
     '*': [ruby]
     trusty: [ruby, ruby-dev]
-    wily: [ruby, ruby-dev]
     xenial: [ruby, ruby-dev]
     yakkety: [ruby, ruby-dev]
     zesty: [ruby, ruby-dev]

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -81,7 +81,6 @@ ruby:
   nixos: [ruby]
   ubuntu:
     '*': [ruby]
-    natty: [ruby1.8-dev, libruby1.8, rubygems1.8]
     oneiric: [ruby1.8-dev, libruby1.8, rubygems1.8]
     precise: [ruby1.8-dev, libruby1.8, rubygems1.8]
     quantal: [ruby, ruby-dev]

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -15,7 +15,6 @@ facets:
     '*':
       gem: [facets]
     bionic: [ruby-facets]
-    xenial: [ruby-facets]
 flexmock:
   debian: [ruby-flexmock]
   fedora: [rubygem-flexmock]
@@ -80,7 +79,6 @@ ruby:
   nixos: [ruby]
   ubuntu:
     '*': [ruby]
-    xenial: [ruby, ruby-dev]
 ruby-backports:
   debian: [ruby-backports]
   gentoo: [dev-ruby/backports]

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -82,7 +82,6 @@ ruby:
     '*': [ruby]
     trusty: [ruby, ruby-dev]
     xenial: [ruby, ruby-dev]
-    yakkety: [ruby, ruby-dev]
     zesty: [ruby, ruby-dev]
 ruby-backports:
   debian: [ruby-backports]

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -80,7 +80,6 @@ ruby:
   nixos: [ruby]
   ubuntu:
     '*': [ruby]
-    saucy: [ruby, ruby-dev]
     trusty: [ruby, ruby-dev]
     utopic: [ruby, ruby-dev]
     vivid: [ruby, ruby-dev]

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -81,7 +81,6 @@ ruby:
   ubuntu:
     '*': [ruby]
     trusty: [ruby, ruby-dev]
-    vivid: [ruby, ruby-dev]
     wily: [ruby, ruby-dev]
     xenial: [ruby, ruby-dev]
     yakkety: [ruby, ruby-dev]

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -81,7 +81,6 @@ ruby:
   nixos: [ruby]
   ubuntu:
     '*': [ruby]
-    oneiric: [ruby1.8-dev, libruby1.8, rubygems1.8]
     precise: [ruby1.8-dev, libruby1.8, rubygems1.8]
     quantal: [ruby, ruby-dev]
     raring: [ruby, ruby-dev]

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -80,7 +80,6 @@ ruby:
   nixos: [ruby]
   ubuntu:
     '*': [ruby]
-    quantal: [ruby, ruby-dev]
     raring: [ruby, ruby-dev]
     saucy: [ruby, ruby-dev]
     trusty: [ruby, ruby-dev]

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -71,7 +71,6 @@ ruby:
   arch: [ruby]
   debian:
     '*': [ruby]
-    jessie: [ruby, ruby-dev]
     stretch: [ruby, ruby-dev]
   fedora: [ruby, ruby-devel, openssl-devel, rubygems]
   gentoo: [dev-lang/ruby]

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -80,7 +80,6 @@ ruby:
   nixos: [ruby]
   ubuntu:
     '*': [ruby]
-    trusty: [ruby, ruby-dev]
     xenial: [ruby, ruby-dev]
 ruby-backports:
   debian: [ruby-backports]

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -31,10 +31,6 @@ hoe:
 jekyll:
   debian: [jekyll]
   gentoo: [www-apps/jekyll]
-  ubuntu:
-      gem:
-        depends: [ruby1.9.3]
-        packages: [jekyll]
 metaruby:
   debian:
     gem: [metaruby]

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -102,8 +102,6 @@ ruby-sass:
   fedora: [rubygem-sass]
   gentoo: [dev-ruby/sass]
   ubuntu: [ruby-sass]
-ruby1.9.3:
-  ubuntu:
 utilrb:
   debian:
     gem: [utilrb]

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -81,7 +81,6 @@ ruby:
   ubuntu:
     '*': [ruby]
     trusty: [ruby, ruby-dev]
-    utopic: [ruby, ruby-dev]
     vivid: [ruby, ruby-dev]
     wily: [ruby, ruby-dev]
     xenial: [ruby, ruby-dev]

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -81,7 +81,6 @@ ruby:
   nixos: [ruby]
   ubuntu:
     '*': [ruby]
-    lucid: [ruby1.8-dev, libopenssl-ruby1.8, rubygems1.8]
     maverick: [ruby1.8-dev, libruby1.8, rubygems1.8]
     natty: [ruby1.8-dev, libruby1.8, rubygems1.8]
     oneiric: [ruby1.8-dev, libruby1.8, rubygems1.8]


### PR DESCRIPTION
This is a repository cleanup. I have removed all the specific rules for ubuntu distros older than bionic and debian distros older than stretch. 

* Jessie went [out of LTS support in June 2020](https://www.debian.org/releases/jessie/)
* Xenial [left LTS in April of 2021](https://wiki.ubuntu.com/Releases)
* Ardent was [EOL in 2018](https://wiki.ubuntu.com/Releases)

This will hopefully make maintaining the rosdep database a little bit easier with fewer lines to search through. 

The recommendation if you're using an older EOL platform is to use a tag of the rosdistro from the last sync of the rosdistro.