### PR TITLE
ament_cmake: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -105,16 +105,16 @@ repositories:
       - ament_cmake_gtest
       - ament_cmake_include_directories
       - ament_cmake_libraries
-      - ament_cmake_nose
       - ament_cmake_pytest
       - ament_cmake_python
       - ament_cmake_target_dependencies
       - ament_cmake_test
+      - ament_cmake_vendor_package
       - ament_cmake_version
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 1.5.3-6
+      version: 2.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake` to `2.0.0-1`:

- upstream repository: https://github.com/ament/ament_cmake.git
- release repository: https://github.com/ros2-gbp/ament_cmake-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.5.3-6`

## ament_cmake

- No changes

## ament_cmake_auto

```
* Support INTERFACE on ament_auto_add_library (#420 <https://github.com/ament/ament_cmake/issues/420>)
* Contributors: Rin Iwai
```

## ament_cmake_core

```
* ament_cmake_uninstall_target: Correct location of install_manifest.txt (#432 <https://github.com/ament/ament_cmake/issues/432>)
* Contributors: Silvio Traversaro
```

## ament_cmake_export_definitions

- No changes

## ament_cmake_export_dependencies

- No changes

## ament_cmake_export_include_directories

- No changes

## ament_cmake_export_interfaces

- No changes

## ament_cmake_export_libraries

- No changes

## ament_cmake_export_link_flags

- No changes

## ament_cmake_export_targets

- No changes

## ament_cmake_gen_version_h

```
* Changed version gte macro to make it MSVC compatible. Fix #433 <https://github.com/ament/ament_cmake/issues/433> (#434 <https://github.com/ament/ament_cmake/issues/434>)
* Contributors: iquarobotics
```

## ament_cmake_gmock

- No changes

## ament_cmake_google_benchmark

- No changes

## ament_cmake_gtest

- No changes

## ament_cmake_include_directories

- No changes

## ament_cmake_libraries

- No changes

## ament_cmake_pytest

```
* Fix pytest-cov version detection with pytest >=7.0.0 (#436 <https://github.com/ament/ament_cmake/issues/436>)
* use the error handler replace to allow non-utf8 to be decoded (#381 <https://github.com/ament/ament_cmake/issues/381>)
* Contributors: Christophe Bedard, El Jawad Alaa
```

## ament_cmake_python

```
* Support Debian-specific install dir for ament_cmake_python (#431 <https://github.com/ament/ament_cmake/issues/431>)
* Contributors: Timo Röhling
```

## ament_cmake_target_dependencies

- No changes

## ament_cmake_test

```
* use the error handler replace to allow non-utf8 to be decoded (#381 <https://github.com/ament/ament_cmake/issues/381>)
* Contributors: El Jawad Alaa
```

## ament_cmake_vendor_package

```
* Fix the version number of ament_cmake_vendor_package.
* Add ament_cmake_vendor_package package (#429 <https://github.com/ament/ament_cmake/issues/429>)
* Contributors: Chris Lalancette, Scott K Logan
```

## ament_cmake_version

- No changes
