### PR TITLE
python_qt_binding: 1.2.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3539,7 +3539,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/python_qt_binding-release.git
-      version: 1.2.2-5
+      version: 1.2.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `1.2.3-1`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros2-gbp/python_qt_binding-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.2-5`

## python_qt_binding

```
* Fix to allow ninja to use make for generators (#123 <https://github.com/ros-visualization/python_qt_binding/issues/123>)
* Fix flake8 linter regression (#125 <https://github.com/ros-visualization/python_qt_binding/issues/125>)
* Remove pyqt from default binding order for macOS (#118 <https://github.com/ros-visualization/python_qt_binding/issues/118>)
* Contributors: Christoph Hellmann Santos, Cristóbal Arroyo, Michael Carroll, Rhys Mainwaring
```
