### PR TITLE
Add rosdep rules for python3-fpdf2-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7107,6 +7107,16 @@ python3-formant-pip:
   ubuntu:
     pip:
       packages: [formant]
+python3-fpdf2-pip:
+  debian:
+    pip:
+      packages: [fpdf2]
+  fedora:
+    pip:
+      packages: [fpdf2]
+  ubuntu:
+    pip:
+      packages: [fpdf2]
 python3-funcsigs:
   debian: [python3-funcsigs]
   fedora: [python3-funcsigs]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`python3-fpdf2-pip`

## Package Upstream Source:

https://pypi.org/project/fpdf2/

## Purpose of using this:

`fpdf2` is a Python3 library allowing for programmatical creation of PDF documents. Example use cases include automatic generation of project documentation and/or test reports.