### PR TITLE
common_interfaces: 5.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -696,7 +696,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 4.7.0-3
+      version: 5.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_interfaces` to `5.0.0-1`:

- upstream repository: https://github.com/ros2/common_interfaces.git
- release repository: https://github.com/ros2-gbp/common_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.7.0-3`

## actionlib_msgs

- No changes

## common_interfaces

- No changes

## diagnostic_msgs

- No changes

## geometry_msgs

- No changes

## nav_msgs

- No changes

## sensor_msgs

```
* update YUV format codes and documentation (#214 <https://github.com/ros2/common_interfaces/issues/214>)
* sensor_msgs/Range lacks variance field (#181 <https://github.com/ros2/common_interfaces/issues/181>)
* Contributors: Christian Rauch, El Jawad Alaa
```

## sensor_msgs_py

```
* Add missing dep for sensor_msgs_py (#217 <https://github.com/ros2/common_interfaces/issues/217>)
* Contributors: Yadu
```

## shape_msgs

- No changes

## std_msgs

- No changes

## std_srvs

- No changes

## stereo_msgs

- No changes

## trajectory_msgs

- No changes

## visualization_msgs

- No changes
