### PR TITLE
turbojpeg_compressed_image_transport: 0.2.1-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6130,7 +6130,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/turbojpeg_compressed_image_transport-release.git
-      version: 0.2.1-2
+      version: 0.2.1-3
     source:
       type: git
       url: https://github.com/wep21/turbojpeg_compressed_image_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turbojpeg_compressed_image_transport` to `0.2.1-3`:

- upstream repository: https://github.com/wep21/turbojpeg_compressed_image_transport.git
- release repository: https://github.com/ros2-gbp/turbojpeg_compressed_image_transport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.1-2`

## turbojpeg_compressed_image_transport

```
* fix: replace deprecated header
* fix: add missing dependency
* Contributors: Daisuke Nishimatsu
```
