### PR TITLE
geometry2: 0.31.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1500,7 +1500,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.30.0-3
+      version: 0.31.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.31.0-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.30.0-3`

## examples_tf2_py

```
* Enable document generation using rosdoc2 for ament_python pkgs (#587 <https://github.com/ros2/geometry2/issues/587>)
* Contributors: Yadu
```

## geometry2

- No changes

## tf2

```
* Depend on ament_cmake_ros to default SHARED to ON (#591 <https://github.com/ros2/geometry2/issues/591>)
* Fix a potential crash in TimeCache::findClosest (#592 <https://github.com/ros2/geometry2/issues/592>)
* Extend TimeCache API to provide rich ExtrapolationException infos (#586 <https://github.com/ros2/geometry2/issues/586>)
* Contributors: Chris Lalancette, Patrick Roncagliolo, Tyler Weaver
```

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

```
* Add do_transform_polygon_stamped (#582 <https://github.com/ros2/geometry2/issues/582>)
* Contributors: Tony Najjar
```

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Enable TransformListener node-based constructor in Intra-process enabled components (#572 <https://github.com/ros2/geometry2/issues/572>)
* Contributors: Patrick Roncagliolo
```

## tf2_ros_py

```
* Enable document generation using rosdoc2 for ament_python pkgs (#587 <https://github.com/ros2/geometry2/issues/587>)
* Contributors: Yadu
```

## tf2_sensor_msgs

- No changes

## tf2_tools

```
* Enable document generation using rosdoc2 for ament_python pkgs (#587 <https://github.com/ros2/geometry2/issues/587>)
* Contributors: Yadu
```
