### PR TITLE
launch: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2154,7 +2154,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 1.4.1-2
+      version: 2.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `2.0.0-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.4.1-2`

## launch

```
* [rosdoc2] Fix document generation on buildfarm (#701 <https://github.com/ros2/launch/issues/701>)
* Enable document generation using rosdoc2 for ament_python pkgs (#697 <https://github.com/ros2/launch/issues/697>)
* Remove the import of Literal from entity.py. (#694 <https://github.com/ros2/launch/issues/694>)
* Fix flake8 errors. (#695 <https://github.com/ros2/launch/issues/695>)
* add symlink to latest log directory (#686 <https://github.com/ros2/launch/issues/686>)
* Improve type checking (#679 <https://github.com/ros2/launch/issues/679>)
* Contributors: Chris Lalancette, Hervé Audren, Welte, Yadu
```

## launch_pytest

- No changes

## launch_testing

```
* Improve type checking (#679 <https://github.com/ros2/launch/issues/679>)
* Contributors: Hervé Audren
```

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
