### PR TITLE
launch_ros: 0.24.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2189,7 +2189,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.23.0-2
+      version: 0.24.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.24.0-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.23.0-2`

## launch_ros

```
* Use SomeEntitiesType for type checking. (#358 <https://github.com/ros2/launch_ros/issues/358>)
* Contributors: Chris Lalancette
```

## launch_testing_ros

```
* Increase the timeouts in wait_for_topic_launch_test. (#360 <https://github.com/ros2/launch_ros/issues/360>)
* Enable document generation using rosdoc2 (#359 <https://github.com/ros2/launch_ros/issues/359>)
* exit() methods should not reraise the passed-in exception (#357 <https://github.com/ros2/launch_ros/issues/357>)
* Contributors: Chris Lalancette, Giorgio Pintaudi, Yadu
```

## ros2launch

- No changes
