### PR TITLE
rcutils: 6.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3931,7 +3931,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 6.1.1-2
+      version: 6.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `6.2.0-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `6.1.1-2`

## rcutils

```
* Add convenience error handling macros (#421 <https://github.com/ros2/rcutils/issues/421>)
* Calculate the next power-of-two for the user in hash_map_init. (#420 <https://github.com/ros2/rcutils/issues/420>)
* update cast to modern style (#418 <https://github.com/ros2/rcutils/issues/418>)
* Remove deprecated header get_env.h (#417 <https://github.com/ros2/rcutils/issues/417>)
* Updates to rcutils to make rosdoc2 generation happier. (#416 <https://github.com/ros2/rcutils/issues/416>)
* add RCUTILS_LOGGING_AUTOINIT_WITH_ALLOCATOR. (#415 <https://github.com/ros2/rcutils/issues/415>)
* Fix memory leak in string_map.c in rcutils (#411 <https://github.com/ros2/rcutils/issues/411>)
* avoid unnecessary copy for rcutils_char_array_vsprintf. (#412 <https://github.com/ros2/rcutils/issues/412>)
* Contributors: Chris Lalancette, Emerson Knapp, Mario Prats, Nikolai Morin, Tomoya Fujita, methylDragon
```
