### PR TITLE
ros2cli: 0.24.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4596,7 +4596,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.23.0-2
+      version: 0.24.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.24.0-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.23.0-2`

## ros2action

- No changes

## ros2cli

```
* Set automatically_declare_parameters_from_overrides in DirectNode. (#813 <https://github.com/ros2/ros2cli/issues/813>)
* Enable document generation using rosdoc2 (#811 <https://github.com/ros2/ros2cli/issues/811>)
* Contributors: Chris Lalancette, Yadu
```

## ros2cli_test_interfaces

- No changes

## ros2component

```
* Enable document generation using rosdoc2 (#811 <https://github.com/ros2/ros2cli/issues/811>)
* Contributors: Yadu
```

## ros2doctor

```
* Enable document generation using rosdoc2 (#811 <https://github.com/ros2/ros2cli/issues/811>)
  * Fix warnings for ros2component, ros2doctor, ros2interface, and ros2node
* Contributors: Yadu
```

## ros2interface

```
* Enable document generation using rosdoc2 (#811 <https://github.com/ros2/ros2cli/issues/811>)
* Contributors: Yadu
```

## ros2lifecycle

- No changes

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

```
* Enable document generation using rosdoc2 (#811 <https://github.com/ros2/ros2cli/issues/811>)
  * Fix warnings for ros2component, ros2doctor, ros2interface, and ros2node
* Contributors: Yadu
```

## ros2param

- No changes

## ros2pkg

- No changes

## ros2run

- No changes

## ros2service

- No changes

## ros2topic

```
* Fix the type annotation in pub.py. (#814 <https://github.com/ros2/ros2cli/issues/814>)
* Switch to using new event_handler instead of qos_event. (#787 <https://github.com/ros2/ros2cli/issues/787>)
* Contributors: Chris Lalancette
```
