### PR TITLE
rosidl_runtime_py: 0.12.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4932,7 +4932,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
-      version: 0.11.1-2
+      version: 0.12.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_runtime_py` to `0.12.0-1`:

- upstream repository: https://github.com/ros2/rosidl_runtime_py.git
- release repository: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.11.1-2`

## rosidl_runtime_py

```
* Replace the use __slots__ for the appropiate API (#23 <https://github.com/ros2/rosidl_runtime_py/issues/23>)
* fix(typing): get_interface_packages returns a dict (#22 <https://github.com/ros2/rosidl_runtime_py/issues/22>)
* Contributors: Eloy Briceno, 兰陈昕
```
