### PR TITLE
rosidl_dynamic_typesupport: 0.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4905,6 +4905,22 @@ repositories:
       url: https://github.com/ros2/rosidl_defaults.git
       version: rolling
     status: maintained
+  rosidl_dynamic_typesupport:
+    doc:
+      type: git
+      url: https://github.com/ros2-gbp/rosidl_dynamic_typesupport.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_dynamic_typesupport-release.git
+      version: 0.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_dynamic_typesupport.git
+      version: rolling
+    status: maintained
   rosidl_python:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4908,7 +4908,7 @@ repositories:
   rosidl_dynamic_typesupport:
     doc:
       type: git
-      url: https://github.com/ros2-gbp/rosidl_dynamic_typesupport.git
+      url: https://github.com/ros2/rosidl_dynamic_typesupport.git
       version: rolling
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_dynamic_typesupport` to `0.0.2-1`:

- upstream repository: https://github.com/ros2/rosidl_dynamic_typesupport.git
- release repository: https://github.com/ros2-gbp/rosidl_dynamic_typesupport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## rosidl_dynamic_typesupport

```
* Refactor dynamic message type support impl to use allocators (#2 <https://github.com/ros2/rosidl_dynamic_typesupport/issues/2>)
* Runtime Interface Reflection: rosidl_dynamic_typesupport (#1 <https://github.com/ros2/rosidl_dynamic_typesupport/issues/1>)
* Contributors: methylDragon, William Woodall
```
