### PR TITLE
osrf_testing_tools_cpp: 1.5.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3112,7 +3112,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/osrf_testing_tools_cpp-release.git
-      version: 1.5.1-2
+      version: 1.5.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `osrf_testing_tools_cpp` to `1.5.3-1`:

- upstream repository: https://github.com/osrf/osrf_testing_tools_cpp.git
- release repository: https://github.com/ros2-gbp/osrf_testing_tools_cpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.5.1-2`

## osrf_testing_tools_cpp

```
* Fix mpark/variant conditional for MSVC (#77 <https://github.com/osrf/osrf_testing_tools_cpp/issues/77>)
* Changing C++ Compile Version (#76 <https://github.com/osrf/osrf_testing_tools_cpp/issues/76>)
* Update maintainers (#74 <https://github.com/osrf/osrf_testing_tools_cpp/issues/74>)
* Contributors: Audrow Nash, Lucas Wendland, Scott K Logan
```
