### PR TITLE
sros2: 0.11.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5781,7 +5781,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.11.1-2
+      version: 0.11.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.11.2-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.11.1-2`

## sros2

```
* Make type of get_package_share_directory apparent for sphinx (#284 <https://github.com/ros2/sros2/issues/284>)
* Contributors: Yadu
```

## sros2_cmake

- No changes
