### PR TITLE
rosidl: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4833,6 +4833,7 @@ repositories:
       - rosidl_cmake
       - rosidl_generator_c
       - rosidl_generator_cpp
+      - rosidl_generator_type_description
       - rosidl_parser
       - rosidl_pycommon
       - rosidl_runtime_c
@@ -4843,7 +4844,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 3.4.0-2
+      version: 4.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `4.0.0-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.4.0-2`

## rosidl_adapter

- No changes

## rosidl_cli

```
* Fix warnings (#726 <https://github.com/ros2/rosidl/issues/726>)
* Contributors: Yadu
```

## rosidl_cmake

```
* Type Description Codegen and Typesupport  (rep2011) (#727 <https://github.com/ros2/rosidl/issues/727>)
* Type hash in interface codegen (rep2011) (#722 <https://github.com/ros2/rosidl/issues/722>)
* Contributors: Emerson Knapp
```

## rosidl_generator_c

```
* Type Description Codegen and Typesupport  (rep2011) (#727 <https://github.com/ros2/rosidl/issues/727>)
* Expose type hash on typesupports (rep2011) (#729 <https://github.com/ros2/rosidl/issues/729>)
* Type hash in interface codegen (rep2011) (#722 <https://github.com/ros2/rosidl/issues/722>)
* Contributors: Emerson Knapp
```

## rosidl_generator_cpp

```
* Type Description Codegen and Typesupport  (rep2011) (#727 <https://github.com/ros2/rosidl/issues/727>)
* Expose type hash on typesupports (rep2011) (#729 <https://github.com/ros2/rosidl/issues/729>)
* Type hash in interface codegen (rep2011) (#722 <https://github.com/ros2/rosidl/issues/722>)
* Contributors: Emerson Knapp
```

## rosidl_generator_type_description

```
* Type Description Codegen and Typesupport  (rep2011) (#727 <https://github.com/ros2/rosidl/issues/727>)
* Expose type hash on typesupports (rep2011) (#729 <https://github.com/ros2/rosidl/issues/729>)
* Type hash in interface codegen (rep2011) (#722 <https://github.com/ros2/rosidl/issues/722>)
* Contributors: Emerson Knapp
```

## rosidl_parser

- No changes

## rosidl_pycommon

```
* Type Description Codegen and Typesupport  (rep2011) (#727 <https://github.com/ros2/rosidl/issues/727>)
* Type hash in interface codegen (rep2011) (#722 <https://github.com/ros2/rosidl/issues/722>)
* Contributors: Emerson Knapp
```

## rosidl_runtime_c

```
* Dynamic Subscription (BONUS: Allocators): rosidl (#737 <https://github.com/ros2/rosidl/issues/737>)
* Runtime Interface Reflection: rosidl (#728 <https://github.com/ros2/rosidl/issues/728>)
* Type Description Codegen and Typesupport  (rep2011) (#727 <https://github.com/ros2/rosidl/issues/727>)
* Copied type_description_interfaces structs (rep2011) (#732 <https://github.com/ros2/rosidl/issues/732>)
* Expose type hash on typesupports (rep2011) (#729 <https://github.com/ros2/rosidl/issues/729>)
* Type hash in interface codegen (rep2011) (#722 <https://github.com/ros2/rosidl/issues/722>)
* Contributors: Emerson Knapp, methylDragon
```

## rosidl_runtime_cpp

```
* Type Description Codegen and Typesupport  (rep2011) (#727 <https://github.com/ros2/rosidl/issues/727>)
* Copied type_description_interfaces structs (rep2011) (#732 <https://github.com/ros2/rosidl/issues/732>)
* Fix a few more clang analysis problems. (#731 <https://github.com/ros2/rosidl/issues/731>)
* Return reference from BoundedVector::emplace_back (#730 <https://github.com/ros2/rosidl/issues/730>)
* Contributors: Alexander Hans, Chris Lalancette, Emerson Knapp
```

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

```
* Type Description Codegen and Typesupport  (rep2011) (#727 <https://github.com/ros2/rosidl/issues/727>)
* Expose type hash on typesupports (rep2011) (#729 <https://github.com/ros2/rosidl/issues/729>)
* Type hash in interface codegen (rep2011) (#722 <https://github.com/ros2/rosidl/issues/722>)
* Contributors: Emerson Knapp
```

## rosidl_typesupport_introspection_cpp

```
* Type Description Codegen and Typesupport  (rep2011) (#727 <https://github.com/ros2/rosidl/issues/727>)
* Expose type hash on typesupports (rep2011) (#729 <https://github.com/ros2/rosidl/issues/729>)
* Type hash in interface codegen (rep2011) (#722 <https://github.com/ros2/rosidl/issues/722>)
* Contributors: Emerson Knapp
```
