### PR TITLE
rviz: 12.3.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5509,7 +5509,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 12.3.1-4
+      version: 12.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `12.3.2-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `12.3.1-4`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Update Frame shortcut (#958 <https://github.com/ros2/rviz/issues/958>)
  * Update Frame shortcut
* Contributors: David V. Lu!!
```

## rviz_default_plugins

```
* Fix ODR errors with gmock (#967 <https://github.com/ros2/rviz/issues/967>)
* Update Frame shortcut (#958 <https://github.com/ros2/rviz/issues/958>)
* Contributors: David V. Lu!!, methylDragon
```

## rviz_ogre_vendor

```
* Fix build failures on macOS + Apple Silicon (#944 <https://github.com/ros2/rviz/issues/944>)
* Contributors: Yadu
```

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
