### PR TITLE
rmw_dds_common: 2.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4320,7 +4320,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_dds_common-release.git
-      version: 2.0.0-2
+      version: 2.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_dds_common` to `2.0.1-1`:

- upstream repository: https://github.com/ros2/rmw_dds_common.git
- release repository: https://github.com/ros2-gbp/rmw_dds_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-2`

## rmw_dds_common

```
* Type hash in GraphCache, user_data encoding tools (#70 <https://github.com/ros2/rmw_dds_common/issues/70>)
* Mark benchmark _ as unused. (#71 <https://github.com/ros2/rmw_dds_common/issues/71>)
* Contributors: Chris Lalancette, Emerson Knapp
```
