### PR TITLE
actuator_msgs: 0.0.1-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -51,6 +51,15 @@ repositories:
       version: ros2
     status: maintained
   actuator_msgs:
+    doc:
+      type: git
+      url: https://github.com/rudislabs/actuator_msgs.git
+      version: 0.0.1
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/actuator_msgs-release.git
+      version: 0.0.1-2
     source:
       type: git
       url: https://github.com/rudislabs/actuator_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `actuator_msgs` to `0.0.1-2`:

- upstream repository: https://github.com/rudislabs/actuator_msgs.git
- release repository: https://github.com/ros2-gbp/actuator_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## actuator_msgs

```
* Initial commit.
* Contributors: Benjamin Perseghetti
```
