### PR TITLE
Added python3-empy to OSX

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6780,6 +6780,9 @@ python3-empy:
   nixos: [python3Packages.empy]
   openembedded: [python3-empy@meta-ros-common]
   opensuse: [python3-empy]
+  osx:
+    pip:
+      packakges: [empy]
   rhel: ['python%{python3_pkgversion}-empy']
   ubuntu: [python3-empy]
 python3-environs-pip:


### PR DESCRIPTION
This PR adds python3-empy to OSX via pip.

## Package name:

python3-empy

## Package Upstream Source:

https://pypi.org/project/empy/

## Purpose of using this:

There are packages like catkin which require python3-empy, which is already available on Linux platforms and has an available version on pip, similar to python3-empy.

- macOS: https://pypi.org/project/empy/

