### PR TITLE
Adding python3_mock to osx

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7808,6 +7808,9 @@ python3-mock:
   nixos: [python3Packages.mock]
   openembedded: [python3-mock@meta-ros-common]
   opensuse: [python3-mock]
+  osx:
+    pip:
+      packages: [mock]
   rhel: ['python%{python3_pkgversion}-mock']
   ubuntu: [python3-mock]
 python3-more-itertools:


### PR DESCRIPTION
This PR adds the python3_mock pack to OSX via pip

## Package name:

python3_mock

## Package Upstream Source:

https://github.com/testing-cabal/mock

## Purpose of using this:

There are packages like urdfdom_py which require python3_mock, also this package is already used in linux builds, with a package on pip.

- macOS: https://pypi.org/project/mock/
