### PR TITLE
Adding python3-pydot to osx

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8548,6 +8548,9 @@ python3-pydot:
   nixos: [python3Packages.pydot]
   openembedded: [python3-pydot@meta-ros-common]
   opensuse: [python3-pydot]
+  osx:
+    pip:
+      packages: [pydot]
   rhel:
     '*': ['python%{python3_pkgversion}-pydot']
     '7': null


### PR DESCRIPTION
This PR adds the python3-pydot package to OSX via pip.

## Package name:

python3-pydot

## Package Upstream Source:

https://github.com/pydot/pydot

## Purpose of using this:

There are many packages like qt_dotgraph which require python3-pydot and linux systems like ubuntu already require this. Also, there was already a python package on pip.

- macOS: https://github.com/pydot/pydot