### PR TITLE
Add python3-rmsd-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9150,6 +9150,16 @@ python3-river-pip:
   ubuntu:
     pip:
       packages: [river]
+python3-rmsd-pip:
+  debian:
+    pip:
+      packages: [rmsd]
+  osx:
+    pip:
+      packages: [rmsd]
+  ubuntu:
+    pip:
+      packages: [rmsd]
 python3-robodk-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

rmsd

## Package Upstream Source:

https://pypi.org/project/rmsd/

## Purpose of using this:

This package is used for calculating the root-mean-square deviation (RMSD) to compare structural differences between two points sets. It accounts for relative translation and rotation and calculates minimal RMSD.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://pypi.org/project/rmsd/
- Ubuntu: https://packages.ubuntu.com/
  - https://pypi.org/project/rmsd/
- macOS: https://formulae.brew.sh/
  - https://pypi.org/project/rmsd/
