### PR TITLE
Add python3-tikzplotlib-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9775,6 +9775,16 @@ python3-thriftpy:
     xenial:
       pip:
         packages: [thriftpy]
+python3-tikzplotlib-pip:
+  debian:
+    pip:
+      packages: [tikzplotlib]
+  osx:
+    pip:
+      packages: [tikzplotlib]
+  ubuntu:
+    pip:
+      packages: [tikzplotlib]
 python3-tilestache-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

tikzplotlib

## Package Upstream Source:

https://pypi.org/project/tikzplotlib/

## Purpose of using this:

This package is used to convert matplotlib figures to PGFPlots format for native inclusion into LaTeX or ConTeXt documents.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://pypi.org/project/tikzplotlib/
- Ubuntu: https://packages.ubuntu.com/
  - https://pypi.org/project/tikzplotlib/
- macOS: https://formulae.brew.sh/
  - https://pypi.org/project/tikzplotlib/