### PR TITLE
rosidl_dynamic_typesupport: 0.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4922,7 +4922,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_dynamic_typesupport-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_dynamic_typesupport` to `0.0.3-1`:

- upstream repository: https://github.com/ros2/rosidl_dynamic_typesupport.git
- release repository: https://github.com/ros2-gbp/rosidl_dynamic_typesupport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.2-1`

## rosidl_dynamic_typesupport

```
* Fix up the exports for rosidl_dynamic_typesupport. (#5 <https://github.com/ros2/rosidl_dynamic_typesupport/issues/5>)
* Contributors: Chris Lalancette
```
