### PR TITLE
geometric_shapes: 0.6.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3911,7 +3911,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/geometric_shapes-release.git
-      version: 0.6.5-1
+      version: 0.6.6-1
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.6.6-1`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/ros-gbp/geometric_shapes-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.5-1`

## geometric_shapes

```
* Limit indefinite growth of OBBs during merging (#233 <https://github.com/ros-planning/geometric_shapes/issues/233>)
* Correctly initialize OBB with default constructor
* Contributors: Martin Pecka
```
