### PR TITLE
ros_grpc-release: 1.35.0-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8810,6 +8810,19 @@ repositories:
       url: https://github.com/shadow-robot/ros_ethercat_eml.git
       version: noetic-devel
     status: maintained
+  ros_grpc-release:
+    doc:
+      type: git
+      url: https://github.com/DFKI-NI-gbp/ros_grpc-release.git
+      version: release/noetic/ros_grpc
+    release:
+      packages:
+      - ros_grpc
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/DFKI-NI-gbp/ros_grpc-release.git
+      version: 1.35.0-3
+    status: maintained
   ros_ign:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_grpc-release` to `1.35.0-3`:

- upstream repository: https://github.com/grpc/grpc
- release repository: https://github.com/DFKI-NI-gbp/ros_grpc-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
