### PR TITLE
rcutils: 6.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3938,7 +3938,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 6.2.0-1
+      version: 6.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `6.2.1-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `6.2.0-1`

## rcutils

```
* fix memory leak (#423 <https://github.com/ros2/rcutils/issues/423>)
* Contributors: Chen Lihui
```
