### PR TITLE
pyhri: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7643,7 +7643,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros4hri/pyhri-release.git
-      version: 0.3.2-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/ros4hri/pyhri.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyhri` to `0.4.0-1`:

- upstream repository: https://github.com/ros4hri/pyhri.git
- release repository: https://github.com/ros4hri/pyhri-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.2-1`

## pyhri

```
* {hri->pyhri}
  This was causing catkin to not find pyhri when included in other projects
* add callbacks for speech recognition + tests
* fix AttributeError on first detection
* use sensor_msgs/RegionOfInterest msg for compatibility with other ROS4HRI repos
* Contributors: Luca Pozzi, Séverin Lemaignan
```
