### PR TITLE
libstatistics_collector: 1.5.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2258,7 +2258,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libstatistics_collector-release.git
-      version: 1.5.0-3
+      version: 1.5.1-1
     source:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libstatistics_collector` to `1.5.1-1`:

- upstream repository: https://github.com/ros-tooling/libstatistics_collector.git
- release repository: https://github.com/ros2-gbp/libstatistics_collector-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.5.0-3`

## libstatistics_collector

```
* Bump hmarr/auto-approve-action from 3.2.0 to 3.2.1
* Mark benchmark _ as unused. (#158 <https://github.com/ros-tooling/libstatistics_collector/issues/158>)
* Bump hmarr/auto-approve-action from 3.1.0 to 3.2.0
* Bump ros-tooling/action-ros-ci from 0.2 to 0.3
* Bump pascalgn/automerge-action from 0.15.5 to 0.15.6
* Contributors: Chris Lalancette, dependabot[bot]
```
