### PR TITLE
libhri: 0.6.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4706,7 +4706,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros4hri/libhri-release.git
-      version: 0.6.0-1
+      version: 0.6.1-1
     source:
       type: git
       url: https://github.com/ros4hri/libhri.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libhri` to `0.6.1-1`:

- upstream repository: https://github.com/ros4hri/libhri.git
- release repository: https://github.com/ros4hri/libhri-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.0-1`

## hri

```
* add callbacks for when speech is detected on a voice
* Contributors: Séverin Lemaignan
```
