### PR TITLE
robot_body_filter: 1.3.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10615,7 +10615,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/peci1/robot_body_filter-release.git
-      version: 1.2.2-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/peci1/robot_body_filter.git


### PR DESCRIPTION
!! **Merge after https://github.com/ros/rosdistro/pull/36809** !!

Increasing version of package(s) in repository `robot_body_filter` to `1.3.0-1`:

- upstream repository: https://github.com/peci1/robot_body_filter
- release repository: https://github.com/peci1/robot_body_filter-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.2-1`

## robot_body_filter

```
* Removed local implementation of oriented bounding boxes in favor of geometric_shapes/obb. **This change breaks API and ABI**, but I hope nobody explicitly used the OBB part of this library. This change requires geometric_shapes version 0.6.6+ (Melodic) or 0.7.5+ (Noetic) (released April 2023).
* Add example launch & config for ease of use. Thanks Doan Nguyen for the contribution!
* Changed xmlrpc_traits variables to constexpr static instead of inline static to decrease the required C++ language standard for this part. Changed stringType from std::string to const char*.
* Improved xmlrpc_traits to recognize more types of valid structures.
* Make filter_utils FilterBase::getParamVerbose() methods const.
  Allowed by https://github.com/ros/filters/pull/35 (released in Melodic filters 1.8.2 (October 2021) and Noetic filters 1.9.1 (September 2021)).
* Contributors: Doan Nguyen, Martin Pecka
```
