### PR TITLE
rosidl_typesupport: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4975,7 +4975,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-      version: 2.3.1-2
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport` to `3.0.0-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.1-2`

## rosidl_typesupport_c

```
* Type Description Nested Support (#141 <https://github.com/ros2/rosidl_typesupport/issues/141>)
* Fix rosidl_typesupport_c/cpp exec dependencies. (#140 <https://github.com/ros2/rosidl_typesupport/issues/140>)
* Type hashes in typesupport (rep2011) (#135 <https://github.com/ros2/rosidl_typesupport/issues/135>)
* Mark benchmark _ as UNUSED. (#134 <https://github.com/ros2/rosidl_typesupport/issues/134>)
* Contributors: Chris Lalancette, Emerson Knapp
```

## rosidl_typesupport_cpp

```
* Type Description Nested Support (#141 <https://github.com/ros2/rosidl_typesupport/issues/141>)
* Fix rosidl_typesupport_c/cpp exec dependencies. (#140 <https://github.com/ros2/rosidl_typesupport/issues/140>)
* Type hashes in typesupport (rep2011) (#135 <https://github.com/ros2/rosidl_typesupport/issues/135>)
* Mark benchmark _ as UNUSED. (#134 <https://github.com/ros2/rosidl_typesupport/issues/134>)
* Contributors: Chris Lalancette, Emerson Knapp
```
