### PR TITLE
rosidl_typesupport_fastrtps: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4995,7 +4995,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-      version: 2.5.0-2
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_fastrtps` to `3.0.0-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.5.0-2`

## fastrtps_cmake_module

- No changes

## rosidl_typesupport_fastrtps_c

```
* Type Description Nested Support (#101 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/101>)
* Type hashes on typesupport (rep2011) (#98 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/98>)
* Expose type hash to typesupport structs (rep2011) (#95 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/95>)
* Mark benchmark _ as UNUSED. (#96 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/96>)
* Contributors: Chris Lalancette, Emerson Knapp
```

## rosidl_typesupport_fastrtps_cpp

```
* Type Description Nested Support (#101 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/101>)
* Type hashes on typesupport (rep2011) (#98 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/98>)
* Depend on ament_cmake_ros to default SHARED to ON (#99 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/99>)
* Expose type hash to typesupport structs (rep2011) (#95 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/95>)
* Mark benchmark _ as UNUSED. (#96 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/96>)
* Contributors: Chris Lalancette, Emerson Knapp, Tyler Weaver
```
