### PR TITLE
rosidl_dynamic_typesupport_fastrtps: 0.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4929,6 +4929,22 @@ repositories:
       url: https://github.com/ros2/rosidl_dynamic_typesupport.git
       version: rolling
     status: maintained
+  rosidl_dynamic_typesupport_fastrtps:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_dynamic_typesupport_fastrtps-release.git
+      version: 0.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps.git
+      version: rolling
+    status: maintained
   rosidl_python:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_dynamic_typesupport_fastrtps` to `0.0.2-1`:

- upstream repository: https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_dynamic_typesupport_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## rosidl_dynamic_typesupport_fastrtps

```
* Remove more unnecessary semicolons (#4 <https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps/issues/4>)
* Dynamic Subscription (BONUS: Allocators): rosidl_dynamic_typesupport_fastrtps (#3 <https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps/issues/3>)
* Remove unnecessary semicolons. (#2 <https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps/issues/2>)
* Runtime Interface Reflection: rosidl_dynamic_typesupport_fastrtps (#1 <https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps/issues/1>)
* Contributors: Chris Lalancette, methylDragon
```
