### PR TITLE
rmw_cyclonedds: 1.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4310,7 +4310,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 1.5.1-2
+      version: 1.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `1.6.0-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.5.1-2`

## rmw_cyclonedds_cpp

```
* Dynamic Subscription (BONUS: Allocators): rmw_cyclonedds (#451 <https://github.com/ros2/rmw_cyclonedds/issues/451>)
* Add stubs for new rmw interfaces (#447 <https://github.com/ros2/rmw_cyclonedds/issues/447>)
* [rmw_cyclonedds] Improve handling of dynamic discovery (#429 <https://github.com/ros2/rmw_cyclonedds/issues/429>)
* Call get_type_hash_func (#448 <https://github.com/ros2/rmw_cyclonedds/issues/448>)
* Type hash distribution in discovery (rep2011) (#437 <https://github.com/ros2/rmw_cyclonedds/issues/437>)
* Disable inconsistent topic events. (#444 <https://github.com/ros2/rmw_cyclonedds/issues/444>)
* Implement matched event (#435 <https://github.com/ros2/rmw_cyclonedds/issues/435>)
* Implement inconsistent topic. (#431 <https://github.com/ros2/rmw_cyclonedds/issues/431>)
* Contributors: Barry Xu, Chris Lalancette, Emerson Knapp, Geoffrey Biggs, methylDragon
```
