### PR TITLE
generate_parameter_library: 0.3.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1441,7 +1441,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 0.3.1-3
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `generate_parameter_library` to `0.3.2-1`:

- upstream repository: https://github.com/PickNikRobotics/generate_parameter_library.git
- release repository: https://github.com/ros2-gbp/generate_parameter_library-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.1-3`

## generate_parameter_library

- No changes

## generate_parameter_library_example

```
* Populate Range Constraints in Parameter Descriptors from Validation Functions (#103 <https://github.com/PickNikRobotics/generate_parameter_library/issues/103>)
* Mark deprecated rsl method and propose alternative in the docs. (#102 <https://github.com/PickNikRobotics/generate_parameter_library/issues/102>)
* Contributors: Chance Cardona, Dr. Denis
```

## generate_parameter_library_py

```
* Populate Range Constraints in Parameter Descriptors from Validation Functions (#103 <https://github.com/PickNikRobotics/generate_parameter_library/issues/103>)
* Mark deprecated rsl method and propose alternative in the docs. (#102 <https://github.com/PickNikRobotics/generate_parameter_library/issues/102>)
* Allow none type (#99 <https://github.com/PickNikRobotics/generate_parameter_library/issues/99>)
* Fixed tests never failing although file not found (#101 <https://github.com/PickNikRobotics/generate_parameter_library/issues/101>)
* Contributors: Chance Cardona, Dr. Denis, GuiHome
```

## parameter_traits

- No changes
