### PR TITLE
rcl: 6.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3755,7 +3755,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 5.9.0-2
+      version: 6.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `6.0.0-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `5.9.0-2`

## rcl

```
* Add enable_type_description_service node option - API only (#1060 <https://github.com/ros2/rcl/issues/1060>)
* Dynamic Subscription (BONUS: Allocators): rcl (#1057 <https://github.com/ros2/rcl/issues/1057>)
* Runtime Interface Reflection: rcl (#1025 <https://github.com/ros2/rcl/issues/1025>)
* [rcl] Improve handling of dynamic discovery  (#1023 <https://github.com/ros2/rcl/issues/1023>)
* Use get_type_hash_func for typesupports (#1055 <https://github.com/ros2/rcl/issues/1055>)
* publish for rosout topic multiple times to avoid flaky test (#1054 <https://github.com/ros2/rcl/issues/1054>)
* Switch to target_link_libraries in rcl. (#1051 <https://github.com/ros2/rcl/issues/1051>)
* Calculate type hash from TypeDescription (rep2011) (#1027 <https://github.com/ros2/rcl/issues/1027>)
* Implement matched event (#1033 <https://github.com/ros2/rcl/issues/1033>)
* use user-defined allocator to configure logging. (#1047 <https://github.com/ros2/rcl/issues/1047>)
* user defined allocator should be used for rosout publisher. (#1044 <https://github.com/ros2/rcl/issues/1044>)
* Add in inconsistent_topic implementation. (#1024 <https://github.com/ros2/rcl/issues/1024>)
* doc update, ROS message accessibility depends on RMW implementation. (#1043 <https://github.com/ros2/rcl/issues/1043>)
* Fix some warnings from clang. (#1042 <https://github.com/ros2/rcl/issues/1042>)
* avoid unnecessary copy for rcutils_char_array_vsprintf. (#1035 <https://github.com/ros2/rcl/issues/1035>)
* Contributors: Barry Xu, Chen Lihui, Chris Lalancette, Emerson Knapp, Geoffrey Biggs, Tomoya Fujita, methylDragon
```

## rcl_action

```
* doc update, ROS message accessibility depends on RMW implementation. (#1043 <https://github.com/ros2/rcl/issues/1043>)
* Contributors: Tomoya Fujita
```

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

```
* Fix some warnings from clang. (#1042 <https://github.com/ros2/rcl/issues/1042>)
* Contributors: Chris Lalancette
```
