### PR TITLE
ros2_tracing: 6.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4555,7 +4555,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 5.1.0-2
+      version: 6.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `6.0.0-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `5.1.0-2`

## ros2trace

- No changes

## tracetools

```
* Improve tracetools rosdoc2/doxygen output (#57 <https://github.com/ros2/ros2_tracing/issues/57>)
* Update README and other documentation (#55 <https://github.com/ros2/ros2_tracing/issues/55>)
* Disable tracing on macOS (#53 <https://github.com/ros2/ros2_tracing/issues/53>)
* Include tracepoints by default on Linux (#31 <https://github.com/ros2/ros2_tracing/issues/31>)
* Contributors: Christophe Bedard
```

## tracetools_launch

```
* Enable document generation using rosdoc2 for ament_python pkgs (#50 <https://github.com/ros2/ros2_tracing/issues/50>)
* Contributors: Yadu
```

## tracetools_read

- No changes

## tracetools_test

- No changes

## tracetools_trace

```
* Allow requiring minimum lttng package version for is_lttng_installed (#59 <https://github.com/ros2/ros2_tracing/issues/59>)
* Include tracepoints by default on Linux (#31 <https://github.com/ros2/ros2_tracing/issues/31>)
* Enable document generation using rosdoc2 for ament_python pkgs (#50 <https://github.com/ros2/ros2_tracing/issues/50>)
* Contributors: Christophe Bedard, Yadu
```
