### PR TITLE
rclpy: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3871,7 +3871,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 3.10.0-2
+      version: 4.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `4.0.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.10.0-2`

## rclpy

```
* Stub type hash value line in TopicEndpointInfo string (#1110 <https://github.com/ros2/rclpy/issues/1110>)
* Support documentation generation using rosdoc2 (#1103 <https://github.com/ros2/rclpy/issues/1103>)
* Fix Time and Duration raising exception when compared to another type (#1007 <https://github.com/ros2/rclpy/issues/1007>)
* Make rcl_interfaces a build and exec dependency. (#1100 <https://github.com/ros2/rclpy/issues/1100>)
* Solving Atomic undefined on OSX with clang (#1096 <https://github.com/ros2/rclpy/issues/1096>)
* Implement matched event (#1083 <https://github.com/ros2/rclpy/issues/1083>)
* Update service.py documentation (#1094 <https://github.com/ros2/rclpy/issues/1094>)
* Allow space or empty strings when using ros2 param set (#1093 <https://github.com/ros2/rclpy/issues/1093>)
* Hook up the incompatible type event inside of rclpy (#1058 <https://github.com/ros2/rclpy/issues/1058>)
* Switch to using module instead of module_ (#1090 <https://github.com/ros2/rclpy/issues/1090>)
* Add in subscription.get_publisher_count() (#1089 <https://github.com/ros2/rclpy/issues/1089>)
* Contributors: Barry Xu, Chris Lalancette, Emerson Knapp, Erki Suurjaak, Felix Divo, GuiHome, Lucas Wendland, Yadu
```
