### PR TITLE
message_tf_frame_transformer: 1.0.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2424,6 +2424,21 @@ repositories:
       url: https://github.com/ros2/message_filters.git
       version: rolling
     status: maintained
+  message_tf_frame_transformer:
+    doc:
+      type: git
+      url: https://github.com/ika-rwth-aachen/message_tf_frame_transformer.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ika-rwth-aachen/message_tf_frame_transformer-release.git
+      version: 1.0.0-2
+    source:
+      type: git
+      url: https://github.com/ika-rwth-aachen/message_tf_frame_transformer.git
+      version: main
+    status: maintained
   micro_ros_diagnostics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_tf_frame_transformer` to `1.0.0-2`:

- upstream repository: https://github.com/ika-rwth-aachen/message_tf_frame_transformer.git
- release repository: https://github.com/ika-rwth-aachen/message_tf_frame_transformer-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
