### PR TITLE
Adding gpgme to OSX

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3646,6 +3646,9 @@ libgmp:
   fedora: [gmp-devel]
   gentoo: [dev-libs/gmp]
   nixos: [gmp]
+  osx:
+    homebrew:
+      packages: [gpgme]
   ubuntu: [libgmp-dev]
 libgnutls28-dev:
   alpine: [gnutls-dev]

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -247,6 +247,10 @@ libglew-dev:
   osx:
     homebrew:
       packages: [glew]
+libgpgme-dev:
+  osx:
+    homebrew:
+      packages: [gpgme]
 libgsl:
   osx:
     homebrew:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -247,10 +247,6 @@ libglew-dev:
   osx:
     homebrew:
       packages: [glew]
-libgpgme-dev:
-  osx:
-    homebrew:
-      packages: [gpgme]
 libgsl:
   osx:
     homebrew:


### PR DESCRIPTION
This PR adds the libgpgme-dev package to OSX via homebrew.

## Package name:

ibgpgme-dev

## Package Upstream Source:

https://www.gnupg.org/related_software/gpgme/

## Purpose of using this:

There are packages such as rosbag_storage which utilize this library and it is already included in linux builds, so since it's already on homebrew it's worth installing

- macOS: https://formulae.brew.sh/formula/gpgme#default