### PR TITLE
rosbag2: 0.21.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4761,6 +4761,7 @@ repositories:
       - rosbag2_compression_zstd
       - rosbag2_cpp
       - rosbag2_examples_cpp
+      - rosbag2_examples_py
       - rosbag2_interfaces
       - rosbag2_performance_benchmarking
       - rosbag2_performance_benchmarking_msgs
@@ -4768,9 +4769,9 @@ repositories:
       - rosbag2_storage
       - rosbag2_storage_default_plugins
       - rosbag2_storage_mcap
-      - rosbag2_storage_mcap_testdata
       - rosbag2_storage_sqlite3
       - rosbag2_test_common
+      - rosbag2_test_msgdefs
       - rosbag2_tests
       - rosbag2_transport
       - shared_queues_vendor
@@ -4779,7 +4780,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.20.0-2
+      version: 0.21.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.21.0-2`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.20.0-2`

## mcap_vendor

- No changes

## ros2bag

```
* Enable document generation using rosdoc2 for ament_python pkgs (#1260 <https://github.com/ros2/rosbag2/issues/1260>)
* Contributors: Yadu
```

## rosbag2

- No changes

## rosbag2_compression

```
* rosbag2_cpp: move local message definition source out of MCAP plugin (#1265 <https://github.com/ros2/rosbag2/issues/1265>)
* Update rosbag2 to C++17. (#1238 <https://github.com/ros2/rosbag2/issues/1238>)
* Use target_link_libraries instead of ament_target_dependencies (#1202 <https://github.com/ros2/rosbag2/issues/1202>)
* Contributors: Chris Lalancette, Daisuke Nishimatsu, Michael Orlov, james-rms
```

## rosbag2_compression_zstd

```
* Update rosbag2 to C++17. (#1238 <https://github.com/ros2/rosbag2/issues/1238>)
* Use target_link_libraries instead of ament_target_dependencies (#1202 <https://github.com/ros2/rosbag2/issues/1202>)
* Contributors: Chris Lalancette, Daisuke Nishimatsu, Michael Orlov
```

## rosbag2_cpp

```
* rosbag2_cpp: move local message definition source out of MCAP plugin (#1265 <https://github.com/ros2/rosbag2/issues/1265>)
* Update rosbag2 to C++17. (#1238 <https://github.com/ros2/rosbag2/issues/1238>)
* Use target_link_libraries instead of ament_target_dependencies (#1202 <https://github.com/ros2/rosbag2/issues/1202>)
* Fix rwm->rmw spelling (#1249 <https://github.com/ros2/rosbag2/issues/1249>)
* Contributors: Chris Lalancette, Daisuke Nishimatsu, Emerson Knapp, Michael Orlov, james-rms
```

## rosbag2_examples_cpp

```
* Update rosbag2 to C++17. (#1238 <https://github.com/ros2/rosbag2/issues/1238>)
* Use target_link_libraries instead of ament_target_dependencies (#1202 <https://github.com/ros2/rosbag2/issues/1202>)
* Contributors: Chris Lalancette, Daisuke Nishimatsu, Michael Orlov
```

## rosbag2_examples_py

```
* Add API samples for Python [rebased] (#1253 <https://github.com/ros2/rosbag2/issues/1253>)
  * Add API samples for Python
  * Package Renaming and Move
  * linting + copyright
  * more linting
  ---------
  Co-authored-by: Geoffrey Biggs <mailto:gbiggs@killbots.net>
* Contributors: David V. Lu!!
```

## rosbag2_interfaces

```
* Update rosbag2 to C++17. (#1238 <https://github.com/ros2/rosbag2/issues/1238>)
* Contributors: Chris Lalancette
```

## rosbag2_performance_benchmarking

```
* Fix expectations for rosbag2 return code in rosbag2_performance_benchmarking (#1267 <https://github.com/ros2/rosbag2/issues/1267>)
* Update rosbag2 to C++17. (#1238 <https://github.com/ros2/rosbag2/issues/1238>)
* Use thread pool to run benchmark publishers in rosbag2_performance_benchmarking (#1250 <https://github.com/ros2/rosbag2/issues/1250>)
* Use target_link_libraries instead of ament_target_dependencies (#1202 <https://github.com/ros2/rosbag2/issues/1202>)
* Contributors: Chris Lalancette, Daisuke Nishimatsu, Michael Orlov, Shane Loretz, carlossvg
```

## rosbag2_performance_benchmarking_msgs

- No changes

## rosbag2_py

```
* rosbag2_cpp: move local message definition source out of MCAP plugin (#1265 <https://github.com/ros2/rosbag2/issues/1265>)
* Update rosbag2 to C++17. (#1238 <https://github.com/ros2/rosbag2/issues/1238>)
* Use target_link_libraries instead of ament_target_dependencies (#1202 <https://github.com/ros2/rosbag2/issues/1202>)
* Contributors: Chris Lalancette, Daisuke Nishimatsu, Michael Orlov, james-rms
```

## rosbag2_storage

```
* rosbag2_cpp: move local message definition source out of MCAP plugin (#1265 <https://github.com/ros2/rosbag2/issues/1265>)
* Update rosbag2 to C++17. (#1238 <https://github.com/ros2/rosbag2/issues/1238>)
* Use target_link_libraries instead of ament_target_dependencies (#1202 <https://github.com/ros2/rosbag2/issues/1202>)
* Contributors: Chris Lalancette, Daisuke Nishimatsu, Michael Orlov, james-rms
```

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

```
* rosbag2_cpp: move local message definition source out of MCAP plugin (#1265 <https://github.com/ros2/rosbag2/issues/1265>)
* Update rosbag2 to C++17. (#1238 <https://github.com/ros2/rosbag2/issues/1238>)
* Use target_link_libraries instead of ament_target_dependencies (#1202 <https://github.com/ros2/rosbag2/issues/1202>)
* Contributors: Chris Lalancette, Daisuke Nishimatsu, Michael Orlov, james-rms
```

## rosbag2_storage_sqlite3

```
* rosbag2_cpp: move local message definition source out of MCAP plugin (#1265 <https://github.com/ros2/rosbag2/issues/1265>)
* Update rosbag2 to C++17. (#1238 <https://github.com/ros2/rosbag2/issues/1238>)
* Use target_link_libraries instead of ament_target_dependencies (#1202 <https://github.com/ros2/rosbag2/issues/1202>)
* Contributors: Chris Lalancette, Daisuke Nishimatsu, Michael Orlov, james-rms
```

## rosbag2_test_common

```
* Update rosbag2 to C++17. (#1238 <https://github.com/ros2/rosbag2/issues/1238>)
* Use target_link_libraries instead of ament_target_dependencies (#1202 <https://github.com/ros2/rosbag2/issues/1202>)
* Contributors: Chris Lalancette, Daisuke Nishimatsu, Michael Orlov
```

## rosbag2_test_msgdefs

```
* rosbag2_cpp: move local message definition source out of MCAP plugin (#1265 <https://github.com/ros2/rosbag2/issues/1265>)
  The intention of this PR is to move the message-definition-finding capability outside of rosbag2_storage_mcap, and allow any rosbag2 storage plugin to store message definitions.
* Contributors: james-rms
```

## rosbag2_tests

```
* rosbag2_cpp: move local message definition source out of MCAP plugin (#1265 <https://github.com/ros2/rosbag2/issues/1265>)
* Update rosbag2 to C++17. (#1238 <https://github.com/ros2/rosbag2/issues/1238>)
* Use target_link_libraries instead of ament_target_dependencies (#1202 <https://github.com/ros2/rosbag2/issues/1202>)
* Contributors: Chris Lalancette, Daisuke Nishimatsu, Michael Orlov, james-rms
```

## rosbag2_transport

```
* rosbag2_cpp: move local message definition source out of MCAP plugin (#1265 <https://github.com/ros2/rosbag2/issues/1265>)
* Use RMW methods to initialize endpoint info instead of brace initializer to guard against upcoming struct change (#1257 <https://github.com/ros2/rosbag2/issues/1257>)
* Update rosbag2 to C++17. (#1238 <https://github.com/ros2/rosbag2/issues/1238>)
* Use target_link_libraries instead of ament_target_dependencies (#1202 <https://github.com/ros2/rosbag2/issues/1202>)
* Contributors: Chris Lalancette, Daisuke Nishimatsu, Emerson Knapp, Michael Orlov, james-rms
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

```
* Update to sqlite3 3.37.2 (#1274 <https://github.com/ros2/rosbag2/issues/1274>)
  This matches version distributed in Ubuntu Jammy.
* Contributors: Scott K Logan
```

## zstd_vendor

- No changes
