### PR TITLE
maliput_multilane: 0.1.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2738,7 +2738,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput_multilane-release.git
-      version: 0.1.4-1
+      version: 0.1.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_multilane` to `0.1.5-1`:

- upstream repository: https://github.com/maliput/maliput_multilane.git
- release repository: https://github.com/ros2-gbp/maliput_multilane-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.4-1`

## maliput_multilane

```
* RoadGeometry::FindRoadPositions: Uses maliput-provided base method.  (#101 <https://github.com/maliput/maliput_multilane/issues/101>)
* Provides plugins for both builders and improves params configuration. (#99 <https://github.com/maliput/maliput_multilane/issues/99>)
* Contributors: Franco Cipollone
```
