### PR TITLE
maliput_drake: 0.1.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2667,7 +2667,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput_drake-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_drake` to `0.1.2-1`:

- upstream repository: https://github.com/maliput/maliput_drake.git
- release repository: https://github.com/ros2-gbp/maliput_drake-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.1-1`

## maliput_drake

```
* Improves README. (#25 <https://github.com/maliput/maliput_drake/issues/25>)
* Contributors: Franco Cipollone
```
