### PR TITLE
maliput_osm: 0.2.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2786,7 +2786,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput_osm-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_osm` to `0.2.2-1`:

- upstream repository: https://github.com/maliput/maliput_osm.git
- release repository: https://github.com/ros2-gbp/maliput_osm-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.1-1`

## maliput_osm

```
* Adds Town01 map. (#52 <https://github.com/maliput/maliput_osm/issues/52>)
* Contributors: Franco Cipollone
```
