### PR TITLE
maliput_integration: 0.1.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2699,7 +2699,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/maliput_integration-release.git
-      version: 0.1.5-1
+      version: 0.1.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_integration` to `0.1.6-1`:

- upstream repository: https://github.com/maliput/maliput_integration.git
- release repository: https://github.com/ros2-gbp/maliput_integration-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.5-1`

## maliput_integration

```
* Adds more options to the obj creator app. (#132 <https://github.com/maliput/maliput_integration/issues/132>)
* Relies on maliput_multilane's RN builder. (#131 <https://github.com/maliput/maliput_integration/issues/131>)
* Contributors: Franco Cipollone
```
