### PR TITLE
rclcpp: 20.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3855,7 +3855,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 19.3.0-2
+      version: 20.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `20.0.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `19.3.0-2`

## rclcpp

```
* applied tracepoints for ring_buffer (#2091 <https://github.com/ros2/rclcpp/issues/2091>)
* Dynamic Subscription (REP-2011 Subset): Stubs for rclcpp (#2165 <https://github.com/ros2/rclcpp/issues/2165>)
* Add type_hash to cpp TopicEndpointInfo (#2137 <https://github.com/ros2/rclcpp/issues/2137>)
* Trigger the intraprocess guard condition with data (#2164 <https://github.com/ros2/rclcpp/issues/2164>)
* Minor grammar fix (#2149 <https://github.com/ros2/rclcpp/issues/2149>)
* Fix unnecessary allocations in executor.cpp (#2135 <https://github.com/ros2/rclcpp/issues/2135>)
* add Logger::get_effective_level(). (#2141 <https://github.com/ros2/rclcpp/issues/2141>)
* Remove deprecated header (#2139 <https://github.com/ros2/rclcpp/issues/2139>)
* Implement matched event (#2105 <https://github.com/ros2/rclcpp/issues/2105>)
* use allocator via init_options argument. (#2129 <https://github.com/ros2/rclcpp/issues/2129>)
* Fixes to silence some clang warnings. (#2127 <https://github.com/ros2/rclcpp/issues/2127>)
* Documentation improvements on the executor (#2125 <https://github.com/ros2/rclcpp/issues/2125>)
* Avoid losing waitable handles while using MultiThreadedExecutor (#2109 <https://github.com/ros2/rclcpp/issues/2109>)
* Hook up the incompatible type event inside of rclcpp (#2069 <https://github.com/ros2/rclcpp/issues/2069>)
* Update all rclcpp packages to C++17. (#2121 <https://github.com/ros2/rclcpp/issues/2121>)
* Fix clang warning: bugprone-use-after-move (#2116 <https://github.com/ros2/rclcpp/issues/2116>)
* Contributors: Barry Xu, Chris Lalancette, Christopher Wecht, Emerson Knapp, Michael Carroll, Tomoya Fujita, Yadu, mauropasse, methylDragon, ymski
```

## rclcpp_action

```
* extract the result response before the callback is issued. (#2132 <https://github.com/ros2/rclcpp/issues/2132>)
* Update all rclcpp packages to C++17. (#2121 <https://github.com/ros2/rclcpp/issues/2121>)
* Fix the GoalUUID to_string representation (#1999 <https://github.com/ros2/rclcpp/issues/1999>)
* Contributors: Chris Lalancette, Nathan Wiebe Neufeldt, Tomoya Fujita
```

## rclcpp_components

```
* Update all rclcpp packages to C++17. (#2121 <https://github.com/ros2/rclcpp/issues/2121>)
* Contributors: Chris Lalancette
```

## rclcpp_lifecycle

```
* Fixes to silence some clang warnings. (#2127 <https://github.com/ros2/rclcpp/issues/2127>)
* Update all rclcpp packages to C++17. (#2121 <https://github.com/ros2/rclcpp/issues/2121>)
* Use the correct macro for LifecycleNode::get_fully_qualified_name (#2117 <https://github.com/ros2/rclcpp/issues/2117>)
* add get_fully_qualified_name to rclcpp_lifecycle (#2115 <https://github.com/ros2/rclcpp/issues/2115>)
* Contributors: Chris Lalancette, Steve Macenski
```
