### PR TITLE
Adding annoy to OSX

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -579,7 +579,7 @@ python-annoy-pip:
   ubuntu:
     pip:
       packages: [annoy]
-   osx:
+  osx:
     pip:
       packages: [annoy]
 python-anyjson:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -576,10 +576,10 @@ python-annoy-pip:
   fedora:
     pip:
       packages: [annoy]
-  ubuntu:
+  osx:
     pip:
       packages: [annoy]
-  osx:
+  ubuntu:
     pip:
       packages: [annoy]
 python-anyjson:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -579,6 +579,9 @@ python-annoy-pip:
   ubuntu:
     pip:
       packages: [annoy]
+   osx:
+    pip:
+      packages: [annoy]
 python-anyjson:
   debian: [python-anyjson]
   fedora: [python-anyjson]


### PR DESCRIPTION
This adds the annoy package to osx

## Package name:

annoy

## Package Upstream Source:

https://github.com/spotify/annoy

## Purpose of using this:

This is a package that is already available on Linux and with a package on pip it should be added to osx too.

- macOS: https://pypi.org/project/annoy/