### PR TITLE
[rosdep] add ubuntu-sounds entry

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8387,6 +8387,8 @@ ttf-sazanami-mincho:
   fedora: [sazanami-mincho-fonts]
   gentoo: [media-fonts/sazanami]
   ubuntu: [ttf-sazanami-mincho]
+ubuntu-sound:
+  ubuntu: [ubuntu-sounds]
 udev:
   arch: [systemd]
   debian: [udev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8387,7 +8387,7 @@ ttf-sazanami-mincho:
   fedora: [sazanami-mincho-fonts]
   gentoo: [media-fonts/sazanami]
   ubuntu: [ttf-sazanami-mincho]
-ubuntu-sound:
+ubuntu-sounds:
   ubuntu: [ubuntu-sounds]
 udev:
   arch: [systemd]


### PR DESCRIPTION
## Package name:

`ubuntu-sounds` package (Ubuntu's GNOME audio theme)

## Package Upstream Source:

Source package is https://packages.ubuntu.com/source/focal/ubuntu-sounds. I don't where is the original project.

## Purpose of using this:

Our lab have developed [some package](https://github.com/jsk-ros-pkg/jsk_3rdparty/tree/master/ros_speech_recognition) using the sound file in this package. (e.g. `/usr/share/sounds/ubuntu/stereo/bell.ogg`)
And it will be helpful to add the package to rosdep for our package users.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - Not found
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/focal/ubuntu-sounds