### PR TITLE
pal_statistics: 2.1.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3637,7 +3637,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_statistics-release.git
-      version: 2.1.3-1
+      version: 2.1.5-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_statistics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_statistics` to `2.1.5-1`:

- upstream repository: https://github.com/pal-robotics/pal_statistics.git
- release repository: https://github.com/pal-gbp/pal_statistics-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.3-1`

## pal_statistics

```
* miscellaneous enhancements
* refactor gtest_pal_statistics to test also lifecycle nodes
* add support for lifecycle nodes
* add namespace for StaticCircularBuffer
* Contributors: Noel Jimenez
```

## pal_statistics_msgs

```
* miscellaneous enhancements
* Contributors: Noel Jimenez
```
