### PR TITLE
pmb2_navigation: 4.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3870,12 +3870,13 @@ repositories:
     release:
       packages:
       - pmb2_2dnav
+      - pmb2_laser_sensors
       - pmb2_maps
       - pmb2_navigation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_navigation-gbp.git
-      version: 4.0.0-1
+      version: 4.0.3-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_navigation` to `4.0.3-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_navigation.git
- release repository: https://github.com/pal-gbp/pmb2_navigation-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.0-1`

## pmb2_2dnav

- No changes

## pmb2_laser_sensors

```
* Merge branch 'fix/deps' into 'humble-devel'
  temporarily removed sick_tim dependency
  See merge request robots/pmb2_navigation!69
* temporarily removed sick_tim dependency
* Contributors: antoniobrandi
```

## pmb2_maps

- No changes

## pmb2_navigation

- No changes
