### PR TITLE
ros2_controllers: 3.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4523,7 +4523,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 3.4.0-1
+      version: 3.5.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `3.5.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.4.0-1`

## admittance_controller

```
* Misplaced param init in admittance_controller (#547 <https://github.com/ros-controls/ros2_controllers/issues/547>)
* [Parameters] Use gt_eq instead of deprecated lower_bounds in validators (#561 <https://github.com/ros-controls/ros2_controllers/issues/561>)
* Contributors: Dr. Denis, GuiHome
```

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gripper_controllers

```
* [Parameters] Use gt_eq instead of deprecated lower_bounds in validators (#561 <https://github.com/ros-controls/ros2_controllers/issues/561>)
* Contributors: Dr. Denis
```

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* [Parameters] Use gt_eq instead of deprecated lower_bounds in validators (#561 <https://github.com/ros-controls/ros2_controllers/issues/561>)
* [JTC] Disable use of closed-loop PID adapter if controller is used in open-loop mode. (#551 <https://github.com/ros-controls/ros2_controllers/issues/551>)
* Contributors: Dr. Denis
```

## position_controllers

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## tricycle_controller

- No changes

## velocity_controllers

- No changes
