### PR TITLE
Revert "pyhri: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]"

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7643,7 +7643,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros4hri/pyhri-release.git
-      version: 0.4.0-1
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/ros4hri/pyhri.git


### PR DESCRIPTION
Reverts ros/rosdistro#36812

This was mistakenly released during a sync hold. Once the hold is released this revert can itself be reverted.