### PR TITLE
pyhri: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7643,7 +7643,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros4hri/pyhri-release.git
-      version: 0.3.2-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/ros4hri/pyhri.git


### PR DESCRIPTION
This PR restores the release originally in https://github.com/ros/rosdistro/pull/36812 which was mistakenly merged during a sync hold and subsequently reverted.

Reverts ros/rosdistro#36864