### PR TITLE
fmi_adapter: 2.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1276,7 +1276,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fmi_adapter-release.git
-      version: 2.1.1-3
+      version: 2.1.2-1
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fmi_adapter` to `2.1.2-1`:

- upstream repository: https://github.com/boschresearch/fmi_adapter.git
- release repository: https://github.com/ros2-gbp/fmi_adapter-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.1-3`

## fmi_adapter

```
* Updated link to lifecycle_node.hpp.
* Updated include get_env.h to env.h.
* Contributors: Ralph Lange
```

## fmi_adapter_examples

- No changes
