### PR TITLE
Added python3-ftdi1

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5882,6 +5882,14 @@ python3-formant-pip:
   ubuntu:
     pip:
       packages: [formant]
+python3-ftdi1:
+  arch: [libftdi]
+  debian: [python3-ftdi1]
+  fedora: [python3-libftdi]
+  gentoo: ['dev-embedded/libftdi[python]']
+  nixos: [libftdi1]
+  opensuse: [python3-libftdi1]
+  ubuntu: [python3-ftdi1]
 python3-funcsigs:
   debian: [python3-funcsigs]
   fedora: [python3-funcsigs]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-ftdi1

## Package Upstream Source:

https://www.intra2net.com/en/developer/libftdi/download.php

## Purpose of using this:

Python3 version of already existing python-ftdi1 key. Allows communication with FTDI USB-serial chips.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/python3-ftdi1
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/focal/python3-ftdi1
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/libftdi/python3-libftdi/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/community/x86_64/libftdi/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-embedded/libftdi
- macOS: https://formulae.brew.sh/
  - N/A
- Alpine: https://pkgs.alpinelinux.org/packages
  - N/A
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=22.11&show=libftdi1&from=0&size=50&buckets=%7B%22package_attr_set%22%3A%5B%5D%2C%22package_license_set%22%3A%5B%5D%2C%22package_maintainers_set%22%3A%5B%5D%2C%22package_platforms%22%3A%5B%5D%7D&sort=relevance&type=packages&query=ftdi
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python3-libftdi1