### PR TITLE
update uncrustify gentoo lib

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7760,7 +7760,7 @@ uncrustify:
   arch: [uncrustify]
   debian: [uncrustify]
   fedora: [uncrustify]
-  gentoo: [uncrustify]
+  gentoo: [dev-util/uncrustify]
   nixos: [uncrustify]
   openembedded: [uncrustify@meta-ros-common]
   osx:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

While creating manifest of uncrustify on gentoo it was saying the uncrustify package is not a valid package name. So I replaced it by dev-util/uncrustify.

## Package name:

uncrustify

## Package Upstream Source:

https://github.com/uncrustify/uncrustify


## Purpose of using this:

uncrustify is not a valid gentoo package, dev-util/uncrustify is.

Distro packaging links:
https://packages.gentoo.org/packages/dev-util/uncrustify
## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - uncrustify
- Ubuntu: https://packages.ubuntu.com/
  - uncrustify
- Fedora: https://packages.fedoraproject.org/
  - uncrustify
- Arch: https://www.archlinux.org/packages/
  - uncrustify
- Gentoo: https://packages.gentoo.org/
  - dev-util/uncrustify
- macOS: https://formulae.brew.sh/
  - uncrustify
- Alpine: https://pkgs.alpinelinux.org/packages
  - uncrustify
- NixOS/nixpkgs: https://search.nixos.org/packages
  - uncrustify
- openSUSE: https://software.opensuse.org/package/
  - uncrustify


