### PR TITLE
mikrotik_swos_tools: 1.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5294,7 +5294,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/peci1/mikrotik_swos_tools-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/peci1/mikrotik_swos_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mikrotik_swos_tools` to `1.1.1-1`:

- upstream repository: https://github.com/peci1/mikrotik_swos_tools.git
- release repository: https://github.com/peci1/mikrotik_swos_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-1`

## mikrotik_swos_tools

```
* Noetic compatibility (2nd round).
* Contributors: Martin Pecka
```
