### PR TITLE
mrpt2: 2.8.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3023,7 +3023,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt2-release.git
-      version: 2.8.0-1
+      version: 2.8.1-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt2` to `2.8.1-1`:

- upstream repository: https://github.com/MRPT/mrpt.git
- release repository: https://github.com/ros2-gbp/mrpt2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.8.0-1`
