### PR TITLE
jsk_pr2eus: 0.3.15-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4223,6 +4223,24 @@ repositories:
       url: https://github.com/jsk-ros-pkg/jsk_model_tools.git
       version: master
     status: developed
+  jsk_pr2eus:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_pr2eus.git
+      version: master
+    release:
+      packages:
+      - jsk_pr2eus
+      - pr2eus
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/tork-a/jsk_pr2eus-release.git
+      version: 0.3.15-1
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_pr2eus.git
+      version: master
+    status: developed
   jsk_recognition:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_pr2eus` to `0.3.15-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_pr2eus
- release repository: https://github.com/tork-a/jsk_pr2eus-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## jsk_pr2eus

- No changes

## pr2eus

```
* Add *enable-roseus-resume* for installing default interruption handlers (#488 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/488>)
* add displaying error msg method to controller-action-client in robot-interface.l (#460 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/460>)
* .github/workflows/config.yml: enable noetic USE_DEB=true (#484 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/484>)
* Enable either-or tuckarm-pose (#475 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/475>)
* Allow to set :use-torso in :move-end-pos (#476 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/476>)
* disable doc generation if 'catkin bt -vi --cmake-args -DDISABLE_DOCUMENTATION=1' (#482 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/482>)
* [pr2eus] Fix typo :cmd-vel-topi -> :cmd-vel-topic (#480 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/480>)
* [pr2eus] Add key topic-name to :send-cmd-vel-raw (#481 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/481>)
* install pr2-send-joints.l pr2-read-state.l with original permissions (#478 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/478>)
* integrate all .github/workflows/*.yml to config.yml, fix permission issue (#479 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/479>)
* add dummy_jta_server.py and pr2-ri-jta for example code of (#460 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/460>)
* add comments to :move-to (#470 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/470>)
* add test code for (pr2) and (instance pr2-robot :init) (instance r2-sensor-robot :init) (#466 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/466>)
* add test code for #461 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/461> (#468 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/468>)
* Fix wide_stereo camera model parameters (#426 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/426>)
* [pr2eus] Fix doc about timeout of :wait-interpolation (#445 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/445>)
* Add minjerk-interpolation to :angle-vector and :angle-vector-sequence (#456 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/456>)
* [pr2eus] remove j_robotsound advertise (#450 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/450>)
* [pr2eus] add provide in pr2-interface.l and pr2-utils.l (#441 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/441>)
* fix to support namespace (#440 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/440>)
* define methods for interpolation (#443 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/443>)
* add pr2-ri-test-namespace.launch to check (#439 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/439>)
* Fix bug on joint-move-over-180 with tm :fast (#422 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/422>)
* add pr2-ri-test-simple.l to test/pr2-ri-test.launch (#430 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/430>)
* Updates to :stop-motion (#402 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/402>)
* Fix typo move-to-no-wait -> move-to-wait (#409 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/409>)
* [pr2eus] Add correction arg in :move-to-wait (#418 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/418>)
* Fix tilt laser mux topic for obstacle observation (#408 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/408>)
* [pr2eus] add gain key in :stop-grasp (#415 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/415>)
* Fix return value of clear-costmap function (#396 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/396>)
* update :go-velocity, :go-pos-unsafe-no-wait for robto without move-base-trajectory-action, add :send-cmd-vel-raw (#425 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/425>)
* enable to test navigation in gazebo for  pr2-ri-test (#420 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/420>)
* Fix confirmation on warningp (#395 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/395>)
* Avoid unnecessary convex-hull-3d calculation on :start-grasp (#398 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/398>)
* Fix typos in comments about :fast utility in :angle-vector* (#391 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/391>)
* Contributors: Aoi Nakane, Guilherme Affonso, Hiro Ishida, Kei Okada, Naoki Hiraoka, Naoto Tsukamoto, Naoya Yamaguchi, Shingo Kitagawa, Shumpei Wakabayashi, Shun Hasegawa, Yuto Uchimi, Taichi Higashide
```
