### PR TITLE
tiago_navigation: 4.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6869,11 +6869,12 @@ repositories:
     release:
       packages:
       - tiago_2dnav
+      - tiago_laser_sensors
       - tiago_navigation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_navigation-release.git
-      version: 4.0.2-1
+      version: 4.0.4-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_navigation` to `4.0.4-1`:

- upstream repository: https://github.com/pal-robotics/tiago_navigation.git
- release repository: https://github.com/pal-gbp/tiago_navigation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.2-1`

## tiago_laser_sensors

```
* Update package.xml version
* Merge branch 'laser_migration' into 'humble-devel'
  laser sensors migration
  See merge request robots/tiago_navigation!80
* Apply 1 suggestion(s) to 1 file(s)
* updated copyright
* Apply 2 suggestion(s) to 1 file(s)
* typo and using launch_pal
* laser sensors migration
* Contributors: Noel Jimenez, antoniobrandi
```
