### PR TITLE
maliput_ros_interfaces: 0.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2809,6 +2809,26 @@ repositories:
       url: https://github.com/maliput/maliput_py.git
       version: main
     status: developed
+  maliput_ros_interfaces:
+    doc:
+      type: git
+      url: https://github.com/maliput/ros2_maliput.git
+      version: main
+    release:
+      packages:
+      - maliput_ros
+      - maliput_ros_interfaces
+      - maliput_ros_translation
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/maliput_ros_interfaces.git
+      version: 0.1.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/maliput/ros2_maliput.git
+      version: main
+    status: developed
   maliput_sparse:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_ros_interfaces` to `0.1.1-1`:

- upstream repository: https://github.com/maliput/ros2_maliput.git
- release repository: https://github.com/ros2-gbp/maliput_ros_interfaces.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## maliput_ros_interfaces

```
* Adds READMEs to the packages. (#24 <https://github.com/maliput/ros2_maliput/issues/24>)
* Sample lane s route (#21 <https://github.com/maliput/ros2_maliput/issues/21>)
* Routing service (#20 <https://github.com/maliput/ros2_maliput/issues/20>)
* Road position services (#19 <https://github.com/maliput/ros2_maliput/issues/19>)
* Removes tests to avoid breaking CI with generated files. (#13 <https://github.com/maliput/ros2_maliput/issues/13>)
* Adds the translation interface for geometric types. (#4 <https://github.com/maliput/ros2_maliput/issues/4>)
* Adds geometric descriptions and a few basic requests for the entities. (#3 <https://github.com/maliput/ros2_maliput/issues/3>)
* Create a message package (#2 <https://github.com/maliput/ros2_maliput/issues/2>)
* Contributors: Agustin Alba Chicar
```
