### PR TITLE
maliput_ros_translation: 0.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2809,6 +2809,26 @@ repositories:
       url: https://github.com/maliput/maliput_py.git
       version: main
     status: developed
+  maliput_ros_translation:
+    doc:
+      type: git
+      url: https://github.com/maliput/ros2_maliput.git
+      version: main
+    release:
+      packages:
+      - maliput_ros
+      - maliput_ros_interfaces
+      - maliput_ros_translation
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/maliput_ros_translation.git
+      version: 0.1.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/maliput/ros2_maliput.git
+      version: main
+    status: developed
   maliput_sparse:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_ros_translation` to `0.1.1-1`:

- upstream repository: https://github.com/maliput/ros2_maliput.git
- release repository: https://github.com/ros2-gbp/maliput_ros_translation.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## maliput_ros_translation

```
* Adds READMEs to the packages. (#24 <https://github.com/maliput/ros2_maliput/issues/24>)
* Routing service (#20 <https://github.com/maliput/ros2_maliput/issues/20>)
* Road position services (#19 <https://github.com/maliput/ros2_maliput/issues/19>)
* Add get junction service (#14 <https://github.com/maliput/ros2_maliput/issues/14>)
* Completes documentation (#6 <https://github.com/maliput/ros2_maliput/issues/6>)
* Complete tests for geometric type translations (#5 <https://github.com/maliput/ros2_maliput/issues/5>)
* Adds the translation interface for geometric types. (#4 <https://github.com/maliput/ros2_maliput/issues/4>)
* Contributors: Agustin Alba Chicar
```
