### PR TITLE
maliput_ros: 0.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2809,6 +2809,26 @@ repositories:
       url: https://github.com/maliput/maliput_py.git
       version: main
     status: developed
+  maliput_ros:
+    doc:
+      type: git
+      url: https://github.com/maliput/ros2_maliput.git
+      version: main
+    release:
+      packages:
+      - maliput_ros
+      - maliput_ros_interfaces
+      - maliput_ros_translation
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/maliput_ros.git
+      version: 0.1.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/maliput/ros2_maliput.git
+      version: main
+    status: developed
   maliput_sparse:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `maliput_ros` to `0.1.1-1`:

- upstream repository: https://github.com/maliput/ros2_maliput.git
- release repository: https://github.com/ros2-gbp/maliput_ros.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## maliput_ros

```
* Adds READMEs to the packages. (#24 <https://github.com/maliput/ros2_maliput/issues/24>)
* Sample lane s route (#21 <https://github.com/maliput/ros2_maliput/issues/21>)
* Routing service (#20 <https://github.com/maliput/ros2_maliput/issues/20>)
* Road position services (#19 <https://github.com/maliput/ros2_maliput/issues/19>)
* Refactor tests to scale build time (#18 <https://github.com/maliput/ros2_maliput/issues/18>)
* Adds branch point service (#17 <https://github.com/maliput/ros2_maliput/issues/17>)
* Adds lane service (#16 <https://github.com/maliput/ros2_maliput/issues/16>)
* Add get segment service (#15 <https://github.com/maliput/ros2_maliput/issues/15>)
* Add get junction service (#14 <https://github.com/maliput/ros2_maliput/issues/14>)
* Add tests to ROS node (#10 <https://github.com/maliput/ros2_maliput/issues/10>)
* Create maliput ros node (#8 <https://github.com/maliput/ros2_maliput/issues/8>)
* Create maliput_ros package (#7 <https://github.com/maliput/ros2_maliput/issues/7>)
* Contributors: Agustin Alba Chicar
```

