### PR TITLE
Fix `python-attrs-pip` for Ubuntu

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -620,6 +620,9 @@ python-attrs-pip:
   fedora:
     pip:
       packages: [attrs]
+  ubuntu:
+    pip:
+      packages: [attrs]
 python-autobahn:
   debian: [python-autobahn]
   fedora:


### PR DESCRIPTION
Replace Ubuntu in the `python-attrs-pip` key, removed in commit 59517bc9c424.

