### PR TITLE
revert rpi package #36889

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3621,6 +3621,16 @@ python-rpi.gpio:
         packages: [RPi.GPIO]
   ubuntu:
     bionic: [python-rpi.gpio]
+python-rpi.gpio-pip:
+  debian:
+    pip:
+      packages: [RPi.GPIO]
+  fedora:
+    pip:
+      packages: [RPi.GPIO]
+  ubuntu:
+    pip:
+      packages: [RPi.GPIO]
 python-rrdtool:
   debian: [python-rrdtool]
   gentoo: [net-analyzer/rrdtool]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python-rpi.gpio-pip

## Package Upstream Source:

https://pypi.org/project/RPi.GPIO/

## Purpose of using this:

The package is needed to support the GPIO pins for the Raspberry Pi.

Distro packaging links:
- Debian: https://packages.debian.org/
- Ubuntu: https://packages.ubuntu.com/
- Fedora: https://packages.fedoraproject.org/