### PR TITLE
Updates to python-attrs after cleanup introduced an oddity.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -611,8 +611,6 @@ python-attrs:
   ubuntu:
     '*':
       packages: [python-attr]
-      pip:
-        packages: [attrs]
 python-attrs-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -605,12 +605,13 @@ python-astor-pip:
     pip:
       packages: [astor]
 python-attrs:
-  debian: [python-attr]
+  debian:
+    buster: [python-attr]
   gentoo: [dev-python/attrs]
   nixos: [pythonPackages.attrs]
   ubuntu:
-    '*':
-      packages: [python-attr]
+    bionic: [python-attr]
+    focal: [python-attr]
 python-attrs-pip:
   debian:
     pip:


### PR DESCRIPTION
This is prompted by https://github.com/ros/rosdistro/pull/36888.

The current state of `master` includes the following stanza:

```
python-attrs:
  # snip...
  ubuntu:
    '*':
      packages: [python-attr]
      pip:
        packages: [attrs]
```

I'm not even sure if this is a valid spelling. I missed this when reviewing https://github.com/ros/rosdistro/pull/36755/ which is probably an object lesson in small reviewable changes. If I'm very responsible then tomorrow morning I'll test what the behavior of this config actually is.

But in any case it seems like an unintended result, or at least one that is worth confirming its intent.

I took a look at the package availability in Debian and Ubuntu. This package is available in Debian Buster and Ubuntu Bionic and Focal but not in later distributions of either. So I've scoped these packages down to those distributions and then likely this entire key can be retired once they're no longer in rosdep's in-scope distros.