### PR TITLE
image_transport_plugins: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1874,7 +1874,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 2.6.0-2
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `3.0.0-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.6.0-2`

## compressed_depth_image_transport

```
* Replace deprecated cv_bridge.h with cv_bridge.hpp (#118 <https://github.com/ros-perception/image_transport_plugins/issues/118>)
* Update maintainer (#112 <https://github.com/ros-perception/image_transport_plugins/issues/112>)
* Contributors: Kenji Brameld
```

## compressed_image_transport

```
* Deprecated the following parameter names in favor of transport scoped ones. The remapping is listed below:
  * image.format to image.compressed.format
  * image.png_level to image.compressed.png_level
  * image.jpeg_quality to image.compressed.jpeg_quality
  * image.tiff.res_unit to image.compressed.tiff.res_unit
  * image.tiff.xdpi to image.compressed.tiff.xdpi
  * image.tiff.ydpi to image.compressed.tiff.ydpi
  The deprecated parameters emit a warning if explicitly set, but this warning will be removed in future distros.
  (#143 <https://github.com/ros-perception/image_transport_plugins/issues/143>)
* Replace deprecated cv_bridge.h with cv_bridge.hpp (#118 <https://github.com/ros-perception/image_transport_plugins/issues/118>)
* Update maintainer (#112 <https://github.com/ros-perception/image_transport_plugins/issues/112>)
* Compressed image transport parameters are now reconfigurable (#108 <https://github.com/ros-perception/image_transport_plugins/issues/108>)
* Contributors: Bartosz Meglicki, Ivan Santiago Paunovic, Kenji Brameld
```

## image_transport_plugins

```
* Update maintainer (#112 <https://github.com/ros-perception/image_transport_plugins/issues/112>)
* Contributors: Kenji Brameld, Michael Carroll
```

## theora_image_transport

```
* Replace deprecated cv_bridge.h with cv_bridge.hpp (#118 <https://github.com/ros-perception/image_transport_plugins/issues/118>)
* Update maintainer (#112 <https://github.com/ros-perception/image_transport_plugins/issues/112>)
* Contributors: Kenji Brameld, Michael Carroll
```
