### PR TITLE
rcl_interfaces: 1.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3806,7 +3806,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_interfaces-release.git
-      version: 1.5.0-1
+      version: 1.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_interfaces` to `1.6.0-1`:

- upstream repository: https://github.com/ros2/rcl_interfaces.git
- release repository: https://github.com/ros2-gbp/rcl_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.5.0-1`

## action_msgs

- No changes

## builtin_interfaces

- No changes

## composition_interfaces

- No changes

## lifecycle_msgs

- No changes

## rcl_interfaces

```
* Add interfaces for logging service. (#154 <https://github.com/ros2/rcl_interfaces/issues/154>)
* Contributors: Lei Liu
```

## rosgraph_msgs

- No changes

## service_msgs

- No changes

## statistics_msgs

- No changes

## test_msgs

- No changes

## type_description_interfaces

- No changes
