### PR TITLE
ros2cli: 0.25.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4627,7 +4627,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.24.1-1
+      version: 0.25.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.25.0-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.24.1-1`

## ros2action

```
* Make all of the dependencies in pure Python packages exec_depend. (#823 <https://github.com/ros2/ros2cli/issues/823>)
* Contributors: Chris Lalancette
```

## ros2cli

- No changes

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

```
* Make all of the dependencies in pure Python packages exec_depend. (#823 <https://github.com/ros2/ros2cli/issues/823>)
* Contributors: Chris Lalancette
```

## ros2interface

```
* Make all of the dependencies in pure Python packages exec_depend. (#823 <https://github.com/ros2/ros2cli/issues/823>)
* Contributors: Chris Lalancette
```

## ros2lifecycle

```
* Make all of the dependencies in pure Python packages exec_depend. (#823 <https://github.com/ros2/ros2cli/issues/823>)
* Contributors: Chris Lalancette
```

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

```
* Make all of the dependencies in pure Python packages exec_depend. (#823 <https://github.com/ros2/ros2cli/issues/823>)
* Contributors: Chris Lalancette
```

## ros2node

```
* Make all of the dependencies in pure Python packages exec_depend. (#823 <https://github.com/ros2/ros2cli/issues/823>)
* Contributors: Chris Lalancette
```

## ros2param

```
* remove deprecated options (#824 <https://github.com/ros2/ros2cli/issues/824>)
* Make all of the dependencies in pure Python packages exec_depend. (#823 <https://github.com/ros2/ros2cli/issues/823>)
* Contributors: Chris Lalancette, Tomoya Fujita
```

## ros2pkg

```
* Make all of the dependencies in pure Python packages exec_depend. (#823 <https://github.com/ros2/ros2cli/issues/823>)
* Contributors: Chris Lalancette
```

## ros2run

```
* Make all of the dependencies in pure Python packages exec_depend. (#823 <https://github.com/ros2/ros2cli/issues/823>)
* Contributors: Chris Lalancette
```

## ros2service

```
* Make all of the dependencies in pure Python packages exec_depend. (#823 <https://github.com/ros2/ros2cli/issues/823>)
* Contributors: Chris Lalancette
```

## ros2topic

```
* remove deprecated options (#824 <https://github.com/ros2/ros2cli/issues/824>)
* Make all of the dependencies in pure Python packages exec_depend. (#823 <https://github.com/ros2/ros2cli/issues/823>)
* Contributors: Chris Lalancette, Tomoya Fujita
```
