### PR TITLE
rosbag2: 0.22.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4804,7 +4804,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.21.0-2
+      version: 0.22.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.22.0-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.21.0-2`

## mcap_vendor

- No changes

## ros2bag

- No changes

## rosbag2

- No changes

## rosbag2_compression

```
* Add message definition read API (#1292 <https://github.com/ros2/rosbag2/issues/1292>)
* rosbag2_storage: add type description hash to topic metadata (#1272 <https://github.com/ros2/rosbag2/issues/1272>)
* Contributors: james-rms
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Add type_hash in MessageDefinition struct (#1296 <https://github.com/ros2/rosbag2/issues/1296>)
* Add message definition read API (#1292 <https://github.com/ros2/rosbag2/issues/1292>)
* rosbag2_storage: add type description hash to topic metadata (#1272 <https://github.com/ros2/rosbag2/issues/1272>)
* Fix for flaky TimeControllerClockTest::unpaused_sleep_returns_true test (#1290 <https://github.com/ros2/rosbag2/issues/1290>)
* Contributors: Michael Orlov, james-rms
```

## rosbag2_examples_cpp

```
* rosbag2_storage: add type description hash to topic metadata (#1272 <https://github.com/ros2/rosbag2/issues/1272>)
* Contributors: james-rms
```

## rosbag2_examples_py

- No changes

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

```
* Add tests for rosbag2_performance_benchmarking pkg (#1268 <https://github.com/ros2/rosbag2/issues/1268>)
* Contributors: Michael Orlov
```

## rosbag2_performance_benchmarking_msgs

```
* Add tests for rosbag2_performance_benchmarking pkg (#1268 <https://github.com/ros2/rosbag2/issues/1268>)
* Contributors: Michael Orlov
```

## rosbag2_py

```
* Add type_hash in MessageDefinition struct (#1296 <https://github.com/ros2/rosbag2/issues/1296>)
* Store message definitions in SQLite3 storage plugin (#1293 <https://github.com/ros2/rosbag2/issues/1293>)
* Add message definition read API (#1292 <https://github.com/ros2/rosbag2/issues/1292>)
* rosbag2_storage: add type description hash to topic metadata (#1272 <https://github.com/ros2/rosbag2/issues/1272>)
* Contributors: Michael Orlov, james-rms
```

## rosbag2_storage

```
* Add type_hash in MessageDefinition struct (#1296 <https://github.com/ros2/rosbag2/issues/1296>)
* Add message definition read API (#1292 <https://github.com/ros2/rosbag2/issues/1292>)
* rosbag2_storage: add type description hash to topic metadata (#1272 <https://github.com/ros2/rosbag2/issues/1272>)
* Contributors: Michael Orlov, james-rms
```

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

```
* Add type_hash in MessageDefinition struct (#1296 <https://github.com/ros2/rosbag2/issues/1296>)
* Add message definition read API (#1292 <https://github.com/ros2/rosbag2/issues/1292>)
* rosbag2_storage: add type description hash to topic metadata (#1272 <https://github.com/ros2/rosbag2/issues/1272>)
* Contributors: Michael Orlov, james-rms
```

## rosbag2_storage_sqlite3

```
* Add type_hash in MessageDefinition struct (#1296 <https://github.com/ros2/rosbag2/issues/1296>)
* Store message definitions in SQLite3 storage plugin (#1293 <https://github.com/ros2/rosbag2/issues/1293>)
* Add message definition read API (#1292 <https://github.com/ros2/rosbag2/issues/1292>)
* rosbag2_storage: add type description hash to topic metadata (#1272 <https://github.com/ros2/rosbag2/issues/1272>)
* Contributors: Michael Orlov, james-rms
```

## rosbag2_test_common

- No changes

## rosbag2_test_msgdefs

- No changes

## rosbag2_tests

```
* Add type_hash in MessageDefinition struct (#1296 <https://github.com/ros2/rosbag2/issues/1296>)
* Contributors: Michael Orlov
```

## rosbag2_transport

```
* Read message definitions from input files in bag_rewrite (#1295 <https://github.com/ros2/rosbag2/issues/1295>)
* Add message definition read API (#1292 <https://github.com/ros2/rosbag2/issues/1292>)
* Move rosbag2_transport::Recorder implementation to pimpl (#1291 <https://github.com/ros2/rosbag2/issues/1291>)
* rosbag2_storage: add type description hash to topic metadata (#1272 <https://github.com/ros2/rosbag2/issues/1272>)
* Contributors: Emerson Knapp, Michael Orlov, james-rms
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
