### PR TITLE
rclcpp: 21.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3879,7 +3879,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 20.0.0-1
+      version: 21.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `21.0.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `20.0.0-1`

## rclcpp

```
* Add support for logging service. (#2122 <https://github.com/ros2/rclcpp/issues/2122>)
* Picking ABI-incompatible executor changes (#2170 <https://github.com/ros2/rclcpp/issues/2170>)
* add events-executor and timers-manager in rclcpp (#2155 <https://github.com/ros2/rclcpp/issues/2155>)
* Create common structures for executors to use (#2143 <https://github.com/ros2/rclcpp/issues/2143>)
* Implement deliver message kind (#2168 <https://github.com/ros2/rclcpp/issues/2168>)
* Contributors: Alberto Soragna, Lei Liu, Michael Carroll, methylDragon
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* Add support for logging service. (#2122 <https://github.com/ros2/rclcpp/issues/2122>)
* Support publishing loaned messages in LifecyclePublisher (#2159 <https://github.com/ros2/rclcpp/issues/2159>)
* Contributors: Lei Liu, Michael Babenko
```
