### PR TITLE
rclpy: 4.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3895,7 +3895,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 4.0.0-1
+      version: 4.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `4.1.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.0-1`

## rclpy

```
* Logging service support (#1102 <https://github.com/ros2/rclpy/issues/1102>)
* Use custom sourcedir for conf.py (#1109 <https://github.com/ros2/rclpy/issues/1109>)
* ServerGoalHandle should be destroyed before removing. (#1113 <https://github.com/ros2/rclpy/issues/1113>)
* Fix unnecessary list comprehension flake8 (#1112 <https://github.com/ros2/rclpy/issues/1112>)
* Contributors: Barry Xu, Michael Carroll, Tomoya Fujita, Yadu
```
