### PR TITLE
ros2_tracing: 6.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4571,6 +4571,7 @@ repositories:
     release:
       packages:
       - ros2trace
+      - test_tracetools
       - tracetools
       - tracetools_launch
       - tracetools_read
@@ -4579,7 +4580,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 6.1.0-1
+      version: 6.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `6.2.0-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `6.1.0-1`

## ros2trace

```
* Error out if trace already exists unless 'append' option is used (#58 <https://github.com/ros2/ros2_tracing/issues/58>)
* Improve 'ros2 trace' command error handling & add end-to-end tests (#54 <https://github.com/ros2/ros2_tracing/issues/54>)
* Contributors: Christophe Bedard
```

## test_tracetools

- No changes

## tracetools

- No changes

## tracetools_launch

```
* Error out if trace already exists unless 'append' option is used (#58 <https://github.com/ros2/ros2_tracing/issues/58>)
* Improve 'ros2 trace' command error handling & add end-to-end tests (#54 <https://github.com/ros2/ros2_tracing/issues/54>)
* Make subbuffer size configurable with Trace action (#51 <https://github.com/ros2/ros2_tracing/issues/51>)
* Contributors: Christophe Bedard, Christopher Wecht
```

## tracetools_read

- No changes

## tracetools_test

- No changes

## tracetools_trace

```
* Error out if trace already exists unless 'append' option is used (#58 <https://github.com/ros2/ros2_tracing/issues/58>)
* Improve 'ros2 trace' command error handling & add end-to-end tests (#54 <https://github.com/ros2/ros2_tracing/issues/54>)
* Make subbuffer size configurable with Trace action (#51 <https://github.com/ros2/ros2_tracing/issues/51>)
* Contributors: Christophe Bedard, Christopher Wecht
```
