### PR TITLE
moveit: 2.7.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2577,7 +2577,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
-      version: 2.7.1-1
+      version: 2.7.2-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.7.2-1`:

- upstream repository: https://github.com/ros-planning/moveit2.git
- release repository: https://github.com/ros2-gbp/moveit2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.7.1-1`

## chomp_motion_planner

- No changes

## moveit

```
* moveit_py: Python interface for MoveIt 2
* Contributors: Jens Vanhooydonck, Peter David Fagan, Robert Haschke, Sebastian Jahr
```

## moveit_chomp_optimizer_adapter

- No changes

## moveit_common

```
* Switch from qos_event.hpp to event_handler.hpp (#2111 <https://github.com/ros-planning/moveit2/issues/2111>)
  * Switch from qos_event.hpp to event_handler.hpp
  * moveit_common: Add a cmake interface library to keep humble support on main
  * Include qos_event.hpp or event_handler.hpp depending on the ROS 2 version
  * Fix ament_lint_cmake
  * Fix clang-tidy
  * PRIVATE linking in some cases
  * Update moveit_common/cmake/moveit_package.cmake
  Co-authored-by: Chris Thrasher <mailto:chrisjthrasher@gmail.com>
  * Fix servo and cleanup excessive CMake variable usage
  * Cleanup & make compiling
  * Small variable naming and const cleanup
  * Restore OpenCV linking
  * Public/private linking fixup
  * Revert "Restore OpenCV linking"
  This reverts commit 57a9efa806e59223e35a1f7e998d7b52f930c263.
  ---------
  Co-authored-by: JafarAbdi <mailto:jafar.uruc@gmail.com>
  Co-authored-by: Jafar <mailto:cafer.abdi@gmail.com>
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  Co-authored-by: Chris Thrasher <mailto:chrisjthrasher@gmail.com>
* enabled -wformat (#2065 <https://github.com/ros-planning/moveit2/issues/2065>)
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Contributors: Heramb Modugula, Sebastian Jahr
```

## moveit_configs_utils

```
* Update pre-commit (#2094 <https://github.com/ros-planning/moveit2/issues/2094>)
* Use $DISPLAY rather than assuming :0 (#2049 <https://github.com/ros-planning/moveit2/issues/2049>)
  * Use $DISPLAY rather than assuming :
  * Double quotes
  ---------
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Contributors: Shobuj Paul, Stephanie Eng
```

## moveit_core

```
* Add JointModel::satisfiesAccelerationBounds() (#2092 <https://github.com/ros-planning/moveit2/issues/2092>)
  * Add JointModel::satisfiesAccelerationBounds()
  * Check Jerk bounds too
  * Check if bounds exist
  ---------
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* A ROS param for Servo filter coefficient (#2091 <https://github.com/ros-planning/moveit2/issues/2091>)
  * Add generate_parameter_library as dependency
  * Generate and export parameter target
  * Update butterworth filter to use params
  * Move param listener declaration to header
  * Formatting
  * Remove unnecessary rclcpp include
  * Fix alphabetical order
  * Make param listener local
  * Fix target exporting in cmake
  * Add moveit_ prefix to parameter library target
  * Remove obsolete comment
  * Member variable naming
  * Alphabetize
  ---------
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
* Merge pull request #1900 <https://github.com/ros-planning/moveit2/issues/1900> from Abishalini/pr-sync-1245f15
  Sync with MoveIt1
* Readd comment and assign error code
* Merge https://github.com/ros-planning/moveit/commit/1245f151393fe09023efec3e1faead2d26737227
* Add test and debug issue where TOTG returns accels > limit (#2084 <https://github.com/ros-planning/moveit2/issues/2084>)
* Move stateless PlanningScene helper functions out of the class (#2025 <https://github.com/ros-planning/moveit2/issues/2025>)
* Document how collision checking includes descendent links (#2058 <https://github.com/ros-planning/moveit2/issues/2058>)
* Optionally mitigate Ruckig overshoot (#2051 <https://github.com/ros-planning/moveit2/issues/2051>)
  * Optionally mitigate Ruckig overshoot
  * Cleanup
* Delete the Ruckig "batches" option, deprecated by #1990 <https://github.com/ros-planning/moveit2/issues/1990> (#2028 <https://github.com/ros-planning/moveit2/issues/2028>)
* Merge PR #3197 <https://github.com/ros-planning/moveit2/issues/3197>: Improve computeCartesianPath()
* Gracefully handle gtest 1.8 (Melodic)
  gtest 1.8 doesn't provide SetUpTestSuite().
  Thus, we cannot share the RobotModel across tests.
* Add unit tests for computeCartesianPath()
* Add utils to simplify (approximate) equality checks for Eigen entities
* robot_model_test_utils: Add loadIKPluginForGroup()
* Simplify test_cartesian_interpolator.cpp
* Generalize computeCartesianPath() to consider a link_offset
  This allows performing a circular motion about a non-link origin.
* Cleanup CartesianInterpolator
  - Fixup doc comments
  - Add API providing the translation vector = direction * distance
  - Simplify implementation
* Contributors: Abishalini, Abishalini Sivaraman, AndyZe, Robert Haschke, V Mohammed Ibrahim
```

## moveit_hybrid_planning

```
* Switch from qos_event.hpp to event_handler.hpp (#2111 <https://github.com/ros-planning/moveit2/issues/2111>)
  * Switch from qos_event.hpp to event_handler.hpp
  * moveit_common: Add a cmake interface library to keep humble support on main
  * Include qos_event.hpp or event_handler.hpp depending on the ROS 2 version
  * Fix ament_lint_cmake
  * Fix clang-tidy
  * PRIVATE linking in some cases
  * Update moveit_common/cmake/moveit_package.cmake
  Co-authored-by: Chris Thrasher <mailto:chrisjthrasher@gmail.com>
  * Fix servo and cleanup excessive CMake variable usage
  * Cleanup & make compiling
  * Small variable naming and const cleanup
  * Restore OpenCV linking
  * Public/private linking fixup
  * Revert "Restore OpenCV linking"
  This reverts commit 57a9efa806e59223e35a1f7e998d7b52f930c263.
  ---------
  Co-authored-by: JafarAbdi <mailto:jafar.uruc@gmail.com>
  Co-authored-by: Jafar <mailto:cafer.abdi@gmail.com>
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  Co-authored-by: Chris Thrasher <mailto:chrisjthrasher@gmail.com>
* Update pre-commit (#2094 <https://github.com/ros-planning/moveit2/issues/2094>)
* [hybrid planning] improve planning scene monitoring (#1090 <https://github.com/ros-planning/moveit2/issues/1090>)
  * Create new PSM in local constraint solver. Different type of collision checking.
  * Small boolean logic fixup
  * Don't configure planning scene monitor twice and pass scene as const
  * Remove not required call of updateSceneWithCurrentState()
  * Revert PlanningSceneMonitorConstPtr to PlanningSceneMonitorPtr
  * Set planning_scene_monitor update rate
  * Decrease planning scene update rate
  * Use updateSceneWithCurrentState() in psm
  * Revert the manner of collision checking
  ---------
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Contributors: AndyZe, Sebastian Jahr, Shobuj Paul
```

## moveit_kinematics

```
* Fix moveit_kinematics dependency on moveit_ros_planning (#2109 <https://github.com/ros-planning/moveit2/issues/2109>)
  This dependency is unconditionally used even if tests are disabled.
* Update pre-commit (#2094 <https://github.com/ros-planning/moveit2/issues/2094>)
* Readability: kinematic_state -> robot_state (#2078 <https://github.com/ros-planning/moveit2/issues/2078>)
* Contributors: Scott K Logan, Sebastian Jahr, Shobuj Paul
```

## moveit_planners

- No changes

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

```
* Update pre-commit (#2094 <https://github.com/ros-planning/moveit2/issues/2094>)
* Contributors: Shobuj Paul
```

## moveit_plugins

- No changes

## moveit_py

```
* Fix Formatting in Python Documentation (#2085 <https://github.com/ros-planning/moveit2/issues/2085>)
  * fix formatting in docs
  * Fix clang-tidy warnings
  ---------
  Co-authored-by: Tyler Weaver <mailto:maybe@tylerjw.dev>
  Co-authored-by: Tyler Weaver <mailto:tyler@picknik.ai>
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Update moveit_py 'get_planning_scene_monitor' to return NonConst (#2098 <https://github.com/ros-planning/moveit2/issues/2098>)
  Co-authored-by: Jafar <mailto:cafer.abdi@gmail.com>
* Fix MoveItCpp issues (port from MoveIt1) (#2001 <https://github.com/ros-planning/moveit2/issues/2001>)
  * Fix MoveitCpp's const member accessors
  They should return a ConstPtr instead of a const Ptr&!
  * Fix SEVERE ClassLoader warning when releasing MoveItCpp
  - PSM was released before copy of its RobotModel -> removed extra RobotModel copy
  - clearContents() was broken:
  - resets in wrong order: psm_ should be last
  - trajectory_execution_manager_ was missing
  I suggest to omit clearContents() and rely on the (correct) ordering of member variables.
  While this is not explicit, we ensure that we don't miss any newly added member variable.
  Fix: https://github.com/ros-planning/moveit2/issues/1597
  ---------
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
  Co-authored-by: Jafar <mailto:cafer.abdi@gmail.com>
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@tuta.io>
  Co-authored-by: JafarAbdi <mailto:jafar.uruc@gmail.com>
* Extract parallel planning from moveit cpp (#2043 <https://github.com/ros-planning/moveit2/issues/2043>)
  * Add parallel_planning_interface
  * Add parallel planning interface
  * Rename package to pipeline_planning_interface
  * Move plan_responses_container into own header + source file
  * Add plan_responses_contrainer source file
  * Add solution selection and stopping criterion function files
  * Remove parallel planning from moveit_cpp
  * Move parallel planning into planning package
  * Update moveit_cpp
  * Drop planning_interface changes
  * Add documentation
  * Update other moveit packages
  * Remove removed header
  * Address CI complains
  * Address clang-tidy complains
  * Address clang-tidy complains 2
  * Address clang-tidy complains 3
  * Extract planning pipeline map creation function from moveit_cpp
  * Cleanup comment
  * Use const moveit::core::RobotModelConstPtr&
  * Formatting
  * Add header descriptions
  * Remove superfluous TODOs
  * Cleanup
* moveit_py citation (#2029 <https://github.com/ros-planning/moveit2/issues/2029>)
* Added set_robot_trajectory_msg to python bindings (#2050 <https://github.com/ros-planning/moveit2/issues/2050>)
* Contributors: Jens Vanhooydonck, Peter David Fagan, Robert Haschke, Sebastian Jahr
```

## moveit_resources_prbt_ikfast_manipulator_plugin

- No changes

## moveit_resources_prbt_moveit_config

```
* Update pre-commit (#2094 <https://github.com/ros-planning/moveit2/issues/2094>)
* Contributors: Shobuj Paul
```

## moveit_resources_prbt_pg70_support

- No changes

## moveit_resources_prbt_support

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

```
* Update pre-commit (#2094 <https://github.com/ros-planning/moveit2/issues/2094>)
* Extract parallel planning from moveit cpp (#2043 <https://github.com/ros-planning/moveit2/issues/2043>)
  * Add parallel_planning_interface
  * Add parallel planning interface
  * Rename package to pipeline_planning_interface
  * Move plan_responses_container into own header + source file
  * Add plan_responses_contrainer source file
  * Add solution selection and stopping criterion function files
  * Remove parallel planning from moveit_cpp
  * Move parallel planning into planning package
  * Update moveit_cpp
  * Drop planning_interface changes
  * Add documentation
  * Update other moveit packages
  * Remove removed header
  * Address CI complains
  * Address clang-tidy complains
  * Address clang-tidy complains 2
  * Address clang-tidy complains 3
  * Extract planning pipeline map creation function from moveit_cpp
  * Cleanup comment
  * Use const moveit::core::RobotModelConstPtr&
  * Formatting
  * Add header descriptions
  * Remove superfluous TODOs
  * Cleanup
* Contributors: Sebastian Jahr, Shobuj Paul
```

## moveit_ros_control_interface

- No changes

## moveit_ros_move_group

```
* Fix MoveItCpp issues (port from MoveIt1) (#2001 <https://github.com/ros-planning/moveit2/issues/2001>)
  * Fix MoveitCpp's const member accessors
  They should return a ConstPtr instead of a const Ptr&!
  * Fix SEVERE ClassLoader warning when releasing MoveItCpp
  - PSM was released before copy of its RobotModel -> removed extra RobotModel copy
  - clearContents() was broken:
  - resets in wrong order: psm_ should be last
  - trajectory_execution_manager_ was missing
  I suggest to omit clearContents() and rely on the (correct) ordering of member variables.
  While this is not explicit, we ensure that we don't miss any newly added member variable.
  Fix: https://github.com/ros-planning/moveit2/issues/1597
  ---------
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
  Co-authored-by: Jafar <mailto:cafer.abdi@gmail.com>
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@tuta.io>
  Co-authored-by: JafarAbdi <mailto:jafar.uruc@gmail.com>
* Contributors: Robert Haschke
```

## moveit_ros_occupancy_map_monitor

```
* Switch from qos_event.hpp to event_handler.hpp (#2111 <https://github.com/ros-planning/moveit2/issues/2111>)
  * Switch from qos_event.hpp to event_handler.hpp
  * moveit_common: Add a cmake interface library to keep humble support on main
  * Include qos_event.hpp or event_handler.hpp depending on the ROS 2 version
  * Fix ament_lint_cmake
  * Fix clang-tidy
  * PRIVATE linking in some cases
  * Update moveit_common/cmake/moveit_package.cmake
  Co-authored-by: Chris Thrasher <mailto:chrisjthrasher@gmail.com>
  * Fix servo and cleanup excessive CMake variable usage
  * Cleanup & make compiling
  * Small variable naming and const cleanup
  * Restore OpenCV linking
  * Public/private linking fixup
  * Revert "Restore OpenCV linking"
  This reverts commit 57a9efa806e59223e35a1f7e998d7b52f930c263.
  ---------
  Co-authored-by: JafarAbdi <mailto:jafar.uruc@gmail.com>
  Co-authored-by: Jafar <mailto:cafer.abdi@gmail.com>
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  Co-authored-by: Chris Thrasher <mailto:chrisjthrasher@gmail.com>
* Contributors: Sebastian Jahr
```

## moveit_ros_perception

```
* Switch from qos_event.hpp to event_handler.hpp (#2111 <https://github.com/ros-planning/moveit2/issues/2111>)
  * Switch from qos_event.hpp to event_handler.hpp
  * moveit_common: Add a cmake interface library to keep humble support on main
  * Include qos_event.hpp or event_handler.hpp depending on the ROS 2 version
  * Fix ament_lint_cmake
  * Fix clang-tidy
  * PRIVATE linking in some cases
  * Update moveit_common/cmake/moveit_package.cmake
  Co-authored-by: Chris Thrasher <mailto:chrisjthrasher@gmail.com>
  * Fix servo and cleanup excessive CMake variable usage
  * Cleanup & make compiling
  * Small variable naming and const cleanup
  * Restore OpenCV linking
  * Public/private linking fixup
  * Revert "Restore OpenCV linking"
  This reverts commit 57a9efa806e59223e35a1f7e998d7b52f930c263.
  ---------
  Co-authored-by: JafarAbdi <mailto:jafar.uruc@gmail.com>
  Co-authored-by: Jafar <mailto:cafer.abdi@gmail.com>
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  Co-authored-by: Chris Thrasher <mailto:chrisjthrasher@gmail.com>
* Update pre-commit (#2094 <https://github.com/ros-planning/moveit2/issues/2094>)
* Contributors: Sebastian Jahr, Shobuj Paul
```

## moveit_ros_planning

```
* Switch from qos_event.hpp to event_handler.hpp (#2111 <https://github.com/ros-planning/moveit2/issues/2111>)
  * Switch from qos_event.hpp to event_handler.hpp
  * moveit_common: Add a cmake interface library to keep humble support on main
  * Include qos_event.hpp or event_handler.hpp depending on the ROS 2 version
  * Fix ament_lint_cmake
  * Fix clang-tidy
  * PRIVATE linking in some cases
  * Update moveit_common/cmake/moveit_package.cmake
  Co-authored-by: Chris Thrasher <mailto:chrisjthrasher@gmail.com>
  * Fix servo and cleanup excessive CMake variable usage
  * Cleanup & make compiling
  * Small variable naming and const cleanup
  * Restore OpenCV linking
  * Public/private linking fixup
  * Revert "Restore OpenCV linking"
  This reverts commit 57a9efa806e59223e35a1f7e998d7b52f930c263.
  ---------
  Co-authored-by: JafarAbdi <mailto:jafar.uruc@gmail.com>
  Co-authored-by: Jafar <mailto:cafer.abdi@gmail.com>
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  Co-authored-by: Chris Thrasher <mailto:chrisjthrasher@gmail.com>
* Fix MoveItCpp issues (port from MoveIt1) (#2001 <https://github.com/ros-planning/moveit2/issues/2001>)
  * Fix MoveitCpp's const member accessors
  They should return a ConstPtr instead of a const Ptr&!
  * Fix SEVERE ClassLoader warning when releasing MoveItCpp
  - PSM was released before copy of its RobotModel -> removed extra RobotModel copy
  - clearContents() was broken:
  - resets in wrong order: psm_ should be last
  - trajectory_execution_manager_ was missing
  I suggest to omit clearContents() and rely on the (correct) ordering of member variables.
  While this is not explicit, we ensure that we don't miss any newly added member variable.
  Fix: https://github.com/ros-planning/moveit2/issues/1597
  ---------
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
  Co-authored-by: Jafar <mailto:cafer.abdi@gmail.com>
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@tuta.io>
  Co-authored-by: JafarAbdi <mailto:jafar.uruc@gmail.com>
* Extract parallel planning from moveit cpp (#2043 <https://github.com/ros-planning/moveit2/issues/2043>)
  * Add parallel_planning_interface
  * Add parallel planning interface
  * Rename package to pipeline_planning_interface
  * Move plan_responses_container into own header + source file
  * Add plan_responses_contrainer source file
  * Add solution selection and stopping criterion function files
  * Remove parallel planning from moveit_cpp
  * Move parallel planning into planning package
  * Update moveit_cpp
  * Drop planning_interface changes
  * Add documentation
  * Update other moveit packages
  * Remove removed header
  * Address CI complains
  * Address clang-tidy complains
  * Address clang-tidy complains 2
  * Address clang-tidy complains 3
  * Extract planning pipeline map creation function from moveit_cpp
  * Cleanup comment
  * Use const moveit::core::RobotModelConstPtr&
  * Formatting
  * Add header descriptions
  * Remove superfluous TODOs
  * Cleanup
* Move displaced launch file into planning_component_tools (#2044 <https://github.com/ros-planning/moveit2/issues/2044>)
* Contributors: Robert Haschke, Sebastian Jahr
```

## moveit_ros_planning_interface

```
* Update pre-commit (#2094 <https://github.com/ros-planning/moveit2/issues/2094>)
* Merge pull request #1900 <https://github.com/ros-planning/moveit2/issues/1900> from Abishalini/pr-sync-1245f15
  Sync with MoveIt1
* Readd comment and assign error code
* Merge https://github.com/ros-planning/moveit/commit/1245f151393fe09023efec3e1faead2d26737227
* Update description of moveit_ros_planning_interface (#2045 <https://github.com/ros-planning/moveit2/issues/2045>)
  * Update description of moveit_ros_planning_interface
  * Update moveit_ros/planning_interface/package.xml
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  ---------
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Merge PR #3197 <https://github.com/ros-planning/moveit2/issues/3197>: Improve computeCartesianPath()
* Simplify MGI::computeCartesianPath()
* Contributors: Abishalini, Abishalini Sivaraman, Robert Haschke, Sebastian Jahr, Shobuj Paul
```

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

```
* Readability: kinematic_state -> robot_state (#2078 <https://github.com/ros-planning/moveit2/issues/2078>)
* Contributors: Sebastian Jahr
```

## moveit_ros_warehouse

```
* Switch from qos_event.hpp to event_handler.hpp (#2111 <https://github.com/ros-planning/moveit2/issues/2111>)
  * Switch from qos_event.hpp to event_handler.hpp
  * moveit_common: Add a cmake interface library to keep humble support on main
  * Include qos_event.hpp or event_handler.hpp depending on the ROS 2 version
  * Fix ament_lint_cmake
  * Fix clang-tidy
  * PRIVATE linking in some cases
  * Update moveit_common/cmake/moveit_package.cmake
  Co-authored-by: Chris Thrasher <mailto:chrisjthrasher@gmail.com>
  * Fix servo and cleanup excessive CMake variable usage
  * Cleanup & make compiling
  * Small variable naming and const cleanup
  * Restore OpenCV linking
  * Public/private linking fixup
  * Revert "Restore OpenCV linking"
  This reverts commit 57a9efa806e59223e35a1f7e998d7b52f930c263.
  ---------
  Co-authored-by: JafarAbdi <mailto:jafar.uruc@gmail.com>
  Co-authored-by: Jafar <mailto:cafer.abdi@gmail.com>
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  Co-authored-by: Chris Thrasher <mailto:chrisjthrasher@gmail.com>
* Contributors: Sebastian Jahr
```

## moveit_runtime

- No changes

## moveit_servo

```
* Switch from qos_event.hpp to event_handler.hpp (#2111 <https://github.com/ros-planning/moveit2/issues/2111>)
  * Switch from qos_event.hpp to event_handler.hpp
  * moveit_common: Add a cmake interface library to keep humble support on main
  * Include qos_event.hpp or event_handler.hpp depending on the ROS 2 version
  * Fix ament_lint_cmake
  * Fix clang-tidy
  * PRIVATE linking in some cases
  * Update moveit_common/cmake/moveit_package.cmake
  Co-authored-by: Chris Thrasher <mailto:chrisjthrasher@gmail.com>
  * Fix servo and cleanup excessive CMake variable usage
  * Cleanup & make compiling
  * Small variable naming and const cleanup
  * Restore OpenCV linking
  * Public/private linking fixup
  * Revert "Restore OpenCV linking"
  This reverts commit 57a9efa806e59223e35a1f7e998d7b52f930c263.
  ---------
  Co-authored-by: JafarAbdi <mailto:jafar.uruc@gmail.com>
  Co-authored-by: Jafar <mailto:cafer.abdi@gmail.com>
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  Co-authored-by: Chris Thrasher <mailto:chrisjthrasher@gmail.com>
* [Servo] Document the new low-pass filter param (#2114 <https://github.com/ros-planning/moveit2/issues/2114>)
  * [Servo] Document the new low-pass filter param
  * More intuitive parameter ordering
* Update pre-commit (#2094 <https://github.com/ros-planning/moveit2/issues/2094>)
* Compute velocity using central difference (#2080 <https://github.com/ros-planning/moveit2/issues/2080>)
  * Compute velocity using central difference
  * Update calculation
  * Save and use x(t - dt)
  * Fix saving x(t - dt)
  * Fix confusing comment.
  * Explainer comment for last_joint_state_
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * Change x to q in comments to signify joint domain
  * Avoid pass-by-reference for basic types
  ---------
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
* Contributors: AndyZe, Sebastian Jahr, Shobuj Paul, V Mohammed Ibrahim
```

## moveit_setup_app_plugins

- No changes

## moveit_setup_assistant

```
* Update pre-commit (#2094 <https://github.com/ros-planning/moveit2/issues/2094>)
* Contributors: Shobuj Paul
```

## moveit_setup_controllers

```
* Update pre-commit (#2094 <https://github.com/ros-planning/moveit2/issues/2094>)
* Contributors: Shobuj Paul
```

## moveit_setup_core_plugins

```
* Update pre-commit (#2094 <https://github.com/ros-planning/moveit2/issues/2094>)
* Add URDF Loader Exceptions and Fix Infinite While-Loop when URDF file isn't in a ROS Package (#2032 <https://github.com/ros-planning/moveit2/issues/2032>)
  * Fixed infinite while loop in utilities.cpp and added some exception handling to start screen widget
  * Fix trailing whitespace, fix getSharePath exception catch on empty request
  * Fix clang tidy suggestion and error message updates based on pr comments
* Contributors: Chance Cardona, Shobuj Paul
```

## moveit_setup_framework

```
* Add URDF Loader Exceptions and Fix Infinite While-Loop when URDF file isn't in a ROS Package (#2032 <https://github.com/ros-planning/moveit2/issues/2032>)
  * Fixed infinite while loop in utilities.cpp and added some exception handling to start screen widget
  * Fix trailing whitespace, fix getSharePath exception catch on empty request
  * Fix clang tidy suggestion and error message updates based on pr comments
* Contributors: Chance Cardona
```

## moveit_setup_srdf_plugins

- No changes

## moveit_simple_controller_manager

- No changes

## pilz_industrial_motion_planner

```
* Update pre-commit (#2094 <https://github.com/ros-planning/moveit2/issues/2094>)
* PILZ: Throw if IK solver doesn't exist (#2082 <https://github.com/ros-planning/moveit2/issues/2082>)
  * Throw if IK solver doesn't exist
  * Format
* Contributors: Sebastian Jahr, Shobuj Paul
```

## pilz_industrial_motion_planner_testutils

- No changes
