### PR TITLE
ros2_tracing: 6.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4571,7 +4571,6 @@ repositories:
     release:
       packages:
       - ros2trace
-      - test_tracetools
       - tracetools
       - tracetools_launch
       - tracetools_read
@@ -4580,7 +4579,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 6.2.0-1
+      version: 6.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `6.3.0-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `6.2.0-1`

## ros2trace

```
* Move ros2trace tests to new test_ros2trace package (#63 <https://github.com/ros2/ros2_tracing/issues/63>)
* Contributors: Christophe Bedard
```

## tracetools

- No changes

## tracetools_launch

- No changes

## tracetools_read

- No changes

## tracetools_test

- No changes

## tracetools_trace

- No changes
