### PR TITLE
foxglove_msgs: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1339,7 +1339,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_foxglove_msgs-release.git
-      version: 2.1.1-3
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/foxglove/schemas.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_msgs` to `2.2.0-1`:

- upstream repository: https://github.com/foxglove/schemas.git
- release repository: https://github.com/ros2-gbp/ros_foxglove_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.1-3`

## foxglove_msgs

```
* Add TextAnnotation
* add FrameTransforms Message
* Remove "all float64s" comment from PointCloud schema
* Add units to PointsAnnotation and CircleAnnotation
* Update descriptions for PointsAnnotationType and LineType
* Elaborate on required fields for PointCloud and Grid messages
```
