### PR TITLE
husky: 1.0.9-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1910,7 +1910,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 1.0.7-1
+      version: 1.0.9-1
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `1.0.9-1`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.7-1`

## husky_base

```
* [husky_base] Added status topic publishing.
* [husky_base] Fixed typo.
* [husky_base] Added xacro as dep.
* Moved accessories launch into base launch and removed from robot_upstart install.
* [husky_base] Removed old ROS1 launch file.
* Contributors: Tony Baltovski
```

## husky_bringup

```
* [husky_bringup] Fixed bug in accessories launch.
* Added realsense accessory, updated velodyne accessories.
* Moved accessories launch into base launch and removed from robot_upstart install.
* Contributors: Tony Baltovski
```

## husky_control

```
* Added realsense accessory, updated velodyne accessories.
* Change namespaces to match imu_filter name defined in control.launch.py
* [husky_control] Only launch the IMU filter if the IMU envar is set to true.
* Contributors: Georg Jäger, Tony Baltovski
```

## husky_description

```
* [husky_description] Made serial_port an arg and reduced polling time.
* Added realsense accessory, updated velodyne accessories.
* Contributors: Tony Baltovski
```

## husky_desktop

- No changes

## husky_gazebo

```
* [husky_gazebo] Added GAZEBO_MODEL_PATH to gazebo launch to get meshes.
* Contributors: Tony Baltovski
```

## husky_msgs

- No changes

## husky_robot

- No changes

## husky_simulator

- No changes

## husky_viz

- No changes
