### PR TITLE
turtlebot3_manipulation: 2.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -7134,6 +7134,30 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/turtlebot3.git
       version: foxy-devel
     status: developed
+  turtlebot3_manipulation:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_manipulation.git
+      version: foxy-devel
+    release:
+      packages:
+      - turtlebot3_manipulation
+      - turtlebot3_manipulation_bringup
+      - turtlebot3_manipulation_cartographer
+      - turtlebot3_manipulation_description
+      - turtlebot3_manipulation_hardware
+      - turtlebot3_manipulation_moveit_config
+      - turtlebot3_manipulation_navigation2
+      - turtlebot3_manipulation_teleop
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot3_manipulation-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_manipulation.git
+      version: foxy-devel
+    status: developed
   turtlebot3_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_manipulation` to `2.1.0-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_manipulation.git
- release repository: https://github.com/ros2-gbp/turtlebot3_manipulation-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## turtlebot3_manipulation

```
* Support ROS2 Foxy
* MoveIt environment configured (backported from Humble)
* use ros2_control framework instead of ROBOTIS custom library
* removed dependency to turtlebot3_*` and open_manipulator packages
* Contributors: Hye-Jong KIM, Darby Lim, Will Son
```

## turtlebot3_manipulation_bringup

```
* Support ROS2 Foxy
* MoveIt environment configured (backported from Humble)
* use ros2_control framework instead of ROBOTIS custom library
* removed dependency to turtlebot3_*` and open_manipulator packages
* Contributors: Hye-Jong KIM, Darby Lim, Will Son
```

## turtlebot3_manipulation_cartographer

```
* Support ROS2 Foxy
* MoveIt environment configured (backported from Humble)
* use ros2_control framework instead of ROBOTIS custom library
* removed dependency to turtlebot3_*` and open_manipulator packages
* Contributors: Hye-Jong KIM, Darby Lim, Will Son
```

## turtlebot3_manipulation_description

```
* Support ROS2 Foxy
* MoveIt environment configured (backported from Humble)
* use ros2_control framework instead of ROBOTIS custom library
* removed dependency to turtlebot3_*` and open_manipulator packages
* Contributors: Hye-Jong KIM, Darby Lim, Will Son
```

## turtlebot3_manipulation_hardware

```
* Support ROS2 Foxy
* MoveIt environment configured (backported from Humble)
* use ros2_control framework instead of ROBOTIS custom library
* removed dependency to turtlebot3_*` and open_manipulator packages
* Contributors: Hye-Jong KIM, Darby Lim, Will Son
```

## turtlebot3_manipulation_moveit_config

```
* Support ROS2 Foxy
* MoveIt environment configured (backported from Humble)
* use ros2_control framework instead of ROBOTIS custom library
* removed dependency to turtlebot3_*` and open_manipulator packages
* Contributors: Hye-Jong KIM, Darby Lim, Will Son
```

## turtlebot3_manipulation_navigation2

```
* Support ROS2 Foxy
* MoveIt environment configured (backported from Humble)
* use ros2_control framework instead of ROBOTIS custom library
* removed dependency to turtlebot3_*` and open_manipulator packages
* Contributors: Hye-Jong KIM, Darby Lim, Will Son
```

## turtlebot3_manipulation_teleop

```
* Support ROS2 Foxy
* MoveIt environment configured (backported from Humble)
* use ros2_control framework instead of ROBOTIS custom library
* removed dependency to turtlebot3_*` and open_manipulator packages
* Contributors: Hye-Jong KIM, Darby Lim, Will Son
```
