### PR TITLE
astuff_sensor_msgs: 3.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -483,6 +483,31 @@ repositories:
       url: https://github.com/pal-robotics/aruco_ros.git
       version: humble-devel
     status: developed
+  astuff_sensor_msgs:
+    doc:
+      type: git
+      url: https://github.com/astuff/astuff_sensor_msgs.git
+      version: master
+    release:
+      packages:
+      - delphi_esr_msgs
+      - delphi_mrr_msgs
+      - delphi_srr_msgs
+      - derived_object_msgs
+      - ibeo_msgs
+      - kartech_linear_actuator_msgs
+      - mobileye_560_660_msgs
+      - neobotix_usboard_msgs
+      - pacmod_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/astuff/astuff_sensor_msgs-release.git
+      version: 3.3.0-1
+    source:
+      type: git
+      url: https://github.com/astuff/astuff_sensor_msgs.git
+      version: master
+    status: maintained
   async_web_server_cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `astuff_sensor_msgs` to `3.3.0-1`:

- upstream repository: https://github.com/astuff/astuff_sensor_msgs.git
- release repository: https://github.com/astuff/astuff_sensor_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## delphi_esr_msgs

- No changes

## delphi_mrr_msgs

```
* Remove unused MRR messages (#87 <https://github.com/astuff/astuff_sensor_msgs/issues/87>)
* MRR Msgs Cleanup (#85 <https://github.com/astuff/astuff_sensor_msgs/issues/85>)
* Contributors: icolwell-as
```

## delphi_srr_msgs

- No changes

## derived_object_msgs

- No changes

## ibeo_msgs

- No changes

## kartech_linear_actuator_msgs

- No changes

## mobileye_560_660_msgs

- No changes

## neobotix_usboard_msgs

- No changes

## pacmod_msgs

- No changes
