### PR TITLE
add python3-influxdb to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6236,6 +6236,12 @@ python3-inflection-pip:
   ubuntu:
     pip:
       packages: [inflection]
+python3-influxdb:
+  debian: [python3-influxdb]
+  fedora: [python3-influxdb]
+  opensuse: [python3-influxdb]
+  rhel: [python3-influxdb]
+  ubuntu: [python3-influxdb]
 python3-influxdb-client-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-influxdb

## Package Upstream Source:

https://github.com/influxdata/influxdb-python

## Purpose of using this:

To release https://github.com/jsk-ros-pkg/jsk_3rdparty/tree/master/influxdb_store in ubuntu focal.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/buster/python3-influxdb
  - https://packages.debian.org/bullseye/python3-influxdb
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/bionic/python3-influxdb
  - https://packages.ubuntu.com/focal/python3-influxdb
  - https://packages.ubuntu.com/jammy/python3-influxdb
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-influxdb/python3-influxdb/