### PR TITLE
turtlebot3_manipulation: 2.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7089,6 +7089,30 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/turtlebot3.git
       version: humble-devel
     status: maintained
+  turtlebot3_manipulation:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_manipulation.git
+      version: humble-devel
+    release:
+      packages:
+      - turtlebot3_manipulation
+      - turtlebot3_manipulation_bringup
+      - turtlebot3_manipulation_cartographer
+      - turtlebot3_manipulation_description
+      - turtlebot3_manipulation_hardware
+      - turtlebot3_manipulation_moveit_config
+      - turtlebot3_manipulation_navigation2
+      - turtlebot3_manipulation_teleop
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot3_manipulation-release.git
+      version: 2.1.1-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_manipulation.git
+      version: humble-devel
+    status: developed
   turtlebot3_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_manipulation` to `2.1.1-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_manipulation.git
- release repository: https://github.com/ros2-gbp/turtlebot3_manipulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## turtlebot3_manipulation

```
* Support ROS2 Humble
* MoveIt environment configured
* use ros2_control framework instead of ROBOTIS custom library
* removed dependency to turtlebot3_*` and open_manipulator packages
* Contributors: Hye-Jong KIM, Darby Lim, Will Son
```

## turtlebot3_manipulation_bringup

```
* Support ROS2 Humble
* MoveIt environment configured
* use ros2_control framework instead of ROBOTIS custom library
* removed dependency to turtlebot3_*` and open_manipulator packages
* Contributors: Hye-Jong KIM, Darby Lim, Will Son
```

## turtlebot3_manipulation_cartographer

```
* Support ROS2 Humble
* MoveIt environment configured
* use ros2_control framework instead of ROBOTIS custom library
* removed dependency to turtlebot3_*` and open_manipulator packages
* Contributors: Hye-Jong KIM, Darby Lim, Will Son
```

## turtlebot3_manipulation_description

```
* Support ROS2 Humble
* MoveIt environment configured
* use ros2_control framework instead of ROBOTIS custom library
* removed dependency to turtlebot3_*` and open_manipulator packages
* Contributors: Hye-Jong KIM, Darby Lim, Will Son
```

## turtlebot3_manipulation_hardware

```
* Support ROS2 Humble
* MoveIt environment configured
* use ros2_control framework instead of ROBOTIS custom library
* removed dependency to turtlebot3_*` and open_manipulator packages
* Contributors: Hye-Jong KIM, Darby Lim, Will Son
```

## turtlebot3_manipulation_moveit_config

```
* Support ROS2 Humble
* MoveIt environment configured
* use ros2_control framework instead of ROBOTIS custom library
* removed dependency to turtlebot3_*` and open_manipulator packages
* Contributors: Hye-Jong KIM, Darby Lim, Will Son
```

## turtlebot3_manipulation_navigation2

```
* Support ROS2 Humble
* MoveIt environment configured
* use ros2_control framework instead of ROBOTIS custom library
* removed dependency to turtlebot3_*` and open_manipulator packages
* Contributors: Hye-Jong KIM, Darby Lim, Will Son
```

## turtlebot3_manipulation_teleop

```
* Support ROS2 Humble
* MoveIt environment configured
* use ros2_control framework instead of ROBOTIS custom library
* removed dependency to turtlebot3_*` and open_manipulator packages
* Contributors: Hye-Jong KIM, Darby Lim, Will Son
```
