### PR TITLE
jackal: 1.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2118,6 +2118,26 @@ repositories:
       type: git
       url: https://github.com/iRobotEducation/irobot_create_msgs.git
       version: main
+  jackal:
+    doc:
+      type: git
+      url: https://github.com/jackal/jackal.git
+      version: foxy-devel
+    release:
+      packages:
+      - jackal_control
+      - jackal_description
+      - jackal_msgs
+      - jackal_navigation
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/jackal-release.git
+      version: 1.0.4-1
+    source:
+      type: git
+      url: https://github.com/jackal/jackal.git
+      version: foxy-devel
+    status: developed
   joint_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `1.0.4-1`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## jackal_control

```
* Remove gravitational acceleration in ekf_node
* Contributors: Roni Kreinin
```

## jackal_description

```
* [jackal_description] Changed the output type of the gazebo_ros_ray_sensor to LaserScan.
* Contributors: Tony Baltovski
```

## jackal_msgs

- No changes

## jackal_navigation

- No changes
