### PR TITLE
ridgeback: 0.3.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8222,7 +8222,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback-release.git
-      version: 0.3.2-1
+      version: 0.3.3-1
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback` to `0.3.3-1`:

- upstream repository: https://github.com/ridgeback/ridgeback.git
- release repository: https://github.com/clearpath-gbp/ridgeback-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.2-1`

## ridgeback_control

- No changes

## ridgeback_description

```
* Added README to ridgeback description
* Add comments to clarify between RIDGEBACK_MICROSTRAIN_IMU and RIDGEBACK_IMU_MICROSTRAIN.
* Add URDF link and joint for microstrain_inertial_driver Microstrain IMU.
* Contributors: Joey Yang, luis-camero
```

## ridgeback_msgs

- No changes

## ridgeback_navigation

- No changes
