### PR TITLE
Add Iron distribution as pre-release

### DIFF
--- a/index-v4.yaml
+++ b/index-v4.yaml
@@ -69,6 +69,12 @@ distributions:
     distribution_status: end-of-life
     distribution_type: ros1
     python_version: 2
+  iron:
+    distribution: [iron/distribution.yaml]
+    distribution_cache: http://repo.ros2.org/rosdistro_cache/iron-cache.yaml.gz
+    distribution_status: pre-release
+    distribution_type: ros2
+    python_version: 3
   jade:
     distribution: [jade/distribution.yaml]
     distribution_cache: http://repositories.ros.org/rosdistro_cache/jade-cache.yaml.gz

--- a/index.yaml
+++ b/index.yaml
@@ -36,6 +36,9 @@ distributions:
   indigo:
     distribution: [indigo/distribution.yaml]
     distribution_cache: http://repositories.ros.org/rosdistro_cache/indigo-cache.yaml.gz
+  iron:
+    distribution: [iron/distribution.yaml]
+    distribution_cache: http://repo.ros2.org/rosdistro_cache/iron-cache.yaml.gz
   jade:
     distribution: [jade/distribution.yaml]
     distribution_cache: http://repositories.ros.org/rosdistro_cache/jade-cache.yaml.gz

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1,0 +1,8 @@
+%YAML 1.1
+# ROS distribution file
+# see REP 143: http://ros.org/reps/rep-0143.html
+---
+release_platforms: []
+repositories: []
+type: distribution
+version: 2

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -22,6 +22,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/SMACC2-release.git
+      version: 0.4.0-3
     source:
       type: git
       url: https://github.com/robosoft-ai/SMACC2.git
@@ -483,6 +484,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/aws_robomaker_small_warehouse_world-release.git
+      version: 1.0.5-4
     source:
       type: git
       url: https://github.com/aws-robotics/aws-robomaker-small-warehouse-world.git
@@ -741,6 +743,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/control_box_rst-release.git
+      version: 0.0.7-5
     source:
       test_pull_requests: true
       type: git
@@ -1273,6 +1276,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/fmi_adapter-release.git
+      version: 2.1.2-2
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git
@@ -1283,6 +1287,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/fmilibrary_vendor-release.git
+      version: 1.0.1-4
     source:
       type: git
       url: https://github.com/boschresearch/fmilibrary_vendor.git
@@ -1403,6 +1408,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
+      version: 3.7.0-3
     source:
       test_pull_requests: true
       type: git
@@ -1750,6 +1756,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
+      version: 0.6.1-4
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git
@@ -1782,7 +1789,8 @@ repositories:
     release:
       tags:
         release: release/iron/{package}/{version}
-      url: https://github.com/ros2-gbp/ignition_cmake2_vendor-release.git
+      url: https://github.com/ros2-gbp/gz_cmake2_vendor-release.git
+      version: 0.1.0-2
     source:
       test_pull_requests: true
       type: git
@@ -1797,7 +1805,8 @@ repositories:
     release:
       tags:
         release: release/iron/{package}/{version}
-      url: https://github.com/ros2-gbp/ignition_math6_vendor-release.git
+      url: https://github.com/ros2-gbp/gz_math6_vendor-release.git
+      version: 0.0.2-3
     source:
       test_pull_requests: true
       type: git
@@ -2637,6 +2646,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt2-release.git
+      version: 2.8.1-2
     source:
       type: git
       url: https://github.com/MRPT/mrpt.git
@@ -2701,6 +2711,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/mvsim-release.git
+      version: 0.6.1-3
     source:
       type: git
       url: https://github.com/MRPT/mvsim.git
@@ -3041,6 +3052,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
+      version: 1.5.2-4
   openni2_camera:
     doc:
       type: git
@@ -3173,6 +3185,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/perception_open3d-release.git
+      version: 0.1.2-3
     source:
       type: git
       url: https://github.com/ros-perception/perception_open3d.git
@@ -3431,6 +3444,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/proxsuite-release.git
+      version: 0.3.5-3
     source:
       type: git
       url: https://github.com/Simple-Robotics/proxsuite.git
@@ -3461,6 +3475,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_js-release.git
+      version: 0.6.4-3
     source:
       test_pull_requests: true
       type: git
@@ -4154,6 +4169,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_simulation-release.git
+      version: 2.0.0-3
     source:
       type: git
       url: https://github.com/open-rmf/rmf_simulation.git
@@ -4209,6 +4225,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
+      version: 1.6.0-3
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic_editor.git
@@ -4300,6 +4317,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
+      version: 0.14.0-2
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git
@@ -4371,6 +4389,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
+      version: 4.2.0-3
     source:
       type: git
       url: https://github.com/ros2/rmw_gurumdds.git
@@ -4694,6 +4713,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
+      version: 0.244.3-3
     source:
       test_pull_requests: true
       type: git
@@ -4720,6 +4740,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros_industrial_cmake_boilerplate-release.git
+      version: 0.4.0-3
   ros_testing:
     doc:
       type: git
@@ -5453,6 +5474,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/RSL-release.git
+      version: 0.2.2-2
     source:
       type: git
       url: https://github.com/PickNikRobotics/RSL.git
@@ -5587,6 +5609,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/sdformat_urdf-release.git
+      version: 1.0.1-3
     source:
       test_pull_requests: true
       type: git
@@ -6221,6 +6244,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros_tutorials-release.git
+      version: 1.6.0-3
     source:
       test_pull_requests: true
       type: git
@@ -6432,6 +6456,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
+      version: 2.3.1-3
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
@@ -6577,6 +6602,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/usb_cam-release.git
+      version: 0.6.0-2
     source:
       type: git
       url: https://github.com/ros-drivers/usb_cam.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2,7 +2,6925 @@
 # ROS distribution file
 # see REP 143: http://ros.org/reps/rep-0143.html
 ---
-release_platforms: []
-repositories: []
+release_platforms:
+  debian:
+  - bullseye
+  rhel:
+  - '9'
+  ubuntu:
+  - jammy
+repositories:
+  SMACC2:
+    doc:
+      type: git
+      url: https://github.com/robosoft-ai/SMACC2.git
+      version: rolling
+    release:
+      packages:
+      - smacc2
+      - smacc2_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/SMACC2-release.git
+    source:
+      type: git
+      url: https://github.com/robosoft-ai/SMACC2.git
+      version: rolling
+    status: developed
+  acado_vendor:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/acado_vendor-release.git
+      version: 1.0.0-6
+    source:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/acado_vendor.git
+      version: main
+    status: maintained
+  ackermann_msgs:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ackermann_msgs-release.git
+      version: 2.0.2-5
+    source:
+      type: git
+      url: https://github.com/ros-drivers/ackermann_msgs.git
+      version: ros2
+    status: maintained
+  actuator_msgs:
+    doc:
+      type: git
+      url: https://github.com/rudislabs/actuator_msgs.git
+      version: 0.0.1
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/actuator_msgs-release.git
+      version: 0.0.1-3
+    source:
+      type: git
+      url: https://github.com/rudislabs/actuator_msgs.git
+      version: main
+    status: maintained
+  adaptive_component:
+    doc:
+      type: git
+      url: https://github.com/ros-acceleration/adaptive_component.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/adaptive_component-release.git
+      version: 0.2.1-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-acceleration/adaptive_component.git
+      version: rolling
+    status: developed
+  ament_acceleration:
+    doc:
+      type: git
+      url: https://github.com/ros-acceleration/ament_acceleration.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_acceleration-release.git
+      version: 0.2.0-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-acceleration/ament_acceleration.git
+      version: rolling
+    status: developed
+  ament_cmake:
+    doc:
+      type: git
+      url: https://github.com/ament/ament_cmake.git
+      version: rolling
+    release:
+      packages:
+      - ament_cmake
+      - ament_cmake_auto
+      - ament_cmake_core
+      - ament_cmake_export_definitions
+      - ament_cmake_export_dependencies
+      - ament_cmake_export_include_directories
+      - ament_cmake_export_interfaces
+      - ament_cmake_export_libraries
+      - ament_cmake_export_link_flags
+      - ament_cmake_export_targets
+      - ament_cmake_gen_version_h
+      - ament_cmake_gmock
+      - ament_cmake_google_benchmark
+      - ament_cmake_gtest
+      - ament_cmake_include_directories
+      - ament_cmake_libraries
+      - ament_cmake_pytest
+      - ament_cmake_python
+      - ament_cmake_target_dependencies
+      - ament_cmake_test
+      - ament_cmake_vendor_package
+      - ament_cmake_version
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_cmake-release.git
+      version: 2.0.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ament/ament_cmake.git
+      version: rolling
+    status: developed
+  ament_cmake_catch2:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/ament_cmake_catch2.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_cmake_catch2-release.git
+      version: 1.2.0-5
+    source:
+      type: git
+      url: https://github.com/open-rmf/ament_cmake_catch2.git
+      version: rolling
+    status: developed
+  ament_cmake_ros:
+    doc:
+      type: git
+      url: https://github.com/ros2/ament_cmake_ros.git
+      version: rolling
+    release:
+      packages:
+      - ament_cmake_ros
+      - domain_coordinator
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_cmake_ros-release.git
+      version: 0.11.2-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/ament_cmake_ros.git
+      version: rolling
+    status: maintained
+  ament_download:
+    doc:
+      type: git
+      url: https://github.com/samsung-ros/ament_download.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_download-release.git
+      version: 0.0.5-5
+    source:
+      type: git
+      url: https://github.com/samsung-ros/ament_download.git
+      version: ros2
+    status: developed
+  ament_index:
+    doc:
+      type: git
+      url: https://github.com/ament/ament_index.git
+      version: rolling
+    release:
+      packages:
+      - ament_index_cpp
+      - ament_index_python
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_index-release.git
+      version: 1.5.2-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ament/ament_index.git
+      version: rolling
+    status: maintained
+  ament_lint:
+    doc:
+      type: git
+      url: https://github.com/ament/ament_lint.git
+      version: rolling
+    release:
+      packages:
+      - ament_clang_format
+      - ament_clang_tidy
+      - ament_cmake_clang_format
+      - ament_cmake_clang_tidy
+      - ament_cmake_copyright
+      - ament_cmake_cppcheck
+      - ament_cmake_cpplint
+      - ament_cmake_flake8
+      - ament_cmake_lint_cmake
+      - ament_cmake_mypy
+      - ament_cmake_pclint
+      - ament_cmake_pep257
+      - ament_cmake_pycodestyle
+      - ament_cmake_pyflakes
+      - ament_cmake_uncrustify
+      - ament_cmake_xmllint
+      - ament_copyright
+      - ament_cppcheck
+      - ament_cpplint
+      - ament_flake8
+      - ament_lint
+      - ament_lint_auto
+      - ament_lint_cmake
+      - ament_lint_common
+      - ament_mypy
+      - ament_pclint
+      - ament_pep257
+      - ament_pycodestyle
+      - ament_pyflakes
+      - ament_uncrustify
+      - ament_xmllint
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_lint-release.git
+      version: 0.14.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ament/ament_lint.git
+      version: rolling
+    status: developed
+  ament_nodl:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_nodl-release.git
+      version: 0.1.0-6
+    source:
+      type: git
+      url: https://github.com/ubuntu-robotics/ament_nodl.git
+      version: master
+    status: developed
+  ament_package:
+    doc:
+      type: git
+      url: https://github.com/ament/ament_package.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_package-release.git
+      version: 0.15.3-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ament/ament_package.git
+      version: rolling
+    status: developed
+  ament_vitis:
+    doc:
+      type: git
+      url: https://github.com/ros-acceleration/ament_vitis.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_vitis-release.git
+      version: 0.10.1-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-acceleration/ament_vitis.git
+      version: rolling
+    status: developed
+  angles:
+    doc:
+      type: git
+      url: https://github.com/ros/angles.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/angles-release.git
+      version: 1.16.0-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/angles.git
+      version: ros2
+    status: maintained
+  apex_containers:
+    doc:
+      type: git
+      url: https://gitlab.com/ApexAI/apex_containers.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/apex_containers-release.git
+      version: 0.0.4-5
+    source:
+      type: git
+      url: https://gitlab.com/ApexAI/apex_containers.git
+      version: rolling
+    status: developed
+  apex_test_tools:
+    doc:
+      type: git
+      url: https://gitlab.com/ApexAI/apex_test_tools.git
+      version: rolling
+    release:
+      packages:
+      - apex_test_tools
+      - test_apex_test_tools
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/apex_test_tools-release.git
+      version: 0.0.2-8
+    source:
+      type: git
+      url: https://gitlab.com/ApexAI/apex_test_tools.git
+      version: rolling
+    status: developed
+  apriltag:
+    doc:
+      type: git
+      url: https://github.com/AprilRobotics/apriltag.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/apriltag-release.git
+      version: 3.2.0-5
+    source:
+      type: git
+      url: https://github.com/AprilRobotics/apriltag.git
+      version: master
+    status: maintained
+  apriltag_msgs:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/apriltag_msgs-release.git
+      version: 2.0.1-4
+    source:
+      type: git
+      url: https://github.com/christianrauch/apriltag_msgs.git
+      version: master
+    status: maintained
+  apriltag_ros:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/apriltag_ros-release.git
+      version: 3.1.1-4
+    source:
+      type: git
+      url: https://github.com/christianrauch/apriltag_ros.git
+      version: master
+    status: developed
+  aruco_opencv:
+    doc:
+      type: git
+      url: https://github.com/fictionlab/ros_aruco_opencv.git
+      version: rolling
+    release:
+      packages:
+      - aruco_opencv
+      - aruco_opencv_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/aruco_opencv-release.git
+      version: 4.1.0-4
+    source:
+      type: git
+      url: https://github.com/fictionlab/ros_aruco_opencv.git
+      version: rolling
+    status: maintained
+  async_web_server_cpp:
+    doc:
+      type: git
+      url: https://github.com/fkie/async_web_server_cpp.git
+      version: ros2-releases
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/async_web_server_cpp-release.git
+      version: 2.0.0-5
+    source:
+      type: git
+      url: https://github.com/fkie/async_web_server_cpp.git
+      version: ros2-develop
+    status: maintained
+  asyncapi_gencpp:
+    doc:
+      type: git
+      url: https://github.com/hatchbed/asyncapi_gencpp.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/hatchbed/asyncapi_gencpp.git
+      version: main
+    status: developed
+  automotive_autonomy_msgs:
+    doc:
+      type: git
+      url: https://github.com/astuff/automotive_autonomy_msgs.git
+      version: master
+    release:
+      packages:
+      - automotive_autonomy_msgs
+      - automotive_navigation_msgs
+      - automotive_platform_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/automotive_autonomy_msgs-release.git
+      version: 3.0.4-5
+    source:
+      type: git
+      url: https://github.com/astuff/automotive_autonomy_msgs.git
+      version: master
+    status: maintained
+  autoware_auto_msgs:
+    doc:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/autoware_auto_msgs-release.git
+      version: 1.0.0-6
+    source:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
+      version: master
+    status: developed
+  avt_vimba_camera:
+    doc:
+      type: git
+      url: https://github.com/astuff/avt_vimba_camera.git
+      version: ros2_master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/avt_vimba_camera-release.git
+      version: 2001.1.0-5
+    source:
+      type: git
+      url: https://github.com/astuff/avt_vimba_camera.git
+      version: ros2_master
+    status: maintained
+  aws-robomaker-small-warehouse-world:
+    doc:
+      type: git
+      url: https://github.com/aws-robotics/aws-robomaker-small-warehouse-world.git
+      version: ros2
+    release:
+      packages:
+      - aws_robomaker_small_warehouse_world
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/aws_robomaker_small_warehouse_world-release.git
+    source:
+      type: git
+      url: https://github.com/aws-robotics/aws-robomaker-small-warehouse-world.git
+      version: ros2
+    status: maintained
+  backward_ros:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/backward_ros.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/backward_ros-release.git
+      version: 1.0.2-5
+    source:
+      type: git
+      url: https://github.com/pal-robotics/backward_ros.git
+      version: foxy-devel
+    status: maintained
+  bag2_to_image:
+    doc:
+      type: git
+      url: https://github.com/wep21/bag2_to_image.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/bag2_to_image-release.git
+      version: 0.1.0-4
+    source:
+      type: git
+      url: https://github.com/wep21/bag2_to_image.git
+      version: main
+    status: maintained
+  behaviortree_cpp_v3:
+    doc:
+      type: git
+      url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
+      version: v3.8
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/behaviortree_cpp-release.git
+      version: 3.8.3-5
+    source:
+      type: git
+      url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
+      version: v3.8
+    status: developed
+  bno055:
+    doc:
+      type: git
+      url: https://github.com/flynneva/bno055.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/bno055-release.git
+      version: 0.4.1-4
+    source:
+      type: git
+      url: https://github.com/flynneva/bno055.git
+      version: main
+    status: maintained
+  bond_core:
+    doc:
+      type: git
+      url: https://github.com/ros/bond_core.git
+      version: ros2
+    release:
+      packages:
+      - bond
+      - bond_core
+      - bondcpp
+      - smclib
+      - test_bond
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/bond_core-release.git
+      version: 4.0.0-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/bond_core.git
+      version: ros2
+    status: maintained
+  boost_geometry_util:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/boost_geometry_util.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/boost_geometry_util-release.git
+      version: 0.0.1-4
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/boost_geometry_util.git
+      version: master
+    status: developed
+  cartographer:
+    doc:
+      type: git
+      url: https://github.com/ros2/cartographer.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/cartographer-release.git
+      version: 2.0.9002-5
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/cartographer.git
+      version: ros2
+    status: maintained
+  cartographer_ros:
+    doc:
+      type: git
+      url: https://github.com/ros2/cartographer_ros.git
+      version: ros2
+    release:
+      packages:
+      - cartographer_ros
+      - cartographer_ros_msgs
+      - cartographer_rviz
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/cartographer_ros-release.git
+      version: 2.0.9001-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/cartographer_ros.git
+      version: ros2
+    status: maintained
+  cascade_lifecycle:
+    doc:
+      type: git
+      url: https://github.com/fmrico/cascade_lifecycle.git
+      version: rolling-devel
+    release:
+      packages:
+      - cascade_lifecycle_msgs
+      - rclcpp_cascade_lifecycle
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/cascade_lifecycle-release.git
+      version: 1.0.3-5
+    source:
+      type: git
+      url: https://github.com/fmrico/cascade_lifecycle.git
+      version: rolling-devel
+    status: maintained
+  class_loader:
+    doc:
+      type: git
+      url: https://github.com/ros/class_loader.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/class_loader-release.git
+      version: 2.5.0-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/class_loader.git
+      version: rolling
+    status: maintained
+  color_names:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/color_names.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/color_names-release.git
+      version: 0.0.3-5
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/color_names-release.git
+      version: master
+    status: developed
+  color_util:
+    doc:
+      type: git
+      url: https://github.com/MetroRobots/color_util.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/color_util-release.git
+      version: 1.0.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/MetroRobots/color_util.git
+      version: main
+    status: developed
+  common_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ros2/common_interfaces.git
+      version: rolling
+    release:
+      packages:
+      - actionlib_msgs
+      - common_interfaces
+      - diagnostic_msgs
+      - geometry_msgs
+      - nav_msgs
+      - sensor_msgs
+      - sensor_msgs_py
+      - shape_msgs
+      - std_msgs
+      - std_srvs
+      - stereo_msgs
+      - trajectory_msgs
+      - visualization_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/common_interfaces-release.git
+      version: 5.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/common_interfaces.git
+      version: rolling
+    status: maintained
+  console_bridge_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros2/console_bridge_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/console_bridge_vendor-release.git
+      version: 1.6.0-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/console_bridge_vendor.git
+      version: rolling
+    status: maintained
+  control_box_rst:
+    doc:
+      type: git
+      url: https://github.com/rst-tu-dortmund/control_box_rst.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/control_box_rst-release.git
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rst-tu-dortmund/control_box_rst.git
+      version: foxy-devel
+    status: developed
+  control_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/control_msgs.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/control_msgs-release.git
+      version: 4.3.0-2
+    source:
+      type: git
+      url: https://github.com/ros-controls/control_msgs.git
+      version: foxy-devel
+    status: maintained
+  control_toolbox:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/control_toolbox.git
+      version: ros2-master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/control_toolbox-release.git
+      version: 3.0.0-2
+    source:
+      type: git
+      url: https://github.com/ros-controls/control_toolbox.git
+      version: ros2-master
+    status: maintained
+  cpp_polyfills:
+    release:
+      packages:
+      - tcb_span
+      - tl_expected
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/cpp_polyfills-release.git
+      version: 1.0.2-4
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/cpp_polyfills.git
+      version: main
+    status: maintained
+  cudnn_cmake_module:
+    doc:
+      type: git
+      url: https://github.com/tier4/cudnn_cmake_module.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/cudnn_cmake_module-release.git
+      version: 0.0.1-5
+    source:
+      type: git
+      url: https://github.com/tier4/cudnn_cmake_module.git
+      version: main
+    status: maintained
+  cyclonedds:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/cyclonedds-release.git
+      version: 0.10.3-2
+    source:
+      type: git
+      url: https://github.com/eclipse-cyclonedds/cyclonedds.git
+      version: releases/0.10.x
+    status: maintained
+  demos:
+    doc:
+      type: git
+      url: https://github.com/ros2/demos.git
+      version: rolling
+    release:
+      packages:
+      - action_tutorials_cpp
+      - action_tutorials_interfaces
+      - action_tutorials_py
+      - composition
+      - demo_nodes_cpp
+      - demo_nodes_cpp_native
+      - demo_nodes_py
+      - dummy_map_server
+      - dummy_robot_bringup
+      - dummy_sensors
+      - image_tools
+      - intra_process_demo
+      - lifecycle
+      - lifecycle_py
+      - logging_demo
+      - pendulum_control
+      - pendulum_msgs
+      - quality_of_service_demo_cpp
+      - quality_of_service_demo_py
+      - topic_monitor
+      - topic_statistics_demo
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/demos-release.git
+      version: 0.27.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/demos.git
+      version: rolling
+    status: developed
+  depthimage_to_laserscan:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/depthimage_to_laserscan.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/depthimage_to_laserscan-release.git
+      version: 2.5.0-5
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/depthimage_to_laserscan.git
+      version: ros2
+    status: maintained
+  diagnostics:
+    doc:
+      type: git
+      url: https://github.com/ros/diagnostics.git
+      version: ros2
+    release:
+      packages:
+      - diagnostic_aggregator
+      - diagnostic_common_diagnostics
+      - diagnostic_updater
+      - diagnostics
+      - self_test
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/diagnostics-release.git
+      version: 3.1.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/diagnostics.git
+      version: ros2
+    status: maintained
+  dolly:
+    doc:
+      type: git
+      url: https://github.com/chapulina/dolly.git
+      version: galactic
+    release:
+      packages:
+      - dolly
+      - dolly_follow
+      - dolly_gazebo
+      - dolly_ignition
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/dolly-release.git
+      version: 0.4.0-5
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/chapulina/dolly.git
+      version: galactic
+    status: developed
+  domain_bridge:
+    doc:
+      type: git
+      url: https://github.com/ros2/domain_bridge.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/domain_bridge-release.git
+      version: 0.5.0-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/domain_bridge.git
+      version: main
+    status: developed
+  dynamixel_hardware:
+    doc:
+      type: git
+      url: https://github.com/dynamixel-community/dynamixel_hardware.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/dynamixel_hardware-release.git
+      version: 0.3.1-4
+    source:
+      type: git
+      url: https://github.com/dynamixel-community/dynamixel_hardware.git
+      version: rolling
+    status: developed
+  dynamixel_sdk:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
+      version: ros2
+    release:
+      packages:
+      - dynamixel_sdk
+      - dynamixel_sdk_custom_interfaces
+      - dynamixel_sdk_examples
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/dynamixel_sdk-release.git
+      version: 3.7.40-5
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
+      version: ros2
+    status: maintained
+  dynamixel_workbench:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
+      version: ros2
+    release:
+      packages:
+      - dynamixel_workbench
+      - dynamixel_workbench_toolbox
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/dynamixel_workbench-release.git
+      version: 2.2.3-4
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
+      version: ros2
+    status: maintained
+  dynamixel_workbench_msgs:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/dynamixel_workbench_msgs-release.git
+      version: 2.0.3-4
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
+      version: ros2
+    status: maintained
+  ecl_core:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_core.git
+      version: release/1.2.x
+    release:
+      packages:
+      - ecl_command_line
+      - ecl_concepts
+      - ecl_containers
+      - ecl_converters
+      - ecl_core
+      - ecl_core_apps
+      - ecl_devices
+      - ecl_eigen
+      - ecl_exceptions
+      - ecl_filesystem
+      - ecl_formatters
+      - ecl_geometry
+      - ecl_ipc
+      - ecl_linear_algebra
+      - ecl_manipulators
+      - ecl_math
+      - ecl_mobile_robot
+      - ecl_mpl
+      - ecl_sigslots
+      - ecl_statistics
+      - ecl_streams
+      - ecl_threads
+      - ecl_time
+      - ecl_type_traits
+      - ecl_utilities
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ecl_core-release.git
+      version: 1.2.1-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/stonier/ecl_core.git
+      version: devel
+    status: maintained
+  ecl_lite:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_lite.git
+      version: release/1.1.x
+    release:
+      packages:
+      - ecl_config
+      - ecl_console
+      - ecl_converters_lite
+      - ecl_errors
+      - ecl_io
+      - ecl_lite
+      - ecl_sigslots_lite
+      - ecl_time_lite
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ecl_lite-release.git
+      version: 1.2.0-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/stonier/ecl_lite.git
+      version: devel
+    status: maintained
+  ecl_tools:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_tools.git
+      version: release/1.0.x
+    release:
+      packages:
+      - ecl_build
+      - ecl_license
+      - ecl_tools
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ecl_tools-release.git
+      version: 1.0.3-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/stonier/ecl_tools.git
+      version: devel
+    status: maintained
+  eigen3_cmake_module:
+    doc:
+      type: git
+      url: https://github.com/ros2/eigen3_cmake_module.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/eigen3_cmake_module-release.git
+      version: 0.2.2-4
+    source:
+      type: git
+      url: https://github.com/ros2/eigen3_cmake_module.git
+      version: rolling
+    status: maintained
+  eigen_stl_containers:
+    doc:
+      type: git
+      url: https://github.com/ros/eigen_stl_containers.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/eigen_stl_containers-release.git
+      version: 1.0.0-6
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/eigen_stl_containers.git
+      version: ros2
+    status: maintained
+  eigenpy:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/eigenpy.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/eigenpy-release.git
+      version: 2.9.2-5
+    source:
+      type: git
+      url: https://github.com/stack-of-tasks/eigenpy.git
+      version: devel
+    status: maintained
+  example_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ros2/example_interfaces.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/example_interfaces-release.git
+      version: 0.10.2-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/example_interfaces.git
+      version: rolling
+    status: maintained
+  examples:
+    doc:
+      type: git
+      url: https://github.com/ros2/examples.git
+      version: rolling
+    release:
+      packages:
+      - examples_rclcpp_async_client
+      - examples_rclcpp_cbg_executor
+      - examples_rclcpp_minimal_action_client
+      - examples_rclcpp_minimal_action_server
+      - examples_rclcpp_minimal_client
+      - examples_rclcpp_minimal_composition
+      - examples_rclcpp_minimal_publisher
+      - examples_rclcpp_minimal_service
+      - examples_rclcpp_minimal_subscriber
+      - examples_rclcpp_minimal_timer
+      - examples_rclcpp_multithreaded_executor
+      - examples_rclcpp_wait_set
+      - examples_rclpy_executors
+      - examples_rclpy_guard_conditions
+      - examples_rclpy_minimal_action_client
+      - examples_rclpy_minimal_action_server
+      - examples_rclpy_minimal_client
+      - examples_rclpy_minimal_publisher
+      - examples_rclpy_minimal_service
+      - examples_rclpy_minimal_subscriber
+      - examples_rclpy_pointcloud_publisher
+      - launch_testing_examples
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/examples-release.git
+      version: 0.18.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/examples.git
+      version: rolling
+    status: maintained
+  fastcdr:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/fastcdr-release.git
+      version: 1.0.27-3
+    source:
+      test_commits: false
+      test_pull_requests: false
+      type: git
+      url: https://github.com/eProsima/Fast-CDR.git
+      version: master
+    status: maintained
+  fastrtps:
+    doc:
+      type: git
+      url: https://github.com/eProsima/Fast-RTPS.git
+      version: 2.10.x
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/fastrtps-release.git
+      version: 2.10.1-2
+    source:
+      test_commits: true
+      test_pull_requests: false
+      type: git
+      url: https://github.com/eProsima/Fast-DDS.git
+      version: 2.10.x
+    status: maintained
+  filters:
+    doc:
+      type: git
+      url: https://github.com/ros/filters.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/filters-release.git
+      version: 2.1.0-5
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/filters.git
+      version: ros2
+    status: maintained
+  find_object_2d:
+    doc:
+      type: git
+      url: https://github.com/introlab/find-object.git
+      version: rolling-devel
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/find_object_2d-release.git
+      version: 0.7.0-5
+    source:
+      type: git
+      url: https://github.com/introlab/find-object.git
+      version: rolling-devel
+    status: maintained
+  fluent_rviz:
+    doc:
+      type: git
+      url: https://github.com/ForteFibre/FluentRviz.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/fluent_rviz-release.git
+      version: 0.0.3-4
+    source:
+      type: git
+      url: https://github.com/ForteFibre/FluentRviz.git
+      version: ros2
+    status: developed
+  fmi_adapter:
+    doc:
+      type: git
+      url: https://github.com/boschresearch/fmi_adapter.git
+      version: rolling
+    release:
+      packages:
+      - fmi_adapter
+      - fmi_adapter_examples
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/fmi_adapter-release.git
+    source:
+      type: git
+      url: https://github.com/boschresearch/fmi_adapter.git
+      version: rolling
+    status: maintained
+  fmilibrary_vendor:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/fmilibrary_vendor-release.git
+    source:
+      type: git
+      url: https://github.com/boschresearch/fmilibrary_vendor.git
+      version: rolling
+    status: maintained
+  foonathan_memory_vendor:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/foonathan_memory_vendor-release.git
+      version: 1.3.0-4
+    source:
+      type: git
+      url: https://github.com/eProsima/foonathan_memory_vendor.git
+      version: master
+    status: maintained
+  four_wheel_steering_msgs:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/four_wheel_steering_msgs-release.git
+      version: 2.0.1-5
+    source:
+      type: git
+      url: https://github.com/ros-drivers/four_wheel_steering_msgs.git
+      version: ros2
+    status: maintained
+  foxglove_bridge:
+    doc:
+      type: git
+      url: https://github.com/foxglove/ros-foxglove-bridge.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/foxglove_bridge-release.git
+      version: 0.5.3-2
+    source:
+      type: git
+      url: https://github.com/foxglove/ros-foxglove-bridge.git
+      version: main
+    status: developed
+  foxglove_msgs:
+    doc:
+      type: git
+      url: https://github.com/foxglove/schemas.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_foxglove_msgs-release.git
+      version: 2.1.1-4
+    source:
+      type: git
+      url: https://github.com/foxglove/schemas.git
+      version: main
+    status: maintained
+  fuse:
+    doc:
+      type: git
+      url: https://github.com/locusrobotics/fuse.git
+      version: rolling
+    release:
+      packages:
+      - fuse
+      - fuse_constraints
+      - fuse_core
+      - fuse_doc
+      - fuse_graphs
+      - fuse_loss
+      - fuse_models
+      - fuse_msgs
+      - fuse_optimizers
+      - fuse_publishers
+      - fuse_tutorials
+      - fuse_variables
+      - fuse_viz
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/fuse-release.git
+      version: 1.0.1-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/locusrobotics/fuse.git
+      version: rolling
+    status: maintained
+  gazebo_ros2_control:
+    doc:
+      type: git
+      url: https://github.com/ros-simulation/gazebo_ros2_control.git
+      version: master
+    release:
+      packages:
+      - gazebo_ros2_control
+      - gazebo_ros2_control_demos
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
+      version: 0.5.1-4
+    source:
+      type: git
+      url: https://github.com/ros-simulation/gazebo_ros2_control.git
+      version: master
+    status: developed
+  gazebo_ros_pkgs:
+    doc:
+      type: git
+      url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
+      version: ros2
+    release:
+      packages:
+      - gazebo_dev
+      - gazebo_msgs
+      - gazebo_plugins
+      - gazebo_ros
+      - gazebo_ros_pkgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
+      version: ros2
+    status: maintained
+  gc_spl:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/gc_spl.git
+      version: rolling
+    release:
+      packages:
+      - gc_spl_2022
+      - rcgcd_spl_14
+      - rcgcd_spl_14_conversion
+      - rcgcrd_spl_4
+      - rcgcrd_spl_4_conversion
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/gc_spl-release.git
+      version: 3.0.0-4
+    source:
+      type: git
+      url: https://github.com/ros-sports/gc_spl.git
+      version: rolling
+    status: developed
+  generate_parameter_library:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/generate_parameter_library.git
+      version: main
+    release:
+      packages:
+      - generate_parameter_library
+      - generate_parameter_library_example
+      - generate_parameter_library_py
+      - parameter_traits
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/generate_parameter_library-release.git
+      version: 0.3.3-2
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/generate_parameter_library.git
+      version: main
+    status: developed
+  geographic_info:
+    doc:
+      type: git
+      url: https://github.com/ros-geographic-info/geographic_info.git
+      version: ros2
+    release:
+      packages:
+      - geodesy
+      - geographic_info
+      - geographic_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/geographic_info-release.git
+      version: 1.0.4-8
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-geographic-info/geographic_info.git
+      version: ros2
+    status: maintained
+  geometric_shapes:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/geometric_shapes.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/geometric_shapes-release.git
+      version: 2.1.3-4
+    source:
+      type: git
+      url: https://github.com/ros-planning/geometric_shapes.git
+      version: ros2
+    status: maintained
+  geometry2:
+    doc:
+      type: git
+      url: https://github.com/ros2/geometry2.git
+      version: rolling
+    release:
+      packages:
+      - examples_tf2_py
+      - geometry2
+      - tf2
+      - tf2_bullet
+      - tf2_eigen
+      - tf2_eigen_kdl
+      - tf2_geometry_msgs
+      - tf2_kdl
+      - tf2_msgs
+      - tf2_py
+      - tf2_ros
+      - tf2_ros_py
+      - tf2_sensor_msgs
+      - tf2_tools
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/geometry2-release.git
+      version: 0.31.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/geometry2.git
+      version: rolling
+    status: maintained
+  geometry_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros/geometry_tutorials.git
+      version: ros2
+    release:
+      packages:
+      - geometry_tutorials
+      - turtle_tf2_cpp
+      - turtle_tf2_py
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/geometry_tutorials-release.git
+      version: 0.3.6-4
+    source:
+      type: git
+      url: https://github.com/ros/geometry_tutorials.git
+      version: ros2
+    status: developed
+  google_benchmark_vendor:
+    doc:
+      type: git
+      url: https://github.com/ament/google_benchmark_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/google_benchmark_vendor-release.git
+      version: 0.3.0-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ament/google_benchmark_vendor.git
+      version: rolling
+    status: maintained
+  googletest:
+    release:
+      packages:
+      - gmock_vendor
+      - gtest_vendor
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/googletest-release.git
+      version: 1.10.9005-2
+    source:
+      type: git
+      url: https://github.com/ament/googletest.git
+      version: rolling
+    status: maintained
+  gps_umd:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/gps_umd.git
+      version: dashing-devel
+    release:
+      packages:
+      - gps_msgs
+      - gps_tools
+      - gps_umd
+      - gpsd_client
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/gps_umd-release.git
+      version: 1.0.4-5
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/swri-robotics/gps_umd.git
+      version: dashing-devel
+    status: developed
+  graph_msgs:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/graph_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/graph_msgs-release.git
+      version: 0.2.0-5
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/graph_msgs.git
+      version: ros2
+    status: maintained
+  grbl_msgs:
+    doc:
+      type: git
+      url: https://github.com/flynneva/grbl_msgs.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/grbl_msgs-release.git
+      version: 0.0.2-8
+    source:
+      type: git
+      url: https://github.com/flynneva/grbl_msgs.git
+      version: main
+    status: maintained
+  grbl_ros:
+    doc:
+      type: git
+      url: https://github.com/flynneva/grbl_ros.git
+      version: devel
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/grbl_ros-release.git
+      version: 0.0.16-6
+    source:
+      type: git
+      url: https://github.com/flynneva/grbl_ros.git
+      version: devel
+    status: maintained
+  gscam:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/gscam.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/gscam-release.git
+      version: 2.0.2-4
+    source:
+      type: git
+      url: https://github.com/ros-drivers/gscam.git
+      version: ros2
+    status: developed
+  gtsam:
+    doc:
+      type: git
+      url: https://github.com/borglab/gtsam.git
+      version: develop
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/gtsam-release.git
+      version: 4.2.0-4
+    source:
+      type: git
+      url: https://github.com/borglab/gtsam.git
+      version: develop
+    status: developed
+  hash_library_vendor:
+    doc:
+      type: git
+      url: https://github.com/tier4/hash_library_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/hash_library_vendor-release.git
+      version: 0.1.1-5
+    source:
+      type: git
+      url: https://github.com/tier4/hash_library_vendor.git
+      version: main
+    status: maintained
+  hatchbed_common:
+    doc:
+      type: git
+      url: https://github.com/hatchbed/hatchbed_common.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/hatchbed/hatchbed_common.git
+      version: main
+    status: developed
+  hls_lfcd_lds_driver:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
+      version: rolling-devel
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/hls_lfcd_lds_driver-release.git
+      version: 2.0.4-5
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
+      version: rolling-devel
+    status: developed
+  hpp-fcl:
+    doc:
+      type: git
+      url: https://github.com/humanoid-path-planner/hpp-fcl.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/hpp_fcl-release.git
+      version: 2.3.0-5
+    source:
+      type: git
+      url: https://github.com/humanoid-path-planner/hpp-fcl.git
+      version: devel
+    status: developed
+  iceoryx:
+    release:
+      packages:
+      - iceoryx_binding_c
+      - iceoryx_hoofs
+      - iceoryx_posh
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/iceoryx-release.git
+      version: 2.0.3-5
+    source:
+      type: git
+      url: https://github.com/eclipse-iceoryx/iceoryx.git
+      version: release_2.0
+    status: developed
+  ifm3d_core:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ifm3d-release.git
+      version: 0.18.0-9
+    status: developed
+  ign_ros2_control:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/gz_ros2_control.git
+      version: master
+    release:
+      packages:
+      - ign_ros2_control
+      - ign_ros2_control_demos
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ign_ros2_control-release.git
+    source:
+      type: git
+      url: https://github.com/ros-controls/gz_ros2_control.git
+      version: master
+    status: maintained
+  ign_rviz:
+    doc:
+      type: git
+      url: https://github.com/ignitionrobotics/ign-rviz.git
+      version: main
+    release:
+      packages:
+      - ign_rviz
+      - ign_rviz_common
+      - ign_rviz_plugins
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ign_rviz-release.git
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ignitionrobotics/ign-rviz.git
+      version: main
+    status: developed
+  ignition_cmake2_vendor:
+    doc:
+      type: git
+      url: https://github.com/ignition-release/ignition_cmake2_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ignition_cmake2_vendor-release.git
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ignition-release/ignition_cmake2_vendor.git
+      version: rolling
+    status: maintained
+  ignition_math6_vendor:
+    doc:
+      type: git
+      url: https://github.com/ignition-release/ignition_math6_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ignition_math6_vendor-release.git
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ignition-release/ignition_math6_vendor.git
+      version: rolling
+    status: maintained
+  image_common:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/image_common.git
+      version: rolling
+    release:
+      packages:
+      - camera_calibration_parsers
+      - camera_info_manager
+      - image_common
+      - image_transport
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/image_common-release.git
+      version: 4.2.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/image_common.git
+      version: rolling
+    status: maintained
+  image_pipeline:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/image_pipeline.git
+      version: rolling
+    release:
+      packages:
+      - camera_calibration
+      - depth_image_proc
+      - image_pipeline
+      - image_proc
+      - image_publisher
+      - image_rotate
+      - image_view
+      - stereo_image_proc
+      - tracetools_image_pipeline
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/image_pipeline-release.git
+      version: 3.0.1-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/image_pipeline.git
+      version: rolling
+    status: maintained
+  image_transport_plugins:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/image_transport_plugins.git
+      version: rolling
+    release:
+      packages:
+      - compressed_depth_image_transport
+      - compressed_image_transport
+      - image_transport_plugins
+      - theora_image_transport
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/image_transport_plugins-release.git
+      version: 3.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/image_transport_plugins.git
+      version: rolling
+    status: maintained
+  imu_tools:
+    doc:
+      type: git
+      url: https://github.com/CCNYRoboticsLab/imu_tools.git
+      version: rolling
+    release:
+      packages:
+      - imu_complementary_filter
+      - imu_filter_madgwick
+      - imu_tools
+      - rviz_imu_plugin
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/imu_tools-release.git
+      version: 2.1.3-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/CCNYRoboticsLab/imu_tools.git
+      version: rolling
+    status: maintained
+  interactive_markers:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/interactive_markers.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/interactive_markers-release.git
+      version: 2.4.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/interactive_markers.git
+      version: rolling
+    status: maintained
+  irobot_create_msgs:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/irobot_create_msgs-release.git
+      version: 2.1.0-3
+    source:
+      type: git
+      url: https://github.com/iRobotEducation/irobot_create_msgs.git
+      version: rolling
+    status: developed
+  joint_state_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros/joint_state_publisher.git
+      version: ros2
+    release:
+      packages:
+      - joint_state_publisher
+      - joint_state_publisher_gui
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/joint_state_publisher-release.git
+      version: 2.3.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/joint_state_publisher.git
+      version: ros2
+    status: maintained
+  joy_tester:
+    doc:
+      type: git
+      url: https://github.com/joshnewans/joy_tester.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/joy_tester-release.git
+      version: 0.0.2-3
+    source:
+      type: git
+      url: https://github.com/joshnewans/joy_tester.git
+      version: main
+    status: maintained
+  joystick_drivers:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/joystick_drivers.git
+      version: ros2
+    release:
+      packages:
+      - joy
+      - joy_linux
+      - sdl2_vendor
+      - spacenav
+      - wiimote
+      - wiimote_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/joystick_drivers-release.git
+      version: 3.1.0-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/joystick_drivers.git
+      version: ros2
+    status: maintained
+  kdl_parser:
+    doc:
+      type: git
+      url: https://github.com/ros/kdl_parser.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/kdl_parser-release.git
+      version: 2.9.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/kdl_parser.git
+      version: rolling
+    status: maintained
+  keyboard_handler:
+    doc:
+      type: git
+      url: https://github.com/ros-tooling/keyboard_handler.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/keyboard_handler-release.git
+      version: 0.1.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-tooling/keyboard_handler.git
+      version: rolling
+    status: developed
+  kinematics_interface:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/kinematics_interface.git
+      version: master
+    release:
+      packages:
+      - kinematics_interface
+      - kinematics_interface_kdl
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/kinematics_interface-release.git
+      version: 0.1.0-3
+    source:
+      type: git
+      url: https://github.com/ros-controls/kinematics_interface.git
+      version: master
+    status: developed
+  kobuki_core:
+    doc:
+      type: git
+      url: https://github.com/kobuki-base/kobuki_core.git
+      version: release/1.4.x
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/kobuki_core-release.git
+      version: 1.4.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/kobuki-base/kobuki_core.git
+      version: release/1.4.x
+    status: maintained
+  kobuki_ros_interfaces:
+    doc:
+      type: git
+      url: https://github.com/kobuki-base/kobuki_ros_interfaces.git
+      version: release/1.0.x
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/kobuki_ros_interfaces-release.git
+      version: 1.0.0-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/kobuki-base/kobuki_ros_interfaces.git
+      version: release/1.0.x
+    status: maintained
+  kobuki_velocity_smoother:
+    doc:
+      type: git
+      url: https://github.com/kobuki-base/kobuki_velocity_smoother.git
+      version: release/0.15.x
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/kobuki_velocity_smoother-release.git
+      version: 0.15.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/kobuki-base/kobuki_velocity_smoother.git
+      version: release/0.15.x
+    status: maintained
+  lanelet2:
+    doc:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git
+      version: master
+    release:
+      packages:
+      - lanelet2
+      - lanelet2_core
+      - lanelet2_examples
+      - lanelet2_io
+      - lanelet2_maps
+      - lanelet2_projection
+      - lanelet2_python
+      - lanelet2_routing
+      - lanelet2_traffic_rules
+      - lanelet2_validation
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/lanelet2-release.git
+      version: 1.1.1-5
+    source:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git
+      version: master
+    status: maintained
+  laser_filters:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/laser_filters-release.git
+      version: 2.0.6-4
+    source:
+      type: git
+      url: https://github.com/ros-perception/laser_filters.git
+      version: ros2
+    status: maintained
+  laser_geometry:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/laser_geometry.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/laser_geometry-release.git
+      version: 2.5.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/laser_geometry.git
+      version: rolling
+    status: maintained
+  laser_proc:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/laser_proc.git
+      version: ros2-devel
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/laser_proc-release.git
+      version: 1.0.2-6
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/laser_proc.git
+      version: ros2-devel
+    status: maintained
+  launch:
+    doc:
+      type: git
+      url: https://github.com/ros2/launch.git
+      version: rolling
+    release:
+      packages:
+      - launch
+      - launch_pytest
+      - launch_testing
+      - launch_testing_ament_cmake
+      - launch_xml
+      - launch_yaml
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/launch-release.git
+      version: 2.0.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/launch.git
+      version: rolling
+    status: developed
+  launch_param_builder:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/launch_param_builder.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/launch_param_builder-release.git
+      version: 0.1.1-3
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/launch_param_builder.git
+      version: main
+    status: maintained
+  launch_ros:
+    doc:
+      type: git
+      url: https://github.com/ros2/launch_ros.git
+      version: rolling
+    release:
+      packages:
+      - launch_ros
+      - launch_testing_ros
+      - ros2launch
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/launch_ros-release.git
+      version: 0.24.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/launch_ros.git
+      version: rolling
+    status: maintained
+  lgsvl_msgs:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/lgsvl_msgs-release.git
+      version: 0.0.4-4
+    source:
+      type: git
+      url: https://github.com/lgsvl/lgsvl_msgs.git
+      version: foxy-devel
+  libg2o:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/libg2o-release.git
+      version: 2020.5.29-5
+    status: maintained
+  libnabo:
+    doc:
+      type: git
+      url: https://github.com/ethz-asl/libnabo.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/libnabo-release.git
+      version: 1.0.7-4
+    source:
+      type: git
+      url: https://github.com/ethz-asl/libnabo.git
+      version: master
+    status: maintained
+  libpointmatcher:
+    doc:
+      type: git
+      url: https://github.com/ethz-asl/libpointmatcher.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/libpointmatcher-release.git
+      version: 1.3.1-5
+    source:
+      type: git
+      url: https://github.com/ethz-asl/libpointmatcher.git
+      version: master
+    status: maintained
+  libstatistics_collector:
+    doc:
+      type: git
+      url: https://github.com/ros-tooling/libstatistics_collector.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/libstatistics_collector-release.git
+      version: 1.5.1-2
+    source:
+      type: git
+      url: https://github.com/ros-tooling/libstatistics_collector.git
+      version: rolling
+    status: developed
+  libyaml_vendor:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/libyaml_vendor-release.git
+      version: 1.5.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/libyaml_vendor.git
+      version: rolling
+    status: maintained
+  locator_ros_bridge:
+    doc:
+      type: git
+      url: https://github.com/boschglobal/locator_ros_bridge.git
+      version: main
+    release:
+      packages:
+      - bosch_locator_bridge
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/locator_ros_bridge-release.git
+      version: 2.1.9-3
+    source:
+      type: git
+      url: https://github.com/boschglobal/locator_ros_bridge.git
+      version: main
+    status: maintained
+  log_view:
+    doc:
+      type: git
+      url: https://github.com/hatchbed/log_view.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/hatchbed/log_view.git
+      version: ros2
+    status: developed
+  marti_common:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/marti_common.git
+      version: dashing-devel
+    release:
+      packages:
+      - swri_console_util
+      - swri_dbw_interface
+      - swri_geometry_util
+      - swri_image_util
+      - swri_math_util
+      - swri_opencv_util
+      - swri_prefix_tools
+      - swri_roscpp
+      - swri_route_util
+      - swri_serial_util
+      - swri_system_util
+      - swri_transform_util
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/marti_common-release.git
+      version: 3.5.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/swri-robotics/marti_common.git
+      version: dashing-devel
+    status: developed
+  marti_messages:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/marti_messages.git
+      version: dashing-devel
+    release:
+      packages:
+      - marti_can_msgs
+      - marti_common_msgs
+      - marti_dbw_msgs
+      - marti_introspection_msgs
+      - marti_nav_msgs
+      - marti_perception_msgs
+      - marti_sensor_msgs
+      - marti_status_msgs
+      - marti_visualization_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/marti_messages-release.git
+      version: 1.3.0-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/swri-robotics/marti_messages.git
+      version: dashing-devel
+    status: developed
+  mavlink:
+    doc:
+      type: git
+      url: https://github.com/mavlink/mavlink-gbp-release.git
+      version: release/rolling/mavlink
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/mavlink-gbp-release.git
+      version: 2022.12.30-3
+    source:
+      type: git
+      url: https://github.com/mavlink/mavlink-gbp-release.git
+      version: release/rolling/mavlink
+    status: developed
+  mavros:
+    doc:
+      type: git
+      url: https://github.com/mavlink/mavros.git
+      version: ros2
+    release:
+      packages:
+      - libmavconn
+      - mavros
+      - mavros_extras
+      - mavros_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/mavros-release.git
+      version: 2.4.0-3
+    source:
+      type: git
+      url: https://github.com/mavlink/mavros.git
+      version: ros2
+    status: developed
+  menge_vendor:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/menge_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/menge_vendor-release.git
+      version: 1.0.0-4
+    source:
+      type: git
+      url: https://github.com/open-rmf/menge_vendor.git
+      version: rolling
+    status: developed
+  message_filters:
+    doc:
+      type: git
+      url: https://github.com/ros2/message_filters.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_message_filters-release.git
+      version: 4.7.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/message_filters.git
+      version: rolling
+    status: maintained
+  message_tf_frame_transformer:
+    doc:
+      type: git
+      url: https://github.com/ika-rwth-aachen/message_tf_frame_transformer.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/message_tf_frame_transformer-release.git
+      version: 1.0.0-3
+    source:
+      type: git
+      url: https://github.com/ika-rwth-aachen/message_tf_frame_transformer.git
+      version: main
+    status: maintained
+  micro_ros_diagnostics:
+    doc:
+      type: git
+      url: https://github.com/micro-ROS/micro_ros_diagnostics.git
+      version: master
+    release:
+      packages:
+      - micro_ros_diagnostic_bridge
+      - micro_ros_diagnostic_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/micro_ros_diagnostics-release.git
+      version: 0.3.0-5
+    source:
+      type: git
+      url: https://github.com/micro-ROS/micro_ros_diagnostics.git
+      version: master
+    status: developed
+  micro_ros_msgs:
+    doc:
+      type: git
+      url: https://github.com/micro-ROS/micro_ros_msgs.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/micro_ros_msgs-release.git
+      version: 1.0.0-4
+    source:
+      type: git
+      url: https://github.com/micro-ROS/micro_ros_msgs.git
+      version: main
+    status: maintained
+  microstrain_inertial:
+    doc:
+      type: git
+      url: https://github.com/LORD-MicroStrain/microstrain_inertial.git
+      version: ros2
+    release:
+      packages:
+      - microstrain_inertial_driver
+      - microstrain_inertial_examples
+      - microstrain_inertial_msgs
+      - microstrain_inertial_rqt
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/microstrain_inertial-release.git
+      version: 3.0.1-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/LORD-MicroStrain/microstrain_inertial.git
+      version: ros2
+    status: developed
+  mimick_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros2/mimick_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/mimick_vendor-release.git
+      version: 0.3.2-5
+    source:
+      type: git
+      url: https://github.com/ros2/mimick_vendor.git
+      version: rolling
+    status: maintained
+  mir_robot:
+    doc:
+      type: git
+      url: https://github.com/DFKI-NI/mir_robot.git
+      version: rolling
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/DFKI-NI/mir_robot.git
+      version: rolling
+    status: developed
+  moveit:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit2.git
+      version: main
+    release:
+      packages:
+      - chomp_motion_planner
+      - moveit
+      - moveit_chomp_optimizer_adapter
+      - moveit_common
+      - moveit_configs_utils
+      - moveit_core
+      - moveit_hybrid_planning
+      - moveit_kinematics
+      - moveit_planners
+      - moveit_planners_chomp
+      - moveit_planners_ompl
+      - moveit_plugins
+      - moveit_py
+      - moveit_resources_prbt_ikfast_manipulator_plugin
+      - moveit_resources_prbt_moveit_config
+      - moveit_resources_prbt_pg70_support
+      - moveit_resources_prbt_support
+      - moveit_ros
+      - moveit_ros_benchmarks
+      - moveit_ros_control_interface
+      - moveit_ros_move_group
+      - moveit_ros_occupancy_map_monitor
+      - moveit_ros_perception
+      - moveit_ros_planning
+      - moveit_ros_planning_interface
+      - moveit_ros_robot_interaction
+      - moveit_ros_visualization
+      - moveit_ros_warehouse
+      - moveit_runtime
+      - moveit_servo
+      - moveit_setup_app_plugins
+      - moveit_setup_assistant
+      - moveit_setup_controllers
+      - moveit_setup_core_plugins
+      - moveit_setup_framework
+      - moveit_setup_srdf_plugins
+      - moveit_simple_controller_manager
+      - pilz_industrial_motion_planner
+      - pilz_industrial_motion_planner_testutils
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/moveit2-release.git
+      version: 2.7.2-2
+    source:
+      test_commits: false
+      test_pull_requests: false
+      type: git
+      url: https://github.com/ros-planning/moveit2.git
+      version: main
+    status: developed
+  moveit_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/moveit_msgs-release.git
+      version: 2.2.1-3
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_msgs.git
+      version: ros2
+    status: developed
+  moveit_resources:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_resources.git
+      version: ros2
+    release:
+      packages:
+      - moveit_resources
+      - moveit_resources_fanuc_description
+      - moveit_resources_fanuc_moveit_config
+      - moveit_resources_panda_description
+      - moveit_resources_panda_moveit_config
+      - moveit_resources_pr2_description
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/moveit_resources-release.git
+      version: 2.0.6-3
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_resources.git
+      version: ros2
+    status: developed
+  moveit_visual_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_visual_tools.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/moveit_visual_tools-release.git
+      version: 4.1.0-3
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_visual_tools.git
+      version: ros2
+    status: maintained
+  mrpt2:
+    doc:
+      type: git
+      url: https://github.com/MRPT/mrpt.git
+      version: develop
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/mrpt2-release.git
+    source:
+      type: git
+      url: https://github.com/MRPT/mrpt.git
+      version: develop
+    status: developed
+  mrpt_msgs:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/mrpt_msgs-release.git
+      version: 0.4.4-3
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
+      version: master
+    status: maintained
+  mrpt_navigation:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
+      version: ros2
+    status: developed
+  mrpt_sensors:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
+      version: ros2
+    status: developed
+  mrt_cmake_modules:
+    doc:
+      type: git
+      url: https://github.com/KIT-MRT/mrt_cmake_modules.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/mrt_cmake_modules-release.git
+      version: 1.0.9-4
+    source:
+      type: git
+      url: https://github.com/KIT-MRT/mrt_cmake_modules.git
+      version: master
+    status: maintained
+  mvsim:
+    doc:
+      type: git
+      url: https://github.com/MRPT/mvsim.git
+      version: develop
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/mvsim-release.git
+    source:
+      type: git
+      url: https://github.com/MRPT/mvsim.git
+      version: develop
+    status: developed
+  nao_button_sim:
+    doc:
+      type: git
+      url: https://github.com/ijnek/nao_button_sim.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/nao_button_sim-release.git
+      version: 0.1.1-5
+    source:
+      type: git
+      url: https://github.com/ijnek/nao_button_sim.git
+      version: rolling
+    status: developed
+  nao_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ijnek/nao_interfaces.git
+      version: rolling
+    release:
+      packages:
+      - nao_command_msgs
+      - nao_sensor_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/nao_interfaces-release.git
+      version: 0.0.4-4
+    source:
+      type: git
+      url: https://github.com/ijnek/nao_interfaces.git
+      version: rolling
+    status: developed
+  nao_lola:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/nao_lola.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/nao_lola-release.git
+      version: 0.2.0-3
+    source:
+      type: git
+      url: https://github.com/ros-sports/nao_lola.git
+      version: rolling
+    status: developed
+  navigation_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/navigation_msgs.git
+      version: rolling
+    release:
+      packages:
+      - map_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/navigation_msgs-release.git
+      version: 2.2.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-planning/navigation_msgs.git
+      version: rolling
+    status: maintained
+  neo_simulation2:
+    doc:
+      type: git
+      url: https://github.com/neobotix/neo_simulation2.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/neo_simulation2-release.git
+      version: 1.0.0-4
+    source:
+      type: git
+      url: https://github.com/neobotix/neo_simulation2.git
+      version: rolling
+    status: maintained
+  nlohmann_json_schema_validator_vendor:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/nlohmann_json_schema_validator_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/nlohmann_json_schema_validator_vendor-release.git
+      version: 0.2.4-3
+    source:
+      type: git
+      url: https://github.com/open-rmf/nlohmann_json_schema_validator_vendor.git
+      version: main
+    status: developed
+  nmea_hardware_interface:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/nmea_hardware_interface.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/nmea_hardware_interface-release.git
+      version: 0.0.1-4
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/nmea_hardware_interface.git
+      version: master
+    status: developed
+  nmea_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/nmea_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/nmea_msgs-release.git
+      version: 2.0.0-5
+    source:
+      type: git
+      url: https://github.com/ros-drivers/nmea_msgs.git
+      version: ros2
+    status: maintained
+  nmea_navsat_driver:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/nmea_navsat_driver-release.git
+      version: 2.0.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/nmea_navsat_driver.git
+      version: ros2
+    status: developed
+    status_description: ROS2 support is work-in-progress. Help wanted!
+  nodl:
+    doc:
+      type: git
+      url: https://github.com/ubuntu-robotics/nodl.git
+      version: master
+    release:
+      packages:
+      - nodl_python
+      - ros2nodl
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/nodl-release.git
+      version: 0.3.1-4
+    source:
+      type: git
+      url: https://github.com/ubuntu-robotics/nodl.git
+      version: master
+    status: developed
+  nodl_to_policy:
+    doc:
+      type: git
+      url: https://github.com/osrf/nodl_to_policy.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/nodl_to_policy-release.git
+      version: 1.0.0-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/osrf/nodl_to_policy.git
+      version: master
+    status: maintained
+  novatel_gps_driver:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/novatel_gps_driver.git
+      version: dashing-devel
+    release:
+      packages:
+      - novatel_gps_driver
+      - novatel_gps_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/novatel_gps_driver-release.git
+      version: 4.1.0-4
+    source:
+      type: git
+      url: https://github.com/swri-robotics/novatel_gps_driver.git
+      version: dashing-devel
+    status: developed
+  ntpd_driver:
+    doc:
+      type: git
+      url: https://github.com/vooon/ntpd_driver.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ntpd_driver-release.git
+      version: 2.2.0-3
+    source:
+      type: git
+      url: https://github.com/vooon/ntpd_driver.git
+      version: ros2
+    status: maintained
+  ntrip_client:
+    doc:
+      type: git
+      url: https://github.com/LORD-MicroStrain/ntrip_client.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ntrip_client-release.git
+      version: 1.2.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/LORD-MicroStrain/ntrip_client.git
+      version: ros2
+    status: developed
+  object_recognition_msgs:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/object_recognition_msgs-release.git
+      version: 2.0.0-4
+    source:
+      type: git
+      url: https://github.com/wg-perception/object_recognition_msgs.git
+      version: ros2
+    status: maintained
+  octomap:
+    doc:
+      type: git
+      url: https://github.com/octomap/octomap.git
+      version: devel
+    release:
+      packages:
+      - dynamic_edt_3d
+      - octomap
+      - octovis
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/octomap-release.git
+      version: 1.9.8-3
+    source:
+      type: git
+      url: https://github.com/octomap/octomap.git
+      version: devel
+    status: maintained
+  octomap_mapping:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap_mapping.git
+      version: ros2
+    release:
+      packages:
+      - octomap_mapping
+      - octomap_server
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/octomap_mapping-release.git
+      version: 2.0.0-4
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap_mapping.git
+      version: ros2
+    status: maintained
+  octomap_msgs:
+    doc:
+      type: git
+      url: https://github.com/octomap/octomap_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/octomap_msgs-release.git
+      version: 2.0.0-4
+    source:
+      type: git
+      url: https://github.com/octomap/octomap_msgs.git
+      version: ros2
+    status: maintained
+  octomap_ros:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap_ros.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/octomap_ros-release.git
+      version: 0.4.3-3
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap_ros.git
+      version: ros2
+    status: maintained
+  octomap_rviz_plugins:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap_rviz_plugins.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/octomap_rviz_plugins-release.git
+      version: 2.0.0-4
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap_rviz_plugins.git
+      version: ros2
+    status: maintained
+  odom_to_tf_ros2:
+    doc:
+      type: git
+      url: https://github.com/gstavrinos/odom_to_tf_ros2.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/odom_to_tf_ros2-release.git
+      version: 1.0.2-3
+    source:
+      type: git
+      url: https://github.com/gstavrinos/odom_to_tf_ros2.git
+      version: master
+    status: maintained
+  ompl:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ompl-release.git
+  openni2_camera:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/openni2_camera.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/openni2_camera-release.git
+      version: 2.0.1-3
+    source:
+      type: git
+      url: https://github.com/ros-drivers/openni2_camera.git
+      version: ros2
+    status: maintained
+  opensw:
+    doc:
+      type: git
+      url: https://github.com/hatchbed/opensw.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/hatchbed/opensw.git
+      version: main
+    status: developed
+  opensw_ros:
+    doc:
+      type: git
+      url: https://github.com/hatchbed/opensw_ros.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/hatchbed/opensw_ros.git
+      version: ros2
+    status: developed
+  orocos_kdl_vendor:
+    release:
+      packages:
+      - orocos_kdl_vendor
+      - python_orocos_kdl_vendor
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
+      version: 0.3.4-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/orocos_kdl_vendor.git
+      version: rolling
+    status: developed
+  osqp_vendor:
+    doc:
+      type: git
+      url: https://github.com/tier4/osqp_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/osqp_vendor-release.git
+      version: 0.2.0-3
+    source:
+      type: git
+      url: https://github.com/tier4/osqp_vendor.git
+      version: main
+    status: maintained
+  osrf_pycommon:
+    doc:
+      type: git
+      url: https://github.com/osrf/osrf_pycommon.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/osrf_pycommon-release.git
+      version: 2.1.2-3
+    source:
+      type: git
+      url: https://github.com/osrf/osrf_pycommon.git
+      version: master
+    status: maintained
+  osrf_testing_tools_cpp:
+    doc:
+      type: git
+      url: https://github.com/osrf/osrf_testing_tools_cpp.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/osrf_testing_tools_cpp-release.git
+      version: 1.5.3-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/osrf/osrf_testing_tools_cpp.git
+      version: rolling
+    status: maintained
+  ouxt_common:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/ouxt_common.git
+      version: master
+    release:
+      packages:
+      - ouxt_common
+      - ouxt_lint_common
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ouxt_common-release.git
+      version: 0.0.8-4
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/ouxt_common.git
+      version: master
+    status: developed
+  pcl_msgs:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/pcl_msgs-release.git
+      version: 1.0.0-8
+    source:
+      type: git
+      url: https://github.com/ros-perception/pcl_msgs.git
+      version: ros2
+    status: maintained
+  perception_open3d:
+    release:
+      packages:
+      - open3d_conversions
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/perception_open3d-release.git
+    source:
+      type: git
+      url: https://github.com/ros-perception/perception_open3d.git
+      version: ros2
+    status: developed
+  perception_pcl:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/perception_pcl.git
+      version: ros2
+    release:
+      packages:
+      - pcl_conversions
+      - pcl_ros
+      - perception_pcl
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/perception_pcl-release.git
+      version: 2.4.0-5
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/perception_pcl.git
+      version: ros2
+    status: maintained
+  performance_test:
+    doc:
+      type: git
+      url: https://gitlab.com/ApexAI/performance_test.git
+      version: 1.2.1
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/performance_test-release.git
+      version: 1.2.1-4
+    source:
+      type: git
+      url: https://gitlab.com/ApexAI/performance_test.git
+      version: master
+    status: maintained
+  performance_test_fixture:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/performance_test_fixture-release.git
+      version: 0.1.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/performance_test_fixture.git
+      version: rolling
+    status: maintained
+  phidgets_drivers:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/phidgets_drivers.git
+      version: rolling
+    release:
+      packages:
+      - libphidget22
+      - phidgets_accelerometer
+      - phidgets_analog_inputs
+      - phidgets_analog_outputs
+      - phidgets_api
+      - phidgets_digital_inputs
+      - phidgets_digital_outputs
+      - phidgets_drivers
+      - phidgets_gyroscope
+      - phidgets_high_speed_encoder
+      - phidgets_ik
+      - phidgets_magnetometer
+      - phidgets_motors
+      - phidgets_msgs
+      - phidgets_spatial
+      - phidgets_temperature
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/phidgets_drivers-release.git
+      version: 2.3.1-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/phidgets_drivers.git
+      version: rolling
+    status: maintained
+  pick_ik:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/pick_ik.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/pick_ik-release.git
+      version: 1.0.1-2
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/pick_ik.git
+      version: main
+    status: developed
+  picknik_ament_copyright:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/picknik_ament_copyright-release.git
+      version: 0.0.2-4
+  pinocchio:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/pinocchio.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/pinocchio-release.git
+      version: 2.6.17-5
+    source:
+      type: git
+      url: https://github.com/stack-of-tasks/pinocchio.git
+      version: devel
+    status: developed
+  plotjuggler:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/PlotJuggler.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/plotjuggler-release.git
+      version: 3.5.1-3
+    source:
+      type: git
+      url: https://github.com/facontidavide/PlotJuggler.git
+      version: main
+    status: developed
+  plotjuggler_msgs:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/plotjuggler_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/plotjuggler_msgs-release.git
+      version: 0.2.3-4
+    source:
+      type: git
+      url: https://github.com/facontidavide/plotjuggler_msgs.git
+      version: ros2
+    status: developed
+  plotjuggler_ros:
+    doc:
+      type: git
+      url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/plotjuggler-ros-plugins-release.git
+      version: 1.7.3-6
+    source:
+      type: git
+      url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
+      version: rolling
+    status: developed
+  pluginlib:
+    doc:
+      type: git
+      url: https://github.com/ros/pluginlib.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/pluginlib-release.git
+      version: 5.2.2-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/pluginlib.git
+      version: rolling
+    status: maintained
+  point_cloud_msg_wrapper:
+    doc:
+      type: git
+      url: https://gitlab.com/ApexAI/point_cloud_msg_wrapper
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/point_cloud_msg_wrapper-release.git
+      version: 1.0.7-4
+    source:
+      type: git
+      url: https://gitlab.com/ApexAI/point_cloud_msg_wrapper
+      version: rolling
+    status: developed
+  pointcloud_to_laserscan:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/pointcloud_to_laserscan.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/pointcloud_to_laserscan-release.git
+      version: 2.0.1-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/pointcloud_to_laserscan.git
+      version: rolling
+    status: maintained
+  polygon_ros:
+    doc:
+      type: git
+      url: https://github.com/MetroRobots/polygon_ros.git
+      version: main
+    release:
+      packages:
+      - polygon_demos
+      - polygon_msgs
+      - polygon_rviz_plugins
+      - polygon_utils
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/polygon_ros-release.git
+      version: 1.0.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/MetroRobots/polygon_ros.git
+      version: main
+    status: developed
+  pose_cov_ops:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/pose_cov_ops-release.git
+      version: 0.3.10-2
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
+      version: master
+    status: maintained
+  proxsuite:
+    doc:
+      type: git
+      url: https://github.com/Simple-Robotics/proxsuite.git
+      version: devel
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/proxsuite-release.git
+    source:
+      type: git
+      url: https://github.com/Simple-Robotics/proxsuite.git
+      version: devel
+    status: developed
+  py_trees:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees.git
+      version: devel
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/py_trees-release.git
+      version: 2.2.1-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees.git
+      version: devel
+    status: developed
+  py_trees_js:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_js.git
+      version: devel
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/py_trees_js-release.git
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees_js.git
+      version: devel
+    status: maintained
+  py_trees_ros:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros.git
+      version: devel
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/py_trees_ros-release.git
+      version: 2.2.2-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros.git
+      version: devel
+    status: developed
+  py_trees_ros_interfaces:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
+      version: devel
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/py_trees_ros_interfaces-release.git
+      version: 2.1.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
+      version: devel
+    status: developed
+  pybind11_json_vendor:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/pybind11_json_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/pybind11_json_vendor-release.git
+      version: 0.2.2-3
+    source:
+      type: git
+      url: https://github.com/open-rmf/pybind11_json_vendor.git
+      version: main
+    status: developed
+  pybind11_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros2/pybind11_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/pybind11_vendor-release.git
+      version: 3.0.3-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/pybind11_vendor.git
+      version: rolling
+    status: maintained
+  python_cmake_module:
+    doc:
+      type: git
+      url: https://github.com/ros2/python_cmake_module.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/python_cmake_module-release.git
+      version: 0.10.2-3
+    source:
+      type: git
+      url: https://github.com/ros2/python_cmake_module.git
+      version: rolling
+    status: developed
+  python_qt_binding:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/python_qt_binding.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/python_qt_binding-release.git
+      version: 1.2.3-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/python_qt_binding.git
+      version: rolling
+    status: maintained
+  qpoases_vendor:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/qpoases_vendor-release.git
+      version: 3.2.3-4
+    source:
+      type: git
+      url: https://github.com/Autoware-AI/qpoases_vendor.git
+      version: ros2
+    status: maintained
+  qt_gui_core:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/qt_gui_core.git
+      version: rolling
+    release:
+      packages:
+      - qt_dotgraph
+      - qt_gui
+      - qt_gui_app
+      - qt_gui_core
+      - qt_gui_cpp
+      - qt_gui_py_common
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/qt_gui_core-release.git
+      version: 2.4.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/qt_gui_core.git
+      version: rolling
+    status: maintained
+  quaternion_operation:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/quaternion_operation.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/quaternion_operation-release.git
+      version: 0.0.7-4
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/quaternion_operation.git
+      version: ros2
+    status: maintained
+  r2r_spl:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/r2r_spl.git
+      version: rolling
+    release:
+      packages:
+      - r2r_spl_7
+      - splsm_7
+      - splsm_7_conversion
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/r2r_spl-release.git
+      version: 3.0.1-3
+    source:
+      type: git
+      url: https://github.com/ros-sports/r2r_spl.git
+      version: rolling
+    status: developed
+  radar_msgs:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/radar_msgs-release.git
+      version: 0.2.2-3
+    status: maintained
+  random_numbers:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/random_numbers.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/random_numbers-release.git
+      version: 2.0.1-4
+    source:
+      type: git
+      url: https://github.com/ros-planning/random_numbers.git
+      version: ros2
+    status: maintained
+  rc_common_msgs:
+    doc:
+      type: git
+      url: https://github.com/roboception/rc_common_msgs_ros2.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rc_common_msgs_ros2-release.git
+      version: 0.5.3-5
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rc_common_msgs_ros2.git
+      version: master
+    status: developed
+  rc_dynamics_api:
+    doc:
+      type: git
+      url: https://github.com/roboception/rc_dynamics_api.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rc_dynamics_api-release.git
+      version: 0.10.3-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rc_dynamics_api.git
+      version: master
+    status: developed
+  rc_genicam_api:
+    doc:
+      type: git
+      url: https://github.com/roboception/rc_genicam_api.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rc_genicam_api-release.git
+      version: 2.6.1-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rc_genicam_api.git
+      version: master
+    status: developed
+  rc_genicam_driver:
+    doc:
+      type: git
+      url: https://github.com/roboception/rc_genicam_driver_ros2.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rc_genicam_driver_ros2-release.git
+      version: 0.3.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rc_genicam_driver_ros2.git
+      version: master
+    status: developed
+  rc_reason_clients:
+    doc:
+      type: git
+      url: https://github.com/roboception/rc_reason_clients_ros2.git
+      version: master
+    release:
+      packages:
+      - rc_reason_clients
+      - rc_reason_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rc_reason_clients-release.git
+      version: 0.2.1-5
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rc_reason_clients_ros2.git
+      version: master
+    status: developed
+  rcdiscover:
+    doc:
+      type: git
+      url: https://github.com/roboception/rcdiscover.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rcdiscover-release.git
+      version: 1.1.6-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rcdiscover.git
+      version: master
+    status: developed
+  rcl:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcl.git
+      version: rolling
+    release:
+      packages:
+      - rcl
+      - rcl_action
+      - rcl_lifecycle
+      - rcl_yaml_param_parser
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rcl-release.git
+      version: 6.0.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rcl.git
+      version: rolling
+    status: maintained
+  rcl_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcl_interfaces.git
+      version: rolling
+    release:
+      packages:
+      - action_msgs
+      - builtin_interfaces
+      - composition_interfaces
+      - lifecycle_msgs
+      - rcl_interfaces
+      - rosgraph_msgs
+      - service_msgs
+      - statistics_msgs
+      - test_msgs
+      - type_description_interfaces
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rcl_interfaces-release.git
+      version: 1.6.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rcl_interfaces.git
+      version: rolling
+    status: maintained
+  rcl_logging:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcl_logging.git
+      version: rolling
+    release:
+      packages:
+      - rcl_logging_interface
+      - rcl_logging_noop
+      - rcl_logging_spdlog
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rcl_logging-release.git
+      version: 2.5.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rcl_logging.git
+      version: rolling
+    status: maintained
+  rcl_logging_rcutils:
+    doc:
+      type: git
+      url: https://github.com/sloretz/rcl_logging_rcutils.git
+      version: master
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/sloretz/rcl_logging_rcutils.git
+      version: master
+    status: maintained
+  rclc:
+    doc:
+      type: git
+      url: https://github.com/ros2/rclc.git
+      version: master
+    release:
+      packages:
+      - rclc
+      - rclc_examples
+      - rclc_lifecycle
+      - rclc_parameter
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rclc-release.git
+      version: 3.0.9-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rclc.git
+      version: master
+    status: developed
+  rclcpp:
+    doc:
+      type: git
+      url: https://github.com/ros2/rclcpp.git
+      version: rolling
+    release:
+      packages:
+      - rclcpp
+      - rclcpp_action
+      - rclcpp_components
+      - rclcpp_lifecycle
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rclcpp-release.git
+      version: 21.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rclcpp.git
+      version: rolling
+    status: maintained
+  rclpy:
+    doc:
+      type: git
+      url: https://github.com/ros2/rclpy.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rclpy-release.git
+      version: 4.1.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rclpy.git
+      version: rolling
+    status: maintained
+  rcpputils:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcpputils.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rcpputils-release.git
+      version: 2.6.1-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rcpputils.git
+      version: rolling
+    status: developed
+  rcss3d_agent:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/rcss3d_agent.git
+      version: rolling
+    release:
+      packages:
+      - rcss3d_agent
+      - rcss3d_agent_basic
+      - rcss3d_agent_msgs
+      - rcss3d_agent_msgs_to_soccer_interfaces
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rcss3d_agent-release.git
+      version: 0.4.1-3
+    source:
+      type: git
+      url: https://github.com/ros-sports/rcss3d_agent.git
+      version: rolling
+    status: developed
+  rcss3d_nao:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/rcss3d_nao.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rcss3d_nao-release.git
+      version: 0.1.1-3
+    source:
+      type: git
+      url: https://github.com/ros-sports/rcss3d_nao.git
+      version: rolling
+    status: developed
+  rcutils:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcutils.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rcutils-release.git
+      version: 6.2.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rcutils.git
+      version: rolling
+    status: maintained
+  realtime_support:
+    doc:
+      type: git
+      url: https://github.com/ros2/realtime_support.git
+      version: rolling
+    release:
+      packages:
+      - rttest
+      - tlsf_cpp
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/realtime_support-release.git
+      version: 0.15.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/realtime_support.git
+      version: rolling
+    status: maintained
+  realtime_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/realtime_tools.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/realtime_tools-release.git
+      version: 2.5.0-3
+    source:
+      type: git
+      url: https://github.com/ros-controls/realtime_tools.git
+      version: master
+    status: maintained
+  resource_retriever:
+    doc:
+      type: git
+      url: https://github.com/ros/resource_retriever.git
+      version: rolling
+    release:
+      packages:
+      - libcurl_vendor
+      - resource_retriever
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/resource_retriever-release.git
+      version: 3.2.2-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/resource_retriever.git
+      version: rolling
+    status: maintained
+  rig_reconfigure:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rig_reconfigure-release.git
+      version: 1.0.0-5
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/teamspatzenhirn/rig_reconfigure.git
+      version: master
+    status: developed
+  rmf_api_msgs:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_api_msgs.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_api_msgs-release.git
+      version: 0.0.1-6
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_api_msgs.git
+      version: main
+    status: developed
+  rmf_battery:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_battery.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_battery-release.git
+      version: 0.1.4-2
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_battery.git
+      version: main
+    status: developed
+  rmf_building_map_msgs:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_building_map_msgs.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_building_map_msgs-release.git
+      version: 1.2.0-7
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_building_map_msgs.git
+      version: rolling
+    status: developed
+  rmf_cmake_uncrustify:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_cmake_uncrustify.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_cmake_uncrustify-release.git
+      version: 1.2.0-5
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_cmake_uncrustify.git
+      version: rolling
+    status: developed
+  rmf_demos:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_demos.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_demos.git
+      version: main
+    status: developed
+  rmf_internal_msgs:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_internal_msgs.git
+      version: main
+    release:
+      packages:
+      - rmf_charger_msgs
+      - rmf_dispenser_msgs
+      - rmf_door_msgs
+      - rmf_fleet_msgs
+      - rmf_ingestor_msgs
+      - rmf_lift_msgs
+      - rmf_obstacle_msgs
+      - rmf_scheduler_msgs
+      - rmf_site_map_msgs
+      - rmf_task_msgs
+      - rmf_traffic_msgs
+      - rmf_workcell_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
+      version: 3.0.2-3
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_internal_msgs.git
+      version: main
+    status: developed
+  rmf_ros2:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_ros2.git
+      version: main
+    release:
+      packages:
+      - rmf_fleet_adapter
+      - rmf_fleet_adapter_python
+      - rmf_task_ros2
+      - rmf_traffic_ros2
+      - rmf_websocket
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_ros2-release.git
+      version: 2.1.2-3
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_ros2.git
+      version: main
+    status: developed
+  rmf_simulation:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_simulation.git
+      version: main
+    release:
+      packages:
+      - rmf_building_sim_common
+      - rmf_building_sim_gz_classic_plugins
+      - rmf_building_sim_gz_plugins
+      - rmf_robot_sim_common
+      - rmf_robot_sim_gz_classic_plugins
+      - rmf_robot_sim_gz_plugins
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_simulation-release.git
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_simulation.git
+      version: main
+    status: developed
+  rmf_task:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_task.git
+      version: rolling
+    release:
+      packages:
+      - rmf_task
+      - rmf_task_sequence
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_task-release.git
+      version: 2.1.3-2
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_task.git
+      version: rolling
+    status: developed
+  rmf_traffic:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_traffic.git
+      version: main
+    release:
+      packages:
+      - rmf_traffic
+      - rmf_traffic_examples
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_traffic-release.git
+      version: 3.0.0-3
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_traffic.git
+      version: main
+    status: developed
+  rmf_traffic_editor:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_traffic_editor.git
+      version: main
+    release:
+      packages:
+      - rmf_building_map_tools
+      - rmf_traffic_editor
+      - rmf_traffic_editor_assets
+      - rmf_traffic_editor_test_maps
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_traffic_editor.git
+      version: main
+    status: developed
+  rmf_utils:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_utils.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_utils-release.git
+      version: 1.4.0-3
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_utils.git
+      version: main
+    status: developed
+  rmf_visualization:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_visualization.git
+      version: main
+    release:
+      packages:
+      - rmf_visualization
+      - rmf_visualization_building_systems
+      - rmf_visualization_fleet_states
+      - rmf_visualization_floorplans
+      - rmf_visualization_navgraphs
+      - rmf_visualization_obstacles
+      - rmf_visualization_rviz2_plugins
+      - rmf_visualization_schedule
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_visualization-release.git
+      version: 2.0.1-3
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_visualization.git
+      version: main
+    status: developed
+  rmf_visualization_msgs:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_visualization_msgs.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_visualization_msgs-release.git
+      version: 1.2.0-5
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_visualization_msgs.git
+      version: main
+    status: developed
+  rmw:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw.git
+      version: rolling
+    release:
+      packages:
+      - rmw
+      - rmw_implementation_cmake
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw-release.git
+      version: 7.1.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw.git
+      version: rolling
+    status: maintained
+  rmw_connextdds:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_connextdds.git
+      version: rolling
+    release:
+      packages:
+      - rmw_connextdds
+      - rmw_connextdds_common
+      - rti_connext_dds_cmake_module
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_connextdds-release.git
+    source:
+      type: git
+      url: https://github.com/ros2/rmw_connextdds.git
+      version: rolling
+    status: developed
+  rmw_cyclonedds:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_cyclonedds.git
+      version: rolling
+    release:
+      packages:
+      - rmw_cyclonedds_cpp
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
+      version: 1.6.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw_cyclonedds.git
+      version: rolling
+    status: developed
+  rmw_dds_common:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_dds_common.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_dds_common-release.git
+      version: 2.0.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw_dds_common.git
+      version: rolling
+    status: maintained
+  rmw_fastrtps:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_fastrtps.git
+      version: rolling
+    release:
+      packages:
+      - rmw_fastrtps_cpp
+      - rmw_fastrtps_dynamic_cpp
+      - rmw_fastrtps_shared_cpp
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
+      version: 7.1.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw_fastrtps.git
+      version: rolling
+    status: developed
+  rmw_gurumdds:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_gurumdds.git
+      version: rolling
+    release:
+      packages:
+      - gurumdds_cmake_module
+      - rmw_gurumdds_cpp
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
+    source:
+      type: git
+      url: https://github.com/ros2/rmw_gurumdds.git
+      version: rolling
+    status: developed
+  rmw_implementation:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_implementation.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_implementation-release.git
+      version: 2.12.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw_implementation.git
+      version: rolling
+    status: developed
+  robot_calibration:
+    doc:
+      type: git
+      url: https://github.com/mikeferguson/robot_calibration.git
+      version: ros2
+    release:
+      packages:
+      - robot_calibration
+      - robot_calibration_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/robot_calibration-release.git
+      version: 0.8.0-3
+    source:
+      type: git
+      url: https://github.com/mikeferguson/robot_calibration.git
+      version: ros2
+    status: developed
+  robot_localization:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/robot_localization-release.git
+      version: 3.5.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/cra-ros-pkg/robot_localization.git
+      version: ros2
+    status: maintained
+  robot_state_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros/robot_state_publisher.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/robot_state_publisher-release.git
+      version: 3.2.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/robot_state_publisher.git
+      version: rolling
+    status: maintained
+  ros1_bridge:
+    doc:
+      type: git
+      url: https://github.com/ros2/ros1_bridge.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ros1_bridge-release.git
+    source:
+      test_commits: false
+      type: git
+      url: https://github.com/ros2/ros1_bridge.git
+      version: master
+    status: maintained
+  ros2_control:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/ros2_control.git
+      version: master
+    release:
+      packages:
+      - controller_interface
+      - controller_manager
+      - controller_manager_msgs
+      - hardware_interface
+      - joint_limits
+      - ros2_control
+      - ros2_control_test_assets
+      - ros2controlcli
+      - rqt_controller_manager
+      - transmission_interface
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_control-release.git
+      version: 3.12.1-2
+    source:
+      type: git
+      url: https://github.com/ros-controls/ros2_control.git
+      version: master
+    status: developed
+  ros2_controllers:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/ros2_controllers.git
+      version: master
+    release:
+      packages:
+      - admittance_controller
+      - diff_drive_controller
+      - effort_controllers
+      - force_torque_sensor_broadcaster
+      - forward_command_controller
+      - gripper_controllers
+      - imu_sensor_broadcaster
+      - joint_state_broadcaster
+      - joint_trajectory_controller
+      - position_controllers
+      - ros2_controllers
+      - ros2_controllers_test_nodes
+      - rqt_joint_trajectory_controller
+      - tricycle_controller
+      - velocity_controllers
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_controllers-release.git
+      version: 3.5.0-2
+    source:
+      type: git
+      url: https://github.com/ros-controls/ros2_controllers.git
+      version: master
+    status: developed
+  ros2_ouster_drivers:
+    doc:
+      type: git
+      url: https://github.com/SteveMacenski/ros2_ouster_drivers.git
+      version: foxy-devel
+    release:
+      packages:
+      - ouster_msgs
+      - ros2_ouster
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_ouster_drivers-release.git
+      version: 0.5.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/SteveMacenski/ros2_ouster_drivers.git
+      version: foxy-devel
+    status: maintained
+  ros2_socketcan:
+    doc:
+      type: git
+      url: https://github.com/autowarefoundation/ros2_socketcan.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_socketcan-release.git
+      version: 1.1.0-4
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/ros2_socketcan.git
+      version: main
+    status: developed
+  ros2_tracing:
+    doc:
+      type: git
+      url: https://github.com/ros2/ros2_tracing.git
+      version: rolling
+    release:
+      packages:
+      - ros2trace
+      - tracetools
+      - tracetools_launch
+      - tracetools_read
+      - tracetools_test
+      - tracetools_trace
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_tracing-release.git
+      version: 6.3.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/ros2_tracing.git
+      version: rolling
+    status: developed
+  ros2acceleration:
+    doc:
+      type: git
+      url: https://github.com/ros-acceleration/ros2acceleration.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2acceleration-release.git
+      version: 0.5.1-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-acceleration/ros2acceleration.git
+      version: rolling
+    status: developed
+  ros2cli:
+    doc:
+      type: git
+      url: https://github.com/ros2/ros2cli.git
+      version: rolling
+    release:
+      packages:
+      - ros2action
+      - ros2cli
+      - ros2cli_test_interfaces
+      - ros2component
+      - ros2doctor
+      - ros2interface
+      - ros2lifecycle
+      - ros2lifecycle_test_fixtures
+      - ros2multicast
+      - ros2node
+      - ros2param
+      - ros2pkg
+      - ros2run
+      - ros2service
+      - ros2topic
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2cli-release.git
+      version: 0.25.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/ros2cli.git
+      version: rolling
+    status: maintained
+  ros2cli_common_extensions:
+    doc:
+      type: git
+      url: https://github.com/ros2/ros2cli_common_extensions.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2cli_common_extensions-release.git
+      version: 0.2.2-3
+    source:
+      type: git
+      url: https://github.com/ros2/ros2cli_common_extensions.git
+      version: rolling
+    status: maintained
+  ros2launch_security:
+    doc:
+      type: git
+      url: https://github.com/osrf/ros2launch_security.git
+      version: main
+    release:
+      packages:
+      - ros2launch_security
+      - ros2launch_security_examples
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2launch_security-release.git
+      version: 1.0.0-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/osrf/ros2launch_security.git
+      version: main
+    status: maintained
+  ros_canopen:
+    release:
+      packages:
+      - can_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_canopen-release.git
+      version: 2.0.0-5
+    source:
+      type: git
+      url: https://github.com/ros-industrial/ros_canopen.git
+      version: dashing-devel
+    status: developed
+  ros_environment:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_environment.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_environment-release.git
+      version: 4.1.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/ros_environment.git
+      version: rolling
+    status: maintained
+  ros_ign:
+    doc:
+      type: git
+      url: https://github.com/ignitionrobotics/ros_ign.git
+      version: ros2
+    release:
+      packages:
+      - ros_ign
+      - ros_ign_bridge
+      - ros_ign_gazebo
+      - ros_ign_gazebo_demos
+      - ros_ign_image
+      - ros_ign_interfaces
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_ign-release.git
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ignitionrobotics/ros_ign.git
+      version: ros2
+    status: developed
+  ros_image_to_qimage:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/ros_image_to_qimage.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_image_to_qimage-release.git
+      version: 0.4.1-3
+    source:
+      type: git
+      url: https://github.com/ros-sports/ros_image_to_qimage.git
+      version: rolling
+    status: developed
+  ros_industrial_cmake_boilerplate:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_industrial_cmake_boilerplate-release.git
+  ros_testing:
+    doc:
+      type: git
+      url: https://github.com/ros2/ros_testing.git
+      version: rolling
+    release:
+      packages:
+      - ros2test
+      - ros_testing
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_testing-release.git
+      version: 0.5.2-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/ros_testing.git
+      version: rolling
+    status: maintained
+  ros_workspace:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_workspace-release.git
+      version: 1.0.3-4
+    source:
+      type: git
+      url: https://github.com/ros2/ros_workspace.git
+      version: latest
+    status: maintained
+  rosbag2:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosbag2.git
+      version: rolling
+    release:
+      packages:
+      - mcap_vendor
+      - ros2bag
+      - rosbag2
+      - rosbag2_compression
+      - rosbag2_compression_zstd
+      - rosbag2_cpp
+      - rosbag2_examples_cpp
+      - rosbag2_examples_py
+      - rosbag2_interfaces
+      - rosbag2_performance_benchmarking
+      - rosbag2_performance_benchmarking_msgs
+      - rosbag2_py
+      - rosbag2_storage
+      - rosbag2_storage_default_plugins
+      - rosbag2_storage_mcap
+      - rosbag2_storage_sqlite3
+      - rosbag2_test_common
+      - rosbag2_test_msgdefs
+      - rosbag2_tests
+      - rosbag2_transport
+      - shared_queues_vendor
+      - sqlite3_vendor
+      - zstd_vendor
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rosbag2-release.git
+      version: 0.22.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosbag2.git
+      version: rolling
+    status: developed
+  rosbag2_bag_v2:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosbag2_bag_v2.git
+      version: master
+    release:
+      packages:
+      - ros1_rosbag_storage_vendor
+      - rosbag2_bag_v2_plugins
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rosbag2_bag_v2-release.git
+    source:
+      test_commits: false
+      type: git
+      url: https://github.com/ros2/rosbag2_bag_v2.git
+      version: master
+    status: maintained
+  rosbridge_suite:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/rosbridge_suite.git
+      version: ros2
+    release:
+      packages:
+      - rosapi
+      - rosapi_msgs
+      - rosbridge_library
+      - rosbridge_msgs
+      - rosbridge_server
+      - rosbridge_suite
+      - rosbridge_test_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rosbridge_suite-release.git
+      version: 1.3.1-3
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/rosbridge_suite.git
+      version: ros2
+    status: developed
+  rosidl:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl.git
+      version: rolling
+    release:
+      packages:
+      - rosidl_adapter
+      - rosidl_cli
+      - rosidl_cmake
+      - rosidl_generator_c
+      - rosidl_generator_cpp
+      - rosidl_generator_type_description
+      - rosidl_parser
+      - rosidl_pycommon
+      - rosidl_runtime_c
+      - rosidl_runtime_cpp
+      - rosidl_typesupport_interface
+      - rosidl_typesupport_introspection_c
+      - rosidl_typesupport_introspection_cpp
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl-release.git
+      version: 4.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl.git
+      version: rolling
+    status: maintained
+  rosidl_core:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_core.git
+      version: rolling
+    release:
+      packages:
+      - rosidl_core_generators
+      - rosidl_core_runtime
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_core-release.git
+      version: 0.1.1-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_core.git
+      version: rolling
+    status: maintained
+  rosidl_dds:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_dds.git
+      version: rolling
+    release:
+      packages:
+      - rosidl_generator_dds_idl
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_dds-release.git
+      version: 0.10.1-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_dds.git
+      version: rolling
+    status: maintained
+  rosidl_defaults:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_defaults.git
+      version: rolling
+    release:
+      packages:
+      - rosidl_default_generators
+      - rosidl_default_runtime
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_defaults-release.git
+      version: 1.5.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_defaults.git
+      version: rolling
+    status: maintained
+  rosidl_dynamic_typesupport:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_dynamic_typesupport.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_dynamic_typesupport-release.git
+      version: 0.0.3-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_dynamic_typesupport.git
+      version: rolling
+    status: maintained
+  rosidl_dynamic_typesupport_fastrtps:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_dynamic_typesupport_fastrtps-release.git
+      version: 0.0.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps.git
+      version: rolling
+    status: maintained
+  rosidl_python:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_python.git
+      version: rolling
+    release:
+      packages:
+      - rosidl_generator_py
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_python-release.git
+      version: 0.18.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_python.git
+      version: rolling
+    status: maintained
+  rosidl_runtime_py:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_runtime_py.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
+      version: 0.12.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_runtime_py.git
+      version: rolling
+    status: maintained
+  rosidl_typesupport:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport.git
+      version: rolling
+    release:
+      packages:
+      - rosidl_typesupport_c
+      - rosidl_typesupport_cpp
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
+      version: 3.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport.git
+      version: rolling
+    status: maintained
+  rosidl_typesupport_fastrtps:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
+      version: rolling
+    release:
+      packages:
+      - fastrtps_cmake_module
+      - rosidl_typesupport_fastrtps_c
+      - rosidl_typesupport_fastrtps_cpp
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
+      version: 3.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
+      version: rolling
+    status: developed
+  rospy_message_converter:
+    doc:
+      type: git
+      url: https://github.com/DFKI-NI/rospy_message_converter.git
+      version: rolling
+    release:
+      packages:
+      - rclpy_message_converter
+      - rclpy_message_converter_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rospy_message_converter-release.git
+      version: 2.0.1-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/DFKI-NI/rospy_message_converter.git
+      version: rolling
+    status: maintained
+  rot_conv_lib:
+    release:
+      packages:
+      - rot_conv
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rot_conv_lib-release.git
+      version: 1.0.11-3
+    source:
+      type: git
+      url: https://github.com/AIS-Bonn/rot_conv_lib.git
+      version: master
+    status: maintained
+  rplidar_ros:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rplidar_ros-release.git
+      version: 2.1.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/allenh1/rplidar_ros.git
+      version: ros2
+    status: developed
+  rpyutils:
+    doc:
+      type: git
+      url: https://github.com/ros2/rpyutils.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rpyutils-release.git
+      version: 0.3.2-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rpyutils.git
+      version: rolling
+    status: developed
+  rqt:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt.git
+      version: rolling
+    release:
+      packages:
+      - rqt
+      - rqt_gui
+      - rqt_gui_cpp
+      - rqt_gui_py
+      - rqt_py_common
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt-release.git
+      version: 1.3.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt.git
+      version: rolling
+    status: maintained
+  rqt_action:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_action.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_action-release.git
+      version: 2.1.2-3
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_action.git
+      version: rolling
+    status: maintained
+  rqt_bag:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_bag.git
+      version: rolling
+    release:
+      packages:
+      - rqt_bag
+      - rqt_bag_plugins
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_bag-release.git
+      version: 1.3.1-2
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_bag.git
+      version: rolling
+    status: maintained
+  rqt_common_plugins:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_common_plugins.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_common_plugins-release.git
+      version: 1.2.0-3
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_common_plugins.git
+      version: ros2
+    status: maintained
+  rqt_console:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_console.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_console-release.git
+      version: 2.1.1-3
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_console.git
+      version: rolling
+    status: maintained
+  rqt_graph:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_graph.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_graph-release.git
+      version: 1.4.1-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt_graph.git
+      version: rolling
+    status: maintained
+  rqt_image_overlay:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/rqt_image_overlay.git
+      version: rolling
+    release:
+      packages:
+      - rqt_image_overlay
+      - rqt_image_overlay_layer
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_image_overlay-release.git
+      version: 0.3.1-3
+    source:
+      type: git
+      url: https://github.com/ros-sports/rqt_image_overlay.git
+      version: rolling
+    status: developed
+  rqt_image_view:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_image_view.git
+      version: rolling-devel
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_image_view-release.git
+      version: 1.2.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt_image_view.git
+      version: rolling-devel
+    status: maintained
+  rqt_moveit:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_moveit.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_moveit-release.git
+      version: 1.0.1-4
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_moveit.git
+      version: ros2
+    status: maintained
+  rqt_msg:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_msg.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_msg-release.git
+      version: 1.3.1-3
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_msg.git
+      version: rolling
+    status: maintained
+  rqt_plot:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_plot.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_plot-release.git
+      version: 1.2.2-2
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_plot.git
+      version: rolling
+    status: maintained
+  rqt_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_publisher.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_publisher-release.git
+      version: 1.6.3-2
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_publisher.git
+      version: rolling
+    status: maintained
+  rqt_py_console:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_py_console.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_py_console-release.git
+      version: 1.1.1-3
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_py_console.git
+      version: rolling
+    status: maintained
+  rqt_reconfigure:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_reconfigure.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_reconfigure-release.git
+      version: 1.3.3-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt_reconfigure.git
+      version: rolling
+    status: maintained
+  rqt_robot_dashboard:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_dashboard.git
+      version: ROS2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_robot_dashboard-release.git
+      version: 0.6.1-4
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_dashboard.git
+      version: ROS2
+    status: maintained
+  rqt_robot_monitor:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_monitor.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_robot_monitor-release.git
+      version: 1.0.5-3
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_monitor.git
+      version: dashing-devel
+    status: maintained
+  rqt_robot_steering:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_steering.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_robot_steering-release.git
+      version: 1.0.0-5
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_steering.git
+      version: dashing-devel
+    status: maintained
+  rqt_runtime_monitor:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_runtime_monitor.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_runtime_monitor-release.git
+      version: 1.0.0-4
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_runtime_monitor.git
+      version: rolling
+    status: maintained
+  rqt_service_caller:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_service_caller.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_service_caller-release.git
+      version: 1.1.1-3
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_service_caller.git
+      version: rolling
+    status: maintained
+  rqt_shell:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_shell.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_shell-release.git
+      version: 1.1.1-3
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_shell.git
+      version: rolling
+    status: maintained
+  rqt_srv:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_srv.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_srv-release.git
+      version: 1.1.1-3
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_srv.git
+      version: rolling
+    status: maintained
+  rqt_tf_tree:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_tf_tree.git
+      version: humble
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_tf_tree-release.git
+      version: 1.0.4-3
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_tf_tree.git
+      version: humble
+    status: maintained
+  rqt_topic:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_topic.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_topic-release.git
+      version: 1.6.1-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt_topic.git
+      version: rolling
+    status: maintained
+  rsl:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/RSL.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/RSL-release.git
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/RSL.git
+      version: main
+    status: developed
+  rt_manipulators_cpp:
+    doc:
+      type: git
+      url: https://github.com/rt-net/rt_manipulators_cpp.git
+      version: ros2
+    release:
+      packages:
+      - rt_manipulators_cpp
+      - rt_manipulators_examples
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rt_manipulators_cpp-release.git
+      version: 1.0.0-3
+    source:
+      type: git
+      url: https://github.com/rt-net/rt_manipulators_cpp.git
+      version: ros2
+    status: maintained
+  rtabmap:
+    doc:
+      type: git
+      url: https://github.com/introlab/rtabmap.git
+      version: rolling-devel
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rtabmap-release.git
+      version: 0.21.1-3
+    source:
+      type: git
+      url: https://github.com/introlab/rtabmap.git
+      version: rolling-devel
+    status: maintained
+  rtcm_msgs:
+    doc:
+      type: git
+      url: https://github.com/tilk/rtcm_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rtcm_msgs-release.git
+      version: 1.1.6-3
+    source:
+      type: git
+      url: https://github.com/tilk/rtcm_msgs.git
+      version: master
+    status: maintained
+  ruckig:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ruckig-release.git
+      version: 0.9.2-4
+    source:
+      type: git
+      url: https://github.com/pantor/ruckig.git
+      version: master
+    status: developed
+  rviz:
+    doc:
+      type: git
+      url: https://github.com/ros2/rviz.git
+      version: rolling
+    release:
+      packages:
+      - rviz2
+      - rviz_assimp_vendor
+      - rviz_common
+      - rviz_default_plugins
+      - rviz_ogre_vendor
+      - rviz_rendering
+      - rviz_rendering_tests
+      - rviz_visual_testing_framework
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rviz-release.git
+      version: 12.4.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rviz.git
+      version: rolling
+    status: maintained
+  rviz_2d_overlay_plugins:
+    doc:
+      type: git
+      url: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git
+      version: main
+    release:
+      packages:
+      - rviz_2d_overlay_msgs
+      - rviz_2d_overlay_plugins
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rviz_2d_overlay_plugins-release.git
+      version: 1.2.1-3
+    source:
+      type: git
+      url: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git
+      version: main
+    status: maintained
+  rviz_visual_tools:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/rviz_visual_tools.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rviz_visual_tools-release.git
+      version: 4.1.4-3
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/rviz_visual_tools.git
+      version: ros2
+    status: maintained
+  sdformat_urdf:
+    doc:
+      type: git
+      url: https://github.com/ros/sdformat_urdf.git
+      version: ros2
+    release:
+      packages:
+      - sdformat_test_files
+      - sdformat_urdf
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/sdformat_urdf-release.git
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/sdformat_urdf.git
+      version: ros2
+    status: maintained
+  septentrio_gnss_driver:
+    doc:
+      type: git
+      url: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release.git
+      version: 1.2.3-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
+      version: ros2
+    status: maintained
+  simple_actions:
+    doc:
+      type: git
+      url: https://github.com/DLu/simple_actions.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/simple_actions-release.git
+      version: 0.2.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/DLu/simple_actions.git
+      version: main
+    status: developed
+  simple_launch:
+    doc:
+      type: git
+      url: https://github.com/oKermorgant/simple_launch.git
+      version: 1.0.2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/simple_launch-release.git
+      version: 1.7.0-3
+    source:
+      type: git
+      url: https://github.com/oKermorgant/simple_launch.git
+      version: devel
+    status: maintained
+  slider_publisher:
+    doc:
+      type: git
+      url: https://github.com/oKermorgant/slider_publisher.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/slider_publisher-release.git
+      version: 2.2.1-3
+    source:
+      type: git
+      url: https://github.com/oKermorgant/slider_publisher.git
+      version: ros2
+    status: maintained
+  snowbot_operating_system:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/snowbot_operating_system.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/snowbot_release.git
+      version: 0.1.2-4
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/snowbot_operating_system.git
+      version: ros2
+    status: maintained
+  soccer_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/soccer_interfaces.git
+      version: rolling
+    release:
+      packages:
+      - soccer_interfaces
+      - soccer_vision_2d_msgs
+      - soccer_vision_3d_msgs
+      - soccer_vision_attribute_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/soccer_interfaces-release.git
+      version: 0.2.0-3
+    source:
+      type: git
+      url: https://github.com/ros-sports/soccer_interfaces.git
+      version: rolling
+    status: developed
+  soccer_object_msgs:
+    doc:
+      type: git
+      url: https://github.com/ijnek/soccer_object_msgs.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/soccer_object_msgs-release.git
+      version: 1.1.0-3
+    source:
+      type: git
+      url: https://github.com/ijnek/soccer_object_msgs.git
+      version: rolling
+    status: developed
+  soccer_vision_3d_rviz_markers:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/soccer_vision_3d_rviz_markers.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/soccer_vision_3d_rviz_markers-release.git
+      version: 0.0.1-3
+    source:
+      type: git
+      url: https://github.com/ros-sports/soccer_vision_3d_rviz_markers.git
+      version: rolling
+    status: developed
+  soccer_visualization:
+    doc:
+      type: git
+      url: https://github.com/ijnek/soccer_visualization.git
+      version: rolling
+    release:
+      packages:
+      - soccer_marker_generation
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/soccer_visualization-release.git
+      version: 0.1.0-3
+    source:
+      type: git
+      url: https://github.com/ijnek/soccer_visualization.git
+      version: rolling
+    status: developed
+  sol_vendor:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/sol_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/sol_vendor-release.git
+      version: 0.0.3-4
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/sol_vendor.git
+      version: main
+    status: developed
+  sophus:
+    doc:
+      type: git
+      url: https://github.com/stonier/sophus.git
+      version: release/1.2.x
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/sophus-release.git
+      version: 1.3.1-3
+    source:
+      type: git
+      url: https://github.com/stonier/sophus.git
+      version: release/1.2.x
+    status: maintained
+  spdlog_vendor:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/spdlog_vendor-release.git
+      version: 1.4.4-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/spdlog_vendor.git
+      version: rolling
+    status: maintained
+  srdfdom:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/srdfdom.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/srdfdom-release.git
+      version: 2.0.4-3
+    source:
+      type: git
+      url: https://github.com/ros-planning/srdfdom.git
+      version: ros2
+    status: maintained
+  sros2:
+    doc:
+      type: git
+      url: https://github.com/ros2/sros2.git
+      version: rolling
+    release:
+      packages:
+      - sros2
+      - sros2_cmake
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/sros2-release.git
+      version: 0.11.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/sros2.git
+      version: rolling
+    status: developed
+  stomp:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/stomp.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/stomp-release.git
+      version: 0.1.2-3
+    source:
+      type: git
+      url: https://github.com/ros-industrial/stomp.git
+      version: main
+    status: maintained
+  stubborn_buddies:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/stubborn_buddies.git
+      version: main
+    release:
+      packages:
+      - stubborn_buddies
+      - stubborn_buddies_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/stubborn_buddies-release.git
+      version: 1.0.0-6
+    source:
+      type: git
+      url: https://github.com/open-rmf/stubborn_buddies.git
+      version: main
+    status: developed
+  swri_console:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/swri_console.git
+      version: ros2-devel
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/swri_console-release.git
+      version: 2.0.3-3
+    source:
+      type: git
+      url: https://github.com/swri-robotics/swri_console.git
+      version: ros2-devel
+    status: developed
+  system_fingerprint:
+    doc:
+      type: git
+      url: https://github.com/MetroRobots/ros_system_fingerprint.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_system_fingerprint-release.git
+      version: 0.7.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/MetroRobots/ros_system_fingerprint.git
+      version: ros2
+    status: developed
+  system_modes:
+    doc:
+      type: git
+      url: https://github.com/micro-ROS/system_modes.git
+      version: master
+    release:
+      packages:
+      - launch_system_modes
+      - system_modes
+      - system_modes_examples
+      - system_modes_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/system_modes-release.git
+      version: 0.9.0-5
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/micro-ROS/system_modes.git
+      version: master
+    status: developed
+  system_tests:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/system_tests.git
+      version: rolling
+    status: developed
+  tango_icons_vendor:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/tango_icons_vendor-release.git
+      version: 0.2.2-3
+    source:
+      type: git
+      url: https://github.com/ros-visualization/tango_icons_vendor.git
+      version: rolling
+    status: maintained
+  teleop_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-teleop/teleop_tools.git
+      version: foxy-devel
+    release:
+      packages:
+      - joy_teleop
+      - key_teleop
+      - mouse_teleop
+      - teleop_tools
+      - teleop_tools_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/teleop_tools-release.git
+      version: 1.4.0-2
+    source:
+      type: git
+      url: https://github.com/ros-teleop/teleop_tools.git
+      version: foxy-devel
+    status: maintained
+  teleop_twist_joy:
+    doc:
+      type: git
+      url: https://github.com/ros2/teleop_twist_joy.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/teleop_twist_joy-release.git
+      version: 2.4.3-5
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/teleop_twist_joy.git
+      version: rolling
+    status: maintained
+  teleop_twist_keyboard:
+    doc:
+      type: git
+      url: https://github.com/ros2/teleop_twist_keyboard.git
+      version: dashing
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/teleop_twist_keyboard-release.git
+      version: 2.3.2-5
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/teleop_twist_keyboard.git
+      version: dashing
+    status: maintained
+  tensorrt_cmake_module:
+    doc:
+      type: git
+      url: https://github.com/tier4/tensorrt_cmake_module.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/tensorrt_cmake_module-release.git
+      version: 0.0.3-3
+    source:
+      type: git
+      url: https://github.com/tier4/tensorrt_cmake_module.git
+      version: main
+    status: maintained
+  test_interface_files:
+    doc:
+      type: git
+      url: https://github.com/ros2/test_interface_files.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/test_interface_files-release.git
+      version: 0.10.2-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/test_interface_files.git
+      version: rolling
+    status: maintained
+  tf2_2d:
+    doc:
+      type: git
+      url: https://github.com/locusrobotics/tf2_2d.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/tf2_2d-release.git
+      version: 1.0.1-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/locusrobotics/tf2_2d.git
+      version: rolling
+    status: maintained
+  tf_transformations:
+    doc:
+      type: git
+      url: https://github.com/DLu/tf_transformations.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/tf_transformations_release.git
+      version: 1.0.1-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/DLu/tf_transformations.git
+      version: main
+    status: maintained
+  tinyspline_vendor:
+    doc:
+      type: git
+      url: https://github.com/wep21/tinyspline_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/tinyspline_vendor-release.git
+      version: 0.6.0-4
+    source:
+      type: git
+      url: https://github.com/wep21/tinyspline_vendor.git
+      version: main
+    status: maintained
+  tinyxml2_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros2/tinyxml2_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/tinyxml2_vendor-release.git
+      version: 0.8.2-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/tinyxml2_vendor.git
+      version: rolling
+    status: maintained
+  tinyxml_vendor:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/tinyxml_vendor-release.git
+      version: 0.9.2-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/tinyxml_vendor.git
+      version: rolling
+    status: maintained
+  tlsf:
+    doc:
+      type: git
+      url: https://github.com/ros2/tlsf.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/tlsf-release.git
+      version: 0.8.2-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/tlsf.git
+      version: rolling
+    status: maintained
+  topic_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-tooling/topic_tools.git
+      version: main
+    release:
+      packages:
+      - topic_tools
+      - topic_tools_interfaces
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/topic_tools-release.git
+      version: 1.0.0-3
+    source:
+      type: git
+      url: https://github.com/ros-tooling/topic_tools.git
+      version: main
+    status: developed
+  tracetools_acceleration:
+    doc:
+      type: git
+      url: https://github.com/ros-acceleration/tracetools_acceleration.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/tracetools_acceleration-release.git
+      version: 0.4.1-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-acceleration/tracetools_acceleration.git
+      version: rolling
+    status: developed
+  tracetools_analysis:
+    doc:
+      type: git
+      url: https://gitlab.com/ros-tracing/tracetools_analysis.git
+      version: master
+    release:
+      packages:
+      - ros2trace_analysis
+      - tracetools_analysis
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/tracetools_analysis-release.git
+      version: 3.0.0-5
+    source:
+      type: git
+      url: https://gitlab.com/ros-tracing/tracetools_analysis.git
+      version: master
+    status: developed
+  transport_drivers:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/transport_drivers.git
+      version: main
+    release:
+      packages:
+      - asio_cmake_module
+      - io_context
+      - serial_driver
+      - udp_driver
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/transport_drivers-release.git
+      version: 1.2.0-3
+    source:
+      type: git
+      url: https://github.com/ros-drivers/transport_drivers.git
+      version: main
+    status: developed
+  turbojpeg_compressed_image_transport:
+    doc:
+      type: git
+      url: https://github.com/wep21/turbojpeg_compressed_image_transport.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/turbojpeg_compressed_image_transport-release.git
+      version: 0.2.1-4
+    source:
+      type: git
+      url: https://github.com/wep21/turbojpeg_compressed_image_transport.git
+      version: rolling
+    status: maintained
+  turtlebot3_msgs:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
+      version: rolling-devel
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot3_msgs-release.git
+      version: 2.2.1-4
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
+      version: rolling-devel
+    status: developed
+  turtlebot3_simulations:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
+      version: ros2
+    release:
+      packages:
+      - turtlebot3_fake_node
+      - turtlebot3_gazebo
+      - turtlebot3_simulations
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot3_simulations-release.git
+      version: 2.2.5-4
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
+      version: ros2
+    status: maintained
+  turtlesim:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_tutorials.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_tutorials-release.git
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/ros_tutorials.git
+      version: rolling
+    status: maintained
+  tuw_geometry:
+    doc:
+      type: git
+      url: https://github.com/tuw-robotics/tuw_geometry.git
+      version: humble
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/tuw_geometry-release.git
+      version: 0.0.7-4
+    source:
+      type: git
+      url: https://github.com/tuw-robotics/tuw_geometry.git
+      version: humble
+    status: maintained
+  tvm_vendor:
+    doc:
+      type: git
+      url: https://github.com/autowarefoundation/tvm_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/tvm_vendor-release.git
+      version: 0.9.1-3
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/tvm_vendor.git
+      version: main
+    status: maintained
+  twist_mux:
+    doc:
+      type: git
+      url: https://github.com/ros-teleop/twist_mux.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/twist_mux-release.git
+      version: 4.1.0-4
+    source:
+      type: git
+      url: https://github.com/ros-teleop/twist_mux.git
+      version: foxy-devel
+    status: maintained
+  twist_stamper:
+    doc:
+      type: git
+      url: https://github.com/joshnewans/twist_stamper.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/twist_stamper-release.git
+      version: 0.0.3-3
+    source:
+      type: git
+      url: https://github.com/joshnewans/twist_stamper.git
+      version: main
+    status: maintained
+  ublox:
+    doc:
+      type: git
+      url: https://github.com/KumarRobotics/ublox.git
+      version: ros2
+    release:
+      packages:
+      - ublox
+      - ublox_gps
+      - ublox_msgs
+      - ublox_serialization
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ublox-release.git
+      version: 2.3.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/KumarRobotics/ublox.git
+      version: ros2
+    status: maintained
+  ublox_dgnss:
+    doc:
+      type: git
+      url: https://github.com/aussierobots/ublox_dgnss.git
+      version: main
+    release:
+      packages:
+      - ublox_dgnss
+      - ublox_dgnss_node
+      - ublox_ubx_interfaces
+      - ublox_ubx_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ublox_dgnss-release.git
+      version: 0.3.5-5
+    source:
+      type: git
+      url: https://github.com/aussierobots/ublox_dgnss.git
+      version: main
+    status: maintained
+  udp_msgs:
+    doc:
+      type: git
+      url: https://github.com/flynneva/udp_msgs.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/udp_msgs-release.git
+      version: 0.0.3-6
+    source:
+      type: git
+      url: https://github.com/flynneva/udp_msgs.git
+      version: main
+    status: maintained
+  uncrustify_vendor:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/uncrustify_vendor-release.git
+      version: 2.1.2-3
+    source:
+      type: git
+      url: https://github.com/ament/uncrustify_vendor.git
+      version: rolling
+    status: maintained
+  unique_identifier_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros2/unique_identifier_msgs.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/unique_identifier_msgs-release.git
+      version: 2.3.2-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/unique_identifier_msgs.git
+      version: rolling
+    status: maintained
+  ur_client_library:
+    doc:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
+      version: 1.3.1-3
+    source:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git
+      version: master
+    status: developed
+  ur_description:
+    doc:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ur_description-release.git
+      version: 2.0.1-3
+    source:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
+      version: ros2
+    status: developed
+  ur_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/ur_msgs.git
+      version: foxy
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ur_msgs-release.git
+      version: 2.0.0-3
+    source:
+      type: git
+      url: https://github.com/ros-industrial/ur_msgs.git
+      version: foxy
+    status: developed
+  ur_robot_driver:
+    doc:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
+      version: main
+    release:
+      packages:
+      - ur
+      - ur_bringup
+      - ur_calibration
+      - ur_controllers
+      - ur_dashboard_msgs
+      - ur_moveit_config
+      - ur_robot_driver
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
+    source:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
+      version: main
+    status: developed
+  urdf:
+    doc:
+      type: git
+      url: https://github.com/ros2/urdf.git
+      version: rolling
+    release:
+      packages:
+      - urdf
+      - urdf_parser_plugin
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/urdf-release.git
+      version: 2.8.2-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/urdf.git
+      version: rolling
+    status: maintained
+  urdf_parser_py:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf_parser_py.git
+      version: ros2
+    release:
+      packages:
+      - urdfdom_py
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/urdfdom_py-release.git
+      version: 1.2.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/urdf_parser_py.git
+      version: ros2
+    status: maintained
+  urdf_tutorial:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf_tutorial.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/urdf_tutorial-release.git
+      version: 1.0.0-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/urdf_tutorial.git
+      version: ros2
+    status: maintained
+  urdfdom:
+    doc:
+      type: git
+      url: https://github.com/ros/urdfdom.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/urdfdom-release.git
+      version: 3.1.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/urdfdom.git
+      version: master
+    status: maintained
+  urdfdom_headers:
+    doc:
+      type: git
+      url: https://github.com/ros/urdfdom_headers.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/urdfdom_headers-release.git
+      version: 1.1.0-3
+    source:
+      type: git
+      url: https://github.com/ros/urdfdom_headers.git
+      version: master
+    status: maintained
+  urg_c:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/urg_c.git
+      version: ros2-devel
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/urg_c-release.git
+      version: 1.0.4001-5
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/urg_c.git
+      version: ros2-devel
+    status: maintained
+  urg_node:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/urg_node.git
+      version: ros2-devel
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/urg_node-release.git
+      version: 1.1.1-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/urg_node.git
+      version: ros2-devel
+    status: maintained
+  urg_node_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/urg_node_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/urg_node_msgs-release.git
+      version: 1.0.1-7
+    source:
+      type: git
+      url: https://github.com/ros-drivers/urg_node_msgs.git
+      version: master
+    status: maintained
+  usb_cam:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/usb_cam.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/usb_cam-release.git
+    source:
+      type: git
+      url: https://github.com/ros-drivers/usb_cam.git
+      version: ros2
+    status: maintained
+  v4l2_camera:
+    doc:
+      type: git
+      url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_v4l2_camera-release.git
+      version: 0.6.1-3
+    source:
+      type: git
+      url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
+      version: rolling
+    status: developed
+  variants:
+    doc:
+      type: git
+      url: https://github.com/ros2/variants.git
+      version: master
+    release:
+      packages:
+      - desktop
+      - desktop_full
+      - perception
+      - ros_base
+      - ros_core
+      - simulation
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/variants-release.git
+      version: 0.10.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/variants.git
+      version: master
+    status: maintained
+  velodyne:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/velodyne.git
+      version: ros2
+    release:
+      packages:
+      - velodyne
+      - velodyne_driver
+      - velodyne_laserscan
+      - velodyne_msgs
+      - velodyne_pointcloud
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/velodyne-release.git
+      version: 2.3.0-3
+    source:
+      type: git
+      url: https://github.com/ros-drivers/velodyne.git
+      version: ros2
+    status: developed
+  velodyne_simulator:
+    doc:
+      type: git
+      url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
+      version: foxy-devel
+    release:
+      packages:
+      - velodyne_description
+      - velodyne_gazebo_plugins
+      - velodyne_simulator
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/velodyne_simulator-release.git
+      version: 2.0.3-3
+    source:
+      type: git
+      url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
+      version: foxy-devel
+    status: maintained
+  vision_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/vision_msgs.git
+      version: ros2
+    release:
+      packages:
+      - vision_msgs
+      - vision_msgs_rviz_plugins
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/vision_msgs-release.git
+      version: 4.1.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/vision_msgs.git
+      version: ros2
+    status: developed
+  vision_msgs_layers:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/vision_msgs_layers.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/vision_msgs_layers-release.git
+      version: 0.2.0-3
+    source:
+      type: git
+      url: https://github.com/ros-sports/vision_msgs_layers.git
+      version: rolling
+    status: developed
+  vision_opencv:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/vision_opencv.git
+      version: rolling
+    release:
+      packages:
+      - cv_bridge
+      - image_geometry
+      - vision_opencv
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/vision_opencv-release.git
+      version: 3.4.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/vision_opencv.git
+      version: rolling
+    status: maintained
+  visp:
+    doc:
+      type: git
+      url: https://github.com/lagadic/visp.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/visp-release.git
+      version: 3.5.0-3
+    source:
+      type: git
+      url: https://github.com/lagadic/visp.git
+      version: master
+    status: maintained
+  vitis_common:
+    doc:
+      type: git
+      url: https://github.com/ros-acceleration/vitis_common.git
+      version: rolling
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/vitis_common-release.git
+      version: 0.4.2-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-acceleration/vitis_common.git
+      version: rolling
+    status: developed
+  vrpn:
+    doc:
+      type: git
+      url: https://github.com/vrpn/vrpn.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/vrpn-release.git
+      version: 7.35.0-14
+    source:
+      test_commits: false
+      test_pull_requests: false
+      type: git
+      url: https://github.com/vrpn/vrpn.git
+      version: master
+    status: maintained
+  vrpn_mocap:
+    doc:
+      type: git
+      url: https://github.com/alvinsunyixiao/vrpn_mocap.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/vrpn_mocap-release.git
+      version: 1.0.3-3
+    source:
+      type: git
+      url: https://github.com/alvinsunyixiao/vrpn_mocap.git
+      version: main
+    status: developed
+  warehouse_ros:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/warehouse_ros-release.git
+      version: 2.0.4-4
+    source:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros.git
+      version: ros2
+    status: maintained
+  warehouse_ros_mongo:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros_mongo.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/warehouse_ros_mongo-release.git
+    source:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros_mongo.git
+      version: ros2
+    status: maintained
+  warehouse_ros_sqlite:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros_sqlite.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/warehouse_ros_sqlite-release.git
+      version: 1.0.3-3
+    source:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros_sqlite.git
+      version: ros2
+    status: maintained
+  webots_ros2:
+    doc:
+      type: git
+      url: https://github.com/cyberbotics/webots_ros2.git
+      version: master
+    release:
+      packages:
+      - webots_ros2
+      - webots_ros2_control
+      - webots_ros2_driver
+      - webots_ros2_epuck
+      - webots_ros2_importer
+      - webots_ros2_mavic
+      - webots_ros2_msgs
+      - webots_ros2_tesla
+      - webots_ros2_tests
+      - webots_ros2_tiago
+      - webots_ros2_turtlebot
+      - webots_ros2_universal_robot
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/webots_ros2-release.git
+      version: 2023.0.3-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/cyberbotics/webots_ros2.git
+      version: master
+    status: maintained
+  xacro:
+    doc:
+      type: git
+      url: https://github.com/ros/xacro.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/xacro-release.git
+      version: 2.0.9-3
+    source:
+      type: git
+      url: https://github.com/ros/xacro.git
+      version: ros2
+    status: maintained
+  yaml_cpp_vendor:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
+      version: 8.1.2-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/yaml_cpp_vendor.git
+      version: rolling
+    status: maintained
+  zbar_ros:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/zbar_ros.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/zbar_ros-release.git
+      version: 0.4.0-3
+    source:
+      type: git
+      url: https://github.com/ros-drivers/zbar_ros.git
+      version: ros2
+    status: maintained
+  zenoh_bridge_dds:
+    doc:
+      type: git
+      url: https://github.com/eclipse-zenoh/zenoh-plugin-dds.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/zenoh_bridge_dds-release.git
+      version: 0.5.0-4
+    source:
+      type: git
+      url: https://github.com/eclipse-zenoh/zenoh-plugin-dds.git
+      version: master
+    status: developed
+  zmqpp_vendor:
+    doc:
+      type: git
+      url: https://github.com/tier4/zmqpp_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/zmqpp_vendor-release.git
+      version: 0.0.2-3
+    source:
+      type: git
+      url: https://github.com/tier4/zmqpp_vendor.git
+      version: main
+    status: developed
 type: distribution
 version: 2

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6255,7 +6255,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/tuw-robotics/tuw_geometry.git
-      version: humble
+      version: ros2
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -6264,7 +6264,7 @@ repositories:
     source:
       type: git
       url: https://github.com/tuw-robotics/tuw_geometry.git
-      version: humble
+      version: ros2
     status: maintained
   tvm_vendor:
     doc:


### PR DESCRIPTION
This PR adds the `distribution.yaml` file for `iron` generated by running the migration tool with the command
```bash
python3 migration-tools/migrate-rosdistro.py --dest iron --source rolling --source-ref d7676d5c2ce5a99abb43ac2a3e6b4510fe50a261 --release-org ros2-gbp
```
with `source-ref` being the latest commit to `master` at the time of run.

Some repositories were manually migrated due to issues encountered during the first run.