### PR TITLE
novatel_oem7_driver: 20.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3327,6 +3327,14 @@ repositories:
       type: git
       url: https://github.com/novatel/novatel_oem7_driver.git
       version: humble
+    release:
+      packages:
+      - novatel_oem7_driver
+      - novatel_oem7_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
+      version: 20.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_oem7_driver` to `20.0.0-1`:

- upstream repository: https://github.com/novatel/novatel_oem7_driver.git
- release repository: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## novatel_oem7_driver

```
Formal support for Humble; functionality updated to that of ROS1 v4.2.0
Features:
* BESTGNSSPOS, PPPPOS, TERRASTARINFO, TERRASTARSTATUS Oem7 Messages
* imu/data_raw output, source from RAWIMUSX and scaled
* HG4930_AN04, HG4930_AN04_400Hz IMUs
* Odometry Angular velocities
* Optionally, publish Odometry Transform
* Optionally, use first valid GPSFix as Odometry Pose origin
Fixes:
* Rotate Odometry Twist covariances into local frame
```

## novatel_oem7_msgs

```
Formal support for Humble; functionality updated to that of ROS1 v4.2.0
* BESTGNSSPOS, PPPPOS, TERRASTARINFO, TERRASTARSTATUS Oem7 Messages
```
