### PR TITLE
mvsim: 0.7.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3068,7 +3068,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mvsim-release.git
-      version: 0.6.1-1
+      version: 0.7.0-1
     source:
       type: git
       url: https://github.com/MRPT/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.7.0-1`:

- upstream repository: https://github.com/MRPT/mvsim.git
- release repository: https://github.com/ros2-gbp/mvsim-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.1-1`

## mvsim

```
* Automatic detection of collision shapes
* Add turtlebot world demo
* Rely on custom build of Box2D to increase the maximum polygon vertices count (8 to 12).
* fix inconsistent use_sim_time value for ROS 2 (it should be false)
* Expose shadow rendering parameters in the XML world file
* Abort simulation on exceptions in headless mode too
* ROS 1 and 2 nodes now quit cleanly and quickly with SIGINT
* Add ros2 launch for turtlebot world demo
* Automatic determination of zmin/zmax for blocks if not explicitly set in XML
* Force c++17 for python module
* Exit simulator on exceptions in GUI-related threads
* More automated testing
* Add unit tests in C++ too
* Refactor collision shape determination
* New UI checkbox: show collision shapes
* Allow simply geometry definitions without external 3D model file for "blocks"
* Light options are now under <light> XML tag.
* Largest default physics simulation timestep changed from 50ms to 5ms
* GUI: change light direction
* Add GUI checkbox to enable/disable shadows
* Add rplidar A2 sensor model
* Contributors: Jose Luis Blanco-Claraco
```
