### PR TITLE
smacc2: 2.1.21-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6709,12 +6709,15 @@ repositories:
       version: foxy
     release:
       packages:
+      - ros_timer_client
+      - sm_atomic
+      - sm_atomic_mode_states
       - smacc2
       - smacc2_msgs
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/robosoft-ai/SMACC2-release.git
-      version: 2.1.0-1
+      version: 2.1.21-1
     source:
       type: git
       url: https://github.com/robosoft-ai/SMACC2.git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6709,9 +6709,6 @@ repositories:
       version: foxy
     release:
       packages:
-      - ros_timer_client
-      - sm_atomic
-      - sm_atomic_mode_states
       - smacc2
       - smacc2_msgs
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `smacc2` to `2.1.21-1`:

- upstream repository: https://github.com/robosoft-ai/SMACC2.git
- release repository: https://github.com/robosoft-ai/SMACC2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.0-1`
