### PR TITLE
simple_grasping: 0.4.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10437,7 +10437,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/simple_grasping-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/mikeferguson/simple_grasping.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_grasping` to `0.4.1-1`:

- upstream repository: https://github.com/mikeferguson/simple_grasping.git
- release repository: https://github.com/ros-gbp/simple_grasping-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.0-1`

## simple_grasping

```
* remove VTK dependency (#11 <https://github.com/mikeferguson/simple_grasping/issues/11>)
  Debian stretch really isn't a target anymore, and apparently now we have other issues by specifying this dependency
* add LICENSE file
* Contributors: Michael Ferguson
```
