### PR TITLE
novatel_oem7_driver: 20.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3334,7 +3334,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
-      version: 20.0.0-1
+      version: 20.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_oem7_driver` to `20.1.0-1`:

- upstream repository: https://github.com/novatel/novatel_oem7_driver.git
- release repository: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `20.0.0-1`
