### PR TITLE
moveit: 2.7.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2577,7 +2577,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
-      version: 2.7.2-1
+      version: 2.7.3-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.7.3-1`:

- upstream repository: https://github.com/ros-planning/moveit2.git
- release repository: https://github.com/ros2-gbp/moveit2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.7.2-1`

## chomp_motion_planner

```
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Shobuj Paul
```

## moveit

- No changes

## moveit_chomp_optimizer_adapter

```
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Shobuj Paul
```

## moveit_common

```
* Replace check for the ROS_DISTRO env variable with a check for the rclcpp version (#2135 <https://github.com/ros-planning/moveit2/issues/2135>)
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Jafar, Shobuj Paul
```

## moveit_configs_utils

- No changes

## moveit_core

- No changes

## moveit_hybrid_planning

```
* Replace check for the ROS_DISTRO env variable with a check for the rclcpp version (#2135 <https://github.com/ros-planning/moveit2/issues/2135>)
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Jafar, Shobuj Paul
```

## moveit_kinematics

- No changes

## moveit_planners

- No changes

## moveit_planners_chomp

```
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Shobuj Paul
```

## moveit_planners_ompl

```
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Shobuj Paul
```

## moveit_plugins

- No changes

## moveit_py

- No changes

## moveit_resources_prbt_ikfast_manipulator_plugin

```
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Shobuj Paul
```

## moveit_resources_prbt_moveit_config

```
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Shobuj Paul
```

## moveit_resources_prbt_pg70_support

```
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Shobuj Paul
```

## moveit_resources_prbt_support

```
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Shobuj Paul
```

## moveit_ros

- No changes

## moveit_ros_benchmarks

```
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Shobuj Paul
```

## moveit_ros_control_interface

```
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Fix controller_manager_plugin's switch controllers functionality (#2116 <https://github.com/ros-planning/moveit2/issues/2116>)
* Contributors: Jafar, Shobuj Paul
```

## moveit_ros_move_group

```
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Shobuj Paul
```

## moveit_ros_occupancy_map_monitor

```
* Replace check for the ROS_DISTRO env variable with a check for the rclcpp version (#2135 <https://github.com/ros-planning/moveit2/issues/2135>)
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Jafar, Shobuj Paul
```

## moveit_ros_perception

```
* Replace check for the ROS_DISTRO env variable with a check for the rclcpp version (#2135 <https://github.com/ros-planning/moveit2/issues/2135>)
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Jafar, Shobuj Paul
```

## moveit_ros_planning

```
* Replace check for the ROS_DISTRO env variable with a check for the rclcpp version (#2135 <https://github.com/ros-planning/moveit2/issues/2135>)
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Jafar, Shobuj Paul
```

## moveit_ros_planning_interface

```
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Shobuj Paul
```

## moveit_ros_robot_interaction

```
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Shobuj Paul
```

## moveit_ros_visualization

```
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Shobuj Paul
```

## moveit_ros_warehouse

```
* Replace check for the ROS_DISTRO env variable with a check for the rclcpp version (#2135 <https://github.com/ros-planning/moveit2/issues/2135>)
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Jafar, Shobuj Paul
```

## moveit_runtime

- No changes

## moveit_servo

```
* Replace check for the ROS_DISTRO env variable with a check for the rclcpp version (#2135 <https://github.com/ros-planning/moveit2/issues/2135>)
* Document pausing better (#2128 <https://github.com/ros-planning/moveit2/issues/2128>)
* [Servo] Make applyJointUpdate() a free function (#2121 <https://github.com/ros-planning/moveit2/issues/2121>)
  * Change variable names for improved readability
  * Fix issues from rebase
  * Move applyJointUpdate() to utilities
  * Fix comment
  * Fix old-style-cast
  * Use pluginlib::UniquePtr for smoothing class
* Contributors: AndyZe, Jafar, V Mohammed Ibrahim
```

## moveit_setup_app_plugins

```
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Shobuj Paul
```

## moveit_setup_assistant

```
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Shobuj Paul
```

## moveit_setup_controllers

```
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Shobuj Paul
```

## moveit_setup_core_plugins

```
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Shobuj Paul
```

## moveit_setup_framework

```
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Shobuj Paul
```

## moveit_setup_srdf_plugins

```
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Shobuj Paul
```

## moveit_simple_controller_manager

```
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Shobuj Paul
```

## pilz_industrial_motion_planner

```
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Shobuj Paul
```

## pilz_industrial_motion_planner_testutils

```
* Replace Variable PROJECT_NAME in CMakeLists.txt with the actual name (#2020 <https://github.com/ros-planning/moveit2/issues/2020>)
* Contributors: Shobuj Paul
```
