### PR TITLE
rig_reconfigure: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4639,7 +4639,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rig_reconfigure-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rig_reconfigure` to `1.1.0-1`:

- upstream repository: https://github.com/teamspatzenhirn/rig_reconfigure.git
- release repository: https://github.com/ros2-gbp/rig_reconfigure-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-1`

## rig_reconfigure

```
* Accept more parameter path separators
* allow scientific notation for float-parameters
* Manual FPS limiting for VNC sessions
* add support for string parameters
* allow clicking on node text for folding/unfolding
* added buttons for expanding / collapsing all parameter nodes
* sort node names in alphabetical order
* periodic node refreshing + warning about died nodes
* improved sizing of the list box
* Contributors: Dominik, Jonas Otto, Scott K Logan
```
