### PR TITLE
Adding the Carla install to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -132,6 +132,9 @@ carla-pip:
   ubuntu:
     pip:
       packages: [carla]
+   osx:
+    pip:
+      packages: [carla]
 casadi-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -129,10 +129,10 @@ carla-pip:
   fedora:
     pip:
       packages: [carla]
-  ubuntu:
+  osx:
     pip:
       packages: [carla]
-   osx:
+  ubuntu:
     pip:
       packages: [carla]
 casadi-pip:


### PR DESCRIPTION
Carla is a dependency that can be installed via pip on osx.

## Package name:

Carla

## Package Upstream Source:

https://github.com/carla-simulator/carla

## Purpose of using this:

Carla is a dependency and may as well be added to osx

- macOS: https://pypi.org/project/carla/