### PR TITLE
depthai-ros: 2.7.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1787,13 +1787,15 @@ repositories:
       packages:
       - depthai-ros
       - depthai_bridge
+      - depthai_descriptions
       - depthai_examples
+      - depthai_filters
       - depthai_ros_driver
       - depthai_ros_msgs
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/luxonis/depthai-ros-release.git
-      version: 2.6.4-1
+      version: 2.7.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai-ros` to `2.7.1-1`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: https://github.com/luxonis/depthai-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.6.4-1`

## depthai-ros

```
* Add custom output size option for streams
```
