### PR TITLE
fkie_potree_rviz_plugin: 2.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2671,7 +2671,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fkie-release/potree_rviz_plugin-release.git
-      version: 1.0.1-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/fkie/potree_rviz_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fkie_potree_rviz_plugin` to `2.0.0-1`:

- upstream repository: https://github.com/fkie/potree_rviz_plugin.git
- release repository: https://github.com/fkie-release/potree_rviz_plugin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.1-1`

## fkie_potree_rviz_plugin

```
* Add support for Potree 1.8 and 2.0 formats
* Add automatic unloading of unused nodes to limit memory usage
* Fix compatibility with Ubuntu 20.04
* Improve splat rendering
* Contributors: Timo Röhling
```
