### PR TITLE
depthai-ros: 2.7.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -994,12 +994,15 @@ repositories:
       packages:
       - depthai-ros
       - depthai_bridge
+      - depthai_descriptions
       - depthai_examples
+      - depthai_filters
+      - depthai_ros_driver
       - depthai_ros_msgs
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/luxonis/depthai-ros-release.git
-      version: 2.5.3-1
+      version: 2.7.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai-ros` to `2.7.1-1`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: https://github.com/luxonis/depthai-ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.5.3-1`

## depthai-ros

```
* Add custom output size option for streams
```
