### PR TITLE
Add autoconf-archive to rosdep base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -214,6 +214,7 @@ autoconf-archive:
   debian: [autoconf-archive]
   fedora: [autoconf-archive]
   gentoo: [sys-devel/autoconf-archive]
+  macports: [autoconf-archive]
   nixos: [autoconf-archive]
   openembedded: [autoconf-archive@openembedded-core]
   opensuse: [autoconf-archive]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -210,10 +210,12 @@ autoconf:
   rhel: [autoconf]
   ubuntu: [autoconf]
 autoconf-archive:
+  alpine: [autoconf-archive]
   arch: [autoconf-archive]
   debian: [autoconf-archive]
   fedora: [autoconf-archive]
   gentoo: [sys-devel/autoconf-archive]
+  macports: [autoconf-archive]
   nixos: [autoconf-archive]
   openembedded: [autoconf-archive@openembedded-core]
   opensuse: [autoconf-archive]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -209,6 +209,15 @@ autoconf:
   opensuse: [autoconf]
   rhel: [autoconf]
   ubuntu: [autoconf]
+autoconf-archive:
+  arch: [autoconf-archive]
+  debian: [autoconf-archive]
+  fedora: [autoconf-archive]
+  gentoo: [sys-devel/autoconf-archive]
+  nixos: [autoconf-archive]
+  openembedded: [autoconf-archive@openembedded-core]
+  opensuse: [autoconf-archive]
+  ubuntu: [autoconf-archive]
 automake:
   arch: [automake]
   debian: [automake]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -219,6 +219,7 @@ autoconf-archive:
   nixos: [autoconf-archive]
   openembedded: [autoconf-archive@openembedded-core]
   opensuse: [autoconf-archive]
+  rhel: [autoconf-archive]
   ubuntu: [autoconf-archive]
 automake:
   arch: [automake]


### PR DESCRIPTION
## Package name:

`autoconf-archive`

## Package Upstream Source:

https://www.gnu.org/software/autoconf-archive/

## Purpose of using this:

Package required to build [libgpiod v2](https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git) from source. There is no binary for libgpiod v2 yet, so this is the only way to build it now. It is required by the script [autogen.sh](https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/tree/autogen.sh?h=v2.0&id=c367029bc6d37e399b8f275e5f220c20bb8da3c0).

## Links to Distribution Packages

I tried to do my best to find sources for non-required platforms.

- Debian: https://packages.debian.org/
  - https://packages.ubuntu.com/focal/autoconf
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.debian.org/bullseye/autoconf-archive
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/autoconf-archive/autoconf-archive/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/community-staging/any/autoconf-archive/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/sys-devel/autoconf-archive
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/autoconf-archive
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/packages?name=autoconf-archive
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=22.11&show=autoconf-archive&from=0&size=50&sort=relevance&type=packages&query=autoconf-archive
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/autoconf-archive
- OpenEmbedded:
  -  https://layers.openembedded.org/layerindex/recipe/68363/
- RHEL:
  -  http://eastus.azure.repo.almalinux.org/almalinux/9.1/AppStream/x86_64/os/Packages/autoconf-archive-2019.01.06-9.el9.noarch.rpm

