### PR TITLE
ignition_math6_vendor: 0.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1806,7 +1806,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ignition_math6_vendor-release.git
-      version: 0.0.2-2
+      version: 0.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ignition_math6_vendor` to `0.0.3-1`:

- upstream repository: https://github.com/ignition-release/ignition_math6_vendor.git
- release repository: https://github.com/ros2-gbp/ignition_math6_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.2-2`

## ignition_math6_vendor

```
* Forward CMAKE_PREFIX_PATH when building vendor package (#8 <https://github.com/gazebo-release/gz_math6_vendor/issues/8>)
* Contributors: Scott K Logan
```
