### PR TITLE
rclpy: 3.3.8-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4504,7 +4504,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 3.3.7-1
+      version: 3.3.8-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `3.3.8-2`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.3.7-1`

## rclpy

```
* Deal with ParameterUninitializedException for parameter service (backport #1033 <https://github.com/ros2/rclpy/issues/1033>) (#1041 <https://github.com/ros2/rclpy/issues/1041>)
* Fix #983 <https://github.com/ros2/rclpy/issues/983> by saving future and checking for + raising any exceptions (#1073 <https://github.com/ros2/rclpy/issues/1073>) (#1088 <https://github.com/ros2/rclpy/issues/1088>)
* Contributors: Tomoya Fujita, mergify[bot]
```
