### PR TITLE
rclcpp: 16.0.4-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4488,7 +4488,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 16.0.3-1
+      version: 16.0.4-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `16.0.4-2`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `16.0.3-1`

## rclcpp

```
* use allocator via init_options argument. (#2129 <https://github.com/ros2/rclcpp/issues/2129>) (#2131 <https://github.com/ros2/rclcpp/issues/2131>)
* Contributors: mergify[bot]
```

## rclcpp_action

```
* Revert "Revert "extract the result response before the callback is issued. (#2133 <https://github.com/ros2/rclcpp/issues/2133>)" (#2148 <https://github.com/ros2/rclcpp/issues/2148>)" (#2152 <https://github.com/ros2/rclcpp/issues/2152>)
* Revert "extract the result response before the callback is issued. (#2133 <https://github.com/ros2/rclcpp/issues/2133>)" (#2148 <https://github.com/ros2/rclcpp/issues/2148>)
* extract the result response before the callback is issued. (#2133 <https://github.com/ros2/rclcpp/issues/2133>)
* Contributors: Tomoya Fujita
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
