### PR TITLE
rcutils: 5.1.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4555,7 +4555,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 5.1.2-1
+      version: 5.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `5.1.3-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `5.1.2-1`

## rcutils

```
* avoid unnecessary copy for rcutils_char_array_vsprintf. (#412 <https://github.com/ros2/rcutils/issues/412>) (#413 <https://github.com/ros2/rcutils/issues/413>)
* Contributors: mergify[bot]
```
