### PR TITLE
gc_spl: 0.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1618,7 +1618,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/gc_spl-release.git
-      version: 0.0.1-1
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/ros-sports/gc_spl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gc_spl` to `0.0.2-1`:

- upstream repository: https://github.com/ros-sports/gc_spl.git
- release repository: https://github.com/ros2-gbp/gc_spl-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.1-1`

## gc_spl_2022

```
* Use socket.timeout instead of TimeoutError in older python versions (#43 <https://github.com/ros-sports/gc_spl/issues/43>)
* Contributors: Kenji Brameld
```

## rcgcd_spl_14

- No changes

## rcgcd_spl_14_conversion

- No changes

## rcgcrd_spl_4

- No changes

## rcgcrd_spl_4_conversion

- No changes
