### PR TITLE
vrpn_mocap: 1.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7838,6 +7838,21 @@ repositories:
       url: https://github.com/vrpn/vrpn.git
       version: master
     status: maintained
+  vrpn_mocap:
+    doc:
+      type: git
+      url: https://github.com/alvinsunyixiao/vrpn_mocap.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/vrpn_mocap-release.git
+      version: 1.0.4-1
+    source:
+      type: git
+      url: https://github.com/alvinsunyixiao/vrpn_mocap.git
+      version: main
+    status: maintained
   wall_follower_ros2:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn_mocap` to `1.0.4-1`:

- upstream repository: https://github.com/alvinsunyixiao/vrpn_mocap.git
- release repository: https://github.com/ros2-gbp/vrpn_mocap-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## vrpn_mocap

```
* fix readme
* use node clock (#3 <https://github.com/alvinsunyixiao/vrpn_mocap/issues/3>)
* cancel ci run on previous push (#2 <https://github.com/alvinsunyixiao/vrpn_mocap/issues/2>)
* add foxy ci (#1 <https://github.com/alvinsunyixiao/vrpn_mocap/issues/1>)
  * add foxy ci
  * fix package name
  * revert cmake
  * downgrade cmake in CI
  * add rolling and humble CI and badages
* Contributors: Alvin Sun
```
