### PR TITLE
vrpn_mocap: 1.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6797,7 +6797,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/vrpn_mocap-release.git
-      version: 1.0.3-2
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/alvinsunyixiao/vrpn_mocap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn_mocap` to `1.0.4-1`:

- upstream repository: https://github.com/alvinsunyixiao/vrpn_mocap.git
- release repository: https://github.com/ros2-gbp/vrpn_mocap-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.3-2`

## vrpn_mocap

```
* fix readme
* use node clock (#3 <https://github.com/alvinsunyixiao/vrpn_mocap/issues/3>)
* cancel ci run on previous push (#2 <https://github.com/alvinsunyixiao/vrpn_mocap/issues/2>)
* add foxy ci (#1 <https://github.com/alvinsunyixiao/vrpn_mocap/issues/1>)
  * add foxy ci
  * fix package name
  * revert cmake
  * downgrade cmake in CI
  * add rolling and humble CI and badages
* Contributors: Alvin Sun
```
