### PR TITLE
vrpn_mocap: 1.0.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -7752,7 +7752,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/vrpn_mocap-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/alvinsunyixiao/vrpn_mocap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn_mocap` to `1.0.4-1`:

- upstream repository: https://github.com/alvinsunyixiao/vrpn_mocap.git
- release repository: https://github.com/ros2-gbp/vrpn_mocap-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.3-1`

## vrpn_mocap

```
* fix readme
* use node clock (#3 <https://github.com/alvinsunyixiao/vrpn_mocap/issues/3>)
* cancel ci run on previous push (#2 <https://github.com/alvinsunyixiao/vrpn_mocap/issues/2>)
* add foxy ci (#1 <https://github.com/alvinsunyixiao/vrpn_mocap/issues/1>)
  * add foxy ci
  * fix package name
  * revert cmake
  * downgrade cmake in CI
  * add rolling and humble CI and badages
* Contributors: Alvin Sun
```
