### PR TITLE
rmf_ros2: 2.1.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4147,7 +4147,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 2.1.2-2
+      version: 2.1.3-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_ros2` to `2.1.3-1`:

- upstream repository: https://github.com/open-rmf/rmf_ros2.git
- release repository: https://github.com/ros2-gbp/rmf_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.2-2`
