### PR TITLE
Adding flatbuffers

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5901,10 +5901,10 @@ python3-flatbuffers:
     '8': null
   ubuntu:
     '*': [python3-flatbuffers]
-    focal:
+    bionic:
       pip:
         packages: [flatbuffers]
-    bionic:
+    focal:
       pip:
         packages: [flatbuffers]
 python3-fonttools:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5885,8 +5885,10 @@ python3-flask-sqlalchemy:
   ubuntu: [python3-flask-sqlalchemy]
 python3-flatbuffers:
   debian:
-    pip:
-      packages: [flatbuffers]
+    '*': [python3-flatbuffers]
+    buster:
+      pip:
+        packages: [flatbuffers]
   fedora:
     pip:
       packages: [flatbuffers]
@@ -5894,8 +5896,10 @@ python3-flatbuffers:
     pip:
       packages: [flatbuffers]
   ubuntu:
-    pip:
-      packages: [flatbuffers]
+    '*': [python3-flatbuffers]
+    focal:
+      pip:
+        packages: [flatbuffers]
 python3-fonttools:
   arch: [python-fonttools]
   debian: [python3-fonttools]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5883,6 +5883,19 @@ python3-flask-sqlalchemy:
     '*': [python3-flask-sqlalchemy]
     '7': null
   ubuntu: [python3-flask-sqlalchemy]
+python3-flatbuffers:
+  debian:
+    pip:
+      packages: [flatbuffers]
+  fedora:
+    pip:
+      packages: [flatbuffers]
+  osx:
+    pip:
+      packages: [flatbuffers]
+  ubuntu:
+    pip:
+      packages: [flatbuffers]
 python3-fonttools:
   arch: [python-fonttools]
   debian: [python3-fonttools]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5900,6 +5900,9 @@ python3-flatbuffers:
     focal:
       pip:
         packages: [flatbuffers]
+    bionic:
+      pip:
+        packages: [flatbuffers]
 python3-fonttools:
   arch: [python-fonttools]
   debian: [python3-fonttools]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5892,9 +5892,11 @@ python3-flatbuffers:
   fedora:
     pip:
       packages: [flatbuffers]
+  opensuse: [python3-flatbuffers]
   osx:
     pip:
       packages: [flatbuffers]
+  rhel: [python3-flatbuffers]
   ubuntu:
     '*': [python3-flatbuffers]
     focal:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -110,7 +110,7 @@ black:
   gentoo: [dev-python/black]
   nixos: [pythonPackages.black]
   ubuntu:
-    "*": [black]
+    '*': [black]
     bionic: null
 canopen-pip:
   debian:
@@ -252,8 +252,8 @@ ipython3:
   nixos: [python3Packages.ipython]
   openembedded: [python3-ipython@meta-python]
   rhel:
-    "*": [python3-ipython]
-    "7": null
+    '*': [python3-ipython]
+    '7': null
   ubuntu: [ipython3]
 jupyter-nbconvert:
   arch: [jupyter-nbconvert]
@@ -262,14 +262,14 @@ jupyter-nbconvert:
   gentoo: [dev-python/nbconvert]
   nixos: [python3Packages.nbconvert]
   ubuntu:
-    "*": [jupyter-nbconvert]
+    '*': [jupyter-nbconvert]
 jupyter-notebook:
   debian:
-    "*": [jupyter-notebook]
+    '*': [jupyter-notebook]
   fedora: [python3-notebook]
   nixos: [jupyter]
   ubuntu:
-    "*": [jupyter-notebook]
+    '*': [jupyter-notebook]
 libgv-python:
   debian: [libgv-python]
   ubuntu: [libgv-python]
@@ -319,13 +319,13 @@ paramiko:
   gentoo: [dev-python/paramiko]
   macports: [py27-paramiko]
   nixos: [pythonPackages.paramiko]
-  openembedded: ["${PYTHON_PN}-paramiko@meta-ros-common"]
+  openembedded: ['${PYTHON_PN}-paramiko@meta-ros-common']
   opensuse: [python-paramiko]
   osx:
     pip:
       packages: [paramiko]
   rhel:
-    "7": [python-paramiko]
+    '7': [python-paramiko]
   ubuntu: [python-paramiko]
 pi-ina219-pip:
   debian:
@@ -349,13 +349,13 @@ pydocstyle:
   fedora: [python3-pydocstyle]
   gentoo: [dev-python/pydocstyle]
   nixos: [python3Packages.pydocstyle]
-  openembedded: ["${PYTHON_PN}-pydocstyle@meta-ros-common"]
+  openembedded: ['${PYTHON_PN}-pydocstyle@meta-ros-common']
   osx:
     pip:
       packages: [pydocstyle]
   rhel:
-    "*": [python3-pydocstyle]
-    "7": null
+    '*': [python3-pydocstyle]
+    '7': null
   ubuntu: [pydocstyle]
 pydrive-pip:
   debian:
@@ -377,15 +377,15 @@ pyflakes3:
   fedora: [python3-pyflakes]
   gentoo: [dev-python/pyflakes]
   nixos: [python3Packages.pyflakes]
-  openembedded: ["${PYTHON_PN}-pyflakes@meta-ros-common"]
+  openembedded: ['${PYTHON_PN}-pyflakes@meta-ros-common']
   osx:
     pip:
       packages: [pyflakes]
-  rhel: ["python%{python3_pkgversion}-pyflakes"]
+  rhel: ['python%{python3_pkgversion}-pyflakes']
   ubuntu: [pyflakes3]
 pymap3d-pip:
   debian:
-    "*": null
+    '*': null
     buster:
       pip:
         packages: [pymap3d]
@@ -399,7 +399,7 @@ pymap3d-pip:
     pip:
       packages: [pymap3d]
   ubuntu:
-    "*": null
+    '*': null
     bionic:
       pip:
         packages: [pymap3d]
@@ -442,7 +442,7 @@ pyqt5-dev-tools:
   debian: [pyqt5-dev-tools]
   fedora: [python-qt5-devel]
   gentoo: [dev-python/PyQt5]
-  openembedded: ["${PYTHON_PN}-pyqt5@meta-qt5"]
+  openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
   rhel: [python3-qt5-devel]
   ubuntu: [pyqt5-dev-tools]
 pyrebase-pip:
@@ -485,8 +485,8 @@ python:
   openembedded: [python@meta-python2]
   opensuse: [python-devel]
   rhel:
-    "7": [python2-devel]
-    "8": [python2-devel]
+    '7': [python2-devel]
+    '8': [python2-devel]
   slackware:
     slackpkg:
       packages: [python]
@@ -519,7 +519,7 @@ python-alembic:
   fedora: [python-alembic]
   gentoo: [dev-python/alembic]
   ubuntu:
-    "*": [python-alembic]
+    '*': [python-alembic]
 python-amqp:
   debian:
     buster: [python-amqp]
@@ -531,7 +531,7 @@ python-aniso8601:
   debian: [python-aniso8601]
   gentoo: [dev-python/aniso8601]
   rhel:
-    "7": [python-aniso8601]
+    '7': [python-aniso8601]
   ubuntu:
     bionic: [python-aniso8601]
 python-annoy-pip:
@@ -554,7 +554,7 @@ python-anyjson:
   ubuntu: [python-anyjson]
 python-apparmor:
   debian: [python-apparmor]
-  gentoo: ["sys-libs/libapparmor[python]"]
+  gentoo: ['sys-libs/libapparmor[python]']
   ubuntu: [python-apparmor]
 python-argcomplete:
   fedora: [python-argcomplete]
@@ -587,13 +587,13 @@ python-argparse:
     pip:
       packages: [argparse]
   rhel:
-    "7": [python2]
-    "8": [python2]
+    '7': [python2]
+    '8': [python2]
   slackware:
     pip:
       packages: [argparse]
   ubuntu:
-    "*": []
+    '*': []
 python-astor-pip:
   debian:
     pip:
@@ -612,7 +612,7 @@ python-attrs:
   gentoo: [dev-python/attrs]
   nixos: [pythonPackages.attrs]
   ubuntu:
-    "*":
+    '*':
       packages: [python-attr]
       pip:
         packages: [attrs]
@@ -630,17 +630,17 @@ python-autobahn:
       packages: [autobahn]
   gentoo: [dev-python/autobahn]
   nixos: [pythonPackages.autobahn]
-  openembedded: ["${PYTHON_PN}-autobahn@meta-python"]
+  openembedded: ['${PYTHON_PN}-autobahn@meta-python']
   osx:
     pip:
       packages: [autobahn]
   ubuntu:
-    "*": [python-autobahn]
+    '*': [python-autobahn]
 python-avahi:
   arch: [avahi]
   debian: [python-avahi]
   fedora: [avahi-ui-tools]
-  gentoo: ["net-dns/avahi[python]"]
+  gentoo: ['net-dns/avahi[python]']
   nixos: [pythonPackages.avahi]
   opensuse: [python3-avahi]
   ubuntu: [python-avahi]
@@ -672,7 +672,7 @@ python-backports.ssl-match-hostname:
   debian: [python-backports.ssl-match-hostname]
   gentoo: [dev-python/backports-ssl-match-hostname]
   nixos: [pythonPackages.backports_ssl_match_hostname]
-  openembedded: ["${PYTHON_PN}-backports-ssl@meta-python"]
+  openembedded: ['${PYTHON_PN}-backports-ssl@meta-python']
   ubuntu:
     bionic: [python-backports.ssl-match-hostname]
 python-bcrypt:
@@ -723,13 +723,13 @@ python-bloom:
   fedora: [python-bloom]
   gentoo: [dev-python/bloom]
   ubuntu:
-    "*": [python-bloom]
+    '*': [python-bloom]
 python-bluez:
   arch: [python2-pybluez]
   debian: [python-bluez]
   gentoo: [dev-python/pybluez]
   nixos: [pythonPackages.pybluez]
-  openembedded: ["${PYTHON_PN}-pybluez@meta-python"]
+  openembedded: ['${PYTHON_PN}-pybluez@meta-python']
   ubuntu: [python-bluez]
 python-bokeh-pip:
   debian:
@@ -740,7 +740,7 @@ python-bokeh-pip:
       packages: [bokeh]
 python-boltons:
   debian:
-    "*": [python-boltons]
+    '*': [python-boltons]
     wheezy:
       pip:
         packages: [boltons]
@@ -751,16 +751,16 @@ python-boltons:
     pip:
       packages: [boltons]
   ubuntu:
-    "*": [python-boltons]
+    '*': [python-boltons]
 python-boto3:
   arch: [python-boto3]
   debian: [python-boto3]
   gentoo: [dev-python/boto3]
   nixos: [pythonPackages.boto3]
-  openembedded: ["${PYTHON_PN}-boto3@meta-ros-common"]
+  openembedded: ['${PYTHON_PN}-boto3@meta-ros-common']
   opensuse: [python-boto3]
   ubuntu:
-    "*": [python-boto3]
+    '*': [python-boto3]
 python-bottle:
   debian: [python-bottle]
   fedora: [python-bottle]
@@ -784,7 +784,7 @@ python-bson:
   fedora: [python-bson]
   gentoo: [dev-python/pymongo]
   nixos: [pythonPackages.bson]
-  openembedded: ["${PYTHON_PN}-pymongo@meta-python"]
+  openembedded: ['${PYTHON_PN}-pymongo@meta-python']
   osx:
     pip:
       packages: [bson]
@@ -798,8 +798,8 @@ python-cairo:
   nixos: [pythonPackages.pycairo]
   opensuse: [python2-cairo]
   rhel:
-    "7": [pycairo]
-    "8": [python2-cairo]
+    '7': [pycairo]
+    '8': [python2-cairo]
   slackware:
     slackpkg:
       packages: [pycairo]
@@ -839,7 +839,7 @@ python-cantools-pip:
       packages: [cantools]
 python-catkin-lint:
   fedora: [python-catkin_lint]
-  openembedded: ["${PYTHON_PN}-catkin-lint@meta-ros-common"]
+  openembedded: ['${PYTHON_PN}-catkin-lint@meta-ros-common']
   ubuntu: [python-catkin-lint]
 python-catkin-pkg:
   alpine:
@@ -854,13 +854,13 @@ python-catkin-pkg:
   gentoo: [dev-python/catkin_pkg]
   macports: [python-catkin-pkg]
   nixos: [pythonPackages.catkin-pkg]
-  openembedded: ["${PYTHON_PN}-catkin-pkg@meta-ros-common"]
+  openembedded: ['${PYTHON_PN}-catkin-pkg@meta-ros-common']
   opensuse: [python-catkin_pkg]
   osx:
     pip:
       packages: [catkin-pkg]
   rhel:
-    "7": [python2-catkin_pkg]
+    '7': [python2-catkin_pkg]
   slackware:
     pip:
       packages: [catkin-pkg]
@@ -879,7 +879,7 @@ python-catkin-pkg-modules:
   gentoo: [dev-python/catkin_pkg]
   macports: [python-catkin-pkg]
   nixos: [pythonPackages.catkin-pkg]
-  openembedded: ["${PYTHON_PN}-catkin-pkg@meta-ros-common"]
+  openembedded: ['${PYTHON_PN}-catkin-pkg@meta-ros-common']
   opensuse: [python-catkin_pkg]
   osx:
     pip:
@@ -903,13 +903,13 @@ python-catkin-sphinx:
     pip:
       packages: [catkin_sphinx]
   ubuntu:
-    "*": null
+    '*': null
     bionic: [python-catkin-sphinx]
 python-catkin-tools:
   arch: [python2-catkin-tools]
   debian: [python-catkin-tools]
   fedora: [python-catkin_tools]
-  openembedded: ["${PYTHON_PN}-catkin-tools@meta-ros-common"]
+  openembedded: ['${PYTHON_PN}-catkin-tools@meta-ros-common']
   osx:
     pip:
       packages: [catkin_tools]
@@ -987,7 +987,7 @@ python-cheetah:
   fedora: [python-cheetah]
   gentoo: [dev-python/cheetah]
   nixos: [pythonPackages.cheetah]
-  openembedded: ["${PYTHON_PN}-cheetah@meta-python"]
+  openembedded: ['${PYTHON_PN}-cheetah@meta-python']
   opensuse: [python-Cheetah]
   ubuntu: [python-cheetah]
 python-cherrypy:
@@ -999,7 +999,7 @@ python-cherrypy:
 python-clearsilver:
   debian: [python-clearsilver]
   rhel:
-    "7": [python-clearsilver]
+    '7': [python-clearsilver]
   ubuntu: [python-clearsilver]
 python-click:
   debian:
@@ -1008,7 +1008,7 @@ python-click:
   fedora: [python-click]
   gentoo: [dev-python/click]
   nixos: [pythonPackages.click]
-  openembedded: ["${PYTHON_PN}-click@meta-python"]
+  openembedded: ['${PYTHON_PN}-click@meta-python']
   osx:
     pip:
       packages: [click]
@@ -1109,8 +1109,8 @@ python-coverage:
     pip:
       packages: [coverage]
   rhel:
-    "7": [python-coverage]
-    "8": [python2-coverage]
+    '7': [python-coverage]
+    '8': [python2-coverage]
   slackware: [coverage]
   ubuntu:
     bionic: [python-coverage]
@@ -1159,7 +1159,7 @@ python-crypto:
   freebsd: [py27-pycrypto]
   gentoo: [dev-python/pycrypto]
   nixos: [pythonPackages.pycrypto]
-  openembedded: ["${PYTHON_PN}-pycrypto@meta-python"]
+  openembedded: ['${PYTHON_PN}-pycrypto@meta-python']
   opensuse: [python2-pycrypto]
   osx:
     pip:
@@ -1170,18 +1170,18 @@ python-cryptography:
   debian: [python-cryptography]
   gentoo: [dev-python/cryptography]
   rhel:
-    "7": [python2-cryptography]
+    '7': [python2-cryptography]
   ubuntu: [python-cryptography]
 python-cvxopt:
   arch: [python-cvxopt]
   debian:
-    "*": null
+    '*': null
     buster: [python-cvxopt]
   fedora: [python-cvxopt]
   macports: [py27-cvxopt]
   nixos: [pythonPackages.cvxopt]
   ubuntu:
-    "*": null
+    '*': null
     bionic: [python-cvxopt]
 python-cvxpy-pip: &migrate_eol_2025_04_30_python3_cvxpy_pip
   debian:
@@ -1196,7 +1196,7 @@ python-cvxpy-pip: &migrate_eol_2025_04_30_python3_cvxpy_pip
 python-cwiid:
   arch: [cwiid]
   debian: [python-cwiid]
-  gentoo: ["app-misc/cwiid[python]"]
+  gentoo: ['app-misc/cwiid[python]']
   ubuntu: [python-cwiid]
 python-cython-pip:
   arch:
@@ -1262,13 +1262,13 @@ python-defusedxml:
   freebsd: [py27-defusedxml]
   gentoo: [dev-python/defusedxml]
   nixos: [pythonPackages.defusedxml]
-  openembedded: ["${PYTHON_PN}-defusedxml@meta-ros-common"]
+  openembedded: ['${PYTHON_PN}-defusedxml@meta-ros-common']
   opensuse: [python2-defusedxml]
   osx:
     pip:
       packages: [defusedxml]
   rhel:
-    "7": [python2-defusedxml]
+    '7': [python2-defusedxml]
   slackware:
     pip:
       packages: [defusedxml]
@@ -1370,13 +1370,13 @@ python-empy:
   gentoo: [dev-python/empy]
   macports: [py27-empy]
   nixos: [pythonPackages.empy]
-  openembedded: ["${PYTHON_PN}-empy@meta-ros-common"]
+  openembedded: ['${PYTHON_PN}-empy@meta-ros-common']
   opensuse: [python2-empy]
   osx:
     pip:
       packages: [empy]
   rhel:
-    "7": [python2-empy]
+    '7': [python2-empy]
   slackware:
     pip:
       packages: [empy]
@@ -1391,7 +1391,7 @@ python-enum34:
     stretch: [python-enum34]
   gentoo: [virtual/python-enum34]
   nixos: [pythonPackages.enum34]
-  openembedded: ["${PYTHON_PN}-enum34@meta-python"]
+  openembedded: ['${PYTHON_PN}-enum34@meta-python']
   opensuse: [python-enum34]
   ubuntu: [python-enum34]
 python-enum34-pip:
@@ -1506,7 +1506,7 @@ python-flake8:
   fedora: [python-flake8]
   gentoo: [dev-python/flake8]
   nixos: [python3Packages.flake8]
-  openembedded: ["${PYTHON_PN}-flake8@meta-ros-common"]
+  openembedded: ['${PYTHON_PN}-flake8@meta-ros-common']
   ubuntu:
     bionic: [python-flake8]
 python-flask:
@@ -1516,7 +1516,7 @@ python-flask:
   gentoo: [dev-python/flask]
   nixos: [pythonPackages.flask]
   ubuntu:
-    "*": [python-flask]
+    '*': [python-flask]
 python-flask-appbuilder-pip:
   debian:
     pip:
@@ -1575,15 +1575,15 @@ python-funcsigs:
   debian: [python-funcsigs]
   fedora: [python-funcsigs]
   rhel:
-    "7": [python2-funcsigs]
-    "8": [python2-funcsigs]
+    '7': [python2-funcsigs]
+    '8': [python2-funcsigs]
   ubuntu: [python-funcsigs]
 python-future:
   debian: [python-future]
   fedora: [python-future]
   gentoo: [dev-python/future]
   nixos: [pythonPackages.future]
-  openembedded: ["${PYTHON_PN}-future@meta-python"]
+  openembedded: ['${PYTHON_PN}-future@meta-python']
   opensuse: [python2-future]
   osx:
     pip:
@@ -1631,7 +1631,7 @@ python-gdal:
   debian:
     buster: [python-gdal]
     stretch: [python-gdal]
-  gentoo: ["sci-libs/gdal[python]"]
+  gentoo: ['sci-libs/gdal[python]']
   ubuntu:
     bionic: [python-gdal]
 python-gdown-pip: &migrate_eol_2025_04_30_python3_gdown_pip
@@ -1726,22 +1726,22 @@ python-gnupg:
   freebsd: [py27-python-gnupg]
   gentoo: [dev-python/python-gnupg]
   nixos: [pythonPackages.python-gnupg]
-  openembedded: ["${PYTHON_PN}-gnupg@meta-ros-common"]
+  openembedded: ['${PYTHON_PN}-gnupg@meta-ros-common']
   opensuse: [python2-python-gnupg]
   rhel:
-    "7": [python2-gnupg]
+    '7': [python2-gnupg]
   ubuntu: [python-gnupg]
 python-gobject:
   arch: [python2-gobject]
   debian:
-    "*": null
+    '*': null
     buster: [python-gobject]
     stretch: [python-gobject]
   gentoo: [dev-python/pygobject]
   nixos: [pythonPackages.pygobject2]
   opensuse: [python2-gobject]
   ubuntu:
-    "*": null
+    '*': null
     bionic: [python-gobject]
     focal: [python-gobject]
 python-google-cloud-bigquery-pip:
@@ -1761,8 +1761,7 @@ python-google-cloud-speech-pip:
   ubuntu:
     pip:
       packages: [google-cloud-speech]
-python-google-cloud-storage-pip:
-  &migrate_eol_2025_04_30_python3_google_cloud_storage_pip
+python-google-cloud-storage-pip: &migrate_eol_2025_04_30_python3_google_cloud_storage_pip
   debian:
     pip:
       packages: [google-cloud-storage]
@@ -1772,8 +1771,7 @@ python-google-cloud-storage-pip:
   ubuntu:
     pip:
       packages: [google-cloud-storage]
-python-google-cloud-texttospeech-pip:
-  &migrate_eol_2025_04_30_python3_google_cloud_texttospeech_pip
+python-google-cloud-texttospeech-pip: &migrate_eol_2025_04_30_python3_google_cloud_texttospeech_pip
   debian:
     pip:
       packages: [google-cloud-texttospeech]
@@ -1845,21 +1843,21 @@ python-gridfs:
   fedora: [python-pymongo-gridfs]
 python-grpc-tools:
   debian:
-    "*": [python-grpc-tools]
+    '*': [python-grpc-tools]
     stretch:
       pip: [grpcio-tools]
   nixos: [pythonPackages.grpcio-tools]
   ubuntu:
-    "*": [python-grpc-tools]
+    '*': [python-grpc-tools]
     bionic:
       pip: [grpcio-tools]
 python-grpcio:
   debian:
-    "*": [python-grpcio]
+    '*': [python-grpcio]
     stretch:
       pip: [grpcio]
   ubuntu:
-    "*": [python-grpcio]
+    '*': [python-grpcio]
     bionic:
       pip: [grpcio]
 python-gst:
@@ -1871,13 +1869,13 @@ python-gst-1.0:
   debian:
     buster: [python-gst-1.0]
     stretch: [python-gst-1.0]
-  gentoo: ["dev-python/gst-python:1.0"]
+  gentoo: ['dev-python/gst-python:1.0']
   openembedded: [gstreamer1.0-python@openembedded-core]
   ubuntu: [python-gst-1.0]
 python-gtk2:
   arch: [pygtk]
   debian:
-    "*": null
+    '*': null
     buster: [python-gtk2]
   fedora: [pygtk2]
   freebsd: [py-gtk2]
@@ -1889,10 +1887,10 @@ python-gtk2:
     pip:
       packages: []
   rhel:
-    "7": [pygtk2]
-    "8": [pygtk2]
+    '7': [pygtk2]
+    '8': [pygtk2]
   ubuntu:
-    "*": null
+    '*': null
     bionic: [python-gtk2]
 python-gurobipy-pip: &migrate_eol_2025_04_30_python3_gurobipy_pip
   debian:
@@ -1910,19 +1908,19 @@ python-h5py:
   nixos: [pythonPackages.h5py]
   opensuse: [python2-h5py]
   ubuntu:
-    "*": [python-h5py]
+    '*': [python-h5py]
 python-httplib2:
   debian: [python-httplib2]
   fedora: [python-httplib2]
   gentoo: [dev-python/httplib2]
   ubuntu:
-    "*": [python-httplib2]
+    '*': [python-httplib2]
 python-hypothesis:
   debian: [python-hypothesis]
   fedora: [python-hypothesis]
   gentoo: [dev-python/hypothesis]
   ubuntu:
-    "*": [python-hypothesis]
+    '*': [python-hypothesis]
 python-imageio:
   debian:
     buster: [python-imageio]
@@ -1941,25 +1939,25 @@ python-imaging:
   alpine: [py-imaging]
   arch: [python2-pillow]
   debian:
-    "*": [python-pil]
+    '*': [python-pil]
     stretch: [python-imaging]
   fedora: [python-pillow, python-pillow-qt]
   freebsd: [py27-pillow]
   gentoo: [dev-python/pillow]
   macports: [py27-pil]
   nixos: [pythonPackages.pillow]
-  openembedded: ["${PYTHON_PN}-pillow@meta-python"]
+  openembedded: ['${PYTHON_PN}-pillow@meta-python']
   opensuse: [python2-Pillow]
   osx:
     pip:
       packages: [Pillow]
   rhel:
-    "7": [python-imaging]
+    '7': [python-imaging]
   slackware:
     slackpkg:
       packages: [python-pillow]
   ubuntu:
-    "*": [python-pil]
+    '*': [python-pil]
 python-imaging-imagetk:
   debian: [python-pil.imagetk]
   ubuntu: [python-pil.imagetk]
@@ -2010,7 +2008,7 @@ python-ipdb:
   ubuntu: [python-ipdb]
 python-is-python3:
   ubuntu:
-    "*": [python-is-python3]
+    '*': [python-is-python3]
     bionic: null
 python-itsdangerous:
   debian:
@@ -2019,7 +2017,7 @@ python-itsdangerous:
   fedora: [python-itsdangerous]
   gentoo: [dev-python/itsdangerous]
   ubuntu:
-    "*": null
+    '*': null
     bionic: [python-itsdangerous]
 python-j1939-pip: &migrate_eol_2025_04_30_python3_j1939_pip
   debian:
@@ -2147,7 +2145,7 @@ python-kombu:
   debian: [python-kombu]
   fedora: [python-kombu]
   rhel:
-    "7": [python-kombu]
+    '7': [python-kombu]
   ubuntu: [python-kombu]
 python-kombu-pip:
   ubuntu:
@@ -2230,14 +2228,14 @@ python-lxml:
   freebsd: [py27-lxml]
   gentoo: [dev-python/lxml]
   nixos: [pythonPackages.lxml]
-  openembedded: ["${PYTHON_PN}-lxml@meta-python"]
+  openembedded: ['${PYTHON_PN}-lxml@meta-python']
   opensuse: [python2-lxml]
   osx:
     pip:
       packages: [lxml]
   rhel:
-    "7": [python-lxml]
-    "8": [python2-lxml]
+    '7': [python-lxml]
+    '8': [python2-lxml]
   ubuntu:
     bionic: [python-lxml]
     focal: [python-lxml]
@@ -2262,11 +2260,11 @@ python-mapnik:
   ubuntu: [python-mapnik]
 python-marisa:
   debian:
-    "*": null
+    '*': null
     buster: [python-marisa]
     stretch: [python-marisa]
   ubuntu:
-    "*": null
+    '*': null
     bionic: [python-marisa]
 python-markdown:
   debian: [python-markdown]
@@ -2290,14 +2288,14 @@ python-matplotlib:
   gentoo: [dev-python/matplotlib]
   macports: [py27-matplotlib]
   nixos: [pythonPackages.matplotlib]
-  openembedded: ["${PYTHON_PN}-matplotlib@meta-python"]
+  openembedded: ['${PYTHON_PN}-matplotlib@meta-python']
   opensuse: [python2-matplotlib]
   osx:
     pip:
       depends: [pkg-config, freetype, libpng12-dev]
       packages: [matplotlib]
   rhel:
-    "7": [python-matplotlib]
+    '7': [python-matplotlib]
   slackware: [matplotlib]
   ubuntu:
     bionic: [python-matplotlib]
@@ -2310,11 +2308,11 @@ python-mechanize:
   ubuntu: [python-mechanize]
 python-mistune:
   debian:
-    "*": null
+    '*': null
     buster: [python-mistune]
   opensuse: [python2-mistune]
   ubuntu:
-    "*": null
+    '*': null
     bionic: [python-mistune]
 python-mock:
   alpine: [py-mock]
@@ -2324,14 +2322,14 @@ python-mock:
   freebsd: [py27-mock]
   gentoo: [dev-python/mock]
   nixos: [pythonPackages.mock]
-  openembedded: ["${PYTHON_PN}-mock@meta-python"]
+  openembedded: ['${PYTHON_PN}-mock@meta-python']
   opensuse: [python2-mock]
   osx:
     pip:
       packages: [mock]
   rhel:
-    "7": [python2-mock]
-    "8": [python2-mock]
+    '7': [python2-mock]
+    '8': [python2-mock]
   slackware: [mock]
   ubuntu:
     bionic: [python-mock]
@@ -2347,14 +2345,14 @@ python-more-itertools:
   debian: [python-more-itertools]
   fedora: [python-more-itertools]
   ubuntu:
-    "*": [python-more-itertools]
+    '*': [python-more-itertools]
 python-msgpack:
   arch: [python2-msgpack]
   debian: [python-msgpack]
   fedora: [python-msgpack]
   gentoo: [dev-python/msgpack]
   nixos: [pythonPackages.msgpack]
-  openembedded: ["${PYTHON_PN}-msgpack@meta-python2"]
+  openembedded: ['${PYTHON_PN}-msgpack@meta-python2']
   opensuse: [python2-msgpack]
   ubuntu: [python-msgpack]
 python-multicast:
@@ -2434,13 +2432,13 @@ python-netifaces:
   gentoo: [dev-python/netifaces]
   macports: [p27-netifaces]
   nixos: [pythonPackages.netifaces]
-  openembedded: ["${PYTHON_PN}-netifaces@meta-ros-common"]
+  openembedded: ['${PYTHON_PN}-netifaces@meta-ros-common']
   opensuse: [python2-netifaces]
   osx:
     pip:
       packages: [netifaces]
   rhel:
-    "7": [python-netifaces]
+    '7': [python-netifaces]
   slackware: [netifaces]
   ubuntu:
     bionic: [python-netifaces]
@@ -2455,7 +2453,7 @@ python-networkx:
   fedora: [python-networkx]
   gentoo: [dev-python/networkx]
   ubuntu:
-    "*": [python-networkx]
+    '*': [python-networkx]
 python-nose:
   alpine: [py-nose]
   arch: [python2-nose]
@@ -2465,17 +2463,17 @@ python-nose:
   gentoo: [dev-python/nose]
   macports: [py27-nose]
   nixos: [pythonPackages.nose]
-  openembedded: ["${PYTHON_PN}-nose@openembedded-core"]
+  openembedded: ['${PYTHON_PN}-nose@openembedded-core']
   opensuse: [python2-nose]
   osx:
     pip:
       packages: [nose]
   rhel:
-    "7": [python2-nose]
-    "8": [python2-nose]
+    '7': [python2-nose]
+    '8': [python2-nose]
   slackware: [nose]
   ubuntu:
-    "*": [python-nose]
+    '*': [python-nose]
 python-ntplib:
   debian: [python-ntplib]
   fedora: [python-ntplib]
@@ -2490,14 +2488,14 @@ python-numpy:
   gentoo: [dev-python/numpy]
   macports: [py27-numpy]
   nixos: [pythonPackages.numpy]
-  openembedded: ["${PYTHON_PN}-numpy@openembedded-core"]
+  openembedded: ['${PYTHON_PN}-numpy@openembedded-core']
   opensuse: [python2-numpy-devel]
   osx:
     pip:
       packages: [numpy]
   rhel:
-    "7": [python2-numpy]
-    "8": [python2-numpy]
+    '7': [python2-numpy]
+    '8': [python2-numpy]
   slackware: [numpy]
   ubuntu:
     bionic: [python-numpy]
@@ -2547,9 +2545,9 @@ python-omniorb:
   arch: [omniorbpy]
   debian: [python-omniorb, python-omniorb-omg, omniidl-python]
   fedora: [python-omniORB, omniORB-devel]
-  gentoo: ["net-misc/omniORB[python]"]
+  gentoo: ['net-misc/omniORB[python]']
   ubuntu:
-    "*": [python-omniorb, python-omniorb-omg, omniidl-python]
+    '*': [python-omniorb, python-omniorb-omg, omniidl-python]
 python-open3d-pip:
   debian:
     pip:
@@ -2564,12 +2562,12 @@ python-opencv:
   arch: [opencv, python2-numpy]
   debian: [python-opencv]
   freebsd: [py27-opencv]
-  gentoo: ["media-libs/opencv[python]"]
+  gentoo: ['media-libs/opencv[python]']
   nixos: [pythonPackages.opencv3]
   openembedded: [opencv@meta-oe]
   opensuse: [python2-opencv]
   rhel:
-    "7": [opencv-python]
+    '7': [opencv-python]
   slackware: [opencv]
   ubuntu: [python-opencv]
 python-opengl:
@@ -2584,7 +2582,7 @@ python-opengl:
     pip:
       packages: [PyOpenGL]
   rhel:
-    "7": [PyOpenGL]
+    '7': [PyOpenGL]
   slackware: [PyOpenGL]
   ubuntu:
     bionic: [python-opengl]
@@ -2629,7 +2627,7 @@ python-pandas:
   ubuntu: [python-pandas]
 python-parameterized:
   debian:
-    "*": [python-parameterized]
+    '*': [python-parameterized]
     stretch:
       pip:
         packages: [parameterized]
@@ -2648,13 +2646,13 @@ python-paramiko:
   gentoo: [dev-python/paramiko]
   macports: [py27-paramiko]
   nixos: [pythonPackages.paramiko]
-  openembedded: ["${PYTHON_PN}-paramiko@meta-ros-common"]
+  openembedded: ['${PYTHON_PN}-paramiko@meta-ros-common']
   opensuse: [python2-paramiko]
   osx:
     pip:
       packages: [paramiko]
   rhel:
-    "7": [python-paramiko]
+    '7': [python-paramiko]
   slackware: [paramiko]
   ubuntu: [python-paramiko]
 python-parse:
@@ -2699,7 +2697,7 @@ python-pathlib2:
   gentoo: [dev-python/pathlib2]
   nixos: [pythonPackages.pathlib2]
   ubuntu:
-    "*": [python-pathlib2]
+    '*': [python-pathlib2]
 python-pathos-pip:
   debian:
     pip:
@@ -2713,8 +2711,8 @@ python-pbr:
   debian: [python-pbr]
   fedora: [python-pbr]
   rhel:
-    "7": [python2-pbr]
-    "8": [python2-pbr]
+    '7': [python2-pbr]
+    '8': [python2-pbr]
   ubuntu: [python-pbr]
 python-pcapy:
   arch: [python2-pcapy]
@@ -2739,7 +2737,7 @@ python-pep8:
     pip:
       packages: [pep8]
   ubuntu:
-    "*": [python-pep8]
+    '*': [python-pep8]
 python-percol:
   debian:
     pip:
@@ -2791,7 +2789,7 @@ python-pip:
   fedora: [python-pip]
   gentoo: [dev-python/pip]
   nixos: [pythonPackages.pip]
-  openembedded: ["${PYTHON_PN}-pip@meta-python"]
+  openembedded: ['${PYTHON_PN}-pip@meta-python']
   opensuse: [python2-pip]
   ubuntu: [python-pip]
 python-pixel-ring-pip:
@@ -2813,7 +2811,7 @@ python-planar-pip:
     pip:
       packages: [planar]
 python-ply-pip:
-  "*":
+  '*':
     pip:
       packages: [ply]
 python-plyfile-pip:
@@ -2881,23 +2879,23 @@ python-psutil:
   gentoo: [dev-python/psutil]
   macports: [py27-psutil]
   nixos: [pythonPackages.psutil]
-  openembedded: ["${PYTHON_PN}-psutil@meta-python"]
+  openembedded: ['${PYTHON_PN}-psutil@meta-python']
   opensuse: [python2-psutil]
   osx:
     pip:
       packages: [psutil]
   rhel:
-    "7": [python2-psutil]
-    "8": [python2-psutil]
+    '7': [python2-psutil]
+    '8': [python2-psutil]
   slackware: [psutil]
   ubuntu:
-    "*": [python-psutil]
+    '*': [python-psutil]
 python-psycopg2:
   debian: [python-psycopg2]
   fedora: [python-psycopg2]
   gentoo: [=dev-python/psycopg-2*]
   ubuntu:
-    "*": [python-psycopg2]
+    '*': [python-psycopg2]
     focal: [python3-psycopg2]
 python-pulsectl-pip:
   debian:
@@ -2924,22 +2922,22 @@ python-pyaudio:
   debian: [python-pyaudio]
   gentoo: [dev-python/pyaudio]
   nixos: [pythonPackages.pyaudio]
-  openembedded: ["${PYTHON_PN}-pyalsaaudio@meta-python"]
+  openembedded: ['${PYTHON_PN}-pyalsaaudio@meta-python']
   ubuntu: [python-pyaudio]
 python-pycodestyle:
   arch: [python2-pycodestyle]
   debian:
-    "*": null
+    '*': null
     buster: [python-pycodestyle]
     stretch: [python-pycodestyle]
   fedora: [python-pycodestyle]
   gentoo: [dev-python/pycodestyle]
   nixos: [pythonPackages.pycodestyle]
   rhel:
-    "7": [python2-pycodestyle]
-    "8": [python2-pycodestyle]
+    '7': [python2-pycodestyle]
+    '8': [python2-pycodestyle]
   ubuntu:
-    "*": null
+    '*': null
     bionic: [python-pycodestyle]
 python-pycpd-pip:
   debian:
@@ -2957,14 +2955,14 @@ python-pycryptodome:
   fedora: [python-pycryptodomex]
   gentoo: [dev-python/pycryptodome]
   nixos: [pythonPackages.pycryptodomex]
-  openembedded: ["${PYTHON_PN}-pycryptodomex@openembedded-core"]
+  openembedded: ['${PYTHON_PN}-pycryptodomex@openembedded-core']
   opensuse: [python2-pycryptodomex]
   osx:
     pip:
       packages: [pycryptodome]
   rhel:
-    "7": [python2-pycryptodomex]
-    "8": [python2-pycryptodomex]
+    '7': [python2-pycryptodomex]
+    '8': [python2-pycryptodomex]
   ubuntu: [python-pycryptodome]
 python-pycurl:
   debian: [python-pycurl]
@@ -2980,13 +2978,13 @@ python-pydot:
   gentoo: [dev-python/pydot]
   macports: [py27-pydot]
   nixos: [pythonPackages.pydot]
-  openembedded: ["${PYTHON_PN}-pydot@meta-ros-common"]
+  openembedded: ['${PYTHON_PN}-pydot@meta-ros-common']
   opensuse: [python2-pydot]
   osx:
     pip:
       packages: [pydot]
   rhel:
-    "7": [python2-pydot]
+    '7': [python2-pydot]
   slackware: [pydot]
   ubuntu: [python-pydot]
 python-pyexiv2:
@@ -3040,7 +3038,7 @@ python-pygraphviz:
     pip:
       packages: [pygraphviz]
   rhel:
-    "7": [python2-pygraphviz]
+    '7': [python2-pygraphviz]
   slackware: [pygraphviz]
   ubuntu: [python-pygraphviz]
 python-pyinotify:
@@ -3110,13 +3108,13 @@ python-pymongo:
   fedora: [python-pymongo]
   gentoo: [dev-python/pymongo]
   nixos: [pythonPackages.pymongo]
-  openembedded: ["${PYTHON_PN}-pymongo@meta-python"]
+  openembedded: ['${PYTHON_PN}-pymongo@meta-python']
   opensuse: [python2-pymongo]
   osx:
     pip:
       packages: [pymongo]
   ubuntu:
-    "*": [python-pymongo]
+    '*': [python-pymongo]
 python-pymouse:
   debian:
     pip:
@@ -3163,12 +3161,12 @@ python-pyproj:
   debian: [python-pyproj]
   gentoo: [dev-python/pyproj]
   nixos: [pythonPackages.pyproj]
-  openembedded: ["${PYTHON_PN}-pyproj@meta-ros-common"]
+  openembedded: ['${PYTHON_PN}-pyproj@meta-ros-common']
   osx:
     pip:
       packages: [pyproj]
   rhel:
-    "7": [pyproj]
+    '7': [pyproj]
   ubuntu: [python-pyproj]
 python-pyqrcode:
   arch: [python2-qrcode]
@@ -3251,7 +3249,7 @@ python-pytest:
   fedora: [python-pytest]
   gentoo: [dev-python/pytest]
   nixos: [pythonPackages.pytest]
-  openembedded: ["${PYTHON_PN}-pytest@openembedded-core"]
+  openembedded: ['${PYTHON_PN}-pytest@openembedded-core']
   ubuntu: [python-pytest]
 python-pytest-cov:
   arch: [python2-pytest-cov]
@@ -3259,7 +3257,7 @@ python-pytest-cov:
   fedora: [python-pytest-cov]
   gentoo: [dev-python/pytest-cov]
   nixos: [pythonPackages.pytestcov]
-  openembedded: ["${PYTHON_PN}-pytest-cov@meta-ros-common"]
+  openembedded: ['${PYTHON_PN}-pytest-cov@meta-ros-common']
   ubuntu: [python-pytest-cov]
 python-pytest-dependency-pip:
   debian:
@@ -3313,9 +3311,9 @@ python-pyudev:
   fedora: [python-pyudev]
   gentoo: [dev-python/pyudev]
   nixos: [pythonPackages.pyudev]
-  openembedded: ["${PYTHON_PN}-pyudev@meta-python"]
+  openembedded: ['${PYTHON_PN}-pyudev@meta-python']
   ubuntu:
-    "*": [python-pyudev]
+    '*': [python-pyudev]
 python-pyusb-pip:
   debian:
     pip: [pyusb]
@@ -3362,85 +3360,47 @@ python-qrencode:
 python-qt-bindings:
   arch: [python2-pyqt4]
   debian:
-    buster:
-      [
-        python-pyside,
-        libpyside-dev,
-        libshiboken-dev,
-        shiboken,
-        python-qt4,
-        python-qt4-dev,
-        python-sip-dev,
-      ]
+    buster: [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
     squeeze: [python-qt4, python-qt4-dev, python-sip-dev]
-    stretch:
-      [
-        python-pyside,
-        libpyside-dev,
-        libshiboken-dev,
-        shiboken,
-        python-qt4,
-        python-qt4-dev,
-        python-sip-dev,
-      ]
-    wheezy:
-      [
-        python-pyside,
-        libpyside-dev,
-        libshiboken-dev,
-        shiboken,
-        python-qt4,
-        python-qt4-dev,
-        python-sip-dev,
-      ]
+    stretch: [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
+    wheezy: [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
   gentoo: [dev-python/pyside, dev-python/PyQt4]
   macports: [p27-pyqt4]
   opensuse: [python-qt4-devel]
   rhel:
-    "7": [PyQt4, PyQt4-devel, sip-devel]
+    '7': [PyQt4, PyQt4-devel, sip-devel]
   ubuntu:
-    "*":
-      [
-        python-pyside,
-        libpyside-dev,
-        libshiboken-dev,
-        shiboken,
-        python-qt4,
-        python-qt4-dev,
-        python-sip-dev,
-      ]
+    '*': [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
 python-qt-bindings-gl:
   arch: [python2-pyqt4]
   debian: [python-qt4-gl]
-  gentoo: ["dev-python/pyside[opengl]", "dev-python/PyQt4[opengl]"]
+  gentoo: ['dev-python/pyside[opengl]', 'dev-python/PyQt4[opengl]']
   opensuse: [python-qt4-devel]
   ubuntu: [python-qt4-gl]
 python-qt-bindings-qwt5:
   arch: [python2-pyqwt]
   debian: [python-qwt5-qt4]
-  gentoo: ["dev-python/pyqwt:5"]
+  gentoo: ['dev-python/pyqwt:5']
   macports: [qwt52]
   ubuntu: [python-qwt5-qt4]
 python-qt-bindings-webkit:
   debian: [python-qt4]
-  gentoo: ["dev-python/pyside[webkit]", "dev-python/PyQt4[webkit]"]
+  gentoo: ['dev-python/pyside[webkit]', 'dev-python/PyQt4[webkit]']
   ubuntu: [python-qt4]
 python-qt4-gl:
   debian: [python-qt4-gl]
-  gentoo: ["dev-python/pyside[opengl]", "dev-python/PyQt4[opengl]"]
+  gentoo: ['dev-python/pyside[opengl]', 'dev-python/PyQt4[opengl]']
   ubuntu: [python-qt4-gl]
 python-qt5-bindings:
   arch: [python2-pyqt5]
   debian:
-    buster:
-      [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev, qtbase5-dev]
-    stretch:
-      [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev, qtbase5-dev]
+    buster: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev, qtbase5-dev]
+    stretch: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev, qtbase5-dev]
   fedora: [python-qt5-devel, sip]
   freebsd: [py27-qt5]
-  gentoo: ["dev-python/PyQt5[gui,widgets]"]
+  gentoo: ['dev-python/PyQt5[gui,widgets]']
   nixos: [pythonPackages.pyqt5]
-  openembedded: ["${PYTHON_PN}-pyqt5@meta-qt5"]
+  openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
   opensuse: [python2-qt5-devel, python2-sip-devel]
   slackware: [PyQt5]
   ubuntu:
@@ -3452,16 +3412,16 @@ python-qt5-bindings-gl:
     stretch: [python-pyqt5.qtopengl]
   fedora: [python-qt5]
   freebsd: [py27-qt5-opengl]
-  gentoo: ["dev-python/PyQt5[opengl]"]
+  gentoo: ['dev-python/PyQt5[opengl]']
   nixos: [pythonPackages.pyqt5]
-  openembedded: ["${PYTHON_PN}-pyqt5@meta-qt5"]
+  openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
   opensuse: [python2-qt5]
   slackware: [PyQt5]
   ubuntu:
     bionic: [python-pyqt5.qtopengl]
 python-qt5-bindings-qsci:
   debian: [python-pyqt5.qsci]
-  openembedded: ["${PYTHON_PN}-pyqt5@meta-qt5"]
+  openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
   ubuntu: [python-pyqt5.qsci]
 python-qt5-bindings-quick:
   debian: [python-pyqt5.qtquick]
@@ -3473,9 +3433,9 @@ python-qt5-bindings-webkit:
     stretch: [python-pyqt5.qtwebkit]
   fedora: [python-qt5]
   freebsd: [py27-qt5-webkit]
-  gentoo: ["dev-python/PyQt5[webkit]"]
+  gentoo: ['dev-python/PyQt5[webkit]']
   nixos: [pythonPackages.pyqt5_with_qtwebkit]
-  openembedded: ["${PYTHON_PN}-pyqt5@meta-qt5"]
+  openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
   opensuse: [python2-qt5]
   ubuntu:
     bionic: [python-pyqt5.qtwebkit]
@@ -3487,7 +3447,7 @@ python-qtpy:
 python-qwt5-qt4:
   arch: [pyqwt]
   debian: [python-qwt5-qt4]
-  gentoo: ["dev-python/pyqwt:5"]
+  gentoo: ['dev-python/pyqwt:5']
   ubuntu: [python-qwt5-qt4]
 python-rdflib:
   debian: [python-rdflib]
@@ -3512,12 +3472,12 @@ python-requests:
   fedora: [python-requests]
   gentoo: [dev-python/requests]
   nixos: [pythonPackages.requests]
-  openembedded: ["${PYTHON_PN}-requests@openembedded-core"]
+  openembedded: ['${PYTHON_PN}-requests@openembedded-core']
   osx:
     pip:
       packages: [requests]
   ubuntu:
-    "*": [python-requests]
+    '*': [python-requests]
 python-requests-oauthlib:
   debian: [python-requests-oauthlib]
   fedora: [python-requests-oauthlib]
@@ -3542,13 +3502,13 @@ python-rosdep:
       packages: [rosdep]
   gentoo: [dev-util/rosdep]
   nixos: [pythonPackages.rosdep]
-  openembedded: ["${PYTHON_PN}-rosdep@meta-ros-common"]
+  openembedded: ['${PYTHON_PN}-rosdep@meta-ros-common']
   opensuse: [python-rosdep]
   osx:
     pip:
       packages: [rosdep]
   rhel:
-    "7": [python2-rosdep]
+    '7': [python2-rosdep]
   slackware:
     pip:
       packages: [rosdep]
@@ -3566,13 +3526,13 @@ python-rosdep-modules:
       packages: [rosdep]
   gentoo: [dev-util/rosdep]
   nixos: [pythonPackages.rosdep]
-  openembedded: ["${PYTHON_PN}-rosdep@meta-ros-common"]
+  openembedded: ['${PYTHON_PN}-rosdep@meta-ros-common']
   opensuse: [python-rosdep]
   osx:
     pip:
       packages: [rosdep]
   rhel:
-    "7": [python-rosdep]
+    '7': [python-rosdep]
   slackware:
     pip:
       packages: [rosdep]
@@ -3586,7 +3546,7 @@ python-rosdistro:
     pip:
       packages: [rosdistro]
   rhel:
-    "7": [python2-rosdistro]
+    '7': [python2-rosdistro]
 python-rosinstall:
   arch: [python2-rosinstall]
   debian: [python-rosinstall]
@@ -3594,9 +3554,9 @@ python-rosinstall:
   gentoo: [dev-python/rosinstall]
   macports: [p27-rosinstall]
   rhel:
-    "7": [python-rosinstall]
+    '7': [python-rosinstall]
   ubuntu:
-    "*": [python-rosinstall]
+    '*': [python-rosinstall]
 python-rosinstall-generator:
   arch: [python2-rosinstall-generator]
   debian:
@@ -3606,7 +3566,7 @@ python-rosinstall-generator:
   gentoo: [dev-python/rosinstall_generator]
   macports: [py27-rosinstall-generator]
   rhel:
-    "7": [python2-rosinstall_generator]
+    '7': [python2-rosinstall_generator]
   ubuntu: [python-rosinstall-generator]
 python-rospkg:
   alpine:
@@ -3621,18 +3581,18 @@ python-rospkg:
   gentoo: [dev-python/rospkg]
   macports: [py27-rospkg]
   nixos: [pythonPackages.rospkg]
-  openembedded: ["${PYTHON_PN}-rospkg@meta-ros-common"]
+  openembedded: ['${PYTHON_PN}-rospkg@meta-ros-common']
   opensuse: [python-rospkg]
   osx:
     pip:
       packages: [rospkg]
   rhel:
-    "7": [python2-rospkg]
+    '7': [python2-rospkg]
   slackware:
     pip:
       packages: [rospkg]
   ubuntu:
-    "*": [python-rospkg]
+    '*': [python-rospkg]
 python-rospkg-modules:
   alpine:
     pip:
@@ -3651,7 +3611,7 @@ python-rospkg-modules:
     pip:
       packages: [rospkg]
   rhel:
-    "7": [python2-rospkg]
+    '7': [python2-rospkg]
   slackware:
     pip:
       packages: [rospkg]
@@ -3727,7 +3687,7 @@ python-scipy:
       depends: [gfortran]
       packages: [scipy]
   ubuntu:
-    "*": [python-scipy]
+    '*': [python-scipy]
 python-scp:
   debian: [python-scp]
   fedora: [python-scp]
@@ -3782,7 +3742,7 @@ python-serial:
   debian: [python-serial]
   gentoo: [dev-python/pyserial]
   nixos: [pythonPackages.pyserial]
-  openembedded: ["${PYTHON_PN}-pyserial@meta-python"]
+  openembedded: ['${PYTHON_PN}-pyserial@meta-python']
   opensuse: [python2-pyserial]
   ubuntu:
     bionic: [python-serial]
@@ -3796,24 +3756,24 @@ python-setuptools:
   gentoo: [dev-python/setuptools]
   macports: [py27-setuptools]
   nixos: [pythonPackages.setuptools]
-  openembedded: ["${PYTHON_PN}-setuptools@openembedded-core"]
+  openembedded: ['${PYTHON_PN}-setuptools@openembedded-core']
   opensuse: [python2-setuptools]
   osx:
     pip:
       packages: [setuptools]
   rhel:
-    "7": [python2-setuptools]
-    "8": [python2-setuptools]
+    '7': [python2-setuptools]
+    '8': [python2-setuptools]
   ubuntu:
     bionic: [python-setuptools]
 python-sexpdata:
   debian:
-    "*": [python-sexpdata]
+    '*': [python-sexpdata]
     stretch:
       pip:
         packages: [sexpdata]
   ubuntu:
-    "*": [python-sexpdata]
+    '*': [python-sexpdata]
     bionic:
       pip:
         packages: [sexpdata]
@@ -3833,14 +3793,14 @@ python-shapely:
     pip:
       packages: [shapely]
   ubuntu:
-    "*": [python-shapely]
+    '*': [python-shapely]
 python-simplejson:
   arch: [python2-simplejson]
   debian: [python-simplejson]
   fedora: [python-simplejson]
   gentoo: [dev-python/simplejson]
   nixos: [pythonPackages.simplejson]
-  openembedded: ["${PYTHON_PN}-simplejson@openembedded-core"]
+  openembedded: ['${PYTHON_PN}-simplejson@openembedded-core']
   ubuntu: [python-simplejson]
 python-singledispatch:
   debian: [python-singledispatch]
@@ -3857,12 +3817,12 @@ python-sip:
   openembedded: [sip@meta-oe]
   opensuse: [python2-sip-devel]
   rhel:
-    "7": [sip-devel]
+    '7': [sip-devel]
   slackware:
     slackpkg:
       packages: [sip]
   ubuntu:
-    "*": [python-sip-dev]
+    '*': [python-sip-dev]
 python-sip4:
   debian: [python-sip-dev]
   fedora: [sip]
@@ -3874,7 +3834,7 @@ python-six:
   fedora: [python-six]
   gentoo: [dev-python/six]
   nixos: [pythonPackages.six]
-  openembedded: ["${PYTHON_PN}-six@openembedded-core"]
+  openembedded: ['${PYTHON_PN}-six@openembedded-core']
   ubuntu: [python-six]
 python-skimage:
   debian:
@@ -3905,7 +3865,7 @@ python-sklearn:
     pip:
       packages: [scikit-learn]
   ubuntu:
-    "*": [python-sklearn]
+    '*': [python-sklearn]
 python-slackclient-pip:
   debian:
     pip:
@@ -3971,15 +3931,15 @@ python-sphinx:
   gentoo: [dev-python/sphinx]
   macports: [py27-sphinx]
   nixos: [pythonPackages.sphinx]
-  openembedded: ["${PYTHON_PN}-sphinx@meta-ros-common"]
+  openembedded: ['${PYTHON_PN}-sphinx@meta-ros-common']
   opensuse: [python-Sphinx]
   osx:
     pip:
       packages: [Sphinx]
   rhel:
-    "7": [python-sphinx]
+    '7': [python-sphinx]
   ubuntu:
-    "*": [python-sphinx]
+    '*': [python-sphinx]
 python-sphinx-argparse:
   debian:
     buster: [python-sphinx-argparse]
@@ -4022,10 +3982,10 @@ python-statsd:
   ubuntu: [python-statsd]
 python-subprocess32:
   debian:
-    "*": [python-subprocess32]
+    '*': [python-subprocess32]
   gentoo: [dev-python/subprocess32]
   ubuntu:
-    "*": [python-subprocess32]
+    '*': [python-subprocess32]
 python-support:
   debian: [python-support]
   fedora: [python]
@@ -4192,12 +4152,12 @@ python-termcolor:
   fedora: [python-termcolor]
   gentoo: [dev-python/termcolor]
   nixos: [pythonPackages.termcolor]
-  openembedded: ["${PYTHON_PN}-termcolor@openembedded-core"]
+  openembedded: ['${PYTHON_PN}-termcolor@openembedded-core']
   osx:
     pip:
       packages: [termcolor]
   ubuntu:
-    "*": [python-termcolor]
+    '*': [python-termcolor]
 python-testscenarios:
   debian: [python-testscenarios]
   fedora: [python-testscenarios]
@@ -4245,13 +4205,13 @@ python-tk:
   debian: [python-tk]
   fedora: [python2-tkinter]
   nixos: [pythonPackages.tkinter]
-  openembedded: ["${PYTHON_PN}-tkinter@openembedded-core"]
+  openembedded: ['${PYTHON_PN}-tkinter@openembedded-core']
   opensuse: [python-tk]
   rhel:
-    "7": [tkinter]
-    "8": [python2-tkinter]
+    '7': [tkinter]
+    '8': [python2-tkinter]
   ubuntu:
-    "*": [python-tk]
+    '*': [python-tk]
 python-toml:
   debian: [python-toml]
   fedora: [python-toml]
@@ -4296,7 +4256,7 @@ python-transforms3d-pip:
     pip:
       packages: [transforms3d]
   ubuntu:
-    "*": null
+    '*': null
     bionic:
       pip:
         packages: [transforms3d]
@@ -4308,7 +4268,7 @@ python-transforms3d-pip:
         packages: [transforms3d]
 python-transitions:
   debian:
-    "*": [python-transitions]
+    '*': [python-transitions]
     stretch:
       pip:
         packages: [transitions]
@@ -4368,7 +4328,7 @@ python-twisted-core:
   debian: [python-twisted-core]
   gentoo: [dev-python/twisted]
   nixos: [pythonPackages.twisted]
-  openembedded: ["${PYTHON_PN}-twisted-core@meta-python"]
+  openembedded: ['${PYTHON_PN}-twisted-core@meta-python']
   opensuse: [python2-Twisted]
   ubuntu: [python-twisted-core]
 python-twisted-web:
@@ -4390,7 +4350,7 @@ python-typing:
   gentoo: [dev-python/typing]
   nixos: [pythonPackages.typing]
   ubuntu:
-    "*": [python-typing]
+    '*': [python-typing]
 python-typing-pip:
   debian:
     pip:
@@ -4457,7 +4417,7 @@ python-usb:
   debian: [python-usb]
   gentoo: [dev-python/pyusb]
   nixos: [pythonPackages.pyusb]
-  openembedded: ["${PYTHON_PN}-pyusb@meta-python"]
+  openembedded: ['${PYTHON_PN}-pyusb@meta-python']
   ubuntu: [python-usb]
 python-utm-pip:
   debian:
@@ -4508,10 +4468,10 @@ python-virtualenv:
   fedora: [python-virtualenv]
   gentoo: [dev-python/virtualenv]
   nixos: [pythonPackages.virtualenv]
-  openembedded: ["${PYTHON_PN}-virtualenv@meta-ros2"]
+  openembedded: ['${PYTHON_PN}-virtualenv@meta-ros2']
   rhel:
-    "7": [python-virtualenv]
-    "8": [python2-virtualenv]
+    '7': [python-virtualenv]
+    '8': [python2-virtualenv]
   ubuntu: [python-virtualenv]
 python-visual:
   debian: [python-visual]
@@ -4593,7 +4553,7 @@ python-websocket:
   fedora: [python-websocket-client]
   gentoo: [dev-python/websocket-client]
   nixos: [pythonPackages.websocket_client]
-  openembedded: ["${PYTHON_PN}-websocket-client@meta-python"]
+  openembedded: ['${PYTHON_PN}-websocket-client@meta-python']
   opensuse: [python2-websocket-client]
   ubuntu:
     bionic: [python-websocket]
@@ -4650,7 +4610,7 @@ python-wxtools:
   openembedded: [wxpython@meta-ros-python2]
   opensuse: [python-wxWidgets-3_0-devel]
   rhel:
-    "7": [wxPython]
+    '7': [wxPython]
   ubuntu: [python-wxtools]
 python-xdot:
   debian: [xdot]
@@ -4704,22 +4664,22 @@ python-yaml:
   gentoo: [dev-python/pyyaml]
   macports: [py27-yaml]
   nixos: [pythonPackages.pyyaml]
-  openembedded: ["${PYTHON_PN}-pyyaml@meta-python"]
+  openembedded: ['${PYTHON_PN}-pyyaml@meta-python']
   opensuse: [python2-PyYAML]
   osx:
     pip:
       depends: [yaml]
       packages: [PyYAML]
   rhel:
-    "7": [PyYAML]
-    "8": [python2-pyyaml]
+    '7': [PyYAML]
+    '8': [python2-pyyaml]
   slackware: [PyYAML]
   ubuntu:
     bionic: [python-yaml]
     focal: [python-yaml]
 python-zbar:
   debian: [python-zbar]
-  gentoo: ["media-gfx/zbar[python]"]
+  gentoo: ['media-gfx/zbar[python]']
   ubuntu: [python-zbar]
 python-zmq:
   arch: [python2-pyzmq]
@@ -4728,7 +4688,7 @@ python-zmq:
   gentoo: [dev-python/pyzmq]
   nixos: [pythonPackages.pyzmq]
   ubuntu:
-    "*": [python-zmq]
+    '*': [python-zmq]
 python3:
   alpine: [python3]
   arch: [python]
@@ -4738,7 +4698,7 @@ python3:
   nixos: [python3]
   openembedded: [python3@openembedded-core]
   opensuse: [python3-devel]
-  rhel: ["python%{python3_pkgversion}-devel"]
+  rhel: ['python%{python3_pkgversion}-devel']
   ubuntu: [python3-dev]
 python3-adafruit-blinka-pip:
   debian:
@@ -4804,13 +4764,13 @@ python3-aiohttp:
   gentoo: [dev-python/aiohttp]
   opensuse: [python-aiohttp]
   rhel:
-    "*": [python3-aiohttp]
-    "7": null
+    '*': [python3-aiohttp]
+    '7': null
   ubuntu: [python3-aiohttp]
 python3-aiohttp-cors:
   arch: [python-aiohttp-cors]
   debian:
-    "*": [python3-aiohttp-cors]
+    '*': [python3-aiohttp-cors]
     stretch: null
   fedora: [python-aiohttp-cors]
   gentoo: [dev-python/aiohttp-cors]
@@ -4845,8 +4805,8 @@ python3-alembic:
   nixos: [python3Packages.alembic]
   opensuse: [python3-alembic]
   rhel:
-    "*": [python3-alembic]
-    "7": null
+    '*': [python3-alembic]
+    '7': null
   ubuntu: [python3-alembic]
 python3-ansible-runner-pip:
   debian:
@@ -4884,7 +4844,7 @@ python3-argcomplete:
   gentoo: [dev-python/argcomplete]
   nixos: [python3Packages.argcomplete]
   openembedded: [python3-argcomplete@meta-python]
-  rhel: ["python%{python3_pkgversion}-argcomplete"]
+  rhel: ['python%{python3_pkgversion}-argcomplete']
   ubuntu: [python3-argcomplete]
 python3-astropy-pip:
   debian:
@@ -4904,8 +4864,8 @@ python3-autobahn:
   nixos: [python3Packages.autobahn]
   openembedded: [python3-autobahn@meta-python]
   rhel:
-    "*": ["python%{python3_pkgversion}-autobahn"]
-    "7": null
+    '*': ['python%{python3_pkgversion}-autobahn']
+    '7': null
   ubuntu: [python3-autobahn]
 python3-awsiotsdk-pip:
   debian:
@@ -4924,8 +4884,8 @@ python3-babeltrace:
   gentoo: [dev-util/babeltrace]
   opensuse: [python3-babeltrace]
   rhel:
-    "*": [python3-babeltrace]
-    "7": null
+    '*': [python3-babeltrace]
+    '7': null
   ubuntu: [python3-babeltrace]
 python3-backoff-pip:
   arch:
@@ -4952,7 +4912,7 @@ python3-bcrypt:
   gentoo: [dev-python/bcrypt]
   nixos: [python39Packages.bcrypt]
   opensuse: [python3-bcrypt]
-  rhel: ["python%{python3_pkgversion}-bcrypt"]
+  rhel: ['python%{python3_pkgversion}-bcrypt']
   ubuntu: [python3-bcrypt]
 python3-bitarray:
   debian: [python3-bitarray]
@@ -4966,8 +4926,8 @@ python3-bitstring:
   gentoo: [dev-python/bitstring]
   opensuse: [python3-bitstring]
   rhel:
-    "*": [python3-bitstring]
-    "7": [python36-bitstring]
+    '*': [python3-bitstring]
+    '7': [python36-bitstring]
   ubuntu: [python3-bitstring]
 python3-bluerobotics-ping-pip:
   debian:
@@ -4981,7 +4941,7 @@ python3-bluez:
   fedora: [python3-bluez]
   gentoo: [dev-python/pybluez]
   ubuntu:
-    "*": [python3-bluez]
+    '*': [python3-bluez]
     bionic: null
 python3-bokeh-pip:
   debian:
@@ -5025,8 +4985,8 @@ python3-boto3:
   openembedded: [python3-boto3@meta-ros-common]
   opensuse: [python3-boto3]
   rhel:
-    "*": ["python%{python3_pkgversion}-boto3"]
-    "7": null
+    '*': ['python%{python3_pkgversion}-boto3']
+    '7': null
   ubuntu: [python3-boto3]
 python3-bottle:
   debian: [python3-bottle]
@@ -5035,13 +4995,13 @@ python3-bottle:
   ubuntu: [python3-bottle]
 python3-box:
   debian:
-    "*": [python3-box]
+    '*': [python3-box]
     buster:
       pip:
         packages: [python-box]
   fedora: [python3-box]
   ubuntu:
-    "*": [python3-box]
+    '*': [python3-box]
     bionic:
       pip:
         packages: [python-box]
@@ -5053,8 +5013,8 @@ python3-breathe:
   fedora: [python3-breathe]
   opensuse: [python3-breathe]
   rhel:
-    "*": ["python%{python3_pkgversion}-breathe"]
-    "7": null
+    '*': ['python%{python3_pkgversion}-breathe']
+    '7': null
   ubuntu: [python3-breathe]
 python3-bs4:
   arch: [python-beautifulsoup4]
@@ -5071,7 +5031,7 @@ python3-bson:
   osx:
     pip:
       packages: [bson]
-  rhel: ["python%{python3_pkgversion}-bson"]
+  rhel: ['python%{python3_pkgversion}-bson']
   ubuntu: [python3-bson]
 python3-cairo:
   arch: [python-cairo]
@@ -5082,7 +5042,7 @@ python3-cairo:
   nixos: [python3Packages.pycairo]
   openembedded: [python3-pycairo@openembedded-core]
   opensuse: [python3-cairo]
-  rhel: ["python%{python3_pkgversion}-cairo"]
+  rhel: ['python%{python3_pkgversion}-cairo']
   slackware:
     slackpkg:
       packages: [py3cairo]
@@ -5099,7 +5059,7 @@ python3-can:
   debian: [python3-can]
   fedora: [python3-can]
   ubuntu:
-    "*": [python3-can]
+    '*': [python3-can]
 python3-can-j1939-pip:
   debian:
     pip:
@@ -5119,13 +5079,13 @@ python3-cantools-pip:
       packages: [cantools]
 python3-catkin-lint:
   debian:
-    "*": [python3-catkin-lint]
+    '*': [python3-catkin-lint]
     stretch: null
   fedora: [python3-catkin_lint]
   openembedded: [python3-catkin-lint@meta-ros-common]
   rhel: [python3-catkin_lint]
   ubuntu:
-    "*": [python3-catkin-lint]
+    '*': [python3-catkin-lint]
     bionic: null
 python3-catkin-pkg:
   alpine: [py3-catkin-pkg]
@@ -5137,7 +5097,7 @@ python3-catkin-pkg:
   gentoo: [dev-python/catkin_pkg]
   nixos: [python3Packages.catkin-pkg]
   openembedded: [python3-catkin-pkg@meta-ros-common]
-  rhel: ["python%{python3_pkgversion}-catkin_pkg"]
+  rhel: ['python%{python3_pkgversion}-catkin_pkg']
   ubuntu: [python3-catkin-pkg]
 python3-catkin-pkg-modules:
   alpine: [py3-catkin-pkg]
@@ -5152,14 +5112,14 @@ python3-catkin-pkg-modules:
   osx:
     pip:
       packages: [catkin-pkg]
-  rhel: ["python%{python3_pkgversion}-catkin_pkg"]
+  rhel: ['python%{python3_pkgversion}-catkin_pkg']
   ubuntu: [python3-catkin-pkg-modules]
 python3-catkin-sphinx:
   arch:
     pip:
       packages: [catkin_sphinx]
   debian:
-    "*":
+    '*':
       pip:
         packages: [catkin_sphinx]
     buster: [python3-catkin-sphinx]
@@ -5172,7 +5132,7 @@ python3-catkin-sphinx:
       packages: [catkin_sphinx]
   rhel: [python3-catkin-sphinx]
   ubuntu:
-    "*": null
+    '*': null
     focal: [python3-catkin-sphinx]
 python3-catkin-tools:
   debian: [python3-catkin-tools]
@@ -5182,7 +5142,7 @@ python3-catkin-tools:
 python3-cbor2:
   arch: [python-cbor2]
   debian:
-    "*": [python3-cbor2]
+    '*': [python3-cbor2]
     buster:
       pip:
         packages: [cbor2]
@@ -5194,7 +5154,7 @@ python3-cbor2:
     pip:
       packages: [cbor2]
   ubuntu:
-    "*": [python3-cbor2]
+    '*': [python3-cbor2]
     bionic:
       pip:
         packages: [cbor2]
@@ -5207,14 +5167,14 @@ python3-certifi:
   gentoo: [dev-python/certifi]
   nixos: [python39Packages.certifi]
   opensuse: [python3-certifi]
-  rhel: ["python%{python3_pkgversion}-certifi"]
+  rhel: ['python%{python3_pkgversion}-certifi']
   ubuntu: [python3-certifi]
 python3-cffi:
   debian: [python3-cffi]
   fedora: [python3-cffi]
   gentoo: [dev-python/cffi]
   nixos: [python3Packages.cffi]
-  rhel: ["python%{python3_pkgversion}-cffi"]
+  rhel: ['python%{python3_pkgversion}-cffi']
   ubuntu: [python3-cffi]
 python3-chainer-pip: *migrate_eol_2025_04_30_python3_chainer_pip
 python3-charisma-sdk-pip:
@@ -5234,26 +5194,26 @@ python3-click:
   gentoo: [dev-python/click]
   nixos: [python3Packages.click]
   openembedded: [python3-click@meta-python]
-  rhel: ["python%{python3_pkgversion}-click"]
+  rhel: ['python%{python3_pkgversion}-click']
   ubuntu: [python3-click]
 python3-colcon-common-extensions:
   debian: [python3-colcon-common-extensions]
   fedora: [python3-colcon-common-extensions]
-  rhel: ["python%{python3_pkgversion}-colcon-common-extensions"]
+  rhel: ['python%{python3_pkgversion}-colcon-common-extensions']
   ubuntu: [python3-colcon-common-extensions]
 python3-colcon-meson:
   ubuntu:
     jammy: [python3-colcon-meson]
 python3-collada:
   debian:
-    "*": [python3-collada]
+    '*': [python3-collada]
     buster: null
     stretch: null
   fedora: [python3-collada]
   nixos: [python3Packages.pycollada]
-  rhel: ["python%{python3_pkgversion}-collada"]
+  rhel: ['python%{python3_pkgversion}-collada']
   ubuntu:
-    "*": [python3-collada]
+    '*': [python3-collada]
     bionic: null
 python3-collada-pip:
   debian:
@@ -5271,17 +5231,17 @@ python3-colorama:
   gentoo: [dev-python/colorama]
   nixos: [python3Packages.colorama]
   openembedded: [python3-colorama@meta-python]
-  rhel: ["python%{python3_pkgversion}-colorama"]
+  rhel: ['python%{python3_pkgversion}-colorama']
   ubuntu: [python3-colorama]
 python3-colorcet:
   debian:
-    "*": [python3-colorcet]
+    '*': [python3-colorcet]
     buster:
       pip:
         packages: [colorcet]
   fedora: [python3-colorcet]
   ubuntu:
-    "*": [python3-colorcet]
+    '*': [python3-colorcet]
     bionic:
       pip:
         packages: [colorcet]
@@ -5315,8 +5275,8 @@ python3-construct:
   gentoo: [dev-python/construct]
   nixos: [python3Packages.construct]
   rhel:
-    "*": [python3-construct]
-    "7": null
+    '*': [python3-construct]
+    '7': null
   ubuntu: [python3-construct]
 python3-cookiecutter:
   debian:
@@ -5324,7 +5284,7 @@ python3-cookiecutter:
     stretch: [python3-cookiecutter]
   fedora: [python3-cookiecutter]
   ubuntu:
-    "*": [python3-cookiecutter]
+    '*': [python3-cookiecutter]
     focal: null
 python3-coverage:
   debian: [python3-coverage]
@@ -5333,7 +5293,7 @@ python3-coverage:
   nixos: [python3Packages.coverage]
   openembedded: [python3-coverage@meta-python]
   opensuse: [python3-coverage]
-  rhel: ["python%{python3_pkgversion}-coverage"]
+  rhel: ['python%{python3_pkgversion}-coverage']
   ubuntu: [python3-coverage]
 python3-crc16-pip:
   debian:
@@ -5364,7 +5324,7 @@ python3-cryptography:
   nixos: [python3Packages.cryptography]
   openembedded: [python3-cryptography@meta-python]
   opensuse: [python3-cryptography]
-  rhel: ["python%{python3_pkgversion}-cryptography"]
+  rhel: ['python%{python3_pkgversion}-cryptography']
   ubuntu: [python3-cryptography]
 python3-cvxpy-pip: *migrate_eol_2025_04_30_python3_cvxpy_pip
 python3-cycler:
@@ -5374,8 +5334,8 @@ python3-cycler:
   gentoo: [dev-python/cycler]
   opensuse: [python3-Cycler]
   rhel:
-    "*": [python3-cycler]
-    "7": null
+    '*': [python3-cycler]
+    '7': null
   ubuntu: [python3-cycler]
 python3-datadog-pip:
   ubuntu:
@@ -5391,7 +5351,7 @@ python3-dateutil:
   osx:
     pip:
       packages: [python-dateutil]
-  rhel: ["python%{python3_pkgversion}-dateutil"]
+  rhel: ['python%{python3_pkgversion}-dateutil']
   ubuntu: [python3-dateutil]
 python3-dbus:
   debian: [python3-dbus]
@@ -5414,7 +5374,7 @@ python3-deepdiff:
   fedora: [python-deepdiff]
   opensuse: [python3-deepdiff]
   ubuntu:
-    "*": [python3-deepdiff]
+    '*': [python3-deepdiff]
     bionic:
       pip:
         packages: [deepdiff]
@@ -5425,18 +5385,18 @@ python3-defusedxml:
   nixos: [python3Packages.defusedxml]
   openembedded: [python3-defusedxml@meta-python]
   opensuse: [python3-defusedxml]
-  rhel: ["python%{python3_pkgversion}-defusedxml"]
+  rhel: ['python%{python3_pkgversion}-defusedxml']
   ubuntu: [python3-defusedxml]
 python3-deprecated:
   debian:
-    "*": [python3-deprecated]
+    '*': [python3-deprecated]
     buster: null
   fedora: [python3-deprecated]
   rhel:
-    "*": [python3-deprecated]
-    "7": null
+    '*': [python3-deprecated]
+    '7': null
   ubuntu:
-    "*": [python3-deprecated]
+    '*': [python3-deprecated]
     bionic: null
 python3-depthai-pip:
   debian:
@@ -5457,7 +5417,7 @@ python3-dev:
   nixos: [python3]
   openembedded: [python3@openembedded-core]
   opensuse: [python3-devel]
-  rhel: ["python%{python3_pkgversion}-devel"]
+  rhel: ['python%{python3_pkgversion}-devel']
   ubuntu: [python3-dev]
 python3-distro:
   debian: [python3-distro]
@@ -5467,13 +5427,13 @@ python3-distro:
   ubuntu: [python3-distro]
 python3-distutils:
   debian:
-    "*": [python3-distutils]
+    '*': [python3-distutils]
     stretch: null
   fedora: [python3]
   gentoo: [dev-lang/python]
   nixos: [python3]
   ubuntu:
-    "*": [python3-distutils]
+    '*': [python3-distutils]
 python3-django:
   debian: [python3-django]
   fedora: [python3-django]
@@ -5496,8 +5456,8 @@ python3-djangorestframework:
   fedora: [python3-django-rest-framework]
   opensuse: [python3-djangorestframework]
   rhel:
-    "*": [python3-django-rest-framework]
-    "7": null
+    '*': [python3-django-rest-framework]
+    '7': null
   ubuntu: [python3-djangorestframework]
 python3-dlib-pip:
   debian:
@@ -5520,7 +5480,7 @@ python3-docker:
   nixos: [python3Packages.docker]
   opensuse: [python3-docker]
   rhel:
-    "7": ["python%{python3_pkgversion}-docker"]
+    '7': ['python%{python3_pkgversion}-docker']
   ubuntu: [python3-docker]
 python3-docopt:
   arch: [python-docopt]
@@ -5555,12 +5515,12 @@ python3-dubins-pip:
       packages: [dubins]
 python3-easydict:
   debian:
-    "*": [python3-easydict]
+    '*': [python3-easydict]
     buster:
       pip:
         packages: [easydict]
   ubuntu:
-    "*": [python3-easydict]
+    '*': [python3-easydict]
     bionic:
       pip:
         packages: [easydict]
@@ -5572,12 +5532,12 @@ python3-elasticsearch:
   fedora: [python3-elasticsearch]
   opensuse: [python3-elasticsearch]
   rhel:
-    "*": [python3-elasticsearch]
-    "7": null
+    '*': [python3-elasticsearch]
+    '7': null
   ubuntu: [python3-elasticsearch]
 python3-emoji:
   debian:
-    "*": [python3-emoji]
+    '*': [python3-emoji]
     bullseye:
       pip:
         packages: [emoji]
@@ -5590,10 +5550,10 @@ python3-emoji:
   fedora: [python3-emoji]
   opensuse: [python3-emoji]
   rhel:
-    "*": [python3-emoji]
-    "7": null
+    '*': [python3-emoji]
+    '7': null
   ubuntu:
-    "*": [python3-emoji]
+    '*': [python3-emoji]
     bionic:
       pip:
         packages: [emoji]
@@ -5612,7 +5572,7 @@ python3-empy:
   osx:
     pip:
       packakges: [empy]
-  rhel: ["python%{python3_pkgversion}-empy"]
+  rhel: ['python%{python3_pkgversion}-empy']
   ubuntu: [python3-empy]
 python3-environs-pip:
   debian:
@@ -5624,7 +5584,7 @@ python3-environs-pip:
 python3-evdev:
   arch: [python-evdev]
   debian:
-    "*": [python3-evdev]
+    '*': [python3-evdev]
     stretch: null
   fedora: [python3-evdev]
   gentoo: [dev-python/python-evdev]
@@ -5644,7 +5604,7 @@ python3-events-pip:
       packages: [Events]
 python3-ezdxf:
   debian:
-    "*": [python3-ezdxf]
+    '*': [python3-ezdxf]
     buster:
       pip:
         packages: [ezdxf]
@@ -5655,7 +5615,7 @@ python3-ezdxf:
   freebsd: [py37-ezdxf]
   nixos: [python3Packages.ezdxf]
   ubuntu:
-    "*": [python3-ezdxf]
+    '*': [python3-ezdxf]
     bionic:
       pip:
         packages: [ezdxf]
@@ -5675,13 +5635,13 @@ python3-fann2:
 python3-fastapi:
   arch: [python-fastapi]
   debian:
-    "*": [python3-fastapi]
+    '*': [python3-fastapi]
     buster:
       pip:
         packages: [fastapi]
   fedora: [python-fastapi]
   ubuntu:
-    "*": [python3-fastapi]
+    '*': [python3-fastapi]
     bionic:
       pip:
         packages: [fastapi]
@@ -5748,8 +5708,8 @@ python3-fiona:
   fedora: [python3-fiona]
   nixos: [python3Packages.fiona]
   rhel:
-    "*": [python3-fiona]
-    "7": null
+    '*': [python3-fiona]
+    '7': null
   ubuntu: [python3-fiona]
 python3-flake8:
   alpine: [py3-flake8]
@@ -5764,13 +5724,13 @@ python3-flake8:
     pip:
       packages: [flake8]
   rhel:
-    "*": ["python%{python3_pkgversion}-flake8"]
-    "7": null
+    '*': ['python%{python3_pkgversion}-flake8']
+    '7': null
   ubuntu: [python3-flake8]
 python3-flake8-blind-except:
   opensuse: [python3-flake8-blind-except]
   ubuntu:
-    "*": [python3-flake8-blind-except]
+    '*': [python3-flake8-blind-except]
     bionic: null
     focal: null
 python3-flake8-blind-except-pip:
@@ -5780,7 +5740,7 @@ python3-flake8-blind-except-pip:
 python3-flake8-builtins:
   opensuse: [python3-flake8-builtins]
   ubuntu:
-    "*": [python3-flake8-builtins]
+    '*': [python3-flake8-builtins]
     bionic: null
     focal: null
 python3-flake8-builtins-pip:
@@ -5790,7 +5750,7 @@ python3-flake8-builtins-pip:
 python3-flake8-class-newline:
   opensuse: [python3-flake8-class-newline]
   ubuntu:
-    "*": [python3-flake8-class-newline]
+    '*': [python3-flake8-class-newline]
     bionic: null
     focal: null
 python3-flake8-class-newline-pip:
@@ -5799,7 +5759,7 @@ python3-flake8-class-newline-pip:
       packages: [flake8-class-newline]
 python3-flake8-comprehensions:
   ubuntu:
-    "*": [python3-flake8-comprehensions]
+    '*': [python3-flake8-comprehensions]
     bionic: null
     focal: null
 python3-flake8-comprehensions-pip:
@@ -5809,7 +5769,7 @@ python3-flake8-comprehensions-pip:
 python3-flake8-deprecated:
   opensuse: [python3-flake8-deprecated]
   ubuntu:
-    "*": [python3-flake8-deprecated]
+    '*': [python3-flake8-deprecated]
     bionic: null
     focal: null
 python3-flake8-deprecated-pip:
@@ -5822,8 +5782,8 @@ python3-flake8-docstrings:
   fedora: [python3-flake8-docstrings]
   opensuse: [python3-flake8-docstrings]
   rhel:
-    "*": [python3-flake8-docstrings]
-    "7": null
+    '*': [python3-flake8-docstrings]
+    '7': null
   ubuntu: [python3-flake8-docstrings]
 python3-flake8-docstrings-pip:
   ubuntu:
@@ -5833,11 +5793,11 @@ python3-flake8-import-order:
   fedora: [python3-flake8-import-order]
   opensuse: [python3-flake8-import-order]
   rhel:
-    "*": [python3-flake8-import-order]
-    "7": null
-    "8": null
+    '*': [python3-flake8-import-order]
+    '7': null
+    '8': null
   ubuntu:
-    "*": [python3-flake8-import-order]
+    '*': [python3-flake8-import-order]
     bionic: null
     focal: null
 python3-flake8-import-order-pip:
@@ -5846,15 +5806,15 @@ python3-flake8-import-order-pip:
       packages: [flake8-import-order]
 python3-flake8-quotes:
   fedora:
-    "*": [python3-flake8-quotes]
-    "35": null
+    '*': [python3-flake8-quotes]
+    '35': null
   opensuse: [python3-flake8-quotes]
   rhel:
-    "*": [python3-flake8-quotes]
-    "7": null
-    "8": null
+    '*': [python3-flake8-quotes]
+    '7': null
+    '8': null
   ubuntu:
-    "*": [python3-flake8-quotes]
+    '*': [python3-flake8-quotes]
     bionic: null
     focal: null
 python3-flake8-quotes-pip:
@@ -5877,14 +5837,14 @@ python3-flask-cors:
   fedora: [python3-flask-cors]
   nixos: [python3Packages.flask-cors]
   rhel:
-    "*": [python3-flask-cors]
-    "7": null
+    '*': [python3-flask-cors]
+    '7': null
   ubuntu:
-    "*": [python3-flask-cors]
+    '*': [python3-flask-cors]
     bionic: null
 python3-flask-jwt-extended:
   debian:
-    "*": [python3-python-flask-jwt-extended]
+    '*': [python3-python-flask-jwt-extended]
     buster:
       pip:
         packages: [flask-jwt-extended]
@@ -5892,7 +5852,7 @@ python3-flask-jwt-extended:
   nixos: [python39Packages.flask-jwt-extended]
   opensuse: [python-flask-jwt-extended]
   ubuntu:
-    "*": [python3-python-flask-jwt-extended]
+    '*': [python3-python-flask-jwt-extended]
     bionic:
       pip:
         packages: [flask-jwt-extended]
@@ -5901,8 +5861,8 @@ python3-flask-migrate:
   fedora: [python3-flask-migrate]
   gentoo: [dev-python/flask-migrate]
   rhel:
-    "*": ["python%{python3_pkgversion}-flask-migrate"]
-    "7": null
+    '*': ['python%{python3_pkgversion}-flask-migrate']
+    '7': null
   ubuntu: [python3-flask-migrate]
 python3-flask-restplus-pip:
   ubuntu:
@@ -5920,12 +5880,12 @@ python3-flask-sqlalchemy:
   nixos: [python39Packages.flask_sqlalchemy]
   opensuse: [python-Flask-SQLAlchemy]
   rhel:
-    "*": [python3-flask-sqlalchemy]
-    "7": null
+    '*': [python3-flask-sqlalchemy]
+    '7': null
   ubuntu: [python3-flask-sqlalchemy]
 python3-flatbuffers:
   debian:
-    "*": [python3-flatbuffers]
+    '*': [python3-flatbuffers]
     buster:
       pip:
         packages: [flatbuffers]
@@ -5936,11 +5896,8 @@ python3-flatbuffers:
     pip:
       packages: [flatbuffers]
   ubuntu:
-    "*": [python3-flatbuffers]
+    '*': [python3-flatbuffers]
     focal:
-      pip:
-        packages: [flatbuffers]
-    bionic:
       pip:
         packages: [flatbuffers]
 python3-fonttools:
@@ -5962,7 +5919,7 @@ python3-ftdi1:
   arch: [libftdi]
   debian: [python3-ftdi1]
   fedora: [python3-libftdi]
-  gentoo: ["dev-embedded/libftdi[python]"]
+  gentoo: ['dev-embedded/libftdi[python]']
   nixos: [libftdi1]
   opensuse: [python3-libftdi1]
   ubuntu: [python3-ftdi1]
@@ -5976,7 +5933,7 @@ python3-future:
   gentoo: [dev-python/future]
   nixos: [python3Packages.future]
   openembedded: [python3-future@meta-python]
-  rhel: ["python%{python3_pkgversion}-future"]
+  rhel: ['python%{python3_pkgversion}-future']
   ubuntu: [python3-future]
 python3-gdal:
   arch: [python-gdal]
@@ -5985,8 +5942,8 @@ python3-gdal:
   gentoo: [sci-libs/gdal]
   opensuse: [python3-GDAL]
   rhel:
-    "*": [python3-gdal]
-    "7": null
+    '*': [python3-gdal]
+    '7': null
   ubuntu: [python3-gdal]
 python3-gdown-pip: *migrate_eol_2025_04_30_python3_gdown_pip
 python3-geographiclib:
@@ -5997,8 +5954,8 @@ python3-geographiclib:
   nixos: [python3Packages.geographiclib]
   opensuse: [python3-geographiclib]
   rhel:
-    "*": [python3-GeographicLib]
-    "7": null
+    '*': [python3-GeographicLib]
+    '7': null
   ubuntu: [python3-geographiclib]
 python3-geojson:
   arch: [python-geojson]
@@ -6047,27 +6004,27 @@ python3-git:
   gentoo: [dev-python/git-python]
   nixos: [python3Packages.GitPython]
   rhel:
-    "*": [python3-GitPython]
-    "7": null
+    '*': [python3-GitPython]
+    '7': null
   ubuntu: [python3-git]
 python3-github:
   debian: [python3-github]
   fedora: [python3-github]
   gentoo: [dev-python/PyGithub]
   nixos: [python3Packages.PyGithub]
-  rhel: ["python%{python3_pkgversion}-pygithub"]
+  rhel: ['python%{python3_pkgversion}-pygithub']
   ubuntu: [python3-github]
 python3-gitlab:
   debian:
-    "*": [python3-gitlab]
+    '*': [python3-gitlab]
     stretch:
       pip:
         packages: [python-gitlab]
   fedora: [python3-gitlab]
   gentoo: [dev-vcs/python-gitlab]
   rhel:
-    "*": [python3-gitlab]
-    "7": null
+    '*': [python3-gitlab]
+    '7': null
   ubuntu: [python3-gitlab]
 python3-glpk-pip: *migrate_eol_2025_04_30_python3_glpk_pip
 python3-gnupg:
@@ -6083,28 +6040,28 @@ python3-google-auth:
   fedora: [python3-google-auth]
   opensuse: [python3-google-auth]
   rhel:
-    "*": [python3-google-auth]
-    "7": null
+    '*': [python3-google-auth]
+    '7': null
   ubuntu: [python3-google-auth]
 python3-google-auth-httplib2:
   debian:
-    "*": [python3-google-auth-httplib2]
+    '*': [python3-google-auth-httplib2]
     buster: null
   fedora: [python3-google-auth-httplib2]
   opensuse: [python3-google-auth-httplib2]
   ubuntu:
-    "*": [python3-google-auth-httplib2]
+    '*': [python3-google-auth-httplib2]
     bionic: null
 python3-google-auth-oauthlib:
   debian:
-    "*": [python3-google-auth-oauthlib]
+    '*': [python3-google-auth-oauthlib]
     buster: null
   fedora: [python3-google-auth-oauthlib]
   rhel:
-    "*": [python3-google-auth-oauthlib]
-    "7": null
+    '*': [python3-google-auth-oauthlib]
+    '7': null
   ubuntu:
-    "*": [python3-google-auth-oauthlib]
+    '*': [python3-google-auth-oauthlib]
     bionic: null
     focal: null
 python3-google-cloud-pubsub-pip:
@@ -6128,7 +6085,7 @@ python3-gpiozero:
   debian: [python3-gpiozero]
   fedora: [python3-gpiozero]
   ubuntu:
-    "*": [python3-gpiozero]
+    '*': [python3-gpiozero]
     bionic: null
 python3-gpxpy:
   debian: [python3-gpxpy]
@@ -6156,22 +6113,22 @@ python3-graphviz:
   ubuntu: [python3-graphviz]
 python3-grpc-tools:
   debian:
-    "*": [python3-grpc-tools]
+    '*': [python3-grpc-tools]
     stretch: null
   nixos: [python3Packages.grpcio-tools]
   openembedded: [python3-grpcio-tools@meta-python]
   ubuntu:
-    "*": [python3-grpc-tools]
+    '*': [python3-grpc-tools]
     bionic: null
 python3-grpcio:
   debian:
-    "*": [python3-grpcio]
+    '*': [python3-grpcio]
     stretch: null
   fedora: [python3-grpcio]
   nixos: [python3Packages.grpcio]
   openembedded: [python3-grpcio@meta-python]
   ubuntu:
-    "*": [python3-grpcio]
+    '*': [python3-grpcio]
     bionic: null
 python3-gurobipy-pip: *migrate_eol_2025_04_30_python3_gurobipy_pip
 python3-gz-math6:
@@ -6205,7 +6162,7 @@ python3-ifcfg:
     stretch: [python3-ifcfg]
   fedora: [python3-ifcfg]
   openembedded: [python3-ifcfg@meta-ros-common]
-  rhel: ["python%{python3_pkgversion}-ifcfg"]
+  rhel: ['python%{python3_pkgversion}-ifcfg']
   ubuntu:
     bionic: [python3-ifcfg]
     focal: [python3-ifcfg]
@@ -6233,14 +6190,14 @@ python3-img2pdf:
   nixos: [python39Packages.img2pdf]
   opensuse: [python3-img2pdf]
   rhel:
-    "*": [python3-img2pdf]
-    "7": null
+    '*': [python3-img2pdf]
+    '7': null
   ubuntu: [python3-img2pdf]
 python3-importlib-metadata:
   alpine: [py3-importlib-metadata]
   arch: [python-importlib-metadata]
   debian:
-    "*": [python3-importlib-metadata]
+    '*': [python3-importlib-metadata]
     buster:
       pip:
         packages: [importlib-metadata]
@@ -6255,18 +6212,18 @@ python3-importlib-metadata:
     pip:
       packages: [importlib_metadata]
   rhel:
-    "*": [python3]
-    "7": null
-    "8": [python3-importlib-metadata]
+    '*': [python3]
+    '7': null
+    '8': [python3-importlib-metadata]
   ubuntu:
-    "*": [python3-importlib-metadata]
+    '*': [python3-importlib-metadata]
     bionic:
       pip:
         packages: [importlib-metadata]
 python3-importlib-resources:
   arch: [python-importlib_resources]
   debian:
-    "*": [python3-importlib-resources]
+    '*': [python3-importlib-resources]
     buster:
       pip:
         packages: [importlib-resources]
@@ -6281,11 +6238,11 @@ python3-importlib-resources:
     pip:
       packages: [importlib-resources]
   rhel:
-    "*": [python3]
-    "7": null
-    "8": [python3-importlib-resources]
+    '*': [python3]
+    '7': null
+    '8': [python3-importlib-resources]
   ubuntu:
-    "*": [python3-minimal]
+    '*': [python3-minimal]
     bionic:
       pip:
         packages: [importlib-resources]
@@ -6338,8 +6295,8 @@ python3-jinja2:
   gentoo: [=dev-python/jinja-2*]
   nixos: [python3Packages.jinja2]
   rhel:
-    "*": [python3-jinja2]
-    "7": [python36-jinja2]
+    '*': [python3-jinja2]
+    '7': [python36-jinja2]
   ubuntu: [python3-jinja2]
 python3-jmespath:
   arch: [python-jmespath]
@@ -6368,15 +6325,15 @@ python3-jsonschema:
   gentoo: [dev-python/jsonschema]
   nixos: [python3Packages.jsonschema]
   rhel:
-    "*": [python3-jsonschema]
-    "7": [python36-jsonschema]
+    '*': [python3-jsonschema]
+    '7': [python36-jsonschema]
   ubuntu: [python3-jsonschema]
 python3-junitparser:
   debian:
-    "*": [python3-junitparser]
+    '*': [python3-junitparser]
     stretch: null
   ubuntu:
-    "*": [python3-junitparser]
+    '*': [python3-junitparser]
     bionic: null
 python3-jupyros-pip:
   debian:
@@ -6398,10 +6355,10 @@ python3-kitchen:
     pip:
       packages: [kitchen]
   ubuntu:
-    "*": [python3-kitchen]
+    '*': [python3-kitchen]
 python3-kivy:
   debian:
-    "*": [python3-kivy]
+    '*': [python3-kivy]
     buster:
       pip:
         packages: [Kivy]
@@ -6413,10 +6370,10 @@ python3-kiwisolver:
   gentoo: [dev-python/kiwisolver]
   opensuse: [python3-kiwisolver]
   rhel:
-    "*": [python3-kiwisolver]
-    "7": null
+    '*': [python3-kiwisolver]
+    '7': null
   ubuntu:
-    "*": [python3-kiwisolver]
+    '*': [python3-kiwisolver]
     bionic:
       pip:
         packages: [kiwisolver]
@@ -6434,16 +6391,16 @@ python3-lark-parser:
   alpine: [py3-lark-parser]
   arch: [python-lark-parser]
   debian:
-    "*": [python3-lark]
+    '*': [python3-lark]
     buster: [python3-lark-parser]
     stretch: [python3-lark-parser]
   fedora: [python3-lark-parser]
   gentoo: [dev-python/lark]
   nixos: [python3Packages.lark]
   openembedded: [python3-lark-parser@meta-ros-common]
-  rhel: ["python%{python3_pkgversion}-lark-parser"]
+  rhel: ['python%{python3_pkgversion}-lark-parser']
   ubuntu:
-    "*": [python3-lark]
+    '*': [python3-lark]
     bionic: [python3-lark-parser]
 python3-libgpiod:
   alpine: [py3-libgpiod]
@@ -6454,10 +6411,10 @@ python3-libgpiod:
   nixos: [python3Packages.libgpiod]
   opensuse: [python3-gpiod]
   rhel:
-    "*": [python3-libgpiod]
-    "7": null
+    '*': [python3-libgpiod]
+    '7': null
   ubuntu:
-    "*": [python3-libgpiod]
+    '*': [python3-libgpiod]
     bionic: null
 python3-lingua-franca-pip:
   debian:
@@ -6483,8 +6440,8 @@ python3-lttng:
   fedora: [python3-lttng]
   openembedded: [lttng-tools@openembedded-core]
   rhel:
-    "*": [python3-lttng]
-    "7": null
+    '*': [python3-lttng]
+    '7': null
   ubuntu: [python3-lttng]
 python3-lxml:
   alpine: [py3-lxml]
@@ -6499,7 +6456,7 @@ python3-lxml:
   osx:
     pip:
       packages: [lxml]
-  rhel: ["python%{python3_pkgversion}-lxml"]
+  rhel: ['python%{python3_pkgversion}-lxml']
   ubuntu: [python3-lxml]
 python3-mako:
   debian: [python3-mako]
@@ -6507,8 +6464,8 @@ python3-mako:
   gentoo: [dev-python/mako]
   opensuse: [python3-Mako]
   rhel:
-    "*": ["python%{python3_pkgversion}-mako"]
-    "7": null
+    '*': ['python%{python3_pkgversion}-mako']
+    '7': null
   ubuntu: [python3-mako]
 python3-mapbox-earcut-pip:
   debian:
@@ -6544,8 +6501,8 @@ python3-marshmallow:
   nixos: [python39Packages.marshmallow]
   opensuse: [python3-marshmallow]
   rhel:
-    "*": ["python%{python3_pkgversion}-marshmallow"]
-    "7": null
+    '*': ['python%{python3_pkgversion}-marshmallow']
+    '7': null
   ubuntu: [python3-marshmallow]
 python3-marshmallow-dataclass-pip:
   ubuntu:
@@ -6565,18 +6522,18 @@ python3-matplotlib:
       depends: [pkg-config, freetype, libpng12-dev]
       packages: [matplotlib]
   rhel:
-    "*": ["python%{python3_pkgversion}-matplotlib"]
-    "7": null
+    '*': ['python%{python3_pkgversion}-matplotlib']
+    '7': null
   slackware: [python3-matplotlib]
   ubuntu: [python3-matplotlib]
 python3-mechanize:
   debian:
-    "*": [python3-mechanize]
+    '*': [python3-mechanize]
     buster: null
   fedora: [python3-mechanize]
   nixos: [python3Packages.mechanize]
   ubuntu:
-    "*": [python3-mechanize]
+    '*': [python3-mechanize]
     bionic: null
 python3-mediapipe-pip:
   debian:
@@ -6645,7 +6602,7 @@ python3-mock:
   osx:
     pip:
       packages: [mock]
-  rhel: ["python%{python3_pkgversion}-mock"]
+  rhel: ['python%{python3_pkgversion}-mock']
   ubuntu: [python3-mock]
 python3-more-itertools:
   arch: [python-more-itertools]
@@ -6653,17 +6610,17 @@ python3-more-itertools:
   fedora: [python3-more-itertools]
   gentoo: [dev-python/more-itertools]
   rhel:
-    "*": [python3-more-itertools]
-    "7": null
+    '*': [python3-more-itertools]
+    '7': null
   ubuntu: [python3-more-itertools]
 python3-msgpack:
   debian:
-    "*": [python3-msgpack]
+    '*': [python3-msgpack]
     stretch: null
   fedora: [python3-msgpack]
   nixos: [python3Packages.msgpack]
   openembedded: [python3-msgpack@meta-python]
-  rhel: ["python%{python3_pkgversion}-msgpack"]
+  rhel: ['python%{python3_pkgversion}-msgpack']
   ubuntu: [python3-msgpack]
 python3-msk-pip:
   debian:
@@ -6695,8 +6652,8 @@ python3-munkres:
   nixos: [python3Packages.munkre]
   opensuse: [python3-munkres]
   rhel:
-    "*": [python3-munkres]
-    "7": null
+    '*': [python3-munkres]
+    '7': null
   ubuntu: [python3-munkres]
 python3-mycroft-messagebus-client-pip:
   debian:
@@ -6709,7 +6666,7 @@ python3-mypy:
   alpine: [py3-mypy]
   arch: [mypy]
   debian:
-    "*": [python3-mypy]
+    '*': [python3-mypy]
     stretch: [mypy]
   fedora: [python3-mypy]
   gentoo: [dev-python/mypy]
@@ -6720,9 +6677,9 @@ python3-mypy:
     pip:
       packages: [mypy]
   rhel:
-    "*": [python3-mypy]
-    "7": null
-    "8": null
+    '*': [python3-mypy]
+    '7': null
+    '8': null
   ubuntu: [python3-mypy]
 python3-nclib-pip:
   arch:
@@ -6752,7 +6709,7 @@ python3-netifaces:
   nixos: [python3Packages.netifaces]
   openembedded: [python3-netifaces@meta-ros-common]
   opensuse: [python3-netifaces]
-  rhel: ["python%{python3_pkgversion}-netifaces"]
+  rhel: ['python%{python3_pkgversion}-netifaces']
   ubuntu: [python3-netifaces]
 python3-networkmanager:
   debian:
@@ -6767,13 +6724,13 @@ python3-networkx:
 python3-nlopt:
   arch: [nlopt]
   debian:
-    "*": [python3-nlopt]
+    '*': [python3-nlopt]
     buster: null
     stretch: null
   fedora: [python3-NLopt]
   gentoo: [sci-libs/nlopt]
   ubuntu:
-    "*": [python3-nlopt]
+    '*': [python3-nlopt]
     bionic: null
 python3-nose:
   arch: [python-nose]
@@ -6786,7 +6743,7 @@ python3-nose:
   osx:
     pip:
       packages: [nose]
-  rhel: ["python%{python3_pkgversion}-nose"]
+  rhel: ['python%{python3_pkgversion}-nose']
   ubuntu: [python3-nose]
 python3-nose-parameterized:
   debian: [python3-nose-parameterized]
@@ -6801,8 +6758,8 @@ python3-ntplib:
   nixos: [python3Packages.ntplib]
   opensuse: [python3-ntplib]
   rhel:
-    "*": ["python%{python3_pkgversion}-ntplib"]
-    "7": null
+    '*': ['python%{python3_pkgversion}-ntplib']
+    '7': null
   ubuntu: [python3-ntplib]
 python3-numba:
   debian: [python3-numba]
@@ -6816,14 +6773,14 @@ python3-numpy:
   nixos: [python3Packages.numpy]
   openembedded: [python3-numpy@openembedded-core]
   opensuse: [python3-numpy]
-  rhel: ["python%{python3_pkgversion}-numpy"]
+  rhel: ['python%{python3_pkgversion}-numpy']
   ubuntu: [python3-numpy]
 python3-numpy-stl:
   debian: [python3-numpy-stl]
   fedora: [python3-numpy-stl]
   nixos: [python3Packages.numpy-stl]
   ubuntu:
-    "*": [python3-numpy-stl]
+    '*': [python3-numpy-stl]
 python3-nuscenes-devkit-pip:
   arch:
     pip:
@@ -6855,8 +6812,8 @@ python3-oauth2client:
   fedora: [python3-oauth2client]
   opensuse: [python3-oauth2client]
   rhel:
-    "*": [python3-oauth2client]
-    "7": null
+    '*': [python3-oauth2client]
+    '7': null
   ubuntu: [python3-oauth2client]
 python3-odrive-pip:
   debian:
@@ -6902,11 +6859,11 @@ python3-onnxruntime-pip:
       packages: [onnxruntime]
 python3-open3d:
   debian:
-    "*": [python3-open3d]
+    '*': [python3-open3d]
     buster: null
     stretch: null
   ubuntu:
-    "*": [python3-open3d]
+    '*': [python3-open3d]
     bionic: null
     focal: null
 python3-open3d-pip:
@@ -6932,14 +6889,14 @@ python3-openai-pip:
 python3-opencv:
   debian: [python3-opencv]
   fedora: [python3-opencv]
-  gentoo: ["media-libs/opencv[python]"]
+  gentoo: ['media-libs/opencv[python]']
   nixos: [python3Packages.opencv3]
   openembedded: [opencv@meta-oe]
   opensuse: [python3-opencv]
   rhel:
-    "*": [python3-opencv]
-    "7": null
-    "8": null
+    '*': [python3-opencv]
+    '7': null
+    '8': null
   ubuntu: [python3-opencv]
 python3-opengl:
   debian: [python3-opengl]
@@ -6976,7 +6933,7 @@ python3-packaging:
   gentoo: [dev-python/packaging]
   nixos: [python3Packages.packaging]
   openembedded: [python3-packaging@openembedded-core]
-  rhel: ["python%{python3_pkgversion}-packaging"]
+  rhel: ['python%{python3_pkgversion}-packaging']
   ubuntu: [python3-packaging]
 python3-padaos-pip:
   debian:
@@ -6996,10 +6953,10 @@ python3-paho-mqtt:
   debian: [python3-paho-mqtt]
   fedora: [python3-paho-mqtt]
   rhel:
-    "*": [python3-paho-mqtt]
-    "7": null
+    '*': [python3-paho-mqtt]
+    '7': null
   ubuntu:
-    "*": [python3-paho-mqtt]
+    '*': [python3-paho-mqtt]
 python3-pandas:
   debian: [python3-pandas]
   fedora: [python3-pandas]
@@ -7008,8 +6965,8 @@ python3-pandas:
   openembedded: [python3-pandas@meta-python]
   opensuse: [python3-pandas]
   rhel:
-    "*": ["python%{python3_pkgversion}-pandas"]
-    "7": null
+    '*': ['python%{python3_pkgversion}-pandas']
+    '7': null
   ubuntu: [python3-pandas]
 python3-papermill-pip:
   debian:
@@ -7034,7 +6991,7 @@ python3-paramiko:
   nixos: [python3Packages.paramiko]
   openembedded: [python3-paramiko@meta-ros-common]
   opensuse: [python3-paramiko]
-  rhel: ["python%{python3_pkgversion}-paramiko"]
+  rhel: ['python%{python3_pkgversion}-paramiko']
   ubuntu: [python3-paramiko]
 python3-parse:
   arch: [python-parse]
@@ -7043,8 +7000,8 @@ python3-parse:
   gentoo: [dev-python/parse]
   opensuse: [python3-parse]
   rhel:
-    "*": [python3-parse]
-    "7": null
+    '*': [python3-parse]
+    '7': null
   ubuntu: [python3-parse]
 python3-pcg-gazebo-pip:
   debian:
@@ -7078,7 +7035,7 @@ python3-pexpect:
   debian: [python3-pexpect]
   fedora: [python3-pexpect]
   opensuse: [python3-pexpect]
-  rhel: ["python%{python3_pkgversion}-pexpect"]
+  rhel: ['python%{python3_pkgversion}-pexpect']
   ubuntu: [python3-pexpect]
 python3-pickleDB-pip:
   debian:
@@ -7093,7 +7050,7 @@ python3-pickleDB-pip:
 python3-pika:
   debian: [python3-pika]
   fedora: [python3-pika]
-  rhel: ["python%{python3_pkgversion}-pika"]
+  rhel: ['python%{python3_pkgversion}-pika']
   ubuntu: [python3-pika]
 python3-pil:
   alpine: [py3-pillow]
@@ -7130,7 +7087,7 @@ python3-pkg-resources:
   nixos: [python3Packages.setuptools]
   openembedded: [python3-setuptools@openembedded-core]
   opensuse: [python3-setuptools]
-  rhel: ["python%{python3_pkgversion}-setuptools"]
+  rhel: ['python%{python3_pkgversion}-setuptools']
   ubuntu: [python3-pkg-resources]
 python3-playsound-pip:
   debian:
@@ -7149,8 +7106,8 @@ python3-ply:
   gentoo: [dev-python/ply]
   opensuse: [python3-ply]
   rhel:
-    "*": [python3-ply]
-    "7": null
+    '*': [python3-ply]
+    '7': null
   ubuntu: [python3-ply]
 python3-pocketsphinx-pip:
   debian:
@@ -7187,7 +7144,7 @@ python3-pqdict-pip:
       packages: [pqdict]
 python3-pre-commit:
   debian:
-    "*": [pre-commit]
+    '*': [pre-commit]
     buster:
       pip:
         packages: [pre-commit]
@@ -7196,7 +7153,7 @@ python3-pre-commit:
         packages: [pre-commit]
   fedora: [pre-commit]
   ubuntu:
-    "*": [pre-commit]
+    '*': [pre-commit]
     bionic:
       pip:
         packages: [pre-commit]
@@ -7227,8 +7184,8 @@ python3-prometheus-client:
   debian: [python3-prometheus-client]
   fedora: [python3-prometheus_client]
   rhel:
-    "*": [python3-prometheus_client]
-    "7": null
+    '*': [python3-prometheus_client]
+    '7': null
   ubuntu: [python3-prometheus-client]
 python3-prompt-toolkit:
   arch: [python-prompt_toolkit]
@@ -7236,8 +7193,8 @@ python3-prompt-toolkit:
   fedora: [python-prompt-toolkit]
   gentoo: [dev-python/prompt_toolkit]
   rhel:
-    "*": [python3-prompt-toolkit]
-    "7": null
+    '*': [python3-prompt-toolkit]
+    '7': null
   ubuntu: [python3-prompt-toolkit]
 python3-protobuf:
   alpine: [py3-protobuf]
@@ -7246,8 +7203,8 @@ python3-protobuf:
   gentoo: [dev-python/protobuf-python]
   nixos: [python3Packages.protobuf]
   rhel:
-    "*": [python3-protobuf]
-    "7": null
+    '*': [python3-protobuf]
+    '7': null
   ubuntu: [python3-protobuf]
 python3-psutil:
   alpine: [py3-psutil]
@@ -7262,7 +7219,7 @@ python3-psutil:
   osx:
     pip:
       packages: [psutil]
-  rhel: ["python%{python3_pkgversion}-psutil"]
+  rhel: ['python%{python3_pkgversion}-psutil']
   slackware: [psutil]
   ubuntu: [python3-psutil]
 python3-py3exiv2-pip:
@@ -7280,12 +7237,12 @@ python3-py3exiv2-pip:
       packages: [py3exiv2]
 python3-pyassimp:
   debian:
-    "*": [python3-pyassimp]
+    '*': [python3-pyassimp]
     stretch: null
   fedora: [python3-assimp]
   openembedded: [python3-pyassimp@meta-ros-common]
   ubuntu:
-    "*": [python3-pyassimp]
+    '*': [python3-pyassimp]
 python3-pyaudio:
   arch: [python-pyaudio]
   debian: [python3-pyaudio]
@@ -7327,7 +7284,7 @@ python3-pycodestyle:
   osx:
     pip:
       packages: [pycodestyle]
-  rhel: ["python%{python3_pkgversion}-pycodestyle"]
+  rhel: ['python%{python3_pkgversion}-pycodestyle']
   ubuntu: [python3-pycodestyle]
 python3-pycryptodome:
   alpine: [py3-pycryptodome]
@@ -7341,12 +7298,12 @@ python3-pycryptodome:
   osx:
     pip:
       packages: [pycryptodome]
-  rhel: ["python%{python3_pkgversion}-pycryptodomex"]
+  rhel: ['python%{python3_pkgversion}-pycryptodomex']
   ubuntu: [python3-pycryptodome]
 python3-pydantic:
   arch: [python-pydantic]
   debian:
-    "*": [python3-pydantic]
+    '*': [python3-pydantic]
     buster:
       pip: [pydantic]
     stretch:
@@ -7354,7 +7311,7 @@ python3-pydantic:
   fedora: [python3-pydantic]
   gentoo: [dev-python/pydantic]
   ubuntu:
-    "*": [python3-pydantic]
+    '*': [python3-pydantic]
     bionic:
       pip: [pydantic]
 python3-pydbus:
@@ -7362,8 +7319,8 @@ python3-pydbus:
   fedora: [python3-pydbus]
   opensuse: [python3-pydbus]
   rhel:
-    "*": ["python%{python3_pkgversion}-pydbus"]
-    "7": null
+    '*': ['python%{python3_pkgversion}-pydbus']
+    '7': null
   ubuntu: [python3-pydbus]
 python3-pydot:
   alpine: [py3-pydot]
@@ -7378,8 +7335,8 @@ python3-pydot:
     pip:
       packages: [pydot]
   rhel:
-    "*": ["python%{python3_pkgversion}-pydot"]
-    "7": null
+    '*': ['python%{python3_pkgversion}-pydot']
+    '7': null
   ubuntu: [python3-pydot]
 python3-pyee:
   debian: [python3-pyee]
@@ -7400,14 +7357,14 @@ python3-pyftpdlib:
   ubuntu: [python3-pyftpdlib]
 python3-pygame:
   debian:
-    "*": [python3-pygame]
+    '*': [python3-pygame]
     stretch:
       pip: [pygame]
   fedora: [python3-pygame]
   gentoo: [dev-python/pygame]
   nixos: [python3Packages.pygame]
   ubuntu:
-    "*": [python3-pygame]
+    '*': [python3-pygame]
     bionic:
       pip: [pygame]
 python3-pygit2:
@@ -7421,8 +7378,8 @@ python3-pygit2:
     pip:
       packages: [pygit2]
   rhel:
-    "*": [python3-pygit2]
-    "7": null
+    '*': [python3-pygit2]
+    '7': null
   ubuntu: [python3-pygit2]
 python3-pygments:
   alpine: [py3-pygments]
@@ -7433,8 +7390,8 @@ python3-pygments:
   openembedded: [python3-pygments@openembedded-core]
   opensuse: [python3-Pygments]
   rhel:
-    "*": [python3-pygments]
-    "7": null
+    '*': [python3-pygments]
+    '7': null
   ubuntu: [python3-pygments]
 python3-pygraphviz:
   alpine: [py3-pygraphviz]
@@ -7448,26 +7405,26 @@ python3-pygraphviz:
   osx:
     pip:
       packages: [pygraphviz]
-  rhel: ["python%{python3_pkgversion}-pygraphviz"]
+  rhel: ['python%{python3_pkgversion}-pygraphviz']
   slackware: [pygraphviz]
   ubuntu: [python3-pygraphviz]
 python3-pykdl:
   debian:
-    "*": [python3-pykdl]
+    '*': [python3-pykdl]
     stretch: null
   fedora: [python3-pykdl]
   gentoo: [dev-python/python_orocos_kdl]
   nixos: [python3Packages.pykdl]
   openembedded: [python3-pykdl@meta-ros1-noetic]
   rhel:
-    "*": [python3-pykdl]
-    "7": null
+    '*': [python3-pykdl]
+    '7': null
   ubuntu:
-    "*": [python3-pykdl]
+    '*': [python3-pykdl]
     bionic: null
 python3-pylatexenc:
   debian:
-    "*": [python3-pylatexenc]
+    '*': [python3-pylatexenc]
     bullseye:
       pip:
         packages: [pylatexenc]
@@ -7475,7 +7432,7 @@ python3-pylatexenc:
       pip:
         packages: [pylatexenc]
   ubuntu:
-    "*": [python3-pylatexenc]
+    '*': [python3-pylatexenc]
     bionic:
       pip:
         packages: [pylatexenc]
@@ -7484,7 +7441,7 @@ python3-pylatexenc:
         packages: [pylatexenc]
 python3-pylibdmtx:
   debian:
-    "*": [python3-pylibdmtx]
+    '*': [python3-pylibdmtx]
     buster:
       pip:
         packages: [pylibdmtx]
@@ -7495,7 +7452,7 @@ python3-pylibdmtx:
     pip:
       packages: [pylibdmtx]
   ubuntu:
-    "*": [python3-pylibdmtx]
+    '*': [python3-pylibdmtx]
     bionic:
       pip:
         packages: [pylibdmtx]
@@ -7504,12 +7461,12 @@ python3-pylibdmtx:
         packages: [pylibdmtx]
 python3-pymap3d:
   debian:
-    "*": [python3-pymap3d]
+    '*': [python3-pymap3d]
     buster: null
     stretch: null
   gentoo: [sci-geosciences/pymap3d]
   ubuntu:
-    "*": [python3-pymap3d]
+    '*': [python3-pymap3d]
     bionic: null
     focal: null
 python3-pymesh2-pip:
@@ -7524,11 +7481,11 @@ python3-pymesh2-pip:
       packages: [pymesh2]
 python3-pymodbus:
   debian:
-    "*": [python3-pymodbus]
+    '*': [python3-pymodbus]
     stretch: null
   fedora: [python3-pymodbus]
   ubuntu:
-    "*": [python3-pymodbus]
+    '*': [python3-pymodbus]
 python3-pymodbus-pip: *migrate_eol_2027_04_30_python3_pymodbus_pip
 python3-pymongo:
   arch: [python-pymongo]
@@ -7588,7 +7545,7 @@ python3-pypng:
   fedora: [python3-pypng]
   gentoo: [dev-python/pypng]
   ubuntu:
-    "*": [python3-png]
+    '*': [python3-png]
 python3-pyproj:
   arch: [python-pyproj]
   debian: [python3-pyproj]
@@ -7597,8 +7554,8 @@ python3-pyproj:
   nixos: [python3Packages.pyproj]
   openembedded: [python3-pyproj@meta-ros-common]
   rhel:
-    "*": ["python%{python3_pkgversion}-pyproj"]
-    "7": null
+    '*': ['python%{python3_pkgversion}-pyproj']
+    '7': null
   ubuntu: [python3-pyproj]
 python3-pyqrcode:
   arch: [python-qrcode]
@@ -7609,26 +7566,13 @@ python3-pyqrcode:
 python3-pyqt5:
   alpine: [py3-qt5]
   arch: [python-pyqt5]
-  debian:
-    [
-      pyqt5-dev,
-      python3-pyqt5,
-      python3-pyqt5.qtsvg,
-      python3-sip-dev,
-      qtbase5-dev,
-    ]
+  debian: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
   fedora: [python3-qt5-devel, python3-sip-devel, libXext-devel]
   gentoo: [dev-python/PyQt5]
   nixos: [python3Packages.pyqt5]
   openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python3-qt5]
-  rhel:
-    [
-      "python%{python3_pkgversion}-qt5-devel",
-      "python%{python3_pkgversion}-sip-devel",
-      libXext-devel,
-      redhat-rpm-config,
-    ]
+  rhel: ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
   slackware: [python3-PyQt5]
   ubuntu: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
 python3-pyqt5.qtquick:
@@ -7638,7 +7582,7 @@ python3-pyqt5.qtwebengine:
   debian: [python3-pyqt5.qtwebengine]
   fedora: [python3-qt5-webengine]
   nixos: [python3Packages.pyqtwebengine]
-  openembedded: ["${PYTHON_PN}-pyqt5@meta-qt5"]
+  openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
   opensuse: [python3-qtwebengine-qt5]
   ubuntu: [python3-pyqt5.qtwebengine]
 python3-pyqtgraph:
@@ -7659,47 +7603,11 @@ python3-pyrr-pip:
       packages: [pyrr]
 python3-pyside2:
   arch: [pyside2, python-shiboken2, shiboken2]
-  debian:
-    [
-      libpyside2-dev,
-      libshiboken2-dev,
-      python3-pyside2.qtcore,
-      python3-pyside2.qtgui,
-      python3-pyside2.qthelp,
-      python3-pyside2.qtnetwork,
-      python3-pyside2.qtprintsupport,
-      python3-pyside2.qttest,
-      python3-pyside2.qtsvg,
-      python3-pyside2.qtwidgets,
-      python3-pyside2.qtxml,
-      shiboken2,
-    ]
-  fedora:
-    [
-      python3-pyside2,
-      pyside2-tools,
-      python3-pyside2-devel,
-      python3-shiboken2,
-      python3-shiboken2-devel,
-      shiboken2,
-    ]
+  debian: [libpyside2-dev, libshiboken2-dev, python3-pyside2.qtcore, python3-pyside2.qtgui, python3-pyside2.qthelp, python3-pyside2.qtnetwork, python3-pyside2.qtprintsupport, python3-pyside2.qttest, python3-pyside2.qtsvg, python3-pyside2.qtwidgets, python3-pyside2.qtxml, shiboken2]
+  fedora: [python3-pyside2, pyside2-tools, python3-pyside2-devel, python3-shiboken2, python3-shiboken2-devel, shiboken2]
   gentoo: [dev-python/pyside2, dev/python/shiboken2]
   ubuntu:
-    "*":
-      [
-        libpyside2-dev,
-        libshiboken2-dev,
-        python3-pyside2.qtcore,
-        python3-pyside2.qtgui,
-        python3-pyside2.qthelp,
-        python3-pyside2.qtnetwork,
-        python3-pyside2.qtprintsupport,
-        python3-pyside2.qtsvg,
-        python3-pyside2.qttest,
-        python3-pyside2.qtwidgets,
-        python3-pyside2.qtxml,
-        shiboken2,
-      ]
+    "*": [libpyside2-dev, libshiboken2-dev, python3-pyside2.qtcore, python3-pyside2.qtgui, python3-pyside2.qthelp, python3-pyside2.qtnetwork, python3-pyside2.qtprintsupport, python3-pyside2.qtsvg, python3-pyside2.qttest, python3-pyside2.qtwidgets, python3-pyside2.qtxml, shiboken2]
     bionic: null
 python3-pyside2.qtopengl:
   arch: [pyside2]
@@ -7707,7 +7615,7 @@ python3-pyside2.qtopengl:
   fedora: [python3-pyside2]
   gentoo: [dev-python/pyside2]
   ubuntu:
-    "*": [python3-pyside2.qtopengl]
+    '*': [python3-pyside2.qtopengl]
     bionic: null
 python3-pyside2.qtquick:
   arch: [pyside2]
@@ -7715,12 +7623,12 @@ python3-pyside2.qtquick:
   fedora: [python3-pyside2]
   gentoo: [dev-python/pyside2]
   ubuntu:
-    "*": [python3-pyside2.qtquick]
+    '*': [python3-pyside2.qtquick]
     bionic: null
 python3-pyside2.qtuitools:
   debian: [python3-pyside2.qtuitools]
   ubuntu:
-    "*": [python3-pyside2.qtuitools]
+    '*': [python3-pyside2.qtuitools]
     bionic: null
 python3-pysnmp:
   debian: [python3-pysnmp4]
@@ -7729,8 +7637,8 @@ python3-pysnmp:
   nixos: [python3Packages.pysnmp]
   opensuse: [python3-pysnmp]
   rhel:
-    "*": [python3-pysnmp]
-    "7": [pysnmp]
+    '*': [python3-pysnmp]
+    '7': [pysnmp]
   ubuntu: [python3-pysnmp4]
 python3-pystemd:
   debian:
@@ -7738,10 +7646,10 @@ python3-pystemd:
   fedora: [python3-pystemd]
   nixos: [python3Packages.pystemd]
   rhel:
-    "*": [python3-pystemd]
-    "7": null
+    '*': [python3-pystemd]
+    '7': null
   ubuntu:
-    "*": [python3-pystemd]
+    '*': [python3-pystemd]
     bionic:
       pip:
         packages: [pystemd]
@@ -7767,7 +7675,7 @@ python3-pytest:
   osx:
     pip:
       packages: [pytest]
-  rhel: ["python%{python3_pkgversion}-pytest"]
+  rhel: ['python%{python3_pkgversion}-pytest']
   ubuntu: [python3-pytest]
 python3-pytest-asyncio:
   alpine: [py3-pytest-asyncio]
@@ -7781,18 +7689,18 @@ python3-pytest-asyncio:
     pip:
       packages: [pytest-asyncio]
   rhel:
-    "*": [python3-pytest-asyncio]
-    "7": null
+    '*': [python3-pytest-asyncio]
+    '7': null
   ubuntu:
-    "*": [python3-pytest-asyncio]
+    '*': [python3-pytest-asyncio]
     bionic: null
 python3-pytest-benchmark:
   debian: [python3-pytest-benchmark]
   fedora: [python3-pytest-benchmark]
   opensuse: [python3-pytest-benchmark]
   rhel:
-    "*": [python3-pytest-benchmark]
-    "7": null
+    '*': [python3-pytest-benchmark]
+    '7': null
   ubuntu: [python3-pytest-benchmark]
 python3-pytest-cov:
   alpine: [py3-pytest-cov]
@@ -7802,7 +7710,7 @@ python3-pytest-cov:
   gentoo: [dev-python/pytest-cov]
   nixos: [python3Packages.pytestcov]
   openembedded: [python3-pytest-cov@meta-ros-common]
-  rhel: ["python%{python3_pkgversion}-pytest-cov"]
+  rhel: ['python%{python3_pkgversion}-pytest-cov']
   ubuntu: [python3-pytest-cov]
 python3-pytest-mock:
   alpine: [py3-pytest-mock]
@@ -7816,7 +7724,7 @@ python3-pytest-mock:
   osx:
     pip:
       packages: [pytest-mock]
-  rhel: ["python%{python3_pkgversion}-pytest-mock"]
+  rhel: ['python%{python3_pkgversion}-pytest-mock']
   ubuntu: [python3-pytest-mock]
 python3-pytest-timeout:
   arch: [python-pytest-timeout]
@@ -7825,7 +7733,7 @@ python3-pytest-timeout:
   gentoo: [dev-python/pytest-timeout]
   nixos: [python3Packages.pytest-timeout]
   opensuse: [python3-pytest-timeout]
-  rhel: ["python%{python3_pkgversion}-pytest-timeout"]
+  rhel: ['python%{python3_pkgversion}-pytest-timeout']
   ubuntu: [python3-pytest-timeout]
 python3-pytorch-pip: *migrate_eol_2025_04_30_python3_pytorch_pip
 python3-pytrinamic-pip:
@@ -7872,71 +7780,31 @@ python3-qrcode:
   nixos: [python39Packages.qrcode]
   opensuse: [python3-qrcode]
   rhel:
-    "8": [python3-qrcode]
+    '8': [python3-qrcode]
   ubuntu: [python3-qrcode]
 python3-qt5-bindings:
   alpine: [py3-qt5]
   arch: [python-pyqt5]
   debian:
-    "*":
-      [
-        libpyside2-dev,
-        libshiboken2-dev,
-        pyqt5-dev,
-        python3-pyqt5,
-        python3-pyqt5.qtsvg,
-        python3-pyside2.qtsvg,
-        python3-sip-dev,
-        qtbase5-dev,
-        shiboken2,
-      ]
-    stretch:
-      [
-        pyqt5-dev,
-        python3-pyqt5,
-        python3-pyqt5.qtsvg,
-        python3-sip-dev,
-        qtbase5-dev,
-      ]
+    '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2]
+    stretch: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
   fedora: [python3-qt5-devel, python3-sip-devel, libXext-devel]
   gentoo: [dev-python/PyQt5]
   nixos: [python3Packages.pyqt5]
   openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python3-qt5]
   rhel:
-    "*": [clang, python3-devel, python3-pyside2-devel, python3-shiboken2-devel]
-    "7":
-      [
-        "python%{python3_pkgversion}-qt5-devel",
-        "python%{python3_pkgversion}-sip-devel",
-        libXext-devel,
-        redhat-rpm-config,
-      ]
-    "8":
-      [
-        "python%{python3_pkgversion}-qt5-devel",
-        "python%{python3_pkgversion}-sip-devel",
-        libXext-devel,
-        redhat-rpm-config,
-      ]
+    '*': [clang, python3-devel, python3-pyside2-devel, python3-shiboken2-devel]
+    '7': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
+    '8': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
   slackware: [python3-PyQt5]
   ubuntu:
-    "*":
-      [
-        libpyside2-dev,
-        libshiboken2-dev,
-        pyqt5-dev,
-        python3-pyqt5,
-        python3-pyqt5.qtsvg,
-        python3-pyside2.qtsvg,
-        python3-sip-dev,
-        shiboken2,
-      ]
+    '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2]
     bionic: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
 python3-qt5-bindings-gl:
   debian: [python3-pyqt5.qtopengl]
   fedora: [python3-qt5]
-  gentoo: ["dev-python/PyQt5[opengl]"]
+  gentoo: ['dev-python/PyQt5[opengl]']
   nixos: [python3Packages.pyqt5]
   openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python3-qt5]
@@ -7944,7 +7812,7 @@ python3-qt5-bindings-gl:
 python3-qt5-bindings-webkit:
   debian: [python3-pyqt5.qtwebkit]
   fedora: [python3-qt5-webkit]
-  gentoo: ["dev-python/PyQt5[webkit]"]
+  gentoo: ['dev-python/PyQt5[webkit]']
   nixos: [python3Packages.pyqt5_with_qtwebkit]
   openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python3-qt5]
@@ -7956,7 +7824,7 @@ python3-qtpy:
   gentoo: [dev-python/QtPy]
   nixos: [python3Packages.qtpy]
   rhel:
-    "8": [python3-QtPy]
+    '8': [python3-QtPy]
   ubuntu: [python3-qtpy]
 python3-qwt:
   debian: [python3-qwt]
@@ -7991,7 +7859,7 @@ python3-rdflib:
   gentoo: [dev-python/rdflib]
   nixos: [python3Packages.rdflib]
   rhel:
-    "8": ["python%{python3_pkgversion}-rdflib"]
+    '8': ['python%{python3_pkgversion}-rdflib']
   ubuntu: [python3-rdflib]
 python3-reportlab:
   arch: [python-reportlab]
@@ -8004,15 +7872,15 @@ python3-reportlab:
     pip:
       packages: [reportlab]
   rhel:
-    "*": [python3-reportlab]
-    "7": null
+    '*': [python3-reportlab]
+    '7': null
   ubuntu: [python3-reportlab]
 python3-requests:
   debian: [python3-requests]
   fedora: [python3-requests]
   nixos: [python3Packages.requests]
   openembedded: [python3-requests@meta-python]
-  rhel: ["python%{python3_pkgversion}-requests"]
+  rhel: ['python%{python3_pkgversion}-requests']
   ubuntu: [python3-requests]
 python3-requests-futures:
   debian: [python3-requests-futures]
@@ -8025,8 +7893,8 @@ python3-requests-oauthlib:
   nixos: [python3Packages.requests_oauthlib]
   openembedded: [python3-requests-oauthlib@meta-python]
   rhel:
-    "*": ["python%{python3_pkgversion}-requests-oauthlib"]
-    "7": null
+    '*': ['python%{python3_pkgversion}-requests-oauthlib']
+    '7': null
   ubuntu: [python3-requests-oauthlib]
 python3-retrying:
   arch: [python-retrying]
@@ -8073,7 +7941,7 @@ python3-rosdep:
   debian: [python3-rosdep]
   fedora: [python3-rosdep]
   gentoo: [dev-util/rosdep]
-  rhel: ["python%{python3_pkgversion}-rosdep"]
+  rhel: ['python%{python3_pkgversion}-rosdep']
   ubuntu: [python3-rosdep]
 python3-rosdep-modules:
   debian: [python3-rosdep-modules]
@@ -8081,7 +7949,7 @@ python3-rosdep-modules:
   gentoo: [dev-util/rosdep]
   nixos: [python3Packages.rosdep]
   openembedded: [python3-rosdep@meta-ros-common]
-  rhel: ["python%{python3_pkgversion}-rosdep"]
+  rhel: ['python%{python3_pkgversion}-rosdep']
   ubuntu: [python3-rosdep-modules]
 python3-rosdistro-modules:
   alpine: [py3-rosdistro]
@@ -8093,7 +7961,7 @@ python3-rosdistro-modules:
   gentoo: [dev-python/rosdistro]
   nixos: [python3Packages.rosdistro]
   openembedded: [python3-rosdistro@meta-ros-common]
-  rhel: ["python%{python3_pkgversion}-rosdistro"]
+  rhel: ['python%{python3_pkgversion}-rosdistro']
   ubuntu: [python3-rosdistro-modules]
 python3-rosinstall-generator:
   fedora: [python3-rosinstall_generator]
@@ -8113,7 +7981,7 @@ python3-rospkg:
   osx:
     pip:
       packages: [rospkg]
-  rhel: ["python%{python3_pkgversion}-rospkg"]
+  rhel: ['python%{python3_pkgversion}-rospkg']
   slackware:
     pip:
       packages: [rospkg]
@@ -8135,7 +8003,7 @@ python3-rospkg-modules:
   osx:
     pip:
       packages: [rospkg]
-  rhel: ["python%{python3_pkgversion}-rospkg"]
+  rhel: ['python%{python3_pkgversion}-rospkg']
   slackware:
     pip:
       packages: [rospkg]
@@ -8145,8 +8013,8 @@ python3-rtree:
   fedora: [python3-rtree]
   nixos: [python3Packages.Rtree]
   rhel:
-    "*": [python3-rtree]
-    "7": null
+    '*': [python3-rtree]
+    '7': null
   ubuntu: [python3-rtree]
 python3-ruamel.yaml:
   debian:
@@ -8155,7 +8023,7 @@ python3-ruamel.yaml:
   fedora: [python3-ruamel-yaml]
   nixos: [python3Packages.ruamel_yaml]
   openembedded: [python3-ruamel-yaml@meta-python]
-  rhel: ["python%{python3_pkgversion}-ruamel-yaml"]
+  rhel: ['python%{python3_pkgversion}-ruamel-yaml']
   ubuntu: [python3-ruamel.yaml]
 python3-sbp-pip: *migrate_eol_2027_04_30_python3_sbp_pip
 python3-schedule:
@@ -8187,7 +8055,7 @@ python3-scipy:
     pip:
       depends: [gfortran]
       packages: [scipy]
-  rhel: ["python%{python3_pkgversion}-scipy"]
+  rhel: ['python%{python3_pkgversion}-scipy']
   ubuntu: [python3-scipy]
 python3-scp:
   debian: [python3-scp]
@@ -8195,8 +8063,8 @@ python3-scp:
   nixos: [python3Packages.scp]
   opensuse: [python3-scp]
   rhel:
-    "*": [python3-scp]
-    "7": null
+    '*': [python3-scp]
+    '7': null
   ubuntu: [python3-scp]
 python3-seaborn:
   arch: [python-seaborn]
@@ -8206,18 +8074,18 @@ python3-seaborn:
   ubuntu: [python3-seaborn]
 python3-segno:
   debian:
-    "*": [python3-segno]
+    '*': [python3-segno]
     buster: null
   fedora:
-    "*": [python3-segno]
-    "36": null
-    "37": null
+    '*': [python3-segno]
+    '36': null
+    '37': null
   rhel:
-    "*": [python3-segno]
-    "7": null
-    "8": null
+    '*': [python3-segno]
+    '7': null
+    '8': null
   ubuntu:
-    "*": [python3-segno]
+    '*': [python3-segno]
     bionic:
       pip:
         packages: [segno]
@@ -8234,8 +8102,8 @@ python3-selenium:
     pip:
       packages: [selenium]
   rhel:
-    "*": [python3-selenium]
-    "7": null
+    '*': [python3-selenium]
+    '7': null
   ubuntu: [python3-selenium]
 python3-semantic-version:
   debian: [python3-semantic-version]
@@ -8267,8 +8135,8 @@ python3-serial:
   nixos: [python3Packages.pyserial]
   openembedded: [python3-pyserial@meta-python]
   rhel:
-    "*": ["python%{python3_pkgversion}-pyserial"]
-    "7": null
+    '*': ['python%{python3_pkgversion}-pyserial']
+    '7': null
   ubuntu: [python3-serial]
 python3-setuptools:
   alpine: [py3-setuptools]
@@ -8282,18 +8150,18 @@ python3-setuptools:
   osx:
     pip:
       packages: [setuptools]
-  rhel: ["python%{python3_pkgversion}-setuptools"]
+  rhel: ['python%{python3_pkgversion}-setuptools']
   ubuntu: [python3-setuptools]
 python3-sexpdata:
   debian:
-    "*": [python3-sexpdata]
+    '*': [python3-sexpdata]
     stretch:
       pip:
         packages: [sexpdata]
   fedora: [python3-sexpdata]
   nixos: [python3Packages.sexpdata]
   ubuntu:
-    "*": [python3-sexpdata]
+    '*': [python3-sexpdata]
     bionic:
       pip:
         packages: [sexpdata]
@@ -8447,11 +8315,11 @@ python3-smc-pip:
       packages: [smc]
 python3-socketio:
   debian:
-    "*": [python3-socketio]
+    '*': [python3-socketio]
     buster: null
   fedora: [python3-socketio]
   ubuntu:
-    "*": [python3-socketio]
+    '*': [python3-socketio]
     bionic: null
 python3-sortedcollections-pip:
   debian:
@@ -8498,7 +8366,7 @@ python3-sphinx:
   nixos: [python3Packages.sphinx]
   openembedded: [python3-sphinx@meta-ros-common]
   opensuse: [python3-Sphinx]
-  rhel: ["python%{python3_pkgversion}-sphinx"]
+  rhel: ['python%{python3_pkgversion}-sphinx']
   ubuntu: [python3-sphinx]
 python3-sphinx-argparse:
   debian: [python3-sphinx-argparse]
@@ -8509,7 +8377,7 @@ python3-sphinx-rtd-theme:
   debian: [python3-sphinx-rtd-theme]
   fedora: [python3-sphinx_rtd_theme]
   nixos: [python3Packages.sphinx_rtd_theme]
-  rhel: ["python%{python3_pkgversion}-sphinx_rtd_theme"]
+  rhel: ['python%{python3_pkgversion}-sphinx_rtd_theme']
   ubuntu: [python3-sphinx-rtd-theme]
 python3-spidev-pip: *migrate_eol_2025_04_30_python3_spidev_pip
 python3-sqlalchemy:
@@ -8604,15 +8472,15 @@ python3-systemd:
   fedora: [python3-systemd]
   nixos: [python3Packages.systemd]
   rhel:
-    "*": [python3-systemd]
-    "7": null
+    '*': [python3-systemd]
+    '7': null
   ubuntu: [python3-systemd]
 python3-sysv-ipc:
   debian: [python3-sysv-ipc]
   fedora: [python3-sysv_ipc]
   rhel:
-    "*": [python3-sysv_ipc]
-    "7": null
+    '*': [python3-sysv_ipc]
+    '7': null
   ubuntu: [python3-sysv-ipc]
 python3-tables:
   debian: [python3-tables]
@@ -8651,7 +8519,7 @@ python3-texttable:
   gentoo: [dev-python/texttable]
   nixos: [python3Packages.texttable]
   openembedded: [python3-texttable@meta-python]
-  rhel: ["python%{python3_pkgversion}-texttable"]
+  rhel: ['python%{python3_pkgversion}-texttable']
   ubuntu: [python3-texttable]
 python3-thop-pip:
   debian:
@@ -8705,7 +8573,7 @@ python3-tk:
   nixos: [python3Packages.tkinter]
   openembedded: [python3-tkinter@openembedded-core]
   opensuse: [python3-tk]
-  rhel: ["python%{python3_pkgversion}-tkinter"]
+  rhel: ['python%{python3_pkgversion}-tkinter']
   ubuntu: [python3-tk]
 python3-toml:
   debian: [python3-toml]
@@ -8724,7 +8592,7 @@ python3-tornado:
   osx:
     pip:
       packages: [tornado]
-  rhel: ["python%{python3_pkgversion}-tornado"]
+  rhel: ['python%{python3_pkgversion}-tornado']
   ubuntu: [python3-tornado]
 python3-tqdm:
   alpine: [py3-tqdm]
@@ -8735,7 +8603,7 @@ python3-tqdm:
     pip:
       packages: [tqdm]
   ubuntu:
-    "*": [python3-tqdm]
+    '*': [python3-tqdm]
 python3-transformers-pip:
   debian:
     pip:
@@ -8749,7 +8617,7 @@ python3-transforms3d:
       packages: [transforms3d]
   fedora: [python3-transforms3d]
   ubuntu:
-    "*": [python3-transforms3d]
+    '*': [python3-transforms3d]
     bionic:
       pip:
         packages: [transforms3d]
@@ -8758,7 +8626,7 @@ python3-transforms3d:
         packages: [transforms3d]
 python3-transitions:
   debian:
-    "*": [python3-transitions]
+    '*': [python3-transitions]
     buster:
       pip:
         packages: [transitions]
@@ -8803,8 +8671,8 @@ python3-twisted:
   openembedded: [python3-twisted@meta-python]
   opensuse: [python3-Twisted]
   rhel:
-    "*": ["python%{python3_pkgversion}-twisted"]
-    "7": null
+    '*': ['python%{python3_pkgversion}-twisted']
+    '7': null
   ubuntu: [python3-twisted]
 python3-typeguard:
   arch: [python-typeguard]
@@ -8815,10 +8683,10 @@ python3-typeguard:
     pip:
       packages: [typeguard]
   rhel:
-    "*": [python3-typeguard]
-    "7": null
+    '*': [python3-typeguard]
+    '7': null
   ubuntu:
-    "*": [python3-typeguard]
+    '*': [python3-typeguard]
     bionic:
       pip:
         packages: [typeguard]
@@ -8839,10 +8707,10 @@ python3-typing-extensions:
   gentoo: [dev-python/typing-extensions]
   opensuse: [python3-typing_extensions]
   rhel:
-    "*": [python3-typing-extensions]
-    "7": null
+    '*': [python3-typing-extensions]
+    '7': null
   ubuntu:
-    "*": [python3-typing-extensions]
+    '*': [python3-typing-extensions]
     bionic:
       pip:
         packages: [typing-extensions]
@@ -8854,13 +8722,13 @@ python3-tz:
   gentoo: [dev-python/pytz]
   nixos: [python39Packages.pytz]
   rhel:
-    "*": [python3-pytz]
-    "7": null
+    '*': [python3-pytz]
+    '7': null
   ubuntu: [python3-tz]
 python3-ubjson:
   debian: [python3-ubjson]
   ubuntu:
-    "*": [python3-ubjson]
+    '*': [python3-ubjson]
 python3-ujson:
   debian: [python3-ujson]
   fedora: [python3-ujson]
@@ -8870,8 +8738,8 @@ python3-ujson:
     pip:
       packages: [ujson]
   rhel:
-    "*": [python3-ujson]
-    "7": null
+    '*': [python3-ujson]
+    '7': null
   ubuntu: [python3-ujson]
 python3-ultralytics-pip:
   debian:
@@ -8913,7 +8781,7 @@ python3-uvicorn:
   debian: [python3-uvicorn]
   fedora: [python-uvicorn]
   ubuntu:
-    "*": [python3-uvicorn]
+    '*': [python3-uvicorn]
     bionic:
       pip:
         packages: [uvicorn]
@@ -8968,8 +8836,8 @@ python3-voluptuous:
   gentoo: [dev-python/voluptuous]
   opensuse: [python-voluptuous]
   rhel:
-    "*": [python3-voluptuous]
-    "7": null
+    '*': [python3-voluptuous]
+    '7': null
   ubuntu: [python3-voluptuous]
 python3-watchdog:
   debian: [python3-watchdog]
@@ -8994,7 +8862,7 @@ python3-weasyprint-pip:
 python3-webargs:
   arch: [python-webargs]
   debian:
-    "*": [python3-webargs]
+    '*': [python3-webargs]
     bullseye:
       pip:
         packages: [webargs]
@@ -9003,7 +8871,7 @@ python3-webargs:
         packages: [webargs]
   nixos: [python39Packages.webargs]
   ubuntu:
-    "*": [python3-webargs]
+    '*': [python3-webargs]
     bionic:
       pip:
         packages: [webargs]
@@ -9017,7 +8885,7 @@ python3-websocket:
   nixos: [python3Packages.websocket-client]
   openembedded: [python3-websocket-client@meta-python]
   opensuse: [python3-websocket-client]
-  rhel: ["python%{python3_pkgversion}-websocket-client"]
+  rhel: ['python%{python3_pkgversion}-websocket-client']
   ubuntu: [python3-websocket]
 python3-websockets:
   arch: [python-websockets]
@@ -9055,8 +8923,8 @@ python3-whichcraft:
   nixos: [python3Packages.whichcraft]
   openembedded: [python3-whichcraft@meta-ros-common]
   rhel:
-    "*": [python3-whichcraft]
-    "7": null
+    '*': [python3-whichcraft]
+    '7': null
   ubuntu: [python3-whichcraft]
 python3-wrapt:
   arch: [python-wrapt]
@@ -9066,7 +8934,7 @@ python3-wrapt:
   nixos: [python3Packages.wrapt]
   opensuse: [python3-wrapt]
   rhel:
-    "8": [python3-wrapt]
+    '8': [python3-wrapt]
   ubuntu: [python3-wrapt]
 python3-wxgtk4.0:
   debian: [python3-wxgtk4.0]
@@ -9083,7 +8951,7 @@ python3-xdot:
   ubuntu: [xdot]
 python3-xmlschema:
   debian:
-    "*": [python3-xmlschema]
+    '*': [python3-xmlschema]
     buster:
       pip:
         packages: [xmlschema]
@@ -9111,11 +8979,11 @@ python3-yaml:
   osx:
     pip:
       packages: [pyyaml]
-  rhel: ["python%{python3_pkgversion}-yaml"]
+  rhel: ['python%{python3_pkgversion}-yaml']
   ubuntu: [python3-yaml]
 python3-yappi:
   debian:
-    "*": [python3-yappi]
+    '*': [python3-yappi]
     buster: null
     stretch: null
   fedora: [python3-yappi]
@@ -9123,7 +8991,7 @@ python3-yappi:
   osx:
     pip: [yappi]
   ubuntu:
-    "*": [python3-yappi]
+    '*': [python3-yappi]
     bionic: null
 python3-yolov5:
   debian:
@@ -9251,9 +9119,9 @@ wxpython:
   openembedded: [wxpython@meta-ros-python2]
   opensuse: [python-wxWidgets-3_0-devel]
   rhel:
-    "7": [wxPython-devel]
+    '7': [wxPython-devel]
   ubuntu:
-    "*": [python-wxgtk3.0]
+    '*': [python-wxgtk3.0]
 yapf:
   arch: [yapf]
   debian:
@@ -9268,7 +9136,7 @@ yapf3:
   fedora: [python3-yapf]
   nixos: [python3Packages.yapf]
   ubuntu:
-    "*": [yapf3]
+    '*': [yapf3]
 zulip-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5896,7 +5896,11 @@ python3-flatbuffers:
   osx:
     pip:
       packages: [flatbuffers]
-  rhel: [python3-flatbuffers]
+  rhel:
+    '*': [python3-flatbuffers]
+    '8':
+      pip:
+        packages: [flatbuffers]
   ubuntu:
     '*': [python3-flatbuffers]
     focal:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5898,9 +5898,7 @@ python3-flatbuffers:
       packages: [flatbuffers]
   rhel:
     '*': [python3-flatbuffers]
-    '8':
-      pip:
-        packages: [flatbuffers]
+    '8': null
   ubuntu:
     '*': [python3-flatbuffers]
     focal:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -110,7 +110,7 @@ black:
   gentoo: [dev-python/black]
   nixos: [pythonPackages.black]
   ubuntu:
-    '*': [black]
+    "*": [black]
     bionic: null
 canopen-pip:
   debian:
@@ -252,8 +252,8 @@ ipython3:
   nixos: [python3Packages.ipython]
   openembedded: [python3-ipython@meta-python]
   rhel:
-    '*': [python3-ipython]
-    '7': null
+    "*": [python3-ipython]
+    "7": null
   ubuntu: [ipython3]
 jupyter-nbconvert:
   arch: [jupyter-nbconvert]
@@ -262,14 +262,14 @@ jupyter-nbconvert:
   gentoo: [dev-python/nbconvert]
   nixos: [python3Packages.nbconvert]
   ubuntu:
-    '*': [jupyter-nbconvert]
+    "*": [jupyter-nbconvert]
 jupyter-notebook:
   debian:
-    '*': [jupyter-notebook]
+    "*": [jupyter-notebook]
   fedora: [python3-notebook]
   nixos: [jupyter]
   ubuntu:
-    '*': [jupyter-notebook]
+    "*": [jupyter-notebook]
 libgv-python:
   debian: [libgv-python]
   ubuntu: [libgv-python]
@@ -319,13 +319,13 @@ paramiko:
   gentoo: [dev-python/paramiko]
   macports: [py27-paramiko]
   nixos: [pythonPackages.paramiko]
-  openembedded: ['${PYTHON_PN}-paramiko@meta-ros-common']
+  openembedded: ["${PYTHON_PN}-paramiko@meta-ros-common"]
   opensuse: [python-paramiko]
   osx:
     pip:
       packages: [paramiko]
   rhel:
-    '7': [python-paramiko]
+    "7": [python-paramiko]
   ubuntu: [python-paramiko]
 pi-ina219-pip:
   debian:
@@ -349,13 +349,13 @@ pydocstyle:
   fedora: [python3-pydocstyle]
   gentoo: [dev-python/pydocstyle]
   nixos: [python3Packages.pydocstyle]
-  openembedded: ['${PYTHON_PN}-pydocstyle@meta-ros-common']
+  openembedded: ["${PYTHON_PN}-pydocstyle@meta-ros-common"]
   osx:
     pip:
       packages: [pydocstyle]
   rhel:
-    '*': [python3-pydocstyle]
-    '7': null
+    "*": [python3-pydocstyle]
+    "7": null
   ubuntu: [pydocstyle]
 pydrive-pip:
   debian:
@@ -377,15 +377,15 @@ pyflakes3:
   fedora: [python3-pyflakes]
   gentoo: [dev-python/pyflakes]
   nixos: [python3Packages.pyflakes]
-  openembedded: ['${PYTHON_PN}-pyflakes@meta-ros-common']
+  openembedded: ["${PYTHON_PN}-pyflakes@meta-ros-common"]
   osx:
     pip:
       packages: [pyflakes]
-  rhel: ['python%{python3_pkgversion}-pyflakes']
+  rhel: ["python%{python3_pkgversion}-pyflakes"]
   ubuntu: [pyflakes3]
 pymap3d-pip:
   debian:
-    '*': null
+    "*": null
     buster:
       pip:
         packages: [pymap3d]
@@ -399,7 +399,7 @@ pymap3d-pip:
     pip:
       packages: [pymap3d]
   ubuntu:
-    '*': null
+    "*": null
     bionic:
       pip:
         packages: [pymap3d]
@@ -442,7 +442,7 @@ pyqt5-dev-tools:
   debian: [pyqt5-dev-tools]
   fedora: [python-qt5-devel]
   gentoo: [dev-python/PyQt5]
-  openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
+  openembedded: ["${PYTHON_PN}-pyqt5@meta-qt5"]
   rhel: [python3-qt5-devel]
   ubuntu: [pyqt5-dev-tools]
 pyrebase-pip:
@@ -485,8 +485,8 @@ python:
   openembedded: [python@meta-python2]
   opensuse: [python-devel]
   rhel:
-    '7': [python2-devel]
-    '8': [python2-devel]
+    "7": [python2-devel]
+    "8": [python2-devel]
   slackware:
     slackpkg:
       packages: [python]
@@ -519,7 +519,7 @@ python-alembic:
   fedora: [python-alembic]
   gentoo: [dev-python/alembic]
   ubuntu:
-    '*': [python-alembic]
+    "*": [python-alembic]
 python-amqp:
   debian:
     buster: [python-amqp]
@@ -531,7 +531,7 @@ python-aniso8601:
   debian: [python-aniso8601]
   gentoo: [dev-python/aniso8601]
   rhel:
-    '7': [python-aniso8601]
+    "7": [python-aniso8601]
   ubuntu:
     bionic: [python-aniso8601]
 python-annoy-pip:
@@ -554,7 +554,7 @@ python-anyjson:
   ubuntu: [python-anyjson]
 python-apparmor:
   debian: [python-apparmor]
-  gentoo: ['sys-libs/libapparmor[python]']
+  gentoo: ["sys-libs/libapparmor[python]"]
   ubuntu: [python-apparmor]
 python-argcomplete:
   fedora: [python-argcomplete]
@@ -587,13 +587,13 @@ python-argparse:
     pip:
       packages: [argparse]
   rhel:
-    '7': [python2]
-    '8': [python2]
+    "7": [python2]
+    "8": [python2]
   slackware:
     pip:
       packages: [argparse]
   ubuntu:
-    '*': []
+    "*": []
 python-astor-pip:
   debian:
     pip:
@@ -612,7 +612,7 @@ python-attrs:
   gentoo: [dev-python/attrs]
   nixos: [pythonPackages.attrs]
   ubuntu:
-    '*':
+    "*":
       packages: [python-attr]
       pip:
         packages: [attrs]
@@ -630,17 +630,17 @@ python-autobahn:
       packages: [autobahn]
   gentoo: [dev-python/autobahn]
   nixos: [pythonPackages.autobahn]
-  openembedded: ['${PYTHON_PN}-autobahn@meta-python']
+  openembedded: ["${PYTHON_PN}-autobahn@meta-python"]
   osx:
     pip:
       packages: [autobahn]
   ubuntu:
-    '*': [python-autobahn]
+    "*": [python-autobahn]
 python-avahi:
   arch: [avahi]
   debian: [python-avahi]
   fedora: [avahi-ui-tools]
-  gentoo: ['net-dns/avahi[python]']
+  gentoo: ["net-dns/avahi[python]"]
   nixos: [pythonPackages.avahi]
   opensuse: [python3-avahi]
   ubuntu: [python-avahi]
@@ -672,7 +672,7 @@ python-backports.ssl-match-hostname:
   debian: [python-backports.ssl-match-hostname]
   gentoo: [dev-python/backports-ssl-match-hostname]
   nixos: [pythonPackages.backports_ssl_match_hostname]
-  openembedded: ['${PYTHON_PN}-backports-ssl@meta-python']
+  openembedded: ["${PYTHON_PN}-backports-ssl@meta-python"]
   ubuntu:
     bionic: [python-backports.ssl-match-hostname]
 python-bcrypt:
@@ -723,13 +723,13 @@ python-bloom:
   fedora: [python-bloom]
   gentoo: [dev-python/bloom]
   ubuntu:
-    '*': [python-bloom]
+    "*": [python-bloom]
 python-bluez:
   arch: [python2-pybluez]
   debian: [python-bluez]
   gentoo: [dev-python/pybluez]
   nixos: [pythonPackages.pybluez]
-  openembedded: ['${PYTHON_PN}-pybluez@meta-python']
+  openembedded: ["${PYTHON_PN}-pybluez@meta-python"]
   ubuntu: [python-bluez]
 python-bokeh-pip:
   debian:
@@ -740,7 +740,7 @@ python-bokeh-pip:
       packages: [bokeh]
 python-boltons:
   debian:
-    '*': [python-boltons]
+    "*": [python-boltons]
     wheezy:
       pip:
         packages: [boltons]
@@ -751,16 +751,16 @@ python-boltons:
     pip:
       packages: [boltons]
   ubuntu:
-    '*': [python-boltons]
+    "*": [python-boltons]
 python-boto3:
   arch: [python-boto3]
   debian: [python-boto3]
   gentoo: [dev-python/boto3]
   nixos: [pythonPackages.boto3]
-  openembedded: ['${PYTHON_PN}-boto3@meta-ros-common']
+  openembedded: ["${PYTHON_PN}-boto3@meta-ros-common"]
   opensuse: [python-boto3]
   ubuntu:
-    '*': [python-boto3]
+    "*": [python-boto3]
 python-bottle:
   debian: [python-bottle]
   fedora: [python-bottle]
@@ -784,7 +784,7 @@ python-bson:
   fedora: [python-bson]
   gentoo: [dev-python/pymongo]
   nixos: [pythonPackages.bson]
-  openembedded: ['${PYTHON_PN}-pymongo@meta-python']
+  openembedded: ["${PYTHON_PN}-pymongo@meta-python"]
   osx:
     pip:
       packages: [bson]
@@ -798,8 +798,8 @@ python-cairo:
   nixos: [pythonPackages.pycairo]
   opensuse: [python2-cairo]
   rhel:
-    '7': [pycairo]
-    '8': [python2-cairo]
+    "7": [pycairo]
+    "8": [python2-cairo]
   slackware:
     slackpkg:
       packages: [pycairo]
@@ -839,7 +839,7 @@ python-cantools-pip:
       packages: [cantools]
 python-catkin-lint:
   fedora: [python-catkin_lint]
-  openembedded: ['${PYTHON_PN}-catkin-lint@meta-ros-common']
+  openembedded: ["${PYTHON_PN}-catkin-lint@meta-ros-common"]
   ubuntu: [python-catkin-lint]
 python-catkin-pkg:
   alpine:
@@ -854,13 +854,13 @@ python-catkin-pkg:
   gentoo: [dev-python/catkin_pkg]
   macports: [python-catkin-pkg]
   nixos: [pythonPackages.catkin-pkg]
-  openembedded: ['${PYTHON_PN}-catkin-pkg@meta-ros-common']
+  openembedded: ["${PYTHON_PN}-catkin-pkg@meta-ros-common"]
   opensuse: [python-catkin_pkg]
   osx:
     pip:
       packages: [catkin-pkg]
   rhel:
-    '7': [python2-catkin_pkg]
+    "7": [python2-catkin_pkg]
   slackware:
     pip:
       packages: [catkin-pkg]
@@ -879,7 +879,7 @@ python-catkin-pkg-modules:
   gentoo: [dev-python/catkin_pkg]
   macports: [python-catkin-pkg]
   nixos: [pythonPackages.catkin-pkg]
-  openembedded: ['${PYTHON_PN}-catkin-pkg@meta-ros-common']
+  openembedded: ["${PYTHON_PN}-catkin-pkg@meta-ros-common"]
   opensuse: [python-catkin_pkg]
   osx:
     pip:
@@ -903,13 +903,13 @@ python-catkin-sphinx:
     pip:
       packages: [catkin_sphinx]
   ubuntu:
-    '*': null
+    "*": null
     bionic: [python-catkin-sphinx]
 python-catkin-tools:
   arch: [python2-catkin-tools]
   debian: [python-catkin-tools]
   fedora: [python-catkin_tools]
-  openembedded: ['${PYTHON_PN}-catkin-tools@meta-ros-common']
+  openembedded: ["${PYTHON_PN}-catkin-tools@meta-ros-common"]
   osx:
     pip:
       packages: [catkin_tools]
@@ -987,7 +987,7 @@ python-cheetah:
   fedora: [python-cheetah]
   gentoo: [dev-python/cheetah]
   nixos: [pythonPackages.cheetah]
-  openembedded: ['${PYTHON_PN}-cheetah@meta-python']
+  openembedded: ["${PYTHON_PN}-cheetah@meta-python"]
   opensuse: [python-Cheetah]
   ubuntu: [python-cheetah]
 python-cherrypy:
@@ -999,7 +999,7 @@ python-cherrypy:
 python-clearsilver:
   debian: [python-clearsilver]
   rhel:
-    '7': [python-clearsilver]
+    "7": [python-clearsilver]
   ubuntu: [python-clearsilver]
 python-click:
   debian:
@@ -1008,7 +1008,7 @@ python-click:
   fedora: [python-click]
   gentoo: [dev-python/click]
   nixos: [pythonPackages.click]
-  openembedded: ['${PYTHON_PN}-click@meta-python']
+  openembedded: ["${PYTHON_PN}-click@meta-python"]
   osx:
     pip:
       packages: [click]
@@ -1109,8 +1109,8 @@ python-coverage:
     pip:
       packages: [coverage]
   rhel:
-    '7': [python-coverage]
-    '8': [python2-coverage]
+    "7": [python-coverage]
+    "8": [python2-coverage]
   slackware: [coverage]
   ubuntu:
     bionic: [python-coverage]
@@ -1159,7 +1159,7 @@ python-crypto:
   freebsd: [py27-pycrypto]
   gentoo: [dev-python/pycrypto]
   nixos: [pythonPackages.pycrypto]
-  openembedded: ['${PYTHON_PN}-pycrypto@meta-python']
+  openembedded: ["${PYTHON_PN}-pycrypto@meta-python"]
   opensuse: [python2-pycrypto]
   osx:
     pip:
@@ -1170,18 +1170,18 @@ python-cryptography:
   debian: [python-cryptography]
   gentoo: [dev-python/cryptography]
   rhel:
-    '7': [python2-cryptography]
+    "7": [python2-cryptography]
   ubuntu: [python-cryptography]
 python-cvxopt:
   arch: [python-cvxopt]
   debian:
-    '*': null
+    "*": null
     buster: [python-cvxopt]
   fedora: [python-cvxopt]
   macports: [py27-cvxopt]
   nixos: [pythonPackages.cvxopt]
   ubuntu:
-    '*': null
+    "*": null
     bionic: [python-cvxopt]
 python-cvxpy-pip: &migrate_eol_2025_04_30_python3_cvxpy_pip
   debian:
@@ -1196,7 +1196,7 @@ python-cvxpy-pip: &migrate_eol_2025_04_30_python3_cvxpy_pip
 python-cwiid:
   arch: [cwiid]
   debian: [python-cwiid]
-  gentoo: ['app-misc/cwiid[python]']
+  gentoo: ["app-misc/cwiid[python]"]
   ubuntu: [python-cwiid]
 python-cython-pip:
   arch:
@@ -1262,13 +1262,13 @@ python-defusedxml:
   freebsd: [py27-defusedxml]
   gentoo: [dev-python/defusedxml]
   nixos: [pythonPackages.defusedxml]
-  openembedded: ['${PYTHON_PN}-defusedxml@meta-ros-common']
+  openembedded: ["${PYTHON_PN}-defusedxml@meta-ros-common"]
   opensuse: [python2-defusedxml]
   osx:
     pip:
       packages: [defusedxml]
   rhel:
-    '7': [python2-defusedxml]
+    "7": [python2-defusedxml]
   slackware:
     pip:
       packages: [defusedxml]
@@ -1370,13 +1370,13 @@ python-empy:
   gentoo: [dev-python/empy]
   macports: [py27-empy]
   nixos: [pythonPackages.empy]
-  openembedded: ['${PYTHON_PN}-empy@meta-ros-common']
+  openembedded: ["${PYTHON_PN}-empy@meta-ros-common"]
   opensuse: [python2-empy]
   osx:
     pip:
       packages: [empy]
   rhel:
-    '7': [python2-empy]
+    "7": [python2-empy]
   slackware:
     pip:
       packages: [empy]
@@ -1391,7 +1391,7 @@ python-enum34:
     stretch: [python-enum34]
   gentoo: [virtual/python-enum34]
   nixos: [pythonPackages.enum34]
-  openembedded: ['${PYTHON_PN}-enum34@meta-python']
+  openembedded: ["${PYTHON_PN}-enum34@meta-python"]
   opensuse: [python-enum34]
   ubuntu: [python-enum34]
 python-enum34-pip:
@@ -1506,7 +1506,7 @@ python-flake8:
   fedora: [python-flake8]
   gentoo: [dev-python/flake8]
   nixos: [python3Packages.flake8]
-  openembedded: ['${PYTHON_PN}-flake8@meta-ros-common']
+  openembedded: ["${PYTHON_PN}-flake8@meta-ros-common"]
   ubuntu:
     bionic: [python-flake8]
 python-flask:
@@ -1516,7 +1516,7 @@ python-flask:
   gentoo: [dev-python/flask]
   nixos: [pythonPackages.flask]
   ubuntu:
-    '*': [python-flask]
+    "*": [python-flask]
 python-flask-appbuilder-pip:
   debian:
     pip:
@@ -1575,15 +1575,15 @@ python-funcsigs:
   debian: [python-funcsigs]
   fedora: [python-funcsigs]
   rhel:
-    '7': [python2-funcsigs]
-    '8': [python2-funcsigs]
+    "7": [python2-funcsigs]
+    "8": [python2-funcsigs]
   ubuntu: [python-funcsigs]
 python-future:
   debian: [python-future]
   fedora: [python-future]
   gentoo: [dev-python/future]
   nixos: [pythonPackages.future]
-  openembedded: ['${PYTHON_PN}-future@meta-python']
+  openembedded: ["${PYTHON_PN}-future@meta-python"]
   opensuse: [python2-future]
   osx:
     pip:
@@ -1631,7 +1631,7 @@ python-gdal:
   debian:
     buster: [python-gdal]
     stretch: [python-gdal]
-  gentoo: ['sci-libs/gdal[python]']
+  gentoo: ["sci-libs/gdal[python]"]
   ubuntu:
     bionic: [python-gdal]
 python-gdown-pip: &migrate_eol_2025_04_30_python3_gdown_pip
@@ -1726,22 +1726,22 @@ python-gnupg:
   freebsd: [py27-python-gnupg]
   gentoo: [dev-python/python-gnupg]
   nixos: [pythonPackages.python-gnupg]
-  openembedded: ['${PYTHON_PN}-gnupg@meta-ros-common']
+  openembedded: ["${PYTHON_PN}-gnupg@meta-ros-common"]
   opensuse: [python2-python-gnupg]
   rhel:
-    '7': [python2-gnupg]
+    "7": [python2-gnupg]
   ubuntu: [python-gnupg]
 python-gobject:
   arch: [python2-gobject]
   debian:
-    '*': null
+    "*": null
     buster: [python-gobject]
     stretch: [python-gobject]
   gentoo: [dev-python/pygobject]
   nixos: [pythonPackages.pygobject2]
   opensuse: [python2-gobject]
   ubuntu:
-    '*': null
+    "*": null
     bionic: [python-gobject]
     focal: [python-gobject]
 python-google-cloud-bigquery-pip:
@@ -1761,7 +1761,8 @@ python-google-cloud-speech-pip:
   ubuntu:
     pip:
       packages: [google-cloud-speech]
-python-google-cloud-storage-pip: &migrate_eol_2025_04_30_python3_google_cloud_storage_pip
+python-google-cloud-storage-pip:
+  &migrate_eol_2025_04_30_python3_google_cloud_storage_pip
   debian:
     pip:
       packages: [google-cloud-storage]
@@ -1771,7 +1772,8 @@ python-google-cloud-storage-pip: &migrate_eol_2025_04_30_python3_google_cloud_st
   ubuntu:
     pip:
       packages: [google-cloud-storage]
-python-google-cloud-texttospeech-pip: &migrate_eol_2025_04_30_python3_google_cloud_texttospeech_pip
+python-google-cloud-texttospeech-pip:
+  &migrate_eol_2025_04_30_python3_google_cloud_texttospeech_pip
   debian:
     pip:
       packages: [google-cloud-texttospeech]
@@ -1843,21 +1845,21 @@ python-gridfs:
   fedora: [python-pymongo-gridfs]
 python-grpc-tools:
   debian:
-    '*': [python-grpc-tools]
+    "*": [python-grpc-tools]
     stretch:
       pip: [grpcio-tools]
   nixos: [pythonPackages.grpcio-tools]
   ubuntu:
-    '*': [python-grpc-tools]
+    "*": [python-grpc-tools]
     bionic:
       pip: [grpcio-tools]
 python-grpcio:
   debian:
-    '*': [python-grpcio]
+    "*": [python-grpcio]
     stretch:
       pip: [grpcio]
   ubuntu:
-    '*': [python-grpcio]
+    "*": [python-grpcio]
     bionic:
       pip: [grpcio]
 python-gst:
@@ -1869,13 +1871,13 @@ python-gst-1.0:
   debian:
     buster: [python-gst-1.0]
     stretch: [python-gst-1.0]
-  gentoo: ['dev-python/gst-python:1.0']
+  gentoo: ["dev-python/gst-python:1.0"]
   openembedded: [gstreamer1.0-python@openembedded-core]
   ubuntu: [python-gst-1.0]
 python-gtk2:
   arch: [pygtk]
   debian:
-    '*': null
+    "*": null
     buster: [python-gtk2]
   fedora: [pygtk2]
   freebsd: [py-gtk2]
@@ -1887,10 +1889,10 @@ python-gtk2:
     pip:
       packages: []
   rhel:
-    '7': [pygtk2]
-    '8': [pygtk2]
+    "7": [pygtk2]
+    "8": [pygtk2]
   ubuntu:
-    '*': null
+    "*": null
     bionic: [python-gtk2]
 python-gurobipy-pip: &migrate_eol_2025_04_30_python3_gurobipy_pip
   debian:
@@ -1908,19 +1910,19 @@ python-h5py:
   nixos: [pythonPackages.h5py]
   opensuse: [python2-h5py]
   ubuntu:
-    '*': [python-h5py]
+    "*": [python-h5py]
 python-httplib2:
   debian: [python-httplib2]
   fedora: [python-httplib2]
   gentoo: [dev-python/httplib2]
   ubuntu:
-    '*': [python-httplib2]
+    "*": [python-httplib2]
 python-hypothesis:
   debian: [python-hypothesis]
   fedora: [python-hypothesis]
   gentoo: [dev-python/hypothesis]
   ubuntu:
-    '*': [python-hypothesis]
+    "*": [python-hypothesis]
 python-imageio:
   debian:
     buster: [python-imageio]
@@ -1939,25 +1941,25 @@ python-imaging:
   alpine: [py-imaging]
   arch: [python2-pillow]
   debian:
-    '*': [python-pil]
+    "*": [python-pil]
     stretch: [python-imaging]
   fedora: [python-pillow, python-pillow-qt]
   freebsd: [py27-pillow]
   gentoo: [dev-python/pillow]
   macports: [py27-pil]
   nixos: [pythonPackages.pillow]
-  openembedded: ['${PYTHON_PN}-pillow@meta-python']
+  openembedded: ["${PYTHON_PN}-pillow@meta-python"]
   opensuse: [python2-Pillow]
   osx:
     pip:
       packages: [Pillow]
   rhel:
-    '7': [python-imaging]
+    "7": [python-imaging]
   slackware:
     slackpkg:
       packages: [python-pillow]
   ubuntu:
-    '*': [python-pil]
+    "*": [python-pil]
 python-imaging-imagetk:
   debian: [python-pil.imagetk]
   ubuntu: [python-pil.imagetk]
@@ -2008,7 +2010,7 @@ python-ipdb:
   ubuntu: [python-ipdb]
 python-is-python3:
   ubuntu:
-    '*': [python-is-python3]
+    "*": [python-is-python3]
     bionic: null
 python-itsdangerous:
   debian:
@@ -2017,7 +2019,7 @@ python-itsdangerous:
   fedora: [python-itsdangerous]
   gentoo: [dev-python/itsdangerous]
   ubuntu:
-    '*': null
+    "*": null
     bionic: [python-itsdangerous]
 python-j1939-pip: &migrate_eol_2025_04_30_python3_j1939_pip
   debian:
@@ -2145,7 +2147,7 @@ python-kombu:
   debian: [python-kombu]
   fedora: [python-kombu]
   rhel:
-    '7': [python-kombu]
+    "7": [python-kombu]
   ubuntu: [python-kombu]
 python-kombu-pip:
   ubuntu:
@@ -2228,14 +2230,14 @@ python-lxml:
   freebsd: [py27-lxml]
   gentoo: [dev-python/lxml]
   nixos: [pythonPackages.lxml]
-  openembedded: ['${PYTHON_PN}-lxml@meta-python']
+  openembedded: ["${PYTHON_PN}-lxml@meta-python"]
   opensuse: [python2-lxml]
   osx:
     pip:
       packages: [lxml]
   rhel:
-    '7': [python-lxml]
-    '8': [python2-lxml]
+    "7": [python-lxml]
+    "8": [python2-lxml]
   ubuntu:
     bionic: [python-lxml]
     focal: [python-lxml]
@@ -2260,11 +2262,11 @@ python-mapnik:
   ubuntu: [python-mapnik]
 python-marisa:
   debian:
-    '*': null
+    "*": null
     buster: [python-marisa]
     stretch: [python-marisa]
   ubuntu:
-    '*': null
+    "*": null
     bionic: [python-marisa]
 python-markdown:
   debian: [python-markdown]
@@ -2288,14 +2290,14 @@ python-matplotlib:
   gentoo: [dev-python/matplotlib]
   macports: [py27-matplotlib]
   nixos: [pythonPackages.matplotlib]
-  openembedded: ['${PYTHON_PN}-matplotlib@meta-python']
+  openembedded: ["${PYTHON_PN}-matplotlib@meta-python"]
   opensuse: [python2-matplotlib]
   osx:
     pip:
       depends: [pkg-config, freetype, libpng12-dev]
       packages: [matplotlib]
   rhel:
-    '7': [python-matplotlib]
+    "7": [python-matplotlib]
   slackware: [matplotlib]
   ubuntu:
     bionic: [python-matplotlib]
@@ -2308,11 +2310,11 @@ python-mechanize:
   ubuntu: [python-mechanize]
 python-mistune:
   debian:
-    '*': null
+    "*": null
     buster: [python-mistune]
   opensuse: [python2-mistune]
   ubuntu:
-    '*': null
+    "*": null
     bionic: [python-mistune]
 python-mock:
   alpine: [py-mock]
@@ -2322,14 +2324,14 @@ python-mock:
   freebsd: [py27-mock]
   gentoo: [dev-python/mock]
   nixos: [pythonPackages.mock]
-  openembedded: ['${PYTHON_PN}-mock@meta-python']
+  openembedded: ["${PYTHON_PN}-mock@meta-python"]
   opensuse: [python2-mock]
   osx:
     pip:
       packages: [mock]
   rhel:
-    '7': [python2-mock]
-    '8': [python2-mock]
+    "7": [python2-mock]
+    "8": [python2-mock]
   slackware: [mock]
   ubuntu:
     bionic: [python-mock]
@@ -2345,14 +2347,14 @@ python-more-itertools:
   debian: [python-more-itertools]
   fedora: [python-more-itertools]
   ubuntu:
-    '*': [python-more-itertools]
+    "*": [python-more-itertools]
 python-msgpack:
   arch: [python2-msgpack]
   debian: [python-msgpack]
   fedora: [python-msgpack]
   gentoo: [dev-python/msgpack]
   nixos: [pythonPackages.msgpack]
-  openembedded: ['${PYTHON_PN}-msgpack@meta-python2']
+  openembedded: ["${PYTHON_PN}-msgpack@meta-python2"]
   opensuse: [python2-msgpack]
   ubuntu: [python-msgpack]
 python-multicast:
@@ -2432,13 +2434,13 @@ python-netifaces:
   gentoo: [dev-python/netifaces]
   macports: [p27-netifaces]
   nixos: [pythonPackages.netifaces]
-  openembedded: ['${PYTHON_PN}-netifaces@meta-ros-common']
+  openembedded: ["${PYTHON_PN}-netifaces@meta-ros-common"]
   opensuse: [python2-netifaces]
   osx:
     pip:
       packages: [netifaces]
   rhel:
-    '7': [python-netifaces]
+    "7": [python-netifaces]
   slackware: [netifaces]
   ubuntu:
     bionic: [python-netifaces]
@@ -2453,7 +2455,7 @@ python-networkx:
   fedora: [python-networkx]
   gentoo: [dev-python/networkx]
   ubuntu:
-    '*': [python-networkx]
+    "*": [python-networkx]
 python-nose:
   alpine: [py-nose]
   arch: [python2-nose]
@@ -2463,17 +2465,17 @@ python-nose:
   gentoo: [dev-python/nose]
   macports: [py27-nose]
   nixos: [pythonPackages.nose]
-  openembedded: ['${PYTHON_PN}-nose@openembedded-core']
+  openembedded: ["${PYTHON_PN}-nose@openembedded-core"]
   opensuse: [python2-nose]
   osx:
     pip:
       packages: [nose]
   rhel:
-    '7': [python2-nose]
-    '8': [python2-nose]
+    "7": [python2-nose]
+    "8": [python2-nose]
   slackware: [nose]
   ubuntu:
-    '*': [python-nose]
+    "*": [python-nose]
 python-ntplib:
   debian: [python-ntplib]
   fedora: [python-ntplib]
@@ -2488,14 +2490,14 @@ python-numpy:
   gentoo: [dev-python/numpy]
   macports: [py27-numpy]
   nixos: [pythonPackages.numpy]
-  openembedded: ['${PYTHON_PN}-numpy@openembedded-core']
+  openembedded: ["${PYTHON_PN}-numpy@openembedded-core"]
   opensuse: [python2-numpy-devel]
   osx:
     pip:
       packages: [numpy]
   rhel:
-    '7': [python2-numpy]
-    '8': [python2-numpy]
+    "7": [python2-numpy]
+    "8": [python2-numpy]
   slackware: [numpy]
   ubuntu:
     bionic: [python-numpy]
@@ -2545,9 +2547,9 @@ python-omniorb:
   arch: [omniorbpy]
   debian: [python-omniorb, python-omniorb-omg, omniidl-python]
   fedora: [python-omniORB, omniORB-devel]
-  gentoo: ['net-misc/omniORB[python]']
+  gentoo: ["net-misc/omniORB[python]"]
   ubuntu:
-    '*': [python-omniorb, python-omniorb-omg, omniidl-python]
+    "*": [python-omniorb, python-omniorb-omg, omniidl-python]
 python-open3d-pip:
   debian:
     pip:
@@ -2562,12 +2564,12 @@ python-opencv:
   arch: [opencv, python2-numpy]
   debian: [python-opencv]
   freebsd: [py27-opencv]
-  gentoo: ['media-libs/opencv[python]']
+  gentoo: ["media-libs/opencv[python]"]
   nixos: [pythonPackages.opencv3]
   openembedded: [opencv@meta-oe]
   opensuse: [python2-opencv]
   rhel:
-    '7': [opencv-python]
+    "7": [opencv-python]
   slackware: [opencv]
   ubuntu: [python-opencv]
 python-opengl:
@@ -2582,7 +2584,7 @@ python-opengl:
     pip:
       packages: [PyOpenGL]
   rhel:
-    '7': [PyOpenGL]
+    "7": [PyOpenGL]
   slackware: [PyOpenGL]
   ubuntu:
     bionic: [python-opengl]
@@ -2627,7 +2629,7 @@ python-pandas:
   ubuntu: [python-pandas]
 python-parameterized:
   debian:
-    '*': [python-parameterized]
+    "*": [python-parameterized]
     stretch:
       pip:
         packages: [parameterized]
@@ -2646,13 +2648,13 @@ python-paramiko:
   gentoo: [dev-python/paramiko]
   macports: [py27-paramiko]
   nixos: [pythonPackages.paramiko]
-  openembedded: ['${PYTHON_PN}-paramiko@meta-ros-common']
+  openembedded: ["${PYTHON_PN}-paramiko@meta-ros-common"]
   opensuse: [python2-paramiko]
   osx:
     pip:
       packages: [paramiko]
   rhel:
-    '7': [python-paramiko]
+    "7": [python-paramiko]
   slackware: [paramiko]
   ubuntu: [python-paramiko]
 python-parse:
@@ -2697,7 +2699,7 @@ python-pathlib2:
   gentoo: [dev-python/pathlib2]
   nixos: [pythonPackages.pathlib2]
   ubuntu:
-    '*': [python-pathlib2]
+    "*": [python-pathlib2]
 python-pathos-pip:
   debian:
     pip:
@@ -2711,8 +2713,8 @@ python-pbr:
   debian: [python-pbr]
   fedora: [python-pbr]
   rhel:
-    '7': [python2-pbr]
-    '8': [python2-pbr]
+    "7": [python2-pbr]
+    "8": [python2-pbr]
   ubuntu: [python-pbr]
 python-pcapy:
   arch: [python2-pcapy]
@@ -2737,7 +2739,7 @@ python-pep8:
     pip:
       packages: [pep8]
   ubuntu:
-    '*': [python-pep8]
+    "*": [python-pep8]
 python-percol:
   debian:
     pip:
@@ -2789,7 +2791,7 @@ python-pip:
   fedora: [python-pip]
   gentoo: [dev-python/pip]
   nixos: [pythonPackages.pip]
-  openembedded: ['${PYTHON_PN}-pip@meta-python']
+  openembedded: ["${PYTHON_PN}-pip@meta-python"]
   opensuse: [python2-pip]
   ubuntu: [python-pip]
 python-pixel-ring-pip:
@@ -2811,7 +2813,7 @@ python-planar-pip:
     pip:
       packages: [planar]
 python-ply-pip:
-  '*':
+  "*":
     pip:
       packages: [ply]
 python-plyfile-pip:
@@ -2879,23 +2881,23 @@ python-psutil:
   gentoo: [dev-python/psutil]
   macports: [py27-psutil]
   nixos: [pythonPackages.psutil]
-  openembedded: ['${PYTHON_PN}-psutil@meta-python']
+  openembedded: ["${PYTHON_PN}-psutil@meta-python"]
   opensuse: [python2-psutil]
   osx:
     pip:
       packages: [psutil]
   rhel:
-    '7': [python2-psutil]
-    '8': [python2-psutil]
+    "7": [python2-psutil]
+    "8": [python2-psutil]
   slackware: [psutil]
   ubuntu:
-    '*': [python-psutil]
+    "*": [python-psutil]
 python-psycopg2:
   debian: [python-psycopg2]
   fedora: [python-psycopg2]
   gentoo: [=dev-python/psycopg-2*]
   ubuntu:
-    '*': [python-psycopg2]
+    "*": [python-psycopg2]
     focal: [python3-psycopg2]
 python-pulsectl-pip:
   debian:
@@ -2922,22 +2924,22 @@ python-pyaudio:
   debian: [python-pyaudio]
   gentoo: [dev-python/pyaudio]
   nixos: [pythonPackages.pyaudio]
-  openembedded: ['${PYTHON_PN}-pyalsaaudio@meta-python']
+  openembedded: ["${PYTHON_PN}-pyalsaaudio@meta-python"]
   ubuntu: [python-pyaudio]
 python-pycodestyle:
   arch: [python2-pycodestyle]
   debian:
-    '*': null
+    "*": null
     buster: [python-pycodestyle]
     stretch: [python-pycodestyle]
   fedora: [python-pycodestyle]
   gentoo: [dev-python/pycodestyle]
   nixos: [pythonPackages.pycodestyle]
   rhel:
-    '7': [python2-pycodestyle]
-    '8': [python2-pycodestyle]
+    "7": [python2-pycodestyle]
+    "8": [python2-pycodestyle]
   ubuntu:
-    '*': null
+    "*": null
     bionic: [python-pycodestyle]
 python-pycpd-pip:
   debian:
@@ -2955,14 +2957,14 @@ python-pycryptodome:
   fedora: [python-pycryptodomex]
   gentoo: [dev-python/pycryptodome]
   nixos: [pythonPackages.pycryptodomex]
-  openembedded: ['${PYTHON_PN}-pycryptodomex@openembedded-core']
+  openembedded: ["${PYTHON_PN}-pycryptodomex@openembedded-core"]
   opensuse: [python2-pycryptodomex]
   osx:
     pip:
       packages: [pycryptodome]
   rhel:
-    '7': [python2-pycryptodomex]
-    '8': [python2-pycryptodomex]
+    "7": [python2-pycryptodomex]
+    "8": [python2-pycryptodomex]
   ubuntu: [python-pycryptodome]
 python-pycurl:
   debian: [python-pycurl]
@@ -2978,13 +2980,13 @@ python-pydot:
   gentoo: [dev-python/pydot]
   macports: [py27-pydot]
   nixos: [pythonPackages.pydot]
-  openembedded: ['${PYTHON_PN}-pydot@meta-ros-common']
+  openembedded: ["${PYTHON_PN}-pydot@meta-ros-common"]
   opensuse: [python2-pydot]
   osx:
     pip:
       packages: [pydot]
   rhel:
-    '7': [python2-pydot]
+    "7": [python2-pydot]
   slackware: [pydot]
   ubuntu: [python-pydot]
 python-pyexiv2:
@@ -3038,7 +3040,7 @@ python-pygraphviz:
     pip:
       packages: [pygraphviz]
   rhel:
-    '7': [python2-pygraphviz]
+    "7": [python2-pygraphviz]
   slackware: [pygraphviz]
   ubuntu: [python-pygraphviz]
 python-pyinotify:
@@ -3108,13 +3110,13 @@ python-pymongo:
   fedora: [python-pymongo]
   gentoo: [dev-python/pymongo]
   nixos: [pythonPackages.pymongo]
-  openembedded: ['${PYTHON_PN}-pymongo@meta-python']
+  openembedded: ["${PYTHON_PN}-pymongo@meta-python"]
   opensuse: [python2-pymongo]
   osx:
     pip:
       packages: [pymongo]
   ubuntu:
-    '*': [python-pymongo]
+    "*": [python-pymongo]
 python-pymouse:
   debian:
     pip:
@@ -3161,12 +3163,12 @@ python-pyproj:
   debian: [python-pyproj]
   gentoo: [dev-python/pyproj]
   nixos: [pythonPackages.pyproj]
-  openembedded: ['${PYTHON_PN}-pyproj@meta-ros-common']
+  openembedded: ["${PYTHON_PN}-pyproj@meta-ros-common"]
   osx:
     pip:
       packages: [pyproj]
   rhel:
-    '7': [pyproj]
+    "7": [pyproj]
   ubuntu: [python-pyproj]
 python-pyqrcode:
   arch: [python2-qrcode]
@@ -3249,7 +3251,7 @@ python-pytest:
   fedora: [python-pytest]
   gentoo: [dev-python/pytest]
   nixos: [pythonPackages.pytest]
-  openembedded: ['${PYTHON_PN}-pytest@openembedded-core']
+  openembedded: ["${PYTHON_PN}-pytest@openembedded-core"]
   ubuntu: [python-pytest]
 python-pytest-cov:
   arch: [python2-pytest-cov]
@@ -3257,7 +3259,7 @@ python-pytest-cov:
   fedora: [python-pytest-cov]
   gentoo: [dev-python/pytest-cov]
   nixos: [pythonPackages.pytestcov]
-  openembedded: ['${PYTHON_PN}-pytest-cov@meta-ros-common']
+  openembedded: ["${PYTHON_PN}-pytest-cov@meta-ros-common"]
   ubuntu: [python-pytest-cov]
 python-pytest-dependency-pip:
   debian:
@@ -3311,9 +3313,9 @@ python-pyudev:
   fedora: [python-pyudev]
   gentoo: [dev-python/pyudev]
   nixos: [pythonPackages.pyudev]
-  openembedded: ['${PYTHON_PN}-pyudev@meta-python']
+  openembedded: ["${PYTHON_PN}-pyudev@meta-python"]
   ubuntu:
-    '*': [python-pyudev]
+    "*": [python-pyudev]
 python-pyusb-pip:
   debian:
     pip: [pyusb]
@@ -3360,47 +3362,85 @@ python-qrencode:
 python-qt-bindings:
   arch: [python2-pyqt4]
   debian:
-    buster: [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
+    buster:
+      [
+        python-pyside,
+        libpyside-dev,
+        libshiboken-dev,
+        shiboken,
+        python-qt4,
+        python-qt4-dev,
+        python-sip-dev,
+      ]
     squeeze: [python-qt4, python-qt4-dev, python-sip-dev]
-    stretch: [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
-    wheezy: [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
+    stretch:
+      [
+        python-pyside,
+        libpyside-dev,
+        libshiboken-dev,
+        shiboken,
+        python-qt4,
+        python-qt4-dev,
+        python-sip-dev,
+      ]
+    wheezy:
+      [
+        python-pyside,
+        libpyside-dev,
+        libshiboken-dev,
+        shiboken,
+        python-qt4,
+        python-qt4-dev,
+        python-sip-dev,
+      ]
   gentoo: [dev-python/pyside, dev-python/PyQt4]
   macports: [p27-pyqt4]
   opensuse: [python-qt4-devel]
   rhel:
-    '7': [PyQt4, PyQt4-devel, sip-devel]
+    "7": [PyQt4, PyQt4-devel, sip-devel]
   ubuntu:
-    '*': [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
+    "*":
+      [
+        python-pyside,
+        libpyside-dev,
+        libshiboken-dev,
+        shiboken,
+        python-qt4,
+        python-qt4-dev,
+        python-sip-dev,
+      ]
 python-qt-bindings-gl:
   arch: [python2-pyqt4]
   debian: [python-qt4-gl]
-  gentoo: ['dev-python/pyside[opengl]', 'dev-python/PyQt4[opengl]']
+  gentoo: ["dev-python/pyside[opengl]", "dev-python/PyQt4[opengl]"]
   opensuse: [python-qt4-devel]
   ubuntu: [python-qt4-gl]
 python-qt-bindings-qwt5:
   arch: [python2-pyqwt]
   debian: [python-qwt5-qt4]
-  gentoo: ['dev-python/pyqwt:5']
+  gentoo: ["dev-python/pyqwt:5"]
   macports: [qwt52]
   ubuntu: [python-qwt5-qt4]
 python-qt-bindings-webkit:
   debian: [python-qt4]
-  gentoo: ['dev-python/pyside[webkit]', 'dev-python/PyQt4[webkit]']
+  gentoo: ["dev-python/pyside[webkit]", "dev-python/PyQt4[webkit]"]
   ubuntu: [python-qt4]
 python-qt4-gl:
   debian: [python-qt4-gl]
-  gentoo: ['dev-python/pyside[opengl]', 'dev-python/PyQt4[opengl]']
+  gentoo: ["dev-python/pyside[opengl]", "dev-python/PyQt4[opengl]"]
   ubuntu: [python-qt4-gl]
 python-qt5-bindings:
   arch: [python2-pyqt5]
   debian:
-    buster: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev, qtbase5-dev]
-    stretch: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev, qtbase5-dev]
+    buster:
+      [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev, qtbase5-dev]
+    stretch:
+      [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev, qtbase5-dev]
   fedora: [python-qt5-devel, sip]
   freebsd: [py27-qt5]
-  gentoo: ['dev-python/PyQt5[gui,widgets]']
+  gentoo: ["dev-python/PyQt5[gui,widgets]"]
   nixos: [pythonPackages.pyqt5]
-  openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
+  openembedded: ["${PYTHON_PN}-pyqt5@meta-qt5"]
   opensuse: [python2-qt5-devel, python2-sip-devel]
   slackware: [PyQt5]
   ubuntu:
@@ -3412,16 +3452,16 @@ python-qt5-bindings-gl:
     stretch: [python-pyqt5.qtopengl]
   fedora: [python-qt5]
   freebsd: [py27-qt5-opengl]
-  gentoo: ['dev-python/PyQt5[opengl]']
+  gentoo: ["dev-python/PyQt5[opengl]"]
   nixos: [pythonPackages.pyqt5]
-  openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
+  openembedded: ["${PYTHON_PN}-pyqt5@meta-qt5"]
   opensuse: [python2-qt5]
   slackware: [PyQt5]
   ubuntu:
     bionic: [python-pyqt5.qtopengl]
 python-qt5-bindings-qsci:
   debian: [python-pyqt5.qsci]
-  openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
+  openembedded: ["${PYTHON_PN}-pyqt5@meta-qt5"]
   ubuntu: [python-pyqt5.qsci]
 python-qt5-bindings-quick:
   debian: [python-pyqt5.qtquick]
@@ -3433,9 +3473,9 @@ python-qt5-bindings-webkit:
     stretch: [python-pyqt5.qtwebkit]
   fedora: [python-qt5]
   freebsd: [py27-qt5-webkit]
-  gentoo: ['dev-python/PyQt5[webkit]']
+  gentoo: ["dev-python/PyQt5[webkit]"]
   nixos: [pythonPackages.pyqt5_with_qtwebkit]
-  openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
+  openembedded: ["${PYTHON_PN}-pyqt5@meta-qt5"]
   opensuse: [python2-qt5]
   ubuntu:
     bionic: [python-pyqt5.qtwebkit]
@@ -3447,7 +3487,7 @@ python-qtpy:
 python-qwt5-qt4:
   arch: [pyqwt]
   debian: [python-qwt5-qt4]
-  gentoo: ['dev-python/pyqwt:5']
+  gentoo: ["dev-python/pyqwt:5"]
   ubuntu: [python-qwt5-qt4]
 python-rdflib:
   debian: [python-rdflib]
@@ -3472,12 +3512,12 @@ python-requests:
   fedora: [python-requests]
   gentoo: [dev-python/requests]
   nixos: [pythonPackages.requests]
-  openembedded: ['${PYTHON_PN}-requests@openembedded-core']
+  openembedded: ["${PYTHON_PN}-requests@openembedded-core"]
   osx:
     pip:
       packages: [requests]
   ubuntu:
-    '*': [python-requests]
+    "*": [python-requests]
 python-requests-oauthlib:
   debian: [python-requests-oauthlib]
   fedora: [python-requests-oauthlib]
@@ -3502,13 +3542,13 @@ python-rosdep:
       packages: [rosdep]
   gentoo: [dev-util/rosdep]
   nixos: [pythonPackages.rosdep]
-  openembedded: ['${PYTHON_PN}-rosdep@meta-ros-common']
+  openembedded: ["${PYTHON_PN}-rosdep@meta-ros-common"]
   opensuse: [python-rosdep]
   osx:
     pip:
       packages: [rosdep]
   rhel:
-    '7': [python2-rosdep]
+    "7": [python2-rosdep]
   slackware:
     pip:
       packages: [rosdep]
@@ -3526,13 +3566,13 @@ python-rosdep-modules:
       packages: [rosdep]
   gentoo: [dev-util/rosdep]
   nixos: [pythonPackages.rosdep]
-  openembedded: ['${PYTHON_PN}-rosdep@meta-ros-common']
+  openembedded: ["${PYTHON_PN}-rosdep@meta-ros-common"]
   opensuse: [python-rosdep]
   osx:
     pip:
       packages: [rosdep]
   rhel:
-    '7': [python-rosdep]
+    "7": [python-rosdep]
   slackware:
     pip:
       packages: [rosdep]
@@ -3546,7 +3586,7 @@ python-rosdistro:
     pip:
       packages: [rosdistro]
   rhel:
-    '7': [python2-rosdistro]
+    "7": [python2-rosdistro]
 python-rosinstall:
   arch: [python2-rosinstall]
   debian: [python-rosinstall]
@@ -3554,9 +3594,9 @@ python-rosinstall:
   gentoo: [dev-python/rosinstall]
   macports: [p27-rosinstall]
   rhel:
-    '7': [python-rosinstall]
+    "7": [python-rosinstall]
   ubuntu:
-    '*': [python-rosinstall]
+    "*": [python-rosinstall]
 python-rosinstall-generator:
   arch: [python2-rosinstall-generator]
   debian:
@@ -3566,7 +3606,7 @@ python-rosinstall-generator:
   gentoo: [dev-python/rosinstall_generator]
   macports: [py27-rosinstall-generator]
   rhel:
-    '7': [python2-rosinstall_generator]
+    "7": [python2-rosinstall_generator]
   ubuntu: [python-rosinstall-generator]
 python-rospkg:
   alpine:
@@ -3581,18 +3621,18 @@ python-rospkg:
   gentoo: [dev-python/rospkg]
   macports: [py27-rospkg]
   nixos: [pythonPackages.rospkg]
-  openembedded: ['${PYTHON_PN}-rospkg@meta-ros-common']
+  openembedded: ["${PYTHON_PN}-rospkg@meta-ros-common"]
   opensuse: [python-rospkg]
   osx:
     pip:
       packages: [rospkg]
   rhel:
-    '7': [python2-rospkg]
+    "7": [python2-rospkg]
   slackware:
     pip:
       packages: [rospkg]
   ubuntu:
-    '*': [python-rospkg]
+    "*": [python-rospkg]
 python-rospkg-modules:
   alpine:
     pip:
@@ -3611,7 +3651,7 @@ python-rospkg-modules:
     pip:
       packages: [rospkg]
   rhel:
-    '7': [python2-rospkg]
+    "7": [python2-rospkg]
   slackware:
     pip:
       packages: [rospkg]
@@ -3687,7 +3727,7 @@ python-scipy:
       depends: [gfortran]
       packages: [scipy]
   ubuntu:
-    '*': [python-scipy]
+    "*": [python-scipy]
 python-scp:
   debian: [python-scp]
   fedora: [python-scp]
@@ -3742,7 +3782,7 @@ python-serial:
   debian: [python-serial]
   gentoo: [dev-python/pyserial]
   nixos: [pythonPackages.pyserial]
-  openembedded: ['${PYTHON_PN}-pyserial@meta-python']
+  openembedded: ["${PYTHON_PN}-pyserial@meta-python"]
   opensuse: [python2-pyserial]
   ubuntu:
     bionic: [python-serial]
@@ -3756,24 +3796,24 @@ python-setuptools:
   gentoo: [dev-python/setuptools]
   macports: [py27-setuptools]
   nixos: [pythonPackages.setuptools]
-  openembedded: ['${PYTHON_PN}-setuptools@openembedded-core']
+  openembedded: ["${PYTHON_PN}-setuptools@openembedded-core"]
   opensuse: [python2-setuptools]
   osx:
     pip:
       packages: [setuptools]
   rhel:
-    '7': [python2-setuptools]
-    '8': [python2-setuptools]
+    "7": [python2-setuptools]
+    "8": [python2-setuptools]
   ubuntu:
     bionic: [python-setuptools]
 python-sexpdata:
   debian:
-    '*': [python-sexpdata]
+    "*": [python-sexpdata]
     stretch:
       pip:
         packages: [sexpdata]
   ubuntu:
-    '*': [python-sexpdata]
+    "*": [python-sexpdata]
     bionic:
       pip:
         packages: [sexpdata]
@@ -3793,14 +3833,14 @@ python-shapely:
     pip:
       packages: [shapely]
   ubuntu:
-    '*': [python-shapely]
+    "*": [python-shapely]
 python-simplejson:
   arch: [python2-simplejson]
   debian: [python-simplejson]
   fedora: [python-simplejson]
   gentoo: [dev-python/simplejson]
   nixos: [pythonPackages.simplejson]
-  openembedded: ['${PYTHON_PN}-simplejson@openembedded-core']
+  openembedded: ["${PYTHON_PN}-simplejson@openembedded-core"]
   ubuntu: [python-simplejson]
 python-singledispatch:
   debian: [python-singledispatch]
@@ -3817,12 +3857,12 @@ python-sip:
   openembedded: [sip@meta-oe]
   opensuse: [python2-sip-devel]
   rhel:
-    '7': [sip-devel]
+    "7": [sip-devel]
   slackware:
     slackpkg:
       packages: [sip]
   ubuntu:
-    '*': [python-sip-dev]
+    "*": [python-sip-dev]
 python-sip4:
   debian: [python-sip-dev]
   fedora: [sip]
@@ -3834,7 +3874,7 @@ python-six:
   fedora: [python-six]
   gentoo: [dev-python/six]
   nixos: [pythonPackages.six]
-  openembedded: ['${PYTHON_PN}-six@openembedded-core']
+  openembedded: ["${PYTHON_PN}-six@openembedded-core"]
   ubuntu: [python-six]
 python-skimage:
   debian:
@@ -3865,7 +3905,7 @@ python-sklearn:
     pip:
       packages: [scikit-learn]
   ubuntu:
-    '*': [python-sklearn]
+    "*": [python-sklearn]
 python-slackclient-pip:
   debian:
     pip:
@@ -3931,15 +3971,15 @@ python-sphinx:
   gentoo: [dev-python/sphinx]
   macports: [py27-sphinx]
   nixos: [pythonPackages.sphinx]
-  openembedded: ['${PYTHON_PN}-sphinx@meta-ros-common']
+  openembedded: ["${PYTHON_PN}-sphinx@meta-ros-common"]
   opensuse: [python-Sphinx]
   osx:
     pip:
       packages: [Sphinx]
   rhel:
-    '7': [python-sphinx]
+    "7": [python-sphinx]
   ubuntu:
-    '*': [python-sphinx]
+    "*": [python-sphinx]
 python-sphinx-argparse:
   debian:
     buster: [python-sphinx-argparse]
@@ -3982,10 +4022,10 @@ python-statsd:
   ubuntu: [python-statsd]
 python-subprocess32:
   debian:
-    '*': [python-subprocess32]
+    "*": [python-subprocess32]
   gentoo: [dev-python/subprocess32]
   ubuntu:
-    '*': [python-subprocess32]
+    "*": [python-subprocess32]
 python-support:
   debian: [python-support]
   fedora: [python]
@@ -4152,12 +4192,12 @@ python-termcolor:
   fedora: [python-termcolor]
   gentoo: [dev-python/termcolor]
   nixos: [pythonPackages.termcolor]
-  openembedded: ['${PYTHON_PN}-termcolor@openembedded-core']
+  openembedded: ["${PYTHON_PN}-termcolor@openembedded-core"]
   osx:
     pip:
       packages: [termcolor]
   ubuntu:
-    '*': [python-termcolor]
+    "*": [python-termcolor]
 python-testscenarios:
   debian: [python-testscenarios]
   fedora: [python-testscenarios]
@@ -4205,13 +4245,13 @@ python-tk:
   debian: [python-tk]
   fedora: [python2-tkinter]
   nixos: [pythonPackages.tkinter]
-  openembedded: ['${PYTHON_PN}-tkinter@openembedded-core']
+  openembedded: ["${PYTHON_PN}-tkinter@openembedded-core"]
   opensuse: [python-tk]
   rhel:
-    '7': [tkinter]
-    '8': [python2-tkinter]
+    "7": [tkinter]
+    "8": [python2-tkinter]
   ubuntu:
-    '*': [python-tk]
+    "*": [python-tk]
 python-toml:
   debian: [python-toml]
   fedora: [python-toml]
@@ -4256,7 +4296,7 @@ python-transforms3d-pip:
     pip:
       packages: [transforms3d]
   ubuntu:
-    '*': null
+    "*": null
     bionic:
       pip:
         packages: [transforms3d]
@@ -4268,7 +4308,7 @@ python-transforms3d-pip:
         packages: [transforms3d]
 python-transitions:
   debian:
-    '*': [python-transitions]
+    "*": [python-transitions]
     stretch:
       pip:
         packages: [transitions]
@@ -4328,7 +4368,7 @@ python-twisted-core:
   debian: [python-twisted-core]
   gentoo: [dev-python/twisted]
   nixos: [pythonPackages.twisted]
-  openembedded: ['${PYTHON_PN}-twisted-core@meta-python']
+  openembedded: ["${PYTHON_PN}-twisted-core@meta-python"]
   opensuse: [python2-Twisted]
   ubuntu: [python-twisted-core]
 python-twisted-web:
@@ -4350,7 +4390,7 @@ python-typing:
   gentoo: [dev-python/typing]
   nixos: [pythonPackages.typing]
   ubuntu:
-    '*': [python-typing]
+    "*": [python-typing]
 python-typing-pip:
   debian:
     pip:
@@ -4417,7 +4457,7 @@ python-usb:
   debian: [python-usb]
   gentoo: [dev-python/pyusb]
   nixos: [pythonPackages.pyusb]
-  openembedded: ['${PYTHON_PN}-pyusb@meta-python']
+  openembedded: ["${PYTHON_PN}-pyusb@meta-python"]
   ubuntu: [python-usb]
 python-utm-pip:
   debian:
@@ -4468,10 +4508,10 @@ python-virtualenv:
   fedora: [python-virtualenv]
   gentoo: [dev-python/virtualenv]
   nixos: [pythonPackages.virtualenv]
-  openembedded: ['${PYTHON_PN}-virtualenv@meta-ros2']
+  openembedded: ["${PYTHON_PN}-virtualenv@meta-ros2"]
   rhel:
-    '7': [python-virtualenv]
-    '8': [python2-virtualenv]
+    "7": [python-virtualenv]
+    "8": [python2-virtualenv]
   ubuntu: [python-virtualenv]
 python-visual:
   debian: [python-visual]
@@ -4553,7 +4593,7 @@ python-websocket:
   fedora: [python-websocket-client]
   gentoo: [dev-python/websocket-client]
   nixos: [pythonPackages.websocket_client]
-  openembedded: ['${PYTHON_PN}-websocket-client@meta-python']
+  openembedded: ["${PYTHON_PN}-websocket-client@meta-python"]
   opensuse: [python2-websocket-client]
   ubuntu:
     bionic: [python-websocket]
@@ -4610,7 +4650,7 @@ python-wxtools:
   openembedded: [wxpython@meta-ros-python2]
   opensuse: [python-wxWidgets-3_0-devel]
   rhel:
-    '7': [wxPython]
+    "7": [wxPython]
   ubuntu: [python-wxtools]
 python-xdot:
   debian: [xdot]
@@ -4664,22 +4704,22 @@ python-yaml:
   gentoo: [dev-python/pyyaml]
   macports: [py27-yaml]
   nixos: [pythonPackages.pyyaml]
-  openembedded: ['${PYTHON_PN}-pyyaml@meta-python']
+  openembedded: ["${PYTHON_PN}-pyyaml@meta-python"]
   opensuse: [python2-PyYAML]
   osx:
     pip:
       depends: [yaml]
       packages: [PyYAML]
   rhel:
-    '7': [PyYAML]
-    '8': [python2-pyyaml]
+    "7": [PyYAML]
+    "8": [python2-pyyaml]
   slackware: [PyYAML]
   ubuntu:
     bionic: [python-yaml]
     focal: [python-yaml]
 python-zbar:
   debian: [python-zbar]
-  gentoo: ['media-gfx/zbar[python]']
+  gentoo: ["media-gfx/zbar[python]"]
   ubuntu: [python-zbar]
 python-zmq:
   arch: [python2-pyzmq]
@@ -4688,7 +4728,7 @@ python-zmq:
   gentoo: [dev-python/pyzmq]
   nixos: [pythonPackages.pyzmq]
   ubuntu:
-    '*': [python-zmq]
+    "*": [python-zmq]
 python3:
   alpine: [python3]
   arch: [python]
@@ -4698,7 +4738,7 @@ python3:
   nixos: [python3]
   openembedded: [python3@openembedded-core]
   opensuse: [python3-devel]
-  rhel: ['python%{python3_pkgversion}-devel']
+  rhel: ["python%{python3_pkgversion}-devel"]
   ubuntu: [python3-dev]
 python3-adafruit-blinka-pip:
   debian:
@@ -4764,13 +4804,13 @@ python3-aiohttp:
   gentoo: [dev-python/aiohttp]
   opensuse: [python-aiohttp]
   rhel:
-    '*': [python3-aiohttp]
-    '7': null
+    "*": [python3-aiohttp]
+    "7": null
   ubuntu: [python3-aiohttp]
 python3-aiohttp-cors:
   arch: [python-aiohttp-cors]
   debian:
-    '*': [python3-aiohttp-cors]
+    "*": [python3-aiohttp-cors]
     stretch: null
   fedora: [python-aiohttp-cors]
   gentoo: [dev-python/aiohttp-cors]
@@ -4805,8 +4845,8 @@ python3-alembic:
   nixos: [python3Packages.alembic]
   opensuse: [python3-alembic]
   rhel:
-    '*': [python3-alembic]
-    '7': null
+    "*": [python3-alembic]
+    "7": null
   ubuntu: [python3-alembic]
 python3-ansible-runner-pip:
   debian:
@@ -4844,7 +4884,7 @@ python3-argcomplete:
   gentoo: [dev-python/argcomplete]
   nixos: [python3Packages.argcomplete]
   openembedded: [python3-argcomplete@meta-python]
-  rhel: ['python%{python3_pkgversion}-argcomplete']
+  rhel: ["python%{python3_pkgversion}-argcomplete"]
   ubuntu: [python3-argcomplete]
 python3-astropy-pip:
   debian:
@@ -4864,8 +4904,8 @@ python3-autobahn:
   nixos: [python3Packages.autobahn]
   openembedded: [python3-autobahn@meta-python]
   rhel:
-    '*': ['python%{python3_pkgversion}-autobahn']
-    '7': null
+    "*": ["python%{python3_pkgversion}-autobahn"]
+    "7": null
   ubuntu: [python3-autobahn]
 python3-awsiotsdk-pip:
   debian:
@@ -4884,8 +4924,8 @@ python3-babeltrace:
   gentoo: [dev-util/babeltrace]
   opensuse: [python3-babeltrace]
   rhel:
-    '*': [python3-babeltrace]
-    '7': null
+    "*": [python3-babeltrace]
+    "7": null
   ubuntu: [python3-babeltrace]
 python3-backoff-pip:
   arch:
@@ -4912,7 +4952,7 @@ python3-bcrypt:
   gentoo: [dev-python/bcrypt]
   nixos: [python39Packages.bcrypt]
   opensuse: [python3-bcrypt]
-  rhel: ['python%{python3_pkgversion}-bcrypt']
+  rhel: ["python%{python3_pkgversion}-bcrypt"]
   ubuntu: [python3-bcrypt]
 python3-bitarray:
   debian: [python3-bitarray]
@@ -4926,8 +4966,8 @@ python3-bitstring:
   gentoo: [dev-python/bitstring]
   opensuse: [python3-bitstring]
   rhel:
-    '*': [python3-bitstring]
-    '7': [python36-bitstring]
+    "*": [python3-bitstring]
+    "7": [python36-bitstring]
   ubuntu: [python3-bitstring]
 python3-bluerobotics-ping-pip:
   debian:
@@ -4941,7 +4981,7 @@ python3-bluez:
   fedora: [python3-bluez]
   gentoo: [dev-python/pybluez]
   ubuntu:
-    '*': [python3-bluez]
+    "*": [python3-bluez]
     bionic: null
 python3-bokeh-pip:
   debian:
@@ -4985,8 +5025,8 @@ python3-boto3:
   openembedded: [python3-boto3@meta-ros-common]
   opensuse: [python3-boto3]
   rhel:
-    '*': ['python%{python3_pkgversion}-boto3']
-    '7': null
+    "*": ["python%{python3_pkgversion}-boto3"]
+    "7": null
   ubuntu: [python3-boto3]
 python3-bottle:
   debian: [python3-bottle]
@@ -4995,13 +5035,13 @@ python3-bottle:
   ubuntu: [python3-bottle]
 python3-box:
   debian:
-    '*': [python3-box]
+    "*": [python3-box]
     buster:
       pip:
         packages: [python-box]
   fedora: [python3-box]
   ubuntu:
-    '*': [python3-box]
+    "*": [python3-box]
     bionic:
       pip:
         packages: [python-box]
@@ -5013,8 +5053,8 @@ python3-breathe:
   fedora: [python3-breathe]
   opensuse: [python3-breathe]
   rhel:
-    '*': ['python%{python3_pkgversion}-breathe']
-    '7': null
+    "*": ["python%{python3_pkgversion}-breathe"]
+    "7": null
   ubuntu: [python3-breathe]
 python3-bs4:
   arch: [python-beautifulsoup4]
@@ -5031,7 +5071,7 @@ python3-bson:
   osx:
     pip:
       packages: [bson]
-  rhel: ['python%{python3_pkgversion}-bson']
+  rhel: ["python%{python3_pkgversion}-bson"]
   ubuntu: [python3-bson]
 python3-cairo:
   arch: [python-cairo]
@@ -5042,7 +5082,7 @@ python3-cairo:
   nixos: [python3Packages.pycairo]
   openembedded: [python3-pycairo@openembedded-core]
   opensuse: [python3-cairo]
-  rhel: ['python%{python3_pkgversion}-cairo']
+  rhel: ["python%{python3_pkgversion}-cairo"]
   slackware:
     slackpkg:
       packages: [py3cairo]
@@ -5059,7 +5099,7 @@ python3-can:
   debian: [python3-can]
   fedora: [python3-can]
   ubuntu:
-    '*': [python3-can]
+    "*": [python3-can]
 python3-can-j1939-pip:
   debian:
     pip:
@@ -5079,13 +5119,13 @@ python3-cantools-pip:
       packages: [cantools]
 python3-catkin-lint:
   debian:
-    '*': [python3-catkin-lint]
+    "*": [python3-catkin-lint]
     stretch: null
   fedora: [python3-catkin_lint]
   openembedded: [python3-catkin-lint@meta-ros-common]
   rhel: [python3-catkin_lint]
   ubuntu:
-    '*': [python3-catkin-lint]
+    "*": [python3-catkin-lint]
     bionic: null
 python3-catkin-pkg:
   alpine: [py3-catkin-pkg]
@@ -5097,7 +5137,7 @@ python3-catkin-pkg:
   gentoo: [dev-python/catkin_pkg]
   nixos: [python3Packages.catkin-pkg]
   openembedded: [python3-catkin-pkg@meta-ros-common]
-  rhel: ['python%{python3_pkgversion}-catkin_pkg']
+  rhel: ["python%{python3_pkgversion}-catkin_pkg"]
   ubuntu: [python3-catkin-pkg]
 python3-catkin-pkg-modules:
   alpine: [py3-catkin-pkg]
@@ -5112,14 +5152,14 @@ python3-catkin-pkg-modules:
   osx:
     pip:
       packages: [catkin-pkg]
-  rhel: ['python%{python3_pkgversion}-catkin_pkg']
+  rhel: ["python%{python3_pkgversion}-catkin_pkg"]
   ubuntu: [python3-catkin-pkg-modules]
 python3-catkin-sphinx:
   arch:
     pip:
       packages: [catkin_sphinx]
   debian:
-    '*':
+    "*":
       pip:
         packages: [catkin_sphinx]
     buster: [python3-catkin-sphinx]
@@ -5132,7 +5172,7 @@ python3-catkin-sphinx:
       packages: [catkin_sphinx]
   rhel: [python3-catkin-sphinx]
   ubuntu:
-    '*': null
+    "*": null
     focal: [python3-catkin-sphinx]
 python3-catkin-tools:
   debian: [python3-catkin-tools]
@@ -5142,7 +5182,7 @@ python3-catkin-tools:
 python3-cbor2:
   arch: [python-cbor2]
   debian:
-    '*': [python3-cbor2]
+    "*": [python3-cbor2]
     buster:
       pip:
         packages: [cbor2]
@@ -5154,7 +5194,7 @@ python3-cbor2:
     pip:
       packages: [cbor2]
   ubuntu:
-    '*': [python3-cbor2]
+    "*": [python3-cbor2]
     bionic:
       pip:
         packages: [cbor2]
@@ -5167,14 +5207,14 @@ python3-certifi:
   gentoo: [dev-python/certifi]
   nixos: [python39Packages.certifi]
   opensuse: [python3-certifi]
-  rhel: ['python%{python3_pkgversion}-certifi']
+  rhel: ["python%{python3_pkgversion}-certifi"]
   ubuntu: [python3-certifi]
 python3-cffi:
   debian: [python3-cffi]
   fedora: [python3-cffi]
   gentoo: [dev-python/cffi]
   nixos: [python3Packages.cffi]
-  rhel: ['python%{python3_pkgversion}-cffi']
+  rhel: ["python%{python3_pkgversion}-cffi"]
   ubuntu: [python3-cffi]
 python3-chainer-pip: *migrate_eol_2025_04_30_python3_chainer_pip
 python3-charisma-sdk-pip:
@@ -5194,26 +5234,26 @@ python3-click:
   gentoo: [dev-python/click]
   nixos: [python3Packages.click]
   openembedded: [python3-click@meta-python]
-  rhel: ['python%{python3_pkgversion}-click']
+  rhel: ["python%{python3_pkgversion}-click"]
   ubuntu: [python3-click]
 python3-colcon-common-extensions:
   debian: [python3-colcon-common-extensions]
   fedora: [python3-colcon-common-extensions]
-  rhel: ['python%{python3_pkgversion}-colcon-common-extensions']
+  rhel: ["python%{python3_pkgversion}-colcon-common-extensions"]
   ubuntu: [python3-colcon-common-extensions]
 python3-colcon-meson:
   ubuntu:
     jammy: [python3-colcon-meson]
 python3-collada:
   debian:
-    '*': [python3-collada]
+    "*": [python3-collada]
     buster: null
     stretch: null
   fedora: [python3-collada]
   nixos: [python3Packages.pycollada]
-  rhel: ['python%{python3_pkgversion}-collada']
+  rhel: ["python%{python3_pkgversion}-collada"]
   ubuntu:
-    '*': [python3-collada]
+    "*": [python3-collada]
     bionic: null
 python3-collada-pip:
   debian:
@@ -5231,17 +5271,17 @@ python3-colorama:
   gentoo: [dev-python/colorama]
   nixos: [python3Packages.colorama]
   openembedded: [python3-colorama@meta-python]
-  rhel: ['python%{python3_pkgversion}-colorama']
+  rhel: ["python%{python3_pkgversion}-colorama"]
   ubuntu: [python3-colorama]
 python3-colorcet:
   debian:
-    '*': [python3-colorcet]
+    "*": [python3-colorcet]
     buster:
       pip:
         packages: [colorcet]
   fedora: [python3-colorcet]
   ubuntu:
-    '*': [python3-colorcet]
+    "*": [python3-colorcet]
     bionic:
       pip:
         packages: [colorcet]
@@ -5275,8 +5315,8 @@ python3-construct:
   gentoo: [dev-python/construct]
   nixos: [python3Packages.construct]
   rhel:
-    '*': [python3-construct]
-    '7': null
+    "*": [python3-construct]
+    "7": null
   ubuntu: [python3-construct]
 python3-cookiecutter:
   debian:
@@ -5284,7 +5324,7 @@ python3-cookiecutter:
     stretch: [python3-cookiecutter]
   fedora: [python3-cookiecutter]
   ubuntu:
-    '*': [python3-cookiecutter]
+    "*": [python3-cookiecutter]
     focal: null
 python3-coverage:
   debian: [python3-coverage]
@@ -5293,7 +5333,7 @@ python3-coverage:
   nixos: [python3Packages.coverage]
   openembedded: [python3-coverage@meta-python]
   opensuse: [python3-coverage]
-  rhel: ['python%{python3_pkgversion}-coverage']
+  rhel: ["python%{python3_pkgversion}-coverage"]
   ubuntu: [python3-coverage]
 python3-crc16-pip:
   debian:
@@ -5324,7 +5364,7 @@ python3-cryptography:
   nixos: [python3Packages.cryptography]
   openembedded: [python3-cryptography@meta-python]
   opensuse: [python3-cryptography]
-  rhel: ['python%{python3_pkgversion}-cryptography']
+  rhel: ["python%{python3_pkgversion}-cryptography"]
   ubuntu: [python3-cryptography]
 python3-cvxpy-pip: *migrate_eol_2025_04_30_python3_cvxpy_pip
 python3-cycler:
@@ -5334,8 +5374,8 @@ python3-cycler:
   gentoo: [dev-python/cycler]
   opensuse: [python3-Cycler]
   rhel:
-    '*': [python3-cycler]
-    '7': null
+    "*": [python3-cycler]
+    "7": null
   ubuntu: [python3-cycler]
 python3-datadog-pip:
   ubuntu:
@@ -5351,7 +5391,7 @@ python3-dateutil:
   osx:
     pip:
       packages: [python-dateutil]
-  rhel: ['python%{python3_pkgversion}-dateutil']
+  rhel: ["python%{python3_pkgversion}-dateutil"]
   ubuntu: [python3-dateutil]
 python3-dbus:
   debian: [python3-dbus]
@@ -5374,7 +5414,7 @@ python3-deepdiff:
   fedora: [python-deepdiff]
   opensuse: [python3-deepdiff]
   ubuntu:
-    '*': [python3-deepdiff]
+    "*": [python3-deepdiff]
     bionic:
       pip:
         packages: [deepdiff]
@@ -5385,18 +5425,18 @@ python3-defusedxml:
   nixos: [python3Packages.defusedxml]
   openembedded: [python3-defusedxml@meta-python]
   opensuse: [python3-defusedxml]
-  rhel: ['python%{python3_pkgversion}-defusedxml']
+  rhel: ["python%{python3_pkgversion}-defusedxml"]
   ubuntu: [python3-defusedxml]
 python3-deprecated:
   debian:
-    '*': [python3-deprecated]
+    "*": [python3-deprecated]
     buster: null
   fedora: [python3-deprecated]
   rhel:
-    '*': [python3-deprecated]
-    '7': null
+    "*": [python3-deprecated]
+    "7": null
   ubuntu:
-    '*': [python3-deprecated]
+    "*": [python3-deprecated]
     bionic: null
 python3-depthai-pip:
   debian:
@@ -5417,7 +5457,7 @@ python3-dev:
   nixos: [python3]
   openembedded: [python3@openembedded-core]
   opensuse: [python3-devel]
-  rhel: ['python%{python3_pkgversion}-devel']
+  rhel: ["python%{python3_pkgversion}-devel"]
   ubuntu: [python3-dev]
 python3-distro:
   debian: [python3-distro]
@@ -5427,13 +5467,13 @@ python3-distro:
   ubuntu: [python3-distro]
 python3-distutils:
   debian:
-    '*': [python3-distutils]
+    "*": [python3-distutils]
     stretch: null
   fedora: [python3]
   gentoo: [dev-lang/python]
   nixos: [python3]
   ubuntu:
-    '*': [python3-distutils]
+    "*": [python3-distutils]
 python3-django:
   debian: [python3-django]
   fedora: [python3-django]
@@ -5456,8 +5496,8 @@ python3-djangorestframework:
   fedora: [python3-django-rest-framework]
   opensuse: [python3-djangorestframework]
   rhel:
-    '*': [python3-django-rest-framework]
-    '7': null
+    "*": [python3-django-rest-framework]
+    "7": null
   ubuntu: [python3-djangorestframework]
 python3-dlib-pip:
   debian:
@@ -5480,7 +5520,7 @@ python3-docker:
   nixos: [python3Packages.docker]
   opensuse: [python3-docker]
   rhel:
-    '7': ['python%{python3_pkgversion}-docker']
+    "7": ["python%{python3_pkgversion}-docker"]
   ubuntu: [python3-docker]
 python3-docopt:
   arch: [python-docopt]
@@ -5515,12 +5555,12 @@ python3-dubins-pip:
       packages: [dubins]
 python3-easydict:
   debian:
-    '*': [python3-easydict]
+    "*": [python3-easydict]
     buster:
       pip:
         packages: [easydict]
   ubuntu:
-    '*': [python3-easydict]
+    "*": [python3-easydict]
     bionic:
       pip:
         packages: [easydict]
@@ -5532,12 +5572,12 @@ python3-elasticsearch:
   fedora: [python3-elasticsearch]
   opensuse: [python3-elasticsearch]
   rhel:
-    '*': [python3-elasticsearch]
-    '7': null
+    "*": [python3-elasticsearch]
+    "7": null
   ubuntu: [python3-elasticsearch]
 python3-emoji:
   debian:
-    '*': [python3-emoji]
+    "*": [python3-emoji]
     bullseye:
       pip:
         packages: [emoji]
@@ -5550,10 +5590,10 @@ python3-emoji:
   fedora: [python3-emoji]
   opensuse: [python3-emoji]
   rhel:
-    '*': [python3-emoji]
-    '7': null
+    "*": [python3-emoji]
+    "7": null
   ubuntu:
-    '*': [python3-emoji]
+    "*": [python3-emoji]
     bionic:
       pip:
         packages: [emoji]
@@ -5572,7 +5612,7 @@ python3-empy:
   osx:
     pip:
       packakges: [empy]
-  rhel: ['python%{python3_pkgversion}-empy']
+  rhel: ["python%{python3_pkgversion}-empy"]
   ubuntu: [python3-empy]
 python3-environs-pip:
   debian:
@@ -5584,7 +5624,7 @@ python3-environs-pip:
 python3-evdev:
   arch: [python-evdev]
   debian:
-    '*': [python3-evdev]
+    "*": [python3-evdev]
     stretch: null
   fedora: [python3-evdev]
   gentoo: [dev-python/python-evdev]
@@ -5604,7 +5644,7 @@ python3-events-pip:
       packages: [Events]
 python3-ezdxf:
   debian:
-    '*': [python3-ezdxf]
+    "*": [python3-ezdxf]
     buster:
       pip:
         packages: [ezdxf]
@@ -5615,7 +5655,7 @@ python3-ezdxf:
   freebsd: [py37-ezdxf]
   nixos: [python3Packages.ezdxf]
   ubuntu:
-    '*': [python3-ezdxf]
+    "*": [python3-ezdxf]
     bionic:
       pip:
         packages: [ezdxf]
@@ -5635,13 +5675,13 @@ python3-fann2:
 python3-fastapi:
   arch: [python-fastapi]
   debian:
-    '*': [python3-fastapi]
+    "*": [python3-fastapi]
     buster:
       pip:
         packages: [fastapi]
   fedora: [python-fastapi]
   ubuntu:
-    '*': [python3-fastapi]
+    "*": [python3-fastapi]
     bionic:
       pip:
         packages: [fastapi]
@@ -5708,8 +5748,8 @@ python3-fiona:
   fedora: [python3-fiona]
   nixos: [python3Packages.fiona]
   rhel:
-    '*': [python3-fiona]
-    '7': null
+    "*": [python3-fiona]
+    "7": null
   ubuntu: [python3-fiona]
 python3-flake8:
   alpine: [py3-flake8]
@@ -5724,13 +5764,13 @@ python3-flake8:
     pip:
       packages: [flake8]
   rhel:
-    '*': ['python%{python3_pkgversion}-flake8']
-    '7': null
+    "*": ["python%{python3_pkgversion}-flake8"]
+    "7": null
   ubuntu: [python3-flake8]
 python3-flake8-blind-except:
   opensuse: [python3-flake8-blind-except]
   ubuntu:
-    '*': [python3-flake8-blind-except]
+    "*": [python3-flake8-blind-except]
     bionic: null
     focal: null
 python3-flake8-blind-except-pip:
@@ -5740,7 +5780,7 @@ python3-flake8-blind-except-pip:
 python3-flake8-builtins:
   opensuse: [python3-flake8-builtins]
   ubuntu:
-    '*': [python3-flake8-builtins]
+    "*": [python3-flake8-builtins]
     bionic: null
     focal: null
 python3-flake8-builtins-pip:
@@ -5750,7 +5790,7 @@ python3-flake8-builtins-pip:
 python3-flake8-class-newline:
   opensuse: [python3-flake8-class-newline]
   ubuntu:
-    '*': [python3-flake8-class-newline]
+    "*": [python3-flake8-class-newline]
     bionic: null
     focal: null
 python3-flake8-class-newline-pip:
@@ -5759,7 +5799,7 @@ python3-flake8-class-newline-pip:
       packages: [flake8-class-newline]
 python3-flake8-comprehensions:
   ubuntu:
-    '*': [python3-flake8-comprehensions]
+    "*": [python3-flake8-comprehensions]
     bionic: null
     focal: null
 python3-flake8-comprehensions-pip:
@@ -5769,7 +5809,7 @@ python3-flake8-comprehensions-pip:
 python3-flake8-deprecated:
   opensuse: [python3-flake8-deprecated]
   ubuntu:
-    '*': [python3-flake8-deprecated]
+    "*": [python3-flake8-deprecated]
     bionic: null
     focal: null
 python3-flake8-deprecated-pip:
@@ -5782,8 +5822,8 @@ python3-flake8-docstrings:
   fedora: [python3-flake8-docstrings]
   opensuse: [python3-flake8-docstrings]
   rhel:
-    '*': [python3-flake8-docstrings]
-    '7': null
+    "*": [python3-flake8-docstrings]
+    "7": null
   ubuntu: [python3-flake8-docstrings]
 python3-flake8-docstrings-pip:
   ubuntu:
@@ -5793,11 +5833,11 @@ python3-flake8-import-order:
   fedora: [python3-flake8-import-order]
   opensuse: [python3-flake8-import-order]
   rhel:
-    '*': [python3-flake8-import-order]
-    '7': null
-    '8': null
+    "*": [python3-flake8-import-order]
+    "7": null
+    "8": null
   ubuntu:
-    '*': [python3-flake8-import-order]
+    "*": [python3-flake8-import-order]
     bionic: null
     focal: null
 python3-flake8-import-order-pip:
@@ -5806,15 +5846,15 @@ python3-flake8-import-order-pip:
       packages: [flake8-import-order]
 python3-flake8-quotes:
   fedora:
-    '*': [python3-flake8-quotes]
-    '35': null
+    "*": [python3-flake8-quotes]
+    "35": null
   opensuse: [python3-flake8-quotes]
   rhel:
-    '*': [python3-flake8-quotes]
-    '7': null
-    '8': null
+    "*": [python3-flake8-quotes]
+    "7": null
+    "8": null
   ubuntu:
-    '*': [python3-flake8-quotes]
+    "*": [python3-flake8-quotes]
     bionic: null
     focal: null
 python3-flake8-quotes-pip:
@@ -5837,14 +5877,14 @@ python3-flask-cors:
   fedora: [python3-flask-cors]
   nixos: [python3Packages.flask-cors]
   rhel:
-    '*': [python3-flask-cors]
-    '7': null
+    "*": [python3-flask-cors]
+    "7": null
   ubuntu:
-    '*': [python3-flask-cors]
+    "*": [python3-flask-cors]
     bionic: null
 python3-flask-jwt-extended:
   debian:
-    '*': [python3-python-flask-jwt-extended]
+    "*": [python3-python-flask-jwt-extended]
     buster:
       pip:
         packages: [flask-jwt-extended]
@@ -5852,7 +5892,7 @@ python3-flask-jwt-extended:
   nixos: [python39Packages.flask-jwt-extended]
   opensuse: [python-flask-jwt-extended]
   ubuntu:
-    '*': [python3-python-flask-jwt-extended]
+    "*": [python3-python-flask-jwt-extended]
     bionic:
       pip:
         packages: [flask-jwt-extended]
@@ -5861,8 +5901,8 @@ python3-flask-migrate:
   fedora: [python3-flask-migrate]
   gentoo: [dev-python/flask-migrate]
   rhel:
-    '*': ['python%{python3_pkgversion}-flask-migrate']
-    '7': null
+    "*": ["python%{python3_pkgversion}-flask-migrate"]
+    "7": null
   ubuntu: [python3-flask-migrate]
 python3-flask-restplus-pip:
   ubuntu:
@@ -5880,12 +5920,12 @@ python3-flask-sqlalchemy:
   nixos: [python39Packages.flask_sqlalchemy]
   opensuse: [python-Flask-SQLAlchemy]
   rhel:
-    '*': [python3-flask-sqlalchemy]
-    '7': null
+    "*": [python3-flask-sqlalchemy]
+    "7": null
   ubuntu: [python3-flask-sqlalchemy]
 python3-flatbuffers:
   debian:
-    '*': [python3-flatbuffers]
+    "*": [python3-flatbuffers]
     buster:
       pip:
         packages: [flatbuffers]
@@ -5896,8 +5936,11 @@ python3-flatbuffers:
     pip:
       packages: [flatbuffers]
   ubuntu:
-    '*': [python3-flatbuffers]
+    "*": [python3-flatbuffers]
     focal:
+      pip:
+        packages: [flatbuffers]
+    bionic:
       pip:
         packages: [flatbuffers]
 python3-fonttools:
@@ -5919,7 +5962,7 @@ python3-ftdi1:
   arch: [libftdi]
   debian: [python3-ftdi1]
   fedora: [python3-libftdi]
-  gentoo: ['dev-embedded/libftdi[python]']
+  gentoo: ["dev-embedded/libftdi[python]"]
   nixos: [libftdi1]
   opensuse: [python3-libftdi1]
   ubuntu: [python3-ftdi1]
@@ -5933,7 +5976,7 @@ python3-future:
   gentoo: [dev-python/future]
   nixos: [python3Packages.future]
   openembedded: [python3-future@meta-python]
-  rhel: ['python%{python3_pkgversion}-future']
+  rhel: ["python%{python3_pkgversion}-future"]
   ubuntu: [python3-future]
 python3-gdal:
   arch: [python-gdal]
@@ -5942,8 +5985,8 @@ python3-gdal:
   gentoo: [sci-libs/gdal]
   opensuse: [python3-GDAL]
   rhel:
-    '*': [python3-gdal]
-    '7': null
+    "*": [python3-gdal]
+    "7": null
   ubuntu: [python3-gdal]
 python3-gdown-pip: *migrate_eol_2025_04_30_python3_gdown_pip
 python3-geographiclib:
@@ -5954,8 +5997,8 @@ python3-geographiclib:
   nixos: [python3Packages.geographiclib]
   opensuse: [python3-geographiclib]
   rhel:
-    '*': [python3-GeographicLib]
-    '7': null
+    "*": [python3-GeographicLib]
+    "7": null
   ubuntu: [python3-geographiclib]
 python3-geojson:
   arch: [python-geojson]
@@ -6004,27 +6047,27 @@ python3-git:
   gentoo: [dev-python/git-python]
   nixos: [python3Packages.GitPython]
   rhel:
-    '*': [python3-GitPython]
-    '7': null
+    "*": [python3-GitPython]
+    "7": null
   ubuntu: [python3-git]
 python3-github:
   debian: [python3-github]
   fedora: [python3-github]
   gentoo: [dev-python/PyGithub]
   nixos: [python3Packages.PyGithub]
-  rhel: ['python%{python3_pkgversion}-pygithub']
+  rhel: ["python%{python3_pkgversion}-pygithub"]
   ubuntu: [python3-github]
 python3-gitlab:
   debian:
-    '*': [python3-gitlab]
+    "*": [python3-gitlab]
     stretch:
       pip:
         packages: [python-gitlab]
   fedora: [python3-gitlab]
   gentoo: [dev-vcs/python-gitlab]
   rhel:
-    '*': [python3-gitlab]
-    '7': null
+    "*": [python3-gitlab]
+    "7": null
   ubuntu: [python3-gitlab]
 python3-glpk-pip: *migrate_eol_2025_04_30_python3_glpk_pip
 python3-gnupg:
@@ -6040,28 +6083,28 @@ python3-google-auth:
   fedora: [python3-google-auth]
   opensuse: [python3-google-auth]
   rhel:
-    '*': [python3-google-auth]
-    '7': null
+    "*": [python3-google-auth]
+    "7": null
   ubuntu: [python3-google-auth]
 python3-google-auth-httplib2:
   debian:
-    '*': [python3-google-auth-httplib2]
+    "*": [python3-google-auth-httplib2]
     buster: null
   fedora: [python3-google-auth-httplib2]
   opensuse: [python3-google-auth-httplib2]
   ubuntu:
-    '*': [python3-google-auth-httplib2]
+    "*": [python3-google-auth-httplib2]
     bionic: null
 python3-google-auth-oauthlib:
   debian:
-    '*': [python3-google-auth-oauthlib]
+    "*": [python3-google-auth-oauthlib]
     buster: null
   fedora: [python3-google-auth-oauthlib]
   rhel:
-    '*': [python3-google-auth-oauthlib]
-    '7': null
+    "*": [python3-google-auth-oauthlib]
+    "7": null
   ubuntu:
-    '*': [python3-google-auth-oauthlib]
+    "*": [python3-google-auth-oauthlib]
     bionic: null
     focal: null
 python3-google-cloud-pubsub-pip:
@@ -6085,7 +6128,7 @@ python3-gpiozero:
   debian: [python3-gpiozero]
   fedora: [python3-gpiozero]
   ubuntu:
-    '*': [python3-gpiozero]
+    "*": [python3-gpiozero]
     bionic: null
 python3-gpxpy:
   debian: [python3-gpxpy]
@@ -6113,22 +6156,22 @@ python3-graphviz:
   ubuntu: [python3-graphviz]
 python3-grpc-tools:
   debian:
-    '*': [python3-grpc-tools]
+    "*": [python3-grpc-tools]
     stretch: null
   nixos: [python3Packages.grpcio-tools]
   openembedded: [python3-grpcio-tools@meta-python]
   ubuntu:
-    '*': [python3-grpc-tools]
+    "*": [python3-grpc-tools]
     bionic: null
 python3-grpcio:
   debian:
-    '*': [python3-grpcio]
+    "*": [python3-grpcio]
     stretch: null
   fedora: [python3-grpcio]
   nixos: [python3Packages.grpcio]
   openembedded: [python3-grpcio@meta-python]
   ubuntu:
-    '*': [python3-grpcio]
+    "*": [python3-grpcio]
     bionic: null
 python3-gurobipy-pip: *migrate_eol_2025_04_30_python3_gurobipy_pip
 python3-gz-math6:
@@ -6162,7 +6205,7 @@ python3-ifcfg:
     stretch: [python3-ifcfg]
   fedora: [python3-ifcfg]
   openembedded: [python3-ifcfg@meta-ros-common]
-  rhel: ['python%{python3_pkgversion}-ifcfg']
+  rhel: ["python%{python3_pkgversion}-ifcfg"]
   ubuntu:
     bionic: [python3-ifcfg]
     focal: [python3-ifcfg]
@@ -6190,14 +6233,14 @@ python3-img2pdf:
   nixos: [python39Packages.img2pdf]
   opensuse: [python3-img2pdf]
   rhel:
-    '*': [python3-img2pdf]
-    '7': null
+    "*": [python3-img2pdf]
+    "7": null
   ubuntu: [python3-img2pdf]
 python3-importlib-metadata:
   alpine: [py3-importlib-metadata]
   arch: [python-importlib-metadata]
   debian:
-    '*': [python3-importlib-metadata]
+    "*": [python3-importlib-metadata]
     buster:
       pip:
         packages: [importlib-metadata]
@@ -6212,18 +6255,18 @@ python3-importlib-metadata:
     pip:
       packages: [importlib_metadata]
   rhel:
-    '*': [python3]
-    '7': null
-    '8': [python3-importlib-metadata]
+    "*": [python3]
+    "7": null
+    "8": [python3-importlib-metadata]
   ubuntu:
-    '*': [python3-importlib-metadata]
+    "*": [python3-importlib-metadata]
     bionic:
       pip:
         packages: [importlib-metadata]
 python3-importlib-resources:
   arch: [python-importlib_resources]
   debian:
-    '*': [python3-importlib-resources]
+    "*": [python3-importlib-resources]
     buster:
       pip:
         packages: [importlib-resources]
@@ -6238,11 +6281,11 @@ python3-importlib-resources:
     pip:
       packages: [importlib-resources]
   rhel:
-    '*': [python3]
-    '7': null
-    '8': [python3-importlib-resources]
+    "*": [python3]
+    "7": null
+    "8": [python3-importlib-resources]
   ubuntu:
-    '*': [python3-minimal]
+    "*": [python3-minimal]
     bionic:
       pip:
         packages: [importlib-resources]
@@ -6295,8 +6338,8 @@ python3-jinja2:
   gentoo: [=dev-python/jinja-2*]
   nixos: [python3Packages.jinja2]
   rhel:
-    '*': [python3-jinja2]
-    '7': [python36-jinja2]
+    "*": [python3-jinja2]
+    "7": [python36-jinja2]
   ubuntu: [python3-jinja2]
 python3-jmespath:
   arch: [python-jmespath]
@@ -6325,15 +6368,15 @@ python3-jsonschema:
   gentoo: [dev-python/jsonschema]
   nixos: [python3Packages.jsonschema]
   rhel:
-    '*': [python3-jsonschema]
-    '7': [python36-jsonschema]
+    "*": [python3-jsonschema]
+    "7": [python36-jsonschema]
   ubuntu: [python3-jsonschema]
 python3-junitparser:
   debian:
-    '*': [python3-junitparser]
+    "*": [python3-junitparser]
     stretch: null
   ubuntu:
-    '*': [python3-junitparser]
+    "*": [python3-junitparser]
     bionic: null
 python3-jupyros-pip:
   debian:
@@ -6355,10 +6398,10 @@ python3-kitchen:
     pip:
       packages: [kitchen]
   ubuntu:
-    '*': [python3-kitchen]
+    "*": [python3-kitchen]
 python3-kivy:
   debian:
-    '*': [python3-kivy]
+    "*": [python3-kivy]
     buster:
       pip:
         packages: [Kivy]
@@ -6370,10 +6413,10 @@ python3-kiwisolver:
   gentoo: [dev-python/kiwisolver]
   opensuse: [python3-kiwisolver]
   rhel:
-    '*': [python3-kiwisolver]
-    '7': null
+    "*": [python3-kiwisolver]
+    "7": null
   ubuntu:
-    '*': [python3-kiwisolver]
+    "*": [python3-kiwisolver]
     bionic:
       pip:
         packages: [kiwisolver]
@@ -6391,16 +6434,16 @@ python3-lark-parser:
   alpine: [py3-lark-parser]
   arch: [python-lark-parser]
   debian:
-    '*': [python3-lark]
+    "*": [python3-lark]
     buster: [python3-lark-parser]
     stretch: [python3-lark-parser]
   fedora: [python3-lark-parser]
   gentoo: [dev-python/lark]
   nixos: [python3Packages.lark]
   openembedded: [python3-lark-parser@meta-ros-common]
-  rhel: ['python%{python3_pkgversion}-lark-parser']
+  rhel: ["python%{python3_pkgversion}-lark-parser"]
   ubuntu:
-    '*': [python3-lark]
+    "*": [python3-lark]
     bionic: [python3-lark-parser]
 python3-libgpiod:
   alpine: [py3-libgpiod]
@@ -6411,10 +6454,10 @@ python3-libgpiod:
   nixos: [python3Packages.libgpiod]
   opensuse: [python3-gpiod]
   rhel:
-    '*': [python3-libgpiod]
-    '7': null
+    "*": [python3-libgpiod]
+    "7": null
   ubuntu:
-    '*': [python3-libgpiod]
+    "*": [python3-libgpiod]
     bionic: null
 python3-lingua-franca-pip:
   debian:
@@ -6440,8 +6483,8 @@ python3-lttng:
   fedora: [python3-lttng]
   openembedded: [lttng-tools@openembedded-core]
   rhel:
-    '*': [python3-lttng]
-    '7': null
+    "*": [python3-lttng]
+    "7": null
   ubuntu: [python3-lttng]
 python3-lxml:
   alpine: [py3-lxml]
@@ -6456,7 +6499,7 @@ python3-lxml:
   osx:
     pip:
       packages: [lxml]
-  rhel: ['python%{python3_pkgversion}-lxml']
+  rhel: ["python%{python3_pkgversion}-lxml"]
   ubuntu: [python3-lxml]
 python3-mako:
   debian: [python3-mako]
@@ -6464,8 +6507,8 @@ python3-mako:
   gentoo: [dev-python/mako]
   opensuse: [python3-Mako]
   rhel:
-    '*': ['python%{python3_pkgversion}-mako']
-    '7': null
+    "*": ["python%{python3_pkgversion}-mako"]
+    "7": null
   ubuntu: [python3-mako]
 python3-mapbox-earcut-pip:
   debian:
@@ -6501,8 +6544,8 @@ python3-marshmallow:
   nixos: [python39Packages.marshmallow]
   opensuse: [python3-marshmallow]
   rhel:
-    '*': ['python%{python3_pkgversion}-marshmallow']
-    '7': null
+    "*": ["python%{python3_pkgversion}-marshmallow"]
+    "7": null
   ubuntu: [python3-marshmallow]
 python3-marshmallow-dataclass-pip:
   ubuntu:
@@ -6522,18 +6565,18 @@ python3-matplotlib:
       depends: [pkg-config, freetype, libpng12-dev]
       packages: [matplotlib]
   rhel:
-    '*': ['python%{python3_pkgversion}-matplotlib']
-    '7': null
+    "*": ["python%{python3_pkgversion}-matplotlib"]
+    "7": null
   slackware: [python3-matplotlib]
   ubuntu: [python3-matplotlib]
 python3-mechanize:
   debian:
-    '*': [python3-mechanize]
+    "*": [python3-mechanize]
     buster: null
   fedora: [python3-mechanize]
   nixos: [python3Packages.mechanize]
   ubuntu:
-    '*': [python3-mechanize]
+    "*": [python3-mechanize]
     bionic: null
 python3-mediapipe-pip:
   debian:
@@ -6602,7 +6645,7 @@ python3-mock:
   osx:
     pip:
       packages: [mock]
-  rhel: ['python%{python3_pkgversion}-mock']
+  rhel: ["python%{python3_pkgversion}-mock"]
   ubuntu: [python3-mock]
 python3-more-itertools:
   arch: [python-more-itertools]
@@ -6610,17 +6653,17 @@ python3-more-itertools:
   fedora: [python3-more-itertools]
   gentoo: [dev-python/more-itertools]
   rhel:
-    '*': [python3-more-itertools]
-    '7': null
+    "*": [python3-more-itertools]
+    "7": null
   ubuntu: [python3-more-itertools]
 python3-msgpack:
   debian:
-    '*': [python3-msgpack]
+    "*": [python3-msgpack]
     stretch: null
   fedora: [python3-msgpack]
   nixos: [python3Packages.msgpack]
   openembedded: [python3-msgpack@meta-python]
-  rhel: ['python%{python3_pkgversion}-msgpack']
+  rhel: ["python%{python3_pkgversion}-msgpack"]
   ubuntu: [python3-msgpack]
 python3-msk-pip:
   debian:
@@ -6652,8 +6695,8 @@ python3-munkres:
   nixos: [python3Packages.munkre]
   opensuse: [python3-munkres]
   rhel:
-    '*': [python3-munkres]
-    '7': null
+    "*": [python3-munkres]
+    "7": null
   ubuntu: [python3-munkres]
 python3-mycroft-messagebus-client-pip:
   debian:
@@ -6666,7 +6709,7 @@ python3-mypy:
   alpine: [py3-mypy]
   arch: [mypy]
   debian:
-    '*': [python3-mypy]
+    "*": [python3-mypy]
     stretch: [mypy]
   fedora: [python3-mypy]
   gentoo: [dev-python/mypy]
@@ -6677,9 +6720,9 @@ python3-mypy:
     pip:
       packages: [mypy]
   rhel:
-    '*': [python3-mypy]
-    '7': null
-    '8': null
+    "*": [python3-mypy]
+    "7": null
+    "8": null
   ubuntu: [python3-mypy]
 python3-nclib-pip:
   arch:
@@ -6709,7 +6752,7 @@ python3-netifaces:
   nixos: [python3Packages.netifaces]
   openembedded: [python3-netifaces@meta-ros-common]
   opensuse: [python3-netifaces]
-  rhel: ['python%{python3_pkgversion}-netifaces']
+  rhel: ["python%{python3_pkgversion}-netifaces"]
   ubuntu: [python3-netifaces]
 python3-networkmanager:
   debian:
@@ -6724,13 +6767,13 @@ python3-networkx:
 python3-nlopt:
   arch: [nlopt]
   debian:
-    '*': [python3-nlopt]
+    "*": [python3-nlopt]
     buster: null
     stretch: null
   fedora: [python3-NLopt]
   gentoo: [sci-libs/nlopt]
   ubuntu:
-    '*': [python3-nlopt]
+    "*": [python3-nlopt]
     bionic: null
 python3-nose:
   arch: [python-nose]
@@ -6743,7 +6786,7 @@ python3-nose:
   osx:
     pip:
       packages: [nose]
-  rhel: ['python%{python3_pkgversion}-nose']
+  rhel: ["python%{python3_pkgversion}-nose"]
   ubuntu: [python3-nose]
 python3-nose-parameterized:
   debian: [python3-nose-parameterized]
@@ -6758,8 +6801,8 @@ python3-ntplib:
   nixos: [python3Packages.ntplib]
   opensuse: [python3-ntplib]
   rhel:
-    '*': ['python%{python3_pkgversion}-ntplib']
-    '7': null
+    "*": ["python%{python3_pkgversion}-ntplib"]
+    "7": null
   ubuntu: [python3-ntplib]
 python3-numba:
   debian: [python3-numba]
@@ -6773,14 +6816,14 @@ python3-numpy:
   nixos: [python3Packages.numpy]
   openembedded: [python3-numpy@openembedded-core]
   opensuse: [python3-numpy]
-  rhel: ['python%{python3_pkgversion}-numpy']
+  rhel: ["python%{python3_pkgversion}-numpy"]
   ubuntu: [python3-numpy]
 python3-numpy-stl:
   debian: [python3-numpy-stl]
   fedora: [python3-numpy-stl]
   nixos: [python3Packages.numpy-stl]
   ubuntu:
-    '*': [python3-numpy-stl]
+    "*": [python3-numpy-stl]
 python3-nuscenes-devkit-pip:
   arch:
     pip:
@@ -6812,8 +6855,8 @@ python3-oauth2client:
   fedora: [python3-oauth2client]
   opensuse: [python3-oauth2client]
   rhel:
-    '*': [python3-oauth2client]
-    '7': null
+    "*": [python3-oauth2client]
+    "7": null
   ubuntu: [python3-oauth2client]
 python3-odrive-pip:
   debian:
@@ -6859,11 +6902,11 @@ python3-onnxruntime-pip:
       packages: [onnxruntime]
 python3-open3d:
   debian:
-    '*': [python3-open3d]
+    "*": [python3-open3d]
     buster: null
     stretch: null
   ubuntu:
-    '*': [python3-open3d]
+    "*": [python3-open3d]
     bionic: null
     focal: null
 python3-open3d-pip:
@@ -6889,14 +6932,14 @@ python3-openai-pip:
 python3-opencv:
   debian: [python3-opencv]
   fedora: [python3-opencv]
-  gentoo: ['media-libs/opencv[python]']
+  gentoo: ["media-libs/opencv[python]"]
   nixos: [python3Packages.opencv3]
   openembedded: [opencv@meta-oe]
   opensuse: [python3-opencv]
   rhel:
-    '*': [python3-opencv]
-    '7': null
-    '8': null
+    "*": [python3-opencv]
+    "7": null
+    "8": null
   ubuntu: [python3-opencv]
 python3-opengl:
   debian: [python3-opengl]
@@ -6933,7 +6976,7 @@ python3-packaging:
   gentoo: [dev-python/packaging]
   nixos: [python3Packages.packaging]
   openembedded: [python3-packaging@openembedded-core]
-  rhel: ['python%{python3_pkgversion}-packaging']
+  rhel: ["python%{python3_pkgversion}-packaging"]
   ubuntu: [python3-packaging]
 python3-padaos-pip:
   debian:
@@ -6953,10 +6996,10 @@ python3-paho-mqtt:
   debian: [python3-paho-mqtt]
   fedora: [python3-paho-mqtt]
   rhel:
-    '*': [python3-paho-mqtt]
-    '7': null
+    "*": [python3-paho-mqtt]
+    "7": null
   ubuntu:
-    '*': [python3-paho-mqtt]
+    "*": [python3-paho-mqtt]
 python3-pandas:
   debian: [python3-pandas]
   fedora: [python3-pandas]
@@ -6965,8 +7008,8 @@ python3-pandas:
   openembedded: [python3-pandas@meta-python]
   opensuse: [python3-pandas]
   rhel:
-    '*': ['python%{python3_pkgversion}-pandas']
-    '7': null
+    "*": ["python%{python3_pkgversion}-pandas"]
+    "7": null
   ubuntu: [python3-pandas]
 python3-papermill-pip:
   debian:
@@ -6991,7 +7034,7 @@ python3-paramiko:
   nixos: [python3Packages.paramiko]
   openembedded: [python3-paramiko@meta-ros-common]
   opensuse: [python3-paramiko]
-  rhel: ['python%{python3_pkgversion}-paramiko']
+  rhel: ["python%{python3_pkgversion}-paramiko"]
   ubuntu: [python3-paramiko]
 python3-parse:
   arch: [python-parse]
@@ -7000,8 +7043,8 @@ python3-parse:
   gentoo: [dev-python/parse]
   opensuse: [python3-parse]
   rhel:
-    '*': [python3-parse]
-    '7': null
+    "*": [python3-parse]
+    "7": null
   ubuntu: [python3-parse]
 python3-pcg-gazebo-pip:
   debian:
@@ -7035,7 +7078,7 @@ python3-pexpect:
   debian: [python3-pexpect]
   fedora: [python3-pexpect]
   opensuse: [python3-pexpect]
-  rhel: ['python%{python3_pkgversion}-pexpect']
+  rhel: ["python%{python3_pkgversion}-pexpect"]
   ubuntu: [python3-pexpect]
 python3-pickleDB-pip:
   debian:
@@ -7050,7 +7093,7 @@ python3-pickleDB-pip:
 python3-pika:
   debian: [python3-pika]
   fedora: [python3-pika]
-  rhel: ['python%{python3_pkgversion}-pika']
+  rhel: ["python%{python3_pkgversion}-pika"]
   ubuntu: [python3-pika]
 python3-pil:
   alpine: [py3-pillow]
@@ -7087,7 +7130,7 @@ python3-pkg-resources:
   nixos: [python3Packages.setuptools]
   openembedded: [python3-setuptools@openembedded-core]
   opensuse: [python3-setuptools]
-  rhel: ['python%{python3_pkgversion}-setuptools']
+  rhel: ["python%{python3_pkgversion}-setuptools"]
   ubuntu: [python3-pkg-resources]
 python3-playsound-pip:
   debian:
@@ -7106,8 +7149,8 @@ python3-ply:
   gentoo: [dev-python/ply]
   opensuse: [python3-ply]
   rhel:
-    '*': [python3-ply]
-    '7': null
+    "*": [python3-ply]
+    "7": null
   ubuntu: [python3-ply]
 python3-pocketsphinx-pip:
   debian:
@@ -7144,7 +7187,7 @@ python3-pqdict-pip:
       packages: [pqdict]
 python3-pre-commit:
   debian:
-    '*': [pre-commit]
+    "*": [pre-commit]
     buster:
       pip:
         packages: [pre-commit]
@@ -7153,7 +7196,7 @@ python3-pre-commit:
         packages: [pre-commit]
   fedora: [pre-commit]
   ubuntu:
-    '*': [pre-commit]
+    "*": [pre-commit]
     bionic:
       pip:
         packages: [pre-commit]
@@ -7184,8 +7227,8 @@ python3-prometheus-client:
   debian: [python3-prometheus-client]
   fedora: [python3-prometheus_client]
   rhel:
-    '*': [python3-prometheus_client]
-    '7': null
+    "*": [python3-prometheus_client]
+    "7": null
   ubuntu: [python3-prometheus-client]
 python3-prompt-toolkit:
   arch: [python-prompt_toolkit]
@@ -7193,8 +7236,8 @@ python3-prompt-toolkit:
   fedora: [python-prompt-toolkit]
   gentoo: [dev-python/prompt_toolkit]
   rhel:
-    '*': [python3-prompt-toolkit]
-    '7': null
+    "*": [python3-prompt-toolkit]
+    "7": null
   ubuntu: [python3-prompt-toolkit]
 python3-protobuf:
   alpine: [py3-protobuf]
@@ -7203,8 +7246,8 @@ python3-protobuf:
   gentoo: [dev-python/protobuf-python]
   nixos: [python3Packages.protobuf]
   rhel:
-    '*': [python3-protobuf]
-    '7': null
+    "*": [python3-protobuf]
+    "7": null
   ubuntu: [python3-protobuf]
 python3-psutil:
   alpine: [py3-psutil]
@@ -7219,7 +7262,7 @@ python3-psutil:
   osx:
     pip:
       packages: [psutil]
-  rhel: ['python%{python3_pkgversion}-psutil']
+  rhel: ["python%{python3_pkgversion}-psutil"]
   slackware: [psutil]
   ubuntu: [python3-psutil]
 python3-py3exiv2-pip:
@@ -7237,12 +7280,12 @@ python3-py3exiv2-pip:
       packages: [py3exiv2]
 python3-pyassimp:
   debian:
-    '*': [python3-pyassimp]
+    "*": [python3-pyassimp]
     stretch: null
   fedora: [python3-assimp]
   openembedded: [python3-pyassimp@meta-ros-common]
   ubuntu:
-    '*': [python3-pyassimp]
+    "*": [python3-pyassimp]
 python3-pyaudio:
   arch: [python-pyaudio]
   debian: [python3-pyaudio]
@@ -7284,7 +7327,7 @@ python3-pycodestyle:
   osx:
     pip:
       packages: [pycodestyle]
-  rhel: ['python%{python3_pkgversion}-pycodestyle']
+  rhel: ["python%{python3_pkgversion}-pycodestyle"]
   ubuntu: [python3-pycodestyle]
 python3-pycryptodome:
   alpine: [py3-pycryptodome]
@@ -7298,12 +7341,12 @@ python3-pycryptodome:
   osx:
     pip:
       packages: [pycryptodome]
-  rhel: ['python%{python3_pkgversion}-pycryptodomex']
+  rhel: ["python%{python3_pkgversion}-pycryptodomex"]
   ubuntu: [python3-pycryptodome]
 python3-pydantic:
   arch: [python-pydantic]
   debian:
-    '*': [python3-pydantic]
+    "*": [python3-pydantic]
     buster:
       pip: [pydantic]
     stretch:
@@ -7311,7 +7354,7 @@ python3-pydantic:
   fedora: [python3-pydantic]
   gentoo: [dev-python/pydantic]
   ubuntu:
-    '*': [python3-pydantic]
+    "*": [python3-pydantic]
     bionic:
       pip: [pydantic]
 python3-pydbus:
@@ -7319,8 +7362,8 @@ python3-pydbus:
   fedora: [python3-pydbus]
   opensuse: [python3-pydbus]
   rhel:
-    '*': ['python%{python3_pkgversion}-pydbus']
-    '7': null
+    "*": ["python%{python3_pkgversion}-pydbus"]
+    "7": null
   ubuntu: [python3-pydbus]
 python3-pydot:
   alpine: [py3-pydot]
@@ -7335,8 +7378,8 @@ python3-pydot:
     pip:
       packages: [pydot]
   rhel:
-    '*': ['python%{python3_pkgversion}-pydot']
-    '7': null
+    "*": ["python%{python3_pkgversion}-pydot"]
+    "7": null
   ubuntu: [python3-pydot]
 python3-pyee:
   debian: [python3-pyee]
@@ -7357,14 +7400,14 @@ python3-pyftpdlib:
   ubuntu: [python3-pyftpdlib]
 python3-pygame:
   debian:
-    '*': [python3-pygame]
+    "*": [python3-pygame]
     stretch:
       pip: [pygame]
   fedora: [python3-pygame]
   gentoo: [dev-python/pygame]
   nixos: [python3Packages.pygame]
   ubuntu:
-    '*': [python3-pygame]
+    "*": [python3-pygame]
     bionic:
       pip: [pygame]
 python3-pygit2:
@@ -7378,8 +7421,8 @@ python3-pygit2:
     pip:
       packages: [pygit2]
   rhel:
-    '*': [python3-pygit2]
-    '7': null
+    "*": [python3-pygit2]
+    "7": null
   ubuntu: [python3-pygit2]
 python3-pygments:
   alpine: [py3-pygments]
@@ -7390,8 +7433,8 @@ python3-pygments:
   openembedded: [python3-pygments@openembedded-core]
   opensuse: [python3-Pygments]
   rhel:
-    '*': [python3-pygments]
-    '7': null
+    "*": [python3-pygments]
+    "7": null
   ubuntu: [python3-pygments]
 python3-pygraphviz:
   alpine: [py3-pygraphviz]
@@ -7405,26 +7448,26 @@ python3-pygraphviz:
   osx:
     pip:
       packages: [pygraphviz]
-  rhel: ['python%{python3_pkgversion}-pygraphviz']
+  rhel: ["python%{python3_pkgversion}-pygraphviz"]
   slackware: [pygraphviz]
   ubuntu: [python3-pygraphviz]
 python3-pykdl:
   debian:
-    '*': [python3-pykdl]
+    "*": [python3-pykdl]
     stretch: null
   fedora: [python3-pykdl]
   gentoo: [dev-python/python_orocos_kdl]
   nixos: [python3Packages.pykdl]
   openembedded: [python3-pykdl@meta-ros1-noetic]
   rhel:
-    '*': [python3-pykdl]
-    '7': null
+    "*": [python3-pykdl]
+    "7": null
   ubuntu:
-    '*': [python3-pykdl]
+    "*": [python3-pykdl]
     bionic: null
 python3-pylatexenc:
   debian:
-    '*': [python3-pylatexenc]
+    "*": [python3-pylatexenc]
     bullseye:
       pip:
         packages: [pylatexenc]
@@ -7432,7 +7475,7 @@ python3-pylatexenc:
       pip:
         packages: [pylatexenc]
   ubuntu:
-    '*': [python3-pylatexenc]
+    "*": [python3-pylatexenc]
     bionic:
       pip:
         packages: [pylatexenc]
@@ -7441,7 +7484,7 @@ python3-pylatexenc:
         packages: [pylatexenc]
 python3-pylibdmtx:
   debian:
-    '*': [python3-pylibdmtx]
+    "*": [python3-pylibdmtx]
     buster:
       pip:
         packages: [pylibdmtx]
@@ -7452,7 +7495,7 @@ python3-pylibdmtx:
     pip:
       packages: [pylibdmtx]
   ubuntu:
-    '*': [python3-pylibdmtx]
+    "*": [python3-pylibdmtx]
     bionic:
       pip:
         packages: [pylibdmtx]
@@ -7461,12 +7504,12 @@ python3-pylibdmtx:
         packages: [pylibdmtx]
 python3-pymap3d:
   debian:
-    '*': [python3-pymap3d]
+    "*": [python3-pymap3d]
     buster: null
     stretch: null
   gentoo: [sci-geosciences/pymap3d]
   ubuntu:
-    '*': [python3-pymap3d]
+    "*": [python3-pymap3d]
     bionic: null
     focal: null
 python3-pymesh2-pip:
@@ -7481,11 +7524,11 @@ python3-pymesh2-pip:
       packages: [pymesh2]
 python3-pymodbus:
   debian:
-    '*': [python3-pymodbus]
+    "*": [python3-pymodbus]
     stretch: null
   fedora: [python3-pymodbus]
   ubuntu:
-    '*': [python3-pymodbus]
+    "*": [python3-pymodbus]
 python3-pymodbus-pip: *migrate_eol_2027_04_30_python3_pymodbus_pip
 python3-pymongo:
   arch: [python-pymongo]
@@ -7545,7 +7588,7 @@ python3-pypng:
   fedora: [python3-pypng]
   gentoo: [dev-python/pypng]
   ubuntu:
-    '*': [python3-png]
+    "*": [python3-png]
 python3-pyproj:
   arch: [python-pyproj]
   debian: [python3-pyproj]
@@ -7554,8 +7597,8 @@ python3-pyproj:
   nixos: [python3Packages.pyproj]
   openembedded: [python3-pyproj@meta-ros-common]
   rhel:
-    '*': ['python%{python3_pkgversion}-pyproj']
-    '7': null
+    "*": ["python%{python3_pkgversion}-pyproj"]
+    "7": null
   ubuntu: [python3-pyproj]
 python3-pyqrcode:
   arch: [python-qrcode]
@@ -7566,13 +7609,26 @@ python3-pyqrcode:
 python3-pyqt5:
   alpine: [py3-qt5]
   arch: [python-pyqt5]
-  debian: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
+  debian:
+    [
+      pyqt5-dev,
+      python3-pyqt5,
+      python3-pyqt5.qtsvg,
+      python3-sip-dev,
+      qtbase5-dev,
+    ]
   fedora: [python3-qt5-devel, python3-sip-devel, libXext-devel]
   gentoo: [dev-python/PyQt5]
   nixos: [python3Packages.pyqt5]
   openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python3-qt5]
-  rhel: ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
+  rhel:
+    [
+      "python%{python3_pkgversion}-qt5-devel",
+      "python%{python3_pkgversion}-sip-devel",
+      libXext-devel,
+      redhat-rpm-config,
+    ]
   slackware: [python3-PyQt5]
   ubuntu: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
 python3-pyqt5.qtquick:
@@ -7582,7 +7638,7 @@ python3-pyqt5.qtwebengine:
   debian: [python3-pyqt5.qtwebengine]
   fedora: [python3-qt5-webengine]
   nixos: [python3Packages.pyqtwebengine]
-  openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
+  openembedded: ["${PYTHON_PN}-pyqt5@meta-qt5"]
   opensuse: [python3-qtwebengine-qt5]
   ubuntu: [python3-pyqt5.qtwebengine]
 python3-pyqtgraph:
@@ -7603,11 +7659,47 @@ python3-pyrr-pip:
       packages: [pyrr]
 python3-pyside2:
   arch: [pyside2, python-shiboken2, shiboken2]
-  debian: [libpyside2-dev, libshiboken2-dev, python3-pyside2.qtcore, python3-pyside2.qtgui, python3-pyside2.qthelp, python3-pyside2.qtnetwork, python3-pyside2.qtprintsupport, python3-pyside2.qttest, python3-pyside2.qtsvg, python3-pyside2.qtwidgets, python3-pyside2.qtxml, shiboken2]
-  fedora: [python3-pyside2, pyside2-tools, python3-pyside2-devel, python3-shiboken2, python3-shiboken2-devel, shiboken2]
+  debian:
+    [
+      libpyside2-dev,
+      libshiboken2-dev,
+      python3-pyside2.qtcore,
+      python3-pyside2.qtgui,
+      python3-pyside2.qthelp,
+      python3-pyside2.qtnetwork,
+      python3-pyside2.qtprintsupport,
+      python3-pyside2.qttest,
+      python3-pyside2.qtsvg,
+      python3-pyside2.qtwidgets,
+      python3-pyside2.qtxml,
+      shiboken2,
+    ]
+  fedora:
+    [
+      python3-pyside2,
+      pyside2-tools,
+      python3-pyside2-devel,
+      python3-shiboken2,
+      python3-shiboken2-devel,
+      shiboken2,
+    ]
   gentoo: [dev-python/pyside2, dev/python/shiboken2]
   ubuntu:
-    "*": [libpyside2-dev, libshiboken2-dev, python3-pyside2.qtcore, python3-pyside2.qtgui, python3-pyside2.qthelp, python3-pyside2.qtnetwork, python3-pyside2.qtprintsupport, python3-pyside2.qtsvg, python3-pyside2.qttest, python3-pyside2.qtwidgets, python3-pyside2.qtxml, shiboken2]
+    "*":
+      [
+        libpyside2-dev,
+        libshiboken2-dev,
+        python3-pyside2.qtcore,
+        python3-pyside2.qtgui,
+        python3-pyside2.qthelp,
+        python3-pyside2.qtnetwork,
+        python3-pyside2.qtprintsupport,
+        python3-pyside2.qtsvg,
+        python3-pyside2.qttest,
+        python3-pyside2.qtwidgets,
+        python3-pyside2.qtxml,
+        shiboken2,
+      ]
     bionic: null
 python3-pyside2.qtopengl:
   arch: [pyside2]
@@ -7615,7 +7707,7 @@ python3-pyside2.qtopengl:
   fedora: [python3-pyside2]
   gentoo: [dev-python/pyside2]
   ubuntu:
-    '*': [python3-pyside2.qtopengl]
+    "*": [python3-pyside2.qtopengl]
     bionic: null
 python3-pyside2.qtquick:
   arch: [pyside2]
@@ -7623,12 +7715,12 @@ python3-pyside2.qtquick:
   fedora: [python3-pyside2]
   gentoo: [dev-python/pyside2]
   ubuntu:
-    '*': [python3-pyside2.qtquick]
+    "*": [python3-pyside2.qtquick]
     bionic: null
 python3-pyside2.qtuitools:
   debian: [python3-pyside2.qtuitools]
   ubuntu:
-    '*': [python3-pyside2.qtuitools]
+    "*": [python3-pyside2.qtuitools]
     bionic: null
 python3-pysnmp:
   debian: [python3-pysnmp4]
@@ -7637,8 +7729,8 @@ python3-pysnmp:
   nixos: [python3Packages.pysnmp]
   opensuse: [python3-pysnmp]
   rhel:
-    '*': [python3-pysnmp]
-    '7': [pysnmp]
+    "*": [python3-pysnmp]
+    "7": [pysnmp]
   ubuntu: [python3-pysnmp4]
 python3-pystemd:
   debian:
@@ -7646,10 +7738,10 @@ python3-pystemd:
   fedora: [python3-pystemd]
   nixos: [python3Packages.pystemd]
   rhel:
-    '*': [python3-pystemd]
-    '7': null
+    "*": [python3-pystemd]
+    "7": null
   ubuntu:
-    '*': [python3-pystemd]
+    "*": [python3-pystemd]
     bionic:
       pip:
         packages: [pystemd]
@@ -7675,7 +7767,7 @@ python3-pytest:
   osx:
     pip:
       packages: [pytest]
-  rhel: ['python%{python3_pkgversion}-pytest']
+  rhel: ["python%{python3_pkgversion}-pytest"]
   ubuntu: [python3-pytest]
 python3-pytest-asyncio:
   alpine: [py3-pytest-asyncio]
@@ -7689,18 +7781,18 @@ python3-pytest-asyncio:
     pip:
       packages: [pytest-asyncio]
   rhel:
-    '*': [python3-pytest-asyncio]
-    '7': null
+    "*": [python3-pytest-asyncio]
+    "7": null
   ubuntu:
-    '*': [python3-pytest-asyncio]
+    "*": [python3-pytest-asyncio]
     bionic: null
 python3-pytest-benchmark:
   debian: [python3-pytest-benchmark]
   fedora: [python3-pytest-benchmark]
   opensuse: [python3-pytest-benchmark]
   rhel:
-    '*': [python3-pytest-benchmark]
-    '7': null
+    "*": [python3-pytest-benchmark]
+    "7": null
   ubuntu: [python3-pytest-benchmark]
 python3-pytest-cov:
   alpine: [py3-pytest-cov]
@@ -7710,7 +7802,7 @@ python3-pytest-cov:
   gentoo: [dev-python/pytest-cov]
   nixos: [python3Packages.pytestcov]
   openembedded: [python3-pytest-cov@meta-ros-common]
-  rhel: ['python%{python3_pkgversion}-pytest-cov']
+  rhel: ["python%{python3_pkgversion}-pytest-cov"]
   ubuntu: [python3-pytest-cov]
 python3-pytest-mock:
   alpine: [py3-pytest-mock]
@@ -7724,7 +7816,7 @@ python3-pytest-mock:
   osx:
     pip:
       packages: [pytest-mock]
-  rhel: ['python%{python3_pkgversion}-pytest-mock']
+  rhel: ["python%{python3_pkgversion}-pytest-mock"]
   ubuntu: [python3-pytest-mock]
 python3-pytest-timeout:
   arch: [python-pytest-timeout]
@@ -7733,7 +7825,7 @@ python3-pytest-timeout:
   gentoo: [dev-python/pytest-timeout]
   nixos: [python3Packages.pytest-timeout]
   opensuse: [python3-pytest-timeout]
-  rhel: ['python%{python3_pkgversion}-pytest-timeout']
+  rhel: ["python%{python3_pkgversion}-pytest-timeout"]
   ubuntu: [python3-pytest-timeout]
 python3-pytorch-pip: *migrate_eol_2025_04_30_python3_pytorch_pip
 python3-pytrinamic-pip:
@@ -7780,31 +7872,71 @@ python3-qrcode:
   nixos: [python39Packages.qrcode]
   opensuse: [python3-qrcode]
   rhel:
-    '8': [python3-qrcode]
+    "8": [python3-qrcode]
   ubuntu: [python3-qrcode]
 python3-qt5-bindings:
   alpine: [py3-qt5]
   arch: [python-pyqt5]
   debian:
-    '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2]
-    stretch: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
+    "*":
+      [
+        libpyside2-dev,
+        libshiboken2-dev,
+        pyqt5-dev,
+        python3-pyqt5,
+        python3-pyqt5.qtsvg,
+        python3-pyside2.qtsvg,
+        python3-sip-dev,
+        qtbase5-dev,
+        shiboken2,
+      ]
+    stretch:
+      [
+        pyqt5-dev,
+        python3-pyqt5,
+        python3-pyqt5.qtsvg,
+        python3-sip-dev,
+        qtbase5-dev,
+      ]
   fedora: [python3-qt5-devel, python3-sip-devel, libXext-devel]
   gentoo: [dev-python/PyQt5]
   nixos: [python3Packages.pyqt5]
   openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python3-qt5]
   rhel:
-    '*': [clang, python3-devel, python3-pyside2-devel, python3-shiboken2-devel]
-    '7': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
-    '8': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
+    "*": [clang, python3-devel, python3-pyside2-devel, python3-shiboken2-devel]
+    "7":
+      [
+        "python%{python3_pkgversion}-qt5-devel",
+        "python%{python3_pkgversion}-sip-devel",
+        libXext-devel,
+        redhat-rpm-config,
+      ]
+    "8":
+      [
+        "python%{python3_pkgversion}-qt5-devel",
+        "python%{python3_pkgversion}-sip-devel",
+        libXext-devel,
+        redhat-rpm-config,
+      ]
   slackware: [python3-PyQt5]
   ubuntu:
-    '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2]
+    "*":
+      [
+        libpyside2-dev,
+        libshiboken2-dev,
+        pyqt5-dev,
+        python3-pyqt5,
+        python3-pyqt5.qtsvg,
+        python3-pyside2.qtsvg,
+        python3-sip-dev,
+        shiboken2,
+      ]
     bionic: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
 python3-qt5-bindings-gl:
   debian: [python3-pyqt5.qtopengl]
   fedora: [python3-qt5]
-  gentoo: ['dev-python/PyQt5[opengl]']
+  gentoo: ["dev-python/PyQt5[opengl]"]
   nixos: [python3Packages.pyqt5]
   openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python3-qt5]
@@ -7812,7 +7944,7 @@ python3-qt5-bindings-gl:
 python3-qt5-bindings-webkit:
   debian: [python3-pyqt5.qtwebkit]
   fedora: [python3-qt5-webkit]
-  gentoo: ['dev-python/PyQt5[webkit]']
+  gentoo: ["dev-python/PyQt5[webkit]"]
   nixos: [python3Packages.pyqt5_with_qtwebkit]
   openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python3-qt5]
@@ -7824,7 +7956,7 @@ python3-qtpy:
   gentoo: [dev-python/QtPy]
   nixos: [python3Packages.qtpy]
   rhel:
-    '8': [python3-QtPy]
+    "8": [python3-QtPy]
   ubuntu: [python3-qtpy]
 python3-qwt:
   debian: [python3-qwt]
@@ -7859,7 +7991,7 @@ python3-rdflib:
   gentoo: [dev-python/rdflib]
   nixos: [python3Packages.rdflib]
   rhel:
-    '8': ['python%{python3_pkgversion}-rdflib']
+    "8": ["python%{python3_pkgversion}-rdflib"]
   ubuntu: [python3-rdflib]
 python3-reportlab:
   arch: [python-reportlab]
@@ -7872,15 +8004,15 @@ python3-reportlab:
     pip:
       packages: [reportlab]
   rhel:
-    '*': [python3-reportlab]
-    '7': null
+    "*": [python3-reportlab]
+    "7": null
   ubuntu: [python3-reportlab]
 python3-requests:
   debian: [python3-requests]
   fedora: [python3-requests]
   nixos: [python3Packages.requests]
   openembedded: [python3-requests@meta-python]
-  rhel: ['python%{python3_pkgversion}-requests']
+  rhel: ["python%{python3_pkgversion}-requests"]
   ubuntu: [python3-requests]
 python3-requests-futures:
   debian: [python3-requests-futures]
@@ -7893,8 +8025,8 @@ python3-requests-oauthlib:
   nixos: [python3Packages.requests_oauthlib]
   openembedded: [python3-requests-oauthlib@meta-python]
   rhel:
-    '*': ['python%{python3_pkgversion}-requests-oauthlib']
-    '7': null
+    "*": ["python%{python3_pkgversion}-requests-oauthlib"]
+    "7": null
   ubuntu: [python3-requests-oauthlib]
 python3-retrying:
   arch: [python-retrying]
@@ -7941,7 +8073,7 @@ python3-rosdep:
   debian: [python3-rosdep]
   fedora: [python3-rosdep]
   gentoo: [dev-util/rosdep]
-  rhel: ['python%{python3_pkgversion}-rosdep']
+  rhel: ["python%{python3_pkgversion}-rosdep"]
   ubuntu: [python3-rosdep]
 python3-rosdep-modules:
   debian: [python3-rosdep-modules]
@@ -7949,7 +8081,7 @@ python3-rosdep-modules:
   gentoo: [dev-util/rosdep]
   nixos: [python3Packages.rosdep]
   openembedded: [python3-rosdep@meta-ros-common]
-  rhel: ['python%{python3_pkgversion}-rosdep']
+  rhel: ["python%{python3_pkgversion}-rosdep"]
   ubuntu: [python3-rosdep-modules]
 python3-rosdistro-modules:
   alpine: [py3-rosdistro]
@@ -7961,7 +8093,7 @@ python3-rosdistro-modules:
   gentoo: [dev-python/rosdistro]
   nixos: [python3Packages.rosdistro]
   openembedded: [python3-rosdistro@meta-ros-common]
-  rhel: ['python%{python3_pkgversion}-rosdistro']
+  rhel: ["python%{python3_pkgversion}-rosdistro"]
   ubuntu: [python3-rosdistro-modules]
 python3-rosinstall-generator:
   fedora: [python3-rosinstall_generator]
@@ -7981,7 +8113,7 @@ python3-rospkg:
   osx:
     pip:
       packages: [rospkg]
-  rhel: ['python%{python3_pkgversion}-rospkg']
+  rhel: ["python%{python3_pkgversion}-rospkg"]
   slackware:
     pip:
       packages: [rospkg]
@@ -8003,7 +8135,7 @@ python3-rospkg-modules:
   osx:
     pip:
       packages: [rospkg]
-  rhel: ['python%{python3_pkgversion}-rospkg']
+  rhel: ["python%{python3_pkgversion}-rospkg"]
   slackware:
     pip:
       packages: [rospkg]
@@ -8013,8 +8145,8 @@ python3-rtree:
   fedora: [python3-rtree]
   nixos: [python3Packages.Rtree]
   rhel:
-    '*': [python3-rtree]
-    '7': null
+    "*": [python3-rtree]
+    "7": null
   ubuntu: [python3-rtree]
 python3-ruamel.yaml:
   debian:
@@ -8023,7 +8155,7 @@ python3-ruamel.yaml:
   fedora: [python3-ruamel-yaml]
   nixos: [python3Packages.ruamel_yaml]
   openembedded: [python3-ruamel-yaml@meta-python]
-  rhel: ['python%{python3_pkgversion}-ruamel-yaml']
+  rhel: ["python%{python3_pkgversion}-ruamel-yaml"]
   ubuntu: [python3-ruamel.yaml]
 python3-sbp-pip: *migrate_eol_2027_04_30_python3_sbp_pip
 python3-schedule:
@@ -8055,7 +8187,7 @@ python3-scipy:
     pip:
       depends: [gfortran]
       packages: [scipy]
-  rhel: ['python%{python3_pkgversion}-scipy']
+  rhel: ["python%{python3_pkgversion}-scipy"]
   ubuntu: [python3-scipy]
 python3-scp:
   debian: [python3-scp]
@@ -8063,8 +8195,8 @@ python3-scp:
   nixos: [python3Packages.scp]
   opensuse: [python3-scp]
   rhel:
-    '*': [python3-scp]
-    '7': null
+    "*": [python3-scp]
+    "7": null
   ubuntu: [python3-scp]
 python3-seaborn:
   arch: [python-seaborn]
@@ -8074,18 +8206,18 @@ python3-seaborn:
   ubuntu: [python3-seaborn]
 python3-segno:
   debian:
-    '*': [python3-segno]
+    "*": [python3-segno]
     buster: null
   fedora:
-    '*': [python3-segno]
-    '36': null
-    '37': null
+    "*": [python3-segno]
+    "36": null
+    "37": null
   rhel:
-    '*': [python3-segno]
-    '7': null
-    '8': null
+    "*": [python3-segno]
+    "7": null
+    "8": null
   ubuntu:
-    '*': [python3-segno]
+    "*": [python3-segno]
     bionic:
       pip:
         packages: [segno]
@@ -8102,8 +8234,8 @@ python3-selenium:
     pip:
       packages: [selenium]
   rhel:
-    '*': [python3-selenium]
-    '7': null
+    "*": [python3-selenium]
+    "7": null
   ubuntu: [python3-selenium]
 python3-semantic-version:
   debian: [python3-semantic-version]
@@ -8135,8 +8267,8 @@ python3-serial:
   nixos: [python3Packages.pyserial]
   openembedded: [python3-pyserial@meta-python]
   rhel:
-    '*': ['python%{python3_pkgversion}-pyserial']
-    '7': null
+    "*": ["python%{python3_pkgversion}-pyserial"]
+    "7": null
   ubuntu: [python3-serial]
 python3-setuptools:
   alpine: [py3-setuptools]
@@ -8150,18 +8282,18 @@ python3-setuptools:
   osx:
     pip:
       packages: [setuptools]
-  rhel: ['python%{python3_pkgversion}-setuptools']
+  rhel: ["python%{python3_pkgversion}-setuptools"]
   ubuntu: [python3-setuptools]
 python3-sexpdata:
   debian:
-    '*': [python3-sexpdata]
+    "*": [python3-sexpdata]
     stretch:
       pip:
         packages: [sexpdata]
   fedora: [python3-sexpdata]
   nixos: [python3Packages.sexpdata]
   ubuntu:
-    '*': [python3-sexpdata]
+    "*": [python3-sexpdata]
     bionic:
       pip:
         packages: [sexpdata]
@@ -8315,11 +8447,11 @@ python3-smc-pip:
       packages: [smc]
 python3-socketio:
   debian:
-    '*': [python3-socketio]
+    "*": [python3-socketio]
     buster: null
   fedora: [python3-socketio]
   ubuntu:
-    '*': [python3-socketio]
+    "*": [python3-socketio]
     bionic: null
 python3-sortedcollections-pip:
   debian:
@@ -8366,7 +8498,7 @@ python3-sphinx:
   nixos: [python3Packages.sphinx]
   openembedded: [python3-sphinx@meta-ros-common]
   opensuse: [python3-Sphinx]
-  rhel: ['python%{python3_pkgversion}-sphinx']
+  rhel: ["python%{python3_pkgversion}-sphinx"]
   ubuntu: [python3-sphinx]
 python3-sphinx-argparse:
   debian: [python3-sphinx-argparse]
@@ -8377,7 +8509,7 @@ python3-sphinx-rtd-theme:
   debian: [python3-sphinx-rtd-theme]
   fedora: [python3-sphinx_rtd_theme]
   nixos: [python3Packages.sphinx_rtd_theme]
-  rhel: ['python%{python3_pkgversion}-sphinx_rtd_theme']
+  rhel: ["python%{python3_pkgversion}-sphinx_rtd_theme"]
   ubuntu: [python3-sphinx-rtd-theme]
 python3-spidev-pip: *migrate_eol_2025_04_30_python3_spidev_pip
 python3-sqlalchemy:
@@ -8472,15 +8604,15 @@ python3-systemd:
   fedora: [python3-systemd]
   nixos: [python3Packages.systemd]
   rhel:
-    '*': [python3-systemd]
-    '7': null
+    "*": [python3-systemd]
+    "7": null
   ubuntu: [python3-systemd]
 python3-sysv-ipc:
   debian: [python3-sysv-ipc]
   fedora: [python3-sysv_ipc]
   rhel:
-    '*': [python3-sysv_ipc]
-    '7': null
+    "*": [python3-sysv_ipc]
+    "7": null
   ubuntu: [python3-sysv-ipc]
 python3-tables:
   debian: [python3-tables]
@@ -8519,7 +8651,7 @@ python3-texttable:
   gentoo: [dev-python/texttable]
   nixos: [python3Packages.texttable]
   openembedded: [python3-texttable@meta-python]
-  rhel: ['python%{python3_pkgversion}-texttable']
+  rhel: ["python%{python3_pkgversion}-texttable"]
   ubuntu: [python3-texttable]
 python3-thop-pip:
   debian:
@@ -8573,7 +8705,7 @@ python3-tk:
   nixos: [python3Packages.tkinter]
   openembedded: [python3-tkinter@openembedded-core]
   opensuse: [python3-tk]
-  rhel: ['python%{python3_pkgversion}-tkinter']
+  rhel: ["python%{python3_pkgversion}-tkinter"]
   ubuntu: [python3-tk]
 python3-toml:
   debian: [python3-toml]
@@ -8592,7 +8724,7 @@ python3-tornado:
   osx:
     pip:
       packages: [tornado]
-  rhel: ['python%{python3_pkgversion}-tornado']
+  rhel: ["python%{python3_pkgversion}-tornado"]
   ubuntu: [python3-tornado]
 python3-tqdm:
   alpine: [py3-tqdm]
@@ -8603,7 +8735,7 @@ python3-tqdm:
     pip:
       packages: [tqdm]
   ubuntu:
-    '*': [python3-tqdm]
+    "*": [python3-tqdm]
 python3-transformers-pip:
   debian:
     pip:
@@ -8617,7 +8749,7 @@ python3-transforms3d:
       packages: [transforms3d]
   fedora: [python3-transforms3d]
   ubuntu:
-    '*': [python3-transforms3d]
+    "*": [python3-transforms3d]
     bionic:
       pip:
         packages: [transforms3d]
@@ -8626,7 +8758,7 @@ python3-transforms3d:
         packages: [transforms3d]
 python3-transitions:
   debian:
-    '*': [python3-transitions]
+    "*": [python3-transitions]
     buster:
       pip:
         packages: [transitions]
@@ -8671,8 +8803,8 @@ python3-twisted:
   openembedded: [python3-twisted@meta-python]
   opensuse: [python3-Twisted]
   rhel:
-    '*': ['python%{python3_pkgversion}-twisted']
-    '7': null
+    "*": ["python%{python3_pkgversion}-twisted"]
+    "7": null
   ubuntu: [python3-twisted]
 python3-typeguard:
   arch: [python-typeguard]
@@ -8683,10 +8815,10 @@ python3-typeguard:
     pip:
       packages: [typeguard]
   rhel:
-    '*': [python3-typeguard]
-    '7': null
+    "*": [python3-typeguard]
+    "7": null
   ubuntu:
-    '*': [python3-typeguard]
+    "*": [python3-typeguard]
     bionic:
       pip:
         packages: [typeguard]
@@ -8707,10 +8839,10 @@ python3-typing-extensions:
   gentoo: [dev-python/typing-extensions]
   opensuse: [python3-typing_extensions]
   rhel:
-    '*': [python3-typing-extensions]
-    '7': null
+    "*": [python3-typing-extensions]
+    "7": null
   ubuntu:
-    '*': [python3-typing-extensions]
+    "*": [python3-typing-extensions]
     bionic:
       pip:
         packages: [typing-extensions]
@@ -8722,13 +8854,13 @@ python3-tz:
   gentoo: [dev-python/pytz]
   nixos: [python39Packages.pytz]
   rhel:
-    '*': [python3-pytz]
-    '7': null
+    "*": [python3-pytz]
+    "7": null
   ubuntu: [python3-tz]
 python3-ubjson:
   debian: [python3-ubjson]
   ubuntu:
-    '*': [python3-ubjson]
+    "*": [python3-ubjson]
 python3-ujson:
   debian: [python3-ujson]
   fedora: [python3-ujson]
@@ -8738,8 +8870,8 @@ python3-ujson:
     pip:
       packages: [ujson]
   rhel:
-    '*': [python3-ujson]
-    '7': null
+    "*": [python3-ujson]
+    "7": null
   ubuntu: [python3-ujson]
 python3-ultralytics-pip:
   debian:
@@ -8781,7 +8913,7 @@ python3-uvicorn:
   debian: [python3-uvicorn]
   fedora: [python-uvicorn]
   ubuntu:
-    '*': [python3-uvicorn]
+    "*": [python3-uvicorn]
     bionic:
       pip:
         packages: [uvicorn]
@@ -8836,8 +8968,8 @@ python3-voluptuous:
   gentoo: [dev-python/voluptuous]
   opensuse: [python-voluptuous]
   rhel:
-    '*': [python3-voluptuous]
-    '7': null
+    "*": [python3-voluptuous]
+    "7": null
   ubuntu: [python3-voluptuous]
 python3-watchdog:
   debian: [python3-watchdog]
@@ -8862,7 +8994,7 @@ python3-weasyprint-pip:
 python3-webargs:
   arch: [python-webargs]
   debian:
-    '*': [python3-webargs]
+    "*": [python3-webargs]
     bullseye:
       pip:
         packages: [webargs]
@@ -8871,7 +9003,7 @@ python3-webargs:
         packages: [webargs]
   nixos: [python39Packages.webargs]
   ubuntu:
-    '*': [python3-webargs]
+    "*": [python3-webargs]
     bionic:
       pip:
         packages: [webargs]
@@ -8885,7 +9017,7 @@ python3-websocket:
   nixos: [python3Packages.websocket-client]
   openembedded: [python3-websocket-client@meta-python]
   opensuse: [python3-websocket-client]
-  rhel: ['python%{python3_pkgversion}-websocket-client']
+  rhel: ["python%{python3_pkgversion}-websocket-client"]
   ubuntu: [python3-websocket]
 python3-websockets:
   arch: [python-websockets]
@@ -8923,8 +9055,8 @@ python3-whichcraft:
   nixos: [python3Packages.whichcraft]
   openembedded: [python3-whichcraft@meta-ros-common]
   rhel:
-    '*': [python3-whichcraft]
-    '7': null
+    "*": [python3-whichcraft]
+    "7": null
   ubuntu: [python3-whichcraft]
 python3-wrapt:
   arch: [python-wrapt]
@@ -8934,7 +9066,7 @@ python3-wrapt:
   nixos: [python3Packages.wrapt]
   opensuse: [python3-wrapt]
   rhel:
-    '8': [python3-wrapt]
+    "8": [python3-wrapt]
   ubuntu: [python3-wrapt]
 python3-wxgtk4.0:
   debian: [python3-wxgtk4.0]
@@ -8951,7 +9083,7 @@ python3-xdot:
   ubuntu: [xdot]
 python3-xmlschema:
   debian:
-    '*': [python3-xmlschema]
+    "*": [python3-xmlschema]
     buster:
       pip:
         packages: [xmlschema]
@@ -8979,11 +9111,11 @@ python3-yaml:
   osx:
     pip:
       packages: [pyyaml]
-  rhel: ['python%{python3_pkgversion}-yaml']
+  rhel: ["python%{python3_pkgversion}-yaml"]
   ubuntu: [python3-yaml]
 python3-yappi:
   debian:
-    '*': [python3-yappi]
+    "*": [python3-yappi]
     buster: null
     stretch: null
   fedora: [python3-yappi]
@@ -8991,7 +9123,7 @@ python3-yappi:
   osx:
     pip: [yappi]
   ubuntu:
-    '*': [python3-yappi]
+    "*": [python3-yappi]
     bionic: null
 python3-yolov5:
   debian:
@@ -9119,9 +9251,9 @@ wxpython:
   openembedded: [wxpython@meta-ros-python2]
   opensuse: [python-wxWidgets-3_0-devel]
   rhel:
-    '7': [wxPython-devel]
+    "7": [wxPython-devel]
   ubuntu:
-    '*': [python-wxgtk3.0]
+    "*": [python-wxgtk3.0]
 yapf:
   arch: [yapf]
   debian:
@@ -9136,7 +9268,7 @@ yapf3:
   fedora: [python3-yapf]
   nixos: [python3Packages.yapf]
   ubuntu:
-    '*': [yapf3]
+    "*": [yapf3]
 zulip-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

flatbuffers

## Package Upstream Source:

https://github.com/google/flatbuffers

## Purpose of using this:

it is needed to decode the fbl logfiles of https://github.com/BehaviorTree/BehaviorTree.CPP

Distro packaging links:

## Links to Distribution Packages
- Ubuntu 
from jammy: https://packages.ubuntu.com/jammy/python3-flatbuffers
- Debian
In debian 11 there is https://packages.debian.org/bullseye/python3-flatbuffers
- Opensuse
https://software.opensuse.org/package/python-flatbuffers
- Redhat
https://mirrors.lug.mtu.edu/epel/9/Everything/x86_64/Packages/p/python3-flatbuffers-2.0.8-2.el9.noarch.rpm

There are no other distro packages available, so I propose to use https://pypi.org/project/flatbuffers/
