### PR TITLE
rot_conv_lib: 1.0.12-2 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5069,7 +5069,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rot_conv_lib-release.git
-      version: 1.0.11-3
+      version: 1.0.12-2
     source:
       type: git
       url: https://github.com/AIS-Bonn/rot_conv_lib.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rot_conv_lib` to `1.0.12-2`:

- upstream repository: https://github.com/AIS-Bonn/rot_conv_lib.git
- release repository: https://github.com/ros2-gbp/rot_conv_lib-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.11-3`
