### PR TITLE
mimick_vendor: 0.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2511,7 +2511,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mimick_vendor-release.git
-      version: 0.3.2-4
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/ros2/mimick_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mimick_vendor` to `0.4.0-1`:

- upstream repository: https://github.com/ros2/mimick_vendor.git
- release repository: https://github.com/ros2-gbp/mimick_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.2-4`

## mimick_vendor

- No changes
