### PR TITLE
performance_test_fixture: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3231,7 +3231,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/performance_test_fixture-release.git
-      version: 0.1.1-1
+      version: 0.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `performance_test_fixture` to `0.2.0-1`:

- upstream repository: https://github.com/ros2/performance_test_fixture.git
- release repository: https://github.com/ros2-gbp/performance_test_fixture-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.1-1`

## performance_test_fixture

- No changes
