### PR TITLE
realtime_support: 0.16.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3981,7 +3981,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_support-release.git
-      version: 0.15.0-2
+      version: 0.16.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_support` to `0.16.0-1`:

- upstream repository: https://github.com/ros2/realtime_support.git
- release repository: https://github.com/ros2-gbp/realtime_support-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.15.0-2`

## rttest

- No changes

## tlsf_cpp

- No changes
