### PR TITLE
add fluidsynth

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1102,6 +1102,10 @@ fluid:
   nixos: [fltk]
   opensuse: [fltk-devel]
   ubuntu: [fluid]
+fluidsynth:
+  arch: [fluidsynth]
+  debian: [fluidsynth]
+  ubuntu: [fluidsynth]
 fmt:
   arch: [fmt]
   debian: [libfmt-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1103,8 +1103,12 @@ fluid:
   opensuse: [fltk-devel]
   ubuntu: [fluid]
 fluidsynth:
+  alpine: [fluidsynth]
   arch: [fluidsynth]
   debian: [fluidsynth]
+  fedora: [fluidsynth]
+  opensuse: [fluidsynth]
+  rhel: [fluidsynth]
   ubuntu: [fluidsynth]
 fmt:
   arch: [fmt]


### PR DESCRIPTION

Please add the following dependency to the rosdep database.

## Package name:

fluidsynth


Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - [REQUIRED](https://packages.debian.org/bullseye/fluidsynth)
- Ubuntu: https://packages.ubuntu.com/
  - [REQUIRED](https://packages.ubuntu.com/kinetic/fluidsynth)


<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->



# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [x ] This package is expected to build on the submitted rosdistro
