### PR TITLE
Added xlsxwriter python3

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4628,6 +4628,10 @@ python-xlrd:
   debian: [python-xlrd]
   fedora: [python-xlrd]
   ubuntu: [python-xlrd]
+python3-xlsxwriter:
+  debian: [python3-xlsxwriter]
+  fedora: [python3-xlsxwriter]
+  ubuntu: [python3-xlsxwriter]
 python-xmlplain-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4632,6 +4632,8 @@ python3-xlsxwriter:
   debian: [python3-xlsxwriter]
   fedora: [python3-xlsxwriter]
   ubuntu: [python3-xlsxwriter]
+  rhel: [python3-xlsxwriter]
+  opensuse: [python3-XlsxWriter]
 python-xmlplain-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4628,12 +4628,6 @@ python-xlrd:
   debian: [python-xlrd]
   fedora: [python-xlrd]
   ubuntu: [python-xlrd]
-python3-xlsxwriter:
-  debian: [python3-xlsxwriter]
-  fedora: [python3-xlsxwriter]
-  ubuntu: [python3-xlsxwriter]
-  rhel: [python3-xlsxwriter]
-  opensuse: [python3-XlsxWriter]
 python-xmlplain-pip:
   debian:
     pip:
@@ -8938,6 +8932,12 @@ python3-xdot:
   gentoo: [media-gfx/xdot]
   nixos: [xdot]
   ubuntu: [xdot]
+python3-xlsxwriter:
+  debian: [python3-xlsxwriter]
+  fedora: [python3-xlsxwriter]
+  opensuse: [python3-XlsxWriter]
+  rhel: [python3-xlsxwriter]
+  ubuntu: [python3-xlsxwriter]
 python3-xmlschema:
   debian:
     '*': [python3-xmlschema]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

Package name:
xlsxwriter

Package Upstream Source:
https://github.com/jmcnamara/XlsxWriter

Purpose of using this:
Python Excel generation library (https://pypi.org/project/XlsxWriter/)

Links to Distribution Packages
Debian: https://packages.debian.org/bullseye/python3-xlsxwriter
Ubuntu: https://packages.ubuntu.com/jammy/python3-xlsxwriter
Fedora: https://packages.fedoraproject.org/pkgs/python-xlsxwriter/python3-xlsxwriter
OpenSuse: https://software.opensuse.org/package/python3-XlsxWriter
RHEL: http://mirror.math.princeton.edu/pub/epel/9/Everything/x86_64/Packages/p/python3-xlsxwriter-3.1.0-1.el9.noarch.rpm
