### PR TITLE
rosidl_core: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4894,7 +4894,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_core-release.git
-      version: 0.1.1-2
+      version: 0.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_core` to `0.2.0-1`:

- upstream repository: https://github.com/ros2/rosidl_core.git
- release repository: https://github.com/ros2-gbp/rosidl_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.1-2`

## rosidl_core_generators

- No changes

## rosidl_core_runtime

- No changes
