### PR TITLE
rosidl_defaults: 1.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4931,7 +4931,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_defaults-release.git
-      version: 1.5.0-2
+      version: 1.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_defaults` to `1.6.0-1`:

- upstream repository: https://github.com/ros2/rosidl_defaults.git
- release repository: https://github.com/ros2-gbp/rosidl_defaults-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.5.0-2`

## rosidl_default_generators

- No changes

## rosidl_default_runtime

- No changes
