### PR TITLE
test_interface_files: 0.11.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6016,7 +6016,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/test_interface_files-release.git
-      version: 0.10.2-2
+      version: 0.11.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `test_interface_files` to `0.11.0-1`:

- upstream repository: https://github.com/ros2/test_interface_files.git
- release repository: https://github.com/ros2-gbp/test_interface_files-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.10.2-2`

## test_interface_files

- No changes
