### PR TITLE
tinyxml_vendor: 0.10.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6091,7 +6091,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tinyxml_vendor-release.git
-      version: 0.9.2-2
+      version: 0.10.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tinyxml_vendor` to `0.10.0-1`:

- upstream repository: https://github.com/ros2/tinyxml_vendor.git
- release repository: https://github.com/ros2-gbp/tinyxml_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.9.2-2`
