### PR TITLE
turtlesim: 1.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6244,7 +6244,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_tutorials-release.git
-      version: 1.6.0-2
+      version: 1.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlesim` to `1.7.0-1`:

- upstream repository: https://github.com/ros/ros_tutorials.git
- release repository: https://github.com/ros2-gbp/ros_tutorials-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.6.0-2`

## turtlesim

- No changes
