### PR TITLE
uncrustify_vendor: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6372,7 +6372,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/uncrustify_vendor-release.git
-      version: 2.1.2-2
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/ament/uncrustify_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `uncrustify_vendor` to `2.2.0-1`:

- upstream repository: https://github.com/ament/uncrustify_vendor.git
- release repository: https://github.com/ros2-gbp/uncrustify_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.2-2`
