### PR TITLE
ignition_cmake2_vendor: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1790,7 +1790,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ignition_cmake2_vendor-release.git
-      version: 0.1.0-1
+      version: 0.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ignition_cmake2_vendor` to `0.2.0-1`:

- upstream repository: https://github.com/ignition-release/ignition_cmake2_vendor.git
- release repository: https://github.com/ros2-gbp/ignition_cmake2_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.0-1`

## ignition_cmake2_vendor

- No changes
