### PR TITLE
nao_lola: 0.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3116,7 +3116,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/nao_lola-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/ros-sports/nao_lola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_lola` to `0.1.1-1`:

- upstream repository: https://github.com/ros-sports/nao_lola.git
- release repository: https://github.com/ros2-gbp/nao_lola-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.1.0-1`

## nao_lola

```
* fix race condition on packer
* Contributors: ijnek
```
