### PR TITLE
cob_command_tools: 0.6.32-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -959,7 +959,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_command_tools-release.git
-      version: 0.6.31-1
+      version: 0.6.32-1
     source:
       type: git
       url: https://github.com/ipa320/cob_command_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.32-1`:

- upstream repository: https://github.com/ipa320/cob_command_tools.git
- release repository: https://github.com/ipa320/cob_command_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.31-1`

## cob_command_gui

- No changes

## cob_command_tools

- No changes

## cob_dashboard

- No changes

## cob_helper_tools

- No changes

## cob_interactive_teleop

- No changes

## cob_monitoring

```
* Merge pull request #329 <https://github.com/ipa320/cob_command_tools/issues/329> from Deleh/fix/netdata_diagnostics_level
  Change NetData malformed data diagnostics level from ERROR to WARN
* remove type hints
* adjust string formatting syntax
* move netdata communication to interface class
* change netdata malformed data diagnostic level
* Merge pull request #328 <https://github.com/ipa320/cob_command_tools/issues/328> from Deleh/feature/wlan_monitor_reconnect
  Reconnect if SSH session is inactive
* finalize
* add ssh_connection_state to diagnostics
* reconnect if session is inactive
* Contributors: Denis Lehmann, Felix Messmer, fmessmer
```

## cob_script_server

- No changes

## cob_teleop

- No changes

## generic_throttle

- No changes

## scenario_test_tools

- No changes

## service_tools

- No changes
