### PR TITLE
cob_control: 0.8.22-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1014,7 +1014,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_control-release.git
-      version: 0.8.21-1
+      version: 0.8.22-1
     source:
       type: git
       url: https://github.com/ipa320/cob_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.8.22-1`:

- upstream repository: https://github.com/ipa320/cob_control.git
- release repository: https://github.com/ipa320/cob_control-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.8.21-1`

## cob_base_controller_utils

```
* Merge pull request #273 <https://github.com/ipa320/cob_control/issues/273> from Deleh/fix/recover_diagnostics_when_stopped
  Recover on Diagnostics When Stopped
* recover on diagnostics when stopped
* Contributors: Denis Lehmann, Felix Messmer
```

## cob_base_velocity_smoother

- No changes

## cob_cartesian_controller

- No changes

## cob_collision_velocity_filter

- No changes

## cob_control

- No changes

## cob_control_mode_adapter

- No changes

## cob_control_msgs

- No changes

## cob_footprint_observer

- No changes

## cob_frame_tracker

- No changes

## cob_hardware_emulation

```
* Merge pull request #276 <https://github.com/ipa320/cob_control/issues/276> from fmessmer/fix/emulation_odom_laser
  publish odom_laser tf with current time
* publish odom_laser tf with current time
* Merge pull request #275 <https://github.com/ipa320/cob_control/issues/275> from FrederikPlahl/fix/odom_laser
  Fix emulation bug in transform odom -> base_footprint
* remove obsolete import
* Change frequency
* Fix tf publishing bug
* Merge pull request #274 <https://github.com/ipa320/cob_control/issues/274> from HannesBachter/fix/rename_scan_odom
  rename scan odom to /scan_odom_node/scan_odom/odometry
* rename scan odom to /scan_odom_node/scan_odom/odometry
* Contributors: Felix Messmer, FrederikPlahl, HannesBachter, fmessmer
```

## cob_mecanum_controller

- No changes

## cob_model_identifier

- No changes

## cob_obstacle_distance

- No changes

## cob_omni_drive_controller

- No changes

## cob_trajectory_controller

- No changes

## cob_tricycle_controller

- No changes

## cob_twist_controller

- No changes
