### PR TITLE
ros2_controllers: 3.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4523,7 +4523,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 3.5.0-1
+      version: 3.6.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `3.6.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.5.0-1`

## admittance_controller

```
* Renovate load controller tests (#569 <https://github.com/ros-controls/ros2_controllers/issues/569>)
* Fix docs format (#589 <https://github.com/ros-controls/ros2_controllers/issues/589>)
* Contributors: Bence Magyar, Christoph Fröhlich
```

## diff_drive_controller

```
* Renovate load controller tests (#569 <https://github.com/ros-controls/ros2_controllers/issues/569>)
* adjusted open_loop param description in diff_drive_controller_parameter.yaml (#570 <https://github.com/ros-controls/ros2_controllers/issues/570>)
* Contributors: Bence Magyar, muritane
```

## effort_controllers

```
* Renovate load controller tests (#569 <https://github.com/ros-controls/ros2_controllers/issues/569>)
* Contributors: Bence Magyar
```

## force_torque_sensor_broadcaster

```
* Renovate load controller tests (#569 <https://github.com/ros-controls/ros2_controllers/issues/569>)
* Contributors: Bence Magyar
```

## forward_command_controller

```
* Renovate load controller tests (#569 <https://github.com/ros-controls/ros2_controllers/issues/569>)
* Fix docs format (#589 <https://github.com/ros-controls/ros2_controllers/issues/589>)
* Contributors: Bence Magyar, Christoph Fröhlich
```

## gripper_controllers

```
* Renovate load controller tests (#569 <https://github.com/ros-controls/ros2_controllers/issues/569>)
* Contributors: Bence Magyar
```

## imu_sensor_broadcaster

```
* Renovate load controller tests (#569 <https://github.com/ros-controls/ros2_controllers/issues/569>)
* Contributors: Bence Magyar
```

## joint_state_broadcaster

```
* Renovate load controller tests (#569 <https://github.com/ros-controls/ros2_controllers/issues/569>)
* Fix docs format (#589 <https://github.com/ros-controls/ros2_controllers/issues/589>)
* Contributors: Bence Magyar, Christoph Fröhlich
```

## joint_trajectory_controller

```
* Renovate load controller tests (#569 <https://github.com/ros-controls/ros2_controllers/issues/569>)
* Fix docs format (#589 <https://github.com/ros-controls/ros2_controllers/issues/589>)
* [JTC] Implement new ~/controller_state message (#557 <https://github.com/ros-controls/ros2_controllers/issues/557>)
* Contributors: Bence Magyar, Christoph Fröhlich
```

## position_controllers

```
* Renovate load controller tests (#569 <https://github.com/ros-controls/ros2_controllers/issues/569>)
* Contributors: Bence Magyar
```

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## tricycle_controller

```
* Renovate load controller tests (#569 <https://github.com/ros-controls/ros2_controllers/issues/569>)
* Contributors: Bence Magyar
```

## velocity_controllers

```
* Renovate load controller tests (#569 <https://github.com/ros-controls/ros2_controllers/issues/569>)
* Contributors: Bence Magyar
```
