### PR TITLE
ros2_controllers: 2.18.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5181,7 +5181,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.17.3-1
+      version: 2.18.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.18.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.17.3-1`

## admittance_controller

```
* Fix docs format (#591 <https://github.com/ros-controls/ros2_controllers/issues/591>)
* Contributors: Christoph Fröhlich
```

## diff_drive_controller

```
* adjusted open_loop param description in diff_drive_controller_parameter.yaml (#570 <https://github.com/ros-controls/ros2_controllers/issues/570>) (#576 <https://github.com/ros-controls/ros2_controllers/issues/576>)
* Contributors: muritane
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

```
* Fix docs format (#591 <https://github.com/ros-controls/ros2_controllers/issues/591>)
* Contributors: Christoph Fröhlich
```

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

```
* Fix docs format (#591 <https://github.com/ros-controls/ros2_controllers/issues/591>)
* Contributors: Christoph Fröhlich
```

## joint_trajectory_controller

```
* Fix docs format (#591 <https://github.com/ros-controls/ros2_controllers/issues/591>)
* [JTC] Configurable joint positon error normalization behavior (#491 <https://github.com/ros-controls/ros2_controllers/issues/491>) (#579 <https://github.com/ros-controls/ros2_controllers/issues/579>)
* Contributors: Christoph Fröhlich, Bence Magyar
```

## position_controllers

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## tricycle_controller

- No changes

## velocity_controllers

- No changes
