### PR TITLE
add rt-tests key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7127,6 +7127,14 @@ rsyslog:
   debian: [rsyslog]
   fedora: [rsyslog]
   ubuntu: [rsyslog]
+rt-tests:
+  arch: [rt-tests]
+  debian: [rt-tests]
+  fedora: [rt-tests]
+  gentoo: [dev-util/rt-tests]
+  nixos: [rt-tests]
+  opensuse: [rt-tests]
+  ubuntu: [rt-tests]
 rti-connext-dds-5.3.1:
   nixos: []
   ubuntu:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

rt-tests

## Package Upstream Source:

https://git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git

## Purpose of using this:

For testing realtime kernel performance.

## Links to Distribution Packages

- Debian:  https://packages.debian.org/bullseye/rt-tests
- Ubuntu: https://packages.ubuntu.com/bionic/misc/rt-tests
- Fedora: https://packages.fedoraproject.org/pkgs/rt/rt-tests/
- Arch: https://archlinux.org/packages/community/x86_64/rt-tests/
- Gentoo: https://packages.gentoo.org/packages/dev-util/rt-tests
- NixOS/nixpkgs: https://github.com/NixOS/nixpkgs/blob/nixos-22.11/pkgs/os-specific/linux/rt-tests/default.nix#L29
- openSUSE: https://software.opensuse.org/package/rt-tests
- macOS: Not available
- Alpine: Not available