### PR TITLE
add sysbench key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7514,6 +7514,18 @@ swig:
   ubuntu: [swig]
 swig-wx:
   gentoo: [dev-lang/swig]
+sysbench:
+  alpine: [sysbench]
+  arch: [sysbench]
+  debian: [sysbench]
+  fedora: [sysbench]
+  gentoo: [app-benchmarks/sysbench]
+  nixos: [sysbench]
+  opensuse: [sysbench]
+  osx:
+    homebrew:
+      packages: [sysbench]
+  ubuntu: [sysbench]
 sysstat:
   arch: [sysstat]
   debian: [sysstat]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7525,6 +7525,7 @@ sysbench:
   osx:
     homebrew:
       packages: [sysbench]
+  rhel: [sysbench]
   ubuntu: [sysbench]
 sysstat:
   arch: [sysstat]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

sysbench

## Package Upstream Source:

https://github.com/akopytov/sysbench

## Purpose of using this:

Benchmarking the robot computers

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/sysbench
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/bionic/sysbench
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/sysbench/sysbench/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/community/x86_64/sysbench/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/app-benchmarks/sysbench
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/sysbench
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/community/x86_64/sysbench
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://github.com/NixOS/nixpkgs/blob/nixos-22.11/pkgs/development/tools/misc/sysbench/default.nix#L43
- openSUSE: https://software.opensuse.org/package/
  - https://build.opensuse.org/package/show/openSUSE:Factory/sysbench
