### PR TITLE
add stress-ng key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7445,6 +7445,7 @@ stress-ng:
   osx:
     homebrew:
       packages: [stress-ng]
+  rhel: [stress-ng]
   ubuntu: [stress-ng]
 subversion:
   arch: [subversion]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7435,6 +7435,17 @@ stress:
   gentoo: [app-benchmarks/stress]
   nixos: [stress]
   ubuntu: [stress]
+stress-ng:
+  alpine: [stress-ng]
+  debian: [stress-ng]
+  fedora: [stress-ng]
+  gentoo: [app-benchmarks/stress-ng]
+  nixos: [stress-ng]
+  opensuse: [stress-ng]
+  osx:
+    homebrew:
+      packages: [stress-ng]
+  ubuntu: [stress-ng]
 subversion:
   arch: [subversion]
   debian: [subversion]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

stress-ng

## Package Upstream Source:

https://github.com/ColinIanKing/stress-ng

## Purpose of using this:

For benchmarking robot computer

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/stress-ng
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/bionic/stress-ng
- Fedora: https://packages.fedoraproject.org/
  - https://src.fedoraproject.org/rpms/stress-ng
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/app-benchmarks/stress-ng
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/stress-ng
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/community/x86_64/stress-ng
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://github.com/NixOS/nixpkgs/blob/nixos-22.11/pkgs/tools/system/stress-ng/default.nix#L42
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/stress-ng
- Arch: https://www.archlinux.org/packages/
  - Not available

