### PR TITLE
Adding rosgpt to documentation index for distro

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11633,6 +11633,16 @@ repositories:
       url: https://github.com/xqms/rosfmt.git
       version: master
     status: developed
+  rosgpt:
+    doc:
+      type: git
+      url: https://github.com/ZHY109/rosgpt.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/ZHY109/rosgpt.git
+      version: main
+    status: developed
   roslint:
     doc:
       type: git


### PR DESCRIPTION
i'd like my repo "rosgpt" to be index and documented on ros.rog.