### PR TITLE
urdf_parser_py: 1.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6492,7 +6492,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom_py-release.git
-      version: 1.2.0-2
+      version: 1.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_parser_py` to `1.2.1-1`:

- upstream repository: https://github.com/ros/urdf_parser_py.git
- release repository: https://github.com/ros2-gbp/urdfdom_py-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.0-2`

## urdfdom_py

```
* Switch to unittest.mock (#78 <https://github.com/ros/urdf_parser_py/issues/78>)
* Add BSD LICENSE file (#77 <https://github.com/ros/urdf_parser_py/issues/77>)
* Update Maintainers (#76 <https://github.com/ros/urdf_parser_py/issues/76>)
* Contributors: Audrow Nash, Scott K Logan, Silvio Traversaro
```
