### PR TITLE
libcamera: 0.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2477,7 +2477,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/libcamera-release.git
-      version: 0.0.4-6
+      version: 0.0.5-1
     source:
       type: git
       url: https://git.libcamera.org/libcamera/libcamera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libcamera` to `0.0.5-1`:

- upstream repository: https://git.libcamera.org/libcamera/libcamera.git
- release repository: https://github.com/ros2-gbp/libcamera-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.4-6`
