### PR TITLE
pmb2_robot: 5.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3919,7 +3919,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_robot-gbp.git
-      version: 5.0.3-1
+      version: 5.0.4-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_robot` to `5.0.4-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_robot.git
- release repository: https://github.com/pal-gbp/pmb2_robot-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `5.0.3-1`

## pmb2_bringup

- No changes

## pmb2_controller_configuration

```
* set sim time for gazebo controller_manager
* Contributors: Noel Jimenez
```

## pmb2_description

```
* fix indentation
* fix odometry plugin tags
* Contributors: Noel Jimenez
```

## pmb2_robot

- No changes
