### PR TITLE
pal_gazebo_worlds: 4.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3604,7 +3604,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_gazebo_worlds-ros2-release.git
-      version: 3.0.3-1
+      version: 4.0.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_gazebo_worlds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_gazebo_worlds` to `4.0.0-1`:

- upstream repository: https://github.com/pal-robotics/pal_gazebo_worlds.git
- release repository: https://github.com/pal-gbp/pal_gazebo_worlds-ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.3-1`

## pal_gazebo_worlds

- No changes
