### PR TITLE
tiago_robot: 4.0.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6903,7 +6903,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_robot-release.git
-      version: 4.0.6-1
+      version: 4.0.7-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_robot` to `4.0.7-1`:

- upstream repository: https://github.com/pal-robotics/tiago_robot
- release repository: https://github.com/pal-gbp/tiago_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.6-1`

## tiago_bringup

- No changes

## tiago_controller_configuration

```
* set sim time for gazebo controller_manager
* Contributors: Noel Jimenez
```

## tiago_description

- No changes

## tiago_robot

- No changes
