### PR TITLE
pal_navigation_cfg_public: 3.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3642,7 +3642,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_navigation_cfg_public-release.git
-      version: 3.0.1-1
+      version: 3.0.4-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_navigation_cfg_public.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_navigation_cfg_public` to `3.0.4-1`:

- upstream repository: https://github.com/pal-robotics/pal_navigation_cfg_public.git
- release repository: https://github.com/pal-gbp/pal_navigation_cfg_public-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.1-1`

## pal_navigation_cfg

- No changes

## pal_navigation_cfg_bringup

- No changes

## pal_navigation_cfg_params

```
* Merge branch 'fix/add-odom-topic' into 'humble-devel'
  Add odom_topic to controller server node
  See merge request navigation/pal_navigation_cfg_public!48
* Add odom_topic to controller server node
* Contributors: antoniobrandi
```
