### PR TITLE
sick_tim: 0.0.18-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10423,7 +10423,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/uos-gbp/sick_tim-release.git
-      version: 0.0.17-1
+      version: 0.0.18-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_tim` to `0.0.18-1`:

- upstream repository: https://github.com/uos/sick_tim
- release repository: https://github.com/uos-gbp/sick_tim-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.17-1`

## sick_tim

```
* Add Dockerfile-noetic
* Fix Dockerfile-kinetic
* README: Change http -> https
* Update Dockerfiles to new ros:*-ros-core images
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```
