### PR TITLE
Revert "tuw_geometry: 0.0.8-3 in 'humble/distribution.yaml' [bloom]"

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7273,7 +7273,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/tuw-robotics/tuw_geometry-release.git
-      version: 0.0.8-3
+      version: 0.0.7-1
     source:
       type: git
       url: https://github.com/tuw-robotics/tuw_geometry.git


### PR DESCRIPTION
Reverts ros/rosdistro#36660

It seems this has been failing in the buildfarm for a while. For example:
https://build.ros2.org/view/Hbin_uJ64/job/Hbin_uJ64__tuw_geometry__ubuntu_jammy_amd64__binary/40/

FYI @maxbader 