### PR TITLE
 Adding rose2 to documentation index for distro 

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9186,6 +9186,10 @@ repositories:
       version: master
     status: maintained
   rose2:
+  doc:
+      type: git
+      url: https://github.com/aislabunimi/ROSE2.git
+      version: main
     source:
       type: git
       url: https://github.com/aislabunimi/ROSE2.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9185,6 +9185,12 @@ repositories:
       url: https://github.com/ros-infrastructure/rosdoc_lite.git
       version: master
     status: maintained
+  rose2:
+    source:
+      type: git
+      url: https://github.com/aislabunimi/ROSE2
+      version: main
+    status: maintained
   rosee_msg:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9188,7 +9188,7 @@ repositories:
   rose2:
     source:
       type: git
-      url: https://github.com/aislabunimi/ROSE2
+      url: https://github.com/aislabunimi/ROSE2.git
       version: main
     status: maintained
   rosee_msg:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9186,7 +9186,7 @@ repositories:
       version: master
     status: maintained
   rose2:
-  doc:
+    doc:
       type: git
       url: https://github.com/aislabunimi/ROSE2.git
       version: main


### PR DESCRIPTION
I'd like rose2 (https://github.com/aislabunimi/ROSE2) to be indexed and documented on ros.org
