### PR TITLE
[iron] Switch source version to iron for core repos

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -134,7 +134,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ament/ament_cmake.git
-      version: rolling
+      version: iron
     status: developed
   ament_cmake_catch2:
     doc:
@@ -168,7 +168,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/ament_cmake_ros.git
-      version: rolling
+      version: iron
     status: maintained
   ament_download:
     doc:
@@ -202,7 +202,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ament/ament_index.git
-      version: rolling
+      version: iron
     status: maintained
   ament_lint:
     doc:
@@ -250,7 +250,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ament/ament_lint.git
-      version: rolling
+      version: iron
     status: developed
   ament_nodl:
     release:
@@ -277,7 +277,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ament/ament_package.git
-      version: rolling
+      version: iron
     status: developed
   ament_vitis:
     doc:
@@ -655,7 +655,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/class_loader.git
-      version: rolling
+      version: iron
     status: maintained
   color_names:
     doc:
@@ -716,7 +716,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/common_interfaces.git
-      version: rolling
+      version: iron
     status: maintained
   console_bridge_vendor:
     doc:
@@ -732,7 +732,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/console_bridge_vendor.git
-      version: rolling
+      version: iron
     status: maintained
   control_box_rst:
     doc:
@@ -856,7 +856,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/demos.git
-      version: rolling
+      version: iron
     status: developed
   depthimage_to_laserscan:
     doc:
@@ -1100,7 +1100,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/eigen3_cmake_module.git
-      version: rolling
+      version: iron
     status: maintained
   eigen_stl_containers:
     doc:
@@ -1147,7 +1147,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/example_interfaces.git
-      version: rolling
+      version: iron
     status: maintained
   examples:
     doc:
@@ -1186,7 +1186,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/examples.git
-      version: rolling
+      version: iron
     status: maintained
   fastcdr:
     release:
@@ -1520,7 +1520,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/geometry2.git
-      version: rolling
+      version: iron
     status: maintained
   geometry_tutorials:
     doc:
@@ -1555,7 +1555,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ament/google_benchmark_vendor.git
-      version: rolling
+      version: iron
     status: maintained
   googletest:
     release:
@@ -1569,7 +1569,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ament/googletest.git
-      version: rolling
+      version: iron
     status: maintained
   gps_umd:
     doc:
@@ -1832,7 +1832,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/image_common.git
-      version: rolling
+      version: iron
     status: maintained
   image_pipeline:
     doc:
@@ -1916,7 +1916,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/interactive_markers.git
-      version: rolling
+      version: iron
     status: maintained
   irobot_create_msgs:
     release:
@@ -2000,7 +2000,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/kdl_parser.git
-      version: rolling
+      version: iron
     status: maintained
   keyboard_handler:
     doc:
@@ -2016,7 +2016,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-tooling/keyboard_handler.git
-      version: rolling
+      version: iron
     status: developed
   kinematics_interface:
     doc:
@@ -2135,7 +2135,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/laser_geometry.git
-      version: rolling
+      version: iron
     status: maintained
   laser_proc:
     doc:
@@ -2174,7 +2174,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/launch.git
-      version: rolling
+      version: iron
     status: developed
   launch_param_builder:
     doc:
@@ -2209,7 +2209,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/launch_ros.git
-      version: rolling
+      version: iron
     status: maintained
   lgsvl_msgs:
     release:
@@ -2271,7 +2271,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git
-      version: rolling
+      version: iron
     status: developed
   libyaml_vendor:
     release:
@@ -2283,7 +2283,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/libyaml_vendor.git
-      version: rolling
+      version: iron
     status: maintained
   locator_ros_bridge:
     doc:
@@ -2431,7 +2431,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/message_filters.git
-      version: rolling
+      version: iron
     status: maintained
   message_tf_frame_transformer:
     doc:
@@ -2515,7 +2515,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/mimick_vendor.git
-      version: rolling
+      version: iron
     status: maintained
   mir_robot:
     doc:
@@ -2781,7 +2781,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-planning/navigation_msgs.git
-      version: rolling
+      version: iron
     status: maintained
   neo_simulation2:
     doc:
@@ -3101,7 +3101,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/orocos_kdl_vendor.git
-      version: rolling
+      version: iron
     status: developed
   osqp_vendor:
     doc:
@@ -3147,7 +3147,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/osrf/osrf_testing_tools_cpp.git
-      version: rolling
+      version: iron
     status: maintained
   ouxt_common:
     doc:
@@ -3236,7 +3236,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/performance_test_fixture.git
-      version: rolling
+      version: iron
     status: maintained
   phidgets_drivers:
     doc:
@@ -3366,7 +3366,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/pluginlib.git
-      version: rolling
+      version: iron
     status: maintained
   point_cloud_msg_wrapper:
     doc:
@@ -3543,7 +3543,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/pybind11_vendor.git
-      version: rolling
+      version: iron
     status: maintained
   python_cmake_module:
     doc:
@@ -3558,7 +3558,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/python_cmake_module.git
-      version: rolling
+      version: iron
     status: developed
   python_qt_binding:
     doc:
@@ -3574,7 +3574,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git
-      version: rolling
+      version: iron
     status: maintained
   qpoases_vendor:
     release:
@@ -3608,7 +3608,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/qt_gui_core.git
-      version: rolling
+      version: iron
     status: maintained
   quaternion_operation:
     doc:
@@ -3784,7 +3784,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcl.git
-      version: rolling
+      version: iron
     status: maintained
   rcl_interfaces:
     doc:
@@ -3811,7 +3811,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcl_interfaces.git
-      version: rolling
+      version: iron
     status: maintained
   rcl_logging:
     doc:
@@ -3831,7 +3831,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcl_logging.git
-      version: rolling
+      version: iron
     status: maintained
   rcl_logging_rcutils:
     doc:
@@ -3884,7 +3884,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclcpp.git
-      version: rolling
+      version: iron
     status: maintained
   rclpy:
     doc:
@@ -3900,7 +3900,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclpy.git
-      version: rolling
+      version: iron
     status: maintained
   rcpputils:
     doc:
@@ -3916,7 +3916,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcpputils.git
-      version: rolling
+      version: iron
     status: developed
   rcss3d_agent:
     doc:
@@ -3967,7 +3967,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcutils.git
-      version: rolling
+      version: iron
     status: maintained
   realtime_support:
     doc:
@@ -3986,7 +3986,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/realtime_support.git
-      version: rolling
+      version: iron
     status: maintained
   realtime_tools:
     doc:
@@ -4020,7 +4020,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/resource_retriever.git
-      version: rolling
+      version: iron
     status: maintained
   rig_reconfigure:
     release:
@@ -4302,7 +4302,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw.git
-      version: rolling
+      version: iron
     status: maintained
   rmw_connextdds:
     doc:
@@ -4321,7 +4321,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git
-      version: rolling
+      version: iron
     status: developed
   rmw_cyclonedds:
     doc:
@@ -4339,7 +4339,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_cyclonedds.git
-      version: rolling
+      version: iron
     status: developed
   rmw_dds_common:
     doc:
@@ -4355,7 +4355,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_dds_common.git
-      version: rolling
+      version: iron
     status: maintained
   rmw_fastrtps:
     doc:
@@ -4375,7 +4375,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_fastrtps.git
-      version: rolling
+      version: iron
     status: developed
   rmw_gurumdds:
     doc:
@@ -4409,7 +4409,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_implementation.git
-      version: rolling
+      version: iron
     status: developed
   robot_calibration:
     doc:
@@ -4455,7 +4455,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/robot_state_publisher.git
-      version: rolling
+      version: iron
     status: maintained
   ros1_bridge:
     doc:
@@ -4584,7 +4584,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/ros2_tracing.git
-      version: rolling
+      version: iron
     status: developed
   ros2acceleration:
     doc:
@@ -4632,7 +4632,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/ros2cli.git
-      version: rolling
+      version: iron
     status: maintained
   ros2cli_common_extensions:
     doc:
@@ -4647,7 +4647,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/ros2cli_common_extensions.git
-      version: rolling
+      version: iron
     status: maintained
   ros2launch_security:
     doc:
@@ -4695,7 +4695,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/ros_environment.git
-      version: rolling
+      version: iron
     status: maintained
   ros_ign:
     doc:
@@ -4758,7 +4758,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/ros_testing.git
-      version: rolling
+      version: iron
     status: maintained
   ros_workspace:
     release:
@@ -4809,7 +4809,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosbag2.git
-      version: rolling
+      version: iron
     status: developed
   rosbag2_bag_v2:
     doc:
@@ -4880,7 +4880,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl.git
-      version: rolling
+      version: iron
     status: maintained
   rosidl_core:
     doc:
@@ -4899,7 +4899,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_core.git
-      version: rolling
+      version: iron
     status: maintained
   rosidl_dds:
     doc:
@@ -4917,7 +4917,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_dds.git
-      version: rolling
+      version: iron
     status: maintained
   rosidl_defaults:
     doc:
@@ -4936,7 +4936,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_defaults.git
-      version: rolling
+      version: iron
     status: maintained
   rosidl_dynamic_typesupport:
     doc:
@@ -4952,7 +4952,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_dynamic_typesupport.git
-      version: rolling
+      version: iron
     status: maintained
   rosidl_dynamic_typesupport_fastrtps:
     doc:
@@ -4968,7 +4968,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps.git
-      version: rolling
+      version: iron
     status: maintained
   rosidl_python:
     doc:
@@ -4986,7 +4986,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_python.git
-      version: rolling
+      version: iron
     status: maintained
   rosidl_runtime_py:
     doc:
@@ -5002,7 +5002,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_runtime_py.git
-      version: rolling
+      version: iron
     status: maintained
   rosidl_typesupport:
     doc:
@@ -5021,7 +5021,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_typesupport.git
-      version: rolling
+      version: iron
     status: maintained
   rosidl_typesupport_fastrtps:
     doc:
@@ -5041,7 +5041,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
-      version: rolling
+      version: iron
     status: developed
   rospy_message_converter:
     doc:
@@ -5101,7 +5101,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rpyutils.git
-      version: rolling
+      version: iron
     status: developed
   rqt:
     doc:
@@ -5123,7 +5123,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt.git
-      version: rolling
+      version: iron
     status: maintained
   rqt_action:
     doc:
@@ -5138,7 +5138,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_action.git
-      version: rolling
+      version: iron
     status: maintained
   rqt_bag:
     doc:
@@ -5156,7 +5156,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git
-      version: rolling
+      version: iron
     status: maintained
   rqt_common_plugins:
     doc:
@@ -5186,7 +5186,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git
-      version: rolling
+      version: iron
     status: maintained
   rqt_graph:
     doc:
@@ -5202,7 +5202,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_graph.git
-      version: rolling
+      version: iron
     status: maintained
   rqt_image_overlay:
     doc:
@@ -5266,7 +5266,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_msg.git
-      version: rolling
+      version: iron
     status: maintained
   rqt_plot:
     doc:
@@ -5281,7 +5281,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git
-      version: rolling
+      version: iron
     status: maintained
   rqt_publisher:
     doc:
@@ -5296,7 +5296,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git
-      version: rolling
+      version: iron
     status: maintained
   rqt_py_console:
     doc:
@@ -5311,7 +5311,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_py_console.git
-      version: rolling
+      version: iron
     status: maintained
   rqt_reconfigure:
     doc:
@@ -5327,7 +5327,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_reconfigure.git
-      version: rolling
+      version: iron
     status: maintained
   rqt_robot_dashboard:
     doc:
@@ -5402,7 +5402,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_service_caller.git
-      version: rolling
+      version: iron
     status: maintained
   rqt_shell:
     doc:
@@ -5417,7 +5417,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_shell.git
-      version: rolling
+      version: iron
     status: maintained
   rqt_srv:
     doc:
@@ -5432,7 +5432,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_srv.git
-      version: rolling
+      version: iron
     status: maintained
   rqt_tf_tree:
     doc:
@@ -5463,7 +5463,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_topic.git
-      version: rolling
+      version: iron
     status: maintained
   rsl:
     doc:
@@ -5562,7 +5562,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rviz.git
-      version: rolling
+      version: iron
     status: maintained
   rviz_2d_overlay_plugins:
     doc:
@@ -5800,7 +5800,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/spdlog_vendor.git
-      version: rolling
+      version: iron
     status: maintained
   srdfdom:
     doc:
@@ -5834,7 +5834,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/sros2.git
-      version: rolling
+      version: iron
     status: developed
   stomp:
     doc:
@@ -5926,7 +5926,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/system_tests.git
-      version: rolling
+      version: iron
     status: developed
   tango_icons_vendor:
     release:
@@ -5937,7 +5937,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/tango_icons_vendor.git
-      version: rolling
+      version: iron
     status: maintained
   teleop_tools:
     doc:
@@ -6021,7 +6021,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/test_interface_files.git
-      version: rolling
+      version: iron
     status: maintained
   tf2_2d:
     doc:
@@ -6084,7 +6084,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/tinyxml2_vendor.git
-      version: rolling
+      version: iron
     status: maintained
   tinyxml_vendor:
     release:
@@ -6096,7 +6096,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/tinyxml_vendor.git
-      version: rolling
+      version: iron
     status: maintained
   tlsf:
     doc:
@@ -6112,7 +6112,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/tlsf.git
-      version: rolling
+      version: iron
     status: maintained
   topic_tools:
     doc:
@@ -6376,7 +6376,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ament/uncrustify_vendor.git
-      version: rolling
+      version: iron
     status: maintained
   unique_identifier_msgs:
     doc:
@@ -6392,7 +6392,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/unique_identifier_msgs.git
-      version: rolling
+      version: iron
     status: maintained
   ur_client_library:
     doc:
@@ -6479,7 +6479,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/urdf.git
-      version: rolling
+      version: iron
     status: maintained
   urdf_parser_py:
     doc:
@@ -6529,7 +6529,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/urdfdom.git
-      version: master
+      version: iron
     status: maintained
   urdfdom_headers:
     doc:
@@ -6544,7 +6544,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/urdfdom_headers.git
-      version: master
+      version: iron
     status: maintained
   urg_c:
     doc:
@@ -6901,7 +6901,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/yaml_cpp_vendor.git
-      version: rolling
+      version: iron
     status: maintained
   zbar_ros:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -101,7 +101,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ament/ament_cmake.git
-      version: rolling
+      version: iron
     release:
       packages:
       - ament_cmake
@@ -155,7 +155,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/ament_cmake_ros.git
-      version: rolling
+      version: iron
     release:
       packages:
       - ament_cmake_ros
@@ -189,7 +189,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ament/ament_index.git
-      version: rolling
+      version: iron
     release:
       packages:
       - ament_index_cpp
@@ -208,7 +208,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ament/ament_lint.git
-      version: rolling
+      version: iron
     release:
       packages:
       - ament_clang_format
@@ -267,7 +267,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ament/ament_package.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -645,7 +645,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/class_loader.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -692,7 +692,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/common_interfaces.git
-      version: rolling
+      version: iron
     release:
       packages:
       - actionlib_msgs
@@ -722,7 +722,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/console_bridge_vendor.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -824,7 +824,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/demos.git
-      version: rolling
+      version: iron
     release:
       packages:
       - action_tutorials_cpp
@@ -1091,7 +1091,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/eigen3_cmake_module.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -1137,7 +1137,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/example_interfaces.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -1153,7 +1153,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/examples.git
-      version: rolling
+      version: iron
     release:
       packages:
       - examples_rclcpp_async_client
@@ -1495,7 +1495,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/geometry2.git
-      version: rolling
+      version: iron
     release:
       packages:
       - examples_tf2_py
@@ -1545,7 +1545,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ament/google_benchmark_vendor.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -1817,7 +1817,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/image_common.git
-      version: rolling
+      version: iron
     release:
       packages:
       - camera_calibration_parsers
@@ -1906,7 +1906,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/interactive_markers.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -1990,7 +1990,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/kdl_parser.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -2006,7 +2006,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-tooling/keyboard_handler.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -2125,7 +2125,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/laser_geometry.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -2157,7 +2157,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/launch.git
-      version: rolling
+      version: iron
     release:
       packages:
       - launch
@@ -2195,7 +2195,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/launch_ros.git
-      version: rolling
+      version: iron
     release:
       packages:
       - launch_ros
@@ -2262,7 +2262,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -2421,7 +2421,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/message_filters.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -2506,7 +2506,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/mimick_vendor.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -2769,7 +2769,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-planning/navigation_msgs.git
-      version: rolling
+      version: iron
     release:
       packages:
       - map_msgs
@@ -3137,7 +3137,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/osrf/osrf_testing_tools_cpp.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -3356,7 +3356,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/pluginlib.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -3533,7 +3533,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/pybind11_vendor.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -3549,7 +3549,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/python_cmake_module.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -3564,7 +3564,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -3591,7 +3591,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/qt_gui_core.git
-      version: rolling
+      version: iron
     release:
       packages:
       - qt_dotgraph
@@ -3769,7 +3769,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rcl.git
-      version: rolling
+      version: iron
     release:
       packages:
       - rcl
@@ -3790,7 +3790,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rcl_interfaces.git
-      version: rolling
+      version: iron
     release:
       packages:
       - action_msgs
@@ -3817,7 +3817,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rcl_logging.git
-      version: rolling
+      version: iron
     release:
       packages:
       - rcl_logging_interface
@@ -3869,7 +3869,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rclcpp.git
-      version: rolling
+      version: iron
     release:
       packages:
       - rclcpp
@@ -3890,7 +3890,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rclpy.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -3906,7 +3906,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rcpputils.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -3957,7 +3957,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rcutils.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -3973,7 +3973,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/realtime_support.git
-      version: rolling
+      version: iron
     release:
       packages:
       - rttest
@@ -4007,7 +4007,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/resource_retriever.git
-      version: rolling
+      version: iron
     release:
       packages:
       - libcurl_vendor
@@ -4289,7 +4289,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rmw.git
-      version: rolling
+      version: iron
     release:
       packages:
       - rmw
@@ -4308,7 +4308,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git
-      version: rolling
+      version: iron
     release:
       packages:
       - rmw_connextdds
@@ -4327,7 +4327,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rmw_cyclonedds.git
-      version: rolling
+      version: iron
     release:
       packages:
       - rmw_cyclonedds_cpp
@@ -4345,7 +4345,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rmw_dds_common.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -4361,7 +4361,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rmw_fastrtps.git
-      version: rolling
+      version: iron
     release:
       packages:
       - rmw_fastrtps_cpp
@@ -4399,7 +4399,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rmw_implementation.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -4445,7 +4445,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/robot_state_publisher.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -4567,7 +4567,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/ros2_tracing.git
-      version: rolling
+      version: iron
     release:
       packages:
       - ros2trace
@@ -4606,7 +4606,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/ros2cli.git
-      version: rolling
+      version: iron
     release:
       packages:
       - ros2action
@@ -4638,7 +4638,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/ros2cli_common_extensions.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -4685,7 +4685,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/ros_environment.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -4745,7 +4745,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/ros_testing.git
-      version: rolling
+      version: iron
     release:
       packages:
       - ros2test
@@ -4775,7 +4775,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rosbag2.git
-      version: rolling
+      version: iron
     release:
       packages:
       - mcap_vendor
@@ -4856,7 +4856,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rosidl.git
-      version: rolling
+      version: iron
     release:
       packages:
       - rosidl_adapter
@@ -4886,7 +4886,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_core.git
-      version: rolling
+      version: iron
     release:
       packages:
       - rosidl_core_generators
@@ -4905,7 +4905,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_dds.git
-      version: rolling
+      version: iron
     release:
       packages:
       - rosidl_generator_dds_idl
@@ -4923,7 +4923,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_defaults.git
-      version: rolling
+      version: iron
     release:
       packages:
       - rosidl_default_generators
@@ -4942,7 +4942,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_dynamic_typesupport.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -4958,7 +4958,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -4974,7 +4974,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_python.git
-      version: rolling
+      version: iron
     release:
       packages:
       - rosidl_generator_py
@@ -4992,7 +4992,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_runtime_py.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -5008,7 +5008,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_typesupport.git
-      version: rolling
+      version: iron
     release:
       packages:
       - rosidl_typesupport_c
@@ -5027,7 +5027,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
-      version: rolling
+      version: iron
     release:
       packages:
       - fastrtps_cmake_module
@@ -5091,7 +5091,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rpyutils.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -5107,7 +5107,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt.git
-      version: rolling
+      version: iron
     release:
       packages:
       - rqt
@@ -5129,7 +5129,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_action.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -5144,7 +5144,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git
-      version: rolling
+      version: iron
     release:
       packages:
       - rqt_bag
@@ -5177,7 +5177,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -5192,7 +5192,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_graph.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -5257,7 +5257,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_msg.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -5272,7 +5272,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -5287,7 +5287,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -5302,7 +5302,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_py_console.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -5317,7 +5317,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_reconfigure.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -5393,7 +5393,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_service_caller.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -5408,7 +5408,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_shell.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -5423,7 +5423,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_srv.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -5453,7 +5453,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_topic.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -5543,7 +5543,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rviz.git
-      version: rolling
+      version: iron
     release:
       packages:
       - rviz2
@@ -5821,7 +5821,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/sros2.git
-      version: rolling
+      version: iron
     release:
       packages:
       - sros2
@@ -6011,7 +6011,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/test_interface_files.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -6074,7 +6074,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/tinyxml2_vendor.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -6102,7 +6102,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/tlsf.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -6382,7 +6382,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/unique_identifier_msgs.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -6466,7 +6466,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/urdf.git
-      version: rolling
+      version: iron
     release:
       packages:
       - urdf
@@ -6519,7 +6519,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/urdfdom.git
-      version: master
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -6535,7 +6535,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/urdfdom_headers.git
-      version: master
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}


### PR DESCRIPTION
PR https://github.com/ros/rosdistro/pull/36923 added a distribution.yaml for `iron` which was generated by running the migration script. However, the source versions for various core ROS 2 repos remained as `rolling`.

For those pkgs with version `iron` in [ros2.repos](https://github.com/ros2/ros2/blob/iron/ros2.repos) file, the corresponding source versions in the iron/distribution.yaml have been updated in this PR.

Once this is merged, we need to update the iron tracks for these packages in the release repos.