### PR TITLE
dingo: 0.3.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1873,7 +1873,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/dingo-release.git
-      version: 0.3.1-1
+      version: 0.3.1-2
     source:
       type: git
       url: https://github.com/dingo-cpr/dingo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo` to `0.3.1-2`:

- upstream repository: https://github.com/dingo-cpr/dingo.git
- release repository: https://github.com/clearpath-gbp/dingo-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.1-1`

## dingo_control

- No changes

## dingo_description

```
* Adding Sick TIM551 lidar
* Standard mounting locations persist in PACS
* Update README.md
* Update README
* Contributors: Hilary Luo, luis-camero
```

## dingo_msgs

- No changes

## dingo_navigation

- No changes
