### PR TITLE
cras_msgs: 1.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1506,7 +1506,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/cras_msgs
-      version: 1.0.1-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ctu-vras/cras_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_msgs` to `1.1.0-1`:

- upstream repository: https://github.com/ctu-vras/cras_msgs
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/cras_msgs
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.1-1`

## cras_msgs

```
* Added new messages (mostly for electronic_io).
* Clean up undesired includes.
* Contributors: Martin Pecka
```
