### PR TITLE
teleop_tools: 0.5.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10919,7 +10919,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/teleop_tools-release.git
-      version: 0.4.0-1
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10908,7 +10908,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git
-      version: kinetic-devel
+      version: noetic-devel
     release:
       packages:
       - joy_teleop
@@ -10923,7 +10923,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git
-      version: kinetic-devel
+      version: noetic-devel
     status: maintained
   teleop_twist_joy:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_tools` to `0.5.0-1`:

- upstream repository: https://github.com/ros-teleop/teleop_tools.git
- release repository: https://github.com/ros-gbp/teleop_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.0-1`

## joy_teleop

```
* When allow_multiple_commands is True, Use AND operation with match_command instead of OR operation (#82 <https://github.com/ros-teleop/teleop_tools/issues/82>)
  * Use AND operation with match_command instead of OR operation
  * added allow_multiple_commands parameter to have some control over the joystick combinations
* Contributors: Sai Kishor Kothakota
```

## key_teleop

- No changes

## mouse_teleop

- No changes

## teleop_tools

- No changes

## teleop_tools_msgs

- No changes
