### PR TITLE
foxglove_bridge: 0.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1324,7 +1324,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 0.5.3-1
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_bridge` to `0.6.0-1`:

- upstream repository: https://github.com/foxglove/ros-foxglove-bridge.git
- release repository: https://github.com/ros2-gbp/foxglove_bridge-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.5.3-1`

## foxglove_bridge

```
* Add support for nested parameters (ROS1) (#221 <https://github.com/foxglove/ros-foxglove-bridge/issues/221>)
* Catch exceptions thrown in handler functions, send status to client (#210 <https://github.com/foxglove/ros-foxglove-bridge/issues/210>)
* Fix unhandled xmlrpc exception (#218 <https://github.com/foxglove/ros-foxglove-bridge/issues/218>)
* Add support for action topic and services (ROS2) (#214 <https://github.com/foxglove/ros-foxglove-bridge/issues/214>)
* Add parameter to include hidden topics and services (ROS 2) (#216 <https://github.com/foxglove/ros-foxglove-bridge/issues/216>)
* Add workaround for publishers not being cleaned up after they got destroyed (#215 <https://github.com/foxglove/ros-foxglove-bridge/issues/215>)
* Fix error when compiling with C++20 (#212 <https://github.com/foxglove/ros-foxglove-bridge/issues/212>)
* Devcontainer improvements (#213 <https://github.com/foxglove/ros-foxglove-bridge/issues/213>)
* Add parameter for minimum subscription QoS depth (#211 <https://github.com/foxglove/ros-foxglove-bridge/issues/211>)
* Log version and commit hash when node is started (#209 <https://github.com/foxglove/ros-foxglove-bridge/issues/209>)
* Contributors: Hans-Joachim Krauch
```
