### PR TITLE
twist_mux_msgs: 3.0.0-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7331,6 +7331,21 @@ repositories:
       url: https://github.com/ros-teleop/twist_mux.git
       version: foxy-devel
     status: maintained
+  twist_mux_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-teleop/twist_mux_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros-gbp/twist_mux_msgs-release.git
+      version: 3.0.0-2
+    source:
+      type: git
+      url: https://github.com/ros-teleop/twist_mux_msgs.git
+      version: master
+    status: maintained
   twist_stamper:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `twist_mux_msgs` to `3.0.0-2`:

- upstream repository: https://github.com/ros-teleop/twist_mux_msgs.git
- release repository: https://github.com/ros-gbp/twist_mux_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## twist_mux_msgs

```
* Migrate to ROS2 (#2 <https://github.com/ros-teleop/twist_mux_msgs/issues/2>)
* Contributors: Victor Lopez, Noel Jimenez, Bence Magyar
```
