### PR TITLE
add libnanopb

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3512,10 +3512,6 @@ libgps:
   opensuse: [gpsd-devel]
   rhel: [gpsd-devel]
   ubuntu: [libgps-dev]
-libgrpc++-dev:
-  debian: [libgrpc++-dev]
-  fedora: [grpc]
-  ubuntu: [libgrpc++-dev]
 libgsl:
   arch: [gsl]
   debian:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3512,6 +3512,9 @@ libgps:
   opensuse: [gpsd-devel]
   rhel: [gpsd-devel]
   ubuntu: [libgps-dev]
+libgrpc++-dev:
+  debian: [libgrpc++-dev]
+  ubuntu: [libgrpc++-dev]
 libgsl:
   arch: [gsl]
   debian:
@@ -4060,6 +4063,8 @@ libnanoflann-dev:
     '*': [libnanoflann-dev]
     bionic: null
     focal: null
+libnanopb-dev:
+  ubuntu: [libnanopb-dev]
 libncurses:
   arch: [ncurses]
   debian: [libncurses5]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3514,6 +3514,7 @@ libgps:
   ubuntu: [libgps-dev]
 libgrpc++-dev:
   debian: [libgrpc++-dev]
+  fedora: [grpc]
   ubuntu: [libgrpc++-dev]
 libgsl:
   arch: [gsl]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4095,8 +4095,7 @@ libnanoflann-dev:
     bionic: null
     focal: null
 libnanopb-dev:
-  debian:
-    bullseye: [libnanopb-dev]
+  debian: [libnanopb-dev]
   ubuntu:
     '*': [libnanopb-dev]
     bionic: null

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4095,7 +4095,11 @@ libnanoflann-dev:
     bionic: null
     focal: null
 libnanopb-dev:
-  ubuntu: [libnanopb-dev]
+  debian:
+    bullseye: [libnanopb-dev]
+  ubuntu:
+    '*': [libnanopb-dev]
+    bionic: null
 libncurses:
   arch: [ncurses]
   debian: [libncurses5]


### PR DESCRIPTION
Please add the following dependencies to the rosdep database.

## Package name:

libnanop-dev

## Package Upstream Source:

https://github.com/nanopb/nanopb

## Purpose of using this:

nanopb is a commonly used messaging protocol, which is necessary for the ROS2 hardware interface of some KUKA robots

## Links to Distribution Packages

- Debian: 
  - nanopb is still in unstable https://packages.debian.org/sid/libnanopb-dev
- Ubuntu:
  - nanopb: https://packages.ubuntu.com/jammy/libnanopb-dev


UPDATE: I have removed libgrpc, as there is another PR for those packages