### PR TITLE
proxsuite: 0.3.6-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3444,7 +3444,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/proxsuite-release.git
-      version: 0.3.5-3
+      version: 0.3.6-1
     source:
       type: git
       url: https://github.com/Simple-Robotics/proxsuite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `proxsuite` to `0.3.6-1`:

- upstream repository: https://github.com/Simple-Robotics/proxsuite.git
- release repository: https://github.com/ros2-gbp/proxsuite-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.5-3`
