### PR TITLE
mavros: 1.16.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5112,7 +5112,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 1.15.0-1
+      version: 1.16.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `1.16.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.15.0-1`

## libmavconn

- No changes

## mavros

```
* Merge pull request #1829 <https://github.com/mavlink/mavros/issues/1829> from snwu1996/latched_gp_origin_pub
  Made it such that the gp_origin topic publisher is latched.
* made it such that the gp_origin topic published latched.
* Merge pull request #1817 <https://github.com/mavlink/mavros/issues/1817> from lucasw/pluginlib_hpp
  use hpp instead of deprecated .h pluginlib headers
* use hpp instead of deprecated .h pluginlib headers
* Contributors: Lucas Walter, Shu-Nong Wu, Vladimir Ermakov
```

## mavros_extras

```
* Merge pull request #1817 <https://github.com/mavlink/mavros/issues/1817> from lucasw/pluginlib_hpp
  use hpp instead of deprecated .h pluginlib headers
* use hpp instead of deprecated .h pluginlib headers
* Contributors: Lucas Walter, Vladimir Ermakov
```

## mavros_msgs

- No changes

## test_mavros

- No changes
