### PR TITLE
mavros: 2.5.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2997,10 +2997,11 @@ repositories:
       - mavros
       - mavros_extras
       - mavros_msgs
+      - test_mavros
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 2.4.0-1
+      version: 2.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `2.5.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.4.0-1`
