### PR TITLE
image_transport_plugins: 3.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1874,7 +1874,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 3.0.0-1
+      version: 3.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `3.2.0-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.0.0-1`

## compressed_depth_image_transport

```
* Deprecated the following parameter names in favor of transport scoped ones. The remapping is listed below:
  * image.png_level to image.compressedDepth.png_level
  * image.depth_max to image.compressedDepth.depth_max
  * image.quality to image.compressedDepth.depth_quantization
  The deprecated parameters emit a warning if explicitly set, but this warning will be removed in future distros.
  (#145 <https://github.com/ros-perception/image_transport_plugins/issues/145>)
* Contributors: Bartosz Meglicki, Kenji Brameld, Marcel Zeilinger
```

## compressed_image_transport

```
* Allow parameters to be reconfigurable (#144 <https://github.com/ros-perception/image_transport_plugins/issues/144>)
* Contributors: Bartosz Meglicki, Kenji Brameld
```

## image_transport_plugins

- No changes

## theora_image_transport

```
* Deprecated the following parameter names in favor of transport scoped ones. The remapping is listed below:
  * image.optimize_for to image.theora.optimize_for
  * image.target_bitrate to image.theora.target_bitrate
  * image.quality to image.theora.quality
  * image.keyframe_frequency to image.theora.keyframe_frequency
  The deprecated parameters emit a warning if explicitly set, but this warning will be removed in future distros.
  (#146 <https://github.com/ros-perception/image_transport_plugins/issues/146>)
* Contributors: Bartosz Meglicki, Kenji Brameld
```
