### PR TITLE
create_robot: 2.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2107,6 +2107,17 @@ repositories:
       type: git
       url: https://github.com/AutonomyLab/create_robot.git
       version: melodic
+    release:
+      packages:
+      - create_bringup
+      - create_description
+      - create_driver
+      - create_msgs
+      - create_robot
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/autonomylab/create_autonomy-release.git
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/AutonomyLab/create_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `create_robot` to `2.0.0-1`:

- upstream repository: https://github.com/AutonomyLab/create_robot.git
- release repository: https://github.com/autonomylab/create_autonomy-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
