### PR TITLE
add python3-grip key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1843,6 +1843,19 @@ python-graphviz-pip:
 python-gridfs:
   debian: [python-gridfs]
   fedora: [python-pymongo-gridfs]
+python-grip:
+  debian:
+    pip:
+      packages: [grip]
+  fedora:
+    pip:
+      packages: [grip]
+  gentoo:
+    pip:
+      packages: [grip]
+  ubuntu:
+    pip:
+      packages: [grip]
 python-grpc-tools:
   debian:
     '*': [python-grpc-tools]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1844,18 +1844,12 @@ python-gridfs:
   debian: [python-gridfs]
   fedora: [python-pymongo-gridfs]
 python-grip:
-  debian:
-    pip:
-      packages: [grip]
+  debian: [grip]
   fedora:
     pip:
       packages: [grip]
-  gentoo:
-    pip:
-      packages: [grip]
-  ubuntu:
-    pip:
-      packages: [grip]
+  gentoo: [app-text/grip]
+  ubuntu: [grip]
 python-grpc-tools:
   debian:
     '*': [python-grpc-tools]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1843,17 +1843,6 @@ python-graphviz-pip:
 python-gridfs:
   debian: [python-gridfs]
   fedora: [python-pymongo-gridfs]
-python-grip:
-  debian:
-    '*': [grip]
-    bookworm: null
-    bullseye: null
-    buster: [grip]
-  fedora:
-    pip:
-      packages: [grip]
-  gentoo: [app-text/grip]
-  ubuntu: [grip]
 python-grpc-tools:
   debian:
     '*': [python-grpc-tools]
@@ -6141,6 +6130,17 @@ python3-graphviz:
   nixos: [python39Packages.graphviz]
   opensuse: [python3-graphviz]
   ubuntu: [python3-graphviz]
+python3-grip:
+  debian:
+    '*': [grip]
+    bookworm: null
+    bullseye: null
+    buster: [grip]
+  fedora:
+    pip:
+      packages: [grip]
+  gentoo: [app-text/grip]
+  ubuntu: [grip]
 python3-grpc-tools:
   debian:
     '*': [python3-grpc-tools]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1844,7 +1844,11 @@ python-gridfs:
   debian: [python-gridfs]
   fedora: [python-pymongo-gridfs]
 python-grip:
-  debian: [grip]
+  debian:
+    '*': [grip]
+    bookworm: null
+    bullseye: null
+    buster: [grip]
   fedora:
     pip:
       packages: [grip]


### PR DESCRIPTION
Add python-grip pip key
## Package name:

grip

## Package Upstream Source:

https://github.com/joeyespo/grip

## Purpose of using this:

launch markdown server

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - pip: https://pypi.org/project/grip/
- Ubuntu: https://packages.ubuntu.com/
  - pip: https://pypi.org/project/grip/
- Fedora: https://packages.fedoraproject.org/
  - pip: https://pypi.org/project/grip/
- Gentoo: https://packages.gentoo.org/
  - pip: https://pypi.org/project/grip/
