### PR TITLE
Change to the 'master' branch when syncing tracks.yaml branches.

### DIFF
--- a/scripts/sync-ros2-gbp-devel-branch.py
+++ b/scripts/sync-ros2-gbp-devel-branch.py
@@ -219,6 +219,7 @@ This makes it match the source entry in https://github.com/ros/rosdistro/{ros_di
 
             with tempfile.TemporaryDirectory() as tmpdirname:
                 gitrepo = git.Repo.clone_from(release_url, tmpdirname)
+                gitrepo.git.checkout('master')
                 branch = gitrepo.create_head(branch_name)
                 branch.checkout()
                 with open(os.path.join(tmpdirname, 'tracks.yaml'), 'r') as infp:
@@ -232,8 +233,8 @@ This makes it match the source entry in https://github.com/ros/rosdistro/{ros_di
                 try:
                     gitrepo.git.push('--set-upstream', gitrepo.remote(), gitrepo.head.ref)
                 except git.exc.GitCommandError:
-                   print('Could not push to release repo for {ros_distro}: {reponame}, skipping...'.format(ros_distro=ros_distro, reponame=tracks_yaml_distro['name']))
-                   continue
+                    print('Could not push to release repo for {ros_distro}: {reponame}, skipping...'.format(ros_distro=ros_distro, reponame=tracks_yaml_distro['name']))
+                    continue
 
             gh_title = 'Update {ros_distro} devel_branch to match rosdistro source entry'.format(ros_distro=ros_distro)
             gh_repo = gh.get_repo(release_end)


### PR DESCRIPTION
That is, once we clone the related release repository, there is a (small) change that the default branch is not 'master'.  Since we need to use the 'master' branch to get at the tracks.yaml, make sure to check that out before performing further operations.