### PR TITLE
libcreate: 3.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2466,6 +2466,11 @@ repositories:
       type: git
       url: https://github.com/AutonomyLab/libcreate.git
       version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/AutonomyLab/libcreate-release.git
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/AutonomyLab/libcreate.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libcreate` to `3.1.0-1`:

- upstream repository: https://github.com/AutonomyLab/libcreate.git
- release repository: https://github.com/AutonomyLab/libcreate-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## libcreate

```
* Address warnings and errors
* Catch boost exceptions in Serial.h
* Contributors: Swapnil Patel
```
