### PR TITLE
libcreate: 3.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2483,6 +2483,21 @@ repositories:
       url: https://git.libcamera.org/libcamera/libcamera.git
       version: master
     status: developed
+  libcreate:
+    doc:
+      type: git
+      url: https://github.com/AutonomyLab/libcreate.git
+      version: master
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/AutonomyLab/libcreate-release.git
+      version: 3.1.0-1
+    source:
+      type: git
+      url: https://github.com/AutonomyLab/libcreate.git
+      version: master
+    status: maintained
   libg2o:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `libcreate` to `3.1.0-1`:

- upstream repository: https://github.com/AutonomyLab/libcreate.git
- release repository: https://github.com/AutonomyLab/libcreate-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## libcreate

```
* Address warnings and errors
* Catch boost exceptions in Serial.h
* Contributors: Swapnil Patel
```
