### PR TITLE
pybind11_vendor: 3.0.3-3 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3538,7 +3538,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/pybind11_vendor-release.git
-      version: 3.0.3-2
+      version: 3.0.3-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pybind11_vendor` to `3.0.3-3`:

- upstream repository: https://github.com/ros2/pybind11_vendor.git
- release repository: https://github.com/ros2-gbp/pybind11_vendor-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.3-2`

## pybind11_vendor

```
* Add a modified patch from upstream to support Python 3.11 (#22 <https://github.com/ros2/pybind11_vendor/issues/22>)
* Contributors: Scott K Logan
```
