### PR TITLE
remote_serial: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4615,6 +4615,17 @@ repositories:
       url: https://github.com/ros-controls/realtime_tools.git
       version: master
     status: maintained
+  remote_serial:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/openvmp/serial-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/openvmp/serial.git
+      version: main
+    status: developed
   resource_retriever:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `remote_serial` to `1.0.1-1`:

- upstream repository: https://github.com/openvmp/serial.git
- release repository: https://github.com/openvmp/serial-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## remote_serial

- No changes
