### PR TITLE
Adding Libatomic to OSX in the base.yaml file

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2465,6 +2465,9 @@ libatomic:
   gentoo: [sys-devel/gcc]
   nixos: []
   openembedded: [gcc-runtime@openembedded-core]
+  osx:
+    homebrew:
+        packages: [libatomic_ops]
   rhel: [libatomic]
   ubuntu: [libatomic1]
 libav:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2467,7 +2467,7 @@ libatomic:
   openembedded: [gcc-runtime@openembedded-core]
   osx:
     homebrew:
-        packages: [libatomic_ops]
+      packages: [libatomic_ops]
   rhel: [libatomic]
   ubuntu: [libatomic1]
 libav:


### PR DESCRIPTION
This Pull request is supposed to the Libatomic library to OSX, but is done in the `base.yaml` file instead of the `homebrew.yaml`. This will hopefully begin a push to more standardization of OSX libraries, because the homebrew file now seems unnecessary

## Package name:

Libatomic

## Package Upstream Source:

[TODO link to source repository](https://github.com/ivmai/libatomic_ops/)

## Purpose of using this:

libatomic is required for libraries like rcutils and should be available to the MacOS platform.

Distro packaging links:

- macOS: https://formulae.brew.sh/formula/libatomic_ops#default