### PR TITLE
khi_robot: 1.4.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4390,6 +4390,8 @@ repositories:
       - khi_rs007l_moveit_config
       - khi_rs007n_moveit_config
       - khi_rs013n_moveit_config
+      - khi_rs020n_moveit_config
+      - khi_rs025n_moveit_config
       - khi_rs080n_moveit_config
       - khi_rs_description
       - khi_rs_gazebo
@@ -4397,7 +4399,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/Kawasaki-Robotics/khi_robot-release.git
-      version: 1.3.0-2
+      version: 1.4.0-2
     source:
       type: git
       url: https://github.com/Kawasaki-Robotics/khi_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `khi_robot` to `1.4.0-2`:

- upstream repository: https://github.com/Kawasaki-Robotics/khi_robot.git
- release repository: https://github.com/Kawasaki-Robotics/khi_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.3.0-2`

## khi_duaro_description

- No changes

## khi_duaro_gazebo

```
* Merge pull request #62 <https://github.com/Kawasaki-Robotics/khi_robot/issues/62> from y-yosuke/mod-goinitial
  mod go_initial.sh for Gazebo simulator with ROS Melodic.
* mod go_initial.sh for Gazebo simulator with using in ROS Melodic.
* Contributors: HirokiTakami, Yosuke Yamamoto
```

## khi_duaro_ikfast_plugin

- No changes

## khi_duaro_moveit_config

- No changes

## khi_robot

```
* Merge pull request #68 <https://github.com/Kawasaki-Robotics/khi_robot/issues/68> from matsui-hiro/add_rs025n
  Add rs025n
* Add rs025n
* Contributors: HirokiTakami, matsui_hiro
```

## khi_robot_bringup

```
* Merge pull request #79 <https://github.com/Kawasaki-Robotics/khi_robot/issues/79> from ohno-atsushi/add_rs020n
  Add rs020n
* Add rs020n
* Merge pull request #72 <https://github.com/Kawasaki-Robotics/khi_robot/issues/72> from matsui-hiro/rs025n_realrobot
  Add rs025n for real robot
* Add files for real robot
* Merge pull request #71 <https://github.com/Kawasaki-Robotics/khi_robot/issues/71> from matsui-hiro/fix_controller_yml
  Fix controller yml
* Revert duaro_controllers.yaml
* Fix controller yml setting
* Contributors: HirokiTakami, matsui-hiro, matsui_hiro, ohno_atsushi
```

## khi_robot_control

```
* Merge pull request #72 <https://github.com/Kawasaki-Robotics/khi_robot/issues/72> from matsui-hiro/rs025n_realrobot
  Add rs025n for real robot
* update libkrnx(2.3.5)
* Merge pull request #70 <https://github.com/Kawasaki-Robotics/khi_robot/issues/70> from Yuki-cpp/fix-potential-race-condition
  Create the ControllerManager after robot was openned
* Create the ControllerManager after robot was openned
  In the khi_robot_control node, the ControllerManager (cm) provides
  services that require controller classes to be loaded beforehand.
  This loading occurs when we open the robot.
  By moving the creation of the ControllerManager after we try to open
  the robot, we ensure that no race condition will occur and that the
  controllers will always be loaded when the provided services are called.
* Merge pull request #65 <https://github.com/Kawasaki-Robotics/khi_robot/issues/65> from 5567655/master
  Bugfix: contLimitCheck ERROR. Fix for Issue #64 <https://github.com/Kawasaki-Robotics/khi_robot/issues/64>
* Bugfix: contLimitCheck ERROR
  Function that is supposed to return boolean doesn't return anything
* Contributors: 5567655, Hiroki Matsui, HirokiTakami, Leo Ghafari, matsui-hiro
```

## khi_robot_msgs

- No changes

## khi_robot_test

```
* Merge pull request #79 <https://github.com/Kawasaki-Robotics/khi_robot/issues/79> from ohno-atsushi/add_rs020n
  Add rs020n
* Add rs020n
* Merge pull request #72 <https://github.com/Kawasaki-Robotics/khi_robot/issues/72> from matsui-hiro/rs025n_realrobot
  Add rs025n for real robot
* Add files for real robot
* Contributors: HirokiTakami, matsui-hiro, ohno_atsushi
* Merge pull request #79 <https://github.com/Kawasaki-Robotics/khi_robot/issues/79> from ohno-atsushi/add_rs020n
  Add rs020n
* Add rs020n
* Merge pull request #72 <https://github.com/Kawasaki-Robotics/khi_robot/issues/72> from matsui-hiro/rs025n_realrobot
  Add rs025n for real robot
* Add files for real robot
* Contributors: HirokiTakami, matsui-hiro, ohno_atsushi
```

## khi_rs007l_moveit_config

- No changes

## khi_rs007n_moveit_config

- No changes

## khi_rs013n_moveit_config

- No changes

## khi_rs020n_moveit_config

```
* Merge pull request #79 <https://github.com/Kawasaki-Robotics/khi_robot/issues/79> from ohno-atsushi/add_rs020n
  Add rs020n
* Add correction2 rs020n
* Add correction rs020n
* Add rs020n
* Contributors: HirokiTakami, ohno_atsushi
```

## khi_rs025n_moveit_config

```
* Merge pull request #68 <https://github.com/Kawasaki-Robotics/khi_robot/issues/68> from matsui-hiro/add_rs025n
  Add rs025n
* Add rs025n
* Contributors: HirokiTakami, matsui_hiro
```

## khi_rs080n_moveit_config

- No changes

## khi_rs_description

```
* Merge pull request #79 <https://github.com/Kawasaki-Robotics/khi_robot/issues/79> from ohno-atsushi/add_rs020n
  Add rs020n
* Add correction rs020n
* Add rs020n
* Merge pull request #72 <https://github.com/Kawasaki-Robotics/khi_robot/issues/72> from matsui-hiro/rs025n_realrobot
  Add rs025n for real robot
* Change joint_limits.yml
* Merge pull request #68 <https://github.com/Kawasaki-Robotics/khi_robot/issues/68> from matsui-hiro/add_rs025n
  Add rs025n
* Rename roslaunch_test_rs025n .xml to roslaunch_test_rs025n.xml
* Add rs025n
* Contributors: Hiroki Matsui, HirokiTakami, matsui-hiro, matsui_hiro, ohno_atsushi
```

## khi_rs_gazebo

```
* Merge pull request #79 <https://github.com/Kawasaki-Robotics/khi_robot/issues/79> from ohno-atsushi/add_rs020n
  Add rs020n
* Add rs020n
* Merge pull request #71 <https://github.com/Kawasaki-Robotics/khi_robot/issues/71> from matsui-hiro/fix_controller_yml
  Fix controller yml
* Fix controller yml setting
* Merge pull request #68 <https://github.com/Kawasaki-Robotics/khi_robot/issues/68> from matsui-hiro/add_rs025n
  Add rs025n
* Add rs025n
* Contributors: HirokiTakami, matsui_hiro, ohno_atsushi
```

## khi_rs_ikfast_plugin

```
* Merge pull request #79 <https://github.com/Kawasaki-Robotics/khi_robot/issues/79> from ohno-atsushi/add_rs020n
  Add rs020n
* Add rs020n
* Merge pull request #68 <https://github.com/Kawasaki-Robotics/khi_robot/issues/68> from matsui-hiro/add_rs025n
  Add rs025n
* Add rs025n
* Contributors: HirokiTakami, matsui_hiro, ohno_atsushi
```
