### PR TITLE
tf2_client: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13851,6 +13851,21 @@ repositories:
       url: https://github.com/locusrobotics/tf2_2d.git
       version: devel
     status: developed
+  tf2_client:
+    doc:
+      type: git
+      url: https://github.com/tpet/tf2_client.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/tf2_client.git
+      version: 0.0.0-1
+    source:
+      type: git
+      url: https://github.com/tpet/tf2_client.git
+      version: master
+    status: maintained
   tf2_server:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13860,7 +13860,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/tf2_client.git
-      version: 0.0.0-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/tpet/tf2_client.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13860,7 +13860,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/tf2_client.git
-      version: 1.0.0-1
+      version: 1.0.0-2
     source:
       type: git
       url: https://github.com/tpet/tf2_client.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf2_client` to `1.0.0-2`:

- upstream repository: https://github.com/tpet/tf2_client.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/tf2_client
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## tf2_client

```
* Adding default server launcher, with install.
* Cmake refactor, namespaced cpp file, dynamic cast to subclass.
* Fix client/server switch in c++ client.
* Passing private node handle as argument.
* C++ client single node handle, clean up, exporting library.
* Log clearing listener and buffer.
* Allow to clear the listener and buffer if they are not needed any more.
* Fix creating duration object.
* Adding cpp support, clean up of parameter names, conditional param reading.
* Passing Duration object to local Buffer instead of float.
* Initial version (untested).
* Contributors: Martin Pecka, Tomas Petricek
```