### PR TITLE
Add python3-bidict to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4925,7 +4925,6 @@ python3-bidict:
   freebsd: [py39-bidict]
   nixos: [python310Packages.bidict]
   openembedded: [python3-bidict@meta-python]
-  opensuse: [python3-bidict]
   ubuntu:
     '*': [python3-bidict]
     bionic: null

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4925,7 +4925,7 @@ python3-bidict:
   freebsd: [py39-bidict]
   nixos: [python310Packages.bidict]
   openembedded: [python3-bidict@meta-python]
-  opensuse: [python-bidict]
+  opensuse: [python3-bidict]
   ubuntu:
     '*': [python3-bidict]
     bionic: null

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4916,6 +4916,19 @@ python3-bcrypt:
   opensuse: [python3-bcrypt]
   rhel: ['python%{python3_pkgversion}-bcrypt']
   ubuntu: [python3-bcrypt]
+python3-bidict:
+  arch: [python-bidict]
+  debian:
+    '*': [python3-bidict]
+    buster: null
+  fedora: [python3-bidict]
+  freebsd: [py39-bidict]
+  nixos: [python310Packages.bidict]
+  openembedded: [python3-bidict@meta-python]
+  opensuse: [python-bidict]
+  ubuntu:
+    '*': [python3-bidict]
+    bionic: null
 python3-bitarray:
   debian: [python3-bitarray]
   fedora: [python3-bitarray]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`python3-bidict`

## Package Upstream Source:

bidict module on pypi: https://pypi.org/project/bidict/

## Purpose of using this:

Adding the python bidict module as a rosdep, useful module for creating bidirectional dictionaries in python.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/python3-bidict
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/focal/python3-bidict
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-bidict/python3-bidict
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/community/any/python-bidict/
- Gentoo: https://packages.gentoo.org/
  - NOT AVAILABLE
- macOS: https://formulae.brew.sh/
  - NOT AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - NOT AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=unstable&show=python310Packages.bidict&from=0&size=50&sort=relevance&type=packages&query=bidict
- openSUSE: https://software.opensuse.org/package/
  - NOT AVAILABLE
- openembedded:
  - https://layers.openembedded.org/layerindex/recipe/181919/
- freebsd:
  - https://ports.freebsd.org/cgi/ports.cgi?query=bidict&stype=all
