### PR TITLE
Remove toposens from kinetic/melodic/noetic distributions

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13935,44 +13935,6 @@ repositories:
       url: https://gitlab.com/InstitutMaupertuis/topics_rviz_plugin.git
       version: melodic
     status: maintained
-  toposens:
-    doc:
-      type: git
-      url: https://gitlab.com/toposens/public/ros-packages.git
-      version: master
-    release:
-      packages:
-      - toposens
-      - toposens_bringup
-      - toposens_description
-      - toposens_driver
-      - toposens_echo_driver
-      - toposens_markers
-      - toposens_msgs
-      - toposens_pointcloud
-      - toposens_sync
-      tags:
-        release: release/melodic/{package}/{version}
-      url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 2.3.2-1
-    source:
-      type: git
-      url: https://gitlab.com/toposens/public/ros-packages.git
-      version: master
-    status: developed
-  toposens-library:
-    release:
-      packages:
-      - toposens-sensor-library
-      tags:
-        release: release/melodic/{package}/{version}
-      url: https://gitlab.com/toposens/public/toposens-library-release.git
-      version: 1.2.4-4
-    source:
-      type: git
-      url: https://gitlab.com/toposens/public/toposens-library.git
-      version: master
-    status: developed
   tork_moveit_tutorial:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11097,48 +11097,6 @@ repositories:
       url: https://github.com/ThundeRatz/thunder_line_follower_pmr3100.git
       version: master
     status: developed
-  toposens:
-    doc:
-      type: git
-      url: https://gitlab.com/toposens/public/ros-packages.git
-      version: master
-    release:
-      packages:
-      - toposens
-      - toposens_bringup
-      - toposens_description
-      - toposens_driver
-      - toposens_echo_driver
-      - toposens_markers
-      - toposens_msgs
-      - toposens_pointcloud
-      - toposens_sync
-      tags:
-        release: release/noetic/{package}/{version}
-      url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 2.3.2-2
-    source:
-      type: git
-      url: https://gitlab.com/toposens/public/ros-packages.git
-      version: master
-    status: developed
-  toposens-library:
-    doc:
-      type: git
-      url: https://gitlab.com/toposens/public/toposens-library.git
-      version: master
-    release:
-      packages:
-      - toposens-sensor-library
-      tags:
-        release: release/noetic/{package}/{version}
-      url: https://gitlab.com/toposens/public/toposens-library-release.git
-      version: 1.2.4-4
-    source:
-      type: git
-      url: https://gitlab.com/toposens/public/toposens-library.git
-      version: master
-    status: developed
   trac_ik:
     doc:
       type: git


### PR DESCRIPTION
The toposens nodes lack a maintainer and the git repositories are unfortunately no longer available.