### PR TITLE
Release ros_gz for rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4706,10 +4706,16 @@ repositories:
       packages:
       - ros_gz
       - ros_gz_bridge
-      - ros_gz_gazebo
-      - ros_gz_gazebo_demos
       - ros_gz_image
       - ros_gz_interfaces
+      - ros_gz_sim
+      - ros_gz_sim_demos
+      - ros_ign
+      - ros_ign_bridge
+      - ros_ign_gazebo
+      - ros_ign_gazebo_demos
+      - ros_ign_image
+      - ros_ign_interfaces
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4700,7 +4700,7 @@ repositories:
   ros_gz:
     doc:
       type: git
-      url: https://github.com/ignitionrobotics/ros_gz.git
+      url: https://github.com/gazebosim/ros_gz.git
       version: humble
     release:
       packages:
@@ -4723,8 +4723,8 @@ repositories:
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/ignitionrobotics/ros_ign.git
-      version: ros2
+      url: https://github.com/gazebosim/ros_gz.git
+      version: humble
     status: developed
   ros_image_to_qimage:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4697,23 +4697,23 @@ repositories:
       url: https://github.com/ros/ros_environment.git
       version: rolling
     status: maintained
-  ros_ign:
+  ros_gz:
     doc:
       type: git
-      url: https://github.com/ignitionrobotics/ros_ign.git
-      version: ros2
+      url: https://github.com/ignitionrobotics/ros_gz.git
+      version: humble
     release:
       packages:
-      - ros_ign
-      - ros_ign_bridge
-      - ros_ign_gazebo
-      - ros_ign_gazebo_demos
-      - ros_ign_image
-      - ros_ign_interfaces
+      - ros_gz
+      - ros_gz_bridge
+      - ros_gz_gazebo
+      - ros_gz_gazebo_demos
+      - ros_gz_image
+      - ros_gz_interfaces
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 0.244.3-2
+      version: 0.244.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `0.244.10`:

- upstream repository: https://github.com/gazebosim/ros_gz.git
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.244.3-1`