### PR TITLE
Adding Cairo to osx

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -897,6 +897,9 @@ python-cairo:
   gentoo: [dev-python/pycairo]
   nixos: [pythonPackages.pycairo]
   opensuse: [python2-cairo]
+  osx:
+    pip:
+      packages: [cairo-lang]
   rhel:
     '7': [pycairo]
     '8': [python2-cairo]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -899,7 +899,7 @@ python-cairo:
   opensuse: [python2-cairo]
   osx:
     pip:
-      packages: [cairo-lang]
+      packages: [pycairo]
   rhel:
     '7': [pycairo]
     '8': [python2-cairo]


### PR DESCRIPTION
This PR adds the Cairo (Not the Cairo Lang*) package to OSX via python. Cairo is a small 2D graphics library that creates flexibility in ros's overall project.

## Package name:

Python-Cairo

## Package Upstream Source:

https://github.com/msteinert/cairo

## Purpose of using this:

Packages like rqt_bag_plugins need access to the Cairo graphics library and OSX currently didn't have access to it.

Distro packaging links:

## Links to Distribution Packages

- macOS: https://formulae.brew.sh/formula/cairo#default