### PR TITLE
draco: 1.3.6-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2553,10 +2553,6 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/draco.git
       version: 1.3.6-3
-    source:
-      type: git
-      url: https://github.com/google/draco.git
-      version: 1.3.6
     status: maintained
   driver_common:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2543,6 +2543,21 @@ repositories:
       url: https://github.com/ct2034/dockeros-release.git
       version: 1.1.0-1
     status: developed
+  draco:
+    doc:
+      type: git
+      url: https://github.com/google/draco.git
+      version: 1.3.6
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/draco.git
+      version: 1.3.6-3
+    source:
+      type: git
+      url: https://github.com/google/draco.git
+      version: 1.3.6
+    status: maintained
   driver_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `draco` to `1.3.6-3`:

- upstream repository: https://github.com/google/draco
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/draco.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
