### PR TITLE
point_cloud_transport: 1.0.9-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9256,7 +9256,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/ctu-vras/point_cloud_transport.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9256,7 +9256,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ctu-vras/point_cloud_transport.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9247,6 +9247,21 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: melodic-devel
     status: maintained
+  point_cloud_transport:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/point_cloud_transport.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ctu-vras/point_cloud_transport.git
+      version: master
+    status: developed
   pointcloud_to_laserscan:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9256,7 +9256,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport.git
-      version: 1.0.7-1
+      version: 1.0.8-1
     source:
       type: git
       url: https://github.com/ctu-vras/point_cloud_transport.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9256,7 +9256,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/ctu-vras/point_cloud_transport.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9256,7 +9256,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport.git
-      version: 1.0.8-1
+      version: 1.0.9-1
     source:
       type: git
       url: https://github.com/ctu-vras/point_cloud_transport.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9256,7 +9256,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport.git
-      version: 1.0.6-1
+      version: 1.0.7-1
     source:
       type: git
       url: https://github.com/ctu-vras/point_cloud_transport.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9256,7 +9256,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/ctu-vras/point_cloud_transport.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9256,7 +9256,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport.git
-      version: 1.0.5-1
+      version: 1.0.6-1
     source:
       type: git
       url: https://github.com/ctu-vras/point_cloud_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `1.0.9-1`:

- upstream repository: https://github.com/ctu-vras/point_cloud_transport.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## point_cloud_transport

```
* Fixed bad_expected_access bug in simple_subscriber_plugin.
* Split Python API into several files.
* Improved Python API to allow the pub/sub-like usage.
* Fixed bug in republish. Plugin blacklist was acting exactly the opposite way.
* Turned republish into a nodelet (but kept its node version).
* Added Python API for encode()/decode().
* Added possibility to report log messages.
* Reworked the idea to include direct encoders/decoders and not only publishers/subscribers.
* Initial cleanup before releasing. No substantial changes made.
* Forked from https://github.com/paplhjak/point_cloud_transport
* Contributors: Jakub Paplham, Martin Pecka, Tomas Petricek
```
