### PR TITLE
point_cloud_transport_plugins: 1.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9259,7 +9259,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport_plugins.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ctu-vras/point_cloud_transport_plugins.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9247,6 +9247,24 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: melodic-devel
     status: maintained
+  point_cloud_transport_plugins:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/point_cloud_transport_plugins.git
+      version: master
+    release:
+      packages:
+      - draco_point_cloud_transport
+      - point_cloud_transport_plugins
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport_plugins.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ctu-vras/point_cloud_transport_plugins.git
+      version: master
+    status: developed
   pointcloud_to_laserscan:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9259,7 +9259,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport_plugins.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/ctu-vras/point_cloud_transport_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport_plugins` to `1.0.3-1`:

- upstream repository: https://github.com/ctu-vras/point_cloud_transport_plugins.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport_plugins.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## draco_point_cloud_transport

```
* GCC 7 compatibility.
* Report log messages from the transport via the log helper.
* Hide draco library symbols from include files so that it does not have to be exported.
* More robust Draco CMake finding.
* Adopted direct encoders and decoders.
* Moved draco_point_cloud_transport into its own folder
* Forked from https://github.com/paplhjak/draco_point_cloud_transport
* Contributors: Martin Pecka, Jakub Paplham, Tomas Petricek
```

## point_cloud_transport_plugins

```
* Added point_cloud_transport_plugins metapackage to this repo.
* Contributors: Martin Pecka, Jakub Paplham
```
