### PR TITLE
rqt_graph: 1.4.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5197,7 +5197,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_graph-release.git
-      version: 1.4.1-3
+      version: 1.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_graph` to `1.4.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_graph.git
- release repository: https://github.com/ros2-gbp/rqt_graph-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.4.1-3`

## rqt_graph

```
* Refresh rosgraph when params checkbox is clicked (#87 <https://github.com/ros-visualization/rqt_graph/issues/87>)
* Contributors: Yadunund
```
