### PR TITLE
rclpy: 4.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3895,7 +3895,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 4.2.0-1
+      version: 4.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `4.2.1-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.2.0-1`

## rclpy

```
* Fix action server crash when the client goes away. (#1114 <https://github.com/ros2/rclpy/issues/1114>)
* Turn Executor into a ContextManager (#1118 <https://github.com/ros2/rclpy/issues/1118>)
* Turn Context into a ContextManager (#1117 <https://github.com/ros2/rclpy/issues/1117>)
* Fix type in Node init args (#1115 <https://github.com/ros2/rclpy/issues/1115>)
* Contributors: Chris Lalancette, Felix Divo, Russ
```
