### PR TITLE
ros2_tracing: 6.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4579,7 +4579,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 6.4.0-1
+      version: 6.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `6.4.1-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `6.4.0-1`

## ros2trace

```
* Switch <depend> to <exec_depend> in pure Python packages (#67 <https://github.com/ros2/ros2_tracing/issues/67>)
* Contributors: Christophe Bedard
```

## tracetools

```
* Disable tracing on Android (#71 <https://github.com/ros2/ros2_tracing/issues/71>)
* Contributors: Przemysław Dąbrowski
```

## tracetools_launch

- No changes

## tracetools_read

- No changes

## tracetools_test

```
* Switch <depend> to <exec_depend> in pure Python packages (#67 <https://github.com/ros2/ros2_tracing/issues/67>)
* Contributors: Christophe Bedard
```

## tracetools_trace

```
* Detect issue with LTTng and Docker and report error when tracing (#66 <https://github.com/ros2/ros2_tracing/issues/66>)
* Contributors: Christophe Bedard
```
