### PR TITLE
ros2cli: 0.25.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4627,7 +4627,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.25.0-2
+      version: 0.25.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.25.1-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.25.0-2`

## ros2action

- No changes

## ros2cli

- No changes

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

```
* Shutdown ros2doctor hello when ctrl-c is received (#829 <https://github.com/ros2/ros2cli/issues/829>)
* Contributors: Michael Carroll
```

## ros2interface

- No changes

## ros2lifecycle

- No changes

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

- No changes

## ros2param

- No changes

## ros2pkg

```
* Fix typo in ros2pkg warning message. (#828 <https://github.com/ros2/ros2cli/issues/828>)
* Contributors: Tomoya Fujita
```

## ros2run

- No changes

## ros2service

- No changes

## ros2topic

- No changes
