### PR TITLE
rviz: 12.5.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5557,7 +5557,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 12.5.0-2
+      version: 12.5.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `12.5.1-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `12.5.0-2`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Clean Code (#975 <https://github.com/ros2/rviz/issues/975>)
* Contributors: mosfet80
```

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Clean Code (#975 <https://github.com/ros2/rviz/issues/975>)
  * Clean Code
* Contributors: mosfet80
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
