### PR TITLE
Add rosdep key for 'bandit'

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -292,6 +292,16 @@ babeltrace:
   gentoo: [dev-util/babeltrace]
   nixos: [babeltrace]
   ubuntu: [babeltrace]
+bandit:
+  arch: [bandit]
+  debian: [bandit]
+  fedora: [bandit]
+  gentoo: [dev-python/bandit]
+  opensuse: [python3-bandit]
+  osx:
+    homebrew:
+      packages: [bandit]
+  ubuntu: [bandit]
 bazaar:
   arch: [bzr]
   debian: [bzr]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`bandit`

## Package Upstream Source:

https://github.com/PyCQA/bandit

## Purpose of using this:

Bandit is an open source static code analyzer for Python projects. I have developed a wrapper for the ament build system to run Bandit in ROS projects, and opened a [PR on the ament_lint repo](https://github.com/ament/ament_lint/pull/439). For this package to build, the `bandit` rosdep key is required.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/buster/bandit
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/kinetic/bandit
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/bandit/bandit/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/community/any/bandit/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/bandit
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/bandit
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python3-bandit