### PR TITLE
Add rosdep key for 'semgrep'

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7324,6 +7324,11 @@ sdl2-ttf:
   gentoo: [media-libs/sdl2-ttf]
   nixos: [SDL2_ttf]
   ubuntu: [libsdl2-ttf-dev]
+semgrep:
+  osx:
+    homebrew:
+      packages: [semgrep]
+  pip: [semgrep]
 setserial:
   debian: [setserial]
   fedora: [setserial]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7325,10 +7325,15 @@ sdl2-ttf:
   nixos: [SDL2_ttf]
   ubuntu: [libsdl2-ttf-dev]
 semgrep:
+  debian: 
+    pip:
+      packages: [semgrep]
   osx:
     homebrew:
       packages: [semgrep]
-  pip: [semgrep]
+  ubuntu: 
+    pip:
+      packages: [semgrep]
 setserial:
   debian: [setserial]
   fedora: [setserial]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7325,13 +7325,13 @@ sdl2-ttf:
   nixos: [SDL2_ttf]
   ubuntu: [libsdl2-ttf-dev]
 semgrep:
-  debian: 
+  debian:
     pip:
       packages: [semgrep]
   osx:
     homebrew:
       packages: [semgrep]
-  ubuntu: 
+  ubuntu:
     pip:
       packages: [semgrep]
 setserial:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`semgrep`

## Package Upstream Source:

https://github.com/returntocorp/semgrep

## Purpose of using this:

Semgrep is an open source static analysis engine. I have developed a [wrapper for the ament build system](https://github.com/florcabral/ament_semgrep) to run Semgrep in ROS projects. For this package to build, the `semgrep` rosdep key is required.

Distro packaging links:

## Links to Distribution Packages

- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/semgrep
- pip
  - https://pypi.org/project/semgrep/