### PR TITLE
Add exiv2 for image metadata

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -932,7 +932,7 @@ exiv2:
   nixos: [exiv2]
   opensuse: [exiv2]
   rhel: [exiv2]
-  ubuntu: [libexiv2-dev]
+  ubuntu: [exiv2]
 f2c:
   arch: [f2c]
   debian: [f2c, libf2c2, libf2c2-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -923,6 +923,16 @@ exfat-utils:
   gentoo: [sys-fs/exfat-utils]
   nixos: [exfat]
   ubuntu: [exfat-utils]
+exiv2:
+  alpine: [exiv2]
+  arch: [exiv2]
+  debian: [exiv2]
+  fedora: [exiv2]
+  gentoo: [exiv2]
+  nixos: [exiv2]
+  opensuse: [exiv2]
+  rhel: [exiv2]
+  ubuntu: [libexiv2-dev]
 f2c:
   arch: [f2c]
   debian: [f2c, libf2c2, libf2c2-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -931,6 +931,9 @@ exiv2:
   gentoo: [exiv2]
   nixos: [exiv2]
   opensuse: [exiv2]
+  osx:
+    homebrew:
+      packages: [exiv2]
   rhel: [exiv2]
   ubuntu: [exiv2]
 f2c:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -95,6 +95,10 @@ eigen:
     homebrew:
       depends: [gfortran]
       packages: [eigen]
+exiv2:
+  osx:
+    homebrew:
+      packages: [exiv2]
 ffmpeg:
   osx:
     homebrew:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -95,10 +95,6 @@ eigen:
     homebrew:
       depends: [gfortran]
       packages: [eigen]
-exiv2:
-  osx:
-    homebrew:
-      packages: [exiv2]
 ffmpeg:
   osx:
     homebrew:


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name: exiv2

## Package Upstream Source:

[exiv2](https://github.com/Exiv2/exiv2)

## Purpose of using this:

Exiv2 is used to read or add metadata to images for applications such as surveying. Example applications include geotagging. 

Distro packaging links:

## Links to Distribution Packages


- Debian: https://packages.debian.org/bullseye/exiv2
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/jammy/libexiv2-dev
  - REQUIRED
  - https://manpages.ubuntu.com/manpages/kinetic/en/man1/exiv2.1.html
- Fedora: https://packages.fedoraproject.org/pkgs/exiv2/exiv2/
  - IF AVAILABLE
- Arch: https://archlinux.org/packages/extra/x86_64/exiv2/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/packages/media-gfx/exiv2
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/formula/exiv2#default
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages?name=exiv2&branch=edge&repo=&arch=&maintainer=
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=22.11&show=exiv2&from=0&size=50&sort=relevance&type=packages&query=exiv2
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/exiv2
  - IF AVAILABLE

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file: https://github.com/Exiv2/exiv2/blob/main/LICENSE.txt
 - [ ] This package is expected to build on the submitted rosdistro

 Note: This work was done on behalf of[ AeroVironment Inc.](https://www.avinc.com/)