### PR TITLE
static_transform_mux: 1.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13572,7 +13572,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/peci1/static_transform_mux-release.git
-      version: 1.1.0-0
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/tradr-project/static_transform_mux.git


### PR DESCRIPTION
Increasing version of package(s) in repository `static_transform_mux` to `1.1.1-1`:

- upstream repository: https://github.com/tradr-project/static_transform_mux.git
- release repository: https://github.com/peci1/static_transform_mux-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-0`

## static_transform_mux

```
* Noetic compatibility.
* Added possibility to publish to a different topic.
* Contributors: Martin Pecka
```
