### PR TITLE
static_transform_mux: 1.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10809,7 +10809,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/peci1/static_transform_mux-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/tradr-project/static_transform_mux.git


### PR DESCRIPTION
Increasing version of package(s) in repository `static_transform_mux` to `1.1.1-1`:

- upstream repository: https://github.com/tradr-project/static_transform_mux.git
- release repository: https://github.com/peci1/static_transform_mux-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-1`

## static_transform_mux

```
* Noetic compatibility.
* Added possibility to publish to a different topic.
* Contributors: Martin Pecka
```
