### PR TITLE
Adding dlib

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1565,6 +1565,9 @@ python-dlib:
   fedora:
     pip: [dlib]
   nixos: [pythonPackages.dlib]
+  osx:
+    pip:
+      packages: [dlib]
   ubuntu:
     pip: [dlib]
 python-docker:


### PR DESCRIPTION
Please add the dlib dependency to the rosdep database.

## Package name:

dlib

## Package Upstream Source:

https://github.com/davisking/dlib

## Purpose of using this:

There are multiple libraries that use dlib and since there's an option for osx it should be added

Distro packaging links:

## Links to Distribution Packages

- macOS: https://pypi.org/project/dlib/