### PR TITLE
Add rhel to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -45,6 +45,8 @@ More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidel
   - OPTIONAL
 - openSUSE: https://software.opensuse.org/package/
   - IF AVAILABLE
+- rhel: http://eastus.azure.repo.almalinux.org/almalinux/9.2/AppStream/x86_64/os/Packages/
+  - IF AVAILABLE
 
 <!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -45,7 +45,7 @@ More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidel
   - OPTIONAL
 - openSUSE: https://software.opensuse.org/package/
   - IF AVAILABLE
-- rhel: http://eastus.azure.repo.almalinux.org/almalinux/9.2/AppStream/x86_64/os/Packages/
+- rhel: https://rhel.pkgs.org/
   - IF AVAILABLE
 
 <!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->


### PR DESCRIPTION
When working on #37226, I saw in the logs `rhel` was suggested, but it's not part of the PR template. I used the same package URL for `rhel` as recommended in the logs. 

Let me know if you think it should be added. 