### PR TITLE
Fix the contribution recommendation to use rosdistro_reformat with a tool that exists and works

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -316,6 +316,12 @@ These tests require several dependencies that can be installed either from the R
 | unidiff        | python-unidiff (Zesty and higher) | unidiff        |
 | yamllint       | yamllint                          | yamllint       |
 
-There is a tool ``rosdistro_reformat`` which will fix most formatting errors such as alphabetization and correct formatting.
+There is a tool [scripts/check_rosdep](./scripts/check_rosdep.py) which will check most formatting errors such as alphabetization and correct formatting.
+It is recommended to run it before submitting your contribution.
+
+For example, to check a change to `rosdep/base.yaml`:
+```bash
+python3 scripts/check_rosdep.py rosdep/base.yaml
+```
 
 Note: There's a [known issue](https://github.com/disqus/nose-unittest/issues/2) discovered [here](https://github.com/ros/rosdistro/issues/16336) that most tests won't run if you have the python package `nose-unitttest` installed.


### PR DESCRIPTION
Fixes #37227 


If there's a better tool to be running, that you can run as a user, please recommend. This worked great for me to fix up my PR. 

For example, here it gave me the specific error, which was actionable to fix my PR and get CI to pass.
```
ubuntu22@ubuntu22-vm:~/Development/rosdistro$ python3 scripts/check_rosdep.py rosdep/base.yaml
checking for trailing spaces...
checking for blank lines...
checking for incorrect indentation...
checking for non-bracket package lists...
checking for item order...
  ERR: list out of alphabetical order line 925.  'exfat-fuse' should come before 'exiv2'
building yaml dict...
there were errors, please correct the file
```