### PR TITLE
moveit: 1.1.12-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5584,7 +5584,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 1.1.11-1
+      version: 1.1.12-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `1.1.12-1`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.11-1`

## chomp_motion_planner

- No changes

## moveit

- No changes

## moveit_chomp_optimizer_adapter

- No changes

## moveit_commander

```
* Rename argument of execute() to trajectory (#3392 <https://github.com/ros-planning/moveit/issues/3392>)
* Disentangle joint name methods, add group_state (#3345 <https://github.com/ros-planning/moveit/issues/3345>)
* Fix plan() and add corresponding unit tests (#3302 <https://github.com/ros-planning/moveit/issues/3302>)
* Contributors: Michael Görner, Robert Haschke
```

## moveit_core

```
* Generalize RobotState::setFromIK() (https://github.com/ros-planning/moveit/issues/3388 <https://github.com/ros-planning/moveit/issues/3388>)
* Time parameterization with torque limits, based on TOTG (#3412 <https://github.com/ros-planning/moveit/issues/3412>, #3427 <https://github.com/ros-planning/moveit/issues/3427>)
* Make XmlRpcValue arguments const references (#3419 <https://github.com/ros-planning/moveit/issues/3419>)
* Differential drive for planar Joints (#3359 <https://github.com/ros-planning/moveit/issues/3359>)
* Fix deprecation warnings in Debian bookworm (#3397 <https://github.com/ros-planning/moveit/issues/3397>)
* Add JointModel::satisfiesAccelerationBounds() (#3396 <https://github.com/ros-planning/moveit/issues/3396>)
* Add CSM tests (#3395 <https://github.com/ros-planning/moveit/issues/3395>)
* Fix TOTG: could return vels/accels greater than the limits (#3394 <https://github.com/ros-planning/moveit/issues/3394>)
* Propagate "clear octomap" actions to monitoring planning scenes (#3134 <https://github.com/ros-planning/moveit/issues/3134>)
* Fix (some) doxygen warnings (#3315 <https://github.com/ros-planning/moveit/issues/3315>)
* Switch master build to C++17 (#3313 <https://github.com/ros-planning/moveit/issues/3313>)
* Drop lib/ prefix from plugin paths (#3305 <https://github.com/ros-planning/moveit/issues/3305>)
* Improve Ruckig time parameterization
  
    * Check for a Ruckig jerk limit parameter (#3375 <https://github.com/ros-planning/moveit/issues/3375>)
    * Optionally mitigate Ruckig overshoot
    * Reduce number of duration extensions
    * Fix termination condition (#3348 <https://github.com/ros-planning/moveit/issues/3348>)
    * Fix tests (#3300 <https://github.com/ros-planning/moveit/issues/3300>)
  
* Contributors: Andy Zelenak, Filip Sund, Jochen Sprickerhof, Michael Görner, Robert Haschke, Scott Chow, Tobias Fischer
```

## moveit_fake_controller_manager

- No changes

## moveit_kinematics

```
* Fix deprecation warnings in Debian bookworm (#3397 <https://github.com/ros-planning/moveit/issues/3397>)
* Fix (some) doxygen warnings (#3315 <https://github.com/ros-planning/moveit/issues/3315>)
* Drop lib/ prefix from plugin paths (#3305 <https://github.com/ros-planning/moveit/issues/3305>)
* Contributors: Jochen Sprickerhof, Michael Görner, Robert Haschke
```

## moveit_planners

- No changes

## moveit_planners_chomp

```
* Drop lib/ prefix from plugin paths (#3305 <https://github.com/ros-planning/moveit/issues/3305>)
* Contributors: Jochen Sprickerhof
```

## moveit_planners_ompl

```
* Add AITstar, BITstar and ABITstar planners from OMPL >= 1.5 (#3347 <https://github.com/ros-planning/moveit/issues/3347>)
* Differential drive for planar Joints (#3359 <https://github.com/ros-planning/moveit/issues/3359>)
* Fix (some) doxygen warnings (#3315 <https://github.com/ros-planning/moveit/issues/3315>)
* Contributors: Robert Haschke, Scott Chow, alaflaquiere
```

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

```
* Drop lib/ prefix from plugin paths (#3305 <https://github.com/ros-planning/moveit/issues/3305>)
* Contributors: Jochen Sprickerhof
```

## moveit_ros_manipulation

- No changes

## moveit_ros_move_group

```
* Generalize RobotState::setFromIK() (https://github.com/ros-planning/moveit/issues/3388 <https://github.com/ros-planning/moveit/issues/3388>)
* Resolve subframe in cartesian_path_service capability
* Fix MoveItCpp issues (#3369 <https://github.com/ros-planning/moveit/issues/3369>)
* Contributors: Robert Haschke
```

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

```
* MeshFilter: handle both, 32FC1 and 16UC1 encodings of depth images (#3387 <https://github.com/ros-planning/moveit/issues/3387>)
* Fix memory leak in mesh filter (#3371 <https://github.com/ros-planning/moveit/issues/3371>)
* Drop lib/ prefix from plugin paths (#3305 <https://github.com/ros-planning/moveit/issues/3305>)
* Contributors: Berke Algül, Jochen Sprickerhof, Rui Luo
```

## moveit_ros_planning

```
* Add CSM tests (#3395 <https://github.com/ros-planning/moveit/issues/3395>)
* CSM: do not jump back in time (#3393 <https://github.com/ros-planning/moveit/issues/3393>)
* Fix MoveItCpp issues (#3369 <https://github.com/ros-planning/moveit/issues/3369>)
* Skip executing zero-duration trajectories (#3362 <https://github.com/ros-planning/moveit/issues/3362>)
* Drop unnecessary cmake dependency on moveit_resources (#3343 <https://github.com/ros-planning/moveit/issues/3343>)
* Fix (some) doxygen warnings (#3315 <https://github.com/ros-planning/moveit/issues/3315>)
* Switch master build to C++17 (#3313 <https://github.com/ros-planning/moveit/issues/3313>)
* Drop lib/ prefix from plugin paths (#3305 <https://github.com/ros-planning/moveit/issues/3305>)
* Contributors: Jochen Sprickerhof, Michael Görner, Robert Haschke
```

## moveit_ros_planning_interface

```
* Generalize RobotState::setFromIK() (https://github.com/ros-planning/moveit/issues/3388 <https://github.com/ros-planning/moveit/issues/3388>)
* Allow configuration of goal tolerances in kinematics.yaml (#3409 <https://github.com/ros-planning/moveit/issues/3409>)
* Rename MGI::getJointNames() to getVariableNames() (#3345 <https://github.com/ros-planning/moveit/issues/3345>)
* Contributors: Erich Mielke, Michael Görner, Robert Haschke
```

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

```
* MPD: Resolve namespace ambiguity in RobotInteraction (#3403 <https://github.com/ros-planning/moveit/issues/3403>)
* Disallow custom string for planning group property in RViz Display (#3346 <https://github.com/ros-planning/moveit/issues/3346>)
* Fixes to octomap display in PSD (#3385 <https://github.com/ros-planning/moveit/issues/3385>)
* MPD: maintain current item when updating object list
* TrajectoryDisplay: sync visibility of links in trail with main robot (#3337 <https://github.com/ros-planning/moveit/issues/3337>)
* Contributors: Robert Haschke, Simon Schmeisser, Tejal Ashwini Barnwal
```

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_servo

```
* Simplify servo config + reusable launch files (#3326 <https://github.com/ros-planning/moveit/issues/3326>)
* Contributors: Robert Haschke
```

## moveit_setup_assistant

```
* Add AITstar, BITstar and ABITstar planners from OMPL >= 1.5 (#3347 <https://github.com/ros-planning/moveit/issues/3347>)
* Allow configuration of goal tolerances in kinematics.yaml (#3409 <https://github.com/ros-planning/moveit/issues/3409>)
* MSA: Fix 3D Perception widget (#3399 <https://github.com/ros-planning/moveit/issues/3399>)
* Fix deprecation warnings in Debian bookworm (#3397 <https://github.com/ros-planning/moveit/issues/3397>)
* Contributors: Michael Görner, Robert Haschke, alaflaquiere
```

## moveit_simple_controller_manager

- No changes

## pilz_industrial_motion_planner

```
* Fix (some) doxygen warnings (#3315 <https://github.com/ros-planning/moveit/issues/3315>)
* Drop lib/ prefix from plugin paths (#3305 <https://github.com/ros-planning/moveit/issues/3305>)
* Contributors: Jochen Sprickerhof, Robert Haschke
```

## pilz_industrial_motion_planner_testutils

- No changes
