### PR TITLE
create_robot: 3.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -861,6 +861,17 @@ repositories:
       type: git
       url: https://github.com/AutonomyLab/create_robot.git
       version: foxy
+    release:
+      packages:
+      - create_bringup
+      - create_description
+      - create_driver
+      - create_msgs
+      - create_robot
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/AutonomyLab/create_autonomy-release.git
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/AutonomyLab/create_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `create_robot` to `3.0.0-1`:

- upstream repository: https://github.com/AutonomyLab/create_robot.git
- release repository: https://github.com/AutonomyLab/create_autonomy-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## create_bringup

```
* Add execution time dependency on launch_xml
* Update maintainer email
* Updated README (#101 <https://github.com/autonomylab/create_robot/issues/101>)
* Correct create driver node name in parameters YAML (#79 <https://github.com/autonomylab/create_robot/issues/79>)
* Fix description launch files includes (#74 <https://github.com/autonomylab/create_robot/issues/74>)
* Fix joy_teleop config files (#73 <https://github.com/autonomylab/create_robot/issues/73>)
* Port to ROS 2 (foxy) (#8 <https://github.com/autonomylab/create_robot/issues/8>)
* Move launch and config files to create_bringup
* Update maintainer info
* Rename packages for clarity
  Originally the packages were named as 'create_autonomy', with the 'ca_' suffix for short.
  This was due to a name conflict with the turtlebot packages (e.g. create_driver and create_description):
  https://github.com/turtlebot/turtlebot_create.git
  Since the turtlebot packages are not released into ROS Melodic, the plan is to release these packages instead.
  If the turtlebot packages are eventually released, it should be straightforward to adapt them to use the
  description and driver packages here.
  Summary of renaming:
  * create_autonomy -> create_robot
  * ca_description -> create_description
  * ca_driver -> create_driver
  * ca_msgs -> create_msgs
  * ca_tools -> create_bringup
* Contributors: Jacob Perron, Pedro Grojsgold, coderkarl, selimxsuha
```

## create_description

```
* Add execution time dependency on launch_xml
* Update maintainer email
* Update package.xml descriptions
* Fixed left/right wheel joints in gazebo diff drive plugin parameters (#77 <https://github.com/autonomylab/create_robot/issues/77>) (#81 <https://github.com/autonomylab/create_robot/issues/81>)
* Port to ROS 2 (foxy) (#8 <https://github.com/autonomylab/create_robot/issues/8>)
* Fix xacro warning
* Update maintainer info
* Rename packages for clarity
  Originally the packages were named as 'create_autonomy', with the 'ca_' suffix for short.
  This was due to a name conflict with the turtlebot packages (e.g. create_driver and create_description):
  https://github.com/turtlebot/turtlebot_create.git
  Since the turtlebot packages are not released into ROS Melodic, the plan is to release these packages instead.
  If the turtlebot packages are eventually released, it should be straightforward to adapt them to use the
  description and driver packages here.
  Summary of renaming:
  * create_autonomy -> create_robot
  * ca_description -> create_description
  * ca_driver -> create_driver
  * ca_msgs -> create_msgs
  * ca_tools -> create_bringup
* Contributors: Jacob Perron, Pedro Grojsgold
```

## create_driver

```
* Replace Travis CI with GitHub workflow and lint (#102 <https://github.com/autonomylab/create_robot/issues/102>)
* Update maintainer email
* Add parameter to enable the OI mode reporting bug workaround (#95 <https://github.com/autonomylab/create_robot/issues/95>)
* Add cliff sensors (#93 <https://github.com/autonomylab/create_robot/issues/93>)
* Add motor control (#97 <https://github.com/autonomylab/create_robot/issues/97>)
* Disable libcreate's signal handler (#89 <https://github.com/autonomylab/create_robot/issues/89>)
* Use rclcpp::spin instead of own implementation.
* Use Node::now instead of rclcpp::Clock::now.
* Make CreateDriver derive from rclcpp::Node.
* Fix latching condition (#72 <https://github.com/autonomylab/create_robot/issues/72>)
* Port to ROS 2 (foxy) (#8 <https://github.com/autonomylab/create_robot/issues/8>)
* Stricter compile options
* Switch to tf2
* Reduce diagonal covariance values
* Remove old install commands
* Move launch and config files to create_bringup
* Update maintainer info
* Fix catkin lint error
* Rename packages for clarity
  Originally the packages were named as 'create_autonomy', with the 'ca_' suffix for short.
  This was due to a name conflict with the turtlebot packages (e.g. create_driver and create_description):
  https://github.com/turtlebot/turtlebot_create.git
  Since the turtlebot packages are not released into ROS Melodic, the plan is to release these packages instead.
  If the turtlebot packages are eventually released, it should be straightforward to adapt them to use the
  description and driver packages here.
  Summary of renaming:
  * create_autonomy -> create_robot
  * ca_description -> create_description
  * ca_driver -> create_driver
  * ca_msgs -> create_msgs
  * ca_tools -> create_bringup
* Contributors: Jacob Perron, Josh Gadeken, Owen Hooper, Pedro Grojsgold, pgold
```

## create_msgs

```
* Update maintainer email
* Update package.xml descriptions
* Add cliff sensors (#93 <https://github.com/autonomylab/create_robot/issues/93>)
* Add motor control (#97 <https://github.com/autonomylab/create_robot/issues/97>)
* Port to ROS 2 (foxy) (#8 <https://github.com/autonomylab/create_robot/issues/8>)
* Update maintainer info
* Rename packages for clarity
  Originally the packages were named as 'create_autonomy', with the 'ca_' suffix for short.
  This was due to a name conflict with the turtlebot packages (e.g. create_driver and create_description):
  https://github.com/turtlebot/turtlebot_create.git
  Since the turtlebot packages are not released into ROS Melodic, the plan is to release these packages instead.
  If the turtlebot packages are eventually released, it should be straightforward to adapt them to use the
  description and driver packages here.
  Summary of renaming:
  * create_autonomy -> create_robot
  * ca_description -> create_description
  * ca_driver -> create_driver
  * ca_msgs -> create_msgs
  * ca_tools -> create_bringup
* Contributors: Jacob Perron, Owen Hooper, Pedro Grojsgold
```

## create_robot

```
* Update maintainer email
* Port to ROS 2 (foxy) (#8 <https://github.com/autonomylab/create_robot/issues/8>)
* Update URLs to point to autonomylab repository
* Update maintainer info
* Rename packages for clarity
  Originally the packages were named as 'create_autonomy', with the 'ca_' suffix for short.
  This was due to a name conflict with the turtlebot packages (e.g. create_driver and create_description):
  https://github.com/turtlebot/turtlebot_create.git
  Since the turtlebot packages are not released into ROS Melodic, the plan is to release these packages instead.
  If the turtlebot packages are eventually released, it should be straightforward to adapt them to use the
  description and driver packages here.
  Summary of renaming:
  * create_autonomy -> create_robot
  * ca_description -> create_description
  * ca_driver -> create_driver
  * ca_msgs -> create_msgs
  * ca_tools -> create_bringup
* Contributors: Jacob Perron, Pedro Grojsgold
```
