### PR TITLE
ros2_controllers: 2.20.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5197,7 +5197,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.19.0-1
+      version: 2.20.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.20.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.19.0-1`

## admittance_controller

- No changes

## diff_drive_controller

```
* Clear registered handles of DiffDriveController on deactivate (#596 <https://github.com/ros-controls/ros2_controllers/issues/596>) (#606 <https://github.com/ros-controls/ros2_controllers/issues/606>)
* Contributors: Noel Jiménez García
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

- No changes

## position_controllers

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

```
* switch from dash to underscore in setup.cfg (#595 <https://github.com/ros-controls/ros2_controllers/issues/595>) (#599 <https://github.com/ros-controls/ros2_controllers/issues/599>)
* Contributors: mergify[bot]
```

## tricycle_controller

- No changes

## velocity_controllers

- No changes
