### PR TITLE
ros2_controllers: 3.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4523,7 +4523,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 3.7.0-1
+      version: 3.8.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `3.8.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.7.0-1`

## admittance_controller

- No changes

## diff_drive_controller

```
* Clear registered handles of DiffDriveController on deactivate (#596 <https://github.com/ros-controls/ros2_controllers/issues/596>)
* Contributors: Noel Jiménez García
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* [JTC] Import docs from wiki.ros.org (#566 <https://github.com/ros-controls/ros2_controllers/issues/566>)
* Contributors: Christoph Fröhlich
```

## position_controllers

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

```
* switch from dash to underscore in setup.cfg (#595 <https://github.com/ros-controls/ros2_controllers/issues/595>)
* Contributors: Alex Moriarty
```

## tricycle_controller

- No changes

## velocity_controllers

- No changes
