### PR TITLE
cras_ros_utils: 2.2.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1542,7 +1542,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
-      version: 2.2.0-1
+      version: 2.2.1-1
     source:
       type: git
       url: https://github.com/ctu-vras/ros-utils.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1542,7 +1542,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
-      version: 2.2.1-1
+      version: 2.2.2-1
     source:
       type: git
       url: https://github.com/ctu-vras/ros-utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_ros_utils` to `2.2.2-1`:

- upstream repository: https://github.com/ctu-vras/ros-utils
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.0-1`

## cras_cpp_common

- No changes

## cras_docs_common

- No changes

## cras_py_common

```
* message_utils: Added dict_to_dynamic_config_msg().
* ctypes_utils: Added c_array() method.
* message_utils: Added get_srv_types() and get_cfg_module().
* Contributors: Martin Pecka
```

## cras_topic_tools

- No changes

## image_transport_codecs

- No changes
