### PR TITLE
magic_enum: 0.8.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2312,6 +2312,21 @@ repositories:
       url: https://github.com/hatchbed/log_view.git
       version: ros2
     status: developed
+  magic_enum:
+    doc:
+      type: git
+      url: https://github.com/Neargye/magic_enum.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/nobleo/magic_enum-release.git
+      version: 0.8.2-1
+    source:
+      type: git
+      url: https://github.com/Neargye/magic_enum.git
+      version: master
+    status: maintained
   marti_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `magic_enum` to `0.8.2-1`:

- upstream repository: https://github.com/Neargye/magic_enum.git
- release repository: https://github.com/nobleo/magic_enum-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- None
