### PR TITLE
turtlebot4: 1.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7194,7 +7194,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot4.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4` to `1.0.2-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4.git
- release repository: https://github.com/ros2-gbp/turtlebot4-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.1-1`

## turtlebot4_description

```
* New maps and Improved Nav2 Config
* Added namespace arg to urdf for namespacing support in sim
* Replaced wheel drop static transforms with joint state publisher
* Contributors: Hilary Luo, Roni Kreinin
```

## turtlebot4_msgs

- No changes

## turtlebot4_navigation

```
* Added namespacing support in sim
* Set warehouse map as default
* New map files for new and modified worlds
* Updating robot radius to max radius and increasing inflation
* Added missing Nav2 plugin
* Contributors: Hilary Luo, Roni Kreinin
```

## turtlebot4_node

- No changes
