### PR TITLE
tuw_geometry: 0.0.9-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6271,7 +6271,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/tuw-robotics/tuw_geometry-release.git
-      version: 0.0.7-2
+      version: 0.0.9-2
     source:
       type: git
       url: https://github.com/tuw-robotics/tuw_geometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tuw_geometry` to `0.0.9-2`:

- upstream repository: https://github.com/tuw-robotics/tuw_geometry.git
- release repository: https://github.com/tuw-robotics/tuw_geometry-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.7-2`
