### PR TITLE
turtlebot4_simulator: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7254,6 +7254,26 @@ repositories:
       url: https://github.com/turtlebot/turtlebot4_setup.git
       version: humble
     status: developed
+  turtlebot4_simulator:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4_simulator.git
+      version: humble
+    release:
+      packages:
+      - turtlebot4_ignition_bringup
+      - turtlebot4_ignition_gui_plugins
+      - turtlebot4_ignition_toolbox
+      - turtlebot4_simulator
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot4_simulator-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4_simulator.git
+      version: humble
+    status: developed
   turtlebot4_tutorials:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4_simulator` to `1.0.0-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4_simulator.git
- release repository: https://github.com/ros2-gbp/turtlebot4_simulator-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## turtlebot4_ignition_bringup

```
* Multiple robot support
* Spawn robot slightly lower to reduce the drop and rollback, ensuring the robot starts properly docked
* Add default model type for HMI plugin
* Make warehouse the default world
* Fixed model spawning in wall, improved visuals and made locations less ambiguous for slam
* Fixed world name and set max step size for better performance
* Added namespace support
* Contributors: Hilary Luo, Roni Kreinin, roni-kreinin
```

## turtlebot4_ignition_gui_plugins

```
* Updated GUI to have namespace input
* Contributors: Hilary Luo, Roni Kreinin, roni-kreinin
```

## turtlebot4_ignition_toolbox

```
* Multiple robot support
* Contributors: Roni Kreinin, roni-kreinin
```

## turtlebot4_simulator

- No changes
