### PR TITLE
astuff_sensor_msgs: 4.0.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -399,6 +399,30 @@ repositories:
       url: https://github.com/fictionlab/ros_aruco_opencv.git
       version: rolling
     status: maintained
+  astuff_sensor_msgs:
+    doc:
+      type: git
+      url: https://github.com/astuff/astuff_sensor_msgs.git
+      version: master
+    release:
+      packages:
+      - delphi_esr_msgs
+      - delphi_mrr_msgs
+      - delphi_srr_msgs
+      - derived_object_msgs
+      - ibeo_msgs
+      - kartech_linear_actuator_msgs
+      - mobileye_560_660_msgs
+      - neobotix_usboard_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/astuff_sensor_msgs-release.git
+      version: 4.0.0-2
+    source:
+      type: git
+      url: https://github.com/astuff/astuff_sensor_msgs.git
+      version: master
+    status: maintained
   async_web_server_cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `astuff_sensor_msgs` to `4.0.0-2`:

- upstream repository: https://github.com/astuff/astuff_sensor_msgs.git
- release repository: https://github.com/ros2-gbp/astuff_sensor_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## delphi_esr_msgs

- No changes

## delphi_mrr_msgs

- No changes

## delphi_srr_msgs

- No changes

## derived_object_msgs

- No changes

## ibeo_msgs

- No changes

## kartech_linear_actuator_msgs

- No changes

## mobileye_560_660_msgs

- No changes

## neobotix_usboard_msgs

- No changes
