### PR TITLE
astuff_sensor_msgs: 4.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -321,7 +321,6 @@ repositories:
       version: master
     release:
       packages:
-      - astuff_sensor_msgs
       - delphi_esr_msgs
       - delphi_mrr_msgs
       - delphi_srr_msgs
@@ -330,11 +329,10 @@ repositories:
       - kartech_linear_actuator_msgs
       - mobileye_560_660_msgs
       - neobotix_usboard_msgs
-      - pacmod_msgs
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/astuff/astuff_sensor_msgs-release.git
-      version: 3.1.0-1
+      url: https://github.com/ros2-gbp/astuff_sensor_msgs-release.git
+      version: 4.0.0-1
     source:
       type: git
       url: https://github.com/astuff/astuff_sensor_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `astuff_sensor_msgs` to `4.0.0-1`:

- upstream repository: https://github.com/astuff/astuff_sensor_msgs.git
- release repository: https://github.com/ros2-gbp/astuff_sensor_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.1.0-1`

## delphi_esr_msgs

- No changes

## delphi_mrr_msgs

- No changes

## delphi_srr_msgs

- No changes

## derived_object_msgs

- No changes

## ibeo_msgs

- No changes

## kartech_linear_actuator_msgs

- No changes

## mobileye_560_660_msgs

- No changes

## neobotix_usboard_msgs

- No changes
