### PR TITLE
Fedora 36 is EOL, long live Fedora 38

### DIFF
--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -63,8 +63,8 @@ supported_versions:
   debian:
   - bullseye
   fedora:
-  - '36'
   - '37'
+  - '38'
   opensuse:
   - '15.2'
   rhel:
@@ -93,9 +93,9 @@ supported_arches:
 
 name_replacements:
   fedora:
-    '36':
-      '%{__isa_name}': 'x86'
     '37':
+      '%{__isa_name}': 'x86'
+    '38':
       '%{__isa_name}': 'x86'
   rhel:
     '8':


### PR DESCRIPTION
Fedora 36 EOL: https://lists.fedoraproject.org/archives/list/devel-announce@lists.fedoraproject.org/thread/MRNLBAB3RYGGT22KRDUXDOT6IAIIJUX4/
Fedora 38 release: https://lists.fedoraproject.org/archives/list/announce@lists.fedoraproject.org/thread/UUE24AVVRKAF2QYFFGZ4QRFWOSNU4EPP/

Rule error count went from 13 in f37 to 22 in f38.

---

* The following 13 packages were not found for fedora 37 on x86_64:
<details>

- Package Cg for rosdep key nvidia-cg
- Package couchdb for rosdep key couchdb
- Package libusb-devel for rosdep key libusb-dev
- Package mkdocs for rosdep key mkdocs
- Package mkdocs-bootstrap for rosdep key mkdocs-bootstrap
- Package mkdocs-bootswatch for rosdep key mkdocs-bootswatch
- Package openni-nite-devel for rosdep key libopenni-nite-dev
- Package openni-nite-devel for rosdep key nite-dev
- Package python-anyjson for rosdep key python-anyjson
- Package python-argh for rosdep key python-argh
- Package rapidjson for rosdep key rapidjson-dev
- Package wireless-tools for rosdep key wireless-tools
- Package wireless-tools-devel for rosdep key libiw-dev

</details>

* The following 22 packages were not found for fedora 38 on x86_64:
<details>

- Package Cg for rosdep key nvidia-cg
- Package cegui for rosdep key libcegui-mk2-dev
- Package couchdb for rosdep key couchdb
- Package devilspie2 for rosdep key devilspie2
- Package libusb-devel for rosdep key libusb-dev
- Package mkdocs for rosdep key mkdocs
- Package mkdocs-bootstrap for rosdep key mkdocs-bootstrap
- Package mkdocs-bootswatch for rosdep key mkdocs-bootswatch
- Package openni-nite-devel for rosdep key libopenni-nite-dev
- Package openni-nite-devel for rosdep key nite-dev
- Package python-anyjson for rosdep key python-anyjson
- Package python-argh for rosdep key python-argh
- Package python-flask-restful for rosdep key python-flask-restful
- Package python3-segno for rosdep key python3-segno
- Package qcustomplot-devel for rosdep key libqcustomplot-dev
- Package qwt-devel for rosdep key libqwt5-qt4-dev
- Package qwt-devel for rosdep key libqwt6
- Package qwtplot3d-qt4-devel for rosdep key libqwtplot3d-qt4-dev
- Package rapidjson for rosdep key rapidjson-dev
- Package spawn-fcgi for rosdep key fcgi
- Package wireless-tools for rosdep key wireless-tools
- Package wireless-tools-devel for rosdep key libiw-dev

</details>