### PR TITLE
Add natsort to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6715,13 +6715,6 @@ python3-natsort:
   opensuse: [python3-natsort]
   rhel: [python3-natsort]
   ubuntu: [python3-natsort]
-python3-natsort-pip:
-  debian:
-    pip:
-      packages: [natsort]
-  ubuntu:
-    pip:
-      packages: [natsort]
 python3-nclib-pip:
   arch:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -308,6 +308,9 @@ meson:
   ubuntu: [meson]
 python3-natsort:
   debian: [python3-natsort]
+  fedora: [python3-natsort]
+  opensuse: [python3-natsort]
+  rhel: [python3-natsort]
   ubuntu: [python3-natsort]
 python3-natsort-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -306,6 +306,16 @@ meson:
   opensuse: [meson]
   rhel: [meson]
   ubuntu: [meson]
+natsort:
+  debian: [python3-natsort]
+  ubuntu: [python3-natsort]
+natsort-pip:
+  debian:
+    pip:
+      packages: [natsort]
+  ubuntu:
+    pip:
+      packages: [natsort]
 nuitka:
   debian: [nuitka]
   ubuntu: [nuitka]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -306,19 +306,6 @@ meson:
   opensuse: [meson]
   rhel: [meson]
   ubuntu: [meson]
-python3-natsort:
-  debian: [python3-natsort]
-  fedora: [python3-natsort]
-  opensuse: [python3-natsort]
-  rhel: [python3-natsort]
-  ubuntu: [python3-natsort]
-python3-natsort-pip:
-  debian:
-    pip:
-      packages: [natsort]
-  ubuntu:
-    pip:
-      packages: [natsort]
 nuitka:
   debian: [nuitka]
   ubuntu: [nuitka]
@@ -6722,6 +6709,19 @@ python3-mypy:
     '7': null
     '8': null
   ubuntu: [python3-mypy]
+python3-natsort:
+  debian: [python3-natsort]
+  fedora: [python3-natsort]
+  opensuse: [python3-natsort]
+  rhel: [python3-natsort]
+  ubuntu: [python3-natsort]
+python3-natsort-pip:
+  debian:
+    pip:
+      packages: [natsort]
+  ubuntu:
+    pip:
+      packages: [natsort]
 python3-nclib-pip:
   arch:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -306,10 +306,10 @@ meson:
   opensuse: [meson]
   rhel: [meson]
   ubuntu: [meson]
-natsort:
+python3-natsort:
   debian: [python3-natsort]
   ubuntu: [python3-natsort]
-natsort-pip:
+python3-natsort-pip:
   debian:
     pip:
       packages: [natsort]


### PR DESCRIPTION
## Package name:

python3-natsort

## Package Upstream Source:

https://github.com/SethMMorton/natsort

## Purpose of using this:

Provides a better sorting for lists with numbers (date stamped files as an example), the python built-in sort function return a list sorted lexicographically which might be undesired for certain cases

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=python3-natsort
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/focal/python3-natsort
  - https://packages.ubuntu.com/jammy/python3-natsort
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-natsort/python3-natsort/
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python3-natsort
- Redhat: https://mirrors.lug.mtu.edu/epel/9/Everything/x86_64/Packages/p/python3-natsort-7.1.1-5.el9.noarch.rpm