### PR TITLE
diagnostics: 3.1.2-3 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -889,7 +889,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 3.1.2-2
+      version: 3.1.2-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `3.1.2-3`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.1.2-2`

## diagnostic_aggregator

- No changes

## diagnostic_common_diagnostics

```
* replacing ntpdate with ntplib (#289 <https://github.com/ros/diagnostics/issues/289>)
* Contributors: Christian Henkel
```

## diagnostic_updater

- No changes

## diagnostics

- No changes

## self_test

- No changes
