### PR TITLE
turtlebot4_tutorials: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7311,7 +7311,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4_tutorials-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot4_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4_tutorials` to `1.0.1-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4_tutorials.git
- release repository: https://github.com/ros2-gbp/turtlebot4_tutorials-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-1`

## turtlebot4_cpp_tutorials

- No changes

## turtlebot4_python_tutorials

```
* Added mail delivery example
* Add patrol loop example
* Updated poses for the warehouse world
* Contributors: Hilary Luo, Roni Kreinin
```

## turtlebot4_tutorials

- No changes
