### PR TITLE
ros2_control: 3.13.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4521,7 +4521,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.12.2-1
+      version: 3.13.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.13.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.12.2-1`

## controller_interface

- No changes

## controller_manager

```
* Add class for thread management of async hw interfaces (#981 <https://github.com/ros-controls/ros2_control/issues/981>)
* Fix GitHub link on control.ros.org (#1022 <https://github.com/ros-controls/ros2_control/issues/1022>)
* Remove log-level argument from spawner script (#1013 <https://github.com/ros-controls/ros2_control/issues/1013>)
* Contributors: Christoph Fröhlich, Márk Szitanics, Bijou Abraham
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Add class for thread management of async hw interfaces (#981 <https://github.com/ros-controls/ros2_control/issues/981>)
* Fix github links on control.ros.org (#1019 <https://github.com/ros-controls/ros2_control/issues/1019>)
* Update precommit libraries(#1020 <https://github.com/ros-controls/ros2_control/issues/1020>)
* Implement parse_bool and refactor a few (#1014 <https://github.com/ros-controls/ros2_control/issues/1014>)
* docs: Fix link to hardware_components (#1009 <https://github.com/ros-controls/ros2_control/issues/1009>)
* Contributors: Alejandro Bordallo, Christoph Fröhlich, Felix Exner (fexner), Márk Szitanics, mosfet80
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Fix github links on control.ros.org (#1019 <https://github.com/ros-controls/ros2_control/issues/1019>)
* Contributors: Christoph Fröhlich
```

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
