### PR TITLE
rviz_2d_overlay_plugins: 1.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6285,7 +6285,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz_2d_overlay_plugins-release.git
-      version: 1.2.1-1
+      version: 1.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_2d_overlay_plugins` to `1.3.0-1`:

- upstream repository: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git
- release repository: https://github.com/ros2-gbp/rviz_2d_overlay_plugins-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.1-1`

## rviz_2d_overlay_msgs

```
* Removed old position message fields
* Contributors: Dominik, Jonas Otto
```

## rviz_2d_overlay_plugins

```
* Added string to overlay text converter node
* fix QT build warnings
* Contributors: Ernő Horváth, Jonas Otto, szepilot
```
