### PR TITLE
rviz_2d_overlay_plugins: 1.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5611,7 +5611,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz_2d_overlay_plugins-release.git
-      version: 1.2.1-2
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_2d_overlay_plugins` to `1.3.0-1`:

- upstream repository: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git
- release repository: https://github.com/ros2-gbp/rviz_2d_overlay_plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.1-2`

## rviz_2d_overlay_msgs

```
* Removed old position message fields
* Contributors: Dominik, Jonas Otto
```

## rviz_2d_overlay_plugins

```
* Added string to overlay text converter node
* fix QT build warnings
* Contributors: Ernő Horváth, Jonas Otto, szepilot
```
