### PR TITLE
aruco_opencv: 1.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -308,7 +308,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_opencv-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/fictionlab/ros_aruco_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_opencv` to `1.1.1-1`:

- upstream repository: https://github.com/fictionlab/ros_aruco_opencv.git
- release repository: https://github.com/ros2-gbp/aruco_opencv-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-1`

## aruco_opencv

```
* Fix create_marker and create_board script permissions (#22 <https://github.com/fictionlab/aruco_opencv/issues/22>) (#23 <https://github.com/fictionlab/aruco_opencv/issues/23>)
* Contributors: Błażej Sowa
```

## aruco_opencv_msgs

- No changes
