### PR TITLE
moveit_visual_tools: 3.6.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5723,7 +5723,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit_visual_tools-release.git
-      version: 3.6.0-1
+      version: 3.6.1-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `3.6.1-1`:

- upstream repository: https://github.com/ros-planning/moveit_visual_tools.git
- release repository: https://github.com/ros-gbp/moveit_visual_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.6.0-1`

## moveit_visual_tools

```
* publishTrajectoryLine(): issue error when no end-effector tips are found (#129 <https://github.com/ros-planning/moveit_visual_tools/issues/129>)
* Fixed possible null-pointer segfault (#95 <https://github.com/ros-planning/moveit_visual_tools/issues/95>)
* Only set active joints (#84 <https://github.com/ros-planning/moveit_visual_tools/issues/84>)
* Use specified color for EndEffector marker (#96 <https://github.com/ros-planning/moveit_visual_tools/issues/96>)
* Contributors: Felix von Drigalski, Henning Kayser, Jochen Sprickerhof, Michael Görner, Robert Haschke, Simon Schmeisser, Stephanie Eng, Tyler Weaver, Vatan Aksoy Tezer, werner291
```
