### PR TITLE
Release ros_gz into iron

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4717,13 +4717,19 @@ repositories:
       url: https://github.com/ros/ros_environment.git
       version: iron
     status: maintained
-  ros_ign:
+  ros_gz:
     doc:
       type: git
-      url: https://github.com/ignitionrobotics/ros_ign.git
-      version: ros2
+      url: https://github.com/gazebosim/ros_gz.git
+      version: humble
     release:
       packages:
+      - ros_gz
+      - ros_gz_bridge
+      - ros_gz_image
+      - ros_gz_interfaces
+      - ros_gz_sim
+      - ros_gz_sim_demos
       - ros_ign
       - ros_ign_bridge
       - ros_ign_gazebo
@@ -4733,12 +4739,12 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 0.244.3-3
+      version: 0.244.10-1
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/ignitionrobotics/ros_ign.git
-      version: ros2
+      url: https://github.com/gazebosim/ros_gz.git
+      version: humble
     status: developed
   ros_image_to_qimage:
     doc:


### PR DESCRIPTION
Manually done, rather than bloom, as bloom doesn't support renaming

--

Increasing version of package(s) in repository `ros_gz` to `0.244.10-1`:

- upstream repository: https://github.com/gazebosim/ros_gz.git
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.244.3-3`