### PR TITLE
Revert "moveit_msgs: 2.2.2-1 in 'humble/distribution.yaml' [bloom] (#37224)"

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3002,7 +3002,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_msgs-release.git
-      version: 2.2.2-1
+      version: 2.2.1-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_msgs.git


### PR DESCRIPTION
This reverts commit b9eb03ef0db05d22643de4fea9deb6e63c382e5b.

2.2.2 was a breaking change I should not have released for Humble.