### PR TITLE
moveit_resources: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2636,7 +2636,9 @@ repositories:
       version: ros2
     release:
       packages:
+      - dual_arm_panda_moveit_config
       - moveit_resources
+      - moveit_resources_benchmarking
       - moveit_resources_fanuc_description
       - moveit_resources_fanuc_moveit_config
       - moveit_resources_panda_description
@@ -2645,7 +2647,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_resources-release.git
-      version: 2.0.6-2
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_resources.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `2.1.0-1`:

- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros2-gbp/moveit_resources-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.6-2`

## dual_arm_panda_moveit_config

```
* Remove comments from scalars (#169 <https://github.com/ros-planning/moveit_resources/issues/169>)
* Update information about Ruckig and jerk limits (#168 <https://github.com/ros-planning/moveit_resources/issues/168>)
* Add dual arm panda config package from moveit2_tutorials (#164 <https://github.com/ros-planning/moveit_resources/issues/164>)
* Contributors: AndyZe, Sebastian Castro, Stephanie Eng
```

## moveit_resources

- No changes

## moveit_resources_benchmarking

```
* Enable AnytimePathShortening and fix benchmarks (#167 <https://github.com/ros-planning/moveit_resources/issues/167>)
* Add benchmark data package (#162 <https://github.com/ros-planning/moveit_resources/issues/162>)
* Contributors: Sebastian Jahr
```

## moveit_resources_fanuc_description

- No changes

## moveit_resources_fanuc_moveit_config

```
* Remove comments from scalars (#169 <https://github.com/ros-planning/moveit_resources/issues/169>)
* Enable AnytimePathShortening and fix benchmarks (#167 <https://github.com/ros-planning/moveit_resources/issues/167>)
* Update information about Ruckig and jerk limits (#168 <https://github.com/ros-planning/moveit_resources/issues/168>)
* Add execution_duration_monitoring param to the example config (#160 <https://github.com/ros-planning/moveit_resources/issues/160>)
* Contributors: AndyZe, Sebastian Jahr, Stephanie Eng
```

## moveit_resources_panda_description

- No changes

## moveit_resources_panda_moveit_config

```
* Cherry pick TopicBased rename #163 <https://github.com/ros-planning/moveit_resources/issues/163> (#172 <https://github.com/ros-planning/moveit_resources/issues/172>)
  Co-authored-by: Jafar <mailto:cafer.abdi@gmail.com>
* Add STOMP planner config (#171 <https://github.com/ros-planning/moveit_resources/issues/171>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Remove comments from scalars (#169 <https://github.com/ros-planning/moveit_resources/issues/169>)
* Enable AnytimePathShortening and fix benchmarks (#167 <https://github.com/ros-planning/moveit_resources/issues/167>)
* Update information about Ruckig and jerk limits (#168 <https://github.com/ros-planning/moveit_resources/issues/168>)
* Enable acceleration limits so TOTG can work (#166 <https://github.com/ros-planning/moveit_resources/issues/166>)
* Add joint limits to Panda demo launch file + make consistent with tutorials (#165 <https://github.com/ros-planning/moveit_resources/issues/165>)
* [ROS2]: Add a new parameter to panda's xacro to select ros2_control hardware interface type (#158 <https://github.com/ros-planning/moveit_resources/issues/158>)
  * Add xacro parameter to select ros2_control hardware interface type
  * Update panda demo launch file to have ros2_control_hardware_type argument
  * Add argument to the launch description
* Add execution_duration_monitoring param to the example config (#160 <https://github.com/ros-planning/moveit_resources/issues/160>)
* Fix xacro deprecation warning: use xacro.load_yaml() (#156 <https://github.com/ros-planning/moveit_resources/issues/156>)
* Add Pilz to panda launch (#154 <https://github.com/ros-planning/moveit_resources/issues/154>)
* Add pilz_industrial_motion_planner_planning.yaml (#151 <https://github.com/ros-planning/moveit_resources/issues/151>)
* Contributors: AndyZe, Giovanni, Jafar, Marq Rasmussen, Sebastian Castro, Sebastian Jahr, Stephanie Eng
```

## moveit_resources_pr2_description

- No changes
