### PR TITLE
moveit: 2.7.4-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2566,6 +2566,7 @@ repositories:
       - moveit_planners
       - moveit_planners_chomp
       - moveit_planners_ompl
+      - moveit_planners_stomp
       - moveit_plugins
       - moveit_py
       - moveit_resources_prbt_ikfast_manipulator_plugin
@@ -2597,7 +2598,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
-      version: 2.7.3-1
+      version: 2.7.4-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.7.4-1`:

- upstream repository: https://github.com/ros-planning/moveit2.git
- release repository: https://github.com/ros2-gbp/moveit2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.7.3-1`

## chomp_motion_planner

- No changes

## moveit

- No changes

## moveit_chomp_optimizer_adapter

- No changes

## moveit_common

- No changes

## moveit_configs_utils

```
* Parse xacro args from .setup_assistant config in MoveIt Configs Builder (#2172 <https://github.com/ros-planning/moveit2/issues/2172>)
  Co-authored-by: Jafar <mailto:jafar.uruc@gmail.com>
* Update default planning configs to use AddTimeOptimalParameterization (#2167 <https://github.com/ros-planning/moveit2/issues/2167>)
* Contributors: Anthony Baker
```

## moveit_core

```
* Add documentation and cleanups for PlanningRequestAdapter and PlanningRequestAdapterChain classes (#2142 <https://github.com/ros-planning/moveit2/issues/2142>)
  * Cleanups
  * Add documentation and more cleanups
  * Revert size_t change
* Fix collision checking in VisibilityConstraint (#1986 <https://github.com/ros-planning/moveit2/issues/1986>)
* Alphabetize, smart pointer not needed (#2148 <https://github.com/ros-planning/moveit2/issues/2148>)
  * Alphabetize, smart pointer not needed
  * Readability
* Fix getting variable bounds in mimic joints for TOTG (#2030 <https://github.com/ros-planning/moveit2/issues/2030>)
  * Fix getting variable bounds in mimic joints for TOTG
  * Formatting
  * Remove unnecessary code
  * Do not include mimic joints in timing calculations
  * Change joint variable bounds at mimic creation time
  * Braces take you places
  * Fix other single-line if-else without braces in file for clang_tidy
  * Remove mimic bounds modification
  * Variable renaming and a comment
  * Fix index naming
  ---------
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
  Co-authored-by: Jafar <mailto:cafer.abdi@gmail.com>
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
* Contributors: AndyZe, Joseph Schornak, Sebastian Castro, Sebastian Jahr
```

## moveit_hybrid_planning

- No changes

## moveit_kinematics

- No changes

## moveit_planners

```
* Migrate STOMP from ros-planning/stomp_moveit (#2158 <https://github.com/ros-planning/moveit2/issues/2158>)
* Migrate stomp_moveit into moveit_planners
  * Move package into moveit_planners subdirectory
  * Rename stomp_moveit package to moveit_planners_stomp
  * List moveit_planners_stomp as package dependency
* Contributors: Henning Kayser
```

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

```
* Fix Constraint Planning Segfault (#2130 <https://github.com/ros-planning/moveit2/issues/2130>)
  * Fix Constraint Planning Segfault
  * Reuse planner data
  * apply clang formatting
  * apply clang formatting round 2
  * add FIXME note and verbose output of planning graph size
  ---------
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Contributors: Marq Rasmussen
```

## moveit_planners_stomp

```
* Migrate STOMP from ros-planning/stomp_moveit (#2158 <https://github.com/ros-planning/moveit2/issues/2158>)
* Fix clang-tidy warnings
* Improve Documentation and Readability
* Remove MVT example
* Migrate stomp_moveit into moveit_planners
  * Move package into moveit_planners subdirectory
  * Rename stomp_moveit package to moveit_planners_stomp
  * List moveit_planners_stomp as package dependency
* Contributors: Henning Kayser
```

## moveit_plugins

- No changes

## moveit_py

```
* Rename named_target_state_values to get_named_target_state_values (#2181 <https://github.com/ros-planning/moveit2/issues/2181>)
* Deprecate MoveItCpp::execute() use of blocking flag (#1984 <https://github.com/ros-planning/moveit2/issues/1984>)
* Add Python binding for link_model_names and get_only_one_end_effector_tip + update stubs (#1985 <https://github.com/ros-planning/moveit2/issues/1985>)
* Contributors: Jafar, Lucas Wendland
```

## moveit_resources_prbt_ikfast_manipulator_plugin

- No changes

## moveit_resources_prbt_moveit_config

- No changes

## moveit_resources_prbt_pg70_support

- No changes

## moveit_resources_prbt_support

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

- No changes

## moveit_ros_move_group

```
* Fix MoveGroup action cancel callback (#2118 <https://github.com/ros-planning/moveit2/issues/2118>)
  Moves the execution callback into its own thread to avoid blocking and actually calls the preempt function in with the cancel callback.
* Scale acceleration and velocity of cartesian interpolations (#1968 <https://github.com/ros-planning/moveit2/issues/1968>)
* Contributors: Jonathan Grebe, Yadu
```

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

- No changes

## moveit_ros_planning

```
* Update default planning configs to use AddTimeOptimalParameterization (#2167 <https://github.com/ros-planning/moveit2/issues/2167>)
* Deprecate MoveItCpp::execute() use of blocking flag (#1984 <https://github.com/ros-planning/moveit2/issues/1984>)
* Contributors: Anthony Baker, Lucas Wendland
```

## moveit_ros_planning_interface

```
* Scale acceleration and velocity of cartesian interpolations (#1968 <https://github.com/ros-planning/moveit2/issues/1968>)
* Contributors: Yadu
```

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

- No changes

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_servo

```
* [Servo] Remove soon-to-be obsolete functions (#2175 <https://github.com/ros-planning/moveit2/issues/2175>)
  * Remove unused functions
  * Remove drift and control dimension client in tests
  * Remove gazebo specific message redundancy
* [Servo] Restore namespace to parameters (#2171 <https://github.com/ros-planning/moveit2/issues/2171>)
  * Add  namespace to parameters
  * Minor cleanups
* [Servo] Fix stop callback, delete pause/unpause mode (#2139 <https://github.com/ros-planning/moveit2/issues/2139>)
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
* [Servo] Make conversion operations into free functions (#2149 <https://github.com/ros-planning/moveit2/issues/2149>)
  * Move conversion operations to free functions
  * Optimizations
  * Fix const references
  * Readability updates
  * Remove unused header
  * Comment update
  ---------
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
* [Servo] Avoid unnecessary checks for initializing ik_base_to_tip_frame (#2146 <https://github.com/ros-planning/moveit2/issues/2146>)
  * Avoid unnecessary check
  * Make ik_base_to_tip_frame_ local
  * Remove use_inv_jacobian flag
  * Use nullptr instead of NULL
  * Alphabetize + clang-tidy
  * Remove unused header
* [Servo] Update MoveIt Servo to use generate_parameter_library (#2096 <https://github.com/ros-planning/moveit2/issues/2096>)
  * Add generate_parameter_library as dependency
  * Add parameters file
  * Update parameters file
  * Fix one_of syntax
  * Add parameter generation
  * Include servo param header
  * Test if parameters are loaded
  * Make servo_node partially use ParamListener
  * Make Servo partially use ParamListener
  * Make ServoCalcs partially use ParamListener
  * Fix frame name
  * Handle parameter updates
  * Remove old param lib dependency in CollisionCheck
  * Remove old param lib dependency in ServoCalcs
  * Remove old param lib dependency in Servo
  * Remove old param lib dependency in ServoNode
  * Remove old parameter librarysources
  * Remove parameter_descriptor_builder sources
  * Update parameter library header name
  * Formatting
  * Remove old param lib headers
  * Add parameter to enable/disable continous parameter update check
  * Update pose tracking demo
  * Fix launch time parameter loading for pose tracking
  * Move PID parameters to generate_parameter_library
  * Fix launch time parameter loading for servo example
  * Fix unit tests
  * Fix interface test
  * Fix pose tracking test
  * Redorder member variable initialization
  * Cleanup
  * Group parameters
  * Make parameter listener const
  * Revert disabled lint tests
  * Fix issues from rebase
  * Apply performance suggestion from CI
  * Apply variable naming suggestion from CI
  * Apply pass params by reference suggestion by CI
  * Apply review suggestions
  * Apply review suggestions
  * Remove unused parameter
  * Change parameter listener to unique_ptr
  * Add validations for some parameters
  * Changes from review
  * Make docstring more informative
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  * Change validation failure from warning to error
  * Fix parameter loading in test launch files
  * Remove defaults for robot specific params
  * Update description for params with no default value
  * Pass by reference
  * Clang-tidy
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  ---------
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
* Contributors: Sebastian Castro, V Mohammed Ibrahim
```

## moveit_setup_app_plugins

- No changes

## moveit_setup_assistant

- No changes

## moveit_setup_controllers

- No changes

## moveit_setup_core_plugins

- No changes

## moveit_setup_framework

- No changes

## moveit_setup_srdf_plugins

- No changes

## moveit_simple_controller_manager

- No changes

## pilz_industrial_motion_planner

- No changes

## pilz_industrial_motion_planner_testutils

- No changes
