### PR TITLE
Add source entry for social_nav_ros

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6769,6 +6769,12 @@ repositories:
       url: https://github.com/ijnek/soccer_object_msgs.git
       version: rolling
     status: developed
+  social_nav_ros:
+    source:
+      type: git
+      url: https://github.com/MetroRobots/social_nav_ros.git
+      version: main
+    status: developed
   sol_vendor:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

social_nav_ros

# The source is here:

https://github.com/MetroRobots/social_nav_ros

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
