### PR TITLE
rosbag2: 0.22.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4830,7 +4830,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.22.0-2
+      version: 0.22.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.22.1-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.22.0-2`

## mcap_vendor

- No changes

## ros2bag

```
* Cleanup the help text for ros2 bag record. (#1329 <https://github.com/ros2/rosbag2/issues/1329>) (#1333 <https://github.com/ros2/rosbag2/issues/1333>)
* Contributors: mergify[bot]
```

## rosbag2

- No changes

## rosbag2_compression

```
* Add in a missing cstdint include. (#1321 <https://github.com/ros2/rosbag2/issues/1321>) (#1322 <https://github.com/ros2/rosbag2/issues/1322>)
* Fix warning from ClassLoader in sequential compression reader and writer (#1299 <https://github.com/ros2/rosbag2/issues/1299>) (#1316 <https://github.com/ros2/rosbag2/issues/1316>)
* Contributors: mergify[bot]
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Add recorder stop() API (#1300 <https://github.com/ros2/rosbag2/issues/1300>) (#1334 <https://github.com/ros2/rosbag2/issues/1334>)
* Contributors: mergify[bot]
```

## rosbag2_examples_cpp

- No changes

## rosbag2_examples_py

```
* Fix a warning from python setuptools. (#1312 <https://github.com/ros2/rosbag2/issues/1312>) (#1314 <https://github.com/ros2/rosbag2/issues/1314>)
* Contributors: mergify[bot]
```

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_performance_benchmarking_msgs

- No changes

## rosbag2_py

```
* Add binding to close the writer (#1339 <https://github.com/ros2/rosbag2/issues/1339>) (#1340 <https://github.com/ros2/rosbag2/issues/1340>)
* Contributors: mergify[bot]
```

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

- No changes

## rosbag2_storage_sqlite3

- No changes

## rosbag2_test_common

```
* Address flakiness in rosbag2_play_end_to_end tests (#1297 <https://github.com/ros2/rosbag2/issues/1297>) (#1330 <https://github.com/ros2/rosbag2/issues/1330>)
* Contributors: mergify[bot]
```

## rosbag2_test_msgdefs

- No changes

## rosbag2_tests

```
* Address flakiness in rosbag2_play_end_to_end tests (#1297 <https://github.com/ros2/rosbag2/issues/1297>) (#1330 <https://github.com/ros2/rosbag2/issues/1330>)
* Contributors: mergify[bot]
```

## rosbag2_transport

```
* Change subscriptions from GenericSubscripton to SubscriptionBase (#1338 <https://github.com/ros2/rosbag2/issues/1338>)
* Add recorder stop() API (#1300 <https://github.com/ros2/rosbag2/issues/1300>) (#1334 <https://github.com/ros2/rosbag2/issues/1334>)
* Contributors: Emerson Knapp, mergify[bot]
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
