### PR TITLE
moveit_resources: 2.1.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2627,6 +2627,7 @@ repositories:
       version: ros2
     release:
       packages:
+      - dual_arm_panda_moveit_config
       - moveit_resources
       - moveit_resources_fanuc_description
       - moveit_resources_fanuc_moveit_config
@@ -2636,7 +2637,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_resources-release.git
-      version: 2.0.6-3
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_resources.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `2.1.1-1`:

- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros2-gbp/moveit_resources-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.6-3`

## dual_arm_panda_moveit_config

- No changes

## moveit_resources

- No changes

## moveit_resources_fanuc_description

- No changes

## moveit_resources_fanuc_moveit_config

- No changes

## moveit_resources_panda_description

- No changes

## moveit_resources_panda_moveit_config

- No changes

## moveit_resources_pr2_description

- No changes
