### PR TITLE
moveit_resources: 2.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2636,6 +2636,7 @@ repositories:
       version: ros2
     release:
       packages:
+      - dual_arm_panda_moveit_config
       - moveit_resources
       - moveit_resources_fanuc_description
       - moveit_resources_fanuc_moveit_config
@@ -2645,7 +2646,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_resources-release.git
-      version: 2.0.6-2
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_resources.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `2.1.1-1`:

- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros2-gbp/moveit_resources-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.6-2`

## dual_arm_panda_moveit_config

- No changes

## moveit_resources

- No changes

## moveit_resources_fanuc_description

- No changes

## moveit_resources_fanuc_moveit_config

- No changes

## moveit_resources_panda_description

- No changes

## moveit_resources_panda_moveit_config

- No changes

## moveit_resources_pr2_description

- No changes
