### PR TITLE
sros2: 0.12.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5864,7 +5864,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.12.0-1
+      version: 0.12.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.12.1-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.12.0-1`

## sros2

```
* Fix SSH commands in SROS2_Linux.md (#286 <https://github.com/ros2/sros2/issues/286>)
* Contributors: Boris Boutillier
```

## sros2_cmake

- No changes
