### PR TITLE
plotjuggler: 3.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3347,7 +3347,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.5.1-2
+      version: 3.7.0-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.7.0-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/ros2-gbp/plotjuggler-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.5.1-2`

## plotjuggler

```
* Handle protobuf maps (#824 <https://github.com/facontidavide/PlotJuggler/issues/824>)
  Protobuf maps are just repeated protobuf messages with only 2 fields
  "key" and "value". Extract the map's key and use it in the series name
  and skip adding series for "key" fields to reduce the number of non
  useful series. Additionally don't include "value" in the series name for
  the value of a map.
* add progress dialog to MCAP loading
* new plugin: DataTamer parser
* performance optimization in pushBack
* more information in MCAP error
* optimization in MoveData
* address #820 <https://github.com/facontidavide/PlotJuggler/issues/820>
* Prevent runtime_error exceptions from plugins crashing the main app (#812 <https://github.com/facontidavide/PlotJuggler/issues/812>)
  Catch runtime_error exceptions thrown from the plugins and skip the throwing plugins, so that the main app can continue its normal operation.
* fix(snap): add libzstd for mcap support (#815 <https://github.com/facontidavide/PlotJuggler/issues/815>)
* Update README.md
* Add a "central difference" method of derivative calculation (#813 <https://github.com/facontidavide/PlotJuggler/issues/813>)
* Updating COMPILE dependencies to install (#810 <https://github.com/facontidavide/PlotJuggler/issues/810>)
  Taken from CI: https://github.com/facontidavide/PlotJuggler/blob/main/.github/workflows/ubuntu.yaml#L20-L31
* Fix the bug where the shared library Parquet is not linked (#807 <https://github.com/facontidavide/PlotJuggler/issues/807>)
  The actual path to the shared library is in ${PARQUET_SHARED_LIB} instead of in
  ${PARQUET_LIBRARIES}.
* Add CMake into comp vars and minor format improvements (#804 <https://github.com/facontidavide/PlotJuggler/issues/804>)
  Co-authored-by: Erick G. Islas Osuna <mailto:eislasosuna@netflix.com>
* Fix for missing preferences (#795 <https://github.com/facontidavide/PlotJuggler/issues/795>)
* fix typos in "tips and tricks" cheatsheet (#798 <https://github.com/facontidavide/PlotJuggler/issues/798>)
  fix a couple of minor typos in dialog text
* Support Proto's That Reference Google/Protobuf (#793 <https://github.com/facontidavide/PlotJuggler/issues/793>)
* Fix for segfault in DataLoadCSV destructor (#784 <https://github.com/facontidavide/PlotJuggler/issues/784>)
  - Change order of deletion for dialogs.
  - First delete child dialog _dateTime_dialog then parent
  _dialog.
* Add CodeQL workflow (#765 <https://github.com/facontidavide/PlotJuggler/issues/765>)
* [bugfix] String deserialization (#780 <https://github.com/facontidavide/PlotJuggler/issues/780>)
* forgot throw
* fixing nan check (#777 <https://github.com/facontidavide/PlotJuggler/issues/777>)
* Update Reactive Scripts on playback loop (#771 <https://github.com/facontidavide/PlotJuggler/issues/771>)
* fix
* Contributors: Alistair, AndyZe, Bartimaeus-, Connor Anderson, Davide Faconti, Erick G. Islas-Osuna, Guillaume Beuzeboc, Mark Cutler, Michael Orlov, Peter Stöckli, Sam Pfeiffer, Zach Davis, Zheng Qu, augustinmanecy, ozzdemir
```
