### PR TITLE
Add fluent_bit_vendor in humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1359,6 +1359,16 @@ repositories:
       url: https://github.com/introlab/find-object.git
       version: humble-devel
     status: maintained
+  fluent_bit_vendor:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/minipada/fluent_bit_vendor-release.git
+      version: 2.0.0
+    source:
+      type: git
+      url: https://gitlab.com/minipada/fluent_bit_vendor.git
+      version: humble
   fluent_rviz:
     release:
       tags:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1367,7 +1367,7 @@ repositories:
       version: 2.0.0
     source:
       type: git
-      url: https://gitlab.com/minipada/fluent_bit_vendor.git
+      url: https://github.com/minipada/fluent_bit_vendor.git
       version: humble
   fluent_rviz:
     release:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1360,11 +1360,6 @@ repositories:
       version: humble-devel
     status: maintained
   fluent_bit_vendor:
-    release:
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/minipada/fluent_bit_vendor-release.git
-      version: 2.0.0
     source:
       type: git
       url: https://github.com/minipada/fluent_bit_vendor.git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

fluent_bit_vendor

## Package Upstream Source:

https://github.com/Minipada/fluent_bit_vendor

## Purpose of using this:

I want to use Fluent Bit as a third party library for https://github.com/Minipada/ros2_data_collection
At the moment it is in this repo but I want to take it out.

Distro packaging links:

## Links to Distribution Packages

# Please Add This Package to be indexed in the rosdistro.

humble

# The source is here:

https://github.com/fluent/fluent-bit

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
