### PR TITLE
slam_toolbox: 2.7.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5691,6 +5691,22 @@ repositories:
       url: https://github.com/oKermorgant/simple_launch.git
       version: devel
     status: maintained
+  slam_toolbox:
+    doc:
+      type: git
+      url: https://github.com/SteveMacenski/slam_toolbox.git
+      version: iron
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/SteveMacenski/slam_toolbox-release.git
+      version: 2.7.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/SteveMacenski/slam_toolbox.git
+      version: iron
+    status: maintained
   slider_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_toolbox` to `2.7.0-1`:

- upstream repository: https://github.com/SteveMacenski/slam_toolbox.git
- release repository: https://github.com/SteveMacenski/slam_toolbox-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
