### PR TITLE
ros2_control: 2.26.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5181,7 +5181,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.25.3-1
+      version: 2.26.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.26.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.25.3-1`

## controller_interface

- No changes

## controller_manager

```
* Revert "Add diagnostics (#1015 <https://github.com/ros-controls/ros2_control/issues/1015>) #abi-breaking
* Fix GitHub link on control.ros.org (#1022 <https://github.com/ros-controls/ros2_control/issues/1022>) (#1024 <https://github.com/ros-controls/ros2_control/issues/1024>)
* Contributors: Joseph Schornak, Christoph Fröhlich
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* docs: Fix link to hardware_components (#1009 <https://github.com/ros-controls/ros2_control/issues/1009>) (#1011 <https://github.com/ros-controls/ros2_control/issues/1011>)
* Contributors: Christoph Fröhlich
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
