### PR TITLE
nao_lola: 0.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2790,7 +2790,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nao_lola-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/ros-sports/nao_lola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_lola` to `0.3.1-1`:

- upstream repository: https://github.com/ros-sports/nao_lola.git
- release repository: https://github.com/ros2-gbp/nao_lola-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.0-1`

## nao_lola

```
* Retain state of all effectors
* Send effectors in every cycle
* Contributors: ijnek
```
