### PR TITLE
mrpt_msgs: 0.4.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2692,7 +2692,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_msgs-release.git
-      version: 0.4.4-2
+      version: 0.4.5-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_msgs` to `0.4.5-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
- release repository: https://github.com/ros2-gbp/mrpt_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.4-2`

## mrpt_msgs

```
* Add Waypoint messages
* Contributors: Jose Luis Blanco-Claraco
```
