### PR TITLE
grid_map: 2.1.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1637,6 +1637,37 @@ repositories:
       url: https://github.com/flynneva/grbl_ros.git
       version: devel
     status: maintained
+  grid_map:
+    doc:
+      type: git
+      url: https://github.com/ANYbotics/grid_map.git
+      version: iron
+    release:
+      packages:
+      - grid_map
+      - grid_map_cmake_helpers
+      - grid_map_core
+      - grid_map_costmap_2d
+      - grid_map_cv
+      - grid_map_demos
+      - grid_map_filters
+      - grid_map_loader
+      - grid_map_msgs
+      - grid_map_octomap
+      - grid_map_pcl
+      - grid_map_ros
+      - grid_map_rviz_plugin
+      - grid_map_sdf
+      - grid_map_visualization
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/grid_map-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/ANYbotics/grid_map.git
+      version: iron
+    status: developed
   gscam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grid_map` to `2.1.0-1`:

- upstream repository: https://github.com/ANYbotics/grid_map.git
- release repository: https://github.com/ros2-gbp/grid_map-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## grid_map

- No changes

## grid_map_cmake_helpers

- No changes

## grid_map_core

- No changes

## grid_map_costmap_2d

- No changes

## grid_map_cv

```
* fix: change cv_bridge.h -> .hpp (#376 <https://github.com/ANYbotics/grid_map/issues/376>)
* Contributors: Iván López Broceño
```

## grid_map_demos

```
* fix: change cv_bridge.h -> .hpp (#376 <https://github.com/ANYbotics/grid_map/issues/376>)
* Contributors: Iván López Broceño
```

## grid_map_filters

- No changes

## grid_map_loader

- No changes

## grid_map_msgs

- No changes

## grid_map_octomap

- No changes

## grid_map_pcl

- No changes

## grid_map_ros

```
* fix: change cv_bridge.h -> .hpp (#376 <https://github.com/ANYbotics/grid_map/issues/376>)
* Contributors: Iván López Broceño
```

## grid_map_rviz_plugin

- No changes

## grid_map_sdf

- No changes

## grid_map_visualization

- No changes
