### PR TITLE
create_robot: 3.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -909,6 +909,27 @@ repositories:
       url: https://github.com/iRobotEducation/create3_sim.git
       version: main
     status: developed
+  create_robot:
+    doc:
+      type: git
+      url: https://github.com/AutonomyLab/create_robot.git
+      version: humble
+    release:
+      packages:
+      - create_bringup
+      - create_description
+      - create_driver
+      - create_msgs
+      - create_robot
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/AutonomyLab/create_autonomy-release.git
+      version: 3.1.0-1
+    source:
+      type: git
+      url: https://github.com/AutonomyLab/create_robot.git
+      version: humble
+    status: maintained
   cudnn_cmake_module:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `create_robot` to `3.1.0-1`:

- upstream repository: https://github.com/AutonomyLab/create_robot.git
- release repository: https://github.com/AutonomyLab/create_autonomy-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## create_bringup

- No changes

## create_description

- No changes

## create_driver

```
* Fix compilation for ROS Humble
* Contributors: Jacob Perron
```

## create_msgs

- No changes

## create_robot

- No changes
