### PR TITLE
libcreate: 3.1.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2226,6 +2226,21 @@ repositories:
       type: git
       url: https://github.com/lgsvl/lgsvl_msgs.git
       version: foxy-devel
+  libcreate:
+    doc:
+      type: git
+      url: https://github.com/AutonomyLab/libcreate.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/AutonomyLab/libcreate-release.git
+      version: 3.1.0-1
+    source:
+      type: git
+      url: https://github.com/AutonomyLab/libcreate.git
+      version: master
+    status: maintained
   libg2o:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `libcreate` to `3.1.0-1`:

- upstream repository: https://github.com/AutonomyLab/libcreate.git
- release repository: https://github.com/AutonomyLab/libcreate-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## libcreate

```
* Address warnings and errors
* Catch boost exceptions in Serial.h
* Contributors: Swapnil Patel
```
