### PR TITLE
flexbe: 1.4.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2741,7 +2741,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/FlexBE/flexbe_behavior_engine-release.git
-      version: 1.3.1-1
+      version: 1.4.0-2
     source:
       type: git
       url: https://github.com/team-vigir/flexbe_behavior_engine.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flexbe` to `1.4.0-2`:

- upstream repository: https://github.com/FlexBE/flexbe_behavior_engine.git
- release repository: https://github.com/FlexBE/flexbe_behavior_engine-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.1-1`

## flexbe_behavior_engine

```
* Updates for Melodic and Noetic releases on github.com/FlexBE
* [flexbe_core] Merge pull request #153 from omercans/fix/set-current-state-of-cc-to-none-on-forced-exit
* [flexbe_core] Merge pull request #154 from duwke/patch-1 - Check topic availability before returning last_msg
* [flexbe_states] Merge pull request #160 from cpswarm/fix_namespace - namespace fix for topic lookup with rostopic in subscriber state
* [flexbe_core] Merge pull request #163 from LoyVanBeek/fix/nested_sm_userdata - Fix nested state machine userdata
* [flexbe_onboard] Merge pull request #165 from HannesBachter/feature/get_userdata - get userdata by service
```

## flexbe_core

```
* Updates for Melodic and Noetic releases on github.com/FlexBE
* [flexbe_core] Fix handling of boolean behavior args
* [flexbe_core] Merge pull request #153 from omercans/fix/set-current-state-of-cc-to-none-on-forced-exit
* [flexbe_core] Merge pull request #154 from duwke/patch-1 - Check topic availability before returning last_msg
* [flexbe_core] Merge pull request #163 from LoyVanBeek/fix/nested_sm_userdata - Fix nested state machine userdata
```

## flexbe_input

```
* Updates for Melodic and Noetic releases on github.com/FlexBE
```

## flexbe_mirror

```
* Updates for Melodic and Noetic releases on github.com/FlexBE
```

## flexbe_msgs

```
* Updates for Melodic and Noetic releases on github.com/FlexBE
* [flexbe_msgs] Merge pull request #165 from HannesBachter/feature/get_userdata - get userdata by service
```

## flexbe_onboard

```
* Updates for Melodic and Noetic releases on github.com/FlexBE
* [flexbe_onboard] Merge pull request #165 from HannesBachter/feature/get_userdata - get userdata by service
```

## flexbe_states

```
* Updates for Melodic and Noetic releases on github.com/FlexBE
```

## flexbe_testing

```
* Updates for Melodic and Noetic releases on github.com/FlexBE
```

## flexbe_widget

```
* Updates for Melodic and Noetic releases on github.com/FlexBE
```
