### PR TITLE
flexbe_app: 2.4.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2747,6 +2747,16 @@ repositories:
       url: https://github.com/team-vigir/flexbe_behavior_engine.git
       version: master
     status: developed
+  flexbe_app:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/FlexBE/flexbe_app-release.git
+      version: 2.4.1-1
+    source:
+      type: git
+      url: https://github.com/FlexBE/flexbe_app.git
+      version: master
   flir_camera_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `flexbe_app` to `2.4.1-1`:

- upstream repository: https://github.com/FlexBE/flexbe_app.git
- release repository: https://github.com/FlexBE/flexbe_app-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## flexbe_app

```
* merge PR #74 <https://github.com/FlexBE/flexbe_app/issues/74>, 76, 77; tweak CI workflow
* Merge pull request #60 <https://github.com/FlexBE/flexbe_app/issues/60> from fmessmer/fix/catkin_lint
  some catkin_lint fixes
* some catkin_lint fixes
* Contributors: David Conner, dcconner, fmessmer
```
