### PR TITLE
Revert "mavlink: 2023.5.5-1 in 'humble/distribution.yaml' [bloom]"

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2804,7 +2804,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mavlink-gbp-release.git
-      version: 2023.5.5-1
+      version: 2022.12.30-1
     source:
       type: git
       url: https://github.com/ros2-gbp/mavlink-gbp-release.git


### PR DESCRIPTION
Reverts ros/rosdistro#37152 because it fails to build in the buildfarm: https://build.ros2.org/view/Hbin_uJ64/job/Hbin_uJ64__mavlink__ubuntu_jammy_amd64__binary/11/

FYI @vooon 