### PR TITLE
Add source entry for urdf_launch

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -7467,6 +7467,12 @@ repositories:
       url: https://github.com/ros2/urdf.git
       version: foxy
     status: maintained
+  urdf_launch:
+    source:
+      type: git
+      url: https://github.com/MetroRobots/urdf_launch.git
+      version: main
+    status: developed
   urdf_parser_py:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

urdf_launch

# The source is here:

https://github.com/MetroRobots/urdf_launch.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
