### PR TITLE
Unrelease darknet_ros because it fails to build on all platforms

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1622,7 +1622,6 @@ repositories:
       version: master
     release:
       packages:
-      - darknet_ros
       - darknet_ros_msgs
       tags:
         release: release/noetic/{package}/{version}


### PR DESCRIPTION
Context: https://github.com/leggedrobotics/darknet_ros/issues/411