### PR TITLE
Unrelease diffbot_base because it is failing to build on all platforms

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1866,7 +1866,6 @@ repositories:
       version: noetic-devel
     release:
       packages:
-      - diffbot_base
       - diffbot_bringup
       - diffbot_control
       - diffbot_description
@@ -1874,7 +1873,6 @@ repositories:
       - diffbot_mbf
       - diffbot_msgs
       - diffbot_navigation
-      - diffbot_robot
       - diffbot_slam
       tags:
         release: release/noetic/{package}/{version}


### PR DESCRIPTION
Context: https://github.com/ros-mobile-robots/diffbot/issues/82