### PR TITLE
Unrelease joy_mouse because it fails to build on all platforms

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4225,7 +4225,6 @@ repositories:
       - eus_nlopt
       - eus_qp
       - eus_qpoases
-      - joy_mouse
       - jsk_calibration
       - jsk_control
       - jsk_footstep_controller


### PR DESCRIPTION
Context: https://github.com/jsk-ros-pkg/jsk_control/issues/783