### PR TITLE
Unrelease l3cam_ros because it fails to build on all platforms

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4487,11 +4487,6 @@ repositories:
       type: git
       url: https://github.com/beamaginelidar/l3cam_ros.git
       version: master
-    release:
-      tags:
-        release: release/noetic/{package}/{version}
-      url: https://github.com/beamaginelidar/l3cam_ros-release.git
-      version: 0.0.3-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Context: https://github.com/beamaginelidar/l3cam_ros/issues/1