### PR TITLE
Unrelease qb_chain_controllers and qb_chain because the former fails …

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7776,9 +7776,7 @@ repositories:
       version: production-noetic
     release:
       packages:
-      - qb_chain
       - qb_chain_control
-      - qb_chain_controllers
       - qb_chain_description
       - qb_chain_msgs
       tags:


### PR DESCRIPTION
Context: https://bitbucket.org/qbrobotics/qbchain-ros/issues/2/noetic-package-qb_chain_controllers-fails