### PR TITLE
play_motion2: 0.0.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3885,7 +3885,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/play_motion2-release.git
-      version: 0.0.7-1
+      version: 0.0.8-1
     source:
       type: git
       url: https://github.com/pal-robotics/play_motion2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `play_motion2` to `0.0.8-1`:

- upstream repository: https://github.com/pal-robotics/play_motion2.git
- release repository: https://github.com/pal-gbp/play_motion2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.7-1`

## play_motion2

```
* add 1 extra second to motions timeout
  To avoid that motions with only one position fail when the robot is
  already in that position
* fill error field and be more verbose
* cancel action goals when requested
* Contributors: Noel Jimenez
```

## play_motion2_msgs

- No changes
