### PR TITLE
feat: add gymnasium to python deps

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -218,6 +218,19 @@ gym-pip:
   ubuntu:
     pip:
       packages: [gym]
+gymnasium-pip:
+  debian:
+    pip:
+      packages: [gymnasium]
+  fedora:
+    pip:
+      packages: [gymnasium]
+  osx:
+    pip:
+      packages: [gymnasium]
+  ubuntu:
+    pip:
+      packages: [gymnasium]
 imgaug-pip:
   debian:
     pip:


### PR DESCRIPTION
This commit makes the [gymnasium](https://gymnasium.farama.org/) package
available as a python dependency. This package is the currently maintained version
of the old OpenAI Gym package.

<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

[gymnasium](https://gymnasium.farama.org/)

## Package Upstream Source:

https://github.com/Farama-Foundation/Gymnasium

## Purpose of using this:

The old OpenAI gym package is no longer maintained (see https://www.gymlibrary.dev/). As a result gym should be replaced with gymnasium. Gym is kept in the dependency list for back-compatibility.

Pypi packaging links:

- https://pypi.org/project/gymnasium/
