### PR TITLE
Update python3-tqdm in python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8652,7 +8652,7 @@ python3-tqdm:
     '*': [python3-tqdm]
     'focal':
       'pip':
-         packages: [tqdm]
+        packages: [tqdm]
 python3-transformers-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8650,6 +8650,9 @@ python3-tqdm:
       packages: [tqdm]
   ubuntu:
     '*': [python3-tqdm]
+    'focal':
+      'pip':
+         packages: [tqdm]
 python3-transformers-pip:
   debian:
     pip:


### PR DESCRIPTION
Moved from apt to pip dependency for `python3-tqdm` in ubuntu focal because last apt version available in focal is from Mai 2019 latest pip version is from March 23.

<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name: python3-tqdm


## Package Upstream Source:

[repo](https://github.com/tqdm/tqdm)

## Purpose of using this:

Instantly make your loops show a smart progress meter. Looking good!

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/buster/python3-tqdm
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/focal/python/python3-tqdm
  - REQUIRED
- PyPi: https://pypi.org/project/tqdm/

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
