### PR TITLE
webots_ros2: 2023.0.4-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6948,7 +6948,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/webots_ros2-release.git
-      version: 2023.0.3-3
+      version: 2023.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `webots_ros2` to `2023.0.4-1`:

- upstream repository: https://github.com/cyberbotics/webots_ros2.git
- release repository: https://github.com/ros2-gbp/webots_ros2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2023.0.3-3`

## webots_ros2

```
* Drop support for Foxy.
* Fixed vertical field of view in static RangeFinder plugin.
* Added support for painted point clouds
* Fixed ability to launch RViz without other tools in e-puck example.
* Fixed command line arguments in importer tools.
* Added custom handler in driver interface to start nodes when Webots is ready.
```

## webots_ros2_driver

```
* Fixed vertical field of view in static RangeFinder plugin.
* Added support for painted point clouds
* Added custom handler to start nodes when Webots is ready.
```

## webots_ros2_epuck

```
* Fixed ability to launch RViz without other tools.
* Start ros control and navigation nodes when Webots is ready.
```

## webots_ros2_importer

```
* Fixed argument parsing
```

## webots_ros2_tests

```
* Added support for painted point clouds
```

## webots_ros2_tiago

```
* Start ros control and navigation nodes when Webots is ready.
```

## webots_ros2_turtlebot

```
* Start ros control and navigation nodes when Webots is ready.
```

## webots_ros2_universal_robot

```
* Start ros control nodes when Webots is ready.
```
