### PR TITLE
Add source entry for classic_bags

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -681,6 +681,12 @@ repositories:
       url: https://github.com/ros/class_loader.git
       version: rolling
     status: maintained
+  classic_bags:
+    source:
+      type: git
+      url: https://github.com/MetroRobots/classic_bags.git
+      version: main
+    status: developed
   color_names:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

classic_bags

# The source is here:

https://github.com/MetroRobots/classic_bags.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
