### PR TITLE
gazebo_ros2_control: 0.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1411,7 +1411,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.5.1-3
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros2_control` to `0.6.0-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros2_control.git
- release repository: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.5.1-3`

## gazebo_ros2_control

```
* add copy operator to SafeEnum (#197 <https://github.com/ros-controls/gazebo_ros2_control/issues/197>)
* Fixed rolling compilation (#195 <https://github.com/ros-controls/gazebo_ros2_control/issues/195>)
* Export all dependencies (#183 <https://github.com/ros-controls/gazebo_ros2_control/issues/183>) (#184 <https://github.com/ros-controls/gazebo_ros2_control/issues/184>)
* Contributors: Alejandro Hernández Cordero, Noel Jiménez García, Adrian Zwiener
```

## gazebo_ros2_control_demos

```
* Clean shutdown position example (#196 <https://github.com/ros-controls/gazebo_ros2_control/issues/196>)
* Remove publish_rate parameter (#179 <https://github.com/ros-controls/gazebo_ros2_control/issues/179>)
* Contributors: Alejandro Hernández Cordero, Tony Najjar
```
