### PR TITLE
gazebo_ros2_control: 0.4.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1557,7 +1557,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.4.2-1
+      version: 0.4.3-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros2_control` to `0.4.3-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros2_control.git
- release repository: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.2-1`

## gazebo_ros2_control

```
* add copy operator to SafeEnum (#197 <https://github.com/ros-controls/gazebo_ros2_control/issues/197>) (#198 <https://github.com/ros-controls/gazebo_ros2_control/issues/198>)
* Contributors: mergify[bot]
```

## gazebo_ros2_control_demos

```
* Clean shutdown position example (#196 <https://github.com/ros-controls/gazebo_ros2_control/issues/196>) (#199 <https://github.com/ros-controls/gazebo_ros2_control/issues/199>)
* Contributors: mergify[bot]
```
