### PR TITLE
ros_gz: 0.245.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4750,7 +4750,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 0.244.10-1
+      version: 0.245.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `0.245.0-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.244.10-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* Backport: Add missing rosidl_cmake dep to ros_gz_bridge (#391 <https://github.com/gazebosim/ros_gz/issues/391>) (#396 <https://github.com/gazebosim/ros_gz/issues/396>)
* Contributors: Michael Carroll, Yadu, Chris Lalancette
```

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

- No changes

## ros_gz_sim_demos

- No changes

## ros_ign

- No changes

## ros_ign_bridge

- No changes

## ros_ign_gazebo

- No changes

## ros_ign_gazebo_demos

- No changes

## ros_ign_image

- No changes

## ros_ign_interfaces

- No changes
