### PR TITLE
point_cloud_transport: 1.0.10-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9270,7 +9270,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport.git
-      version: 1.0.9-1
+      version: 1.0.10-1
     source:
       type: git
       url: https://github.com/ctu-vras/point_cloud_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `1.0.10-1`:

- upstream repository: https://github.com/ctu-vras/point_cloud_transport.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.9-1`

## point_cloud_transport

```
* Fixed wrong dependency version.
* Contributors: Martin Pecka
```
