### PR TITLE
Adding ros2_benchmark to index for Humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5197,6 +5197,17 @@ repositories:
       url: https://github.com/ros2/ros1_bridge.git
       version: master
     status: maintained
+  ros2_benchmark:
+    doc:
+      type: git
+      url: https://github.com/NVIDIA-ISAAC-ROS/ros2_benchmark.git
+      version: main
+    source:
+      test_commits: false
+      type: git
+      url: https://github.com/NVIDIA-ISAAC-ROS/ros2_benchmark.git
+      version: main
+    status: maintained
   ros2_control:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

Humble

# The source is here:

https://github.com/NVIDIA-ISAAC-ROS/ros2_benchmark

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
