### PR TITLE
ublox_dgnss: 0.4.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7489,14 +7489,16 @@ repositories:
       version: main
     release:
       packages:
+      - ntrip_client_node
       - ublox_dgnss
       - ublox_dgnss_node
+      - ublox_nav_sat_fix_hp_node
       - ublox_ubx_interfaces
       - ublox_ubx_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ublox_dgnss-release.git
-      version: 0.3.5-4
+      version: 0.4.4-1
     source:
       type: git
       url: https://github.com/aussierobots/ublox_dgnss.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ublox_dgnss` to `0.4.4-1`:

- upstream repository: https://github.com/aussierobots/ublox_dgnss
- release repository: https://github.com/ros2-gbp/ublox_dgnss-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.5-4`

## ntrip_client_node

```
* cmake uncrustify changes
* Contributors: Nick Hortovanyi
```

## ublox_dgnss

- No changes

## ublox_dgnss_node

```
* cmake uncrustify changes
* Contributors: Nick Hortovanyi
```

## ublox_nav_sat_fix_hp_node

```
* cmake uncrustify changes
* Contributors: Nick Hortovanyi
```

## ublox_ubx_interfaces

- No changes

## ublox_ubx_msgs

- No changes
