### PR TITLE
Add classic_bags source repo to humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -762,7 +762,7 @@ repositories:
     source:
       type: git
       url: https://github.com/MetroRobots/classic_bags.git
-      version: devel
+      version: main
     status: developed
   color_names:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -758,6 +758,12 @@ repositories:
       url: https://github.com/ros/class_loader.git
       version: humble
     status: maintained
+  classic_bags:
+    source:
+      type: git
+      url: https://github.com/MetroRobots/classic_bags.git
+      version: devel
+    status: developed
   color_names:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

classic_bags

# The source is here:

https://github.com/MetroRobots/classic_bags.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
