### PR TITLE
topic_based_ros2_control: 0.1.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6249,6 +6249,12 @@ repositories:
       url: https://github.com/ros2/tlsf.git
       version: iron
     status: maintained
+  topic_based_ros2_control:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/PickNikRobotics/topic_based_ros2_control-release.git
+      version: 0.1.0-1
   topic_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_based_ros2_control` to `0.1.0-1`:

- upstream repository: https://github.com/PickNikRobotics/topic_based_ros2_control.git
- release repository: https://github.com/PickNikRobotics/topic_based_ros2_control-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## topic_based_ros2_control

```
* Fix joint state for mimic joints & expose epsilon parameter (#7 <https://github.com/PickNikRobotics/topic_based_ros2_control/issues/7>)
  * Check the difference between command and current joint state to stop command publication
  * Set mimic joints values
  * Move magic numbers to constants
  * Remove last_position_command_ variable
* Replace Isaac with TopicBased and generalize package (#5 <https://github.com/PickNikRobotics/topic_based_ros2_control/issues/5>)
* Clean up documentation (#4 <https://github.com/PickNikRobotics/topic_based_ros2_control/issues/4>)
* Removed unused node. (#3 <https://github.com/PickNikRobotics/topic_based_ros2_control/issues/3>)
* Add issac ros2 control hardware interface (#1 <https://github.com/PickNikRobotics/topic_based_ros2_control/issues/1>)
* Contributors: Alex Moriarty, Giovanni, Jafar Uruç
```
