### PR TITLE
draco: 1.5.6-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1944,6 +1944,21 @@ repositories:
       url: https://github.com/UbiquityRobotics-release/dnn_detect-release.git
       version: 0.1.0-1
     status: maintained
+  draco:
+    doc:
+      type: git
+      url: https://github.com/google/draco.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/draco.git
+      version: 1.5.6-3
+    source:
+      type: git
+      url: https://github.com/google/draco.git
+      version: master
+    status: maintained
   driver_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `draco` to `1.5.6-3`:

- upstream repository: https://github.com/google/draco
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/draco.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
