### PR TITLE
point_cloud_transport: 1.0.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7213,6 +7213,21 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: noetic-devel
     status: maintained
+  point_cloud_transport:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/point_cloud_transport.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport.git
+      version: 1.0.10-1
+    source:
+      type: git
+      url: https://github.com/ctu-vras/point_cloud_transport.git
+      version: master
+    status: developed
   pointcloud_to_laserscan:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `1.0.10-1`:

- upstream repository: https://github.com/ctu-vras/point_cloud_transport.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## point_cloud_transport

```
* Fixed wrong dependency version.
* Contributors: Martin Pecka
```
