### PR TITLE
point_cloud_transport_plugins: 1.0.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7213,6 +7213,24 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: noetic-devel
     status: maintained
+  point_cloud_transport_plugins:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/point_cloud_transport_plugins.git
+      version: master
+    release:
+      packages:
+      - draco_point_cloud_transport
+      - point_cloud_transport_plugins
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport_plugins.git
+      version: 1.0.3-1
+    source:
+      type: git
+      url: https://github.com/ctu-vras/point_cloud_transport_plugins.git
+      version: master
+    status: developed
   pointcloud_to_laserscan:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport_plugins` to `1.0.3-1`:

- upstream repository: https://github.com/ctu-vras/point_cloud_transport_plugins.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport_plugins.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## draco_point_cloud_transport

```
* Compatibility with GCC 7.
* Contributors: Martin Pecka
```

## point_cloud_transport_plugins

- No changes
