### PR TITLE
Revert "mavros: 2.4.0-1 in 'foxy/distribution.yaml' [bloom] (#35726)"

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3015,7 +3015,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 2.4.0-1
+      version: 2.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
This reverts commit b8a48d54d1b4ef0e8dbf0855fc08d7c490a73db8.

See https://github.com/ros/rosdistro/pull/37147#issuecomment-1561835938