### PR TITLE
urg_node_msgs: update branch names

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -7589,7 +7589,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/urg_node_msgs.git
-      version: master
+      version: iron
     release:
       tags:
         release: release/foxy/{package}/{version}

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7749,7 +7749,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/urg_node_msgs.git
-      version: master
+      version: iron
     release:
       tags:
         release: release/humble/{package}/{version}

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6719,7 +6719,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/urg_node_msgs.git
-      version: master
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6631,7 +6631,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/urg_node_msgs.git
-      version: master
+      version: main
     release:
       tags:
         release: release/rolling/{package}/{version}


### PR DESCRIPTION
We have a first change in like 5 years in this package - so it was time to branch off "Iron and earlier", and then rolling moving forward. Took the opportunity to also change from master -> main.