### PR TITLE
rclcpp: 2.4.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4742,7 +4742,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 2.4.2-1
+      version: 2.4.3-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `2.4.3-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.4.2-1`

## rclcpp

```
* Do not attempt to use void allocators for memory allocation. (backport #1657 <https://github.com/ros2/rclcpp/issues/1657>) (#2004 <https://github.com/ros2/rclcpp/issues/2004>)
* Contributors: Michel Hidalgo
```

## rclcpp_action

```
* Revert "Revert "extract the result response before the callback is is… (backport #2152 <https://github.com/ros2/rclcpp/issues/2152>) (#2153 <https://github.com/ros2/rclcpp/issues/2153>)
* Contributors: Tomoya Fujita
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
