### PR TITLE
rclpy: 1.0.13-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4759,7 +4759,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 1.0.12-1
+      version: 1.0.13-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `1.0.13-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.12-1`

## rclpy

```
* Fix #983 <https://github.com/ros2/rclpy/issues/983> by saving future and checking for + raising any exceptions (#1073 <https://github.com/ros2/rclpy/issues/1073>) (#1116 <https://github.com/ros2/rclpy/issues/1116>)
* Contributors: Achille Verheye, Tomoya Fujita
```
