### PR TITLE
ros1_bridge: 0.9.7-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5336,7 +5336,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros1_bridge-release.git
-      version: 0.9.6-1
+      version: 0.9.7-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros1_bridge` to `0.9.7-1`:

- upstream repository: https://github.com/ros2/ros1_bridge.git
- release repository: https://github.com/ros2-gbp/ros1_bridge-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.9.6-1`

## ros1_bridge

```
* remove xmlrpcpp from package.xml (#406 <https://github.com/ros2/ros1_bridge/issues/406>)
* Parametrization of parameter_bridge quality of service [Port of the commits (ec44770) and (86b4245) to foxy branch] (#401 <https://github.com/ros2/ros1_bridge/issues/401>)
* Contributors: Dharini Dutia, Lucyanno Frota
```
