### PR TITLE
rosidl: 1.3.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5809,7 +5809,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `1.3.1-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.0-1`

## rosidl_adapter

- No changes

## rosidl_cmake

```
* Use target output name for exporting typesupport library (#625 <https://github.com/ros2/rosidl/issues/625>) (#639 <https://github.com/ros2/rosidl/issues/639>)
* Contributors: Jonathan Selling, Shane Loretz
```

## rosidl_generator_c

- No changes

## rosidl_generator_cpp

```
* Generate typesupport getter declarations for actions, messages and services. (#744 <https://github.com/ros2/rosidl/issues/744>)
* Contributors: Stefan Fabian
```

## rosidl_parser

- No changes

## rosidl_runtime_c

- No changes

## rosidl_runtime_cpp

- No changes

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

- No changes

## rosidl_typesupport_introspection_cpp

- No changes
