### PR TITLE
velodyne: 2.4.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7834,7 +7834,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/velodyne-release.git
-      version: 2.3.0-1
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/ros-drivers/velodyne.git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne` to `2.4.0-1`:

- upstream repository: https://github.com/ros-drivers/velodyne.git
- release repository: https://github.com/ros2-gbp/velodyne-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.0-1`

## velodyne

```
* Unify tf frame parameters between transform and cloud nodes (#344 <https://github.com/ros-drivers/velodyne/issues/344>) (#453 <https://github.com/ros-drivers/velodyne/issues/453>)
  * Unify tf frame parameters between transform and cloud nodes
  At this point there is no need any more for cloud node because transform node includes all features of cloud node.
  Co-authored-by: AndreasR30 <mailto:andreas-reich@live.de>
  Co-authored-by: anre <mailto:andreas.reich@unibw.de>
* Contributors: Daisuke Nishimatsu
```

## velodyne_driver

```
* Disable cut_angle by default. (#497 <https://github.com/ros-drivers/velodyne/issues/497>)
* Unify tf frame parameters between transform and cloud nodes (#344 <https://github.com/ros-drivers/velodyne/issues/344>) (#453 <https://github.com/ros-drivers/velodyne/issues/453>)
  * Unify tf frame parameters between transform and cloud nodes
  At this point there is no need any more for cloud node because transform node includes all features of cloud node.
  Co-authored-by: AndreasR30 <mailto:andreas-reich@live.de>
  Co-authored-by: anre <mailto:andreas.reich@unibw.de>
* Contributors: Daisuke Nishimatsu, Joshua Whitley
```

## velodyne_laserscan

```
* using std::round to calculate the scan array size (#459 <https://github.com/ros-drivers/velodyne/issues/459>)
* Contributors: Gianluca Bardaro
```

## velodyne_msgs

- No changes

## velodyne_pointcloud

```
* Add invalid points in organized cloud (#360 <https://github.com/ros-drivers/velodyne/issues/360>) (#492 <https://github.com/ros-drivers/velodyne/issues/492>)
  * Set NaN in ordered point cloud in case of no return
  * Adapt to current master
  * consider min/max angle and timing_offsets also in organized mode
  Co-authored-by: Sebastian Scherer <mailto:sebastian.scherer2@de.bosch.com>
  Co-authored-by: Nuernberg Thomas (CR/AEV4) <mailto:thomas.nuernberg@de.bosch.com>
* Fixed row_step=0 when init_width=0 (dense cloud) (#404 <https://github.com/ros-drivers/velodyne/issues/404>) (#494 <https://github.com/ros-drivers/velodyne/issues/494>)
  The PointCloud2 msg will be then valid: http://docs.ros.org/en/melodic/api/sensor_msgs/html/msg/PointCloud2.html
  Referred issues:
  * https://answers.ros.org/question/377470/rtabmap-icp_odometrycpp453callbackcloud-fatal-error/
  * http://official-rtab-map-forum.67519.x6.nabble.com/Condition-scan3dMsg-data-size-scan3dMsg-row-step-scan3dMsg-height-not-met-td7852.html
  Co-authored-by: matlabbe <mailto:matlabbe@gmail.com>
* Unify tf frame parameters between transform and cloud nodes (#344 <https://github.com/ros-drivers/velodyne/issues/344>) (#453 <https://github.com/ros-drivers/velodyne/issues/453>)
  * Unify tf frame parameters between transform and cloud nodes
  At this point there is no need any more for cloud node because transform node includes all features of cloud node.
  Co-authored-by: AndreasR30 <mailto:andreas-reich@live.de>
  Co-authored-by: anre <mailto:andreas.reich@unibw.de>
* fix: modify some tests (#452 <https://github.com/ros-drivers/velodyne/issues/452>)
  * Fixing new linter errors.
  * Changing command for running tests.
  * remove relative file path
  * remove unnecessary main
  * fix: restore hdl64e s2 float intensities test
  Co-authored-by: Joshua Whitley <mailto:jwhitley@autonomoustuff.com>
* Contributors: Daisuke Nishimatsu
```