### PR TITLE
jsk_control: 0.1.17-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4227,6 +4227,8 @@ repositories:
       - eus_nlopt
       - eus_qp
       - eus_qpoases
+      - eus_teleop
+      - joy_mouse
       - jsk_calibration
       - jsk_control
       - jsk_footstep_controller
@@ -4236,7 +4238,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tork-a/jsk_control-release.git
-      version: 0.1.16-1
+      version: 0.1.17-2
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_control` to `0.1.17-2`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_control.git
- release repository: https://github.com/tork-a/jsk_control-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.16-1`

## cmd_vel_smoother

- No changes

## contact_states_observer

- No changes

## eus_nlopt

```
* use message(WARNING for 'NLopt missing'
* Contributors: Kei Okada
```

## eus_qp

- No changes

## eus_qpoases

- No changes

## eus_teleop

```
* add eus_teleop
* Contributors: Shingo Kitagawa
```

## joy_mouse

```
* jsk_mouse: fix wrong rosdep keys
  https://github.com/jsk-ros-pkg/jsk_control/pull/779/files changes rosdep key from python-pyudev to python-udev, which does not exists
* [joy_mouse] update joy_mouse python3 deps for noetic
* Contributors: Kei Okada, Shingo Kitagawa
```

## jsk_calibration

- No changes

## jsk_control

- No changes

## jsk_footstep_controller

- No changes

## jsk_footstep_planner

- No changes

## jsk_ik_server

- No changes

## jsk_teleop_joy

- No changes
