### PR TITLE
Adding vizanti and line_planner to documentation index for noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4855,6 +4855,16 @@ repositories:
       url: https://github.com/ros-drivers/libuvc_ros.git
       version: master
     status: unmaintained
+  line_planner:
+    doc:
+      type: git
+      url: https://github.com/MoffKalast/line_planner.git
+      version: noetic-devel
+    source:
+      type: git
+      url: https://github.com/MoffKalast/line_planner.git
+      version: noetic-devel
+    status: maintained
   linux_peripheral_interfaces:
     doc:
       type: git
@@ -11915,6 +11925,16 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/visualization_tutorials.git
+      version: noetic-devel
+    status: maintained
+  vizanti:
+    doc:
+      type: git
+      url: https://github.com/MoffKalast/vizanti.git
+      version: noetic-devel
+    source:
+      type: git
+      url: https://github.com/MoffKalast/vizanti.git
       version: noetic-devel
     status: maintained
   vl53l1x_ros:


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add These Packages to be indexed in the rosdistro.

Noetic

# The source is here:

https://github.com/MoffKalast/vizanti
https://github.com/MoffKalast/line_planner

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] These repositories have a LICENSE file
 - [x] These packages are expected to build on the submitted rosdistro
