### PR TITLE
ros2_controllers: 3.9.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4649,7 +4649,9 @@ repositories:
       version: master
     release:
       packages:
+      - ackermann_steering_controller
       - admittance_controller
+      - bicycle_steering_controller
       - diff_drive_controller
       - effort_controllers
       - force_torque_sensor_broadcaster
@@ -4662,12 +4664,14 @@ repositories:
       - ros2_controllers
       - ros2_controllers_test_nodes
       - rqt_joint_trajectory_controller
+      - steering_controllers_library
       - tricycle_controller
+      - tricycle_steering_controller
       - velocity_controllers
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 3.5.0-2
+      version: 3.9.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `3.9.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.5.0-2`

## ackermann_steering_controller

```
* Fix sphinx for steering odometry library/controllers (#626 <https://github.com/ros-controls/ros2_controllers/issues/626>)
* Steering odometry library and controllers (#484 <https://github.com/ros-controls/ros2_controllers/issues/484>)
* Contributors: Bence Magyar, Christoph Fröhlich, Tomislav Petković
```

## admittance_controller

```
* Use branch name substitution for all links (#618 <https://github.com/ros-controls/ros2_controllers/issues/618>)
* Fix github links on control.ros.org (#604 <https://github.com/ros-controls/ros2_controllers/issues/604>)
* Contributors: Christoph Fröhlich
```

## bicycle_steering_controller

```
* Fix sphinx for steering odometry library/controllers (#626 <https://github.com/ros-controls/ros2_controllers/issues/626>)
* Steering odometry library and controllers (#484 <https://github.com/ros-controls/ros2_controllers/issues/484>)
* Contributors: Bence Magyar, Christoph Fröhlich, Tomislav Petković
```

## diff_drive_controller

```
* Use generate_parameter_library for all params (#601 <https://github.com/ros-controls/ros2_controllers/issues/601>)
* Use branch name substitution for all links (#618 <https://github.com/ros-controls/ros2_controllers/issues/618>)
* Fix compilation warnings (#621 <https://github.com/ros-controls/ros2_controllers/issues/621>)
* Fix github links on control.ros.org (#604 <https://github.com/ros-controls/ros2_controllers/issues/604>)
* Contributors: Christoph Fröhlich, Noel Jiménez García, Mathias Lüdtke
```

## effort_controllers

```
* Use branch name substitution for all links (#618 <https://github.com/ros-controls/ros2_controllers/issues/618>)
* Fix github links on control.ros.org (#604 <https://github.com/ros-controls/ros2_controllers/issues/604>)
* Contributors: Christoph Fröhlich
```

## force_torque_sensor_broadcaster

```
* Use branch name substitution for all links (#618 <https://github.com/ros-controls/ros2_controllers/issues/618>)
* Fix github links on control.ros.org (#604 <https://github.com/ros-controls/ros2_controllers/issues/604>)
* Contributors: Christoph Fröhlich
```

## forward_command_controller

```
* Use branch name substitution for all links (#618 <https://github.com/ros-controls/ros2_controllers/issues/618>)
* Fix github links on control.ros.org (#604 <https://github.com/ros-controls/ros2_controllers/issues/604>)
* Contributors: Christoph Fröhlich
```

## gripper_controllers

```
* Fix compilation warnings (#621 <https://github.com/ros-controls/ros2_controllers/issues/621>)
* Contributors: Noel Jiménez García, Mathias Lüdtke
```

## imu_sensor_broadcaster

```
* Use branch name substitution for all links (#618 <https://github.com/ros-controls/ros2_controllers/issues/618>)
* Fix github links on control.ros.org (#604 <https://github.com/ros-controls/ros2_controllers/issues/604>)
* Contributors: Christoph Fröhlich
```

## joint_state_broadcaster

```
* Use branch name substitution for all links (#618 <https://github.com/ros-controls/ros2_controllers/issues/618>)
* [JTC] Fix deprecated header (#610 <https://github.com/ros-controls/ros2_controllers/issues/610>)
* Fix github links on control.ros.org (#604 <https://github.com/ros-controls/ros2_controllers/issues/604>)
* Contributors: Christoph Fröhlich
```

## joint_trajectory_controller

```
* Use branch name substitution for all links (#618 <https://github.com/ros-controls/ros2_controllers/issues/618>)
* [JTC] Fix deprecated header (#610 <https://github.com/ros-controls/ros2_controllers/issues/610>)
* Fix github links on control.ros.org (#604 <https://github.com/ros-controls/ros2_controllers/issues/604>)
* Contributors: Christoph Fröhlich
```

## position_controllers

```
* Use branch name substitution for all links (#618 <https://github.com/ros-controls/ros2_controllers/issues/618>)
* Fix github links on control.ros.org (#604 <https://github.com/ros-controls/ros2_controllers/issues/604>)
* Contributors: Christoph Fröhlich
```

## ros2_controllers

```
* Steering odometry library and controllers (#484 <https://github.com/ros-controls/ros2_controllers/issues/484>)
* Contributors: Tomislav Petković
```

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Fix sphinx for steering odometry library/controllers (#626 <https://github.com/ros-controls/ros2_controllers/issues/626>)
* Steering odometry library and controllers (#484 <https://github.com/ros-controls/ros2_controllers/issues/484>)
* Contributors: Bence Magyar, Christoph Fröhlich, Tomislav Petković
```

## tricycle_controller

```
* Use branch name substitution for all links (#618 <https://github.com/ros-controls/ros2_controllers/issues/618>)
* Fix github links on control.ros.org (#604 <https://github.com/ros-controls/ros2_controllers/issues/604>)
* Contributors: Christoph Fröhlich
```

## tricycle_steering_controller

```
* Fix sphinx for steering odometry library/controllers (#626 <https://github.com/ros-controls/ros2_controllers/issues/626>)
* Steering odometry library and controllers (#484 <https://github.com/ros-controls/ros2_controllers/issues/484>)
* Contributors: Bence Magyar, Christoph Fröhlich, Tomislav Petković
```

## velocity_controllers

```
* Use branch name substitution for all links (#618 <https://github.com/ros-controls/ros2_controllers/issues/618>)
* Fix github links on control.ros.org (#604 <https://github.com/ros-controls/ros2_controllers/issues/604>)
* Contributors: Christoph Fröhlich
```
