### PR TITLE
sensor_filters: 1.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13138,7 +13138,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ctu-vras/sensor_filters-release.git
-      version: 1.0.3-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ctu-vras/sensor_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sensor_filters` to `1.1.0-1`:

- upstream repository: https://github.com/ctu-vras/sensor_filters.git
- release repository: https://github.com/ctu-vras/sensor_filters-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.3-1`

## sensor_filters

```
* Using image_transport and point_cloud_transport where applicable.
* Noetic compatibility.
* Improved README and added example files.
  Closes #1 <https://github.com/ctu-vras/sensor_filters/issues/1>.
* Contributors: Martin Pecka
```
