### PR TITLE
visualization_rwt: 0.1.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11878,6 +11878,7 @@ repositories:
       version: kinetic-devel
     release:
       packages:
+      - rwt_app_chooser
       - rwt_image_view
       - rwt_nav
       - rwt_plot
@@ -11885,10 +11886,11 @@ repositories:
       - rwt_speech_recognition
       - rwt_steer
       - rwt_utils_3rdparty
+      - visualization_rwt
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tork-a/visualization_rwt-release.git
-      version: 0.1.1-2
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/tork-a/visualization_rwt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `visualization_rwt` to `0.1.2-1`:

- upstream repository: https://github.com/tork-a/visualization_rwt.git
- release repository: https://github.com/tork-a/visualization_rwt-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.1-2`

## rwt_app_chooser

```
* [rwt_app_chooser] support app args (#117 <https://github.com/tork-a/visualization_rwt//issues/117>)
  
    * It is introduced in https://github.com/PR2/app_manager/pull/27 and released as 1.3.0 on Nov, 8, 2021
  
* fix for noetic (#130 <https://github.com/tork-a/visualization_rwt//issues/130>)
  
    * fix test code for selenium version >= 4.3.0
  
* Fix typo in disconnect notification (#120 <https://github.com/tork-a/visualization_rwt//issues/120>)
* Contributors: Guilherme Affonso, Kei Okada, Koki Shinjo
```

## rwt_image_view

```
* Merge branch 'kinetic-devel' of https://github.com/tork-a/visualization_rwt into kinetic-devel
* fix for noetic (#130 <https://github.com/tork-a/visualization_rwt//issues/130>)
  
    * fix test code for selenium version >= 4.3.0
  
* [rwt_utils_3rdparty] update jquery from 1.8.3 to 1.12.4 (#124 <https://github.com/tork-a/visualization_rwt//issues/124>)
* [rwt_plot][rwt_image_view] use rwt_utils_3rdparty/www/jquery.min.js instead of rwt_utils_3rdparty/www/jquery/jquery.min.js
* Contributors: Kei Okada, Koki Shinjo
```

## rwt_nav

```
* fix for noetic (#130 <https://github.com/tork-a/visualization_rwt//issues/130>)
  
    * fix test code for selenium version >= 4.3.0
  
* move_base/goal requires frame_id, without starting '/' (#119 <https://github.com/tork-a/visualization_rwt//issues/119>)
  
    * Warning: Invalid argument /map passed to canTransform argument source_frame in tf2 frame_ids cannot start with a '/' like:
      at line 134 in /tmp/binarydeb/ros-melodic-tf2-0.6.5/src/buffer_core.cpp
      [ WARN] [1645522151.660224428, 19134.759000000]: Failed to transform the goal pose from /map into the map frame: Invalid argument /map passed to lookupTransform argument source_frame in tf2 frame_ids cannot start with a '/' like:
      [ERROR] [1645522151.660344650, 19134.759000000]: The goal pose passed to this planner must be in the map frame.  It is instead in the /map frame.
      Closes #118 <https://github.com/tork-a/visualization_rwt//issues/118>
  
* Contributors: Kei Okada
```

## rwt_plot

```
* fix for noetic (#130 <https://github.com/tork-a/visualization_rwt//issues/130>)
  
    * fix test code for selenium version >= 4.3.0
  
* [rwt_utils_3rdparty] update jquery from 1.8.3 to 1.12.4 (#124 <https://github.com/tork-a/visualization_rwt//issues/124>)
* [rwt_plot][rwt_image_view] use rwt_utils_3rdparty/www/jquery.min.js instead of rwt_utils_3rdparty/www/jquery/jquery.min.js
* Contributors: Kei Okada, Koki Shinjo
```

## rwt_robot_monitor

```
* fix for noetic (#130 <https://github.com/tork-a/visualization_rwt//issues/130>)
  
    * fix test code for selenium version >= 4.3.0
  
* Contributors: Kei Okada
```

## rwt_speech_recognition

```
* fix for noetic (#130 <https://github.com/tork-a/visualization_rwt//issues/130>)
  
    * fix test code for selenium version >= 4.3.0
  
* Contributors: Kei Okada
```

## rwt_steer

```
* fix for noetic (#130 <https://github.com/tork-a/visualization_rwt//issues/130>)
  
    * fix test code for selenium version >= 4.3.0
  
* Contributors: Kei Okada
```

## rwt_utils_3rdparty

```
* [rwt_utils_3rdparty] update jquery from 1.8.3 to 1.12.4 (#124 <https://github.com/tork-a/visualization_rwt//issues/124>)
* Contributors: Koki Shinjo
```

## visualization_rwt

- No changes
