### PR TITLE
adding include-what-you-use library to cygwin

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2179,6 +2179,7 @@ iputils-ping:
   nixos: [unixtools.ping]
   ubuntu: [iputils-ping]
 iwyu:
+  cygwin: [include-what-you-use]
   debian: [iwyu]
   nixos: [include-what-you-use]
   ubuntu: [iwyu]


### PR DESCRIPTION
add [include-what-you-use] in cygwin

<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

[include-what-you-use]

## Package Upstream Source:

https://github.com/include-what-you-use/include-what-you-use

## Purpose of using this:

TODO Replace. This dependency is being used for this reason. This is why I think it's valuable to be added to the rosdep database.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->