### PR TITLE
marti_common: 3.5.2-3 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2938,6 +2938,7 @@ repositories:
       version: dashing-devel
     release:
       packages:
+      - swri_cli_tools
       - swri_console_util
       - swri_dbw_interface
       - swri_geometry_util
@@ -2953,7 +2954,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/marti_common-release.git
-      version: 3.5.1-1
+      version: 3.5.2-3
     source:
       test_pull_requests: true
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2935,7 +2935,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/swri-robotics/marti_common.git
-      version: dashing-devel
+      version: ros2-devel
     release:
       packages:
       - swri_cli_tools
@@ -2959,7 +2959,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/swri-robotics/marti_common.git
-      version: dashing-devel
+      version: ros2-devel
     status: developed
   marti_messages:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `3.5.2-3`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/ros2-gbp/marti_common-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.5.1-1`

## swri_cli_tools

```
* Add CLI Tools to ROS 2 (#701 <https://github.com/danthony06/marti_common/issues/701>)
  * Add ability to document running system for either all nodes or a set of nodes.
* Contributors: David Anthony
```

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

- No changes

## swri_image_util

- No changes

## swri_math_util

- No changes

## swri_opencv_util

- No changes

## swri_prefix_tools

- No changes

## swri_roscpp

```
* Fix dependencies (#704 <https://github.com/danthony06/marti_common/issues/704>)
  * Fixing build process so dependencies are correctly exported.
* Contributors: David Anthony
```

## swri_route_util

- No changes

## swri_serial_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

```
* Fix dependencies (#704 <https://github.com/danthony06/marti_common/issues/704>)
  * Fixing build process so dependencies are correctly exported.
* Make timeout 0.1 seconds instead of 0 (#694 <https://github.com/danthony06/marti_common/issues/694>)
* Set origin (#696 <https://github.com/danthony06/marti_common/issues/696>)
  * Improved origin initialization
  ---------
  Co-authored-by: tcappellari <mailto:tiffany.cappellari@swri.org>
* Contributors: David Anthony, Tiffany Cappellari, Veronica Knisley
```
