### PR TITLE
mapviz: 2.2.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2908,7 +2908,7 @@ repositories:
       - tile_map
       tags:
         release: release/foxy/{package}/{version}
-      url: git@github.com:ros2-gbp/mapviz-release.git
+      url: https://github.com/ros2-gbp/mapviz-release.git
       version: 2.2.1-1
     source:
       test_pull_requests: true

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2908,8 +2908,8 @@ repositories:
       - tile_map
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/swri-robotics-gbp/mapviz-release.git
-      version: 2.1.0-1
+      url: git@github.com:ros2-gbp/mapviz-release.git
+      version: 2.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.2.1-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: git@github.com:ros2-gbp/mapviz-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.0-1`

## mapviz

```
* Updating maintainers list (#778 <https://github.com/swri-robotics/mapviz/issues/778>)
* Contributors: David Anthony
```

## mapviz_interfaces

```
* Updating maintainers list (#778 <https://github.com/swri-robotics/mapviz/issues/778>)
* Contributors: David Anthony
```

## mapviz_plugins

```
* Updating maintainers list (#778 <https://github.com/swri-robotics/mapviz/issues/778>)
* Fix Plan Route plugin in ROS2 Humble (#765 <https://github.com/swri-robotics/mapviz/issues/765>)
* Merge pull request #759 <https://github.com/swri-robotics/mapviz/issues/759> from agyoungs/fix-marker-plugin-subs
* Check topic for type to determine which subscription callback to trigger
* Contributors: Alex Youngs, David Anthony, P. J. Reed
```

## multires_image

```
* Updating maintainers list (#778 <https://github.com/swri-robotics/mapviz/issues/778>)
* Merge pull request #754 <https://github.com/swri-robotics/mapviz/issues/754> from cottsay/python3-shebang
* Use python3 in mapviz_tile_loader shebang
* Contributors: David Anthony, Scott K Logan
```

## tile_map

```
* Updating maintainers list (#778 <https://github.com/swri-robotics/mapviz/issues/778>)
* Contributors: David Anthony
```
