### PR TITLE
lsc_ros_driver: 1.0.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4930,7 +4930,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/AutonicsLiDAR-release/lsc_ros_driver-release.git
-      version: 1.0.2-2
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/AutonicsLiDAR/lsc_ros_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lsc_ros_driver` to `1.0.3-1`:

- upstream repository: https://github.com/AutonicsLiDAR/lsc_ros_driver.git
- release repository: https://github.com/AutonicsLiDAR-release/lsc_ros_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.2-2`

## lsc_ros_driver

```
* fixed #2 cpu usage issue
* add topic_name parameter
```
