### PR TITLE
clearpath_msg: 0.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -764,6 +764,24 @@ repositories:
       url: https://github.com/MetroRobots/classic_bags.git
       version: main
     status: developed
+  clearpath_msg:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_msgs.git
+      version: main
+    release:
+      packages:
+      - clearpath_msgs
+      - clearpath_platform_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/clearpath_msgs-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_msgs.git
+      version: main
+    status: developed
   color_names:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_msg` to `0.0.2-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_msgs.git
- release repository: https://github.com/clearpath-gbp/clearpath_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## clearpath_msgs

- No changes

## clearpath_platform_msgs

```
* [clearpath_platform_msgs] Fixed typo in Power msg enum.
* [clearpath_platform_msgs] Added size constants for A200 values.
* Contributors: Tony Baltovski
```
