### PR TITLE
neonavigation: 0.13.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6178,7 +6178,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.12.2-1
+      version: 0.13.0-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.13.0-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.12.2-1`

## costmap_cspace

```
* costmap_cspace: export costmap_3d_layers library (#691 <https://github.com/at-wat/neonavigation/issues/691>)
* costmap_cspace: install all headers (#690 <https://github.com/at-wat/neonavigation/issues/690>)
* costmap_cspace: added update_chain_entry bool arguement to processMapOverlay function (#689 <https://github.com/at-wat/neonavigation/issues/689>)
* costmap_cspace: add costmap_3d_layers library (#688 <https://github.com/at-wat/neonavigation/issues/688>)
* Contributors: ゆうちゃん
```

## joystick_interrupt

- No changes

## map_organizer

- No changes

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

```
* neonavigation_launch: revert unintended change to demo config (#699 <https://github.com/at-wat/neonavigation/issues/699>)
* planner_cspace: fix fast map update (#692 <https://github.com/at-wat/neonavigation/issues/692>)
* Contributors: Atsushi Watanabe
```

## obj_to_pointcloud

- No changes

## planner_cspace

```
* planner_cspace: fix fast map update (#692 <https://github.com/at-wat/neonavigation/issues/692>)
* planner_cspace: fix status when goal or robot is in rock on updating goal (#694 <https://github.com/at-wat/neonavigation/issues/694>)
* planner_cspace: fix string template constexpr in test (#685 <https://github.com/at-wat/neonavigation/issues/685>)
* Contributors: Atsushi Watanabe
```

## safety_limiter

- No changes

## track_odometry

- No changes

## trajectory_tracker

- No changes
