### PR TITLE
rosbag2: 0.3.11-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5705,7 +5705,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.3.10-1
+      version: 0.3.11-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.3.11-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.10-1`

## bag_recorder_nodes

- No changes

## ros2bag

```
* [backport foxy] Add QoS decoding translation for infinite durations to RMW_DURATION_INFINITE (backport #684 <https://github.com/ros2/rosbag2/issues/684>) (#1088 <https://github.com/ros2/rosbag2/issues/1088>)
* [foxy] Disable test_record_qos_profiles tests on Windows (#1349 <https://github.com/ros2/rosbag2/issues/1349>)
* Contributors: Emerson Knapp, Michael Orlov
```

## rosbag2

- No changes

## rosbag2_compression

- No changes

## rosbag2_converter_default_plugins

- No changes

## rosbag2_cpp

- No changes

## rosbag2_storage

```
* [foxy] Fix YAML_CPP_DLL warnings on Windows (#1353 <https://github.com/ros2/rosbag2/issues/1353>)
* Contributors: Emerson Knapp
```

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

```
* [foxy] Fix YAML_CPP_DLL warnings on Windows (#1353 <https://github.com/ros2/rosbag2/issues/1353>)
* [backport foxy] Add QoS decoding translation for infinite durations to RMW_DURATION_INFINITE (backport #684 <https://github.com/ros2/rosbag2/issues/684>) (#1088 <https://github.com/ros2/rosbag2/issues/1088>)
* Copy recorder QoS profile to local variable so that temporary value isn't cleared (#803 <https://github.com/ros2/rosbag2/issues/803>) (#1335 <https://github.com/ros2/rosbag2/issues/1335>)
* Contributors: Emerson Knapp, Michael Orlov
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

```
* Revert "[Foxy] rosbag2_storage_mcap: merge into rosbag2 repo (backport #1163 <https://github.com/ros2/rosbag2/issues/1163>) (#1198 <https://github.com/ros2/rosbag2/issues/1198>)" (#1347 <https://github.com/ros2/rosbag2/issues/1347>)
* [Foxy] rosbag2_storage_mcap: merge into rosbag2 repo (backport #1163 <https://github.com/ros2/rosbag2/issues/1163>) (#1198 <https://github.com/ros2/rosbag2/issues/1198>)
* Contributors: james-rms, Michael Orlov
```
