### PR TITLE
visualization_rwt: 0.1.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11902,7 +11902,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tork-a/visualization_rwt-release.git
-      version: 0.1.2-1
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/tork-a/visualization_rwt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `visualization_rwt` to `0.1.3-1`:

- upstream repository: https://github.com/tork-a/visualization_rwt.git
- release repository: https://github.com/tork-a/visualization_rwt-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.2-1`

## rwt_app_chooser

```
* add missing test_depends (#131 <https://github.com/tork-a/visualization_rwt//issues/131>)
  fixes https://build.ros.org/job/Nbin_uF64__rwt_app_chooser__ubuntu_focal_amd64__binary/1/console
  ```
  13:43:55 -- Using Python nosetests: /usr/bin/nosetests3
  13:43:55 -- catkin 0.8.10
  13:43:55 -- BUILD_SHARED_LIBS is on
  13:43:55 -- Could NOT find roslaunch (missing: roslaunch_DIR)
  13:43:55 -- Could not find the required component 'roslaunch'. The following CMake error indicates that you either need to install the package with the same name or change your environment so that it can be found.
  13:43:55 CMake Error at /opt/ros/noetic/share/catkin/cmake/catkinConfig.cmake:83 (find_package):
  13:43:55   Could not find a package configuration file provided by "roslaunch" with
  13:43:55   any of the following names:
  13:43:55
  13:43:55     roslaunchConfig.cmake
  13:43:55     roslaunch-config.cmake
  13:43:55
  13:43:55   Add the installation prefix of "roslaunch" to CMAKE_PREFIX_PATH or set
  13:43:55   "roslaunch_DIR" to a directory containing one of the above files.  If
  13:43:55   "roslaunch" provides a separate development package or SDK, be sure it has
  13:43:55   been installed.
  13:43:55 Call Stack (most recent call first):
  13:43:55   CMakeLists.txt:13 (find_package)
  13:43:55
  13:43:55
  13:43:55 -- Configuring incomplete, errors occurred!
  13:43:55 See also "/tmp/binarydeb/ros-noetic-rwt-app-chooser-0.1
  ```
* Contributors: Kei Okada
```

## rwt_image_view

```
* add missing test_depends (#131 <https://github.com/tork-a/visualization_rwt//issues/131>)
  fixes https://build.ros.org/job/Nbin_uF64__rwt_app_chooser__ubuntu_focal_amd64__binary/1/console
  ```
  13:43:55 -- Using Python nosetests: /usr/bin/nosetests3
  13:43:55 -- catkin 0.8.10
  13:43:55 -- BUILD_SHARED_LIBS is on
  13:43:55 -- Could NOT find roslaunch (missing: roslaunch_DIR)
  13:43:55 -- Could not find the required component 'roslaunch'. The following CMake error indicates that you either need to install the package with the same name or change your environment so that it can be found.
  13:43:55 CMake Error at /opt/ros/noetic/share/catkin/cmake/catkinConfig.cmake:83 (find_package):
  13:43:55   Could not find a package configuration file provided by "roslaunch" with
  13:43:55   any of the following names:
  13:43:55
  13:43:55     roslaunchConfig.cmake
  13:43:55     roslaunch-config.cmake
  13:43:55
  13:43:55   Add the installation prefix of "roslaunch" to CMAKE_PREFIX_PATH or set
  13:43:55   "roslaunch_DIR" to a directory containing one of the above files.  If
  13:43:55   "roslaunch" provides a separate development package or SDK, be sure it has
  13:43:55   been installed.
  13:43:55 Call Stack (most recent call first):
  13:43:55   CMakeLists.txt:13 (find_package)
  13:43:55
  13:43:55
  13:43:55 -- Configuring incomplete, errors occurred!
  13:43:55 See also "/tmp/binarydeb/ros-noetic-rwt-app-chooser-0.1
  ```
* Contributors: Kei Okada
```

## rwt_nav

```
* add missing test_depends (#131 <https://github.com/tork-a/visualization_rwt//issues/131>)
  fixes https://build.ros.org/job/Nbin_uF64__rwt_app_chooser__ubuntu_focal_amd64__binary/1/console
  ```
  13:43:55 -- Using Python nosetests: /usr/bin/nosetests3
  13:43:55 -- catkin 0.8.10
  13:43:55 -- BUILD_SHARED_LIBS is on
  13:43:55 -- Could NOT find roslaunch (missing: roslaunch_DIR)
  13:43:55 -- Could not find the required component 'roslaunch'. The following CMake error indicates that you either need to install the package with the same name or change your environment so that it can be found.
  13:43:55 CMake Error at /opt/ros/noetic/share/catkin/cmake/catkinConfig.cmake:83 (find_package):
  13:43:55   Could not find a package configuration file provided by "roslaunch" with
  13:43:55   any of the following names:
  13:43:55
  13:43:55     roslaunchConfig.cmake
  13:43:55     roslaunch-config.cmake
  13:43:55
  13:43:55   Add the installation prefix of "roslaunch" to CMAKE_PREFIX_PATH or set
  13:43:55   "roslaunch_DIR" to a directory containing one of the above files.  If
  13:43:55   "roslaunch" provides a separate development package or SDK, be sure it has
  13:43:55   been installed.
  13:43:55 Call Stack (most recent call first):
  13:43:55   CMakeLists.txt:13 (find_package)
  13:43:55
  13:43:55
  13:43:55 -- Configuring incomplete, errors occurred!
  13:43:55 See also "/tmp/binarydeb/ros-noetic-rwt-app-chooser-0.1
  ```
* Contributors: Kei Okada
```

## rwt_plot

```
* add missing test_depends (#131 <https://github.com/tork-a/visualization_rwt//issues/131>)
  fixes https://build.ros.org/job/Nbin_uF64__rwt_app_chooser__ubuntu_focal_amd64__binary/1/console
  ```
  13:43:55 -- Using Python nosetests: /usr/bin/nosetests3
  13:43:55 -- catkin 0.8.10
  13:43:55 -- BUILD_SHARED_LIBS is on
  13:43:55 -- Could NOT find roslaunch (missing: roslaunch_DIR)
  13:43:55 -- Could not find the required component 'roslaunch'. The following CMake error indicates that you either need to install the package with the same name or change your environment so that it can be found.
  13:43:55 CMake Error at /opt/ros/noetic/share/catkin/cmake/catkinConfig.cmake:83 (find_package):
  13:43:55   Could not find a package configuration file provided by "roslaunch" with
  13:43:55   any of the following names:
  13:43:55
  13:43:55     roslaunchConfig.cmake
  13:43:55     roslaunch-config.cmake
  13:43:55
  13:43:55   Add the installation prefix of "roslaunch" to CMAKE_PREFIX_PATH or set
  13:43:55   "roslaunch_DIR" to a directory containing one of the above files.  If
  13:43:55   "roslaunch" provides a separate development package or SDK, be sure it has
  13:43:55   been installed.
  13:43:55 Call Stack (most recent call first):
  13:43:55   CMakeLists.txt:13 (find_package)
  13:43:55
  13:43:55
  13:43:55 -- Configuring incomplete, errors occurred!
  13:43:55 See also "/tmp/binarydeb/ros-noetic-rwt-app-chooser-0.1
  ```
* Contributors: Kei Okada
```

## rwt_robot_monitor

```
* add missing test_depends (#131 <https://github.com/tork-a/visualization_rwt//issues/131>)
  fixes https://build.ros.org/job/Nbin_uF64__rwt_app_chooser__ubuntu_focal_amd64__binary/1/console
  ```
  13:43:55 -- Using Python nosetests: /usr/bin/nosetests3
  13:43:55 -- catkin 0.8.10
  13:43:55 -- BUILD_SHARED_LIBS is on
  13:43:55 -- Could NOT find roslaunch (missing: roslaunch_DIR)
  13:43:55 -- Could not find the required component 'roslaunch'. The following CMake error indicates that you either need to install the package with the same name or change your environment so that it can be found.
  13:43:55 CMake Error at /opt/ros/noetic/share/catkin/cmake/catkinConfig.cmake:83 (find_package):
  13:43:55   Could not find a package configuration file provided by "roslaunch" with
  13:43:55   any of the following names:
  13:43:55
  13:43:55     roslaunchConfig.cmake
  13:43:55     roslaunch-config.cmake
  13:43:55
  13:43:55   Add the installation prefix of "roslaunch" to CMAKE_PREFIX_PATH or set
  13:43:55   "roslaunch_DIR" to a directory containing one of the above files.  If
  13:43:55   "roslaunch" provides a separate development package or SDK, be sure it has
  13:43:55   been installed.
  13:43:55 Call Stack (most recent call first):
  13:43:55   CMakeLists.txt:13 (find_package)
  13:43:55
  13:43:55
  13:43:55 -- Configuring incomplete, errors occurred!
  13:43:55 See also "/tmp/binarydeb/ros-noetic-rwt-app-chooser-0.1
  ```
* Contributors: Kei Okada
```

## rwt_speech_recognition

- No changes

## rwt_steer

```
* add missing test_depends (#131 <https://github.com/tork-a/visualization_rwt//issues/131>)
  fixes https://build.ros.org/job/Nbin_uF64__rwt_app_chooser__ubuntu_focal_amd64__binary/1/console
  ```
  13:43:55 -- Using Python nosetests: /usr/bin/nosetests3
  13:43:55 -- catkin 0.8.10
  13:43:55 -- BUILD_SHARED_LIBS is on
  13:43:55 -- Could NOT find roslaunch (missing: roslaunch_DIR)
  13:43:55 -- Could not find the required component 'roslaunch'. The following CMake error indicates that you either need to install the package with the same name or change your environment so that it can be found.
  13:43:55 CMake Error at /opt/ros/noetic/share/catkin/cmake/catkinConfig.cmake:83 (find_package):
  13:43:55   Could not find a package configuration file provided by "roslaunch" with
  13:43:55   any of the following names:
  13:43:55
  13:43:55     roslaunchConfig.cmake
  13:43:55     roslaunch-config.cmake
  13:43:55
  13:43:55   Add the installation prefix of "roslaunch" to CMAKE_PREFIX_PATH or set
  13:43:55   "roslaunch_DIR" to a directory containing one of the above files.  If
  13:43:55   "roslaunch" provides a separate development package or SDK, be sure it has
  13:43:55   been installed.
  13:43:55 Call Stack (most recent call first):
  13:43:55   CMakeLists.txt:13 (find_package)
  13:43:55
  13:43:55
  13:43:55 -- Configuring incomplete, errors occurred!
  13:43:55 See also "/tmp/binarydeb/ros-noetic-rwt-app-chooser-0.1
  ```
* Contributors: Kei Okada
```

## rwt_utils_3rdparty

- No changes

## visualization_rwt

- No changes
