### PR TITLE
ament_cmake_catch2: 1.2.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -192,7 +192,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake_catch2-release.git
-      version: 1.2.0-3
+      version: 1.2.1-1
     source:
       type: git
       url: https://github.com/open-rmf/ament_cmake_catch2.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -187,7 +187,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/ament_cmake_catch2.git
-      version: rolling
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -196,7 +196,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/ament_cmake_catch2.git
-      version: rolling
+      version: humble
     status: developed
   ament_cmake_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake_catch2` to `1.2.1-1`:

- upstream repository: https://github.com/open-rmf/ament_cmake_catch2.git
- release repository: https://github.com/ros2-gbp/ament_cmake_catch2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.0-3`

## ament_cmake_catch2

- No changes
