### PR TITLE
menge_vendor: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2874,7 +2874,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/menge_vendor.git
-      version: rolling
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -2883,7 +2883,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/menge_vendor.git
-      version: rolling
+      version: humble
     status: developed
   message_filters:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2879,7 +2879,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/menge_vendor-release.git
-      version: 1.0.0-4
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/open-rmf/menge_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `menge_vendor` to `1.0.1-1`:

- upstream repository: https://github.com/open-rmf/menge_vendor.git
- release repository: https://github.com/ros2-gbp/menge_vendor-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-4`

## menge_vendor

- No changes
