### PR TITLE
magic_enum: 0.9.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5015,7 +5015,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/nobleo/magic_enum-release.git
-      version: 0.9.0-1
+      version: 0.9.1-1
     source:
       type: git
       url: https://github.com/Neargye/magic_enum.git


### PR DESCRIPTION
Increasing version of package(s) in repository `magic_enum` to `0.9.1-1`:

- upstream repository: https://github.com/Neargye/magic_enum.git
- release repository: https://github.com/nobleo/magic_enum-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.9.0-1`
