### PR TITLE
pybind11_json_vendor: 0.2.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4209,7 +4209,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/pybind11_json_vendor.git
-      version: main
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -4218,7 +4218,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/pybind11_json_vendor.git
-      version: main
+      version: humble
     status: developed
   pybind11_vendor:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4214,7 +4214,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pybind11_json_vendor-release.git
-      version: 0.2.2-1
+      version: 0.2.3-1
     source:
       type: git
       url: https://github.com/open-rmf/pybind11_json_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pybind11_json_vendor` to `0.2.3-1`:

- upstream repository: https://github.com/open-rmf/pybind11_json_vendor
- release repository: https://github.com/ros2-gbp/pybind11_json_vendor-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.2-1`

## pybind11_json_vendor

```
* Update maintainer
* Switch CHANGELOG to rst format.
* Contributors: Yadunund
```
