### PR TITLE
rmf_api_msgs: 0.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4752,7 +4752,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_api_msgs.git
-      version: main
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4757,7 +4757,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_api_msgs-release.git
-      version: 0.0.1-1
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_api_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_api_msgs` to `0.0.2-1`:

- upstream repository: https://github.com/open-rmf/rmf_api_msgs
- release repository: https://github.com/ros2-gbp/rmf_api_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.1-1`

## rmf_api_msgs

```
* Update maintainer.
* Switch CHANGELOG to rst format.
* Fix typo in title of fleet_log.json (#26 <https://github.com/open-rmf/rmf_api_msgs/pull/26>)
* Contributors: Teo Koon Peng, Yadunund
```
