### PR TITLE
rmf_battery: 0.1.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4772,7 +4772,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_battery-release.git
-      version: 0.1.3-2
+      version: 0.1.5-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_battery.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4767,7 +4767,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_battery.git
-      version: main
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -4776,7 +4776,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_battery.git
-      version: main
+      version: humble
     status: developed
   rmf_building_map_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_battery` to `0.1.5-1`:

- upstream repository: https://github.com/open-rmf/rmf_battery.git
- release repository: https://github.com/ros2-gbp/rmf_battery-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.3-2`

## rmf_battery

- No changes
