### PR TITLE
rmf_building_map_msgs: 1.2.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4782,7 +4782,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_building_map_msgs.git
-      version: rolling
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -4791,7 +4791,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_building_map_msgs.git
-      version: rolling
+      version: humble
     status: developed
   rmf_cmake_uncrustify:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4787,7 +4787,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_building_map_msgs-release.git
-      version: 1.2.0-6
+      version: 1.2.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_building_map_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_building_map_msgs` to `1.2.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_building_map_msgs
- release repository: https://github.com/ros2-gbp/rmf_building_map_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.0-6`

## rmf_building_map_msgs

```

```
