### PR TITLE
sick_safetyscanners: 1.0.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10471,7 +10471,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/SICKAG/sick_safetyscanners-release.git
-      version: 1.0.8-1
+      version: 1.0.9-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_safetyscanners.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safetyscanners` to `1.0.9-1`:

- upstream repository: https://github.com/SICKAG/sick_safetyscanners.git
- release repository: https://github.com/SICKAG/sick_safetyscanners-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.8-1`

## sick_safetyscanners

```
* added StatusOverview service
* added ConfigMetadata service
* add application and contamination errors to diagnostics
* add checksums to diagnostics
* add firmware version to diagnostics
* Add missing map include.
* adjusted readme for multicast and interface IP
* adjusted launch file for interface IP
* allowing to define multicast IPs from ROS
* added .hpp to install directive in CMakeList
* Contributors: Christian Wurm, Ivor Wanders, Lennart Puck, Rein Appeldoorn, Tom de Winter, Yannick de Hoop
```
