### PR TITLE
ur_description: 2.1.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6493,7 +6493,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
-      version: ros2
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -6502,7 +6502,7 @@ repositories:
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
-      version: ros2
+      version: rolling
     status: developed
   ur_msgs:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6498,7 +6498,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.0.1-2
+      version: 2.1.0-2
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.1.0-2`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.1-2`

## ur_description

```
* added missing handback interface - ros2control mock interface won't work otherwise (#68 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/68>)
  Co-authored-by: Lennart Nachtigall <mailto:lennart.nachtigall@sci-mo.de>
* remove ticks from tf_prefix (#60 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/60>)
  Co-authored-by: Lennart Nachtigall <mailto:lennart.nachtigall@sci-mo.de>
* Replace duplicated ``prefix`` parameter with ``tf_prefix``
* Whitespace fixes
* Update pre-commit workflows to current versions
* This commits adds additional configuration fields which are needed for multiarm support: (#47 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/47>)
  - Added trajectory_port        - Port needed for the trajectory sending interface
  - Added non_blocking_read      - Takes control of the update rate from ur interface by immediately returning from the read method
  - Added keep_alive_count field - Configures the amount of allowed reading timeouts on the robot side
  Additionally it adds the ${prefix} argument for the gpios and the force torque sensor in the ur.ros2_control.xacro file
  Co-authored-by: Lennart Nachtigall <mailto:firesurfer@firesurfer.de>
* Set the default tool voltage in the description to 0 (#41 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/41>)
  I am not sure whether this will actually affect something, as I don't think
  we actually set the value initially, but it still makes sense to keep the
  default tool voltage at 0 to emphasize that by default, this will not be
  set higher.
* Run prerelease tests on current distros (#44 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/44>)
* Contributors: Felix Exner, Felix Exner (fexner), Lennart Nachtigall
```
