### PR TITLE
rmf_internal_msgs: 3.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4840,7 +4840,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
-      version: 3.0.2-1
+      version: 3.0.3-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_internal_msgs.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4822,7 +4822,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_internal_msgs.git
-      version: main
+      version: humble
     release:
       packages:
       - rmf_charger_msgs
@@ -4844,7 +4844,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_internal_msgs.git
-      version: main
+      version: humble
     status: developed
   rmf_ros2:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_internal_msgs` to `3.0.3-1`:

- upstream repository: https://github.com/open-rmf/rmf_internal_msgs.git
- release repository: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.2-1`

## rmf_charger_msgs

```
* Version updates from latest release synced to main (#54 <https://github.com/open-rmf/rmf_internal_msgs/pull/54>)
* Contributors: Esteban Martinena Guerrero
```

## rmf_dispenser_msgs

```
* Version updates from latest release synced to main (#54 <https://github.com/open-rmf/rmf_internal_msgs/pull/54>)
* Contributors: Esteban Martinena Guerrero
```

## rmf_door_msgs

```
* Version updates from latest release synced to main (#54 <https://github.com/open-rmf/rmf_internal_msgs/pull/54>)
* Contributors: Esteban Martinena Guerrero
```

## rmf_fleet_msgs

```
* Version updates from latest release synced to main (#54 <https://github.com/open-rmf/rmf_internal_msgs/pull/54>)
* Contributors: Esteban Martinena Guerrero
```

## rmf_ingestor_msgs

```
* Version updates from latest release synced to main (#54 <https://github.com/open-rmf/rmf_internal_msgs/pull/54>)
* Contributors: Esteban Martinena Guerrero
```

## rmf_lift_msgs

```
* Version updates from latest release synced to main (#54 <https://github.com/open-rmf/rmf_internal_msgs/pull/54>)
* Contributors: Esteban Martinena Guerrero
```

## rmf_obstacle_msgs

```
* Version updates from latest release synced to main (#54 <https://github.com/open-rmf/rmf_internal_msgs/pull/54>)
* Contributors: Esteban Martinena Guerrero
```

## rmf_scheduler_msgs

```
* Version updates from latest release synced to main (#54 <https://github.com/open-rmf/rmf_internal_msgs/pull/54>)
* Contributors: Esteban Martinena Guerrero
```

## rmf_site_map_msgs

```
* Version updates from latest release synced to main (#54 <https://github.com/open-rmf/rmf_internal_msgs/pull/54>)
* Contributors: Esteban Martinena Guerrero
```

## rmf_task_msgs

```
* Version updates from latest release synced to main (#54 <https://github.com/open-rmf/rmf_internal_msgs/pull/54>)
* Contributors: Esteban Martinena Guerrero
```

## rmf_traffic_msgs

```
* Version updates from latest release synced to main (#54 <https://github.com/open-rmf/rmf_internal_msgs/pull/54>)
* Contributors: Esteban Martinena Guerrero
```

## rmf_workcell_msgs

```
* Version updates from latest release synced to main (#54 <https://github.com/open-rmf/rmf_internal_msgs/pull/54>)
* Contributors: Esteban Martinena Guerrero
```
