### PR TITLE
rmf_ros2: 2.1.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4861,7 +4861,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 2.1.5-1
+      version: 2.1.6-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_ros2` to `2.1.6-1`:

- upstream repository: https://github.com/open-rmf/rmf_ros2.git
- release repository: https://github.com/ros2-gbp/rmf_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.5-1`

## rmf_fleet_adapter

```
* Fix race condition related to the ``finished`` callback of ``perform_action`` events: (#273 <https://github.com/open-rmf/rmf_ros2/pull/273>)
* Switch to rst changelogs (#276 <https://github.com/open-rmf/rmf_ros2/pull/276>)
* Contributors: Grey, Yadunund
```

## rmf_fleet_adapter_python

```
* Switch to rst changelogs (#276 <https://github.com/open-rmf/rmf_ros2/pull/276>)
* Contributors: Yadunund
```

## rmf_task_ros2

```
* Switch to rst changelogs (#276 <https://github.com/open-rmf/rmf_ros2/pull/276>)
* Contributors: Yadunund
```

## rmf_traffic_ros2

```
* Switch to rst changelogs (#276 <https://github.com/open-rmf/rmf_ros2/pull/276>)
* Contributors: Yadunund
```

## rmf_websocket

```
* Switch to rst changelogs (#276 <https://github.com/open-rmf/rmf_ros2/pull/276>)
* Contributors: Yadunund
```
