### PR TITLE
rmf_simulation: 2.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4883,7 +4883,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_simulation-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_simulation.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4871,7 +4871,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_simulation.git
-      version: main
+      version: humble
     release:
       packages:
       - rmf_building_sim_common
@@ -4887,7 +4887,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_simulation.git
-      version: main
+      version: humble
     status: developed
   rmf_task:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_simulation` to `2.0.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_simulation.git
- release repository: https://github.com/ros2-gbp/rmf_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-1`

## rmf_building_sim_common

```
* Switch to rst changelogs (#101 <https://github.com/open-rmf/rmf_simulation/pull/101>)
* Don't print warning if lift is going to same floor (#89 <https://github.com/open-rmf/rmf_simulation/pull/89>)
* Contributors: Luca Della Vedova, Yadunund
```

## rmf_building_sim_gz_classic_plugins

```
* Switch to rst changelogs (#101 <https://github.com/open-rmf/rmf_simulation/pull/101>)
* Contributors: Yadunund
```

## rmf_building_sim_gz_plugins

```
* Switch to rst changelogs (#101 <https://github.com/open-rmf/rmf_simulation/pull/101>)
* Contributors: Yadunund
```

## rmf_robot_sim_common

```
* Switch to rst changelogs (#101 <https://github.com/open-rmf/rmf_simulation/pull/101>)
* Fix eigen not found when building rpm (#102 <https://github.com/open-rmf/rmf_simulation/pull/102>)
* Fix library linking (#97 <https://github.com/open-rmf/rmf_simulation/pull/97>)
* Contributors: Esteban Martinena Guerrero, Grey, Yadunund
```

## rmf_robot_sim_gz_classic_plugins

```
* Switch to rst changelogs (#101 <https://github.com/open-rmf/rmf_simulation/issues/101>)
* Contributors: Yadunund
```

## rmf_robot_sim_gz_plugins

```
* Switch to rst changelogs (#101 <https://github.com/open-rmf/rmf_simulation/issues/101>)
* Contributors: Yadunund
```
