### PR TITLE
ur_robot_driver: 2.3.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6527,7 +6527,6 @@ repositories:
     release:
       packages:
       - ur
-      - ur_bringup
       - ur_calibration
       - ur_controllers
       - ur_dashboard_msgs
@@ -6536,7 +6535,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.3.1-2
+      version: 2.3.2-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.3.2-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.1-2`

## ur

- No changes

## ur_calibration

```
* Fixed formatting (#685 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/685>)
  * Removed empty lines from python files
  * Fixed typo in changelogs
* Contributors: Felix Exner (fexner)
```

## ur_controllers

```
* added missing command interfaces into gpio controller (#693 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/693>)
* Fixed formatting (#685 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/685>)
  * Removed empty lines from python files
  * Fixed typo in changelogs
* Adding maximum retry counter in gpio controller (Multiarm part 3) - v2 (#672 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/672>)
* Ported controllers to generate_parameters library and added prefix for controllers (Multiarm part 2) (#594 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/594>)
* Switched out a deprecated header to avoid buildfarm warnings.
* Introduce hand back control service (#528 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/528>)
* Contributors: Felix Exner, Felix Exner (fexner), Lennart Nachtigall, livanov93
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* Fixed formatting (#685 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/685>)
  * Removed empty lines from python files
  * Fixed typo in changelogs
* Define default maximum accelerations for MoveIt (#645 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/645>)
* Contributors: Felix Exner (fexner), RobertWilbrandt
```

## ur_robot_driver

```
* Adds full nonblocking readout support (Multiarm part 4)  - v2 (#673 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/673>)
* Removed workaround also in export_command_interfaces (#692 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/692>)
* Calling on_deactivate in dtr (#679 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/679>)
* Fixed formatting (#685 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/685>)
* Remove tf_prefix workaround in hw interface
* Ported controllers to generate_parameters library and added prefix for controllers (Multiarm part 2) (#594 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/594>)
* Remove ur_bringup package (#666 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/666>)
* Introduce hand back control service (#528 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/528>)
* Apply suggestions from code review
* Update definition of test goals to new version.
* Wait longer for controllers to load and activate
* Fix flaky tests (#641 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/641>)
  * Move robot startup into test's setUp function
  * Robustify robot startup
* This commits adds additional configuration parameters needed for multiarm support.
* Add timeout to execution test
* Improve logging for robot execution tests
* Contributors: Denis Štogl, Dr. Denis, Felix Exner, Felix Exner (fexner), Lennart Nachtigall, Robert Wilbrandt, livanov93
```
