### PR TITLE
ur_robot_driver: 2.2.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7639,7 +7639,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.2.6-1
+      version: 2.2.7-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.2.7-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.6-1`

## ur

- No changes

## ur_bringup

```
* Default path to ur_client_library urscript (#316 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/316>) (#553 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/553>)
  * Change default path for urscript for headless mode.
  * Replace urscript path also in newer ur_robot_driver launchfile
* This commits adds additional configuration parameters needed for multiarm support.
* Contributors: Lennart Nachtigall, mergify[bot], livanov93
```

## ur_calibration

- No changes

## ur_controllers

```
* added missing command interfaces into gpio controller (#693 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/693>) (#702 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/702>)
* Adding maximum retry counter in gpio controller (Multiarm part 3) - v2 (#672 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/672>) (#696 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/696>)
* Ported controllers to generate_parameters library and added prefix for controllers (Multiarm part 2) (#594 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/594>) (#695 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/695>)
* Introduce hand back control service (#528 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/528>) (#670 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/670>)
* Added services to set tool voltage and zero force torque sensor (#466 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/466>) (#582 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/582>)
* Contributors: mergify[bot], Mads Holm Peters, Lennart Nachtigall, livanov93
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* Update linters & checkers (backport #426 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/426>) (#556 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/556>)
* Contributors: mergify[bot], Felix Exner
```

## ur_robot_driver

```
* Calling on_deactivate in dtr (#679 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/679>) (#704 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/704>)
* Adds full nonblocking readout support (Multiarm part 4)  - v2 (#673 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/673>) (#703 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/703>)
* Correct calibration correction launch file in doc (#590 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/590>)
* Introduce hand back control service (#528 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/528>) (#670 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/670>)
* Update definition of test goals to new version. (backport #637 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/637>) (#668 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/668>)
* Default path to ur_client_library urscript (#316 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/316>) (#553 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/553>)
  * Change default path for urscript for headless mode.
  * Replace urscript path also in newer ur_robot_driver launchfile
* Wait longer for controllers to load and activate
* Fix flaky tests (#641 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/641>)
* Added services to set tool voltage and zero force torque sensor (#466 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/466>) (#582 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/582>)
* Controller spawner timeout (backport #608 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/608>) (#609 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/609>)
* Fix cmake dependency on controller_manager (backport #598 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/598>) (#599 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/599>)
* Increase timeout for first test service call to driver (Backport of #605 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/605>) (#607 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/607>)
* Update linters & checkers (backport #426 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/426>) (#556 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/556>)
* Clean up & improve execution tests (Backport of #512 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/512>) (#552 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/552>)
* Contributors: Felix Exner (fexner), Lennart Nachtigall, Robert Wilbrandt, mergify[bot], Denis Stogl, livanov93, Mads Holm Peters
```
