### PR TITLE
Removed turtlesim key

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4838,6 +4838,8 @@ repositories:
       url: https://github.com/ros/ros_tutorials.git
       version: rolling
     release:
+      packages:
+      - turtlesim
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_tutorials-release.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4832,6 +4832,22 @@ repositories:
       url: https://github.com/ros2/ros_testing.git
       version: rolling
     status: maintained
+  ros_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_tutorials.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_tutorials-release.git
+      version: 1.7.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/ros_tutorials.git
+      version: rolling
+    status: maintained
   ros_workspace:
     release:
       tags:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6313,22 +6313,6 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
       version: ros2
     status: maintained
-  turtlesim:
-    doc:
-      type: git
-      url: https://github.com/ros/ros_tutorials.git
-      version: rolling
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/ros_tutorials-release.git
-      version: 1.7.1-1
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/ros/ros_tutorials.git
-      version: rolling
-    status: maintained
   tuw_geometry:
     doc:
       type: git


### PR DESCRIPTION
Removed `turtlesim` key. Related with the comment from @clalancette in this PR https://github.com/ros/ros_tutorials/pull/153. 

If I'm not wrong we should remove the key in rolling and then release the package with the right key, isn't it ?
