### PR TITLE
Add doc and source for mrpt_path_planning

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5865,6 +5865,15 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
       version: ros1
     status: developed
+  mrpt_path_planning:
+    doc:
+      type: git
+      url: https://github.com/MRPT/mrpt_path_planning.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/MRPT/mrpt_path_planning.git
+      version: develop
   mrpt_sensors:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2739,6 +2739,15 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
       version: ros2
     status: developed
+  mrpt_path_planning:
+    doc:
+      type: git
+      url: https://github.com/MRPT/mrpt_path_planning.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/MRPT/mrpt_path_planning.git
+      version: develop
   mrpt_sensors:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

- noetic
- rolling

# The source is here:

https://github.com/MRPT/mrpt_path_planning

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
