### PR TITLE
ros2_socketcan: 1.2.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4683,10 +4683,13 @@ repositories:
       url: https://github.com/autowarefoundation/ros2_socketcan.git
       version: main
     release:
+      packages:
+      - ros2_socketcan
+      - ros2_socketcan_msgs
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_socketcan-release.git
-      version: 1.1.0-4
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/ros2_socketcan.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_socketcan` to `1.2.0-1`:

- upstream repository: https://github.com/autowarefoundation/ros2_socketcan.git
- release repository: https://github.com/ros2-gbp/ros2_socketcan-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-4`

## ros2_socketcan

```
* Add CAN FD Support (#28 <https://github.com/autowarefoundation/ros2_socketcan/issues/28>)
  * Add FD support to ROS2 interface.
  * Add FD send/receive.
  * Missed some fields in Frame msg.
  * Make standard and FD mutually exclusive.
  * Enable runtime checks for standard vs FD.
  * Try to minimize API changes.
  * Fix receive_id/fd_receive_id mix-up.
  * Make new message FD-specific.
  * Use FdFrame message.
  * Remove unused functions.
  * Always resize fd frame buffer to 64 before receive.
  * Add enable_can_fd to socket_can_bridge.launch.xml.
  ---------
* SocketCAN filters (#25 <https://github.com/autowarefoundation/ros2_socketcan/issues/25>)
  * SocketCAN filters
  Filters can be set using launch parameter.
  A list of pairs (can id and mask) are fetched and applied to
  socket filter.
  Added unit test for filters application and fuctionality.
  * Full support of SocketCAN filters
  SocketCAN filters can be now
  with string description used
  by candump utility.
  Added support for error masks
  and joined CAN filters.
  Instead of list of integers, receiver
  node now uses string parameter
  in order to receive filters. Filters will
  now be parsed and setup during
  configuration.
  Added unit test for parsing and
  updated filters unit test.
  * Reference to man-pages docs of filters syntax
  Added links referencing man-pages docs for candump,
  containing more information about socketcan filters
  syntax used. Links were added to doxygen documentation
  of filters parsing method and to launch argument
  description.
* Fix unit conversion bug in to_timeval() (#24 <https://github.com/autowarefoundation/ros2_socketcan/issues/24>)
* Reorganize folders for adding ros2_socketcan_msgs (#23 <https://github.com/autowarefoundation/ros2_socketcan/issues/23>)
  Reorganize folders to permit adding a msgs package.
* Contributors: Joshua Whitley, Marcel Dudek, ljuricic
```

## ros2_socketcan_msgs

```
* Add CAN FD Support (#28 <https://github.com/autowarefoundation/ros2_socketcan/issues/28>)
  * Add FD support to ROS2 interface.
  * Add FD send/receive.
  * Missed some fields in Frame msg.
  * Make standard and FD mutually exclusive.
  * Enable runtime checks for standard vs FD.
  * Try to minimize API changes.
  * Fix receive_id/fd_receive_id mix-up.
  * Make new message FD-specific.
  * Use FdFrame message.
  * Remove unused functions.
  * Always resize fd frame buffer to 64 before receive.
  * Add enable_can_fd to socket_can_bridge.launch.xml.
  ---------
* Adding ros2_socketcan_msgs (#26 <https://github.com/autowarefoundation/ros2_socketcan/issues/26>)
* Contributors: Joshua Whitley
* Add CAN FD Support (#28 <https://github.com/autowarefoundation/ros2_socketcan/issues/28>)
  * Add FD support to ROS2 interface.
  * Add FD send/receive.
  * Missed some fields in Frame msg.
  * Make standard and FD mutually exclusive.
  * Enable runtime checks for standard vs FD.
  * Try to minimize API changes.
  * Fix receive_id/fd_receive_id mix-up.
  * Make new message FD-specific.
  * Use FdFrame message.
  * Remove unused functions.
  * Always resize fd frame buffer to 64 before receive.
  * Add enable_can_fd to socket_can_bridge.launch.xml.
  ---------
* Adding ros2_socketcan_msgs (#26 <https://github.com/autowarefoundation/ros2_socketcan/issues/26>)
* Contributors: Joshua Whitley
```
