### PR TITLE
rmf_traffic: 3.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4911,7 +4911,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_traffic.git
-      version: main
+      version: humble
     release:
       packages:
       - rmf_traffic
@@ -4923,7 +4923,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic.git
-      version: main
+      version: humble
     status: developed
   rmf_traffic_editor:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4919,7 +4919,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic-release.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_traffic` to `3.0.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_traffic.git
- release repository: https://github.com/ros2-gbp/rmf_traffic-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.0-1`

## rmf_traffic

```
* Switch to rst changelogs
* Fix multi floor anomaly (#97 <https://github.com/open-rmf/rmf_traffic/issues/97>)
* Fix end_versions initialization capacity error in ``NegotiatingRouteValidator::Generator::all()`` function (#58 <https://github.com/open-rmf/rmf_traffic/issues/58>)
* Contributors: 0to1, Grey, Yadunund
```

## rmf_traffic_examples

```
* Switch to rst changelogs
* Contributors: Yadunund
```
