### PR TITLE
rmf_traffic_editor: 1.6.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4939,7 +4939,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
-      version: 1.6.0-1
+      version: 1.6.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic_editor.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4929,7 +4929,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_traffic_editor.git
-      version: main
+      version: humble
     release:
       packages:
       - rmf_building_map_tools
@@ -4943,7 +4943,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic_editor.git
-      version: main
+      version: humble
     status: developed
   rmf_utils:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_traffic_editor` to `1.6.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_traffic_editor.git
- release repository: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.6.0-1`

## rmf_building_map_tools

```
* Switch changelogs to rst format.
* Add texture for a white wall (#463 <https://github.com/open-rmf/rmf_traffic_editor/pull/463>)
* Fix navgraph generation for connected docking waypoints (#452 <https://github.com/open-rmf/rmf_traffic_editor/pull/452>)
* Added 5 retries for model downloading failure (#455 <https://github.com/open-rmf/rmf_traffic_editor/pull/455>)
* Migrate to using gzsim server url for fuel (#454 <https://github.com/open-rmf/rmf_traffic_editor/pull/454>)
* Exiting model downloader with non-zero exit code (#453 <https://github.com/open-rmf/rmf_traffic_editor/pull/453>)
* Contributors: Aaron Chong, Esteban Martinena Guerrero, Luca Della Vedova, Yadu, Yadunund
```

## rmf_traffic_editor

```
* Switch changelogs to rst format.
* Contributors: Yadunund
```

## rmf_traffic_editor_assets

```
* Switch changelogs to rst format.
* Migrate to using gzsim server url for fuel (#454 <https://github.com/open-rmf/rmf_traffic_editor/pull/454>)
* Contributors: Aaron Chong, Yadunund
```

## rmf_traffic_editor_test_maps

```
* Switch changelogs to rst format.
* Fix test map generation with new commands (#456 <https://github.com/open-rmf/rmf_traffic_editor/pull/456>)
* Contributors: Aaron Chong, Yadunund
```
