### PR TITLE
rmf_utils: 1.4.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4954,7 +4954,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_utils-release.git
-      version: 1.4.0-2
+      version: 1.4.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_utils.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4949,7 +4949,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_utils.git
-      version: main
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -4958,7 +4958,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_utils.git
-      version: main
+      version: humble
     status: developed
   rmf_visualization:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_utils` to `1.4.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_utils.git
- release repository: https://github.com/ros2-gbp/rmf_utils-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.4.0-2`

## rmf_utils

```
* Switch to rst changelogs (#28 <https://github.com/open-rmf/rmf_utils/pull/28>)
* Reusable CI (#24 <https://github.com/open-rmf/rmf_utils/pull/24>)
* Contributors: Esteban Martinena Guerrero, Yadunund
```
