### PR TITLE
rmf_visualization: 2.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4978,7 +4978,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_visualization-release.git
-      version: 2.0.0-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_visualization.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4964,7 +4964,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_visualization.git
-      version: main
+      version: humble
     release:
       packages:
       - rmf_visualization
@@ -4982,7 +4982,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_visualization.git
-      version: main
+      version: humble
     status: developed
   rmf_visualization_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_visualization` to `2.0.2-1`:

- upstream repository: https://github.com/open-rmf/rmf_visualization.git
- release repository: https://github.com/ros2-gbp/rmf_visualization-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-1`

## rmf_visualization

```
* Port version bump and changes from main to humble
* Switch to rst changelogs (#57 <https://github.com/open-rmf/rmf_visualization/issues/57>)
* Contributors: Esteban Martinena, Grey, Yadunund
```

## rmf_visualization_building_systems

```
* Port version bump and changes from main to humble
* Switch to rst changelogs (#57 <https://github.com/open-rmf/rmf_visualization/issues/57>)
* Contributors: Esteban Martinena, Grey, Yadunund
```

## rmf_visualization_fleet_states

```
* Port version bump and changes from main to humble
* Switch to rst changelogs (#57 <https://github.com/open-rmf/rmf_visualization/issues/57>)
* Contributors: Esteban Martinena, Grey, Yadunund
```

## rmf_visualization_floorplans

```
* Port version bump and changes from main to humble
* Switch to rst changelogs (#57 <https://github.com/open-rmf/rmf_visualization/issues/57>)
* Contributors: Esteban Martinena, Grey, Yadunund
```

## rmf_visualization_navgraphs

```
* Port version bump and changes from main to humble
* Switch to rst changelogs (#57 <https://github.com/open-rmf/rmf_visualization/issues/57>)
* Contributors: Esteban Martinena, Grey, Yadunund
```

## rmf_visualization_obstacles

```
* Port version bump and changes from main to humble
* Switch to rst changelogs (#57 <https://github.com/open-rmf/rmf_visualization/issues/57>)
* Contributors: Esteban Martinena, Grey, Yadunund
```

## rmf_visualization_rviz2_plugins

```
* Port version bump and changes from main to humble
* Switch to rst changelogs (#57 <https://github.com/open-rmf/rmf_visualization/issues/57>)
* Contributors: Esteban Martinena, Grey, Yadunund
```

## rmf_visualization_schedule

```
* Port version bump and changes from main to humble
* Switch to rst changelogs (#57 <https://github.com/open-rmf/rmf_visualization/issues/57>)
* Contributors: Esteban Martinena, Grey, Yadunund
```
