### PR TITLE
ros_tutorials: 1.7.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4843,7 +4843,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_tutorials-release.git
-      version: 1.7.1-1
+      version: 1.7.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_tutorials` to `1.7.2-1`:

- upstream repository: https://github.com/ros/ros_tutorials.git
- release repository: https://github.com/ros2-gbp/ros_tutorials-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.7.1-1`

## turtlesim

```
* Added common tests (#154 <https://github.com/ros/ros_tutorials/issues/154>)
* Heavy cleanup of the draw_square tutorial. (#152 <https://github.com/ros/ros_tutorials/issues/152>)
  * Heavy cleanup of the draw_square tutorial.
  In particular:
  1. Make it conform to the current ROS 2 style.
  2. Add in copyright information.
  3. Refactor the entire code into a class, which tidies it
  up quite a bit and removes a bunch of globals.
  4. Make sure to wait for the reset to complete before trying
  to move the turtle.
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```
