### PR TITLE
Revert "mavlink: 2023.5.5-1 in 'melodic/distribution.yaml' [bloom] (#…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6538,7 +6538,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mavlink/mavlink-gbp-release.git
-      version: 2023.5.5-1
+      version: 2022.12.30-1
     source:
       type: git
       url: https://github.com/mavlink/mavlink-gbp-release.git


### PR DESCRIPTION
…37150)"

This reverts commit 18c62e19dfc6dd53258cc14c76903fc00cd6ce22.

This has failed to build since it was merged: https://build.ros.org/job/Mbin_uB64__mavlink__ubuntu_bionic_amd64__binary/ .  FYI @vooon 