### PR TITLE
ros_inorbit_samples: 0.3.0-1 in 'noetic/distribution.yaml'

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8973,7 +8973,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/inorbit-ai/ros_inorbit_samples-release.git
-      version: 0.2.5-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/inorbit-ai/ros_inorbit_samples.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_inorbit_samples` to `0.3.0-1`:

- upstream repository: https://github.com/inorbit-ai/ros_inorbit_samples.git
- release repository: https://github.com/inorbit-ai/ros_inorbit_samples-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.5-1`

```
0.3.0 (2023-06-03)
* Add an explicit latched property for republishers (https://github.com/inorbit-ai/ros_inorbit_samples/pull/17)
* Contributors: mechatheo
```
