### PR TITLE
Add torch and torchvision to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8653,7 +8653,10 @@ python3-toml:
   ubuntu: [python3-toml]
 python3-torch:
   debian: [python3-torch]
-  ubuntu: [python3-torch]
+  ubuntu:
+    '*': [python3-torch]
+    bionic: null
+    focal: null
   arch: [python-pytorch]
   gentoo: [pytorch]
   osx: [pytorch]
@@ -8661,11 +8664,16 @@ python3-torch:
   opensuse: [python3-torch]
 python3-torchvision:
   debian: [python3-torchvision]
-  ubuntu: [python3-torchvision]
+  ubuntu:
+    '*': [python3-torchvision]
+    bionic: null
+    focal: null
   arch: [python-torchvision]
   osx: [torchvision]
   nixos: [python3Packages.torchvision]
-  opensuse: [python3-torchvision]
+  opensuse:
+    '*': [python3-torchvision]
+    '15.2': null
 python3-tornado:
   arch: [python-tornado]
   debian: [python3-tornado]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8652,28 +8652,28 @@ python3-toml:
   nixos: [python3Packages.toml]
   ubuntu: [python3-toml]
 python3-torch:
+  arch: [python-pytorch]
   debian: [python3-torch]
+  gentoo: [pytorch]
+  nixos: [python3Packages.torch]
+  opensuse: [python3-torch]
+  osx: [pytorch]
   ubuntu:
     '*': [python3-torch]
     bionic: null
     focal: null
-  arch: [python-pytorch]
-  gentoo: [pytorch]
-  osx: [pytorch]
-  nixos: [python3Packages.torch]
-  opensuse: [python3-torch]
 python3-torchvision:
-  debian: [python3-torchvision]
-  ubuntu:
-    '*': [python3-torchvision]
-    bionic: null
-    focal: null
   arch: [python-torchvision]
-  osx: [torchvision]
+  debian: [python3-torchvision]
   nixos: [python3Packages.torchvision]
   opensuse:
     '*': [python3-torchvision]
     '15.2': null
+  osx: [torchvision]
+  ubuntu:
+    '*': [python3-torchvision]
+    bionic: null
+    focal: null
 python3-tornado:
   arch: [python-tornado]
   debian: [python3-tornado]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8651,6 +8651,21 @@ python3-toml:
   gentoo: [dev-python/toml]
   nixos: [python3Packages.toml]
   ubuntu: [python3-toml]
+python3-torch:
+  debian: [python3-torch]
+  ubuntu: [python3-torch]
+  arch: [python-pytorch]
+  gentoo: [pytorch]
+  osx: [pytorch]
+  nixos: [python3Packages.torch]
+  opensuse: [python3-torch]
+python3-torchvision:
+  debian: [python3-torchvision]
+  ubuntu: [python3-torchvision]
+  arch: [python-torchvision]
+  osx: [torchvision]
+  nixos: [python3Packages.torchvision]
+  opensuse: [python3-torchvision]
 python3-tornado:
   arch: [python-tornado]
   debian: [python3-tornado]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-torch, python3-torchvision

## Package Upstream Source:

https://pytorch.org, https://github.com/pytorch/vision

## Purpose of using this:

Machine learning.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/bullseye/python3-torch, https://packages.debian.org/bullseye/python3-torchvision
- Ubuntu: https://packages.ubuntu.com/jammy/python3-torch, https://packages.ubuntu.com/jammy/python3-torchvision
- Fedora: not available
- Arch: https://archlinux.org/packages/extra/x86_64/python-pytorch, https://archlinux.org/packages/extra/x86_64/python-torchvision
- Gentoo: https://packages.gentoo.org/packages/sci-libs/pytorch, torchvision not available
- macOS: https://formulae.brew.sh/formula/pytorch, https://formulae.brew.sh/formula/torchvision
- Alpine: not available
- NixOS/nixpkgs: python311Packages.torch, python311Packages.torchvision
- openSUSE: https://software.opensuse.org/package/python3-torch, https://software.opensuse.org/package/python3-torchvision