### PR TITLE
depthai: 2.21.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -858,6 +858,22 @@ repositories:
       url: https://github.com/ros2/demos.git
       version: iron
     status: developed
+  depthai:
+    doc:
+      type: git
+      url: https://github.com/luxonis/depthai-core.git
+      version: ros-release
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/luxonis/depthai-core-release.git
+      version: 2.21.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/luxonis/depthai-core.git
+      version: ros-release
+    status: developed
   depthimage_to_laserscan:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai` to `2.21.2-1`:

- upstream repository: https://github.com/luxonis/depthai-core.git
- release repository: https://github.com/luxonis/depthai-core-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## depthai

```
* UPDATE: Use v2.21.2 due to issues this version carries
* Contributors: Alex Bougdan, Szabolcs Gergely, Martin Peterlin
```
