### PR TITLE
rosbag2: 0.15.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5611,7 +5611,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.15.5-1
+      version: 0.15.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.15.6-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.15.5-1`
- Closes https://github.com/ros2/rosbag2/issues/1365

## mcap_vendor

- No changes

## ros2bag

- No changes

## rosbag2

- No changes

## rosbag2_compression

```
* Deconstruct compression classloader factory in correct order with classes loaded (#1362 <https://github.com/ros2/rosbag2/issues/1362>)
* Fx memory issue when multiple writers with message compression_mode required (#1331 <https://github.com/ros2/rosbag2/issues/1331>)
  - Deep copy message when sequential compression writer is writing
  Co-authored-by: zeal <mailto:ziyaolin.zeal@gmail.com>
* Contributors: Emerson Knapp, zeal-up
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Added close to writer (#1363 <https://github.com/ros2/rosbag2/issues/1363>)
  Co-authored-by: Bernat <mailto:bernat.gaston@movvo.eu>
* Contributors: Bernat
```

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_py

- No changes

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

- No changes

## rosbag2_storage_mcap_testdata

- No changes

## rosbag2_test_common

```
* Add extra checks in execute_and_wait_until_completion(..) (#1346 <https://github.com/ros2/rosbag2/issues/1346>) (#1357 <https://github.com/ros2/rosbag2/issues/1357>)
  - Add check if process was terminated by the signal or really exited
  (cherry picked from commit 1215440903c61e0bcbefcf8779b58c86fe31daa6)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Contributors: Michael Orlov
```

## rosbag2_tests

- No changes

## rosbag2_transport

```
* [Humble] Bugfix for parameters not passing to recorder's node from child component (backport #1360 <https://github.com/ros2/rosbag2/issues/1360>) (#1368 <https://github.com/ros2/rosbag2/issues/1368>)
  * Bugfix for parameters not passing to recorder's node from child component (#1360 <https://github.com/ros2/rosbag2/issues/1360>)
  * Update recorder.cpp
  * Regression test
  * Fix test for composable recorder with parameter override option
  ---------
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
  (cherry picked from commit 13f51510342e9f06327ae1146820780baee06c4a)
  ---------
  Co-authored-by: Patrick Roncagliolo <mailto:ronca.pat@gmail.com>
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Fix memory issue when multiple writers with message compression_mode required (#1331 <https://github.com/ros2/rosbag2/issues/1331>)
  - Deep copy message when sequential compression writer is writing
  Co-authored-by: zeal <mailto:ziyaolin.zeal@gmail.com>
* Print "Hidden topics are not recorded" only once. (#1225 <https://github.com/ros2/rosbag2/issues/1225>) (#1323 <https://github.com/ros2/rosbag2/issues/1323>)
  (cherry picked from commit a640adaeeee3bbffaa6cd73cde3f3e8781f12e89)
  Co-authored-by: rshanor <mailto:rickshanor@gmail.com>
* Contributors: zeal-up, Michael Orlov, Patrick Roncagliolo, rshanor
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
