### PR TITLE
add ros2_canopen repository

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4534,6 +4534,16 @@ repositories:
       url: https://github.com/ros2/ros1_bridge.git
       version: master
     status: maintained
+  ros2_canopen:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/ros2_canopen
+      version: master
+    source:
+      type: git
+      url: https://github.com/ros-industrial/ros2_canopen
+      version: master
+    status: developed
   ros2_control:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4537,11 +4537,11 @@ repositories:
   ros2_canopen:
     doc:
       type: git
-      url: https://github.com/ros-industrial/ros2_canopen
+      url: https://github.com/ros-industrial/ros2_canopen.git
       version: master
     source:
       type: git
-      url: https://github.com/ros-industrial/ros2_canopen
+      url: https://github.com/ros-industrial/ros2_canopen.git
       version: master
     status: developed
   ros2_control:


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

rolling

# The source is here:

https://github.com/ros-industrial/ros2_canopen/tree/master

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file - in each package
 - [x] This package is expected to build on the submitted rosdistro
