### PR TITLE
nlohmann_json_schema_validator_vendor: 0.3.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2935,7 +2935,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/nlohmann_json_schema_validator_vendor.git
-      version: main
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -2944,7 +2944,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/nlohmann_json_schema_validator_vendor.git
-      version: main
+      version: iron
     status: developed
   nmea_hardware_interface:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2940,7 +2940,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/nlohmann_json_schema_validator_vendor-release.git
-      version: 0.2.4-3
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/open-rmf/nlohmann_json_schema_validator_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nlohmann_json_schema_validator_vendor` to `0.3.0-1`:

- upstream repository: https://github.com/open-rmf/nlohmann_json_schema_validator_vendor
- release repository: https://github.com/ros2-gbp/nlohmann_json_schema_validator_vendor-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.4-3`

## nlohmann_json_schema_validator_vendor

```
* Switch to rst changelogs
* Contributors: Yadunund
```
