### PR TITLE
pybind11_json_vendor: 0.3.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3663,7 +3663,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/pybind11_json_vendor.git
-      version: main
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -3672,7 +3672,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/pybind11_json_vendor.git
-      version: main
+      version: iron
     status: developed
   pybind11_vendor:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3668,7 +3668,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/pybind11_json_vendor-release.git
-      version: 0.2.2-3
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/open-rmf/pybind11_json_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pybind11_json_vendor` to `0.3.0-1`:

- upstream repository: https://github.com/open-rmf/pybind11_json_vendor
- release repository: https://github.com/ros2-gbp/pybind11_json_vendor-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.2-3`

## pybind11_json_vendor

```
* Switch to rst changelogs
* Update maintainer
* Add initial build workflow (#9 <https://github.com/open-rmf/pybind11_json_vendor/issues/9>)
* Contributors: Esteban Martinena, Yadunund
```
