### PR TITLE
rmf_api_msgs: 0.1.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4188,7 +4188,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_api_msgs-release.git
-      version: 0.0.1-6
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_api_msgs.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4183,7 +4183,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_api_msgs.git
-      version: main
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -4192,7 +4192,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_api_msgs.git
-      version: main
+      version: iron
     status: developed
   rmf_battery:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_api_msgs` to `0.1.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_api_msgs
- release repository: https://github.com/ros2-gbp/rmf_api_msgs-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.1-6`

## rmf_api_msgs

```
* Update maintainer
* Switch to rst changelog (#36 <https://github.com/open-rmf/rmf_api_msgs/pull/36>)
* Fix typo in title of fleet_log.json (#26 <https://github.com/open-rmf/rmf_api_msgs/pull/26>)
* Contributors: Teo Koon Peng, Yadunund
```
