### PR TITLE
rmf_battery: 0.2.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4203,7 +4203,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_battery-release.git
-      version: 0.1.4-2
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_battery.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4198,7 +4198,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_battery.git
-      version: main
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -4207,7 +4207,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_battery.git
-      version: main
+      version: iron
     status: developed
   rmf_building_map_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_battery` to `0.2.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_battery.git
- release repository: https://github.com/ros2-gbp/rmf_battery-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.4-2`

## rmf_battery

```
* Switch to rst changelogs
* Contributors: Yadunund
```
