### PR TITLE
rmf_building_map_msgs: 1.3.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4218,7 +4218,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_building_map_msgs-release.git
-      version: 1.2.0-7
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_building_map_msgs.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4213,7 +4213,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_building_map_msgs.git
-      version: rolling
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -4222,7 +4222,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_building_map_msgs.git
-      version: rolling
+      version: iron
     status: developed
   rmf_cmake_uncrustify:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_building_map_msgs` to `1.3.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_building_map_msgs.git
- release repository: https://github.com/ros2-gbp/rmf_building_map_msgs-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.0-7`

## rmf_building_map_msgs

- No changes
