### PR TITLE
rmf_internal_msgs: 3.1.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4253,7 +4253,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_internal_msgs.git
-      version: main
+      version: iron
     release:
       packages:
       - rmf_charger_msgs
@@ -4275,7 +4275,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_internal_msgs.git
-      version: main
+      version: iron
     status: developed
   rmf_ros2:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4271,7 +4271,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
-      version: 3.0.2-3
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_internal_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_internal_msgs` to `3.1.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_internal_msgs.git
- release repository: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.2-3`

## rmf_charger_msgs

```
* Switch to rst changelogs
* Version updates from latest release synced to main (#54 <https://github.com/open-rmf/rmf_internal_msgs/pull/54>)
* Contributors: Esteban Martinena Guerrero, Yadunund
```

## rmf_dispenser_msgs

```
* Switch to rst changelogs
* Version updates from latest release synced to main (#54 <https://github.com/open-rmf/rmf_internal_msgs/pull/54>)
* Contributors: Esteban Martinena Guerrero, Yadunund
```

## rmf_door_msgs

```
* Switch to rst changelogs
* Version updates from latest release synced to main (#54 <https://github.com/open-rmf/rmf_internal_msgs/pull/54>)
* Contributors: Esteban Martinena Guerrero, Yadunund
```

## rmf_fleet_msgs

```
* Switch to rst changelogs
* Version updates from latest release synced to main (#54 <https://github.com/open-rmf/rmf_internal_msgs/pull/54>)
* Contributors: Esteban Martinena Guerrero, Yadunund
```

## rmf_ingestor_msgs

```
* Switch to rst changelogs
* Version updates from latest release synced to main (#54 <https://github.com/open-rmf/rmf_internal_msgs/pull/54>)
* Contributors: Esteban Martinena Guerrero, Yadunund
```

## rmf_lift_msgs

```
* Switch to rst changelogs
* Version updates from latest release synced to main (#54 <https://github.com/open-rmf/rmf_internal_msgs/pull/54>)
* Contributors: Esteban Martinena Guerrero, Yadunund
```

## rmf_obstacle_msgs

```
* Switch to rst changelogs
* Version updates from latest release synced to main (#54 <https://github.com/open-rmf/rmf_internal_msgs/pull/54>)
* Contributors: Esteban Martinena Guerrero, Yadunund
```

## rmf_scheduler_msgs

```
* Switch to rst changelogs
* Version updates from latest release synced to main (#54 <https://github.com/open-rmf/rmf_internal_msgs/pull/54>)
* Contributors: Esteban Martinena Guerrero, Yadunund
```

## rmf_site_map_msgs

```
* Switch to rst changelogs
* Version updates from latest release synced to main (#54 <https://github.com/open-rmf/rmf_internal_msgs/pull/54>)
* Contributors: Esteban Martinena Guerrero, Yadunund
```

## rmf_task_msgs

```
* Switch to rst changelogs
* Version updates from latest release synced to main (#54 <https://github.com/open-rmf/rmf_internal_msgs/pull/54>)
* Contributors: Esteban Martinena Guerrero, Yadunund
```

## rmf_traffic_msgs

```
* Switch to rst changelogs
* Version updates from latest release synced to main (#54 <https://github.com/open-rmf/rmf_internal_msgs/pull/54>)
* Contributors: Esteban Martinena Guerrero, Yadunund
```

## rmf_workcell_msgs

```
* Switch to rst changelogs
* Version updates from latest release synced to main (#54 <https://github.com/open-rmf/rmf_internal_msgs/pull/54>)
* Contributors: Esteban Martinena Guerrero, Yadunund
```
