### PR TITLE
rmf_ros2: 2.2.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4281,7 +4281,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git
-      version: main
+      version: iron
     release:
       packages:
       - rmf_fleet_adapter
@@ -4296,7 +4296,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git
-      version: main
+      version: iron
     status: developed
   rmf_simulation:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4292,7 +4292,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 2.1.2-3
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_ros2` to `2.2.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_ros2.git
- release repository: https://github.com/ros2-gbp/rmf_ros2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.2-3`

## rmf_fleet_adapter

```
* Fix race condition related to the ``finished`` callback of ``perform_action`` events: (#273 <https://github.com/open-rmf/rmf_ros2/pull/273>)
* Switch to rst changelogs (#276 <https://github.com/open-rmf/rmf_ros2/pull/276>)
* Contributors: Grey, Yadunund
```

## rmf_fleet_adapter_python

```
* Switch to rst changelogs (#276 <https://github.com/open-rmf/rmf_ros2/pull/276>)
* Contributors: Yadunund
```

## rmf_task_ros2

```
* Switch to rst changelogs (#276 <https://github.com/open-rmf/rmf_ros2/pull/276>)
* Contributors: Yadunund
```

## rmf_traffic_ros2

```
* Switch to rst changelogs (#276 <https://github.com/open-rmf/rmf_ros2/pull/276>)
* Contributors: Yadunund
```

## rmf_websocket

```
* Switch to rst changelogs (#276 <https://github.com/open-rmf/rmf_ros2/pull/276>)
* Contributors: Yadunund
```
