### PR TITLE
rmf_simulation: 2.1.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4302,7 +4302,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_simulation.git
-      version: main
+      version: iron
     release:
       packages:
       - rmf_building_sim_common
@@ -4318,7 +4318,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_simulation.git
-      version: main
+      version: iron
     status: developed
   rmf_task:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4314,7 +4314,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_simulation-release.git
-      version: 2.0.0-3
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_simulation` to `2.1.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_simulation.git
- release repository: https://github.com/ros2-gbp/rmf_simulation-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-3`

## rmf_building_sim_common

```
* Switch to rst changelogs (#101 <https://github.com/open-rmf/rmf_simulation/pull/101>)
* Don't print warning if lift is going to same floor (#89 <https://github.com/open-rmf/rmf_simulation/pull/89>)
* Contributors: Luca Della Vedova, Yadunund
```

## rmf_building_sim_gz_classic_plugins

```
* Switch to rst changelogs (#101 <https://github.com/open-rmf/rmf_simulation/pull/101>)
* Contributors: Yadunund
```

## rmf_building_sim_gz_plugins

```
* Switch to rst changelogs (#101 <https://github.com/open-rmf/rmf_simulation/pull/101>)
* Contributors: Yadunund
```

## rmf_robot_sim_common

```
* Switch to rst changelogs (#101 <https://github.com/open-rmf/rmf_simulation/pull/101>)
* Fix eigen not found when building rpm (#102 <https://github.com/open-rmf/rmf_simulation/pull/102>)
* Fix library linking (#97 <https://github.com/open-rmf/rmf_simulation/pull/97>)
* Contributors: Esteban Martinena Guerrero, Grey, Yadunund
```

## rmf_robot_sim_gz_classic_plugins

```
* Switch to rst changelogs (#101 <https://github.com/open-rmf/rmf_simulation/pull/101>)
* Contributors: Yadunund
```

## rmf_robot_sim_gz_plugins

```
* Switch to rst changelogs (#101 <https://github.com/open-rmf/rmf_simulation/pull/101>)
* Contributors: Yadunund
```
