### PR TITLE
rmf_task: 2.2.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4332,7 +4332,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
-      version: 2.1.3-2
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_task.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4324,7 +4324,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_task.git
-      version: rolling
+      version: iron
     release:
       packages:
       - rmf_task
@@ -4336,7 +4336,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_task.git
-      version: rolling
+      version: iron
     status: developed
   rmf_traffic:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_task` to `2.2.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_task.git
- release repository: https://github.com/ros2-gbp/rmf_task-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.3-2`

## rmf_task

```
* Switch to rst changelogs
* Update github actions and fix style as per uncrustify 0.72 (#74 <https://github.com/open-rmf/rmf_task/pull/74>)
* Fix build with apple clang (#77 <https://github.com/open-rmf/rmf_task/pull/77>)
* Contributors: Esteban Martinena, Yadunund
```

## rmf_task_sequence

```
* Switch to rst changelogs
* Contributors: Yadunund
```
