### PR TITLE
rmf_traffic: 3.1.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4350,7 +4350,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic-release.git
-      version: 3.0.0-3
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4342,7 +4342,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_traffic.git
-      version: main
+      version: iron
     release:
       packages:
       - rmf_traffic
@@ -4354,7 +4354,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic.git
-      version: main
+      version: iron
     status: developed
   rmf_traffic_editor:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_traffic` to `3.1.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_traffic.git
- release repository: https://github.com/ros2-gbp/rmf_traffic-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.0-3`

## rmf_traffic

```
* Switch to rst changelogs (#100 <https://github.com/open-rmf/rmf_traffic/pull/100>)
* Fix multi floor anomaly (#97 <https://github.com/open-rmf/rmf_traffic/pull/97>)
* Fix end_versions initialization capacity error in ``NegotiatingRouteValidator::Generator::all()`` function (#58 <https://github.com/open-rmf/rmf_traffic/pull/58>)
* Contributors: 0to1, Grey, Yadunund
```

## rmf_traffic_examples

```
* Switch to rst changelogs (#100 <https://github.com/open-rmf/rmf_traffic/pull/100>)
* Contributors: Yadunund
```
