### PR TITLE
rmf_traffic_editor: 1.7.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4370,7 +4370,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
-      version: 1.6.0-3
+      version: 1.7.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic_editor.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4360,7 +4360,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_traffic_editor.git
-      version: main
+      version: iron
     release:
       packages:
       - rmf_building_map_tools
@@ -4374,7 +4374,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic_editor.git
-      version: main
+      version: iron
     status: developed
   rmf_utils:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_traffic_editor` to `1.7.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_traffic_editor.git
- release repository: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.6.0-3`

## rmf_building_map_tools

```
* Switch to rst changelogs (#464 <https://github.com/open-rmf/rmf_traffic_editor/pull/464>)
* Add texture for white wall (#463 <https://github.com/open-rmf/rmf_traffic_editor/pull/463>)
* Fix navgraph generation for connected docking waypoints (#452 <https://github.com/open-rmf/rmf_traffic_editor/pull/452>)
* Added 5 retries for model downloading failure (#455 <https://github.com/open-rmf/rmf_traffic_editor/pull/455>)
* Migrate to using gzsim server url for fuel (#454 <https://github.com/open-rmf/rmf_traffic_editor/pull/454>)
* Exiting model downloader with non-zero exit code (#453 <https://github.com/open-rmf/rmf_traffic_editor/pull/453>)
* Contributors: Aaron Chong, Luca Della Vedova, Yadunund
```

## rmf_traffic_editor

```
* Switch to rst changelogs (#464 <https://github.com/open-rmf/rmf_traffic_editor/pull/464>)
* Contributors: Yadunund
```

## rmf_traffic_editor_assets

```
* Switch to rst changelogs (#464 <https://github.com/open-rmf/rmf_traffic_editor/pull/464>)
* Migrate to using gzsim server url for fuel (#454 <https://github.com/open-rmf/rmf_traffic_editor/pull/454>)
* Contributors: Aaron Chong, Yadunund
```

## rmf_traffic_editor_test_maps

```
* Switch to rst changelogs (#464 <https://github.com/open-rmf/rmf_traffic_editor/pull/464>)
* Fix test map generation with new commands (#456 <https://github.com/open-rmf/rmf_traffic_editor/pull/456>)
* Contributors: Aaron Chong, Yadunund
```
