### PR TITLE
rmf_utils: 1.5.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4385,7 +4385,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_utils-release.git
-      version: 1.4.0-3
+      version: 1.5.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_utils.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4380,7 +4380,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_utils.git
-      version: main
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -4389,7 +4389,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_utils.git
-      version: main
+      version: iron
     status: developed
   rmf_visualization:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_utils` to `1.5.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_utils.git
- release repository: https://github.com/ros2-gbp/rmf_utils-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.4.0-3`

## rmf_utils

```
* Switch to rst changelogs (#28 <https://github.com/open-rmf/rmf_utils/pull/28>)
* Reusable CI (#24 <https://github.com/open-rmf/rmf_utils/pull/24>)
* Contributors: Esteban Martinena Guerrero, Yadunund
```
