### PR TITLE
rmf_visualization: 2.1.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4395,7 +4395,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_visualization.git
-      version: main
+      version: iron
     release:
       packages:
       - rmf_visualization
@@ -4413,7 +4413,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_visualization.git
-      version: main
+      version: iron
     status: developed
   rmf_visualization_msgs:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4409,7 +4409,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_visualization-release.git
-      version: 2.0.1-3
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_visualization` to `2.1.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_visualization.git
- release repository: https://github.com/ros2-gbp/rmf_visualization-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.1-3`

## rmf_visualization

```
* Switch to rst changelogs (#57 <https://github.com/open-rmf/rmf_visualization/pull/57>)
* Contributors: Yadunund
```

## rmf_visualization_building_systems

```
* Switch to rst changelogs (#57 <https://github.com/open-rmf/rmf_visualization/pull/57>)
* Contributors: Yadunund
```

## rmf_visualization_fleet_states

```
* Switch to rst changelogs (#57 <https://github.com/open-rmf/rmf_visualization/pull/57>)
* Contributors: Yadunund
```

## rmf_visualization_floorplans

```
* Switch to rst changelogs (#57 <https://github.com/open-rmf/rmf_visualization/pull/57>)
* Contributors: Yadunund
```

## rmf_visualization_navgraphs

```
* Switch to rst changelogs (#57 <https://github.com/open-rmf/rmf_visualization/pull/57>)
* Contributors: Yadunund
```

## rmf_visualization_obstacles

```
* Switch to rst changelogs (#57 <https://github.com/open-rmf/rmf_visualization/pull/57>)
* Contributors: Yadunund
```

## rmf_visualization_rviz2_plugins

```
* Switch to rst changelogs (#57 <https://github.com/open-rmf/rmf_visualization/pull/57>)
* Contributors: Yadunund
```

## rmf_visualization_schedule

```
* Switch to rst changelogs (#57 <https://github.com/open-rmf/rmf_visualization/pull/57>)
* Contributors: Yadunund
```
