### PR TITLE
rmf_visualization_msgs: 1.3.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4424,7 +4424,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_visualization_msgs-release.git
-      version: 1.2.0-5
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_visualization_msgs.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4419,7 +4419,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_visualization_msgs.git
-      version: main
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -4428,7 +4428,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_visualization_msgs.git
-      version: main
+      version: iron
     status: developed
   rmw:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_visualization_msgs` to `1.3.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_visualization_msgs.git
- release repository: https://github.com/ros2-gbp/rmf_visualization_msgs-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.0-5`

## rmf_visualization_msgs

```
* Switch to rst changelogs (#7 <https://github.com/open-rmf/rmf_visualization_msgs/pull/7>)
* Contributors: Yadunund
```
