### PR TITLE
rosdep: pylint3 unavailable on Fedora, Ubuntu 20.04 onward

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3098,7 +3098,9 @@ python-pylint3:
   debian: [pylint3]
   fedora: [python3-pylint]
   gentoo: [dev-python/pylint]
-  ubuntu: [pylint3]
+  ubuntu:
+    '*': [pylint]
+    bionic: [pylint3]
 python-pymavlink:
   debian:
     pip:


### PR DESCRIPTION
# Issue

- `rosdep install`  exec for `python-pylint3` rosdep key error on Jammy (but not on <s>Focal</s> Bionic. Later [I confirmed it fails on Focal](https://github.com/ros/rosdistro/actions/runs/5197879128)).
   ```
   # lsb_release -a; apt update; rosdep update; rosdep install --from-paths src --ignore-src -r -y
   :
   Description:	Ubuntu 22.04.2 LTS
   :
   executing command [apt-get install -y pylint3]
   Reading package lists... Done
   Building dependency tree... Done
   Reading state information... Done
   E: Unable to locate package pylint3
   ERROR: the following rosdeps failed to install
     apt: command [apt-get install -y pylint3] failed
     apt: Failed to detect successful installation of [pylint3]
   ```
   I interpreted the output above as "The requested rosdep key does exist, but apt pkg doesn't".

   `apt` fails too.
   ```
   # apt install pylint3
   Reading package lists... Done
   Building dependency tree... Done
   Reading state information... Done
   E: Unable to locate package pylint3
   ```
# Background
- The rosdep key seems to have been added in https://github.com/ros/rosdistro/pull/21204, which includes websites as rationale.
   - Same web links still exist.
      - Debian https://packages.debian.org/bullseye/pylint3
      - gentoo https://packages.gentoo.org/packages/dev-python/pylint
   - Same links lead to "Not found" or equivalent.
      - Fedora https://apps.fedoraproject.org/packages/python3-pylint
      - Ubuntu website https://packages.ubuntu.com/bionic/pylint3 
- On Bionic (Docker image that I just pulled. Haven't verified when it was built) I confirmed the pkg is still available via `apt`.
   <details><summary>log</summary>
   
   ```
   $ docker pull ros:melodic-ros-base-bionic 
   :
   36b05b7b63adec64f29ed7b397779f11123dcfff3b262a90af818a785
   Status: Downloaded newer image for ros:melodic-ros-base-bionic
   docker.io/library/ros:melodic-ros-base-bionic
   $ docker run -it ros:melodic-ros-base-bionic bash
   
   root@44b2cff94d2a:/# lsb_release -a
   No LSB modules are available.
   Distributor ID: Ubuntu
   Description:    Ubuntu 18.04.6 LTS
   Release:        18.04
   
   root@44b2cff94d2a:/# apt update; apt install pylint3
   :
   Get:20 http://archive.ubuntu.com/ubuntu bionic-backports/main amd64 Packages [64.0 kB]              Fetched 28.9 MB in 1min 12s (399 kB/s)
   :
   Reading state information... Done
   The following additional packages will be installed:
     blt libtcl8.6 libtk8.6 libxft2 libxss1 python3-astroid python3-isort python3-lazy-object-proxy python3-logilab-common python3-mccabe python3-pkg-resources python3-setuptools python3-six python3-tk python3-wrapt tk8.6-blt2.5
   Suggested packages:
     blt-demo tcl8.6 tk8.6 pylint-doc python-setuptools-doc tix python3-tk-dbg
   The following NEW packages will be installed:
     blt libtcl8.6 libtk8.6 libxft2 libxss1 pylint3 python3-astroid python3-isort python3-lazy-object-proxy python3-logilab-common python3-mccabe python3-pkg-resources python3-setuptools python3-six python3-tk python3-wrapt tk8.6-blt2.5
   0 upgraded, 17 newly installed, 0 to remove and 0 not upgraded.
   Need to get 3304 kB of archives.
   After this operation, 16.0 MB of additional disk space will be used.
   Do you want to continue? [Y/n] n
   Abort.
   ```
   </details>
# Open question
- [x] I only assume this pkg will no longer be added back to future distros. I was not sure how to describe that in the rosdep key list. --> Because it's only available on Bionic on Ubuntu distros that are reasonably in use, set it only to Bionic.
- [x] Haven't verified on running Fedora. --> https://github.com/ros/rosdistro/pull/37509#discussion_r1224641530 Fedora ver is confirmed to exist.
