### PR TITLE
Add source entry for new package rmf_variants

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4308,6 +4308,12 @@ repositories:
       url: https://github.com/open-rmf/rmf_utils.git
       version: main
     status: developed
+  rmf_variants:
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_variants.git
+      version: main
+    status: developed
   rmf_visualization:
     doc:
       type: git


### PR DESCRIPTION
Create a new source entry for package [rmf_variants](https://github.com/open-rmf/rmf_variants) before the release repository can be created and bloomed.