### PR TITLE
teleop_twist_joy: 2.4.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6923,7 +6923,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_twist_joy-release.git
-      version: 2.4.3-4
+      version: 2.4.4-1
     source:
       test_pull_requests: true
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6918,7 +6918,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/teleop_twist_joy.git
-      version: rolling
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -6928,7 +6928,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/teleop_twist_joy.git
-      version: rolling
+      version: humble
     status: maintained
   teleop_twist_keyboard:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_joy` to `2.4.4-1`:

- upstream repository: https://github.com/ros2/teleop_twist_joy.git
- release repository: https://github.com/ros2-gbp/teleop_twist_joy-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.4.3-4`

## teleop_twist_joy

```
* Install includes to include/${PROJECT_NAME} (#30 <https://github.com/ros2/teleop_twist_joy/issues/30>)
* joy_vel argument (#29 <https://github.com/ros2/teleop_twist_joy/issues/29>)
* Contributors: Raffaello Bonghi, Shane Loretz
```
