### PR TITLE
teleop_twist_joy: 2.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6062,7 +6062,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_twist_joy-release.git
-      version: 2.4.3-4
+      version: 2.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_joy` to `2.6.0-1`:

- upstream repository: https://github.com/ros2/teleop_twist_joy.git
- release repository: https://github.com/ros2-gbp/teleop_twist_joy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.4.3-4`

## teleop_twist_joy

```
* add inverted reverse param (#35 <https://github.com/ros2/teleop_twist_joy/issues/35>)
* [rolling] Update maintainers - 2022-11-07 (#33 <https://github.com/ros2/teleop_twist_joy/issues/33>)
* Enable uncrustify and cpplint.
* Cleanup CMakeLists.txt.
* Remove checking of types from parameter_callback.
* Install includes to include/${PROJECT_NAME} (#30 <https://github.com/ros2/teleop_twist_joy/issues/30>)
* joy_vel argument (#29 <https://github.com/ros2/teleop_twist_joy/issues/29>)
* Contributors: Audrow Nash, Chris Lalancette, Máté, Raffaello Bonghi, Shane Loretz
```
