### PR TITLE
rviz: 12.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5650,7 +5650,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 12.5.1-1
+      version: 12.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `12.6.0-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `12.5.1-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Remove onHelpWiki. (#985 <https://github.com/ros2/rviz/issues/985>)
* Contributors: Chris Lalancette
```

## rviz_default_plugins

```
* Modify access specifier to protected or public for the scope of processMessage() member function (#984 <https://github.com/ros2/rviz/issues/984>)
* Contributors: Hyunseok
```

## rviz_ogre_vendor

```
* CMake: rename FeatureSummary.cmake to avoid name clashes (#953 <https://github.com/ros2/rviz/issues/953>)
* FIX CVE in external libraries (#961 <https://github.com/ros2/rviz/issues/961>)
* Contributors: Gökçe Aydos, mosfet80
```

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
