### PR TITLE
rosidl_typesupport_fastrtps: 3.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5129,7 +5129,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-      version: 3.1.0-1
+      version: 3.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_fastrtps` to `3.2.0-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.1.0-1`

## fastrtps_cmake_module

- No changes

## rosidl_typesupport_fastrtps_c

- No changes

## rosidl_typesupport_fastrtps_cpp

```
* Avoid redundant declarations in generated code for services and actions (#102 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/102>)
* Contributors: Emerson Knapp
```
