### PR TITLE
rosidl_typesupport: 3.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5109,7 +5109,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-      version: 3.1.0-1
+      version: 3.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport` to `3.2.0-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.1.0-1`

## rosidl_typesupport_c

```
* Don't override user provided compile definitions (#145 <https://github.com/ros2/rosidl_typesupport/issues/145>)
* Contributors: Emerson Knapp
```

## rosidl_typesupport_cpp

```
* Don't override user provided compile definitions (#145 <https://github.com/ros2/rosidl_typesupport/issues/145>)
* Added C interfaces to obtain service and action type support. (#143 <https://github.com/ros2/rosidl_typesupport/issues/143>)
* Contributors: Emerson Knapp, Stefan Fabian
```
