### PR TITLE
rclpy: 4.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3957,7 +3957,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 4.2.1-1
+      version: 4.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `4.2.2-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.2.1-1`

## rclpy

```
* Fix iteration over modified list (#1129 <https://github.com/ros2/rclpy/issues/1129>)
* making optional things Optional (#974 <https://github.com/ros2/rclpy/issues/974>)
* Fix type signature of Client.wait_for_service (#1128 <https://github.com/ros2/rclpy/issues/1128>)
* Contributors: Brian, Felix Divo
```
