### PR TITLE
rcl: 6.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3841,7 +3841,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 6.1.1-1
+      version: 6.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `6.2.0-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `6.1.1-1`

## rcl

```
* fix comment (#1073 <https://github.com/ros2/rcl/issues/1073>)
* localhost_only prevails auto discovery options if enabled. (#1069 <https://github.com/ros2/rcl/issues/1069>)
* Avoid dynamic allocation of message before sending over rosout (#1067 <https://github.com/ros2/rcl/issues/1067>)
* Contributors: Chen Lihui, Christopher Wecht, Tomoya Fujita
```

## rcl_action

- No changes

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

- No changes
