### PR TITLE
rclcpp: 21.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3941,7 +3941,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 21.1.1-1
+      version: 21.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `21.2.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `21.1.1-1`

## rclcpp

```
* remove nolint since ament_cpplint updated for the c++17 header (#2198 <https://github.com/ros2/rclcpp/issues/2198>)
* Feature/available capacity of ipm (#2173 <https://github.com/ros2/rclcpp/issues/2173>)
* add mutex to protect events_executor current entity collection (#2187 <https://github.com/ros2/rclcpp/issues/2187>)
* Declare rclcpp callbacks before the rcl entities (#2024 <https://github.com/ros2/rclcpp/issues/2024>)
* Contributors: Alberto Soragna, Chen Lihui, DensoADAS, mauropasse
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
