### PR TITLE
sensor_filters: 1.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10416,7 +10416,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ctu-vras/sensor_filters-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/ctu-vras/sensor_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sensor_filters` to `1.1.1-1`:

- upstream repository: https://github.com/ctu-vras/sensor_filters.git
- release repository: https://github.com/ctu-vras/sensor_filters-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-1`

## sensor_filters

```
* Reformatted, added catkin lint.
* Simplified the license statements.
* Contributors: Martin Pecka
```
