### PR TITLE
mapviz: 2.2.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2421,6 +2421,27 @@ repositories:
       url: https://github.com/Neargye/magic_enum.git
       version: master
     status: maintained
+  mapviz:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/mapviz.git
+      version: ros2-devel
+    release:
+      packages:
+      - mapviz
+      - mapviz_interfaces
+      - mapviz_plugins
+      - multires_image
+      - tile_map
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/mapviz-release.git
+      version: 2.2.2-1
+    source:
+      type: git
+      url: https://github.com/swri-robotics/mapviz.git
+      version: ros2-devel
+    status: developed
   marti_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.2.2-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## mapviz

```
* Add ros_environment as dependency
* Iron Compatibility (#779 <https://github.com/swri-robotics/mapviz/issues/779>)
* Contributors: David Anthony
```

## mapviz_interfaces

- No changes

## mapviz_plugins

```
* Add ros_environment as dependency
* Iron Compatibility (#779 <https://github.com/swri-robotics/mapviz/issues/779>)
* Contributors: David Anthony
```

## multires_image

```
* Iron Compatibility (#779 <https://github.com/swri-robotics/mapviz/issues/779>)
* Contributors: David Anthony
```

## tile_map

```
* Iron Compatibility (#779 <https://github.com/swri-robotics/mapviz/issues/779>)
* Contributors: David Anthony
```
