### PR TITLE
swri_console: 2.0.4-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6099,7 +6099,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/swri_console-release.git
-      version: 2.0.3-3
+      version: 2.0.4-1
     source:
       type: git
       url: https://github.com/swri-robotics/swri_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_console` to `2.0.4-1`:

- upstream repository: https://github.com/swri-robotics/swri_console.git
- release repository: https://github.com/ros2-gbp/swri_console-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.3-3`

## swri_console

```
* Adding missing dependency needed by build farm (#58 <https://github.com/swri-robotics/swri_console/issues/58>)
* Contributors: David Anthony
```
