### PR TITLE
rmf_battery: 0.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4146,7 +4146,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_battery-release.git
-      version: 0.1.4-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_battery.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_battery` to `0.3.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_battery.git
- release repository: https://github.com/ros2-gbp/rmf_battery-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.4-1`

## rmf_battery

- No changes
