### PR TITLE
rmf_task: 2.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4275,7 +4275,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
-      version: 2.1.3-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_task.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4267,7 +4267,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_task.git
-      version: rolling
+      version: main
     release:
       packages:
       - rmf_task
@@ -4279,7 +4279,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_task.git
-      version: rolling
+      version: main
     status: developed
   rmf_traffic:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_task` to `2.3.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_task.git
- release repository: https://github.com/ros2-gbp/rmf_task-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.3-1`

## rmf_task

- No changes

## rmf_task_sequence

- No changes
