### PR TITLE
Add fanucpy

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5662,6 +5662,16 @@ python3-fann2:
   debian: [python3-fann2]
   opensuse: [python3-fann2]
   ubuntu: [python3-fann2]
+python3-fanucpy-pip:
+  debian:
+    pip:
+      packages: [fanucpy]
+  fedora:
+    pip:
+      packages: [fanucpy]
+  ubuntu:
+    pip:
+      packages: [fanucpy]
 python3-fastapi:
   arch: [python-fastapi]
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5663,13 +5663,7 @@ python3-fann2:
   opensuse: [python3-fann2]
   ubuntu: [python3-fann2]
 python3-fanucpy-pip:
-  debian:
-    pip:
-      packages: [fanucpy]
-  fedora:
-    pip:
-      packages: [fanucpy]
-  ubuntu:
+  '*':
     pip:
       packages: [fanucpy]
 python3-fastapi:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

- python3-fanucpy-pip

## Package Upstream Source:

- fanucpy: [torayeff/fanucpy](https://github.com/torayeff/fanucpy)

## Purpose of using this:

The [`fanucpy`](https://github.com/torayeff/fanucpy) package is an easy wrapper for Python to communicate with Fanuc robots.

Distro packaging links:

## Links to Distribution Packages

The package is solely distributed via [PyPI.org](https://pypi.org/project/fanucpy/).

- Debian: https://packages.debian.org/
  - [not available](https://packages.debian.org/search?keywords=fanucpy&searchon=names&suite=stable&section=all)
- Ubuntu: https://packages.ubuntu.com/
  - [not available](https://packages.ubuntu.com/search?keywords=fanucpy&searchon=names&suite=all&section=all)
- Fedora: https://packages.fedoraproject.org/
  - [not available](https://packages.fedoraproject.org/search?query=fanucpy)

Same for all other OS...

But `fanucpy` is OS and architecture independent, as it is pure Python code
