### PR TITLE
ament_cmake_catch2: 1.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -140,7 +140,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/ament_cmake_catch2.git
-      version: rolling
+      version: main
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -149,7 +149,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/ament_cmake_catch2.git
-      version: rolling
+      version: main
     status: developed
   ament_cmake_ros:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -145,7 +145,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake_catch2-release.git
-      version: 1.2.0-4
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/open-rmf/ament_cmake_catch2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake_catch2` to `1.4.0-1`:

- upstream repository: https://github.com/open-rmf/ament_cmake_catch2.git
- release repository: https://github.com/ros2-gbp/ament_cmake_catch2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.0-4`

## ament_cmake_catch2

- No changes
