### PR TITLE
menge_vendor: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2483,7 +2483,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/menge_vendor.git
-      version: rolling
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2492,7 +2492,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/menge_vendor.git
-      version: rolling
+      version: master
     status: developed
   message_filters:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2488,7 +2488,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/menge_vendor-release.git
-      version: 1.0.0-3
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/open-rmf/menge_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `menge_vendor` to `1.2.0-1`:

- upstream repository: https://github.com/open-rmf/menge_vendor.git
- release repository: https://github.com/ros2-gbp/menge_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-3`

## menge_vendor

- No changes
