### PR TITLE
rmf_building_map_msgs: 1.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4156,7 +4156,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_building_map_msgs.git
-      version: rolling
+      version: main
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -4165,7 +4165,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_building_map_msgs.git
-      version: rolling
+      version: main
     status: developed
   rmf_cmake_uncrustify:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4161,7 +4161,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_building_map_msgs-release.git
-      version: 1.2.0-6
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_building_map_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_building_map_msgs` to `1.4.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_building_map_msgs.git
- release repository: https://github.com/ros2-gbp/rmf_building_map_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.0-6`

## rmf_building_map_msgs

- No changes
