### PR TITLE
rmf_simulation: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4257,7 +4257,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_simulation-release.git
-      version: 2.0.0-2
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_simulation` to `2.2.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_simulation.git
- release repository: https://github.com/ros2-gbp/rmf_simulation-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-2`

## rmf_building_sim_common

- No changes

## rmf_building_sim_gz_classic_plugins

- No changes

## rmf_building_sim_gz_plugins

- No changes

## rmf_robot_sim_common

- No changes

## rmf_robot_sim_gz_classic_plugins

- No changes

## rmf_robot_sim_gz_plugins

- No changes
