### PR TITLE
rmf_visualization_msgs: 1.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4373,7 +4373,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_visualization_msgs-release.git
-      version: 1.2.0-4
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_visualization_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_visualization_msgs` to `1.4.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_visualization_msgs.git
- release repository: https://github.com/ros2-gbp/rmf_visualization_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.0-4`

## rmf_visualization_msgs

- No changes
