### PR TITLE
audio_common: 0.3.17-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -702,7 +702,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/audio_common-release.git
-      version: 0.3.16-1
+      version: 0.3.17-1
     source:
       type: git
       url: https://github.com/ros-drivers/audio_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common` to `0.3.17-1`:

- upstream repository: https://github.com/ros-drivers/audio_common.git
- release repository: https://github.com/ros-gbp/audio_common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.16-1`

## audio_capture

```
* Merge pull request #220 <https://github.com/ros-drivers/audio_common/issues/220> from v4hn/master
* on real systems publish system clock time in capture node
* The capture node is hard-coded to alsasrc
* Contributors: Shingo Kitagawa, v4hn
```

## audio_common

- No changes

## audio_common_msgs

- No changes

## audio_play

- No changes

## sound_play

```
* Merge pull request #231 <https://github.com/ros-drivers/audio_common/issues/231> from knorth55/no-wait-mode
* dont wait when rospy.Duration(0) is set for timeout
* Merge pull request #229 <https://github.com/ros-drivers/audio_common/issues/229> from furushchev/flite-plugin-lazy-load
  FlitePlugin: Lazy loading default voice path
* FlitePlugin: Lazy loading default voice path
* Contributors: Shingo Kitagawa, Yuki Furuta
```
