### PR TITLE
jsk_3rdparty: 2.1.25-4 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4148,36 +4148,47 @@ repositories:
       version: master
     release:
       packages:
+      - aques_talk
       - assimp_devel
       - bayesian_belief_networks
+      - chaplus_ros
       - collada_urdf_jsk_patch
       - dialogflow_task_executive
       - downward
       - ff
       - ffha
       - gdrive_ros
+      - google_chat_ros
+      - google_cloud_texttospeech
+      - influxdb_store
       - jsk_3rdparty
       - julius
       - julius_ros
-      - laser_filters_jsk_patch
       - libcmt
       - libsiftfast
       - lpg_planner
       - mini_maxwell
+      - nfc_ros
       - opt_camera
+      - osqp
       - pgm_learner
       - respeaker_ros
+      - ros_google_cloud_language
       - ros_speech_recognition
       - rospatlite
       - rosping
       - rostwitter
       - sesame_ros
       - slic
+      - switchbot_ros
       - voice_text
+      - webrtcvad_ros
+      - zdepth
+      - zdepth_image_transport
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
-      version: 2.1.21-2
+      version: 2.1.25-4
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_3rdparty` to `2.1.25-4`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
- release repository: https://github.com/tork-a/jsk_3rdparty-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.21-2`

## aques_talk

```
* [aques_talk] build as x86 when dpkg cpu check fails (#387 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/387>)
* GithubAction: add test for  aarch64(melodic) / indigo (arm64) (#365 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/365>)
* Contributors: Aoi Nakane, Kei Okada, Naoto Tsukamoto, Shingo Kitagawa, Yoshiki Obinata
```

## assimp_devel

```
* fix catkin build stacks in GA (#316 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/316>)
* [assimp_devel] remove compile warning
* Contributors: Kei Okada, Naoya Yamaguchi, Shingo Kitagawa
```

## bayesian_belief_networks

- No changes

## chaplus_ros

```
* [chaplus_ros] support mebo (#374 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/374>)
* [chaplus_ros] change a3rt urls (#360 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/360>)
* .github/workflow:  integrate all yaml to one (#338 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/338>)
* Fix for noetic (#332 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/332>)
  
    * [chaplus_ros][switchbot_ros]fix exec_depend in ros noetic
    * [chaplus_ros]support installation of python3-requests
  
* Contributors: Kei Okada, Miyabi Tanemoto, Shingo Kitagawa, Yoshiki Obinata, Ayaka Fujii
```

## collada_urdf_jsk_patch

- No changes

## dialogflow_task_executive

```
* Add option to use project_id from json, instead of credentials (#460 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/460>)
* add test to check if ros node is loadable (#463 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/463>)
  
    * install python files under CATKIN_PACKAGE_BIN_DESTINATION
    * dialogflow_task_executive: add missing dependencies to package.xml
    * dialogflow_task_executive: pip -i only works with 64 bit (x86_64 and aarch64), other archtecture skips rospy_node.test
    * dialogflow_task_executive/CMakeLists.txt: test/test_rospy_node.test depends on generate_messages
    * dialogflow_task_executive/requirements.txt.indigo: specify grpcio for indigo
    * add catkin_install_python for test, it is also change installed directory from BIN to SHARE, because we want to have same directory structure between devel and install
    * add test to check if ros node is loadable
      If we use python2 PYTHON_INTERPRETER on 20.04, python2 fails to load rospy in /opt/ros/noetic, because rospy moduels are alraedy updated.
      If we use python3 PYTHON_INTERPRETER on 18.04, python3 can load rospy in /opt/ros/melodic by chance.
      c.f. https://github.com/jsk-ros-pkg/jsk_3rdparty/pull/367
  
* [dialogflow_task_executive] chmod -x because of catkin_virtualenv (#449 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/449>)
* [dialogflow_task_executive] not use map for python3 in task_executive (#447 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/447>)
* [dialogflow_task_executive] fix typo in dialogflow_client.py (#445 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/445>)
  
    * chmod -x because of catkin_virtualenv
    * not use map for python3 in task_executive
    * fix typo in dialogflow_client.py
  
* [dialogflow_task_executive] add sample apps (#293 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/293>)
* [dialogflow_task_executive] add speech_to_text_other topic name in speech_to_text_mux (#302 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/302>)
* [CI] build catkin_virtualenv packages in indigo. (#419 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/419>)
* [dialogflow_task_executive] check if ROS_PYTHON_VERSION is set to support indigo in dialogflow_client (#408 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/408>)
* [#405 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/405> and #410 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/410>] Fix CI (#415 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/415>)
* [dialogflow_task_executive] Support noetic (#362 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/362>)
* Fix GithubAction (#386 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/386>)
* [dialogflow_task_executive] Enable aarch64 (#364 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/364>)
* GithubAction: add test for  aarch64(melodic) / indigo (arm64) (#365 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/365>)
* [dialogflow_task_executive] set optenv as default false (#368 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/368>)
* Explicit python interpreter in catkin_virtualenv (#367 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/367>)
* [dialogflow_task_executive] add comments in DialogResponse.msg (#366 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/366>)
* [dialogflow_task_executive] adding some args in dialogflow_ros.launch (#361 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/361>)
* [dialogflow_task_executive] fix warn bug when got unknown action (#363 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/363>)
* fix type on dialogflow_task_executive/requirements.txt.indigo (#355 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/355>)
* [dialogflow_task_executive] add requirements.txt in .gitignore (#353 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/353>)
* [dialogflow_task_executive] add doc in launch (#349 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/349>)
* [dialogflow_task_executive]separate dialogflow API client and app execution from dialogflow_task_executive (#343 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/343>)
* dialogflow_task_executive: re-enable idnigo (#342 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/342>)
* dialogflow_task_executive: more depends and udpate README.md (#334 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/334>)
* [dialogflow_task_executive] Fix bugs when subscribing /text (std_msgs/String) topic (#328 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/328>)
* [dialogflow_task_executive] load dialogflow project_id from credentials (#319 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/319>)
* [dialogflow_task_executive] Fix merging #317 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/317> (#318 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/318>)
* Support dialogflow hotword yaml (#307 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/307>)
* add sample code of dialogflow (#317 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/317>)
* Contributors: Kei Okada, Koki Shinjo, Naoto Tsukamoto, Naoya Yamaguchi, Shingo Kitagawa, Yoshiki Obinata, Iory Yanokura
```

## downward

- No changes

## ff

```
* fix catkin build stacks in GA (#316 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/316>)
  
    * [ff] remove compile warning
  
* Contributors: Kei Okada, Naoya Yamaguchi, Shingo Kitagawa
```

## ffha

```
* fix catkin build stacks in GA (#316 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/316>)
  
    * [ffha] remove compile warning
  
* Contributors: Kei Okada, Naoya Yamaguchi, Shingo Kitagawa
```

## gdrive_ros

```
* gdrive_ros: use virtualenv (#458 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/458>)
  
    * use python3 for pydrive_ros
      latest pydrive requires newer rsa??
    * gdrive_ros: catkin_virtualenv changes mode to 100644
    * gdrive_ros: enable to use relative path for settings_yaml
    * gdrive_ros: use catkin_virtualenv
  
* [gdrive_ros] fix sys.version error (#429 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/429>)
* [gdrive_ros] Add ros client library and examples ( for roseus and rospy) (#295 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/295>)
  
    * euslisp directory is installed via 'install(DIRECTORY euslisp', so we can remove 'install(PROGRAMS euslisp/sample-gdrive-ros-client.l'
    * [gdrive_ros] fix module import
    * [gdrive_ros] add rospy client and update examples
    * [gdrive_ros] update CMakeLists.txt to add installation of euslisp and sample
    * [gdrive_ros] Add a roseus client library and sample
    * [gdrive_ros] add gdrive_ros client
  
* [gdrive_ros] add machine arg in gdrive_server.launch (#288 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/288>)
  
    * add machine arg in gdrive_server.launch
  
* Contributors: Aoi Nakane, Kei Okada, Koki Shinjo, Naoto Tsukamoto, Shingo Kitagawa
```

## google_chat_ros

```
* google_chat_ros_node.py: display project_id, subscription_id (#459 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/459>)
* add test to check if ros node is loadable, (#463 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/463>)
  
    * install python files under CATKIN_PACKAGE_BIN_DESTINATION
    * google_chat_ros/test_rospy_node.py: skip healper.py
      helper.py depends on dialogflow_task_executive. However, when we add this to the <depend> of package.xml, it appempts to build venv using 'dialogflow_task_executive/requirements.txt'. This requires having the same PYTHON_INTERPRETER for both dialogflow and chat ros package. The issue is that dialogflow_task_executive heavily relies on system Python modules, including ROS, making it difficult to use dialogflow with Python3 on Melodic
    * add catkin_install_python for test, it is also change installed directory from BIN to SHARE, because we want to have same directory structure between devel and install
    * add test to check if ros node is loadable
      If we use python2 PYTHON_INTERPRETER on 20.04, python2 fails to load rospy in /opt/ros/noetic, because rospy moduels are alraedy updated.
      If we use python3 PYTHON_INTERPRETER on 18.04, python3 can load rospy in /opt/ros/melodic by chance.
      c.f. https://github.com/jsk-ros-pkg/jsk_3rdparty/pull/367
  
* google_chat_ros/README.md: add troubleshooting (#450 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/450>)
* fix google_chat_ros noetic build errors (#422 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/422>)
* use same timestamp for one goal (#403 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/403>)
  * save google chat image in /chat_notification with timestamp
* add google_chat_ros (#392 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/392>)
* Contributors: Aoi Nakane, Kei Okada, Naoto Tsukamoto, Shingo Kitagawa, Yoshiki Obinata
```

## google_cloud_texttospeech

```
* [google_cloud_texttospeech] Add cache option (#267 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/267>)
* Contributors: Kei Okada, Iory Yanokura
```

## influxdb_store

```
* [influxdb_store] fix package deps for python3 (#455 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/455>)
* [influxdb_store] add stop_all_services.bash (#379 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/379>)
* add influxdb_store package (#354 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/354>)
* Contributors: Kei Okada, Naoto Tsukamoto, Shingo Kitagawa, Yoshiki Obinata
```

## jsk_3rdparty

```
* [OSQP] add a wrapper package for OSQP, which is a library to solve QP (#442 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/442>)
* [jsk_3rdparty] fix typo in package.xml (#426 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/426>)
* Add nfc_ros (#406 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/406>)
* add zdepth and zdepth_image_transport package (#389 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/389>)
* [jsk_3rdparty] list all packages in jsk_3rdparty (#424 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/424>)
* Contributors: Aoi Nakane, Kei Okada, Koki Shinjo, Moju Zhao, Naoto Tsukamoto, Shingo Kitagawa
```

## julius

```
* julius: Use DEB_TARGET_GNU_TYPE to fix https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/467 (#470 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/470>)
* GA: enable melodic/aarch64 (#432 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/432>)
* fix catkin build stacks in GA (#316 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/316>)
  
    * use wget to download from osdn, to use mirror site
    * download .zip file from https://osdn.net/dl/julius/
  
* Contributors: Aoi Nakane, Kei Okada, Naoto Tsukamoto, Naoya Yamaguchi, Shingo Kitagawa
```

## julius_ros

```
* Pr/use sound themes freedesktop (#472 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/472>)
* add test to check if ros node is loadable (#463 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/463>)
* Contributors: Kei Okada, Koki Shinjo
```

## libcmt

```
* fix catkin build stacks in GA (#316 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/316>)
  
    * [libcmt] remove compile warning
  
* Contributors: Kei Okada, Naoya Yamaguchi, Shingo Kitagawa
```

## libsiftfast

- No changes

## lpg_planner

```
* [lpg_planner] install lpg_planner from jsk-ros-pkg/archieve (#280 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/280>)
* Contributors: Kei Okada, Shingo Kitagawa
```

## mini_maxwell

```
* .github/workflow:  integrate all yaml to one (#338 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/338>)
* Contributors: Kei Okada, Shingo Kitagawa
```

## nfc_ros

```
* add test to check if ros node is loadable (#463 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/463>)
* Add nfc_ros (#406 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/406>)
* Contributors: Aoi Nakane, Kei Okada, Koki Shinjo, Naoto Tsukamoto, Shingo Kitagawa
```

## opt_camera

```
* [opt_camera] remove compile warning (#316 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/316>)
* Contributors: Kei Okada, Naoya Yamaguchi, Shingo Kitagawa
```

## osqp

```
* [OSQP] add a wrapper package for OSQP, which is a library to solve QP (#442 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/442>)
* Contributors: Kei Okada, Moju Zhao, Naoki Hiraoka, Naoto Tsukamoto
```

## pgm_learner

```
* GithubAction: add test for  aarch64(melodic) / indigo (arm64) (#365 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/365>)
  
    * pgm_learner/respeaker_ros/ros_speech_recognition/rosping: increase time-limit/wait-time
  
* Contributors: Kei Okada, Shingo Kitagawa, Yoshiki Obinata
```

## respeaker_ros

```
* add test to check if ros node is loadable (#463 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/463>)
* [respeaker_ros] add FileNotFoundError in respeaker for python3 (#428 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/428>)
* [respeaker_ros] Stop timer on shutdown (#385 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/385>)
* [ros_speech_recogniton, respeaker_ros] add confidence field (#411 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/411>)
* [#405 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/405> and #410 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/410>] Fix CI (#415 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/415>)
* GithubAction: add test for  aarch64(melodic) / indigo (arm64) (#365 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/365>)
  
    * pgm_learner/respeaker_ros/ros_speech_recognition/rosping: increase time-limit/wait-time
  
* [respeaker_ros] Add documentation for displaying Japanese /speech_to_text (#352 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/352>)
* [respeaker_ros] Display helpful setting command when udev rule is not set (#351 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/351>)
* Using RespeakerInterface instead of init_respeaker (#305 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/305>)
* respeaker_ros for Python 2.x and 3.x (#284 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/284>)
* Contributors: Aoi Nakane, Dirk Gorissen, Kei Okada, Naoto Tsukamoto, Naoya Yamaguchi, Shingo Kitagawa, Yoshiki Obinata
```

## ros_google_cloud_language

```
* add test to check if ros node is loadable (#463 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/463>)
* add ROS interface for https://cloud.google.com/natural-language (#304 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/304>)
  * [ros_google_cloud_language] add syntax result
* Natural Language AIとChaplus APIを組み合わせたデモ (#6 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/6>)
* Contributors: Kei Okada, MiyabiTane, Shingo Kitagawa
```

## ros_speech_recognition

```
* [ros_speech_recognition] Add vosk engine (#474 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/474>)
* Pr/use sound themes freedesktop (#472 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/472>)
* add test to check if ros node is loadable (#463 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/463>)
* add self.conf_thresh in __init__ function (#457 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/457>)
* [ros_speech_recognition] add ubuntu-sounds dependency (#453 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/453>)
* [ros_speech_recognition] Return if result is empty (#443 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/443>)
* [ros_speece_recognition] Set confidence value of google (#434 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/434>)
* [ros_speech_recognition] add parrotry.launch (#414 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/414>)
* [ros_ speech_recognition] update default arg for speech_recognition.launch (#412 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/412>)
* [ros_speech_recogniton, respeaker_ros] add confidence field (#411 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/411>)
* [ros_speech_recognition] add self cancellation for speech recogntion (#413 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/413>)
* [#405 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/405> and #410 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/410>] Fix CI (#415 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/415>)
* add ROS interface for https://cloud.google.com/natural-language (#304 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/304>)
* GithubAction: add test for  aarch64(melodic) / indigo (arm64) (#365 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/365>)
  
    * pgm_learner/respeaker_ros/ros_speech_recognition/rosping: increase time-limit/wait-time
  
* Explicit python interpreter in catkin_virtualenv (#367 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/367>)
* .github/workflow:  integrate all yaml to one (#338 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/338>)
* [ros_speech_recognition] Fixed the behavior of launch file (#336 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/336>)
* [ros_speech_recognition] add auto_start in speech_recognition_node.py (#301 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/301>)
* [ros_speech_recognition] add SpeechRecognitionCandidatesToString node (#303 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/303>)
* Enable sound play flag (#315 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/315>)
* Contributors: Aiko Ichikura, Aoi Nakane, Kei Okada, Koki Shinjo, Naoto Tsukamoto, Naoya Yamaguchi, Shingo Kitagawa, Yoshiki Obinata, Iory Yanokura
```

## rospatlite

- No changes

## rosping

```
* GithubAction: add test for  aarch64(melodic) / indigo (arm64) (#365 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/365>)
  
    * pgm_learner/respeaker_ros/ros_speech_recognition/rosping: increase time-limit/wait-time
  
* Contributors: Kei Okada, Shingo Kitagawa, Yoshiki Obinata
```

## rostwitter

```
* [rostwitter] use sub and not delete (#446 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/446>)
* [rostwitter] reduce save file io (#441 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/441>)
* [rostwitter] Support extracting base64 images and tweet them from text. with jpeg suffix support (#437 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/437>)
* [tweet_image_server] control volume by dynamic_reconfigure (#398 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/398>)
* rostwitter : install resource directory (#370 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/370>)
* [rostwitter] Suppress tweet log (#378 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/378>)
* GithubAction: add test for  aarch64(melodic) / indigo (arm64) (#365 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/365>)
  
    * tweet_image_server.py: sound_play version < 0.3.7 does not support 'sound_action' argument, so it uses robot_sound, instead of robot_sound_jp
  
* add rostwitter.test (#285 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/285>)
* [rostwitter] set_aborted when error in tweet_image_server.py (#277 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/277>)
* Contributors: Aoi Nakane, Iori Yanokura, Kei Okada, Naoto Tsukamoto, Shingo Kitagawa, Yoshiki Obinata
```

## sesame_ros

```
* add test to check if ros node is loadable (#463 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/463>)
* Explicit python interpreter in catkin_virtualenv (#367 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/367>)
* Contributors: Kei Okada, Shingo Kitagawa, Yoshiki Obinata
```

## slic

- No changes

## switchbot_ros

```
* [switchbot_ros] add actionlib_msgs and std_msgs as build_depend (#357 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/357>)
* [switchbot_ros] add obinata as maintainer for switchbot_ros (#358 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/358>)
* Pr/add switchbot device list publisher (#344 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/344>)
* [switchbot_ros] update switchbot_ros client (#345 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/345>)
* [chaplus_ros][switchbot_ros]fix exec_depend in ros noetic (#332 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/332>)
* [switchbot_ros] update ReadMe.md (#324 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/324>)
* [switchbot_ros] Sort device_list (#331 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/331>)
* [switchbot_ros] remove catching base exception and output more specific key error when the switchbot id not exists on the server (#321 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/321>)
* add install section to switchbot_ros/CMakeLists.txt (#294 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/294>)
* [switchbot_ros] use python setup to avoid relative import in switchbot_ros (#278 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/278>)
* [switchbot_ros] catch the exception when init the node (#279 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/279>)
* Contributors: Kei Okada, Koki Shinjo, Naoya Yamaguchi, Shingo Kitagawa, Yoshiki Obinata, Iory Yanokura
```

## voice_text

```
* GA: enable melodic/aarch64 (#432 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/432>)
* Restart voice text if verification fails (#300 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/300>)
* Add verification check rosinfo (#298 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/298>)
* Contributors: Aoi Nakane, Kei Okada, Naoto Tsukamoto, Naoya Yamaguchi, Shingo Kitagawa, Yoshiki Obinata
```

## webrtcvad_ros

```
* webrtcvad_ros: fix release version in package.xml (#348 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/348>)
* [webrtcvad_ros] update CMakeLists.txt and package.xml (#282 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/282>)
* webrtcvad_ros: fix release version in package.xml (#348 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/348>)
* [webrtcvad_ros] add webrtcvad_ros package (#282 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/282>)
* Contributors: Kei Okada, Koki Shinjo, Shingo Kitagawa
```

## zdepth

```
* [zdepth, zdepth_image_transport] fix zdepth package version to 2.1.24 (#427 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/427>)
* add zdepth and zdepth_image_transport package (#389 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/389>)
* Contributors: Aoi Nakane, Kei Okada, Naoto Tsukamoto, Shingo Kitagawa
```

## zdepth_image_transport

```
* [zdepth_image_transport] add readme for zdepth_image_transport (#430 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/430>)
* [zdepth, zdepth_image_transport] fix zdepth package version to 2.1.24 (#427 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/427>)
* add zdepth and zdepth_image_transport package (#389 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/389>)
* [zdepth_image_transport] add readme for zdepth_image_transport (#430 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/430>)
* Contributors: Aoi Nakane, Kei Okada, Naoto Tsukamoto, Shingo Kitagawa
```
