### PR TITLE
gps_umd: 1.0.9-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1760,7 +1760,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/gps_umd-release.git
-      version: 1.0.8-1
+      version: 1.0.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_umd` to `1.0.9-1`:

- upstream repository: https://github.com/swri-robotics/gps_umd.git
- release repository: https://github.com/ros2-gbp/gps_umd-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.8-1`

## gps_msgs

- No changes

## gps_tools

```
* Backporting CMake and package.xml fixes (#77 <https://github.com/swri-robotics/gps_umd/issues/77>)
* Contributors: David Anthony
```

## gps_umd

```
* Backporting CMake and package.xml fixes (#77 <https://github.com/swri-robotics/gps_umd/issues/77>)
* Contributors: David Anthony
```

## gpsd_client

- No changes
