### PR TITLE
rmf_variants: 0.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4977,6 +4977,23 @@ repositories:
       url: https://github.com/open-rmf/rmf_utils.git
       version: humble
     status: developed
+  rmf_variants:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_variants.git
+      version: main
+    release:
+      packages:
+      - rmf_dev
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_variants-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_variants.git
+      version: main
+    status: developed
   rmf_visualization:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_variants` to `0.0.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_variants.git
- release repository: https://github.com/ros2-gbp/rmf_variants-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## rmf_dev

```
* Define rmf_dev variant
* Contributors: Yadunund
```
