### PR TITLE
gazebo_ros2_control: 0.6.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1434,7 +1434,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.6.0-1
+      version: 0.6.1-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros2_control` to `0.6.1-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros2_control.git
- release repository: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.0-1`

## gazebo_ros2_control

```
* Add pre-commit and CI-format (#206 <https://github.com/ros-controls/gazebo_ros2_control/issues/206>)
  * Add pre-commit and ci-format
* Compile with ROS iron and rolling (#202 <https://github.com/ros-controls/gazebo_ros2_control/issues/202>)
* Contributors: Alejandro Hernández Cordero, Christoph Fröhlich
```

## gazebo_ros2_control_demos

```
* Add pre-commit and CI-format (#206 <https://github.com/ros-controls/gazebo_ros2_control/issues/206>)
  * Add pre-commit and ci-format
* Contributors: Christoph Fröhlich
```
