### PR TITLE
Add in a libqt5-svg key.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5253,7 +5253,15 @@ libqt5-sql:
   gentoo: ['dev-qt/qtsql:5']
   nixos: [qt5.qtbase]
   ubuntu: [libqt5sql5]
+libqt5-svg:
+  arch: [qt5-svg]
+  debian: [libqt5svg5]
+  fedora: [qt5-qtsvg]
+  opensuse: [libqt5-qtsvg]
+  rhel: [qt5-qtsvg]
+  ubuntu: [libqt5svg5]
 libqt5-svg-dev:
+  arch: [qt5-svg]
   debian: [libqt5svg5-dev]
   fedora: [qt5-qtsvg-devel]
   freebsd: [qt5-svg]


### PR DESCRIPTION
While this doesn't follow our normal convention of just using the Ubuntu key, it follows more closely the existing dev package (libqt5-svg-dev).

Please add the following dependency to the rosdep database.

## Package name:

libqt5-svg

## Package Upstream Source:

https://doc.qt.io/qt-5/qtsvg-index.html

## Purpose of using this:

This is the runtime dependency for Qt5 SVG support.  We'll need it to fix an SVG loading problem in RViz2 (https://github.com/ros2/rviz/issues/987).

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=libqt5svg5&searchon=names&suite=all&section=all
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=libqt5svg5&searchon=names&suite=all&section=all
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/qt5-qtsvg/qt5-qtsvg/
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/libqt5-qtsvg