### PR TITLE
navigation2: 1.1.7-3 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3267,6 +3267,7 @@ repositories:
       - nav2_dwb_controller
       - nav2_lifecycle_manager
       - nav2_map_server
+      - nav2_mppi_controller
       - nav2_msgs
       - nav2_navfn_planner
       - nav2_planner
@@ -3288,7 +3289,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/SteveMacenski/navigation2-release.git
-      version: 1.1.6-1
+      version: 1.1.7-3
     source:
       type: git
       url: https://github.com/ros-planning/navigation2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation2` to `1.1.7-3`:

- upstream repository: https://github.com/ros-planning/navigation2.git
- release repository: https://github.com/SteveMacenski/navigation2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.6-1`
