### PR TITLE
mqtt_client: 2.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5829,10 +5829,13 @@ repositories:
       url: https://github.com/ika-rwth-aachen/mqtt_client.git
       version: main
     release:
+      packages:
+      - mqtt_client
+      - mqtt_client_interfaces
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ika-rwth-aachen/mqtt_client-release.git
-      version: 1.1.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ika-rwth-aachen/mqtt_client.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mqtt_client` to `2.0.1-1`:

- upstream repository: https://github.com/ika-rwth-aachen/mqtt_client.git
- release repository: https://github.com/ika-rwth-aachen/mqtt_client-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-1`

## mqtt_client

```
* Add support for ROS2 by @lreiher in https://github.com/ika-rwth-aachen/mqtt_client/pull/16
* Integrate docker-ros by @lreiher in https://github.com/ika-rwth-aachen/mqtt_client/pull/23
* fix unrecognized build type with catkin_make_isolated
* Contributors: Lennart Reiher
```

## mqtt_client_interfaces

```
* initial release
* Contributors: Lennart Reiher
```
