### PR TITLE
mqtt_client: 2.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3133,6 +3133,24 @@ repositories:
       url: https://github.com/ros-planning/moveit_visual_tools.git
       version: ros2
     status: maintained
+  mqtt_client:
+    doc:
+      type: git
+      url: https://github.com/ika-rwth-aachen/mqtt_client.git
+      version: main
+    release:
+      packages:
+      - mqtt_client
+      - mqtt_client_interfaces
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ika-rwth-aachen/mqtt_client-release.git
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://github.com/ika-rwth-aachen/mqtt_client.git
+      version: main
+    status: maintained
   mrpt2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mqtt_client` to `2.0.1-1`:

- upstream repository: https://github.com/ika-rwth-aachen/mqtt_client.git
- release repository: https://github.com/ika-rwth-aachen/mqtt_client-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## mqtt_client (initial release for ROS 2)

```
* Add support for ROS2 by @lreiher in https://github.com/ika-rwth-aachen/mqtt_client/pull/16
* Integrate docker-ros by @lreiher in https://github.com/ika-rwth-aachen/mqtt_client/pull/23
* fix unrecognized build type with catkin_make_isolated
* Contributors: Lennart Reiher
```

## mqtt_client_interfaces (initial release for ROS 2)

```
* initial release
* Contributors: Lennart Reiher
```
