### PR TITLE
mvsim: 0.7.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6009,7 +6009,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
-      version: 0.7.0-1
+      version: 0.7.1-1
     source:
       type: git
       url: https://github.com/ual-arm-ros-pkg/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.7.1-1`:

- upstream repository: https://github.com/ual-arm-ros-pkg/mvsim.git
- release repository: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.0-1`

## mvsim

```
* ROS node: fix potential race condition creating publisher for highrate sensors
* Add IMU sensors
* New property <visual enabled='true|false'>
* lidar2d xml: add option "sensor_custom_visual"
* FIX: Crash if launching an empty world
* Trigger an error if using use_sim_time to avoid mistakes
* Add new (fake) controller: twist_ideal
* ROS 1: don't enforce /use_sim_time
* Add ROS 2 launch for the 2-robot demo
* Fix cmake leftover
* Contributors: Jose Luis Blanco-Claraco
```
