### PR TITLE
Add gtsam doc/source to noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3393,6 +3393,16 @@ repositories:
       url: https://github.com/CogRob/catkin_grpc.git
       version: master
     status: maintained
+  gtsam:
+    doc:
+      type: git
+      url: https://github.com/borglab/gtsam.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/borglab/gtsam.git
+      version: develop
+    status: developed  
   haf_grasping:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3402,7 +3402,7 @@ repositories:
       type: git
       url: https://github.com/borglab/gtsam.git
       version: develop
-    status: developed  
+    status: developed
   haf_grasping:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

noetic

(Already added to all ROS 2 distros)

# The source is here:

https://github.com/borglab/gtsam

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
