### PR TITLE
gtsam: 4.2.0-5 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1725,7 +1725,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/gtsam-release.git
-      version: 4.2.0-4
+      version: 4.2.0-5
     source:
       type: git
       url: https://github.com/borglab/gtsam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gtsam` to `4.2.0-5`:

- upstream repository: https://github.com/borglab/gtsam.git
- release repository: https://github.com/ros2-gbp/gtsam-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.2.0-4`
