### PR TITLE
demos: 0.30.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -898,7 +898,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.29.0-1
+      version: 0.30.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.30.0-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.29.0-1`

## action_tutorials_cpp

- No changes

## action_tutorials_interfaces

- No changes

## action_tutorials_py

- No changes

## composition

- No changes

## demo_nodes_cpp

```
* Small cleanups to the demos when running through them. (#639 <https://github.com/ros2/demos/issues/639>)
* Cleanup demo_nodes_cpp CMake and dependencies (#638 <https://github.com/ros2/demos/issues/638>)
* Change the service introspection parameter off value to 'disabled' (#634 <https://github.com/ros2/demos/issues/634>)
* Contributors: Chris Lalancette
```

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

```
* Change the service introspection parameter off value to 'disabled' (#634 <https://github.com/ros2/demos/issues/634>)
  With this we can avoid the tricky bits around YAML
  interpretation of 'off' as a boolean.
* Contributors: Chris Lalancette
```

## dummy_map_server

- No changes

## dummy_robot_bringup

```
* Switch to file-content launch substitution (#627 <https://github.com/ros2/demos/issues/627>)
* Contributors: Scott K Logan
```

## dummy_sensors

- No changes

## image_tools

- No changes

## intra_process_demo

- No changes

## lifecycle

- No changes

## lifecycle_py

- No changes

## logging_demo

- No changes

## pendulum_control

- No changes

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

- No changes

## quality_of_service_demo_py

- No changes

## topic_monitor

- No changes

## topic_statistics_demo

- No changes
