### PR TITLE
Humble: Add source entry of `executive_smach`

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6694,6 +6694,16 @@ repositories:
       url: https://github.com/robosoft-ai/SMACC2.git
       version: humble
     status: developed
+  smach:
+    doc:
+      type: git
+      url: https://github.com/ros/executive_smach.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/ros/executive_smach.git
+      version: ros2
+    status: maintained
   snowbot_operating_system:
     doc:
       type: git


### PR DESCRIPTION
<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

humble

# The source is here:

https://github.com/ros/executive_smach

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
