### PR TITLE
clearpath_config: 0.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -781,6 +781,21 @@ repositories:
       url: https://github.com/MetroRobots/classic_bags.git
       version: main
     status: developed
+  clearpath_config:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_config.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/clearpath_config-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_config.git
+      version: main
+    status: developed
   clearpath_msg:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `0.0.2-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## clearpath_config

```
* Fixed gps indexing
* Added system ROS2 parameters
* Decorations enabled by default
* Added resource and package.xml to install data files
* Contributors: Luis Camero
```
