### PR TITLE
Fixed typo in repository name for Humble clearpath_msgs.

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -781,7 +781,7 @@ repositories:
       url: https://github.com/MetroRobots/classic_bags.git
       version: main
     status: developed
-  clearpath_msg:
+  clearpath_msgs:
     doc:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_msgs.git


### PR DESCRIPTION
## Package name:

clearpath_msgs

## Package Upstream Source:

https://github.com/clearpathrobotics/clearpath_msgs.git

## Purpose of using this:

Renaming repository entry to match upstream source name.    
Distro packaging links:


# Please Add This Package to be indexed in the rosdistro.

Humble
# The source is here:

http://sourcecode_url

# Checks
 - [X ] All packages have a declared license in the package.xml
 - [X ] This repository has a LICENSE file
 - [X ] This package is expected to build on the submitted rosdistro
