### PR TITLE
feat: add 'sphinx-autoapi' pip dependency

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8447,6 +8447,19 @@ python3-sphinx-argparse:
   fedora: [python3-sphinx-argparse]
   nixos: [python3Packages.sphinx-argparse]
   ubuntu: [python3-sphinx-argparse]
+python3-sphinx-autoapi:
+  debian:
+    pip:
+      packages: [sphinx-autoapi]
+  fedora:
+    pip:
+      packages: [sphinx-autoapi]
+  osx:
+    pip:
+      packages: [sphinx-autoapi]
+  ubuntu:
+    pip:
+      packages: [sphinx-autoapi]
 python3-sphinx-rtd-theme:
   debian: [python3-sphinx-rtd-theme]
   fedora: [python3-sphinx_rtd_theme]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

sphinx-autoapi

## Package Upstream Source:

https://github.com/readthedocs/sphinx-autoapi

## Purpose of using this:

This PR adds the [sphinx-autoapi](https://sphinx-autoapi.readthedocs.io/en/latest/tutorials.html) package
as a pip python dependency. This package can be used to automatically create sphinx code API documentation. It can therefore be useful to add this dependency as a `<doc_depend>` in the `package.xml`.

**Distro packaging links:**

PIP: https://pypi.org/project/sphinx-autoapi/

## Links to Distribution Packages

**N/a**