### PR TITLE
feat: add  pip MyST-Parser  pip dependency

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6749,6 +6749,19 @@ python3-mypy:
     '7': null
     '8': null
   ubuntu: [python3-mypy]
+python3-myst-parser:
+  debian:
+    pip:
+      packages: [myst-parser]
+  fedora:
+    pip:
+      packages: [myst-parser]
+  osx:
+    pip:
+      packages: [myst-parser]
+  ubuntu:
+    pip:
+      packages: [myst-parser]
 python3-natsort:
   debian: [python3-natsort]
   fedora: [python3-natsort]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6749,7 +6749,7 @@ python3-mypy:
     '7': null
     '8': null
   ubuntu: [python3-mypy]
-python3-myst-parser:
+python3-myst-parser-pip:
   debian:
     pip:
       packages: [myst-parser]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

MyST-Parser

## Package Upstream Source:

https://github.com/executablebooks/MyST-Parser

## Purpose of using this:

This PR adds the [myst-parser](https://pypi.org/project/myst-parser/) pip package as a python dependency. This package can be used to parse markdown for sphinx-based documentation projects. It can be useful to include as a `<doc_depend>` in the `package.xml`.

**Distro packaging links:**

PIP: https://pypi.org/project/myst-parser/

## Links to Distribution Packages

**N/a**