### PR TITLE
Add rosdep key for sshkeyboard

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8483,6 +8483,16 @@ python3-squaternion-pip:
   ubuntu:
     pip:
       packages: [squaternion]
+python3-sshkeyboard-pip:
+  debian:
+    pip:
+      packages: [sshkeyboard]
+  osx:
+    pip:
+      packages: [sshkeyboard]
+  ubuntu:
+    pip:
+      packages: [sshkeyboard]
 python3-sshtunnel:
   debian: [python3-sshtunnel]
   fedora: [python3-sshtunnel]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

sshkeyboard

## Package Upstream Source:

https://github.com/ollipal/sshkeyboard

## Purpose of using this:

A library to react to user keyboard input through SSH 

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://pypi.org/project/sshkeyboard/
- Ubuntu: https://packages.ubuntu.com/
  - https://pypi.org/project/sshkeyboard/
- macOS: https://formulae.brew.sh/
  - https://pypi.org/project/sshkeyboard/

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
