### PR TITLE
urg_node_msgs: 1.0.1-7 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6752,7 +6752,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urg_node_msgs-release.git
-      version: 1.0.1-6
+      version: 1.0.1-7
     source:
       type: git
       url: https://github.com/ros-drivers/urg_node_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_node_msgs` to `1.0.1-7`:

- upstream repository: https://github.com/ros-drivers/urg_node_msgs.git
- release repository: https://github.com/ros2-gbp/urg_node_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.1-6`

## urg_node_msgs

```
* add myself as maintainer (#4 <https://github.com/ros-drivers/urg_node_msgs/issues/4>)
* Contributors: Michael Ferguson
```
