### PR TITLE
executive_smach: 2.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3065,7 +3065,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/executive_smach-release.git
-      version: 2.0.1-0
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/ros/executive_smach.git


### PR DESCRIPTION
Increasing version of package(s) in repository `executive_smach` to `2.0.2-1`:

- upstream repository: https://github.com/ros/executive_smach.git
- release repository: https://github.com/ros-gbp/executive_smach-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.1-0`

## executive_smach

- No changes

## smach

```
* Fix: state.py Docstrings' @type descriptions #59 <https://github.com/ros/executive_smach/issues/59>
* Fix: Typo set_shutdown_cb() --> set_shutdown_check() #56 <https://github.com/ros/executive_smach/issues/56>
```

## smach_msgs

- No changes

## smach_ros

- No changes
