### PR TITLE
executive_smach: 2.5.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2426,7 +2426,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/executive_smach-release.git
-      version: 2.5.1-1
+      version: 2.5.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `executive_smach` to `2.5.2-1`:

- upstream repository: https://github.com/ros/executive_smach.git
- release repository: https://github.com/ros-gbp/executive_smach-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.5.1-1`

## executive_smach

- No changes

## smach

```
* Fix outcome_map disambiguation for Concurrence #80 <https://github.com/ros/executive_smach/issues/80>
* Fix is_running behaviour in case of exception in the state #50 <https://github.com/ros/executive_smach/issues/50>
* Executing an empty Concurrence container hangs forever #51 <https://github.com/ros/executive_smach/issues/51>
```

## smach_msgs

- No changes

## smach_ros

```
* Fix is_running behaviour in case of exception in the state #50 <https://github.com/ros/executive_smach/issues/50>
* Executing an empty Concurrence container hangs forever #51 <https://github.com/ros/executive_smach/issues/51>
```
