### PR TITLE
gtsam: 4.2.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3398,6 +3398,11 @@ repositories:
       type: git
       url: https://github.com/borglab/gtsam.git
       version: develop
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/mrpt-ros-pkg-release/gtsam-release.git
+      version: 4.2.0-2
     source:
       type: git
       url: https://github.com/borglab/gtsam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gtsam` to `4.2.0-2`:

- upstream repository: https://github.com/borglab/gtsam.git
- release repository: https://github.com/mrpt-ros-pkg-release/gtsam-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
