### PR TITLE
Add REACH to rosdistro

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4805,12 +4805,12 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-industrial/reach.git
-      version: 1.3.0
+      version: master
   reach_ros:
     source:
       type: git
       url: https://github.com/ros-industrial/reach_ros2.git
-      version: 1.1.0
+      version: master
   realsense2_camera:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4801,6 +4801,16 @@ repositories:
       url: https://github.com/ros2/rcutils.git
       version: foxy
     status: maintained
+  reach:
+    source:
+      type: git
+      url: https://github.com/ros-industrial/reach.git
+      version: 1.3.0
+  reach_ros:
+    source:
+      type: git
+      url: https://github.com/ros-industrial/reach_ros2.git
+      version: 1.1.0
   realsense2_camera:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4801,16 +4801,6 @@ repositories:
       url: https://github.com/ros2/rcutils.git
       version: foxy
     status: maintained
-  reach:
-    source:
-      type: git
-      url: https://github.com/ros-industrial/reach.git
-      version: master
-  reach_ros:
-    source:
-      type: git
-      url: https://github.com/ros-industrial/reach_ros2.git
-      version: master
   realsense2_camera:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4700,6 +4700,16 @@ repositories:
       url: https://github.com/ros2/rcutils.git
       version: humble
     status: maintained
+  reach:
+    source:
+      type: git
+      url: https://github.com/ros-industrial/reach.git
+      version: 1.3.0
+  reach_ros:
+    source:
+      type: git
+      url: https://github.com/ros-industrial/reach_ros2.git
+      version: 1.1.0
   realsense2_camera:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4704,12 +4704,12 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-industrial/reach.git
-      version: 1.3.0
+      version: master
   reach_ros:
     source:
       type: git
       url: https://github.com/ros-industrial/reach_ros2.git
-      version: 1.1.0
+      version: master
   realsense2_camera:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8255,12 +8255,12 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-industrial/reach.git
-      version: 1.3.0
+      version: master
   reach_ros:
     source:
       type: git
       url: https://github.com/ros-industrial/reach_ros.git
-      version: 1.1.0
+      version: master
   realsense2_camera:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8251,6 +8251,16 @@ repositories:
       url: https://github.com/roboception/rcdiscover.git
       version: master
     status: developed
+  reach:
+    source:
+      type: git
+      url: https://github.com/ros-industrial/reach.git
+      version: 1.3.0
+  reach_ros:
+    source:
+      type: git
+      url: https://github.com/ros-industrial/reach_ros.git
+      version: 1.1.0
   realsense2_camera:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4089,12 +4089,12 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-industrial/reach.git
-      version: 1.3.0
+      version: master
   reach_ros:
     source:
       type: git
       url: https://github.com/ros-industrial/reach_ros2.git
-      version: 1.1.0
+      version: master
   realtime_support:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4085,6 +4085,16 @@ repositories:
       url: https://github.com/ros2/rcutils.git
       version: rolling
     status: maintained
+  reach:
+    source:
+      type: git
+      url: https://github.com/ros-industrial/reach.git
+      version: 1.3.0
+  reach_ros:
+    source:
+      type: git
+      url: https://github.com/ros-industrial/reach_ros2.git
+      version: 1.1.0
   realtime_support:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

- `reach` (core package)
- `reach_ros` (ROS binding of core package)

# The source is here:

https://github.com/ros-industrial/reach.git
https://github.com/ros-industrial/reach_ros.git
https://github.com/ros-industrial/reach_ros2.git

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
