### PR TITLE
rviz_robot_description_topic: 1.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10235,6 +10235,21 @@ repositories:
       url: https://github.com/ros-visualization/rviz_animated_view_controller.git
       version: noetic-devel
     status: maintained
+  rviz_robot_description_topic:
+    doc:
+      type: git
+      url: https://github.com/nobleo/rviz_robot_description_topic.git
+      version: main
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/nobleo/rviz_robot_description_topic-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/nobleo/rviz_robot_description_topic.git
+      version: main
+    status: maintained
   rviz_satellite:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_robot_description_topic` to `1.0.0-1`:

- upstream repository: https://github.com/nobleo/rviz_robot_description_topic.git
- release repository: https://github.com/nobleo/rviz_robot_description_topic-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## rviz_robot_description_topic

```
* RobotModel display using a /robot_description topic instead of a parameter
* Contributors: Tim Clephas
```
