### PR TITLE
mrpt_sensors: 0.0.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5924,10 +5924,11 @@ repositories:
       - mrpt_generic_sensor
       - mrpt_sensorlib
       - mrpt_sensors
+      - mrpt_sensors_examples
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_sensors-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_sensors` to `0.0.3-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_sensors-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.2-1`

## mrpt_generic_sensor

```
* towards templatized specific sensor nodes
* Contributors: Jose Luis Blanco Claraco
```

## mrpt_sensorlib

```
* Fix build errors with latest mrpt versions
* Implement publisher for velodyne sensor
* start publish ros
* fix install dir
* towards templatized specific sensor nodes
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensors

```
* towards templatized specific sensor nodes
* Contributors: Jose Luis Blanco Claraco
```

## mrpt_sensors_examples

```
* fix wrong changelog
* towards templatized specific sensor nodes
* Contributors: Jose Luis Blanco Claraco
```
