### PR TITLE
mrpt_path_planning: 0.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5910,10 +5910,16 @@ repositories:
       type: git
       url: https://github.com/MRPT/mrpt_path_planning.git
       version: develop
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/mrpt-ros-pkg-release/mrpt_path_planning-release.git
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_path_planning.git
       version: develop
+    status: developed
   mrpt_sensors:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_path_planning` to `0.1.0-1`:

- upstream repository: https://github.com/MRPT/mrpt_path_planning.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_path_planning-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## mrpt_path_planning

```
* First release since initial development in May 2019.
* Contributors: Jose Luis Blanco-Claraco, Shravan S Rai
```
