### PR TITLE
mrpt_path_planning: 0.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3181,6 +3181,21 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
       version: master
     status: maintained
+  mrpt_path_planning:
+    doc:
+      type: git
+      url: https://github.com/MRPT/mrpt_path_planning.git
+      version: develop
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/mrpt_path_planning-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/MRPT/mrpt_path_planning.git
+      version: develop
+    status: developed
   mrt_cmake_modules:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_path_planning` to `0.1.0-1`:

- upstream repository: https://github.com/MRPT/mrpt_path_planning.git
- release repository: https://github.com/ros2-gbp/mrpt_path_planning-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## mrpt_path_planning

```
* First release since initial development in May 2019.
* Contributors: Jose Luis Blanco-Claraco, Shravan S Rai
```
