### PR TITLE
roscpp_core: Change branch to melodic-devel

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11605,7 +11605,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/roscpp_core.git
-      version: kinetic-devel
+      version: melodic-devel
     release:
       packages:
       - cpp_common
@@ -11621,7 +11621,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/roscpp_core.git
-      version: kinetic-devel
+      version: melodic-devel
     status: maintained
   rosdoc_lite:
     doc:


### PR DESCRIPTION
I'd like to switch roscpp_core on Melodic to melodic-devel branch for the last sync.