### PR TITLE
Add zsh to rosdep/base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8427,6 +8427,7 @@ zsh:
   macports: [zsh]
   nixos: [zsh]
   opensuse: [zsh]
+  rhel: [zsh]
   ubuntu: [zsh]
 zziplib:
   arch: [zziplib]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8417,6 +8417,17 @@ zlib:
     slackpkg:
       packages: [zlib]
   ubuntu: [zlib1g-dev]
+zsh:
+  alpine: [zsh]
+  arch: [zsh]
+  debian: [zsh]
+  fedora: [zsh]
+  freebsd: [zsh]
+  gentoo: [shells/zsh]
+  macports: [zsh]
+  nixos: [zsh]
+  opensuse: [zsh]
+  ubuntu: [zsh]
 zziplib:
   arch: [zziplib]
   debian: [libzzip-0-13, libzzip-dev]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

zsh

## Package Upstream Source:

https://www.zsh.org/

## Purpose of using this:

Zsh has a more forgiving scripting environment than bash.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=zsh&searchon=names&exact=1&suite=all&section=all
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=zsh&searchon=names&exact=1&suite=all&section=all
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/zsh/zsh/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/zsh/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/app-shells/zsh
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/zsh#default
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/packages?name=zsh&branch=edge&repo=&arch=&maintainer=
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=23.05&show=zsh&from=0&size=1&sort=relevance&type=packages&query=zsh
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/zsh
- FreeBSD:
  - https://cgit.freebsd.org/ports/tree/shells/zsh
- RHEL:
  - https://repo.almalinux.org/almalinux/9.2/BaseOS/x86_64/os/Packages/zsh-5.8-9.el9.x86_64.rpm