### PR TITLE
gps_umd: 0.3.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4063,7 +4063,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/gps_umd-release.git
-      version: 0.3.3-1
+      version: 0.3.4-1
     source:
       type: git
       url: https://github.com/swri-robotics/gps_umd.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_umd` to `0.3.4-1`:

- upstream repository: https://github.com/swri-robotics/gps_umd.git
- release repository: https://github.com/swri-robotics-gbp/gps_umd-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.3-1`

## gps_common

- No changes

## gps_umd

- No changes

## gpsd_client

```
* GPSD API v12 Compatibility (#78 <https://github.com/swri-robotics/gps_umd/issues/78>)
* Contributors: MariuszSzczepanikSpyrosoft
```
