### PR TITLE
witmotion_ros: 1.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12287,7 +12287,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/twdragon/witmotion_ros-release.git
-      version: 1.2.28-1
+      version: 1.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `witmotion_ros` to `1.3.0-1`:

- upstream repository: https://github.com/ElettraSciComp/witmotion_IMU_ros.git
- release repository: https://github.com/twdragon/witmotion_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.28-1`

## witmotion_ros

```
* Added support for serial port timeout behaviour (timeout_ms)
* Updated README.md
* Merged pull request #27 <https://github.com/ElettraSciComp/witmotion_IMU_ros/pull/27> from gsokoll
* Version bump to 1.3.0
* Matched versions for ROS node and underlying library after merging pull request #7 <https://github.com/ElettraSciComp/witmotion_IMU_QT/pull/7>
```
