### PR TITLE
ros2_controllers: 2.22.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5318,7 +5318,9 @@ repositories:
       version: humble
     release:
       packages:
+      - ackermann_steering_controller
       - admittance_controller
+      - bicycle_steering_controller
       - diff_drive_controller
       - effort_controllers
       - force_torque_sensor_broadcaster
@@ -5331,12 +5333,14 @@ repositories:
       - ros2_controllers
       - ros2_controllers_test_nodes
       - rqt_joint_trajectory_controller
+      - steering_controllers_library
       - tricycle_controller
+      - tricycle_steering_controller
       - velocity_controllers
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.21.0-1
+      version: 2.22.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.22.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.21.0-1`

## ackermann_steering_controller

```
* Bump versions for release
* Let sphinx add parameter description to documentation (backport #651 <https://github.com/ros-controls/ros2_controllers/issues/651>) (#663 <https://github.com/ros-controls/ros2_controllers/issues/663>)
* Fix sphinx for steering odometry library/controllers (#626 <https://github.com/ros-controls/ros2_controllers/issues/626>) (#661 <https://github.com/ros-controls/ros2_controllers/issues/661>)
* Steering odometry library and controllers (backport #484 <https://github.com/ros-controls/ros2_controllers/issues/484>) (`#624 <https://github.com/ros-controls/
* Contributors: Bence Magyar, Christoph Fröhlich, Tomislav Petković, Reza Kermani, Denis Štogl
```

## admittance_controller

```
* Docs: Use branch name substitution for all links (backport #618 <https://github.com/ros-controls/ros2_controllers/issues/618>) (#633 <https://github.com/ros-controls/ros2_controllers/issues/633>)
* [JTC] Fix missing parameter deprecation warnings (#630 <https://github.com/ros-controls/ros2_controllers/issues/630>)
* [Formatting] enable ReflowComments to also use ColumnLimit on comments   (#628 <https://github.com/ros-controls/ros2_controllers/issues/628>)
* Contributors: Noel Jiménez García, Sai Kishor Kothakota, Christoph Fröhlich
```

## bicycle_steering_controller

```
* Bump versions for release
* Let sphinx add parameter description to documentation (backport #651 <https://github.com/ros-controls/ros2_controllers/issues/651>) (#663 <https://github.com/ros-controls/ros2_controllers/issues/663>)
* Fix sphinx for steering odometry library/controllers (#626 <https://github.com/ros-controls/ros2_controllers/issues/626>) (#661 <https://github.com/ros-controls/ros2_controllers/issues/661>)
* Steering odometry library and controllers (backport #484 <https://github.com/ros-controls/ros2_controllers/issues/484>) (#624 <https://github.com/ros-controls/ros2_controllers/issues/624>)
* Contributors: Bence Magyar, Christoph Fröhlich, Tomislav Petković, Reza Kermani, Denis Štogl
```

## diff_drive_controller

```
* Use generate_parameter_library for all params (#601 <https://github.com/ros-controls/ros2_controllers/issues/601>) (#627 <https://github.com/ros-controls/ros2_controllers/issues/627>)
* Docs: Use branch name substitution for all links (backport #618 <https://github.com/ros-controls/ros2_controllers/issues/618>) (#633 <https://github.com/ros-controls/ros2_controllers/issues/633>)
* [Formatting] enable ReflowComments to also use ColumnLimit on comments   (#628 <https://github.com/ros-controls/ros2_controllers/issues/628>)
* Contributors: Sai Kishor Kothakota, Christoph Fröhlich
```

## effort_controllers

```
* Docs: Use branch name substitution for all links (backport #618 <https://github.com/ros-controls/ros2_controllers/issues/618>) (#633 <https://github.com/ros-controls/ros2_controllers/issues/633>)
* Contributors: Christoph Fröhlich
```

## force_torque_sensor_broadcaster

```
* Docs: Use branch name substitution for all links (backport #618 <https://github.com/ros-controls/ros2_controllers/issues/618>) (#633 <https://github.com/ros-controls/ros2_controllers/issues/633>)
* Contributors: Christoph Fröhlich
```

## forward_command_controller

```
* Let sphinx add parameter description to documentation (backport #651 <https://github.com/ros-controls/ros2_controllers/issues/651>) (#663 <https://github.com/ros-controls/ros2_controllers/issues/663>)
* Docs: Use branch name substitution for all links (backport #618 <https://github.com/ros-controls/ros2_controllers/issues/618>) (#633 <https://github.com/ros-controls/ros2_controllers/issues/633>)
* Contributors: Sai Kishor Kothakota, Christoph Fröhlich
```

## gripper_controllers

```
* Let sphinx add parameter description to documentation (backport #651 <https://github.com/ros-controls/ros2_controllers/issues/651>) (#663 <https://github.com/ros-controls/ros2_controllers/issues/663>)
* [JTC] Fix missing parameter deprecation warnings (#630 <https://github.com/ros-controls/ros2_controllers/issues/630>)
* Contributors: Noel Jiménez García, Christoph Fröhlich
```

## imu_sensor_broadcaster

```
* Let sphinx add parameter description to documentation (backport #651 <https://github.com/ros-controls/ros2_controllers/issues/651>) (#663 <https://github.com/ros-controls/ros2_controllers/issues/663>)
* Docs: Use branch name substitution for all links (backport #618 <https://github.com/ros-controls/ros2_controllers/issues/618>) (#633 <https://github.com/ros-controls/ros2_controllers/issues/633>)
* Contributors: Christoph Fröhlich
```

## joint_state_broadcaster

```
* Docs: Use branch name substitution for all links (backport #618 <https://github.com/ros-controls/ros2_controllers/issues/618>) (#633 <https://github.com/ros-controls/ros2_controllers/issues/633>)
* Contributors: Christoph Fröhlich
```

## joint_trajectory_controller

```
* Docs: Use branch name substitution for all links (backport #618 <https://github.com/ros-controls/ros2_controllers/issues/618>) (#633 <https://github.com/ros-controls/ros2_controllers/issues/633>)
* [JTC] Import docs from wiki.ros.org (backport #566 <https://github.com/ros-controls/ros2_controllers/issues/566>) (#634 <https://github.com/ros-controls/ros2_controllers/issues/634>)
* [Formatting] enable ReflowComments to also use ColumnLimit on comments   (#628 <https://github.com/ros-controls/ros2_controllers/issues/628>)
* Contributors: Sai Kishor Kothakota, Christoph Fröhlich
```

## position_controllers

```
* Docs: Use branch name substitution for all links (backport #618 <https://github.com/ros-controls/ros2_controllers/issues/618>) (#633 <https://github.com/ros-controls/ros2_controllers/issues/633>)
* Contributors: Christoph Fröhlich
```

## ros2_controllers

```
* Steering odometry library and controllers (backport #484 <https://github.com/ros-controls/ros2_controllers/issues/484>) (#624 <https://github.com/ros-controls/ros2_controllers/issues/624>)
* Contributors: Tomislav Petković, Reza Kermani, Denis Štogl
```

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Bump versions for release
* Let sphinx add parameter description to documentation (backport #651 <https://github.com/ros-controls/ros2_controllers/issues/651>) (#663 <https://github.com/ros-controls/ros2_controllers/issues/663>)
* Second round of dependencies fix (#655 <https://github.com/ros-controls/ros2_controllers/issues/655>) (#656 <https://github.com/ros-controls/ros2_controllers/issues/656>)
* Fix sphinx for steering odometry library/controllers (#626 <https://github.com/ros-controls/ros2_controllers/issues/626>) (#661 <https://github.com/ros-controls/ros2_controllers/issues/661>)
* Remove unnecessary include (backport #645 <https://github.com/ros-controls/ros2_controllers/issues/645>) (#646 <https://github.com/ros-controls/ros2_controllers/issues/646>)
* Steering odometry library and controllers (backport #484 <https://github.com/ros-controls/ros2_controllers/issues/484>) (#624 <https://github.com/ros-controls/ros2_controllers/issues/624>)
* Contributors: Bence Magyar, Christoph Fröhlich, Tomislav Petković, Reza Kermani, Denis Štogl
```

## tricycle_controller

```
* Docs: Use branch name substitution for all links (backport #618 <https://github.com/ros-controls/ros2_controllers/issues/618>) (#633 <https://github.com/ros-controls/ros2_controllers/issues/633>)
* [Formatting] enable ReflowComments to also use ColumnLimit on comments   (#628 <https://github.com/ros-controls/ros2_controllers/issues/628>)
* Contributors: Sai Kishor Kothakota, Christoph Fröhlich
```

## tricycle_steering_controller

```
* Bump versions for release
* Let sphinx add parameter description to documentation (backport #651 <https://github.com/ros-controls/ros2_controllers/issues/651>) (#663 <https://github.com/ros-controls/ros2_controllers/issues/663>)
* Fix sphinx for steering odometry library/controllers (#626 <https://github.com/ros-controls/ros2_controllers/issues/626>) (#661 <https://github.com/ros-controls/ros2_controllers/issues/661>)
* Steering odometry library and controllers (backport #484 <https://github.com/ros-controls/ros2_controllers/issues/484>) (#624 <https://github.com/ros-controls/ros2_controllers/issues/624>)
* Contributors: Bence Magyar, Christoph Fröhlich, Tomislav Petković, Reza Kermani, Denis Štogl
```

## velocity_controllers

```
* Docs: Use branch name substitution for all links (backport #618 <https://github.com/ros-controls/ros2_controllers/issues/618>) (#633 <https://github.com/ros-controls/ros2_controllers/issues/633>)
* Contributors: Christoph Fröhlich
```
