### PR TITLE
Update libtool for debian in base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5638,10 +5638,9 @@ libtins-dev:
 libtool:
   arch: [libtool]
   debian:
-    buster: [libtool, libltdl-dev, libtool-bin]
+    '*': [libtool, libltdl-dev, libtool-bin]
     lenny: [libtool, libltdl3-dev]
     squeeze: [libtool, libltdl-dev]
-    stretch: [libtool, libltdl-dev, libtool-bin]
     wheezy: [libtool, libltdl-dev]
   fedora: [libtool, libtool-ltdl-devel]
   freebsd: [libtool]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5637,11 +5637,7 @@ libtins-dev:
   ubuntu: [libtins-dev]
 libtool:
   arch: [libtool]
-  debian:
-    '*': [libtool, libltdl-dev, libtool-bin]
-    lenny: [libtool, libltdl3-dev]
-    squeeze: [libtool, libltdl-dev]
-    wheezy: [libtool, libltdl-dev]
+  debian: [libtool, libltdl-dev, libtool-bin]
   fedora: [libtool, libtool-ltdl-devel]
   freebsd: [libtool]
   gentoo: [sys-devel/libtool]
@@ -5651,10 +5647,7 @@ libtool:
   opensuse: [libtool, libltdl7]
   rhel: [libtool, libtool-ltdl-devel]
   slackware: [libtool]
-  ubuntu:
-    bionic: [libtool, libltdl-dev, libtool-bin]
-    focal: [libtool, libltdl-dev, libtool-bin]
-    jammy: [libtool, libltdl-dev, libtool-bin]
+  ubuntu: [libtool, libltdl-dev, libtool-bin]
 libttspico:
   debian: [libttspico-dev, libttspico-data, libttspico-utils, libttspico0]
   ubuntu: [libttspico-dev, libttspico-data, libttspico-utils, libttspico0]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

libtool

## Package Upstream Source:

https://www.gnu.org/software/libtool/libtool.html

## Purpose of using this:

Adding bullseye support and shortening debian entry through wildcard.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - libtool-bin: https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=libtool-bin
  - libtool: https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=libtool
  - libltdl-dev: https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=libltdl-dev