### PR TITLE
euslisp: 9.29.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2406,7 +2406,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tork-a/euslisp-release.git
-      version: 9.29.0-1
+      version: 9.29.0-2
     source:
       type: git
       url: https://github.com/euslisp/EusLisp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `euslisp` to `9.29.0-2`:

- upstream repository: https://github.com/euslisp/EusLisp
- release repository: https://github.com/tork-a/euslisp-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `9.29.0-1`
