### PR TITLE
septentrio_gnss_driver: 1.3.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13154,7 +13154,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/septentrio-users/septentrio_gnss_driver-release.git
-      version: 1.2.3-2
+      version: 1.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `septentrio_gnss_driver` to `1.3.0-1`:

- upstream repository: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
- release repository: https://github.com/septentrio-users/septentrio_gnss_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.3-2`
