### PR TITLE
roscpp_core: 0.7.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9287,7 +9287,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/roscpp_core-release.git
-      version: 0.7.2-1
+      version: 0.7.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscpp_core` to `0.7.3-1`:

- upstream repository: git@github.com:ros/roscpp_core.git
- release repository: https://github.com/ros-gbp/roscpp_core-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.2-1`

## cpp_common

```
* Changed maintainer to Martin Pecka
* Contributors: Martin Pecka
```

## roscpp_core

```
* Changed maintainer to Martin Pecka
* Contributors: Martin Pecka
```

## roscpp_serialization

```
* Documented the API misuse in serializeServiceResponse
* Fixed wrong serialization of messages on ARM with GCC 9.3 and -O3 optimizations
* Changed maintainer to Martin Pecka
* Fix usage of deprecated std::allocator::rebind (#124 <https://github.com/ros/roscpp_core/issues/124>)
* Contributors: Martin Pecka, poggenhans
```

## roscpp_traits

```
* Changed maintainer to Martin Pecka
* Contributors: Martin Pecka
```

## rostime

```
* Fix min() usage
* Use shorter wall sleeps in sim time for very short durations
* Changed maintainer to Martin Pecka
* Removed constants for WEEK and YEAR as they might be ambiguous.
* rostime: Added <limits> headers wherever std::numeric_limits are used.
* Fixed handling of infinite or >int64 doubles in Time and Duration constructors. Added tests for Rate(double) constructor, verified Rate(inf) works and Rate(0) does not.
* rostime: Added useful time and duration constants.
* Contributors: Martin Pecka
```
