### PR TITLE
rc_reason_clients: 0.3.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4586,7 +4586,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/roboception-gbp/rc_reason_clients-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_reason_clients` to `0.3.1-1`:

- upstream repository: https://github.com/roboception/rc_reason_clients_ros2.git
- release repository: https://github.com/roboception-gbp/rc_reason_clients-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.0-1`

## rc_reason_clients

```
* rc_hand_eye_calibration_client: fix getting inital calib
```

## rc_reason_msgs

- No changes
