### PR TITLE
rclc: 6.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3974,7 +3974,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
-      version: 3.0.9-2
+      version: 6.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclc` to `6.1.0-1`:

- upstream repository: https://github.com/ros2/rclc.git
- release repository: https://github.com/ros2-gbp/rclc-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.9-2`

## rclc

```
* Data structures interfaces for multi-threaded executor (#355)
* update ros-tooling versions (#361)
* updated actions/checkout version (#367)
* updated branch names to rolling (#370)
```

## rclc_examples

```
* no changes
```

## rclc_lifecycle

```
* no changes
```

## rclc_parameter

```
* Add empty set_atomically parameter service (#354)
```
