### PR TITLE
rclc: changed source branch to iron

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2913,7 +2913,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rclc.git
-      version: master
+      version: humble
     release:
       packages:
       - rclc
@@ -2928,7 +2928,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclc.git
-      version: master
+      version: humble
     status: developed
   rclcpp:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4065,7 +4065,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rclc.git
-      version: master
+      version: iron
     release:
       packages:
       - rclc
@@ -4080,7 +4080,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclc.git
-      version: master
+      version: iron
     status: developed
   rclcpp:
     doc:


### PR DESCRIPTION
see PR: https://github.com/ros/rosdistro/pull/37664
Just updating the branch name to `iron`, because this configuration has failed with bloom-release tool.
