### PR TITLE
rclc: changed source branch to rolling

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2913,7 +2913,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rclc.git
-      version: master
+      version: humble
     release:
       packages:
       - rclc
@@ -2928,7 +2928,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclc.git
-      version: master
+      version: humble
     status: developed
   rclcpp:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3964,7 +3964,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rclc.git
-      version: master
+      version: rolling
     release:
       packages:
       - rclc
@@ -3979,7 +3979,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclc.git
-      version: master
+      version: rolling
     status: developed
   rclcpp:
     doc:


### PR DESCRIPTION
See PR: https://github.com/ros/rosdistro/pull/37675
Only changed source branch to `rolling`.