### PR TITLE
lms1xx: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2680,6 +2680,21 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: humble
     status: maintained
+  lms1xx:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/LMS1xx.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/LMS1xx-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/LMS1xx.git
+      version: humble-devel
+    status: maintained
   locator_ros_bridge:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lms1xx` to `1.0.0-1`:

- upstream repository: https://github.com/clearpathrobotics/LMS1xx.git
- release repository: https://github.com/clearpath-gbp/LMS1xx-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## lms1xx

```
* Removed TravisCI badge.
* Fixed CMakeLists.txt finding deleted packages
* Fixed formatting issues and dependencies
* Update ROS2CI.yml
* Create ROS2CI.yml
* Create depends.repos
* Improvements on connecting to lidars
* add back sprintf but dont printf
* comment out sprintf
* Fix min max angle
* Fix qos for gazebo simulation
* Make gazebo simulation work
* Add humble support for Husky LMS_111 lidars
* migration to ros2 foxy
* Contributors: Daniel Duran-Rojas, Fredrik, SRai22, Samuel Lindgren, Tony Baltovski, fazzrazz
```
