### PR TITLE
Revert "rplidar_ros: 2.1.2-1 in 'humble/distribution.yaml' [bloom]"

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5883,15 +5883,11 @@ repositories:
       version: master
     status: maintained
   rplidar_ros:
-    doc:
-      type: git
-      url: https://github.com/Slamtec/rplidar_ros.git
-      version: ros2
     release:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rplidar_ros-release.git
-      version: 2.1.2-1
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#37606

This is a breaking change not made by an existing maintainer: https://github.com/ros/rosdistro/issues/37679#issuecomment-1593770833
