### PR TITLE
hri_actions_msgs: 0.4.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3581,6 +3581,16 @@ repositories:
       url: https://github.com/humanoid-path-planner/hpp-fcl.git
       version: devel
     status: maintained
+  hri_actions_msgs:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros4hri/hri_actions_msgs-release.git
+      version: 0.4.2-1
+    source:
+      type: git
+      url: https://github.com/ros4hri/hri_actions_msgs.git
+      version: main
   hri_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hri_actions_msgs` to `0.4.2-1`:

- upstream repository: https://github.com/ros4hri/hri_actions_msgs.git
- release repository: https://github.com/ros4hri/hri_actions_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## hri_actions_msgs

Since this is the first bloom release of this package, I copy the whole `CHANGELOG`:
```
0.4.2 (2023-06-16)
------------------
* Revert "add actions to start/stop ASR"
  This reverts commit bbd9646771a5ba4ac6e680c1c2e036f4b4730fa6.
* Contributors: Séverin Lemaignan

0.4.1 (2023-01-17)
------------------
* add actions to start/stop ASR
* Contributors: Séverin Lemaignan

0.4.0 (2023-01-03)
------------------
* string constants should not use quotes
  While here:
  - remove a spurious comment on one of the comments lines
  - prefix moadlity string constants with __modality\_ for consistency
* Contributors: Séverin Lemaignan

0.3.2 (2022-12-05)
------------------
* Simple action to control (start/stop) applications
* Contributors: Séverin Lemaignan

0.3.1 (2022-12-05)
------------------
* Intent.msg: rename the field 'action' to 'intent' to avoid confusion
* Contributors: Séverin Lemaignan

0.3.0 (2022-12-02)
------------------
* add intents via Intent.msg
  'Intents' represents actions that a user (or sometimes, the robot
  itself) wants to be performed by the robot.
  They are used to decouple the user intent perception from the robot
  controller.
  The Intent.msg specifies an abstract model for these intents.
* Contributors: Séverin Lemaignan

0.2.0 (2022-08-18)
------------------
* add LookAtWithStyle.msg
* Contributors: Séverin Lemaignan

0.1.0 (2022-06-28)
------------------
* stamp PointTrajectory
* add PointTrajectoryAction
* add gaze action
* Contributors: Sara Cooper, Luca Lach


```
