### PR TITLE
point_cloud_transport: 1.0.11-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9271,7 +9271,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport.git
-      version: 1.0.10-1
+      version: 1.0.11-1
     source:
       type: git
       url: https://github.com/ctu-vras/point_cloud_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `1.0.11-1`:

- upstream repository: https://github.com/ctu-vras/point_cloud_transport.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.10-1`

## point_cloud_transport

```
* Fixed bad_expected_access error when pointcloud encoding fails.
* Added known transports to readme.
* Update README.md
* Contributors: Martin Pecka
```
