### PR TITLE
point_cloud_transport: 1.0.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7309,6 +7309,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ctu-vras/point_cloud_transport.git
+      version: master
     status: developed
   point_cloud_transport_plugins:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7305,10 +7305,11 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport.git
-      version: 1.0.10-1
+      version: 1.0.11-1
     source:
       type: git
       url: https://github.com/ctu-vras/point_cloud_transport.git
+    status: developed
   point_cloud_transport_plugins:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `1.0.11-1`:

- upstream repository: https://github.com/ctu-vras/point_cloud_transport.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.10-1`

## point_cloud_transport

```
* Fixed bad_expected_access error when pointcloud encoding fails.
* Added known transports to readme.
* Update README.md
* Contributors: Martin Pecka
```
