### PR TITLE
point_cloud_transport_plugins: 1.0.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9289,7 +9289,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport_plugins.git
-      version: 1.0.3-1
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/ctu-vras/point_cloud_transport_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport_plugins` to `1.0.5-1`:

- upstream repository: https://github.com/ctu-vras/point_cloud_transport_plugins.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport_plugins.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.3-1`

## draco_point_cloud_transport

```
* Fixed formatting.
* Contributors: Martin Pecka
```

## point_cloud_transport_plugins

- No changes
