### PR TITLE
Add python3-pyro-ppl-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3228,6 +3228,16 @@ python-pyrealsense2-pip:
   ubuntu:
     pip:
       packages: [pyrealsense2]
+python-pyro-ppl-pip:
+  debian:
+    pip:
+      packages: [pyro-ppl]
+  fedora:
+    pip:
+      packages: [pyro-ppl]
+  ubuntu:
+    pip:
+      packages: [pyro-ppl]
 python-pyside:
   arch: [python2-pyside]
   debian: [python-pyside]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3228,16 +3228,6 @@ python-pyrealsense2-pip:
   ubuntu:
     pip:
       packages: [pyrealsense2]
-python-pyro-ppl-pip:
-  debian:
-    pip:
-      packages: [pyro-ppl]
-  fedora:
-    pip:
-      packages: [pyro-ppl]
-  ubuntu:
-    pip:
-      packages: [pyro-ppl]
 python-pyside:
   arch: [python2-pyside]
   debian: [python-pyside]
@@ -7675,6 +7665,16 @@ python3-pyqtgraph:
   gentoo: [dev-python/pyqtgraph]
   nixos: [python3Packages.pyqtgraph]
   ubuntu: [python3-pyqtgraph]
+python3-pyro-ppl-pip:
+  debian:
+    pip:
+      packages: [pyro-ppl]
+  fedora:
+    pip:
+      packages: [pyro-ppl]
+  ubuntu:
+    pip:
+      packages: [pyro-ppl]
 python3-pyrr-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7672,6 +7672,9 @@ python3-pyro-ppl-pip:
   fedora:
     pip:
       packages: [pyro-ppl]
+  osx:
+    pip:
+      packages: [pyro-ppl]
   ubuntu:
     pip:
       packages: [pyro-ppl]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-pyro-ppl-pip

## Package Upstream Source:

pyro-ppl: [pyro-ppl/pyro](https://github.com/pyro-ppl/pyro)

## Purpose of using this:

The [pyro-ppl](https://github.com/pyro-ppl/pyro) package is a probabilistic programming framework built on top of the [Pytorch](https://github.com/pytorch/pytorch) library. From the project's homepage, [pyro.ai](pyro.ai):

> Pyro is a universal probabilistic programming language (PPL) written in Python and supported by [PyTorch](http://pytorch.org/) on the backend. Pyro enables flexible and expressive deep probabilistic modeling, unifying the best of modern deep learning and Bayesian modeling. 

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

The package is solely distributed via [PyPI.org](https://pypi.org/project/pyro-ppl/).

- Debian: https://packages.debian.org/
  - [not available](https://packages.debian.org/search?suite=stable&section=all&arch=any&searchon=names&keywords=pyro)
- Ubuntu: https://packages.ubuntu.com/
  - [not available](https://packages.ubuntu.com/search?keywords=pyro&searchon=names&suite=all&section=all)
- Fedora: https://packages.fedoraproject.org/
  - [not available](https://packages.fedoraproject.org/search?query=pyro)

As far as I'm aware, [pyro-ppl](https://github.com/pyro-ppl/pyro)  is not available through any OS package manager.

I acknowledge that any ROS packages which depend on [pyro-ppl](https://github.com/pyro-ppl/pyro) cannot be released to the official build farm.