### PR TITLE
add python-qpsolvers-pip to rosdep database

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3373,6 +3373,16 @@ python-pyzbar-pip:
   ubuntu:
     pip:
       packages: [pyzbar]
+python-qpsolvers-pip:
+  debian:
+    pip:
+      packages: [qpsolvers]
+  osx:
+    pip:
+      packages: [qpsolvers]
+  ubuntu:
+    pip:
+      packages: [qpsolvers]
 python-qrencode:
   debian: [python-qrencode]
   gentoo: [media-gfx/qrencode-python]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3373,16 +3373,6 @@ python-pyzbar-pip:
   ubuntu:
     pip:
       packages: [pyzbar]
-python-qpsolvers-pip:
-  debian:
-    pip:
-      packages: [qpsolvers]
-  osx:
-    pip:
-      packages: [qpsolvers]
-  ubuntu:
-    pip:
-      packages: [qpsolvers]
 python-qrencode:
   debian: [python-qrencode]
   gentoo: [media-gfx/qrencode-python]
@@ -7881,6 +7871,16 @@ python3-pyxdg-pip:
   ubuntu:
     pip:
       packages: [pyxdg]
+python3-qpsolvers-pip:
+  debian:
+    pip:
+      packages: [qpsolvers]
+  osx:
+    pip:
+      packages: [qpsolvers]
+  ubuntu:
+    pip:
+      packages: [qpsolvers]
 python3-qrcode:
   arch: [python-qrcode]
   debian: [python3-qrcode]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

qpsolvers

## Package Upstream Source:

https://pypi.org/project/qpsolvers/

## Purpose of using this:

This dependency is being used for solving Quadratic Programming (QP) problem.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://pypi.org/project/qpsolvers/
- Ubuntu: https://pypi.org/project/qpsolvers/
- macOS: https://pypi.org/project/qpsolvers/