### PR TITLE
foxglove_bridge: 0.6.3-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1357,7 +1357,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 0.6.2-1
+      version: 0.6.3-1
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_bridge` to `0.6.3-1`:

- upstream repository: https://github.com/foxglove/ros-foxglove-bridge.git
- release repository: https://github.com/ros2-gbp/foxglove_bridge-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.2-1`

## foxglove_bridge

```
* Add iron build to CI (#234 <https://github.com/foxglove/ros-foxglove-bridge/issues/234>)
* Fix QoS history being unknown when copied from existing publisher (#233 <https://github.com/foxglove/ros-foxglove-bridge/issues/233>)
* Extract ROS 2 bridge header (#228 <https://github.com/foxglove/ros-foxglove-bridge/issues/228>)
* Contributors: Hans-Joachim Krauch, Milan Vukov
```
