### PR TITLE
electronic-io: 1.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2300,6 +2300,24 @@ repositories:
       url: https://github.com/stack-of-tasks/eiquadprog.git
       version: devel
     status: maintained
+  electronic-io:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/electronic-io.git
+      version: master
+    release:
+      packages:
+      - electronic_io
+      - electronic_io_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/electronic-io.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ctu-vras/electronic-io.git
+      version: master
+    status: developed
   eml:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `electronic-io` to `1.0.1-1`:

- upstream repository: https://github.com/ctu-vras/electronic-io.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/electronic-io.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## electronic_io

```
* Added support for simplified specification of pins in config.
* Added BinaryPWM virtual pin.
* Added virtual pins.
* It topic is set to empty, the topics and services will not be created.
* Added Battery device.
* Export the provided devices.
* Allow setting queue_size and latching for output devices.
* Added support for output groups.
* Robustified IO board client.
* Initial commit
* Contributors: Martin Pecka
```

## electronic_io_msgs

```
* Initial commit
* Contributors: Martin Pecka
```
