### PR TITLE
point_cloud_color: 1.2.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9262,6 +9262,21 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: melodic-devel
     status: maintained
+  point_cloud_color:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/point_cloud_color.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_color.git
+      version: 1.2.1-1
+    source:
+      type: git
+      url: https://github.com/ctu-vras/point_cloud_color.git
+      version: master
+    status: maintained
   point_cloud_transport:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_color` to `1.2.1-1`:

- upstream repository: https://github.com/ctu-vras/point_cloud_color.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_color.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## point_cloud_color

```
* Added point_cloud_transport integration.
* Support MONO8 images.
* Noetic compatibility.
* Fix passing image_transport parameters
* Fixed coloring of clouds with NaNs and fix publishing color as rgba
* Compute remaining duration of waiting for transform.
* Update row step to pass asserts in debug, clip values according to types.
* Refactored for various image types, custom field name, minor speed up.
* Shortening cloud queue size option (backward compatible).
* Set default value before coloring.
* Camera warnings refactored, warning type enum.
* Refactored to handle various image types.
* OpenCV constant updated for compatibility with 20.04/Noetic.
* Initial commit.
* Contributors: Martin Pecka, Tomas Petricek
```
