### PR TITLE
compass: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1860,6 +1860,24 @@ repositories:
       url: https://github.com/ros/common_tutorials.git
       version: indigo-devel
     status: maintained
+  compass:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/compass.git
+      version: master
+    release:
+      packages:
+      - compass
+      - compass_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/compass.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ctu-vras/compass.git
+      version: master
+    status: maintained
   computer_status_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `compass` to `1.0.1-1`:

- upstream repository: https://github.com/ctu-vras/compass.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/compass.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## compass

```
* Made use of cras_cpp_common's node_from_nodelet CMake macro.
* Removed imu_transformer workaround
* Added option to force magnetic declination value.
* Added visualization of azimuth.
* Fixed IMU orientation covariance transformation.
* Renamed magnetometer_compass package to compass.
* Added variance to magnetometer compass outputs. It now also outputs fully valid georeferenced IMU messages instead of just writing the orientation into them.
* Contributors: Martin Pecka
```

## compass_msgs

```
* Added variance to Azimuth message.
* Added improved version of compass.
* Contributors: Martin Pecka
```
