### PR TITLE
compass: 1.0.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1405,7 +1405,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/compass.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ctu-vras/compass.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1400,12 +1400,12 @@ repositories:
       version: master
     release:
       packages:
-      - compass
       - compass_msgs
+      - magnetometer_compass
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/compass.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/ctu-vras/compass.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1393,6 +1393,24 @@ repositories:
       url: https://github.com/ros/common_tutorials.git
       version: noetic-devel
     status: maintained
+  compass:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/compass.git
+      version: master
+    release:
+      packages:
+      - compass
+      - compass_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/compass.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ctu-vras/compass.git
+      version: master
+    status: maintained
   computer_status_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `compass` to `1.0.3-1`:

- upstream repository: https://github.com/ctu-vras/compass.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/compass.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## magnetometer_compass

```
* Fixed install of data
* Renamed compass -> magnetometer_compass 
* Made use of cras_cpp_common's node_from_nodelet CMake macro.
* Removed imu_transformer workaround
* Added option to force magnetic declination value.
* Added visualization of azimuth.
* Fixed IMU orientation covariance transformation.
* Renamed magnetometer_compass package to compass.
* Added variance to magnetometer compass outputs. It now also outputs fully valid georeferenced IMU messages instead of just writing the orientation into them.
* Contributors: Martin Pecka
```

## compass_msgs

```
* Added variance to Azimuth message.
* Added improved version of compass.
* Contributors: Martin Pecka
```
