### PR TITLE
neonavigation_rviz_plugins: 0.11.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6287,7 +6287,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/at-wat/neonavigation_rviz_plugins-release.git
-      version: 0.11.6-1
+      version: 0.11.7-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation_rviz_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation_rviz_plugins` to `0.11.7-1`:

- upstream repository: https://github.com/at-wat/neonavigation_rviz_plugins.git
- release repository: https://github.com/at-wat/neonavigation_rviz_plugins-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.11.6-1`

## costmap_cspace_rviz_plugins

- No changes

## neonavigation_rviz_plugins

```
* neonavigation_rviz_plugins: add costmap_cspace_rviz_plugins as exec dependency (#43 <https://github.com/at-wat/neonavigation_rviz_plugins/issues/43>)
* Contributors: f-fl0
```

## trajectory_tracker_rviz_plugins

- No changes
