### PR TITLE
http_relay: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4595,6 +4595,21 @@ repositories:
       url: https://github.com/fkanehiro/hrpsys-base.git
       version: master
     status: maintained
+  http_relay:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/http_relay.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/http_relay.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ctu-vras/http_relay.git
+      version: master
+    status: maintained
   human_description:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `http_relay` to `1.0.1-1`:

- upstream repository: https://github.com/ctu-vras/http_relay.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/http_relay.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## http_relay

```
* Noetic compatibility.
* Added sigkill_on_stream_stop so that the relay is only killed if there is a stale request.
* Added sigkill_timeout for automatic restarting of the node even if it hangs on a connection.
* Support NTRIP in Python 3
* Fix Python3 NTRIP relay.
* Initial commit.
* Contributors: Martin Pecka
```
