### PR TITLE
http_relay: 1.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3620,7 +3620,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/http_relay.git
-      version: 1.0.1-1
+      version: 2.1.3-1
     source:
       type: git
       url: https://github.com/ctu-vras/http_relay.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3617,10 +3617,12 @@ repositories:
       url: https://github.com/ctu-vras/http_relay.git
       version: master
     release:
+      packages:
+        - python3-http-relay
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/http_relay.git
-      version: 2.1.3-1
+      version: 2.1.3-2
     source:
       type: git
       url: https://github.com/ctu-vras/http_relay.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3620,7 +3620,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/http_relay.git
-      version: 2.1.3-1
+      version: 2.1.3-2
     source:
       type: git
       url: https://github.com/ctu-vras/http_relay.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3611,6 +3611,21 @@ repositories:
       url: https://github.com/ros4hri/hri_rviz.git
       version: main
     status: developed
+  http_relay:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/http_relay.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/http_relay.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ctu-vras/http_relay.git
+      version: master
+    status: maintained
   human_description:
     doc:
       type: git

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6208,6 +6208,40 @@ python3-h5py:
   nixos: [python3Packages.h5py]
   openembedded: [python3-h5py@meta-python]
   ubuntu: [python3-h5py]
+python3-http-relay:
+  arch:
+    pip:
+      packages: [http-relay]
+  debian:
+    '*': [python3-http-relay]
+    bookworm:
+      pip:
+        packages: [http-relay]
+    bullseye:
+      pip:
+        packages: [http-relay]
+    buster: null
+  fedora:
+    pip:
+      packages: [http-relay]
+  gentoo:
+    pip:
+      packages: [http-relay]
+  nixos:
+    pip:
+      packages: [http-relay]
+  osx:
+    pip:
+      packages: [http-relay]
+  rhel:
+    pip:
+      packages: [http-relay]
+  ubuntu:
+    '*': [python3-http-relay]
+    focal: null
+    jammy:
+      pip:
+        packages: [http-relay]
 python3-httplib2:
   debian: [python3-httplib2]
   fedora: [python3-httplib2]


### PR DESCRIPTION
Increasing version of package(s) in repository `http_relay` to `1.0.1-1`:

- upstream repository: https://github.com/ctu-vras/http_relay.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/http_relay.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## http_relay

```
* Noetic compatibility.
* Added sigkill_on_stream_stop so that the relay is only killed if there is a stale request.
* Added sigkill_timeout for automatic restarting of the node even if it hangs on a connection.
* Support NTRIP in Python 3
* Fix Python3 NTRIP relay.
* Initial commit.
* Contributors: Martin Pecka
```
