### PR TITLE
cras_laser_geometry: 1.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2061,6 +2061,21 @@ repositories:
       url: https://github.com/rt-net/crane_x7_ros.git
       version: master
     status: developed
+  cras_laser_geometry:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/cras_laser_geometry.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/cras_laser_geometry.git
+      version: 1.1.1-1
+    source:
+      type: git
+      url: https://github.com/ctu-vras/cras_laser_geometry.git
+      version: master
+    status: maintained
   cras_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_laser_geometry` to `1.1.1-1`:

- upstream repository: https://github.com/ctu-vras/cras_laser_geometry.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/cras_laser_geometry.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## cras_laser_geometry

```
* Noetic compatibility.
* Initial commit.
* Contributors: Martin Pecka
```
