### PR TITLE
relative_positional_controller: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10457,6 +10457,21 @@ repositories:
       url: https://github.com/ros-controls/realtime_tools.git
       version: melodic-devel
     status: maintained
+  relative_positional_controller:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/relative_positional_controller.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/relative_positional_controller.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ctu-vras/relative_positional_controller.git
+      version: master
+    status: maintained
   remote_rosbag_record:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `relative_positional_controller` to `1.0.1-1`:

- upstream repository: https://github.com/ctu-vras/relative_positional_controller.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/relative_positional_controller.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## relative_positional_controller

```
* Noetic compatibility.
* Initial commit
* Contributors: Martin Pecka
```
