### PR TITLE
cras_imu_tools: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2061,6 +2061,21 @@ repositories:
       url: https://github.com/rt-net/crane_x7_ros.git
       version: master
     status: developed
+  cras_imu_tools:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/cras_imu_tools.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/cras_imu_tools.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ctu-vras/cras_imu_tools.git
+      version: master
+    status: maintained
   cras_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_imu_tools` to `1.0.1-1`:

- upstream repository: https://github.com/ctu-vras/cras_imu_tools.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/cras_imu_tools.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## cras_imu_tools

```
* Removed cras imu transformer as it got fixed upstream
* Noetic compatibility.
* Publish commands to disable robot motion while doing the initial calibration.
* More fine-grained speak interface.
* Initial commit with gyro bias remover and fixed imu_transformer.
* Contributors: Martin Pecka
```
