### PR TITLE
cras_laser_geometry: 1.1.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1539,6 +1539,21 @@ repositories:
       url: https://github.com/ctu-vras/cras_imu_tools.git
       version: master
     status: maintained
+  cras_laser_geometry:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/cras_laser_geometry.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/cras_laser_geometry.git
+      version: 1.1.2-1
+    source:
+      type: git
+      url: https://github.com/ctu-vras/cras_laser_geometry.git
+      version: master
+    status: maintained
   cras_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_laser_geometry` to `1.1.2-1`:

- upstream repository: https://github.com/ctu-vras/cras_laser_geometry.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/cras_laser_geometry.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## cras_laser_geometry

```
* Fixed build
* Contributors: Martin Pecka
```
