### PR TITLE
Add helyos_agent_sdk to rosdep database

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6232,6 +6232,10 @@ python3-h5py:
   nixos: [python3Packages.h5py]
   openembedded: [python3-h5py@meta-python]
   ubuntu: [python3-h5py]
+python3-helyos_agent_sdk-pip:
+  '*':
+    pip:
+      packages: [helyos_agent_sdk]
 python3-httplib2:
   debian: [python3-httplib2]
   fedora: [python3-httplib2]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

- python3-helyos_agent_sdk-pip

## Package Upstream Source:

[helyOS Agent SDK](https://github.com/FraunhoferIVI/helyOS-agent-sdk)

## Purpose of using this:

The helyos-agent-sdk python package encloses methods and data structure definitions that facilitate the connection of autonomous vehicles to [helyOS Framework](https://helyos-manual.readthedocs.io/en/latest/) through rabbitMQ.

Distro packaging links:

## Links to Distribution Packages
The package is OS independent and distributed via [PyPI](https://pypi.org/project/helyos-agent-sdk/)

- Debian: https://packages.debian.org/
  - [not available](https://packages.debian.org/search?suite=stable&section=all&arch=any&searchon=names&keywords=helyos_agent_sdk)
- Ubuntu: https://packages.ubuntu.com/
  - [not available](https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=helyos_agent_sdk&searchon=names)

We are aware of the restriction that packages depending on pip packages cannot be released to the official build farm