### PR TITLE
navigation2: 1.1.8-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3307,7 +3307,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/SteveMacenski/navigation2-release.git
-      version: 1.1.7-3
+      version: 1.1.8-2
     source:
       type: git
       url: https://github.com/ros-planning/navigation2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation2` to `1.1.8-2`:

- upstream repository: https://github.com/ros-planning/navigation2.git
- release repository: https://github.com/SteveMacenski/navigation2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.7-3`
