### PR TITLE
added onvif_zeep with pip for ubuntu

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -322,6 +322,10 @@ meson:
 nuitka:
   debian: [nuitka]
   ubuntu: [nuitka]
+onvif_zeep:
+  ubuntu:
+    pip:
+      packages: [onvif_zeep]
 opcua-pip:
   ubuntu:
     pip:


### PR DESCRIPTION
a package for [onvif protocol](https://en.wikipedia.org/wiki/ONVIF) commonly used for [PTZ Cameras](https://en.wikipedia.org/wiki/Pan%E2%80%93tilt%E2%80%93zoom_camera).