### PR TITLE
hri_rviz: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3605,7 +3605,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros4hri/hri_rviz-release.git
-      version: 0.3.1-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/ros4hri/hri_rviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hri_rviz` to `0.4.0-1`:

- upstream repository: https://github.com/ros4hri/hri_rviz.git
- release repository: https://github.com/ros4hri/hri_rviz-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.1-1`

## hri_rviz

```
* Merge branch 'skeletons' into 'main'
  skeleton extension for Humans plugin
  See merge request ros4hri/hri_rviz!5
* joint visualization as circles
* Optimized iteration over bodies for skeleton representation
* Introducing skeleton visualization
  It is now possible to visualize 2D skeletons using the humans
  rviz plugin.
* add LICENSE
* Contributors: Séverin Lemaignan, lorenzoferrini
```
