### PR TITLE
behaviortree_cpp_v4: 4.3.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -626,7 +626,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.2.1-2
+      version: 4.3.1-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp_v4` to `4.3.1-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.2.1-2`

## behaviortree_cpp

```
* fix issue #592 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/592>
* use lambda in tutorial
* add script condition
* "fix" issue #587 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/587>: ReactiveSequence should set conditions to IDLE
* better error message
* Fix issue #585 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/585>
* Contributors: Davide Faconti
```
