### PR TITLE
behaviortree_cpp_v4: 4.3.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -546,7 +546,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.2.1-1
+      version: 4.3.1-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp_v4` to `4.3.1-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.2.1-1`

## behaviortree_cpp

```
* fix issue #592 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/592>
* use lambda in tutorial
* add script condition
* "fix" issue #587 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/587>: ReactiveSequence should set conditions to IDLE
* better error message
* Fix issue #585 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/585>
* Contributors: Davide Faconti
```
