### PR TITLE
ros2_canopen: 0.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4628,7 +4628,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_canopen-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/ros-industrial/ros2_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_canopen` to `0.2.1-1`:

- upstream repository: https://github.com/ros-industrial/ros2_canopen.git
- release repository: https://github.com/ros2-gbp/ros2_canopen-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.0-1`

## canopen

- No changes

## canopen_402_driver

```
* Fix boost/std placeholders ambiguity in older boost versions
* Contributors: Christoph Hellmann Santos
```

## canopen_base_driver

```
* Fix base driver lifecyle
* Fix node polling mode in base driver
* Contributors: Błażej Sowa, Christoph Hellmann Santos
```

## canopen_core

```
* Fix master and driver lifecycle
* Fix QoS build warning in canopen_core
* Use consistenlty HEX output for NodeID and Index.
* Contributors: Christoph Hellmann Santos, Denis Štogl, Vishnuprasad Prachandabhanu
```

## canopen_fake_slaves

```
* Fix fake slave for PDOs
* Contributors: Christoph Hellmann Santos
```

## canopen_interfaces

- No changes

## canopen_master_driver

```
* Fix master lifecycle
* Contributors: Christoph Hellmann Santos
```

## canopen_proxy_driver

```
* Use consistenlty (uppercase) HEX output for NodeID and Index.
* Contributors: Christoph Hellmann Santos, Denis Štogl
```

## canopen_ros2_control

```
* Use consistenlty (uppercase) HEX output for NodeID and Index.
* Contributors: Christoph Hellmann Santos, Denis Štogl
```

## canopen_ros2_controllers

```
* Fix QoS build warning canopen_ros2_controllers
* Don't use ros2_control_test_assets since not needed anymore. Add load tests for all controllers.
* Contributors: Christoph Hellmann Santos, Denis Štogl, Vishnuprasad Prachandabhanu
```

## canopen_tests

```
* Add trvivial integration test for robot_control
* Add trivial integration tests for cia402_driver
* Use the more tidy launch_test_node
* Contributors: Christoph Hellmann Santos
```

## canopen_utils

```
* Add more tidy launch_test_node.py
* Contributors: Christoph Hellmann Santos
```

## lely_core_libraries

```
* Do not build dcf-tools bdist in lely_core_libraries anymore, fixes buildfarm issue
* Contributors: Christoph Hellmann Santos
```
