### PR TITLE
Add python3-ahrs-pip rosdep key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4765,6 +4765,16 @@ python3-adapt-parser-pip:
   ubuntu:
     pip:
       packages: [adapt-parser]
+python3-ahrs-pip:
+  debian:
+    pip:
+      packages: [ahrs]
+  fedora:
+    pip:
+      packages: [ahrs]
+  ubuntu:
+    pip:
+      packages: [ahrs]
 python3-aio-pika-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`ahrs` (as `python3-ahrs-pip`)

## Package Upstream Source:

[ahrs](https://github.com/Mayitzin/ahrs)

## Purpose of using this:

`ahrs` is a pure Python library of Attitude and Heading Reference Systems. Quite handy during prototyping.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - [not available](https://packages.debian.org/search?suite=stable&section=all&arch=any&searchon=names&keywords=ahrs)
- Ubuntu: https://packages.ubuntu.com/
  - [not available](https://packages.ubuntu.com/search?suite=all&searchon=names&keywords=ahrs)
- Fedora: https://packages.fedoraproject.org/
  - [not available](https://packages.fedoraproject.org/search?query=ahrs)

Only distributed through PyPI.