### PR TITLE
Revert "jsk_3rdparty: 2.1.26-1 in 'melodic/distribution.yaml' [bloom]…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5312,9 +5312,7 @@ repositories:
       - ff
       - ffha
       - gdrive_ros
-      - google_chat_ros
       - google_cloud_texttospeech
-      - influxdb_store
       - jsk_3rdparty
       - julius
       - julius_ros
@@ -5322,13 +5320,10 @@ repositories:
       - libsiftfast
       - lpg_planner
       - mini_maxwell
-      - nfc_ros
       - nlopt
       - opt_camera
-      - osqp
       - pgm_learner
       - respeaker_ros
-      - ros_google_cloud_language
       - ros_speech_recognition
       - rospatlite
       - rosping
@@ -5337,13 +5332,10 @@ repositories:
       - slic
       - switchbot_ros
       - voice_text
-      - webrtcvad_ros
-      - zdepth
-      - zdepth_image_transport
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
-      version: 2.1.26-1
+      version: 2.1.24-2
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git


### PR DESCRIPTION
… (#37637)"

This reverts commit a5c836d4638c83f4cae4be89782d4a06b9e97940.

Many of the packages failed to build:

* https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__aques_talk__ubuntu_bionic_amd64__binary/
* https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__chaplus_ros__ubuntu_bionic_amd64__binary/
* https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__google_chat_ros__ubuntu_bionic_amd64__binary/
* https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__lpg_planner__ubuntu_bionic_amd64__binary/
* https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__nfc_ros__ubuntu_bionic_amd64__binary/
* https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__respeaker_ros__ubuntu_bionic_amd64__binary/
* https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__ros_google_cloud_language__ubuntu_bionic_amd64__binary/
* https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__sesame_ros__ubuntu_bionic_amd64__binary/
* https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__zdepth_image_transport__ubuntu_bionic_amd64__binary/

@k-okada FYI