### PR TITLE
Switch python3-vcstool for Debian to upstream deb

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8884,9 +8884,7 @@ python3-uvicorn:
         packages: [uvicorn]
 python3-vcstool:
   alpine: [vcstool]
-  debian:
-    pip:
-      packages: [vcstool]
+  debian: [python3-vcstool]
   fedora: [python3-vcstool]
   gentoo: [vcstool]
   macports:


### PR DESCRIPTION
This is now a dependency of `ament_cmake_vendor_package`, so it would be best if we source the package from a deb.

Debian upstream has it: https://packages.debian.org/search?suite=all&searchon=names&keywords=python3-vcstool