### PR TITLE
clearpath_common: 0.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -787,6 +787,30 @@ repositories:
       url: https://github.com/MetroRobots/classic_bags.git
       version: main
     status: developed
+  clearpath_common:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_common.git
+      version: humble
+    release:
+      packages:
+      - clearpath_common
+      - clearpath_control
+      - clearpath_description
+      - clearpath_generator_common
+      - clearpath_mounts_description
+      - clearpath_platform
+      - clearpath_platform_description
+      - clearpath_sensors_description
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/clearpath_common-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_common.git
+      version: humble
+    status: developed
   clearpath_config:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `0.0.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## clearpath_common

```
* Updated dependencies
* Bishop sensors/mounts
* [clearpath_common] Added metapackage.
* Contributors: Roni Kreinin, Tony Baltovski
```

## clearpath_control

```
* Updated launch writer make writing different object types easier
  Localization parameter fixes
  Updated gazebo wheel friction
* Added namespacing support
* Added clearpath_generator_common
  Moved clearpath_platform to clearpath_common
  Fixed use_sim_time parameter issue with ekf_node
* Use generated configs for control, localization, teleop
* use_sim_time support
  Added lidar gazebo plugins
* Fixed dependencies
* Moved description generator to clearpath_generators
  Added accessory urdf's
  Use launch arg for choosing controller
* Moved IMU filter to platform launch
  Moved localization into a separate launch file
  Updated decoration urdfs
  Added structure urdf
* Remapped topics to match API
* Corrected imu_filter_node topics and parameter node name
  Use joy_linux
* Bishop sensors/mounts
* Added realsense description
* [clearpath_control] Renamed robot_model to platform_model.
* control launch fixes
  Added ark enclosure for j100 top_plate
* Move clearpath_description to clearpath_platform_description and switched robot names to robot model number.
* [clearpath_control] Switched to using model number.
* [clearpath_control] Changed depends to exec_depends.
* [clearpath_control] Updated platform names to model.
* Select launch configuration without launch context
* Initial commit of clearpath_control.
* Contributors: Roni Kreinin, Tony Baltovski
```

## clearpath_description

```
* Added clearpath_sensors_description.
* Select launch configuration without launch context
* Initial jackal description.
* Added tf and tf_static remapping to support namespacing.
* Initial clearpath_description with only Husky.
* Contributors: Roni Kreinin, Tony Baltovski
```

## clearpath_generator_common

```
* Updated launch writer make writing different object types easier
  Localization parameter fixes
  Updated gazebo wheel friction
* Added namespacing support
* Updated dependencies
* Added clearpath_generator_common
  Moved clearpath_platform to clearpath_common
  Fixed use_sim_time parameter issue with ekf_node
* Contributors: Roni Kreinin
```

## clearpath_mounts_description

```
* Standard urdf and yaml file name and path
  Fixed spacing in urdfs
* Description classes
* PACS mounts
  Common PACS Riser
  Hokuyo and novatel description fixes
* Initial commit with platform, decoration and mounts generating
* Added clearpath_mounts_description.
* Contributors: Roni Kreinin, Tony Baltovski
```

## clearpath_platform

```
* Added namespacing support
* Updated dependencies
* Added clearpath_generator_common
  Moved clearpath_platform to clearpath_common
  Fixed use_sim_time parameter issue with ekf_node
* Contributors: Roni Kreinin
```

## clearpath_platform_description

```
* Updated launch writer make writing different object types easier
  Localization parameter fixes
  Updated gazebo wheel friction
* Added namespacing support
* Increased J100 navsat update rate to 10hz
* Jackal sim support
* Added GPS
  Added realsense gazebo parameters
* Added gazebo IMU plugin
* use_sim_time support
  Added lidar gazebo plugins
* Sim fixes
* Fixed dependencies
* Moved description generator to clearpath_generators
  Added accessory urdf's
  Use launch arg for choosing controller
* [clearpath_platform_description] Made the serial_port an arg for the a200 and reduced polling timeout.
* Moved IMU filter to platform launch
  Moved localization into a separate launch file
  Updated decoration urdfs
  Added structure urdf
* Remapped topics to match API
* Bishop sensors/mounts
* Added velodyne
* [clearpath_platform_description] Fixed hardware plugin for A200.
* control launch fixes
  Added ark enclosure for j100 top_plate
* J100 support
* Standard urdf and yaml file name and path
  Fixed spacing in urdfs
* Description classes
* PACS mounts
  Common PACS Riser
  Hokuyo and novatel description fixes
* Initial commit with platform, decoration and mounts generating
* [clearpath_platform_description] Fixed mesh paths.
* [clearpath_sensors_description] Moved Novatel and Hokuyo into sensors from J100.
* [clearpath_platform_description] Renamed all dashes to underscores.
* [clearpath_platform_description] Fixed incorrect path.
* Move clearpath_description to clearpath_platform_description and switched robot names to robot model number.
* Contributors: Roni Kreinin, Tony Baltovski
```

## clearpath_sensors_description

```
* Added GPS
  Added realsense gazebo parameters
* Added gazebo IMU plugin
* use_sim_time support
  Added lidar gazebo plugins
* Sim fixes
* Bishop sensors/mounts
* Added microstrain
* Added velodyne
* Added realsense description
* Updated sensor naming
* Sensor descriptions
* Standard urdf and yaml file name and path
  Fixed spacing in urdfs
* Description classes
* PACS mounts
  Common PACS Riser
  Hokuyo and novatel description fixes
* [clearpath_sensors_description] Moved Novatel and Hokuyo into sensors from J100.
* Added clearpath_sensors_description.
* Contributors: Roni Kreinin, Tony Baltovski
```
