### PR TITLE
Adding catch_ros2 to rolling and iron distros

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -658,6 +658,16 @@ repositories:
       url: https://github.com/fmrico/cascade_lifecycle.git
       version: rolling-devel
     status: maintained
+  catch_ros2:
+    doc:
+      type: git
+      url: https://github.com/ngmor/catch_ros2.git
+      version: iron
+    source:
+      type: git
+      url: https://github.com/ngmor/catch_ros2.git
+      version: iron
+    status: maintained
   class_loader:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -682,6 +682,16 @@ repositories:
       url: https://github.com/fmrico/cascade_lifecycle.git
       version: rolling-devel
     status: maintained
+  catch_ros2:
+    doc:
+      type: git
+      url: https://github.com/ngmor/catch_ros2.git
+      version: rolling
+    source:
+      type: git
+      url: https://github.com/ngmor/catch_ros2.git
+      version: rolling
+    status: maintained
   class_loader:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

rolling, iron

# The source is here:

https://github.com/ngmor/catch_ros2

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
