### PR TITLE
ros2_canopen: 0.2.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4628,7 +4628,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_canopen-release.git
-      version: 0.2.3-1
+      version: 0.2.4-1
     source:
       type: git
       url: https://github.com/ros-industrial/ros2_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_canopen` to `0.2.4-1`:

- upstream repository: https://github.com/ros-industrial/ros2_canopen.git
- release repository: https://github.com/ros2-gbp/ros2_canopen-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.3-1`

## canopen

- No changes

## canopen_402_driver

- No changes

## canopen_base_driver

- No changes

## canopen_core

- No changes

## canopen_fake_slaves

- No changes

## canopen_interfaces

- No changes

## canopen_master_driver

- No changes

## canopen_proxy_driver

- No changes

## canopen_ros2_control

- No changes

## canopen_ros2_controllers

- No changes

## canopen_tests

- No changes

## canopen_utils

- No changes

## lely_core_libraries

```
* Add empy dependency for dcfgen
* Clean up lely build folder after install for rpm build
* Contributors: Christoph Hellmann Santos
```
