### PR TITLE
add python3-influxdb

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7453,6 +7453,10 @@ python3-inflection-pip:
   ubuntu:
     pip:
       packages: [inflection]
+python3-influxdb:
+  debian: [python3-influxdb]
+  ubuntu: [python3-influxdb]
+  rhel: [python3-influxdb]
 python3-influxdb-client-pip:
   debian:
     pip:


### PR DESCRIPTION
## Package name:

pytohn3-influxdb

## Package Upstream Source:


https://pkgs.org/download/python3-influxdb
## Purpose of using this:

rosdep already have python-influxdb and to use packages depensd on this key on Noetic, we need pytohn3-influxdb


- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?suite=all&searchon=names&keywords=python3-influxdb
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=python3-influxdb
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-influxdb/python3-influxdb/