### PR TITLE
magic_enum: 0.9.3-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2415,7 +2415,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/nobleo/magic_enum-release.git
-      version: 0.9.2-1
+      version: 0.9.3-1
     source:
       type: git
       url: https://github.com/Neargye/magic_enum.git


### PR DESCRIPTION
Increasing version of package(s) in repository `magic_enum` to `0.9.3-1`:

- upstream repository: https://github.com/Neargye/magic_enum.git
- release repository: https://github.com/nobleo/magic_enum-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.9.2-1`
