### PR TITLE
Fixed gz_ros2_control keys: Iron and Rolling

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1731,6 +1731,24 @@ repositories:
       url: https://github.com/borglab/gtsam.git
       version: develop
     status: developed
+  gz_ros2_control:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/gz_ros2_control.git
+      version: master
+    release:
+      packages:
+      - gz_ros2_control
+      - gz_ros2_control_demos
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ign_ros2_control-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/gz_ros2_control.git
+      version: master
+    status: maintained
   hash_library_vendor:
     doc:
       type: git
@@ -1823,24 +1841,6 @@ repositories:
       url: https://github.com/ros2-gbp/ifm3d-release.git
       version: 0.18.0-9
     status: developed
-  ign_ros2_control:
-    doc:
-      type: git
-      url: https://github.com/ros-controls/gz_ros2_control.git
-      version: master
-    release:
-      packages:
-      - ign_ros2_control
-      - ign_ros2_control_demos
-      tags:
-        release: release/iron/{package}/{version}
-      url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 0.6.1-4
-    source:
-      type: git
-      url: https://github.com/ros-controls/gz_ros2_control.git
-      version: master
-    status: maintained
   ign_rviz:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1714,6 +1714,24 @@ repositories:
       url: https://github.com/borglab/gtsam.git
       version: develop
     status: developed
+  gz_ros2_control:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/gz_ros2_control.git
+      version: master
+    release:
+      packages:
+      - gz_ros2_control
+      - gz_ros2_control_demos
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ign_ros2_control-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/gz_ros2_control.git
+      version: master
+    status: maintained
   hash_library_vendor:
     doc:
       type: git
@@ -1806,24 +1824,6 @@ repositories:
       url: https://github.com/ros2-gbp/ifm3d-release.git
       version: 0.18.0-8
     status: developed
-  ign_ros2_control:
-    doc:
-      type: git
-      url: https://github.com/ros-controls/gz_ros2_control.git
-      version: master
-    release:
-      packages:
-      - ign_ros2_control
-      - ign_ros2_control_demos
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 0.6.1-2
-    source:
-      type: git
-      url: https://github.com/ros-controls/gz_ros2_control.git
-      version: master
-    status: maintained
   ign_rviz:
     doc:
       type: git


### PR DESCRIPTION
Due the renaming from ign to gz this package should use a different key, package names have changed too.