### PR TITLE
Add libsoundio-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5465,6 +5465,14 @@ libsoqt4-dev:
   fedora: [SoQt-devel]
   gentoo: [media-libs/SoQt]
   ubuntu: [libsoqt4-dev]
+libsoundio-dev:
+  alpine: [libsoundio]
+  debian: [libsoundio-dev]
+  fedora: [libsoundio]
+  gentoo: [libsoundio]
+  macports: [libsoundio]
+  nixos: [libsoundio]
+  ubuntu: [libsoundio-dev]
 libspatialindex-dev:
   debian: [libspatialindex-dev]
   fedora: [spatialindex-devel]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

libsoundio-dev

## Package Upstream Source:

https://github.com/andrewrk/libsoundio

## Purpose of using this:

This is a dependency of the azure kinect driver

## Links to Distribution Packages

- Debian: https://packages.debian.org/bookworm/libsoundio-dev
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/kinetic/libsoundio-dev
  - REQUIRED
- Fedora: https://packages.fedoraproject.org/pkgs/libsoundio/libsoundio/
  - IF AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - NOT AVAILABLE
- Gentoo: https://packages.gentoo.org/packages/media-libs/libsoundio
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/formula/libsoundio
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/package/edge/community/armhf/libsoundio
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=23.05&show=libsoundio&from=0&size=50&sort=relevance&type=packages&query=soundio
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/
  - NOT AVAILABLE
