### PR TITLE
ros2_control: 2.28.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5366,7 +5366,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.27.0-1
+      version: 2.28.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.28.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.27.0-1`

## controller_interface

- No changes

## controller_manager

- No changes

## controller_manager_msgs

- No changes

## hardware_interface

```
* Ensure instantiation of hardware classes work for python bindings (#1058 <https://github.com/ros-controls/ros2_control/issues/1058>) (#1062 <https://github.com/ros-controls/ros2_control/issues/1062>)
* Contributors: Olivier Stasse
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Improve list hardware components output and code for better readability. (backport #1060 <https://github.com/ros-controls/ros2_control/issues/1060>) (#1061 <https://github.com/ros-controls/ros2_control/issues/1061>)
* Contributors: Dr. Denis
```

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
