### PR TITLE
ros2_control: 3.15.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4675,7 +4675,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.14.0-1
+      version: 3.15.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.15.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.14.0-1`

## controller_interface

- No changes

## controller_manager

```
* Enable setting of initial state in HW compoments (#1046 <https://github.com/ros-controls/ros2_control/issues/1046>)
* [CM] Improve output when using robot description topic and give output about correct topic even remapped. (#1059 <https://github.com/ros-controls/ros2_control/issues/1059>)
* Contributors: Dr. Denis
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Enable setting of initial state in HW compoments (#1046 <https://github.com/ros-controls/ros2_control/issues/1046>)
* Ensure instantiation of hardware classes work for python bindings (#1058 <https://github.com/ros-controls/ros2_control/issues/1058>)
* Contributors: Dr. Denis, Olivier Stasse
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Improve list hardware components output and code for better readability. (#1060 <https://github.com/ros-controls/ros2_control/issues/1060>)
* Contributors: Dr. Denis
```

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
