### PR TITLE
jsk_3rdparty: 2.1.27-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5312,7 +5312,9 @@ repositories:
       - ff
       - ffha
       - gdrive_ros
+      - google_chat_ros
       - google_cloud_texttospeech
+      - influxdb_store
       - jsk_3rdparty
       - julius
       - julius_ros
@@ -5320,10 +5322,13 @@ repositories:
       - libsiftfast
       - lpg_planner
       - mini_maxwell
+      - nfc_ros
       - nlopt
       - opt_camera
+      - osqp
       - pgm_learner
       - respeaker_ros
+      - ros_google_cloud_language
       - ros_speech_recognition
       - rospatlite
       - rosping
@@ -5332,10 +5337,13 @@ repositories:
       - slic
       - switchbot_ros
       - voice_text
+      - webrtcvad_ros
+      - zdepth
+      - zdepth_image_transport
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
-      version: 2.1.24-2
+      version: 2.1.27-2
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_3rdparty` to `2.1.27-2`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
- release repository: https://github.com/tork-a/jsk_3rdparty-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.24-2`

## aques_talk

```
* fix package.xml/CMakeLists.txt to supress catkin_lint errors (#479 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/479>)
* Contributors: Kei Okada
```

## assimp_devel

```
* fix package.xml/CMakeLists.txt to supress catkin_lint errors (#479 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/479>)
* Contributors: Kei Okada
```

## bayesian_belief_networks

```
* fix package.xml/CMakeLists.txt to supress catkin_lint errors (#479 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/479>)
* Contributors: Kei Okada
```

## chaplus_ros

- No changes

## collada_urdf_jsk_patch

```
* fix package.xml/CMakeLists.txt to supress catkin_lint errors (#479 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/479>)
* Contributors: Kei Okada
```

## dialogflow_task_executive

```
* fix package.xml/CMakeLists.txt to supress catkin_lint errors (#479 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/479>)
* Contributors: Kei Okada
```

## downward

- No changes

## ff

- No changes

## ffha

- No changes

## gdrive_ros

```
* fix package.xml/CMakeLists.txt to supress catkin_lint errors (#479 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/479>)
* Contributors: Kei Okada
```

## google_chat_ros

```
* fix package.xml/CMakeLists.txt to supress catkin_lint errors (#479 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/479>)
* Contributors: Kei Okada
```

## google_cloud_texttospeech

- No changes

## influxdb_store

- No changes

## jsk_3rdparty

- No changes

## julius

- No changes

## julius_ros

```
* fix package.xml/CMakeLists.txt to supress catkin_lint errors (#479 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/479>)
* Contributors: Kei Okada
```

## libcmt

- No changes

## libsiftfast

```
* fix package.xml/CMakeLists.txt to supress catkin_lint errors (#479 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/479>)
* Contributors: Kei Okada
```

## lpg_planner

- No changes

## mini_maxwell

- No changes

## nfc_ros

```
* fix package.xml/CMakeLists.txt to supress catkin_lint errors (#479 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/479>)
* Contributors: Kei Okada
```

## nlopt

- No changes

## opt_camera

- No changes

## osqp

- No changes

## pgm_learner

```
* fix package.xml/CMakeLists.txt to supress catkin_lint errors (#479 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/479>)
* Contributors: Kei Okada
```

## respeaker_ros

```
* fix package.xml/CMakeLists.txt to supress catkin_lint errors (#479 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/479>)
* Contributors: Kei Okada
```

## ros_google_cloud_language

```
* fix package.xml/CMakeLists.txt to supress catkin_lint errors (#479 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/479>)
* Contributors: Kei Okada
```

## ros_speech_recognition

```
* fix package.xml/CMakeLists.txt to supress catkin_lint errors (#479 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/479>)
* Contributors: Kei Okada
```

## rospatlite

- No changes

## rosping

```
* fix package.xml/CMakeLists.txt to supress catkin_lint errors (#479 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/479>)
* Contributors: Kei Okada
```

## rostwitter

```
* fix package.xml/CMakeLists.txt to supress catkin_lint errors (#479 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/479>)
* Contributors: Kei Okada
```

## sesame_ros

```
* fix package.xml/CMakeLists.txt to supress catkin_lint errors (#479 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/479>)
* Contributors: Kei Okada
```

## slic

- No changes

## switchbot_ros

```
* fix package.xml/CMakeLists.txt to supress catkin_lint errors (#479 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/479>)
* Contributors: Kei Okada
```

## voice_text

- No changes

## webrtcvad_ros

- No changes

## zdepth

- No changes

## zdepth_image_transport

```
* fix package.xml/CMakeLists.txt to supress catkin_lint errors (#479 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/479>)
* Contributors: Kei Okada
```
