### PR TITLE
tuw_geometry: 0.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7555,7 +7555,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/tuw-robotics/tuw_geometry-release.git
-      version: 0.0.9-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/tuw-robotics/tuw_geometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tuw_geometry` to `0.1.1-1`:

- upstream repository: https://github.com/tuw-robotics/tuw_geometry.git
- release repository: https://github.com/tuw-robotics/tuw_geometry-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.9-1`

## tuw_geometry

```
* docs updated
* Doxyfile added
* Contributors: Markus Bader
```
