### PR TITLE
depthai-ros: 2.7.4-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -901,6 +901,30 @@ repositories:
       url: https://github.com/luxonis/depthai-core.git
       version: ros-release
     status: developed
+  depthai-ros:
+    doc:
+      type: git
+      url: https://github.com/luxonis/depthai-ros.git
+      version: iron
+    release:
+      packages:
+      - depthai-ros
+      - depthai_bridge
+      - depthai_descriptions
+      - depthai_examples
+      - depthai_filters
+      - depthai_ros_driver
+      - depthai_ros_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/luxonis/depthai-ros-release.git
+      version: 2.7.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/luxonis/depthai-ros.git
+      version: iron
+    status: developed
   depthimage_to_laserscan:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai-ros` to `2.7.4-1`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: https://github.com/luxonis/depthai-ros-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## depthai-ros

```
* ROS time update
* Minor bugfixes
```
