### PR TITLE
ur_robot_driver: 2.2.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7775,7 +7775,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.2.7-1
+      version: 2.2.8-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.2.8-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.7-1`

## ur

- No changes

## ur_bringup

- No changes

## ur_calibration

- No changes

## ur_controllers

- No changes

## ur_dashboard_msgs

- No changes

## ur_moveit_config

- No changes

## ur_robot_driver

```
* Use tf prefix properly (backport #688 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/688>) (#725 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/725>)
* Use SCHED_FIFO for controller_manager's main thread (#719 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/719>) (#722 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/722>)
* Contributors: mergify[bot]
```
