### PR TITLE
Mark Melodic as End-of-Life.

### DIFF
--- a/.github/labeler-config.yaml
+++ b/.github/labeler-config.yaml
@@ -1,7 +1,3 @@
-# Add 'melodic' label if any files in melodic/ folder are changed by a PR
-melodic:
-  - melodic/*
-
 # Add 'noetic' label if any files in noetic/ folder are changed by a PR
 noetic:
   - noetic/*
@@ -31,6 +27,7 @@ end-of-life:
   - jade/*
   - kinetic/*
   - lunar/*
+  - melodic/*
   # ROS 2
   - ardent/*
   - bouncy/*

--- a/index-v4.yaml
+++ b/index-v4.yaml
@@ -96,7 +96,7 @@ distributions:
   melodic:
     distribution: [melodic/distribution.yaml]
     distribution_cache: http://repositories.ros.org/rosdistro_cache/melodic-cache.yaml.gz
-    distribution_status: active
+    distribution_status: end-of-life
     distribution_type: ros1
     python_version: 2
   noetic:


### PR DESCRIPTION
Note to rosdistro reviewers to please not merge this right away; I'll do it once we are ready.

@nuclearsandwich Copying and modifying your list from https://github.com/ros/rosdistro/pull/37746#issuecomment-1608100563:

## Melodic build farm wind-down

- [x] Stop merging all melodic-related ros/rosdistro PRs
- [x] Disable melodic jobs from ros-infrastructure/ros_buildfarm_config: https://github.com/ros-infrastructure/ros_buildfarm_config/pull/223
- [x] Disable jobs using the method described in https://github.com/ros-infrastructure/ros_buildfarm/blob/master/doc/ongoing_operations.rst (but with batching)
- [x] Merge this PR
- [ ] Update distro in https://github.com/ros-infrastructure/rosindex/blob/ros2/_config.yml
- [ ] After a few weeks, assuming that no one has asked to resurrect melodic for a fixup sync, the jobs can be deleted using a modified copy of the disabling script.