### PR TITLE
add ros2_canopen repository for humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5357,6 +5357,16 @@ repositories:
       url: https://github.com/ros2/ros1_bridge.git
       version: master
     status: maintained
+  ros2_canopen:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/ros2_canopen.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/ros-industrial/ros2_canopen.git
+      version: humble
+    status: developed
   ros2_control:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.
humble

# The source is here:

https://github.com/ros-industrial/ros2_canopen/tree/humble

for our  reference: https://github.com/ros-industrial/ros2_canopen/issues/166

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
