### PR TITLE
fix: fix incorrect 'sphinx-autoapi' key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8495,7 +8495,7 @@ python3-sphinx-argparse:
   fedora: [python3-sphinx-argparse]
   nixos: [python3Packages.sphinx-argparse]
   ubuntu: [python3-sphinx-argparse]
-python3-sphinx-autoapi:
+python3-sphinx-autoapi-pip:
   debian:
     pip:
       packages: [sphinx-autoapi]


### PR DESCRIPTION
@mjcarroll, @adityapande-1995 I forgot to add the `pip` suffix in #37625. Since this pull request was merged less than a week ago, it is still safe to fix this.