### PR TITLE
behaviortree_cpp_v3: 3.8.4-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -529,7 +529,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp-release.git
-      version: 3.8.3-5
+      version: 3.8.4-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp_v3` to `3.8.4-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/ros2-gbp/behaviortree_cpp-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.8.3-5`

## behaviortree_cpp_v3

```
* Update ros2.yaml
* Update ros1.yaml
* Issue 563 (#596 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/596>)
  * failing test
  * fix issue 563 (?)
  * better solution
* use lambda in tutorial
* Merge pull request #583 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/583> from BehaviorTree/issue563
  Issue563
* better default port
* restore type check
* fix issue #563 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/563>
* fix test
* Issue563
* Merge pull request #579 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/579> from open-navigation/hi
  changing resetStatus to public
* Update tree_node.h
* changing resetStatus to public
* Merge branch 'v3.8' of github.com:BehaviorTree/BehaviorTree.CPP into v3.8
* backporting fixes from branch 4.x
* Merge pull request #546 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/546> from divbyzerofordummies/fix_ROS_include
  Fix issue #545 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/545>
* Fix issue #545 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/545>
* bug fix: halting a Node must invoke the Loggers
* unit test added
* Contributors: Daniel Muschick, Davide Faconti, Steve Macenski, stevemacenski
```
