### PR TITLE
webots_ros2: 2023.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7085,7 +7085,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/webots_ros2-release.git
-      version: 2023.0.4-1
+      version: 2023.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `webots_ros2` to `2023.1.0-1`:

- upstream repository: https://github.com/cyberbotics/webots_ros2.git
- release repository: https://github.com/ros2-gbp/webots_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2023.0.4-1`

## webots_ros2

```
* Added Ros2Pen static plugin.
* Added support for Navigation2 in Iron.
* Clean simulation reset in launch files.
* Fixed Universal Robot trajectory interpolation.
* Added new TIAGo project to webots_ros2_tiago to run real robot configuration.
* Added new WebotsController node in the driver interface to launch robot controller plugins.
* Fixed unfound robot window library in Tesla example.
* Default to canonical topic name and fix camera_info stamp in Ros2Camera, Ros2RangeFinder.
* Added VacuumGripper gripper support in webots_ros2_driver.
* Added BoolStamped message in webots_ros2_msgs.
* Added GetBool service in webots_ros2_msgs.
* Fixed webots_ros2_control component activation.
```

## webots_ros2_control

```
* Fixed component activation.
```

## webots_ros2_driver

```
* Added Ros2Pen static plugin.
* Added parameters to rename Camera and RangeFinder topics.
* Added new WebotsController node to launch robot controller plugins.
* Added compilation of the generic robot window library.
* Default to canonical topic name and fix camera_info stamp in Ros2Camera, Ros2RangeFinder.
* Added VacuumGripper device support
```

## webots_ros2_epuck

```
* Added support for Navigation2 in Iron.
* Clean simulation reset in launch file.
* Update driver node to new WebotsController node.
```

## webots_ros2_mavic

```
* Clean simulation reset in launch file.
* Update driver node to new WebotsController node.
```

## webots_ros2_msgs

```
* Added BoolStamped message
* Added GetBool message
* Added pen ink properties message.
```

## webots_ros2_tesla

```
* Clean simulation reset in launch file.
* Update driver node to new WebotsController node.
```

## webots_ros2_tests

```
* Added iron tests support.
* Update webots_ros2_driver test to new WebotsController node.
```

## webots_ros2_tiago

```
* Added support for Navigation2 in Iron.
* Clean simulation reset in launch file.
* Added new world, resources and launch file to start the TIAGo with real robot configuration.
* Update driver node to new WebotsController node.
```

## webots_ros2_turtlebot

```
* Clean simulation reset in launch file.
* Update driver node to new WebotsController node.
```

## webots_ros2_universal_robot

```
* Clean simulation reset in launch file.
* Fixed JTC interpolation.
* Fixed deprecated load_yaml() function.
* Update driver node to new WebotsController node.
```
