### PR TITLE
smach: 3.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6766,6 +6766,16 @@ repositories:
       type: git
       url: https://github.com/ros/executive_smach.git
       version: ros2
+    release:
+      packages:
+      - executive_smach
+      - smach
+      - smach_msgs
+      - smach_ros
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/executive_smach-release.git
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/ros/executive_smach.git


### PR DESCRIPTION
Increasing version of package(s) in repository `smach` to `3.0.2-1`:

- upstream repository: https://github.com/ros/executive_smach.git
- release repository: https://github.com/ros2-gbp/executive_smach-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## executive_smach

```
* Fix #92 <https://github.com/ros/executive_smach/issues/92>
```

## smach

```
* Fix #92 <https://github.com/ros/executive_smach/issues/92>
```

## smach_msgs

- No changes

## smach_ros

- No changes
