### PR TITLE
smach: 3.0.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6001,6 +6001,26 @@ repositories:
       url: https://github.com/oKermorgant/slider_publisher.git
       version: ros2
     status: maintained
+  smach:
+    doc:
+      type: git
+      url: https://github.com/ros/executive_smach.git
+      version: ros2
+    release:
+      packages:
+      - executive_smach
+      - smach
+      - smach_msgs
+      - smach_ros
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/executive_smach-release.git
+      version: 3.0.2-1
+    source:
+      type: git
+      url: https://github.com/ros/executive_smach.git
+      version: ros2
+    status: maintained
   snowbot_operating_system:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `smach` to `3.0.2-1`:

- upstream repository: https://github.com/ros/executive_smach.git
- release repository: https://github.com/ros2-gbp/executive_smach-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## executive_smach

```
* Fix #92 <https://github.com/ros/executive_smach/issues/92>
```

## smach

```
* Fix #92 <https://github.com/ros/executive_smach/issues/92>
```

## smach_msgs

- No changes

## smach_ros

- No changes
