### PR TITLE
hey5_description: 3.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1979,7 +1979,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/hey5_description-release.git
-      version: 3.0.2-1
+      version: 3.0.3-1
     source:
       type: git
       url: https://github.com/pal-robotics/hey5_description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hey5_description` to `3.0.3-1`:

- upstream repository: https://github.com/pal-robotics/hey5_description.git
- release repository: https://github.com/pal-gbp/hey5_description-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.2-1`

## hey5_description

```
* create hey5 ros2_control and transmission xacro files
* Contributors: Noel Jimenez
```
