### PR TITLE
pmb2_navigation: 4.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4104,7 +4104,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_navigation-gbp.git
-      version: 4.0.4-1
+      version: 4.0.5-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_navigation` to `4.0.5-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_navigation.git
- release repository: https://github.com/pal-gbp/pmb2_navigation-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.4-1`

## pmb2_2dnav

```
* Merge branch 'feat/laser-filters' into 'humble-devel'
  using laser filters in simulation
  See merge request robots/pmb2_navigation!70
* changed is_public_sim arg order
* clarifying remapping file usage
* declaring is_sim before using it
* added private dependencies
* added is_public_sim argument
* added is_public_sim
* updated dependencies and rviz config
* using sim bringup
* fix linter
* start laser filters for simulation
* using laser filters in simulation
* Contributors: antoniobrandi
```

## pmb2_laser_sensors

```
* Merge branch 'feat/laser-filters' into 'humble-devel'
  using laser filters in simulation
  See merge request robots/pmb2_navigation!70
* added private dependencies
* using laser filters in simulation
* Contributors: antoniobrandi
```

## pmb2_maps

- No changes

## pmb2_navigation

- No changes
