### PR TITLE
pmb2_simulation: 4.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4142,7 +4142,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_simulation-release.git
-      version: 4.0.3-1
+      version: 4.0.4-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_simulation` to `4.0.4-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_simulation.git
- release repository: https://github.com/pal-gbp/pmb2_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.3-1`

## pmb2_gazebo

```
* Merge branch 'fix/set-is-robot' into 'humble-devel'
  Use a different navigation launcher for simulation
  See merge request robots/pmb2_simulation!60
* use pmb2_sim_navigation
* setting is_robot argument for simulation
* Contributors: antoniobrandi
```

## pmb2_simulation

- No changes
