### PR TITLE
pal_gazebo_plugins: 4.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3788,7 +3788,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_gazebo_plugins-release.git
-      version: 4.0.3-1
+      version: 4.0.4-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_gazebo_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_gazebo_plugins` to `4.0.4-1`:

- upstream repository: https://github.com/pal-robotics/pal_gazebo_plugins.git
- release repository: https://github.com/pal-gbp/pal_gazebo_plugins-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.3-1`

## pal_gazebo_plugins

```
* Merge branch 'fix_warns' into 'humble-devel'
  Fix warnings
  See merge request common/pal_gazebo_plugins!24
* compare gazebo times instead of doubles
* use auto instead of string
* Contributors: Jordan Palacios, Noel Jimenez
```
