### PR TITLE
submit flexbe for ROS 2 naming review prior to creating release repos

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1507,7 +1507,7 @@ repositories:
       version: humble
     release:
       packages:
-        - flexbe_app
+      - flexbe_app
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/flexbe_app-release.git
@@ -1524,15 +1524,15 @@ repositories:
       version: humble
     release:
       packages:
-        - flexbe_behavior_engine
-        - flexbe_core
-        - flexbe_input
-        - flexbe_mirror
-        - flexbe_msgs
-        - flexbe_onboard
-        - flexbe_states
-        - flexbe_testing
-        - flexbe_widget
+      - flexbe_behavior_engine
+      - flexbe_core
+      - flexbe_input
+      - flexbe_mirror
+      - flexbe_msgs
+      - flexbe_onboard
+      - flexbe_states
+      - flexbe_testing
+      - flexbe_widget
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/flexbe_behavior_engine-release.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1505,13 +1505,6 @@ repositories:
       type: git
       url: https://github.com/flexbe/flexbe_app.git
       version: humble
-   # release:
-   #   packages:
-   #   - flexbe_app
-   #   tags:
-   #     release: release/humble/{package}/{version}
-   #   url: https://github.com/ros2-gbp/flexbe_app-release.git
-   #   version: 3.1.0
     source:
       type: git
       url: https://github.com/flexbe/flexbe_app.git
@@ -1522,21 +1515,6 @@ repositories:
       type: git
       url: https://github.com/flexbe/flexbe_behavior_engine.git
       version: humble
-    # release:
-    #   packages:
-    #   - flexbe_behavior_engine
-    #   - flexbe_core
-    #   - flexbe_input
-    #   - flexbe_mirror
-    #   - flexbe_msgs
-    #   - flexbe_onboard
-    #   - flexbe_states
-    #   - flexbe_testing
-    #   - flexbe_widget
-    #   tags:
-    #     release: release/humble/{package}/{version}
-    #   url: https://github.com/ros2-gbp/flexbe_behavior_engine-release.git
-    #   version: 2.2.0
     source:
       type: git
       url: https://github.com/flexbe/flexbe_behavior_engine.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1500,6 +1500,48 @@ repositories:
       url: https://github.com/introlab/find-object.git
       version: humble-devel
     status: maintained
+  flexbe_app:
+    doc:
+      type: git
+      url: https://github.com/flexbe/flexbe_app.git
+      version: humble
+    release:
+      packages:
+        - flexbe_app
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/flexbe_app-release.git
+      version: 3.1.0
+    source:
+      type: git
+      url: https://github.com/flexbe/flexbe_app.git
+      version: humble
+    status: developed
+  flexbe_behavior_engine:
+    doc:
+      type: git
+      url: https://github.com/flexbe/flexbe_behavior_engine.git
+      version: humble
+    release:
+      packages:
+        - flexbe_behavior_engine
+        - flexbe_core
+        - flexbe_input
+        - flexbe_mirror
+        - flexbe_msgs
+        - flexbe_onboard
+        - flexbe_states
+        - flexbe_testing
+        - flexbe_widget
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/flexbe_behavior_engine-release.git
+      version: 2.2.0
+    source:
+      type: git
+      url: https://github.com/flexbe/flexbe_behavior_engine.git
+      version: humble
+    status: developed
   fluent_bit_vendor:
     source:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1505,13 +1505,13 @@ repositories:
       type: git
       url: https://github.com/flexbe/flexbe_app.git
       version: humble
-    release:
-      packages:
-      - flexbe_app
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/ros2-gbp/flexbe_app-release.git
-      version: 3.1.0
+   # release:
+   #   packages:
+   #   - flexbe_app
+   #   tags:
+   #     release: release/humble/{package}/{version}
+   #   url: https://github.com/ros2-gbp/flexbe_app-release.git
+   #   version: 3.1.0
     source:
       type: git
       url: https://github.com/flexbe/flexbe_app.git
@@ -1522,21 +1522,21 @@ repositories:
       type: git
       url: https://github.com/flexbe/flexbe_behavior_engine.git
       version: humble
-    release:
-      packages:
-      - flexbe_behavior_engine
-      - flexbe_core
-      - flexbe_input
-      - flexbe_mirror
-      - flexbe_msgs
-      - flexbe_onboard
-      - flexbe_states
-      - flexbe_testing
-      - flexbe_widget
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/ros2-gbp/flexbe_behavior_engine-release.git
-      version: 2.2.0
+    # release:
+    #   packages:
+    #   - flexbe_behavior_engine
+    #   - flexbe_core
+    #   - flexbe_input
+    #   - flexbe_mirror
+    #   - flexbe_msgs
+    #   - flexbe_onboard
+    #   - flexbe_states
+    #   - flexbe_testing
+    #   - flexbe_widget
+    #   tags:
+    #     release: release/humble/{package}/{version}
+    #   url: https://github.com/ros2-gbp/flexbe_behavior_engine-release.git
+    #   version: 2.2.0
     source:
       type: git
       url: https://github.com/flexbe/flexbe_behavior_engine.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2817,7 +2817,7 @@ repositories:
   flexbe:
     doc:
       type: git
-      url: https://github.com/team-vigir/flexbe_behavior_engine.git
+      url: https://github.com/flexbe/flexbe_behavior_engine.git
       version: master
     release:
       packages:
@@ -2832,22 +2832,22 @@ repositories:
       - flexbe_widget
       tags:
         release: release/noetic/{package}/{version}
-      url: https://github.com/FlexBE/flexbe_behavior_engine-release.git
+      url: https://github.com/flexbe/flexbe_behavior_engine-release.git
       version: 1.4.0-2
     source:
       type: git
-      url: https://github.com/team-vigir/flexbe_behavior_engine.git
+      url: https://github.com/flexbe/flexbe_behavior_engine.git
       version: master
     status: developed
   flexbe_app:
     release:
       tags:
         release: release/noetic/{package}/{version}
-      url: https://github.com/FlexBE/flexbe_app-release.git
+      url: https://github.com/flexbe/flexbe_app-release.git
       version: 2.4.1-1
     source:
       type: git
-      url: https://github.com/FlexBE/flexbe_app.git
+      url: https://github.com/flexbe/flexbe_app.git
       version: master
   flir_camera_driver:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2818,7 +2818,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/flexbe/flexbe_behavior_engine.git
-      version: master
+      version: noetic
     release:
       packages:
       - flexbe_behavior_engine
@@ -2837,7 +2837,7 @@ repositories:
     source:
       type: git
       url: https://github.com/flexbe/flexbe_behavior_engine.git
-      version: master
+      version: noetic
     status: developed
   flexbe_app:
     release:
@@ -2848,7 +2848,7 @@ repositories:
     source:
       type: git
       url: https://github.com/flexbe/flexbe_app.git
-      version: master
+      version: noetic
   flir_camera_driver:
     doc:
       type: git


### PR DESCRIPTION
Submitting FlexBE for naming review before first ROS 2 release.

Will be submitting release team and release repo creation requests tied to this PR.


## Package names:

        - flexbe_app
        - flexbe_behavior_engine
        - flexbe_core
        - flexbe_input
        - flexbe_mirror
        - flexbe_msgs
        - flexbe_onboard
        - flexbe_states
        - flexbe_testing
        - flexbe_widget


## Package Upstream Source:
https://github.com/flexbe/flexbe_app.git
https://github.com/flexbe/flexbe_behavior_engine.git

## Purpose of using this:

FlexBE is available in ROS 1.   The ROS 2 version has been tested, and continuous integration tests are now functioning so ready for ROS 2 release.


Proposed release package names (have not created yet)
https://github.com/ros2-gbp/flexbe_app-release.git
https://github.com/ros2-gbp/flexbe_behavior_engine-release.git

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
