### PR TITLE
Add liblttng-ctl-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3988,6 +3988,12 @@ liblmdb-dev:
   opensuse: [lmdb-devel]
   rhel: [lmdb-devel]
   ubuntu: [liblmdb-dev]
+liblttng-ctl-dev:
+  debian: [liblttng-ctl-dev]
+  fedora: [lttng-tools-devel]
+  opensuse: [lttng-tools-devel]
+  rhel: [lttng-tools-devel]
+  ubuntu: [liblttng-ctl-dev]
 liblttng-ust-dev:
   arch: [lttng-ust]
   debian: [liblttng-ust-dev]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`liblttng-ctl-dev`

## Package Upstream Source:

https://github.com/lttng/lttng-tools

License: LGPL-2.1-only (for the library itself)

## Purpose of using this:

Configuring tracing directly.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

The source repository (https://github.com/lttng/lttng-tools) includes:

- Tracing control library (`liblttng-ctl0` on Ubuntu)
- Tracing control library - development files (`liblttng-ctl-dev` on Ubuntu)
- CLI tool based on the library (`lttng-tools` on Ubuntu)

Some platforms only have "lttng-tools," so they either have all of the above in a single package, or they only offer the CLI tool (and `liblttng-ctl0`) but not the development files for the library.

- Debian: https://packages.debian.org/
  - :heavy_check_mark: https://packages.debian.org/bookworm/liblttng-ctl-dev
- Ubuntu: https://packages.ubuntu.com/
  - :heavy_check_mark: https://packages.ubuntu.com/jammy/liblttng-ctl-dev
- Fedora: https://packages.fedoraproject.org/
  - :heavy_check_mark: https://packages.fedoraproject.org/pkgs/lttng-tools/lttng-tools-devel/
- Arch: https://www.archlinux.org/packages/
  - :x: not found
- Gentoo: https://packages.gentoo.org/
  - :question: not sure if this includes `liblttng-ctl-dev`: https://packages.gentoo.org/packages/dev-util/lttng-tools
- macOS: https://formulae.brew.sh/
  - :x: N/A
- Alpine: https://pkgs.alpinelinux.org/packages
  - :heavy_check_mark: https://pkgs.alpinelinux.org/package/edge/community/x86/lttng-tools-dev
- NixOS/nixpkgs: https://search.nixos.org/packages
  - :question: not sure if this includes `liblttng-ctl-dev`: https://hydra.nixos.org/job/nixos/release-23.05/nixpkgs.lttng-tools.x86_64-linux
- openSUSE: https://software.opensuse.org/package/
  - :heavy_check_mark: provided by https://software.opensuse.org/package/lttng-tools

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->
