### PR TITLE
tesseract: 0.18.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11225,7 +11225,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-industrial-release/tesseract-release.git
-      version: 0.15.2-1
+      version: 0.18.0-1
     source:
       type: git
       url: https://github.com/ros-industrial-consortium/tesseract.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tesseract` to `0.18.0-1`:

- upstream repository: https://github.com/tesseract-robotics/tesseract.git
- release repository: https://github.com/ros-industrial-release/tesseract-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.15.2-1`

## tesseract_collision

```
* Update kinematics group inverse kinematics to harmonize within joint limits (#899 <https://github.com/tesseract-robotics/tesseract/issues/899>)
* Trajectory logging fixup (#908 <https://github.com/tesseract-robotics/tesseract/issues/908>)
* Improve Trajectory Collision Logging (#765 <https://github.com/tesseract-robotics/tesseract/issues/765>)
* Add package cmake flags for testing, examples and benchmarks
* Add assert to ContactResultsMap to make sure key is an ordered pair
* Fix makeConvexMesh to pass through scale used on resource
* Update VHACD to latest (v4.1, tag 454913f) (#896 <https://github.com/tesseract-robotics/tesseract/issues/896>)
* Contributors: John Wason, Levi Armstrong, Roelof, Tyler Marr
```

## tesseract_common

```
* Add package cmake flags for testing, examples and benchmarks
* Removed gcc-specific options from clang config
* Fix JointState equal operator
* Contributors: Levi Armstrong, Roelof
```

## tesseract_environment

```
* Update kinematics group inverse kinematics to harmonize within joint limits (#899 <https://github.com/tesseract-robotics/tesseract/issues/899>)
* Trajectory logging fixup (#908 <https://github.com/tesseract-robotics/tesseract/issues/908>)
* Improve Trajectory Collision Logging (#765 <https://github.com/tesseract-robotics/tesseract/issues/765>)
* Add package cmake flags for testing, examples and benchmarks
* Contributors: John Wason, Levi Armstrong, Tyler Marr
```

## tesseract_geometry

```
* Add package cmake flags for testing, examples and benchmarks
* Fix makeConvexMesh to pass through scale used on resource
* Contributors: Levi Armstrong
```

## tesseract_kinematics

```
* Update kinematics group inverse kinematics to harmonize within joint limits (#899 <https://github.com/tesseract-robotics/tesseract/issues/899>)
* Add package cmake flags for testing, examples and benchmarks
* Contributors: John Wason, Levi Armstrong
```

## tesseract_scene_graph

```
* Add package cmake flags for testing, examples and benchmarks
* Contributors: Levi Armstrong
```

## tesseract_srdf

```
* Add package cmake flags for testing, examples and benchmarks
* Contributors: Levi Armstrong
```

## tesseract_state_solver

```
* Add package cmake flags for testing, examples and benchmarks
* Contributors: Levi Armstrong
```

## tesseract_support

```
* Add package cmake flags for testing, examples and benchmarks
* Contributors: Levi Armstrong
```

## tesseract_urdf

```
* Add package cmake flags for testing, examples and benchmarks
* Contributors: Levi Armstrong
```

## tesseract_visualization

```
* Add package cmake flags for testing, examples and benchmarks
* Contributors: Levi Armstrong
```
