### PR TITLE
Add cpp-httplib

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2979,7 +2979,7 @@ libconsole-bridge-dev:
 libcos4-dev:
   debian: [libcos4-dev]
   ubuntu: [libcos4-dev]
-libcpphttlib-dev:
+libcpp-httplib-dev:
   debian:
     bookworm: [libcpp-httplib-dev]
     sid: [libcpp-httplib-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2991,6 +2991,7 @@ libcpp-httplib-dev:
   rhel: [cpp-httplib-devel]
   ubuntu:
     '*': [libcpp-httplib-dev]
+    bionic: null
     focal: null
 libcpprest-dev:
   debian:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2988,6 +2988,7 @@ libcpp-httplib-dev:
   osx:
     homebrew:
       packages: [cpp-httplib]
+  rhel: [cpp-httplib-devel]
   ubuntu:
     '*': [libcpp-httplib-dev]
     focal: null

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2981,8 +2981,8 @@ libcos4-dev:
   ubuntu: [libcos4-dev]
 libcpp-httplib-dev:
   debian:
-    bookworm: [libcpp-httplib-dev]
-    sid: [libcpp-httplib-dev]
+    '*': [libcpp-httplib-dev]
+    bullseye: null
   fedora: [cpp-httplib-devel]
   gentoo: [cpp-httplib]
   osx:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2988,7 +2988,8 @@ libcpphttlib-dev:
   osx:
     homebrew:
       packages: [cpp-httplib]
-  ubuntu: [libcpp-httplib-dev]
+  ubuntu:
+    jammy: [libcpp-httplib-dev]
 libcpprest-dev:
   debian:
     buster: [libcpprest-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2989,7 +2989,8 @@ libcpp-httplib-dev:
     homebrew:
       packages: [cpp-httplib]
   ubuntu:
-    jammy: [libcpp-httplib-dev]
+    '*': [libcpp-httplib-dev]
+    focal: null
 libcpprest-dev:
   debian:
     buster: [libcpprest-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2979,6 +2979,16 @@ libconsole-bridge-dev:
 libcos4-dev:
   debian: [libcos4-dev]
   ubuntu: [libcos4-dev]
+libcpphttlib-dev:
+  debian:
+    bookworm: [libcpp-httplib-dev]
+    sid: [libcpp-httplib-dev]
+  fedora: [cpp-httplib-devel]
+  gentoo: [cpp-httplib]
+  osx:
+    homebrew:
+      packages: [cpp-httplib]
+  ubuntu: [libcpp-httplib-dev]
 libcpprest-dev:
   debian:
     buster: [libcpprest-dev]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

cpp-httplib (dev)

I couldn't decide on the key name. These are all used:

* `cpp-httplib`
* `libcpphttlib-dev`
* `libcpp-httplib-dev`
* `cpp-httplib-devel`

License: MIT

## Package Upstream Source:

[cpp-httplib](https://github.com/yhirose/cpp-httplib)

## Purpose of using this:

This allows making simple HTTP(S) servers in C++. Header only. 

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/search?suite=bookworm&arch=any&searchon=names&keywords=libcpp-httplib-dev
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/search?suite=jammy&searchon=names&keywords=libcpp-httplib-dev
  - REQUIRED
- Fedora: https://packages.fedoraproject.org/pkgs/cpp-httplib/cpp-httplib-devel/
  - IF AVAILABLE
- Arch: not available
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/packages/dev-cpp/cpp-httplib
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/formula/cpp-httplib#default
  - IF AVAILABLE
- Alpine: not available
  - IF AVAILABLE
- NixOS/nixpkgs: Skipped
  - OPTIONAL
- openSUSE: Skipped
  - IF AVAILABLE
  - 
# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro

 Note: This work was done on behalf of[ AeroVironment Inc.](https://www.avinc.com/)