### PR TITLE
rmf_task: 2.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4335,7 +4335,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
-      version: 2.3.0-1
+      version: 2.3.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_task.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_task` to `2.3.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_task.git
- release repository: https://github.com/ros2-gbp/rmf_task-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.0-1`

## rmf_task

```
* Added ``requester`` and ``request_time`` fields to ``rmf_task::Task::Booking`` (#81 <https://github.com/open-rmf/rmf_task/pull/81>)
* Contributors: Aaron Chong
```

## rmf_task_sequence

```
* Added ``rmf_task_sequence`` to workflows and fixed codestyle (#91 <https://github.com/open-rmf/rmf_task/pull/91>)
* Added ``requester`` and ``request_time`` fields to ``rmf_task::Task::Booking`` (#81 <https://github.com/open-rmf/rmf_task/pull/81>)
* Contributors: Aaron Chong
```
