### PR TITLE
rmf_task: 2.1.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5009,7 +5009,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
-      version: 2.1.4-1
+      version: 2.1.5-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_task.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_task` to `2.1.5-1`:

- upstream repository: https://github.com/open-rmf/rmf_task.git
- release repository: https://github.com/ros2-gbp/rmf_task-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.4-1`

## rmf_task

```
* Added ``requester`` and ``request_time`` fields to ``rmf_task::Task::Booking`` (#81 <https://github.com/open-rmf/rmf_task/pull/81>)
* Contributors: Aaron Chong
```

## rmf_task_sequence

```
* Added ``requester`` and ``request_time`` fields to ``rmf_task::Task::Booking`` (#81 <https://github.com/open-rmf/rmf_task/pull/81>)
* Contributors: Aaron Chong
```
