### PR TITLE
rmf_simulation: 2.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4991,7 +4991,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_simulation-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_simulation` to `2.0.2-1`:

- upstream repository: https://github.com/open-rmf/rmf_simulation.git
- release repository: https://github.com/ros2-gbp/rmf_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.1-1`

## rmf_building_sim_common

- No changes

## rmf_building_sim_gz_classic_plugins

- No changes

## rmf_building_sim_gz_plugins

```
* Use ``JointPositionReset`` for open loop door control (#105 <https://github.com/open-rmf/rmf_simulation/issues/105>)
* Contributors: Luca Della Vedova
```

## rmf_robot_sim_common

- No changes

## rmf_robot_sim_gz_classic_plugins

- No changes

## rmf_robot_sim_gz_plugins

- No changes
