### PR TITLE
rmf_simulation: 2.1.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4432,7 +4432,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_simulation-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_simulation` to `2.1.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_simulation.git
- release repository: https://github.com/ros2-gbp/rmf_simulation-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.0-1`

## rmf_building_sim_common

- No changes

## rmf_building_sim_gz_classic_plugins

- No changes

## rmf_building_sim_gz_plugins

```
* Use JointPositionReset for open loop door control (#106 <https://github.com/open-rmf/rmf_simulation/issues/106>)
* Contributors: Luca Della Vedova
```

## rmf_robot_sim_common

- No changes

## rmf_robot_sim_gz_classic_plugins

- No changes

## rmf_robot_sim_gz_plugins

- No changes
