### PR TITLE
tiago_robot: 4.0.11-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7200,7 +7200,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_robot-release.git
-      version: 4.0.7-1
+      version: 4.0.11-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_robot` to `4.0.11-1`:

- upstream repository: https://github.com/pal-robotics/tiago_robot
- release repository: https://github.com/pal-gbp/tiago_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.7-1`

## tiago_bringup

```
* run gripper_incrementer only when using pal-gripper
* Contributors: Noel Jimenez
```

## tiago_controller_configuration

```
* fix controllers launcher when there is no end_effector
* Contributors: Noel Jimenez
```

## tiago_description

```
* fix get_tiago_hw_suffix method to match yaml files
* move pal-hey5 ros2_control xacro to hey5_description
* Contributors: Noel Jimenez
```

## tiago_robot

- No changes
