### PR TITLE
tiago_navigation: 4.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7180,7 +7180,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_navigation-release.git
-      version: 4.0.4-1
+      version: 4.0.5-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_navigation` to `4.0.5-1`:

- upstream repository: https://github.com/pal-robotics/tiago_navigation.git
- release repository: https://github.com/pal-gbp/tiago_navigation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.4-1`

## tiago_2dnav

```
* Merge branch 'feat/laser-filters' into 'humble-devel'
  using laser filters in simulation
  See merge request robots/tiago_navigation!83
* clarifying remappings usage
* using pmb2_sim_nav_bringup and update deps
* using sim bringup
* start laser filters in simulation
* using laser filters in simulation
* Contributors: antoniobrandi
```

## tiago_laser_sensors

- No changes

## tiago_navigation

- No changes
