### PR TITLE
tiago_simulation: 4.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7218,7 +7218,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_simulation-release.git
-      version: 4.0.2-1
+      version: 4.0.3-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_simulation` to `4.0.3-1`:

- upstream repository: https://github.com/pal-robotics/tiago_simulation
- release repository: https://github.com/pal-gbp/tiago_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.2-1`

## tiago_gazebo

```
* Merge branch 'fix/set-is-robot' into 'humble-devel'
  Use a different navigation launcher for simulation
  See merge request robots/tiago_simulation!116
* use tiago_sim_navigation
* using is_robot argument in simulation
* Merge branch 'ros1_cleanup' into 'humble-devel'
  ROS 1 cleanup for humble-devel
  See merge request robots/tiago_simulation!117
* remove not ported grasping demo
* Remove Media, models and worlds folders
* Contributors: Noel Jimenez, Sai Kishor Kothakota, antoniobrandi, thomaspeyrucain
```

## tiago_simulation

- No changes
