### PR TITLE
Add cedri_ros_monitoring to noetic/distribution.yaml

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -792,6 +792,16 @@ repositories:
       url: https://github.com/alf767443/node_monitoring.git
       version: main
     status: developed
+  cedri_ros_monitoring:
+    doc:
+      type: git
+      url: https://github.com/alf767443/ros_monitoring.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/alf767443/ros_monitoring.git
+      version: main
+    status: developed
   class_loader:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -782,6 +782,16 @@ repositories:
       url: https://github.com/locusrobotics/catkin_virtualenv.git
       version: master
     status: maintained
+  cedri_node_monitoring:
+    doc:
+      type: git
+      url: https://github.com/alf767443/node_monitoring.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/alf767443/node_monitoring.git
+      version: main
+    status: developed
   class_loader:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

* noetic

# The source is here:

https://github.com/alf767443/ros_monitoring

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
