### PR TITLE
lms1xx: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2710,7 +2710,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/LMS1xx-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/LMS1xx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lms1xx` to `1.0.1-1`:

- upstream repository: https://github.com/clearpathrobotics/LMS1xx.git
- release repository: https://github.com/clearpath-gbp/LMS1xx-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-1`

## lms1xx

```
* Added statemachine to prevent driver from blocking executor.
* Contributors: Roni Kreinin
```
