### PR TITLE
ros2_canopen: 0.2.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4660,7 +4660,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_canopen-release.git
-      version: 0.2.6-1
+      version: 0.2.7-1
     source:
       type: git
       url: https://github.com/ros-industrial/ros2_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_canopen` to `0.2.7-1`:

- upstream repository: https://github.com/ros-industrial/ros2_canopen.git
- release repository: https://github.com/ros2-gbp/ros2_canopen-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.6-1`

## canopen

```
* Update ros2_control docs.
* Contributors: Christoph Hellmann Santos, Dr. Denis, Xi Huang
```

## canopen_402_driver

```
* Add missing license headers and activate ament_copyright
* Fix maintainer naming
* Contributors: Christoph Hellmann Santos
```

## canopen_base_driver

```
* Add missing license headers and activate ament_copyright
* Fix maintainer naming
* Update printed output in lely_driver_bridge.cpp
* Contributors: Christoph Hellmann Santos, yos627
```

## canopen_core

```
* Add missing license headers and activate ament_copyright
* Fix maintainer naming
* Contributors: Christoph Hellmann Santos
```

## canopen_fake_slaves

```
* Add missing license headers and activate ament_copyright
* Contributors: Christoph Hellmann Santos
```

## canopen_interfaces

- No changes

## canopen_master_driver

```
* Add missing license headers and activate ament_copyright
* Contributors: Christoph Hellmann Santos
```

## canopen_proxy_driver

```
* Add missing license headers and activate ament_copyright
* Fix maintainer naming
* Contributors: Christoph Hellmann Santos
```

## canopen_ros2_control

```
* Correct Proxy controller after changes and update tests.
* Contributors: Dr. Denis, Christoph Hellmann Santos
```

## canopen_ros2_controllers

```
* Correct Proxy controller after changes and update tests.
* Contributors: Dr. Denis, Christoph Hellmann Santos
```

## canopen_tests

```
* Add missing license headers and activate ament_copyright
* Contributors: Christoph Hellmann Santos
```

## canopen_utils

```
* Add missing license headers and activate ament_copyright
* Fix maintainer naming
* Contributors: Christoph Hellmann Santos
```

## lely_core_libraries

```
* Add missing license headers and activate ament_copyright
* Fix python versions
* Contributors: Christoph Hellmann Santos
```
