### PR TITLE
electronic-io: 1.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2352,7 +2352,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/electronic-io.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ctu-vras/electronic-io.git


### PR DESCRIPTION
Increasing version of package(s) in repository `electronic-io` to `1.0.2-1`:

- upstream repository: https://github.com/ctu-vras/electronic-io.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/electronic-io.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.1-1`

## electronic_io

- No changes

## electronic_io_msgs

```
* Fixed buildfarm tests.
* Contributors: Martin Pecka
```
