### PR TITLE
Remove bionic from the repo check configuration.

### DIFF
--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -71,7 +71,6 @@ supported_versions:
   - '8'
   - '9'
   ubuntu:
-  - bionic
   - focal
   - jammy
 


### PR DESCRIPTION
It is no longer supported as of April 2023, so we shouldn't suggest keys for it anymore.