### PR TITLE
naoqi_driver: 0.6.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6165,7 +6165,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_driver-release.git
-      version: 0.5.13-0
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_driver` to `0.6.0-1`:

- upstream repository: https://github.com/ros-naoqi/naoqi_driver.git
- release repository: https://github.com/ros-naoqi/naoqi_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.5.13-0`

## naoqi_driver

```
* Support for Pepper running NAOqi 2.9 #157
  * Audio is disabled for now
* Update README contents and presentation
* Contributors: Mouad Abrini, Théo Magoudi, Victor Paléologue, Maxime Busy
```
