### PR TITLE
add ros2_robotiq_gripper src entries for naming review

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5500,6 +5500,12 @@ repositories:
       url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system.git
       version: humble-devel
     status: developed
+  ros2_robotiq_gripper:
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/ros2_robotiq_gripper.git
+      version: main
+    status: maintained
   ros2_socketcan:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4876,6 +4876,12 @@ repositories:
       url: https://github.com/ros-controls/ros2_controllers.git
       version: master
     status: developed
+  ros2_robotiq_gripper:
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/ros2_robotiq_gripper.git
+      version: main
+    status: maintained
   ros2_socketcan:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4746,6 +4746,12 @@ repositories:
       url: https://github.com/SteveMacenski/ros2_ouster_drivers.git
       version: foxy-devel
     status: maintained
+  ros2_robotiq_gripper:
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/ros2_robotiq_gripper.git
+      version: main
+    status: maintained
   ros2_socketcan:
     doc:
       type: git


### PR DESCRIPTION
Please add this package to be indexed in the rosdistro for Humble, Iron and Rolling.

Repository:
https://github.com/PickNikRobotics/ros2_robotiq_gripper

Packages:

- robotiq_controllers
- robotiq_description
- robotiq_driver

In ROS 1 there was a ros-industrial/robotiq package here: https://github.com/ros-industrial/robotiq
However as of 2021-05-28 it is marked unmaintained. It has not been released since Kinetic.

This is new repository built on top of ROS 2 Control.

https://github.com/PickNikRobotics/ros2_robotiq_gripper/blob/main/LICENSE

Robotiq is currently not supporting this package.
PickNik Robotics will be maintaining it.
Kinova Robotics will depend on this.

This is related to #37856 as we're preparing to release ROS 2 support for Kinova

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
