### PR TITLE
Add msgpack11 and sick_scan to documentation index for distro noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10686,7 +10686,7 @@ repositories:
     source:
       type: git
       url: https://github.com/SICKAG/sick_scan_xd.git
-      version: master
+      version: feature/bloom_pretest
     status: developed
   sick_tim:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6076,6 +6076,16 @@ repositories:
       url: https://github.com/KIT-MRT/mrt_cmake_modules.git
       version: master
     status: developed
+  msgpack11:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/msgpack11.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/SICKAG/msgpack11.git
+      version: master
+    status: developed
   multi_object_tracking_lidar:
     doc:
       type: git
@@ -10667,17 +10677,15 @@ repositories:
     status: developed
   sick_scan:
     doc:
+      depends:
+      - libsick_ldmrs
+      - msgpack11
       type: git
-      url: https://github.com/SICKAG/sick_scan.git
+      url: https://github.com/SICKAG/sick_scan_xd.git
       version: master
-    release:
-      tags:
-        release: release/noetic/{package}/{version}
-      url: https://github.com/SICKAG/sick_scan-release.git
-      version: 1.10.1-1
     source:
       type: git
-      url: https://github.com/SICKAG/sick_scan.git
+      url: https://github.com/SICKAG/sick_scan_xd.git
       version: master
     status: developed
   sick_tim:


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

ROSDISTRO noetic

# The source is here:

https://github.com/SICKAG/msgpack11
https://github.com/SICKAG/sick_scan_xd

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
