### PR TITLE
add python3-pynmeagps-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7612,6 +7612,13 @@ python3-pynmea2:
     pip:
       packages: [pynmea2]
   ubuntu: [python3-nmea2]
+python3-pynmeagps-pip:
+  debian:
+    pip:
+      packages: [pynmeagps]
+  ubuntu:
+    pip:
+      packages: [pynmeagps]
 python3-pyosmium:
   debian: [python3-pyosmium]
   fedora: [python3-osmium]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

pynmeagps

## Package Upstream Source:

https://github.com/semuconsulting/pynmeagps

## Purpose of using this:

This package has easy to use function to generate nmea frame (compare to pynmea2)

## Links to Distribution Packages

- Debian: https://pypi.org/project/pynmeagps/
- Ubuntu: https://pypi.org/project/pynmeagps/
