### PR TITLE
fkie_potree_rviz_plugin: 2.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2791,7 +2791,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fkie-release/potree_rviz_plugin-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/fkie/potree_rviz_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fkie_potree_rviz_plugin` to `2.0.1-1`:

- upstream repository: https://github.com/fkie/potree_rviz_plugin.git
- release repository: https://github.com/fkie-release/potree_rviz_plugin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-1`

## fkie_potree_rviz_plugin

```
* Improve Potree folder selection
  Use a specialized path property Instead of a generic text property,
  so we can also have a file dialog to pick a folder.
* Explicitly reject unsupported tree encodings
* Contributors: Timo Röhling
```
