### PR TITLE
tiago_robot: 4.0.12-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7224,7 +7224,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_robot-release.git
-      version: 4.0.11-1
+      version: 4.0.12-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_robot` to `4.0.12-1`:

- upstream repository: https://github.com/pal-robotics/tiago_robot
- release repository: https://github.com/pal-gbp/tiago_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.11-1`

## tiago_bringup

```
* Regenerate config for no-arm option
* Fix config files generator
* Remove pal flags dependency
* update hey5 joystick config
* Contributors: Noel Jimenez
```

## tiago_controller_configuration

```
* Remove pal flags dependency
* Contributors: Noel Jimenez
```

## tiago_description

```
* Remove pal flags dependency
* Contributors: Noel Jimenez
```

## tiago_robot

- No changes
