### PR TITLE
libhri: 0.6.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4899,7 +4899,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros4hri/libhri-release.git
-      version: 0.6.1-1
+      version: 0.6.4-1
     source:
       type: git
       url: https://github.com/ros4hri/libhri.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libhri` to `0.6.4-1`:

- upstream repository: https://github.com/ros4hri/libhri.git
- release repository: https://github.com/ros4hri/libhri-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.1-1`

## hri

```
0.6.4 (2023-07-05)
------------------
* Fix Typo in voice.h
  re-apply patch from  juandpenan
  https://github.com/ros4hri/libhri/pull/3
  (patch removed by mistake)
* Contributors: juandpenan

0.6.3 (2023-07-05)
------------------
* change ROI message type to hri_msgs/NormalizedRegionOfInterest2D
* fix tests use of EXPECT_CALL and timeouts
* Contributors: Luka Juricic

0.6.2 (2023-04-21)
------------------
* anonymous field as optional
* Contributors: lorenzoferrini


```
