### PR TITLE
pyhri: 0.4.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7942,7 +7942,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros4hri/pyhri-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/ros4hri/pyhri.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyhri` to `0.4.1-1`:

- upstream repository: https://github.com/ros4hri/pyhri.git
- release repository: https://github.com/ros4hri/pyhri-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.0-1`

## pyhri

```
* fix voice callbacks test
* change RoI message type to hri_msgs/NormalizedRegionOfInterest2D
* Contributors: Luka Juricic
```
