### PR TITLE
clearpath_desktop: 0.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -826,6 +826,25 @@ repositories:
       url: https://github.com/clearpathrobotics/clearpath_config.git
       version: main
     status: developed
+  clearpath_desktop:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_desktop.git
+      version: main
+    release:
+      packages:
+      - clearpath_config_live
+      - clearpath_desktop
+      - clearpath_viz
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/clearpath_desktop-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_desktop.git
+      version: main
+    status: developed
   clearpath_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_desktop` to `0.0.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_desktop.git
- release repository: https://github.com/clearpath-gbp/clearpath_desktop-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## clearpath_config_live

```
* Updated description generator naming
  Updated robot.rviz
* Set version to 0.0.0
* Removed pycache
* Look for /etc/clearpath/robot.yaml by default
* Added license
* Update URDF, tf_static does not
* Added clearpath live
* Contributors: Luis Camero, Roni Kreinin
```

## clearpath_desktop

```
* Initial commit.
* Contributors: Tony Baltovski
```

## clearpath_viz

```
* Removed global namespace for nav2.rviz
* Added view_navigation launch file
* Updated description generator naming
  Updated robot.rviz
* Added clearpath live
* [clearpath_viz] Renamed robot_model to platform_model.
* [clearpath_viz] Removed all forward slashes on topics.
* [clearpath_viz] Added namespace and sim_time support.  Removed per platform rviz configs.
* Initial commit.
* Contributors: Luis Camero, Roni Kreinin, Tony Baltovski
```
