### PR TITLE
clarify that naming request PR must be made manually

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 <!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
 Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE
 
-If you're making a new release with bloom please use bloom to create the pull request automatically.
+If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
 If you've already run the release bloom has a `--pull-request-only` option you can use.-->
 
 <!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->


### PR DESCRIPTION
The PR current template is somewhat confusing because it says that bloom will make the PR automatically, which is not correct for the naming review PR.
See [this issue](https://github.com/ros-infrastructure/bloom/issues/706) filed against bloom.