### PR TITLE
clearpath_simulator: 0.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -863,6 +863,25 @@ repositories:
       url: https://github.com/clearpathrobotics/clearpath_msgs.git
       version: main
     status: developed
+  clearpath_simulator:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_simulator.git
+      version: main
+    release:
+      packages:
+      - clearpath_generator_gz
+      - clearpath_gz
+      - clearpath_simulator
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/clearpath_simulator-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_simulator.git
+      version: main
+    status: developed
   color_names:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_simulator` to `0.0.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_simulator.git
- release repository: https://github.com/clearpath-gbp/clearpath_simulator-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## clearpath_generator_gz

```
* Changed colour to color
* Added dependencies.repos
  Updated topic names to match API
* Support for empty namespace
  Generate tf and cmd_vel bridges
* Namespacing support
* Renamed clearpath_simulator to clearpath_gz
  clearpath_simulator is now a metapackage
  Added clearpath_generator_gz
* Contributors: Roni Kreinin
```

## clearpath_gz

```
* Renamed launch file to simulation.launch.py
* Support for empty namespace
  Generate tf and cmd_vel bridges
* Namespacing support
* Renamed clearpath_simulator to clearpath_gz
  clearpath_simulator is now a metapackage
  Added clearpath_generator_gz
* Contributors: Roni Kreinin
```

## clearpath_simulator

```
* Renamed clearpath_simulator to clearpath_gz
  clearpath_simulator is now a metapackage
  Added clearpath_generator_gz
* Contributors: Roni Kreinin
```
