### PR TITLE
foxglove_bridge: 0.6.4-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1396,7 +1396,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 0.6.3-1
+      version: 0.6.4-1
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_bridge` to `0.6.4-1`:

- upstream repository: https://github.com/foxglove/ros-foxglove-bridge.git
- release repository: https://github.com/ros2-gbp/foxglove_bridge-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.3-1`

## foxglove_bridge

```
* Assume publisher qos depth of 1 if the middleware reports the qos history as unknown (#239 <https://github.com/foxglove/ros-foxglove-bridge/issues/239>)
* devcontainer: Use --include-eol-distros for rosdep update (#237 <https://github.com/foxglove/ros-foxglove-bridge/issues/237>)
* Contributors: Hans-Joachim Krauch
```
