### PR TITLE
twist_mux_msgs: 3.0.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6698,6 +6698,21 @@ repositories:
       url: https://github.com/ros-teleop/twist_mux.git
       version: foxy-devel
     status: maintained
+  twist_mux_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-teleop/twist_mux_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/twist_mux_msgs-release.git
+      version: 3.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-teleop/twist_mux_msgs.git
+      version: master
+    status: maintained
   twist_stamper:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `twist_mux_msgs` to `3.0.1-1`:

- upstream repository: https://github.com/ros-teleop/twist_mux_msgs.git
- release repository: https://github.com/ros2-gbp/twist_mux_msgs-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## twist_mux_msgs

```
* Updates for releasing (#3 <https://github.com/ros-teleop/twist_mux_msgs/issues/3>)
  * Add LICENSE file and update license to apache v2
  * Add contributing file
* Contributors: Bence Magyar
```
