### PR TITLE
clearpath_config: 0.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -820,7 +820,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 0.0.2-2
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `0.0.3-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.2-2`

## clearpath_config

```
* Fixed parsing issues
* Added python3-yaml to dependencies
* Removed old parser
* Removed unused code
* Added updates to change indexing based on serial number
* Added sensors to property system
* Added __init__ to all subfolders
* Added mounts to main config
* Moved mount types to separate folder
* Added read and write functions to ClearpathConfig
* Added accessories to property method
* Updated all configs to use properties instead of setters
* Updated base config to use properties to update config
* Updated clearpath config to property setters
* Removed old common and updated serial number type
* Updated system to use global serial number
* Updated platform to property setters
* Changed System config to property setters
* Contributors: Luis Camero
```
