### PR TITLE
septentrio_gnss_driver: 1.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10624,7 +10624,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/septentrio-users/septentrio_gnss_driver-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `septentrio_gnss_driver` to `1.3.1-1`:

- upstream repository: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
- release repository: https://github.com/septentrio-users/septentrio_gnss_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.0-1`

## septentrio_gnss_driver

```
* New Features
  
  Recovery from connection interruption
  
  Add option to bypass configuration of Rx
  
  OSNMA
  
  Latency compensation for ROS timestamps
  
  Output of SBF block VelCovCartesian
  
  Support for UDP and TCP via IP server
  
  New VSM handling allows for unknown variances (INS firmware >= 1.4.1)
  
  Add heading angle to GPSFix msg (by diverting dip field, cf. readme)
* Improvements
  
  Rework IO core and message handling
  * Unified stream processing
  * Internal data queue
  * Prevent message loss in file reading
  
  Add some explanatory warnings for parameter mismatches
  
  Add units to message definitions
* Fixes
  
  navsatfix for INS
  
  Empty headers
  
  Single antenna receiver setup
* Preliminary Features
  
  Output of localization and tf in ECEF frame, testing and feedback welcome
```
