### PR TITLE
Add robotraconteur package source to iron/distribution.yaml

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4800,6 +4800,12 @@ repositories:
       url: https://github.com/ros/robot_state_publisher.git
       version: iron
     status: maintained
+  robotraconteur:
+    source:
+      type: git
+      url: https://github.com/robotraconteur/robotraconteur.git
+      version: ros2-iron
+    status: maintained
   ros1_bridge:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

robotraconteur

## Package Upstream Source:

https://github.com/robotraconteur/robotraconteur/tree/ros2-humble

## Purpose of using this:

Robot Raconteur is a communication framework with an ecosystem containing a number of standardized industrial robot drivers, and a universal teach pendant under development.

https://github.com/robotraconteur/robotraconteur-directory
https://github.com/pyri-project/pyri-core/blob/master/README.md

Having the core `robotraconteur` package with C++ and Python bindings in rosdep will make integration with ROS easier.

This package was previously accepted to ROS Noetic in #31844 and ROS Humble in #33421

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
