### PR TITLE
Add ros2_kortex src to Humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5511,6 +5511,10 @@ repositories:
       version: humble
     status: developed
   ros2_kortex:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/ros2_kortex.git
+      version: main
     source:
       type: git
       url: https://github.com/PickNikRobotics/ros2_kortex.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5510,6 +5510,12 @@ repositories:
       url: https://github.com/ros-controls/ros2_controllers.git
       version: humble
     status: developed
+  ros2_kortex:
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/ros2_kortex.git
+      version: main
+    status: developed
   ros2_ouster_drivers:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

This is the ROS 2 version of ros_kortex which was added in #37856

packages include:
- kortex_api
- kortex_bringup
- kortex_description
- kortex_driver
- kortex_moveit_config

The only name change between ros_kortex and ros2_kortex is:
- kortex_move_it_config -> kortex_moveit_config

# The source is here:

The source code is now open here:
https://github.com/PickNikRobotics/ros2_kortex

The repository will eventually be transferred to the KinovaRobotics GitHub organization. But we will do this after releasing and supporting the initial release.
- https://github.com/ros2-gbp/ros2-gbp-github-org/issues/291
- https://github.com/ros2-gbp/ros2-gbp-github-org/pull/294

# Checks
 - [x] All packages have a declared license in the package.xml https://github.com/PickNikRobotics/ros2_kortex/pull/146
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
