### PR TITLE
ros2_control: 3.16.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4841,7 +4841,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.15.0-1
+      version: 3.16.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.16.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.15.0-1`

## controller_interface

- No changes

## controller_manager

```
* added controller manager runner to have update cycles (#1075 <https://github.com/ros-controls/ros2_control/issues/1075>)
* [CM] Make error message after trying to active controller more informative. (#1066 <https://github.com/ros-controls/ros2_control/issues/1066>)
* Fix equal and higher controller update rate (#1070 <https://github.com/ros-controls/ros2_control/issues/1070>)
* Create doc file for chained controllers (#985 <https://github.com/ros-controls/ros2_control/issues/985>)
* Contributors: Dr. Denis, Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
