### PR TITLE
Add ros2_kortex src to Rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4727,6 +4727,12 @@ repositories:
       url: https://github.com/ros-controls/ros2_controllers.git
       version: master
     status: developed
+  ros2_kortex:
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/ros2_kortex.git
+      version: main
+    status: developed
   ros2_ouster_drivers:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4728,6 +4728,10 @@ repositories:
       version: master
     status: developed
   ros2_kortex:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/ros2_kortex.git
+      version: main
     source:
       type: git
       url: https://github.com/PickNikRobotics/ros2_kortex.git


### PR DESCRIPTION
- Added to Humble in: https://github.com/ros/rosdistro/pull/37893
- Added to Iron in: https://github.com/ros/rosdistro/pull/37897
- Added to Noetic (as ros_kortex) in #37856

packages include:
- kortex_api
- kortex_bringup
- kortex_description
- kortex_driver
- kortex_moveit_config

The only name change between ros_kortex and ros2_kortex is:
- kortex_move_it_config -> kortex_moveit_config

The source code is now open here:
https://github.com/PickNikRobotics/ros2_kortex

The repository will eventually be transferred to the KinovaRobotics GitHub organization. But we will do this after releasing and supporting the initial release.
- https://github.com/ros2-gbp/ros2-gbp-github-org/issues/291
- https://github.com/ros2-gbp/ros2-gbp-github-org/pull/294

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
