### PR TITLE
rosmon: 2.5.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9542,7 +9542,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/xqms/rosmon-release.git
-      version: 2.4.0-1
+      version: 2.5.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosmon` to `2.5.0-2`:

- upstream repository: https://github.com/xqms/rosmon.git
- release repository: https://github.com/xqms/rosmon-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.4.0-1`

## rosmon

```
* rosmon: fix installation of wrapper script in devel spaces
* Contributors: Max Schwarz
```

## rosmon_core

```
* Fix compilation with clang (Issue #176)
* Systemd-journal & syslog support (PR #172, issue #172)
  Ability to log to the system journal instead of custom log files.
  For syslog/journald logging you now have to specify --log=syslog. This
  keeps us from breaking any old installations where users depend on
  the logs appearing in /tmp.
  Users who want to switch permanently to syslog/journald can do so through
  an environment variable.
* Auto-increment-spawn-delay feature (PR #175)
* Add missing include to #include <boost/mpl/vector.hpp> (PR #174)
* Hide stdout log events if output=screen and UI is disabled (PR #171)
* Support importing args from included files (PR #169)
* rosparam: strip whitespace inside deg() and rad() expressions (Issue #163, PR #164)
* Contributors: Dan Ambrosio, Max Schwarz, Ramon Wijnands, Robin Vanhove, Tobias Fischer
```

## rosmon_msgs

- No changes

## rqt_rosmon

- No changes
