### PR TITLE
rosfmt: 8.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9466,7 +9466,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/xqms/rosfmt-release.git
-      version: 7.0.0-1
+      version: 8.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosfmt` to `8.0.0-1`:

- upstream repository: https://github.com/xqms/rosfmt.git
- release repository: https://github.com/xqms/rosfmt-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `7.0.0-1`

## rosfmt

```
* Make the tests part conditional with CATKIN_ENABLE_TESTING check (PR #10)
* Allow compile time checking of string (missing placeholders, etc) (PR #7)
* Bump fmt to version 9.1.0
* Add CI workflow (PR #8)
* Use default C++ version instead of 11 (PR #6)
* Fix CMake example in README (PR #5)
* Contributors: Lucas Walter, Max Schwarz, Morten Fyhn Amundsen, Romain Reignier, mla
```
