### PR TITLE
rosbag_fancy: 1.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9270,6 +9270,25 @@ repositories:
       url: https://github.com/gt-rail-release/rosauth-release.git
       version: 1.0.1-1
     status: maintained
+  rosbag_fancy:
+    doc:
+      type: git
+      url: https://github.com/xqms/rosbag_fancy.git
+      version: master
+    release:
+      packages:
+      - rosbag_fancy
+      - rosbag_fancy_msgs
+      - rqt_rosbag_fancy
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/xqms/rosbag_fancy-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/xqms/rosbag_fancy.git
+      version: master
+    status: developed
   rosbag_migration_rule:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag_fancy` to `1.0.0-1`:

- upstream repository: https://github.com/xqms/rosbag_fancy
- release repository: https://github.com/xqms/rosbag_fancy-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## rosbag_fancy

```
* play: decompression support (PR #18)
* BagView & TF2 scanner (PR #17)
* CI & unit tests
* play: support for multiple bag files
* play: ui: show current date/time
* play: support for --clock
* ui: remove sub column
* play: faster startup, don't crash if select() is interrupted
* play command
* record: wait for ros::Time to become valid
  This fixes recording with use_sim_time=true (Issue #16)
* tui: fix count display
* tui: display byte & message counts correctly
* GUI/TUI: display messages in bag, not total messages
* rosbag_fancy: properly initialize compression
* split into separate packages (main, _msgs, and _gui)
* Contributors: Max Schwarz
```

## rosbag_fancy_msgs

```
* split into separate packages (main, _msgs, and _gui)
* Contributors: Max Schwarz
```

## rqt_rosbag_fancy

```
* GUI/TUI: display messages in bag, not total messages
* Add rqt GUI (PR #14)
* rqt_rosbag_fancy: rosfmt/full.h is not available on Melodic
* rename rosbag_fancy_gui to rqt_rosbag_fancy
* Contributors: Max Schwarz
```
