### PR TITLE
rosbag_fancy: 1.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9283,7 +9283,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/xqms/rosbag_fancy-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/xqms/rosbag_fancy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag_fancy` to `1.0.1-1`:

- upstream repository: https://github.com/xqms/rosbag_fancy
- release repository: https://github.com/xqms/rosbag_fancy-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-1`

## rosbag_fancy

```
* add missing std_srvs dependency
* Contributors: Max Schwarz
```

## rosbag_fancy_msgs

- No changes

## rqt_rosbag_fancy

```
* add missing std_srvs dependency
* Contributors: Max Schwarz
```
