### PR TITLE
Add python3-insightface-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6373,6 +6373,13 @@ python3-inputimeout-pip:
   ubuntu:
     pip:
       packages: [inputimeout]
+python3-insightface-pip:
+  debian:
+      pip:
+        packages: [insightface]
+  ubuntu:
+    pip:
+      packages: [insightface]
 python3-interpreter:
   arch: [python]
   debian: [python3-minimal]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

InsightFace

## Package Upstream Source:

[insightface](https://github.com/deepinsight/insightface)

## Purpose of using this:

InsightFace is an integrated Python library for 2D&3D face analysis. InsightFace efficiently implements a rich variety of state of the art algorithms of face recognition, face detection and face alignment, which optimized for both training and deployment. Research institute and industrial organization can get benefits from InsightFace library.

## Links to Distribution Packages

- Debian: (https://pypi.org/project/insightface/)
- Ubuntu: (https://pypi.org/project/insightface/)