### PR TITLE
webots_ros2: 2023.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8352,7 +8352,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/webots_ros2-release.git
-      version: 2023.1.0-1
+      version: 2023.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `webots_ros2` to `2023.1.1-1`:

- upstream repository: https://github.com/cyberbotics/webots_ros2.git
- release repository: https://github.com/ros2-gbp/webots_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2023.1.0-1`

## webots_ros2

```
* Added deprecation message when declaring driver node in launch file.
* Fixed RangeFinder activation to also check for point cloud subscriptions.
* Added component remapping parameter to WebotsController to rename PROTO components.
* Added animation_{start,stop}_recording services to Ros2Supervisor node.
* Added /Ros2Supervisor namespace to Ros2Supervisor node.
* Fixed Python plugin termination on SIGINT call or simulation ends.
```

## webots_ros2_driver

```
* Fixed RangeFinder activation to also check for point cloud subscriptions.
* Added component remapping parameter to rename PROTO components.
* Added deprecation message when declaring driver node in launch file.
* Added animation_{start,stop}_recording services to Ros2Supervisor node.
* Added /Ros2Supervisor namespace to Ros2Supervisor node.
* Fixed Python plugin termination on SIGINT call or simulation ends.
```
