### PR TITLE
tiago_robot: 4.0.13-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7298,7 +7298,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_robot-release.git
-      version: 4.0.12-1
+      version: 4.0.13-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_robot` to `4.0.13-1`:

- upstream repository: https://github.com/pal-robotics/tiago_robot
- release repository: https://github.com/pal-gbp/tiago_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.12-1`

## tiago_bringup

```
* Remove schunk wsg option
* Uncomment twist_mux_msgs dependency
* Contributors: Noel Jimenez
```

## tiago_controller_configuration

```
* Remove schunk wsg option
* Launch controllers depending on robot arguments
* Contributors: Noel Jimenez
```

## tiago_description

```
* Remove schunk wsg option
* Remove left arm option
* Contributors: Noel Jimenez
```

## tiago_robot

- No changes
