### PR TITLE
Add action to label inactive PRs as stale

### DIFF
--- a/.github/workflows/stale_labeler.yaml
+++ b/.github/workflows/stale_labeler.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/stale@v8
         with:
           stale-pr-label: 'stale'
-          stale-pr-message: "This PR is being marked as stale because there hasn't been activity in 14 days. It may be closed by a rosdistro maintainer. If this label isn't appropriate, you can remove the label and add the 'dont-mark-as-stale' label. You can find our community contributing guidelines here: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md."
+          stale-pr-message: "This PR is being marked as stale because there hasn't been activity in 14 days. It may be closed by a rosdistro maintainer. If this label isn't appropriate, you can remove the label and add the \"don't mark as stale\" label. You can find our community contributing guidelines here: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md."
           days-before-pr-stale: 14
           days-before-pr-close: -1     # dont close PRs automatically
           days-before-issue-stale: -1  # dont mark issues as stale

--- a/.github/workflows/stale_labeler.yaml
+++ b/.github/workflows/stale_labeler.yaml
@@ -11,9 +11,9 @@ jobs:
       - uses: actions/stale@v8  # https://github.com/marketplace/actions/close-stale-issues
         with:
           stale-pr-label: 'stale'
-          stale-pr-message: "This PR is being marked as stale because there hasn't been activity in 14 days. It may be closed by a rosdistro maintainer. If this label isn't appropriate, you can remove the label and add the \"don't mark as stale\" label. You can find our community contributing guidelines here: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md."
+          stale-pr-message: "This PR is being marked as stale because there hasn't been activity in 14 days. It may be closed by a rosdistro maintainer. If this label isn't appropriate, you can ask a maintainer to remove the label and add the 'persistent' label. You can find our community contributing guidelines here: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md."
           days-before-pr-stale: 14
-          days-before-pr-close: -1     # dont close PRs automatically
-          days-before-issue-stale: -1  # dont mark issues as stale
-          days-before-issue-close: -1  # dont close issues automatically
-          exempt-pr-labels: "don't mark as stale"
+          days-before-pr-close: -1     # don't close PRs automatically
+          days-before-issue-stale: -1  # don't label issues as stale
+          days-before-issue-close: -1  # don't close issues automatically
+          exempt-pr-labels: 'persistent'

--- a/.github/workflows/stale_labeler.yaml
+++ b/.github/workflows/stale_labeler.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/stale@v8  # https://github.com/marketplace/actions/close-stale-issues
         with:
           stale-pr-label: 'stale'
-          stale-pr-message: "This PR is being marked as stale because there hasn't been activity in 14 days. It may be closed by a rosdistro maintainer. If this label isn't appropriate, you can ask a maintainer to remove the label and add the 'persistent' label. You can find our community contributing guidelines here: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md."
+          stale-pr-message: "This PR hasn't been activity in 14 days. If you are still are interested in getting it merged please provide an update. Otherwise it will likely be closed by a rosdistro maintainer following our [contributing policy](https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md). It's been labeled "stale" for visibility to the maintainers. If this label isn't appropriate, you can ask a maintainer to remove the label and add the 'persistent' label.
           days-before-pr-stale: 14
           days-before-pr-close: -1     # don't close PRs automatically
           days-before-issue-stale: -1  # don't label issues as stale

--- a/.github/workflows/stale_labeler.yaml
+++ b/.github/workflows/stale_labeler.yaml
@@ -1,0 +1,19 @@
+name: 'Label inactive PRs as stale'
+
+on:
+  schedule:
+    - cron: '0 11 * * *'  # runs at 11am UTC every day => early morning in US
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-pr-label: 'stale'
+          stale-pr-message: "This PR is being marked as stale because there hasn't been activity in 14 days. It may be closed by a rosdistro maintainer. If this label isn't appropriate, you can remove the label and add the 'dont-mark-as-stale' label. You can find our community contributing guidelines here: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md."
+          days-before-pr-stale: 14
+          days-before-pr-close: -1     # dont close PRs automatically
+          days-before-issue-stale: -1  # dont mark issues as stale
+          days-before-issue-close: -1  # dont close issues automatically
+          exempt-pr-labels: "don't mark as stale"

--- a/.github/workflows/stale_labeler.yaml
+++ b/.github/workflows/stale_labeler.yaml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@v8  # https://github.com/marketplace/actions/close-stale-issues
         with:
           stale-pr-label: 'stale'
           stale-pr-message: "This PR is being marked as stale because there hasn't been activity in 14 days. It may be closed by a rosdistro maintainer. If this label isn't appropriate, you can remove the label and add the \"don't mark as stale\" label. You can find our community contributing guidelines here: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md."


### PR DESCRIPTION
I think this should work as it is. This PR does the following:

- Runs a bot everyday in the early morning, US time, to label PRs that have been inactive for 14 days as stale
- When a PR is stale the PR gets a "stale" label with a comment
- Doesn't label issues as "stale"
- Doesn't close issues or PRs that have the "stale" label
- Ignores PRs with the label "don't mark as stale"

Feel free to help me workshop the comment that users will see when their PR is stale. 

I also created the "stale" and "don't mark as stale" labels.