### PR TITLE
pybind11_vendor: 3.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3686,7 +3686,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pybind11_vendor-release.git
-      version: 3.1.0-2
+      version: 3.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pybind11_vendor` to `3.1.1-1`:

- upstream repository: https://github.com/ros2/pybind11_vendor.git
- release repository: https://github.com/ros2-gbp/pybind11_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.1.0-2`

## pybind11_vendor

```
* Switch to ament_cmake_vendor_package (#24 <https://github.com/ros2/pybind11_vendor/issues/24>)
* Contributors: Scott K Logan
```
