### PR TITLE
yaml_cpp_vendor: 8.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7164,7 +7164,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
-      version: 8.2.0-1
+      version: 8.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `yaml_cpp_vendor` to `8.3.0-1`:

- upstream repository: https://github.com/ros2/yaml_cpp_vendor.git
- release repository: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `8.2.0-1`

## yaml_cpp_vendor

```
* Switch to ament_cmake_vendor_package (#43 <https://github.com/ros2/yaml_cpp_vendor/issues/43>)
* Revamp the extras file to find the correct version. (#42 <https://github.com/ros2/yaml_cpp_vendor/issues/42>)
* Contributors: Chris Lalancette, Scott K Logan
```
