### PR TITLE
libyaml_vendor: 1.6.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2355,7 +2355,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libyaml_vendor-release.git
-      version: 1.6.0-1
+      version: 1.6.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libyaml_vendor` to `1.6.1-1`:

- upstream repository: https://github.com/ros2/libyaml_vendor.git
- release repository: https://github.com/ros2-gbp/libyaml_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.6.0-1`

## libyaml_vendor

```
* Set to C++17. (#59 <https://github.com/ros2/libyaml_vendor/issues/59>)
* Switch to ament_cmake_vendor_package (#58 <https://github.com/ros2/libyaml_vendor/issues/58>)
* Contributors: Chris Lalancette, Scott K Logan
```
