### PR TITLE
osrf_pycommon: 2.1.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3269,7 +3269,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/osrf_pycommon-release.git
-      version: 2.1.2-2
+      version: 2.1.3-1
     source:
       type: git
       url: https://github.com/osrf/osrf_pycommon.git


### PR DESCRIPTION
Increasing version of package(s) in repository `osrf_pycommon` to `2.1.3-1`:

- upstream repository: https://github.com/osrf/osrf_pycommon.git
- release repository: https://github.com/ros2-gbp/osrf_pycommon-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.2-2`

## osrf_pycommon

```
* Add bookworm as a python3 target (#91 <https://github.com/osrf/osrf_pycommon/issues/91>)
* Suppress warning for specifically handled behavior (#87 <https://github.com/osrf/osrf_pycommon/issues/87>)
* Update supported platforms (#93 <https://github.com/osrf/osrf_pycommon/issues/93>)
* Add GitHub Actions CI workflow (#88 <https://github.com/osrf/osrf_pycommon/issues/88>)
* Contributors: Scott K Logan, Tully Foote
```
