### PR TITLE
launch: 2.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2246,7 +2246,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 2.2.0-1
+      version: 2.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `2.2.1-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.0-1`

## launch

```
* Improve launch file parsing error messages (#626 <https://github.com/ros2/launch/issues/626>)
* Contributors: Timon Engelke
```

## launch_pytest

- No changes

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* Improve launch file parsing error messages (#626 <https://github.com/ros2/launch/issues/626>)
* Contributors: Timon Engelke
```

## launch_yaml

```
* Improve launch file parsing error messages (#626 <https://github.com/ros2/launch/issues/626>)
* Contributors: Timon Engelke
```
