### PR TITLE
rmw_connextdds: 0.16.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4482,7 +4482,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 0.15.1-1
+      version: 0.16.0-1
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `0.16.0-1`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.15.1-1`

## rmw_connextdds

- No changes

## rmw_connextdds_common

```
* Add support for listener callbacks (#76 <https://github.com/ros2/rmw_connextdds/issues/76>)
* Contributors: Andrea Sorbini
```

## rti_connext_dds_cmake_module

- No changes
