### PR TITLE
rcl: 7.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3927,7 +3927,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 6.3.0-1
+      version: 7.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `7.0.0-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `6.3.0-1`

## rcl

```
* Add ~/get_type_description service (rep2011) (#1052 <https://github.com/ros2/rcl/issues/1052>)
* Modifies timers API to select autostart state (#1004 <https://github.com/ros2/rcl/issues/1004>)
* test publisher/subscription with the c/cpp typesupport for test_msgs::msg::array (#1074 <https://github.com/ros2/rcl/issues/1074>)
* validation result should be used to print the error message. (#1077 <https://github.com/ros2/rcl/issues/1077>)
* Contributors: Chen Lihui, Eloy Briceno, Hans-Joachim Krauch, Tomoya Fujita
```

## rcl_action

```
* Add ~/get_type_description service (rep2011) (#1052 <https://github.com/ros2/rcl/issues/1052>)
* Modifies timers API to select autostart state (#1004 <https://github.com/ros2/rcl/issues/1004>)
* Contributors: Eloy Briceno, Hans-Joachim Krauch
```

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

- No changes
