### PR TITLE
rclpy: 5.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4043,7 +4043,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 4.2.2-1
+      version: 5.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `5.0.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.2.2-1`

## rclpy

```
* get_type_description service (#1139 <https://github.com/ros2/rclpy/issues/1139>)
* Add in the ability to start timers paused. (#1138 <https://github.com/ros2/rclpy/issues/1138>)
* Modifies ros_timer_init for ros_timer_init2 (#999 <https://github.com/ros2/rclpy/issues/999>)
* Fix/param namespace association 894 (#1132 <https://github.com/ros2/rclpy/issues/1132>)
* Include type hash in topic endpoint info (#1104 <https://github.com/ros2/rclpy/issues/1104>)
* Contributors: Chris Lalancette, Eloy Briceno, Emerson Knapp, Hans-Joachim Krauch, M. Hofstätter
```
