### PR TITLE
rclcpp: 22.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4027,7 +4027,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 21.3.0-1
+      version: 22.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `22.0.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `21.3.0-1`

## rclcpp

```
* Implement get_node_type_descriptions_interface for lifecyclenode and add smoke test for it (#2237 <https://github.com/ros2/rclcpp/issues/2237>)
* Add new node interface TypeDescriptionsInterface to provide GetTypeDescription service (#2224 <https://github.com/ros2/rclcpp/issues/2224>)
* Move always_false_v to detail namespace (#2232 <https://github.com/ros2/rclcpp/issues/2232>)
* Revamp the test_subscription.cpp tests. (#2227 <https://github.com/ros2/rclcpp/issues/2227>)
* warning: comparison of integer expressions of different signedness (#2219 <https://github.com/ros2/rclcpp/issues/2219>)
* Modifies timers API to select autostart state (#2005 <https://github.com/ros2/rclcpp/issues/2005>)
* Enable callback group tests for connextdds (#2182 <https://github.com/ros2/rclcpp/issues/2182>)
* Contributors: Chris Lalancette, Christopher Wecht, Eloy Briceno, Emerson Knapp, Nathan Wiebe Neufeldt, Tomoya Fujita
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* Implement get_node_type_descriptions_interface for lifecyclenode and add smoke test for it (#2237 <https://github.com/ros2/rclcpp/issues/2237>)
* Switch lifecycle to use the RCLCPP macros. (#2233 <https://github.com/ros2/rclcpp/issues/2233>)
* Add new node interface TypeDescriptionsInterface to provide GetTypeDescription service (#2224 <https://github.com/ros2/rclcpp/issues/2224>)
* Contributors: Chris Lalancette, Emerson Knapp
```
