### PR TITLE
launch_ros: 0.26.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2281,7 +2281,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.25.0-1
+      version: 0.26.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.26.0-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.25.0-1`

## launch_ros

```
* cache lookup of importlib metadata in Node action (#365 <https://github.com/ros2/launch_ros/issues/365>)
* Get rid of unnecessary checks in composable_node_container. (#364 <https://github.com/ros2/launch_ros/issues/364>)
* Contributors: Chris Lalancette, William Woodall
```

## launch_testing_ros

```
* WaitForTopics: get content of messages for each topic (#353 <https://github.com/ros2/launch_ros/issues/353>)
* Contributors: Giorgio Pintaudi
```

## ros2launch

- No changes
