### PR TITLE
geometry2: 0.32.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1577,7 +1577,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.32.1-1
+      version: 0.32.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.32.2-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.32.1-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Enable StaticTransformBroadcaster in Intra-process enabled components (#607 <https://github.com/ros2/geometry2/issues/607>)
* Contributors: Patrick Roncagliolo
```

## tf2_ros_py

```
* Add time jump callback (#608 <https://github.com/ros2/geometry2/issues/608>)
* Contributors: Erich L Foster
```

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
