### PR TITLE
ros2cli: 0.28.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4844,7 +4844,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.27.0-1
+      version: 0.28.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.28.0-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.27.0-1`

## ros2action

- No changes

## ros2cli

```
* Fix tests with get_type_description service and param present (#838 <https://github.com/ros2/ros2cli/issues/838>)
* Add marshalling functions for rclpy.type_hash.TypeHash (rep2011) (#816 <https://github.com/ros2/ros2cli/issues/816>)
* Contributors: Emerson Knapp, Hans-Joachim Krauch
```

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

- No changes

## ros2interface

- No changes

## ros2lifecycle

- No changes

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

- No changes

## ros2param

```
* Fix tests with get_type_description service and param present (#838 <https://github.com/ros2/ros2cli/issues/838>)
* Update ros2 param dump dosctring. (#837 <https://github.com/ros2/ros2cli/issues/837>)
* Contributors: Emerson Knapp, Murilo M Marinho
```

## ros2pkg

- No changes

## ros2run

- No changes

## ros2service

```
* Fix tests with get_type_description service and param present (#838 <https://github.com/ros2/ros2cli/issues/838>)
* Contributors: Emerson Knapp
```

## ros2topic

```
* Add marshalling functions for rclpy.type_hash.TypeHash (rep2011) (#816 <https://github.com/ros2/ros2cli/issues/816>)
* Contributors: Hans-Joachim Krauch
```
