### PR TITLE
rviz: 12.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5798,7 +5798,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 12.6.1-1
+      version: 12.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `12.7.0-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `12.6.1-1`

## rviz2

- No changes

## rviz_assimp_vendor

```
* Update to assimp 5.2.2 (#968 <https://github.com/ros2/rviz/issues/968>)
* Fix the vendoring flags for clang compilation. (#1003 <https://github.com/ros2/rviz/issues/1003>)
* Switch to ament_cmake_vendor_package (#995 <https://github.com/ros2/rviz/issues/995>)
* Contributors: Chris Lalancette, Scott K Logan
```

## rviz_common

```
* use static QCoreApplication::processEvents() function without a QApplication instance (#924 <https://github.com/ros2/rviz/issues/924>)
* Re-implemented setName for tools (#989 <https://github.com/ros2/rviz/issues/989>)
* Contributors: Felix Exner (fexner), Yannis Gerlach
```

## rviz_default_plugins

```
* Added Effort plugin (#990 <https://github.com/ros2/rviz/issues/990>)
* Improve the compilation time of rviz_default_plugins (#1007 <https://github.com/ros2/rviz/issues/1007>)
* Switch to ament_cmake_vendor_package (#995 <https://github.com/ros2/rviz/issues/995>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Scott K Logan
```

## rviz_ogre_vendor

```
* Fix the vendoring flags for clang compilation. (#1003 <https://github.com/ros2/rviz/issues/1003>)
  Several of the flags are not available on clang, so
  don't add them there.  This fixes the clang build for
  me locally.
* Switch to ament_cmake_vendor_package (#995 <https://github.com/ros2/rviz/issues/995>)
* Contributors: Chris Lalancette, Scott K Logan
```

## rviz_rendering

```
* Added Effort plugin (#990 <https://github.com/ros2/rviz/issues/990>)
* load GLB meshes (#1001 <https://github.com/ros2/rviz/issues/1001>)
* Fixed camera default plusin crash (#999 <https://github.com/ros2/rviz/issues/999>)
* Contributors: Alejandro Hernández Cordero, Morgan Quigley
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

```
* Improve the compilation time of rviz_default_plugins (#1007 <https://github.com/ros2/rviz/issues/1007>)
* Contributors: Chris Lalancette
```
