### PR TITLE
cras_ros_utils: 2.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1604,7 +1604,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
-      version: 2.2.3-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/ctu-vras/ros-utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_ros_utils` to `2.3.0-1`:

- upstream repository: https://github.com/ctu-vras/ros-utils
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.3-1`

## cras_cpp_common

```
* Increased minimum CMake version to 3.10.2.
* log_utils: Fixed a potential segfault when instances of MemoryLogHelper get recycled.
* Contributors: Martin Pecka
```

## cras_docs_common

```
* Increased minimum CMake version to 3.10.2.
* Contributors: Martin Pecka
```

## cras_py_common

```
* Increased minimum CMake version to 3.10.2.
* Contributors: Martin Pecka
```

## cras_topic_tools

```
* priority_mux: Added possibility to send a message just before disabling a topic.
* shape_shifter: Improved getHeader().
* Increased minimum CMake version to 3.10.2.
* priority_mux: Total rewrite, now it should really work.
* Contributors: Martin Pecka
```

## image_transport_codecs

```
* Increased minimum CMake version to 3.10.2.
* Contributors: Martin Pecka
```
