### PR TITLE
rosbag2: 0.24.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5055,7 +5055,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.23.0-1
+      version: 0.24.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.24.0-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.23.0-1`

## mcap_vendor

```
* Update mcap to v1.1.0 (#1361 <https://github.com/ros2/rosbag2/issues/1361>)
* Contributors: Emerson Knapp
```

## ros2bag

```
* When using sim time, wait for /clock before beginning recording (#1378 <https://github.com/ros2/rosbag2/issues/1378>)
* Revert "Don't record sim-time messages before first /clock (#1354 <https://github.com/ros2/rosbag2/issues/1354>)" (#1377 <https://github.com/ros2/rosbag2/issues/1377>)
* Don't record sim-time messages before first /clock (#1354 <https://github.com/ros2/rosbag2/issues/1354>)
* Fix wrong descritpion for '--ignore-leaf-topics' (#1344 <https://github.com/ros2/rosbag2/issues/1344>)
* Cleanup the help text for ros2 bag record. (#1329 <https://github.com/ros2/rosbag2/issues/1329>)
* Contributors: Barry Xu, Chris Lalancette, Emerson Knapp
```

## rosbag2

- No changes

## rosbag2_compression

```
* Add in a missing cstdint include. (#1321 <https://github.com/ros2/rosbag2/issues/1321>)
* Fix warning from ClassLoader in sequential compression reader and writer (#1299 <https://github.com/ros2/rosbag2/issues/1299>)
* Contributors: Chris Lalancette, Michael Orlov
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Rewrite TimeControllerClockTest.unpaused_sleep_returns_true to be correct (#1384 <https://github.com/ros2/rosbag2/issues/1384>)
* Implement storing and loading ROS_DISTRO from metadata.yaml and mcap files (#1241 <https://github.com/ros2/rosbag2/issues/1241>)
* Don't crash when type definition cannot be found (#1350 <https://github.com/ros2/rosbag2/issues/1350>)
* Add recorder stop() API (#1300 <https://github.com/ros2/rosbag2/issues/1300>)
* Contributors: Emerson Knapp, Michael Orlov
```

## rosbag2_examples_cpp

- No changes

## rosbag2_examples_py

```
* Fix a warning from python setuptools. (#1312 <https://github.com/ros2/rosbag2/issues/1312>)
* Contributors: Chris Lalancette
```

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

```
* Set CPU affinity for producers and recorder from benchmark parameters (#1305 <https://github.com/ros2/rosbag2/issues/1305>)
* Add CPU usage to rosbag2_performance_benchmarking results report (#1304 <https://github.com/ros2/rosbag2/issues/1304>)
* Add config option to use storage_id parameter in benchmark_launch.py (#1303 <https://github.com/ros2/rosbag2/issues/1303>)
* Contributors: Michael Orlov
```

## rosbag2_performance_benchmarking_msgs

- No changes

## rosbag2_py

```
* Gracefully handle SIGINT and SIGTERM in rosbag2 recorder (#1301 <https://github.com/ros2/rosbag2/issues/1301>)
* Implement storing and loading ROS_DISTRO from metadata.yaml and mcap files (#1241 <https://github.com/ros2/rosbag2/issues/1241>)
* Add binding to close the writer (#1339 <https://github.com/ros2/rosbag2/issues/1339>)
* Contributors: Emerson Knapp, Michael Orlov, Yadu
```

## rosbag2_storage

```
* Fix missing cstdint include (#1383 <https://github.com/ros2/rosbag2/issues/1383>)
* Implement storing and loading ROS_DISTRO from metadata.yaml and mcap files (#1241 <https://github.com/ros2/rosbag2/issues/1241>)
* Contributors: Emerson Knapp, Zac Stanton
```

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

```
* Implement storing and loading ROS_DISTRO from metadata.yaml and mcap files (#1241 <https://github.com/ros2/rosbag2/issues/1241>)
* Contributors: Emerson Knapp
```

## rosbag2_storage_sqlite3

```
* Implement storing and loading ROS_DISTRO from metadata.yaml and mcap files (#1241 <https://github.com/ros2/rosbag2/issues/1241>)
* Store metadata in db3 file (#1294 <https://github.com/ros2/rosbag2/issues/1294>)
* Contributors: Emerson Knapp, Michael Orlov
```

## rosbag2_test_common

```
* Add extra checks in execute_and_wait_until_completion(..) (#1346 <https://github.com/ros2/rosbag2/issues/1346>)
* Address flakiness in rosbag2_play_end_to_end tests (#1297 <https://github.com/ros2/rosbag2/issues/1297>)
* Contributors: Michael Orlov
```

## rosbag2_test_msgdefs

```
* Don't crash when type definition cannot be found (#1350 <https://github.com/ros2/rosbag2/issues/1350>)
  * Don't fail when type definition cannot be found
* Contributors: Emerson Knapp
```

## rosbag2_tests

```
* Implement storing and loading ROS_DISTRO from metadata.yaml and mcap files (#1241 <https://github.com/ros2/rosbag2/issues/1241>)
* Address flakiness in rosbag2_play_end_to_end tests (#1297 <https://github.com/ros2/rosbag2/issues/1297>)
* Contributors: Emerson Knapp, Michael Orlov
```

## rosbag2_transport

```
* Fix for rosbag2_transport::Recorder failures due to the unhandled exceptions (#1382 <https://github.com/ros2/rosbag2/issues/1382>)
* When using sim time, wait for /clock before beginning recording (#1378 <https://github.com/ros2/rosbag2/issues/1378>)
* Fix for possible freeze in Recorder::stop() (#1381 <https://github.com/ros2/rosbag2/issues/1381>)
* Revert "Don't record sim-time messages before first /clock (#1354 <https://github.com/ros2/rosbag2/issues/1354>)" (#1377 <https://github.com/ros2/rosbag2/issues/1377>)
* Don't record sim-time messages before first /clock (#1354 <https://github.com/ros2/rosbag2/issues/1354>)
* Fix a clang warning about uninitialized variable. (#1370 <https://github.com/ros2/rosbag2/issues/1370>)
* [bugfix] for parameters not passing to recorder's node from child component (#1360 <https://github.com/ros2/rosbag2/issues/1360>)
* Change subscriptions from GenericSubscripton to SubscriptionBase (#1337 <https://github.com/ros2/rosbag2/issues/1337>)
* Add recorder stop() API (#1300 <https://github.com/ros2/rosbag2/issues/1300>)
* Contributors: Chris Lalancette, Emerson Knapp, Michael Orlov, Patrick Roncagliolo
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

```
* Switch to ament_cmake_vendor_package (#1400 <https://github.com/ros2/rosbag2/issues/1400>)
* Contributors: Scott K Logan
```

## zstd_vendor

```
* Switch to ament_cmake_vendor_package (#1400 <https://github.com/ros2/rosbag2/issues/1400>)
* Contributors: Scott K Logan
```
