### PR TITLE
foxglove_bridge: 0.7.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1668,7 +1668,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 0.6.4-1
+      version: 0.7.0-1
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_bridge` to `0.7.0-1`:

- upstream repository: https://github.com/foxglove/ros-foxglove-bridge.git
- release repository: https://github.com/ros2-gbp/foxglove_bridge-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.4-1`

## foxglove_bridge

```
* Fix ROS2 launch file install rule not installing launch subfolder (#243 <https://github.com/foxglove/ros-foxglove-bridge/issues/243>)
* Support building with boost asio (#247 <https://github.com/foxglove/ros-foxglove-bridge/issues/247>)
* Avoid usage of tmpnam() for creating random filename (#246 <https://github.com/foxglove/ros-foxglove-bridge/issues/246>)
* Implement ws-protocol's fetchAsset specification (#232 <https://github.com/foxglove/ros-foxglove-bridge/issues/232>)
* Use --include-eol-distros for rosdep to fix melodic builds (#244 <https://github.com/foxglove/ros-foxglove-bridge/issues/244>)
* Reduce logging severity for parameter retrieval logs (#240 <https://github.com/foxglove/ros-foxglove-bridge/issues/240>)
* Contributors: Hans-Joachim Krauch, Micah Guttman
```
