### PR TITLE
rclcpp: 21.0.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4186,7 +4186,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 21.0.1-1
+      version: 21.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `21.0.2-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `21.0.1-1`

## rclcpp

```
* Fix warnings related to comparison of integer expressions of different signedness (#2222 <https://github.com/ros2/rclcpp/issues/2222>)
* Fix race condition in events-executor (#2191 <https://github.com/ros2/rclcpp/issues/2191>)
* Contributors: Alberto Soragna, Tomoya Fujita
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
