### PR TITLE
ur_client_library: 1.3.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11717,7 +11717,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
-      version: 1.3.1-1
+      version: 1.3.2-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `1.3.2-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.1-1`

## ur_client_library

```
* Add a cmake option to activate address sanitizers (#146 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/146>)
* Install start ursim (#155 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/155>)
* Add spline interpolation on robot (#151 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/151>)
* Add codecov.yml to exclude test and examples folders (#152 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/152>)
* Make URSim log files available as artifacts also for the CI-industrial (#153 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/153>)
* Remove Foxy from CI
* Add a script to run the examples instead of run-parts
* Add SaveLog command to the Dashboard client
* Make URSim log files available as artifacts
* Specifically set RTDE pipeline producer to FIFO scheduling (#139 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/139>)
* Added support for force_mode, freedrive and tool contact (#138 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/138>)
* Docs: Update link to ros_industrial_cmake_boilerplate
* Added tests for the comm classes (#129 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/129>)
* Changed num_retries from static to an unsigned int (#136 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/136>)
* Build downstream humble version from humble branch (#132 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/132>)
* Contributors: Felix Exner, Mads Holm Peters, Rune Søe-Knudsen, Robert Wilbrandt
```
