### PR TITLE
grepros: 1.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3418,7 +3418,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/suurjaak/grepros-release.git
-      version: 0.6.0-2
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/suurjaak/grepros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grepros` to `1.0.0-1`:

- upstream repository: https://github.com/suurjaak/grepros.git
- release repository: https://github.com/suurjaak/grepros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.0-2`

## grepros

```
* make grepros conveniently usable as a library
* add --no-highlight option
* add --stop-on-error option
* rename options --print-field and --no-print-field to --emit-field and --no-emit-field
* support --emit-field --no-emit-field in CSV and Parquet exports
* handle all numpy types in ROS2 messages, not only ndarrays
* avoid raising errors for unknown message types in ROS2 bags if not reading those topics
* fix grepping and emitting specific messages fields only
* fix not skipping live topics published by grepros itself in ROS2
* fix embag reader
* verify output targets being writable on startup
* provide connection header in writing ROS1 bag if topic has multiple types
* smooth over rosbag bug of ignoring topic and time filters in format v1.2
* print ROS1 master URI in verbose mode on connecting to live topics
* raise error on loading Parquet plugin if libraries unavailable
* support "postgres://" as auto-detected Postgres target in addition to "postgresql://"
* use bagfile format as last when auto-detecting output format
* add MCAP bag interface
* auto-detect MCAP output by file extension
* add inputs.AppSource and outputs.AppSink
* add api.deserialize_message() dict_to_message() make_full_typename() time_message() to_time()
* rename api.get_message_data() to serialize_message()
* fix api.message_to_dict() giving invalid names for temporal types in ROS2
```
