### PR TITLE
rosidl_typesupport_fastrtps: 3.0.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5403,7 +5403,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-      version: 3.0.0-2
+      version: 3.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_fastrtps` to `3.0.1-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.0-2`

## fastrtps_cmake_module

- No changes

## rosidl_typesupport_fastrtps_c

- No changes

## rosidl_typesupport_fastrtps_cpp

```
* Avoid redundant declarations in generated code for services and actions (#103 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/103>)
* Contributors: Emerson Knapp
```
