### PR TITLE
rviz: 12.4.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5924,7 +5924,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 12.4.0-2
+      version: 12.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `12.4.1-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `12.4.0-2`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Re-implemented setName for tools (#997 <https://github.com/ros2/rviz/issues/997>)
* Add a libqt5-svg dependency to rviz_common. (#992 <https://github.com/ros2/rviz/issues/992>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Felix Exner
```

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

```
* CMake: rename FeatureSummary.cmake to avoid name clashes (#988 <https://github.com/ros2/rviz/issues/988>)
* Contributors: Gökçe Aydos, Scott K Logan
```

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
