### PR TITLE
rosbag2: 0.22.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5171,7 +5171,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.22.1-1
+      version: 0.22.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.22.2-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.22.1-1`

## mcap_vendor

- No changes

## ros2bag

```
* Wait for /clock before beginning recording when using sim time (#1391 <https://github.com/ros2/rosbag2/issues/1391>)
* Fix wrong descritpion for '--ignore-leaf-topics' (#1345 <https://github.com/ros2/rosbag2/issues/1345>)
* Contributors: Barry Xu
```

## rosbag2

- No changes

## rosbag2_compression

- No changes

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Rewrite TimeControllerClockTest.unpaused_sleep_returns_true to be correct (#1389 <https://github.com/ros2/rosbag2/issues/1389>)
* Don't crash when type definition cannot be found (#1352 <https://github.com/ros2/rosbag2/issues/1352>)
* Contributors: Emerson Knapp
```

## rosbag2_examples_cpp

- No changes

## rosbag2_examples_py

- No changes

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

```
* Add config option to use storage_id parameter in benchmark_launch.py (#1318 <https://github.com/ros2/rosbag2/issues/1318>)
* Contributors: Michael Orlov
```

## rosbag2_performance_benchmarking_msgs

- No changes

## rosbag2_py

```
* Gracefully handle SIGINT and SIGTERM in rosbag2 recorder (#1394 <https://github.com/ros2/rosbag2/issues/1394>)
* Contributors: Michael Orlov
```

## rosbag2_storage

```
* Fix missing cstdint include (#1385 <https://github.com/ros2/rosbag2/issues/1385>)
* Contributors: Zac Stanton
```

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

```
* Add ROS_DISTRO metadata record to mcap file when opening for writing (#1371 <https://github.com/ros2/rosbag2/issues/1371>)
* Contributors: Emerson Knapp
```

## rosbag2_storage_sqlite3

```
* Store metadata in db3 file (#1319 <https://github.com/ros2/rosbag2/issues/1319>)
* Contributors: Michael Orlov
```

## rosbag2_test_common

```
* Add extra checks in execute_and_wait_until_completion(..) (#1356 <https://github.com/ros2/rosbag2/issues/1356>)
* Contributors: Michael Orlov
```

## rosbag2_test_msgdefs

```
* Don't crash when type definition cannot be found (#1352 <https://github.com/ros2/rosbag2/issues/1352>)
* Contributors: Emerson Knapp
```

## rosbag2_tests

- No changes

## rosbag2_transport

```
* Fix for rosbag2_transport::Recorder failures due to the unhandled exceptions (#1402 <https://github.com/ros2/rosbag2/issues/1402>)
* Fix for possible freeze in Recorder::stop() (#1387 <https://github.com/ros2/rosbag2/issues/1387>)
* Wait for /clock before beginning recording when using sim time (#1391 <https://github.com/ros2/rosbag2/issues/1391>)
* Contributors: Michael Orlov, Patrick Roncagliolo
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
