### PR TITLE
add python3-magic entry

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6561,6 +6561,14 @@ python3-lxml:
       packages: [lxml]
   rhel: ['python%{python3_pkgversion}-lxml']
   ubuntu: [python3-lxml]
+python3-magic:
+  arch: [python-magic]
+  debian: [python3-magic]
+  fedora: [python3-magic]
+  gentoo: [dev-python/python-magic]
+  nixos: [python310Packages.magic]
+  opensuse: [python-magic]
+  ubuntu: [python3-magic]
 python3-mako:
   debian: [python3-mako]
   fedora: [python-mako]


### PR DESCRIPTION
## Package name:

python3-magic

## Package Upstream Source:

https://github.com/ahupp/python-magic

## Purpose of using this:

python-magic is a Python interface to the libmagic file type identification library.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/search?keywords=python3-magic
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/search?keywords=python3-magic
  - REQUIRED
- Fedora: https://packages.fedoraproject.org/pkgs/python-magic/python3-magic/index.html
  - IF AVAILABLE
- Arch: https://archlinux.org/packages/extra/any/python-magic/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/packages/dev-python/python-magic
  - IF AVAILABLE
- macOS: None
  - IF AVAILABLE
- Alpine: None
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=23.05&show=python310Packages.magic&from=0&size=50&sort=relevance&type=packages&query=python+magic
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/python-magic
  - IF AVAILABLE