### PR TITLE
cras_ros_utils: 2.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1604,7 +1604,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
-      version: 2.3.0-2
+      version: 2.3.1-1
     source:
       type: git
       url: https://github.com/ctu-vras/ros-utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_ros_utils` to `2.3.1-1`:

- upstream repository: https://github.com/ctu-vras/ros-utils
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.0-2`

## cras_cpp_common

- No changes

## cras_docs_common

- No changes

## cras_py_common

- No changes

## cras_topic_tools

```
* shape_shifter: Fixed detection of header in messages.
* Contributors: Martin Pecka
```

## image_transport_codecs

- No changes
