### PR TITLE
robot_body_filter: 1.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8599,7 +8599,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/peci1/robot_body_filter-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/peci1/robot_body_filter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_body_filter` to `1.3.1-1`:

- upstream repository: https://github.com/peci1/robot_body_filter
- release repository: https://github.com/peci1/robot_body_filter-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.0-1`

## robot_body_filter

```
* Explicitly specify minimum versions of required libraries.
* Contributors: Martin Pecka
```
