### PR TITLE
picknik_controllers: 0.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3435,6 +3435,18 @@ repositories:
       url: https://github.com/ros2-gbp/picknik_ament_copyright-release.git
       version: 0.0.2-3
   picknik_controllers:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/picknik_controllers.git
+      version: main
+    release:
+      packages:
+      - picknik_reset_fault_controller
+      - picknik_twist_controller
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/picknik_controllers-release.git
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/picknik_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `picknik_controllers` to `0.0.2-1`:

- upstream repository: https://github.com/PickNikRobotics/picknik_controllers.git
- release repository: https://github.com/ros2-gbp/picknik_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## picknik_reset_fault_controller

- No changes

## picknik_twist_controller

```
* fix typo (#10 <https://github.com/PickNikRobotics/picknik_controllers/issues/10>)
  ABI breaking change fixes a typo from original internal package rename for open sourcing
  PicknikTwistControler -> PicknikTwistController
* Contributors: Anthony Baker
```
