### PR TITLE
cascade_lifecycle: 1.0.4-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -652,7 +652,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/cascade_lifecycle-release.git
-      version: 1.0.3-5
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/fmrico/cascade_lifecycle.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cascade_lifecycle` to `1.0.4-1`:

- upstream repository: https://github.com/fmrico/cascade_lifecycle.git
- release repository: https://github.com/ros2-gbp/cascade_lifecycle-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.3-5`

## cascade_lifecycle_msgs

- No changes

## rclcpp_cascade_lifecycle

- No changes
