### PR TITLE
popf: 0.0.15-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3727,6 +3727,22 @@ repositories:
       url: https://github.com/MetroRobots/polygon_ros.git
       version: main
     status: developed
+  popf:
+    doc:
+      type: git
+      url: https://github.com/fmrico/popf.git
+      version: iron-devel
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/popf-release.git
+      version: 0.0.15-1
+    source:
+      type: git
+      url: https://github.com/fmrico/popf.git
+      version: iron-devel
+    status: maintained
+    status_description: maintained
   pose_cov_ops:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `popf` to `0.0.15-1`:

- upstream repository: https://github.com/fmrico/popf.git
- release repository: https://github.com/ros2-gbp/popf-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## popf

- No changes
