### PR TITLE
smacc2: 2.3.18-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6885,9 +6885,6 @@ repositories:
       version: humble
     release:
       packages:
-      - lifecyclenode_client
-      - ros_timer_client
-      - sm_atomic
       - smacc2
       - smacc2_msgs
       tags:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6885,12 +6885,54 @@ repositories:
       version: humble
     release:
       packages:
+      - backward_global_planner
+      - backward_local_planner
+      - eg_conditional_generator
+      - eg_random_generator
+      - forward_global_planner
+      - forward_local_planner
+      - keyboard_client
+      - lifecyclenode_client
+      - moveit2z_client
+      - multirole_sensor_client
+      - nav2z_client
+      - nav2z_planners_common
+      - panda_arm_1_moveit_config
+      - panda_arm_2_moveit_config
+      - pure_spinning_local_planner
+      - ros_publisher_client
+      - ros_timer_client
+      - sm_advanced_recovery_1
+      - sm_atomic
+      - sm_atomic_24hr
+      - sm_atomic_lifecycle
+      - sm_atomic_mode_states
+      - sm_atomic_performance_trace_1
+      - sm_atomic_services
+      - sm_atomic_subscribers_performance_test
+      - sm_branching
+      - sm_coretest_transition_speed_1
+      - sm_dance_bot
+      - sm_dance_bot_warehouse
+      - sm_dance_bot_warehouse_2
+      - sm_dance_bot_warehouse_3
+      - sm_dance_bot_warehouse_4
+      - sm_multi_panda_sim
+      - sm_multi_stage_1
+      - sm_pack_ml
+      - sm_panda_moveit2z_cb_inventory
+      - sm_pubsub_1
+      - sm_three_some
       - smacc2
       - smacc2_msgs
+      - sr_all_events_go
+      - sr_conditional
+      - sr_event_countdown
+      - undo_path_global_planner
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/robosoft-ai/SMACC2-release.git
-      version: 2.3.8-1
+      version: 2.3.16-1
     source:
       type: git
       url: https://github.com/robosoft-ai/SMACC2.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6885,11 +6885,11 @@ repositories:
       version: humble
     release:
       packages:
+      - lifecyclenode_client
       - ros_timer_client
+      - sm_atomic
       - smacc2
       - smacc2_msgs
-      - sm_atomic
-      - lifecyclenode_client
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/robosoft-ai/SMACC2-release.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6885,50 +6885,9 @@ repositories:
       version: humble
     release:
       packages:
-      - backward_global_planner
-      - backward_local_planner
-      - eg_conditional_generator
-      - eg_random_generator
-      - forward_global_planner
-      - forward_local_planner
-      - keyboard_client
-      - lifecyclenode_client
-      - moveit2z_client
-      - multirole_sensor_client
-      - nav2z_client
-      - nav2z_planners_common
-      - panda_arm_1_moveit_config
-      - panda_arm_2_moveit_config
-      - pure_spinning_local_planner
-      - ros_publisher_client
       - ros_timer_client
-      - sm_advanced_recovery_1
-      - sm_atomic
-      - sm_atomic_24hr
-      - sm_atomic_lifecycle
-      - sm_atomic_mode_states
-      - sm_atomic_performance_trace_1
-      - sm_atomic_services
-      - sm_atomic_subscribers_performance_test
-      - sm_branching
-      - sm_coretest_transition_speed_1
-      - sm_dance_bot
-      - sm_dance_bot_warehouse
-      - sm_dance_bot_warehouse_2
-      - sm_dance_bot_warehouse_3
-      - sm_dance_bot_warehouse_4
-      - sm_multi_panda_sim
-      - sm_multi_stage_1
-      - sm_pack_ml
-      - sm_panda_moveit2z_cb_inventory
-      - sm_pubsub_1
-      - sm_three_some
       - smacc2
       - smacc2_msgs
-      - sr_all_events_go
-      - sr_conditional
-      - sr_event_countdown
-      - undo_path_global_planner
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/robosoft-ai/SMACC2-release.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6891,7 +6891,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/robosoft-ai/SMACC2-release.git
-      version: 2.3.16-1
+      version: 2.3.18-1
     source:
       type: git
       url: https://github.com/robosoft-ai/SMACC2.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6888,6 +6888,8 @@ repositories:
       - ros_timer_client
       - smacc2
       - smacc2_msgs
+      - sm_atomic
+      - lifecyclenode_client
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/robosoft-ai/SMACC2-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `smacc2` to `2.3.18-1`:

- upstream repository: https://github.com/robosoft-ai/SMACC2.git
- release repository: https://github.com/robosoft-ai/SMACC2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.8-1`


## lifecyclenode_client

```
* minor
* Merge branch 'humble' of https://github.com/robosoft-ai/SMACC2 into humble
* Brettpac branch (#518 <https://github.com/robosoft-ai/SMACC2/issues/518>)
  * Attempt to fix weird issue with ros buildfarm
  * More on this buildfarm issue
  ---------
  Co-authored-by: brettpac <mailto:brettpac@pop-os.localdomain>
* Contributors: brettpac, pabloinigoblasco
```

## ros_timer_client

```
* Merge branch 'humble' of https://github.com/robosoft-ai/SMACC2 into humble
* Brettpac branch (#518 <https://github.com/robosoft-ai/SMACC2/issues/518>)
  * Attempt to fix weird issue with ros buildfarm
  * More on this buildfarm issue
  ---------
  Co-authored-by: brettpac <mailto:brettpac@pop-os.localdomain>
* Contributors: brettpac, pabloinigoblasco
```

## sm_atomic

```
* Merge branch 'humble' of https://github.com/robosoft-ai/SMACC2 into humble
* Brettpac branch (#518 <https://github.com/robosoft-ai/SMACC2/issues/518>)
  * Attempt to fix weird issue with ros buildfarm
  * More on this buildfarm issue
  ---------
  Co-authored-by: brettpac <mailto:brettpac@pop-os.localdomain>
* Contributors: brettpac, pabloinigoblasco
```