### PR TITLE
gz_ros2_control: 1.1.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1770,6 +1770,25 @@ repositories:
       url: https://github.com/borglab/gtsam.git
       version: develop
     status: developed
+  gz_ros2_control:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/gz_ros2_control.git
+      version: master
+    release:
+      packages:
+      - gz_ros2_control
+      - gz_ros2_control_demos
+      - gz_ros2_control_tests
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros-controls/gz_ros2_control.git
+      version: 1.1.1-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/gz_ros2_control.git
+      version: master
+    status: maintained
   hash_library_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `1.1.1-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control/
- release repository: https://github.com/ros-controls/gz_ros2_control.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## gz_ros2_control

```
* Remove plugin export from ROS 1 (#158 <https://github.com/ros-controls/gz_ros2_control//issues/158>)
* Fixed default gazebo version in CMakeLists.txt (#156 <https://github.com/ros-controls/gz_ros2_control//issues/156>)
* Compile master with iron and rolling (#142 <https://github.com/ros-controls/gz_ros2_control//issues/142>)
* Update package.xml (#141 <https://github.com/ros-controls/gz_ros2_control//issues/141>)
* Contributors: Alejandro Hernández Cordero, Bence Magyar, Christoph Fröhlich
```

## gz_ros2_control_demos

```
* typo fix (#143 <https://github.com/ros-controls/gz_ros2_control//issues/143>)
* Contributors: Reza Kermani
```

## gz_ros2_control_tests

```
* Run end to end test in CI (#152 <https://github.com/ros-controls/gz_ros2_control//issues/152>)
* Add test to check position controller (#134 <https://github.com/ros-controls/gz_ros2_control//issues/134>)
* Contributors: Alejandro Hernández Cordero
```
