### PR TITLE
Removed ign_ros2_control key in Iron

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1862,24 +1862,6 @@ repositories:
       url: https://github.com/ros2-gbp/ifm3d-release.git
       version: 0.18.0-9
     status: developed
-  ign_ros2_control:
-    doc:
-      type: git
-      url: https://github.com/ros-controls/gz_ros2_control.git
-      version: master
-    release:
-      packages:
-      - ign_ros2_control
-      - ign_ros2_control_demos
-      tags:
-        release: release/iron/{package}/{version}
-      url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 0.6.1-4
-    source:
-      type: git
-      url: https://github.com/ros-controls/gz_ros2_control.git
-      version: master
-    status: maintained
   ign_rviz:
     doc:
       type: git


### PR DESCRIPTION
Removed `ign_ros2_control` key and I released `gz_ros2_control` https://github.com/ros/rosdistro/pull/37988