### PR TITLE
ros2_planning_system: 2.0.10-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4920,6 +4920,36 @@ repositories:
       url: https://github.com/PickNikRobotics/ros2_kortex.git
       version: main
     status: developed
+  ros2_planning_system:
+    doc:
+      type: git
+      url: https://github.com/PlanSys2/ros2_planning_system.git
+      version: iron-devel
+    release:
+      packages:
+      - plansys2_bringup
+      - plansys2_bt_actions
+      - plansys2_core
+      - plansys2_domain_expert
+      - plansys2_executor
+      - plansys2_lifecycle_manager
+      - plansys2_msgs
+      - plansys2_pddl_parser
+      - plansys2_planner
+      - plansys2_popf_plan_solver
+      - plansys2_problem_expert
+      - plansys2_terminal
+      - plansys2_tests
+      - plansys2_tools
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_planning_system-release.git
+      version: 2.0.10-1
+    source:
+      type: git
+      url: https://github.com/PlanSys2/ros2_planning_system.git
+      version: iron-devel
+    status: developed
   ros2_robotiq_gripper:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_planning_system` to `2.0.10-1`:

- upstream repository: https://github.com/PlanSys2/ros2_planning_system.git
- release repository: https://github.com/ros2-gbp/ros2_planning_system-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## plansys2_bringup

```
* Merge pull request #251 <https://github.com/PlanSys2/ros2_planning_system/issues/251> from PlanSys2/fix_bt_node
  Fix bt node
* Change double quotes for simple ones (linter)
* Make explicit which BTCreator is being used
* Merge remote-tracking branch 'origin/master' into fix_goal_structure_issue_205
* Merge pull request #240 <https://github.com/PlanSys2/ros2_planning_system/issues/240> from jjzapf/bt-builder-plugins
  New BT Builder and Plugin Interface
* bt-builder-plugins: Setting default BT builder plugin to SimpleBTBuilder.
* bt-builder-plugins: Creating BT builder plugin interface. Moving current BT builder to plugin named SimpleBTBuilder. Adding new and improved STN-based BT builder plugin named STNBTBuilder.
* Merge remote-tracking branch 'origin/master' into fix_goal_structure_issue_205
* Merge pull request #215 <https://github.com/PlanSys2/ros2_planning_system/issues/215> from Splinter1984/master
  add system status check
* revert if statement
* Merge remote-tracking branch 'upstream/master'
* Contributors: Francisco Martín Rico, Josh Zapf, Marco Roveri, Splinter1984
```

## plansys2_bt_actions

```
* Merge pull request #251 <https://github.com/PlanSys2/ros2_planning_system/issues/251> from PlanSys2/fix_bt_node
  Fix bt node
* Insert in blackboard the action ROS 2 Node
* Merge remote-tracking branch 'origin/master' into fix_goal_structure_issue_205
* Merge branch 'master' into bt-builder-plugins
* Merge pull request #236 <https://github.com/PlanSys2/ros2_planning_system/issues/236> from sarcasticnature/feature/misc-fixes
  Fixes for bt_actions and popf_plan_sover
* Correct tick function call in bt_actions test
* Merge remote-tracking branch 'origin/master' into fix_goal_structure_issue_205
* Explicitly ignore feedback in default on_feedback
* Add try/catch to bt creation, reset loggers
* Merge remote-tracking branch 'upstream/master'
* Merge branch 'IntelligentRoboticsLabs:master' into master
* Contributors: Andrianov Roman, Francisco Martín Rico, Jake Keller, Marco Roveri, Splinter1984
```

## plansys2_core

```
* Merge pull request #254 <https://github.com/PlanSys2/ros2_planning_system/issues/254> from PlanSys2/remove_ptr_refs
  Remove reference to SharedPtr
* Remove reference to SharedPtr
* Merge remote-tracking branch 'origin/master' into fix_goal_structure_issue_205
* Merge remote-tracking branch 'upstream/master'
* Contributors: Francisco Martín Rico, Marco Roveri, Splinter1984
```

## plansys2_domain_expert

```
* Merge remote-tracking branch 'origin/humble-devel'
* Merge remote-tracking branch 'origin/master' into fix_goal_structure_issue_205
* Merge remote-tracking branch 'upstream/master'
* Contributors: Francisco Martín Rico, Marco Roveri, Splinter1984
```

## plansys2_executor

```
* Merge remote-tracking branch 'origin/humble-devel'
* Merge pull request #252 <https://github.com/PlanSys2/ros2_planning_system/issues/252> from PlanSys2/check_at_end
  Check at end reqs in bt builder
* Check at end reqs in bt builder
* Merge pull request #251 <https://github.com/PlanSys2/ros2_planning_system/issues/251> from PlanSys2/fix_bt_node
  Fix bt node
* Change MultiThreaded for SingleThreaded in CI failing tests
* Change double quotes for simple ones (linter)
* Insert in blackboard the action ROS 2 Node
* Merge pull request #247 <https://github.com/PlanSys2/ros2_planning_system/issues/247> from jjzapf/standalone-bt-builder
  Standalone BT Builder Service
* Fixing cpplint warning.
* Fixing cpplint warnings.
* Checking for self-referencing edges in STNBTBuilder. Adding standalone compute_bt service.
* Merge remote-tracking branch 'origin/master' into fix_goal_structure_issue_205
* Merge pull request #240 <https://github.com/PlanSys2/ros2_planning_system/issues/240> from jjzapf/bt-builder-plugins
  New BT Builder and Plugin Interface
* bt-builder-plugins: Setting default BT builder plugin to SimpleBTBuilder.
* bt-builder-plugins: Creating BT builder plugin interface. Moving current BT builder to plugin named SimpleBTBuilder. Adding new and improved STN-based BT builder plugin named STNBTBuilder.
* Merge remote-tracking branch 'origin/master' into fix_goal_structure_issue_205
* Merge remote-tracking branch 'upstream/master'
* Merge branch 'IntelligentRoboticsLabs:master' into master
* Contributors: Andrianov Roman, Francisco Martín Rico, Josh Zapf, Marco Roveri, Splinter1984
```

## plansys2_lifecycle_manager

```
* Merge remote-tracking branch 'origin/humble-devel'
* Merge remote-tracking branch 'origin/master' into fix_goal_structure_issue_205
* Merge remote-tracking branch 'upstream/master'
* Contributors: Francisco Martín Rico, Marco Roveri, Splinter1984
```

## plansys2_msgs

```
* Merge remote-tracking branch 'origin/humble-devel'
* Merge remote-tracking branch 'origin/master' into fix_goal_structure_issue_205
* Contributors: Francisco Martín Rico, Marco Roveri
```

## plansys2_pddl_parser

```
* Merge remote-tracking branch 'origin/humble-devel'
* Merge pull request #238 <https://github.com/PlanSys2/ros2_planning_system/issues/238> from roveri-marco/fix_goal_structure_issue_205
  Fix goal structure issue 205
* Merge pull request #246 <https://github.com/PlanSys2/ros2_planning_system/issues/246> from pac48/fix-not-regex-in-parser-utils
  Fix regex for 'not', 'and', 'or' in parser utils
* fix regex for 'and' and 'or'
* fix regex for NOT
* Removed debug code
* Fixed support for complex goals and other changes
* Fixed some errors and some tests to comply with the revised output
* Merge remote-tracking branch 'origin/master' into fix_goal_structure_issue_205
* Fixed support for the complex goal parsing both from the terminal and from file
* Merge remote-tracking branch 'upstream/master'
* Contributors: Francisco Martín Rico, Marco Roveri, Paul Gesel, Splinter1984
```

## plansys2_planner

```
* Merge remote-tracking branch 'origin/humble-devel'
* Merge pull request #238 <https://github.com/PlanSys2/ros2_planning_system/issues/238> from roveri-marco/fix_goal_structure_issue_205
  Fix goal structure issue 205
* Minor changes to the tests to comply with some change in the generated output
* Merge remote-tracking branch 'origin/master' into fix_goal_structure_issue_205
* Merge remote-tracking branch 'upstream/master'
* Contributors: Francisco Martín Rico, Marco Roveri, Splinter1984
```

## plansys2_popf_plan_solver

```
* Merge remote-tracking branch 'origin/humble-devel'
* Merge pull request #254 <https://github.com/PlanSys2/ros2_planning_system/issues/254> from PlanSys2/remove_ptr_refs
  Remove reference to SharedPtr
* Remove reference to SharedPtr
* Merge remote-tracking branch 'origin/master' into fix_goal_structure_issue_205
* Merge branch 'master' into bt-builder-plugins
* Merge pull request #241 <https://github.com/PlanSys2/ros2_planning_system/issues/241> from PlanSys2/fix_popf_plugin
  Fix is_valid_domain by parsing out file
* Fix is_valid_domain by parsing out file
* Merge pull request #236 <https://github.com/PlanSys2/ros2_planning_system/issues/236> from sarcasticnature/feature/misc-fixes
  Fixes for bt_actions and popf_plan_sover
* bt-builder-plugins: Creating BT builder plugin interface. Moving current BT builder to plugin named SimpleBTBuilder. Adding new and improved STN-based BT builder plugin named STNBTBuilder.
* Merge remote-tracking branch 'origin/master' into fix_goal_structure_issue_205
* Fix problem in is_valid_domain function
* Merge pull request #215 <https://github.com/PlanSys2/ros2_planning_system/issues/215> from Splinter1984/master
  add system status check
* add status check into popf_plan_solver
* Merge remote-tracking branch 'upstream/master'
* add semicolom
* add system status check
* Contributors: Andrianov Roman, Francisco Martín Rico, Jake Keller, Josh Zapf, Marco Roveri, Splinter1984
```

## plansys2_problem_expert

```
* Merge remote-tracking branch 'origin/humble-devel'
* Merge pull request #238 <https://github.com/PlanSys2/ros2_planning_system/issues/238> from roveri-marco/fix_goal_structure_issue_205
  Fix goal structure issue 205
* Merge remote-tracking branch 'origin/master' into fix_goal_structure_issue_205
* Minor changes to the tests to comply with some change in the generated output
* Fixed some errors and some tests to comply with the revised output
* Merge branch 'master' into bt-builder-plugins
* Merge pull request #242 <https://github.com/PlanSys2/ros2_planning_system/issues/242> from PlanSys2/duplicate_instances
  Duplicate instances
* Fix typo
* Check instance types and associated tests
* Merge pull request #235 <https://github.com/PlanSys2/ros2_planning_system/issues/235> from MostafaGomaa/problem_expert/Fix_InvalidInstance
  [problem_expert] AddInstance successeeds if instance already exists
* Merge remote-tracking branch 'origin/master' into fix_goal_structure_issue_205
* Fixed support for the complex goal parsing both from the terminal and from file
* [problem_expert] AddInstance successeeds if instance already exists
* Merge remote-tracking branch 'upstream/master'
* Contributors: Francisco Martín Rico, Marco Roveri, Mostafa Gomaa, Splinter1984
```

## plansys2_terminal

```
* Merge remote-tracking branch 'origin/humble-devel'
* Merge pull request #251 <https://github.com/PlanSys2/ros2_planning_system/issues/251> from PlanSys2/fix_bt_node
  Fix bt node
* Change MultiThreaded for SingleThreaded in CI failing tests
* Merge pull request #238 <https://github.com/PlanSys2/ros2_planning_system/issues/238> from roveri-marco/fix_goal_structure_issue_205
  Fix goal structure issue 205
* Fix terminal tests
* Minor fix
* Merge remote-tracking branch 'origin/master' into fix_goal_structure_issue_205
* Merge remote-tracking branch 'upstream/master'
* Merge branch 'IntelligentRoboticsLabs:master' into master
* Contributors: Andrianov Roman, Francisco Martín Rico, Marco Roveri, Splinter1984
```

## plansys2_tests

```
* Merge remote-tracking branch 'origin/humble-devel'
* Merge remote-tracking branch 'origin/master' into fix_goal_structure_issue_205
* Contributors: Francisco Martín Rico, Marco Roveri
```

## plansys2_tools

```
* Merge remote-tracking branch 'origin/humble-devel'
* Merge remote-tracking branch 'origin/master' into fix_goal_structure_issue_205
* Merge remote-tracking branch 'upstream/master'
* Contributors: Francisco Martín Rico, Marco Roveri, Splinter1984
```
