### PR TITLE
clearpath_config: 0.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -820,7 +820,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 0.0.3-1
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `0.0.4-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.3-1`

## clearpath_config

```
* Added __init__ to common
* Only run pytest on clearpath_config
* Linting errors
* Added samples to installed share
* Removed parser
* Updated pytests
* Renamed configs
* Added license file
* Added license headers
* Renamed accessories to links in top level config
* Replaced accessories module with links
* Renamed decorations and accessories
* Standard lists
* Removed all old samples
* Added workspace setter
* Added workspaces
* Fixed rpy type
* Removed copy
* Contributors: Luis Camero
```
