### PR TITLE
dingo_simulator: 0.1.2-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1994,7 +1994,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/dingo_simulator-release.git
-      version: 0.1.2-1
+      version: 0.1.2-2
     source:
       type: git
       url: https://github.com/dingo-cpr/dingo_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_simulator` to `0.1.2-2`:

- upstream repository: https://github.com/dingo-cpr/dingo_simulator.git
- release repository: https://github.com/clearpath-gbp/dingo_simulator-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.2-1`

## dingo_gazebo

```
* Bump CMake version to avoid CMP0048 warning.
* Contributors: Tony Baltovski
```

## dingo_simulator

```
* Bump CMake version to avoid CMP0048 warning.
* Contributors: Tony Baltovski
```
