### PR TITLE
Revert "webots_ros2: 2023.1.1-1 in 'humble/distribution.yaml' [bloom]"

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8374,7 +8374,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/webots_ros2-release.git
-      version: 2023.1.1-1
+      version: 2023.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#37906

This fails on the buildfarm:
https://build.ros2.org/view/Hbin_uJ64/job/Hbin_uJ64__webots_ros2_driver__ubuntu_jammy_amd64__binary/41/console

I think we're missing a build dependency on `yaml-cpp` in the package.xml of `webots_ros2_driver`.
https://github.com/ros/rosdistro/blob/1cc4db2579b370519728a4a4ebe771de51719d8f/rosdep/base.yaml#L8351

FYI @ygoumaz.