### PR TITLE
ros2_robotiq_gripper: 0.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4767,6 +4767,18 @@ repositories:
       version: foxy-devel
     status: maintained
   ros2_robotiq_gripper:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/ros2_robotiq_gripper.git
+      version: main
+    release:
+      packages:
+      - robotiq_controllers
+      - robotiq_description
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_robotiq_gripper-release.git
+      version: 0.0.1-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/ros2_robotiq_gripper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_robotiq_gripper` to `0.0.1-1`:

- upstream repository: https://github.com/PickNikRobotics/ros2_robotiq_gripper.git
- release repository: https://github.com/ros2-gbp/ros2_robotiq_gripper-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## robotiq_controllers

```
* Initial ROS 2 release of robotiq_controllers
  * This package is not supported by Robotiq but is being maintained by PickNik Robotics
* Contributors: Alex Moriarty, Cory Crean
```

## robotiq_description

```
* Initial ROS 2 release of robotiq_description
  * includes support for Robotiq 2F 85
  * This package is not supported by Robotiq but is being maintained by PickNik Robotics
* Contributors: Alex Moriarty, Anthony Baker, Chance Cardona, Cory Crean, Erik Holum, Marq Rasmussen, Sakai Hibiki, Sebastian Castro, marqrazz
```
