### PR TITLE
launch_ros: 0.19.5-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2604,7 +2604,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.19.4-1
+      version: 0.19.5-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.19.5-2`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.19.4-1`

## launch_ros

```
* Run condition for composable nodes (#311 <https://github.com/ros2/launch_ros/issues/311>) (#363 <https://github.com/ros2/launch_ros/issues/363>)
* Fix normalize_parameters_dict for multiple nodes in the same namespace (backport #347 <https://github.com/ros2/launch_ros/issues/347>) (#350 <https://github.com/ros2/launch_ros/issues/350>)
  Co-authored-by: Alexey Merzlyakov <mailto:60094858+AlexeyMerzlyakov@users.noreply.github.com>
* Contributors: mergify[bot]
```

## launch_testing_ros

- No changes

## ros2launch

- No changes
