### PR TITLE
ament_lint: 0.12.7-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -293,7 +293,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.12.6-1
+      version: 0.12.7-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_lint` to `0.12.7-2`:

- upstream repository: https://github.com/ament/ament_lint.git
- release repository: https://github.com/ros2-gbp/ament_lint-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.12.6-1`

## ament_clang_format

- No changes

## ament_clang_tidy

- No changes

## ament_cmake_clang_format

- No changes

## ament_cmake_clang_tidy

- No changes

## ament_cmake_copyright

```
* [ament_lint_auto] General file exclusion with AMENT_LINT_AUTO_FILE_EXCLUDE (#386 <https://github.com/ament/ament_lint/issues/386>) (#445 <https://github.com/ament/ament_lint/issues/445>)
* Contributors: mergify[bot]
```

## ament_cmake_cppcheck

```
* [ament_lint_auto] General file exclusion with AMENT_LINT_AUTO_FILE_EXCLUDE (#386 <https://github.com/ament/ament_lint/issues/386>) (#445 <https://github.com/ament/ament_lint/issues/445>)
* Contributors: mergify[bot]
```

## ament_cmake_cpplint

```
* [ament_lint_auto] General file exclusion with AMENT_LINT_AUTO_FILE_EXCLUDE (#386 <https://github.com/ament/ament_lint/issues/386>) (#445 <https://github.com/ament/ament_lint/issues/445>)
* Contributors: mergify[bot]
```

## ament_cmake_flake8

- No changes

## ament_cmake_lint_cmake

- No changes

## ament_cmake_mypy

- No changes

## ament_cmake_pclint

- No changes

## ament_cmake_pep257

- No changes

## ament_cmake_pycodestyle

- No changes

## ament_cmake_pyflakes

- No changes

## ament_cmake_uncrustify

```
* [ament_lint_auto] General file exclusion with AMENT_LINT_AUTO_FILE_EXCLUDE (#386 <https://github.com/ament/ament_lint/issues/386>) (#445 <https://github.com/ament/ament_lint/issues/445>)
* Contributors: mergify[bot]
```

## ament_cmake_xmllint

- No changes

## ament_copyright

- No changes

## ament_cppcheck

- No changes

## ament_cpplint

- No changes

## ament_flake8

- No changes

## ament_lint

- No changes

## ament_lint_auto

```
* [ament_lint_auto] General file exclusion with AMENT_LINT_AUTO_FILE_EXCLUDE (#386 <https://github.com/ament/ament_lint/issues/386>) (#445 <https://github.com/ament/ament_lint/issues/445>)
* Contributors: mergify[bot]
```

## ament_lint_cmake

- No changes

## ament_lint_common

- No changes

## ament_mypy

- No changes

## ament_pclint

- No changes

## ament_pep257

- No changes

## ament_pycodestyle

- No changes

## ament_pyflakes

- No changes

## ament_uncrustify

- No changes

## ament_xmllint

- No changes
