### PR TITLE
Add python3-pip to alpine

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7193,6 +7193,7 @@ python3-pil:
       packages: [python3-pillow]
   ubuntu: [python3-pil]
 python3-pip:
+  alpine: [py3-pip]
   debian: [python3-pip]
   fedora: [python3-pip]
   nixos: [python3Packages.pip]


### PR DESCRIPTION

Please add the following dependency to the rosdep database.

## Package name:

pip

## Package Upstream Source:

https://pip.pypa.io/en/stable/

## Purpose of using this:

This adds python3-pip for alpine, it already exists for other distros.

Distro packaging links:

## Links to Distribution Packages


- Alpine: https://pkgs.alpinelinux.org/packages?name=py3-pip&branch=v3.18&repo=&arch=&maintainer=
  - IF AVAILABLE


# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro

 Note: This work was done on behalf of[ AeroVironment Inc.](https://www.avinc.com/)
