### PR TITLE
Adding libbdd

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2427,6 +2427,11 @@ libbackward-cpp-dev:
   ubuntu:
     '*': [libbackward-cpp-dev]
     bionic: null
+libbdd-dev:
+  arch: [buddy]
+  debian: [libbdd-dev]
+  gentoo: [sci-libs/buddy]
+  ubuntu: [libbdd-dev]
 libbison-dev:
   debian: [libbison-dev]
   fedora: [bison-devel]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

libbdd

## Package Upstream Source:

https://buddy.sourceforge.net/manual/main.html

## Purpose of using this:

It is important for the usage in the deliberation layer with Binary decision diagrams

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/unstable/libbdd-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/kinetic/libbdd-dev
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/buddy/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/sci-libs/buddy