### PR TITLE
geometry2: 0.25.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1829,7 +1829,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.25.2-1
+      version: 0.25.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.25.3-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.25.2-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

```
* Add do_transform_polygon_stamped (#582 <https://github.com/ros2/geometry2/issues/582>) (#590 <https://github.com/ros2/geometry2/issues/590>)
* Contributors: mergify[bot]
```

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Enable StaticTransformBroadcaster in Intra-process enabled components (backport #607 <https://github.com/ros2/geometry2/issues/607>) (#612 <https://github.com/ros2/geometry2/issues/612>)
* Contributors: mergify[bot]
```

## tf2_ros_py

- No changes

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
