### PR TITLE
rclcpp: 16.0.5-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4792,7 +4792,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 16.0.4-2
+      version: 16.0.5-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `16.0.5-2`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `16.0.4-2`

## rclcpp

```
* warning: comparison of integer expressions of different signedness (#2219 <https://github.com/ros2/rclcpp/issues/2219>) (#2223 <https://github.com/ros2/rclcpp/issues/2223>)
* Trigger the intraprocess guard condition with data (#2164 <https://github.com/ros2/rclcpp/issues/2164>) (#2167 <https://github.com/ros2/rclcpp/issues/2167>)
* Implement validity checks for rclcpp::Clock (#2040 <https://github.com/ros2/rclcpp/issues/2040>) (#2210 <https://github.com/ros2/rclcpp/issues/2210>)
* Contributors: Tomoya Fujita, mergify[bot]
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* Fix thread safety in LifecycleNode::get_current_state() for Humble (#2183 <https://github.com/ros2/rclcpp/issues/2183>)
  * add initially-failing test case
  * apply changes to LifecycleNodeInterfaceImpl from #1756 <https://github.com/ros2/rclcpp/issues/1756>
  * add static member to State for managing state_handle_ access
  * allow parallel read access in MutexMap
* Contributors: Joseph Schornak
```
