### PR TITLE
rclpy: 3.3.9-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4808,7 +4808,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 3.3.8-2
+      version: 3.3.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `3.3.9-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.3.8-2`

## rclpy

```
* ServerGoalHandle should be destroyed before removing. (#1113 <https://github.com/ros2/rclpy/issues/1113>) (#1120 <https://github.com/ros2/rclpy/issues/1120>)
* Contributors: mergify[bot]
```
