### PR TITLE
rosidl: 3.1.5-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5939,7 +5939,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 3.1.4-1
+      version: 3.1.5-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `3.1.5-2`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.1.4-1`

## rosidl_adapter

- No changes

## rosidl_cli

- No changes

## rosidl_cmake

- No changes

## rosidl_generator_c

- No changes

## rosidl_generator_cpp

```
* Merge pull request #752 <https://github.com/ros2/rosidl/issues/752> from ros2/mergify/bp/humble/pr-750
* Fix deprecation warnings for message constants (#750 <https://github.com/ros2/rosidl/issues/750>)
* Contributors: Emerson Knapp
```

## rosidl_parser

- No changes

## rosidl_runtime_c

- No changes

## rosidl_runtime_cpp

- No changes

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

- No changes

## rosidl_typesupport_introspection_cpp

```
* Merge pull request #752 <https://github.com/ros2/rosidl/issues/752> from ros2/mergify/bp/humble/pr-750
* Fix deprecation warnings for message constants (#750 <https://github.com/ros2/rosidl/issues/750>)
* Contributors: Emerson Knapp
```
