### PR TITLE
rviz: 11.2.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6614,7 +6614,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 11.2.5-1
+      version: 11.2.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `11.2.6-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `11.2.5-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Merge pull request #993 <https://github.com/ros2/rviz/issues/993> from ros2/mergify/bp/humble/pr-992
* Merge pull request #998 <https://github.com/ros2/rviz/issues/998> from ros2/mergify/bp/humble/pr-989
* Re-implemented setName for tools (#989 <https://github.com/ros2/rviz/issues/989>)
* Add a libqt5-svg dependency to rviz_common. (#992 <https://github.com/ros2/rviz/issues/992>)
* Update Frame shortcut (#958 <https://github.com/ros2/rviz/issues/958>) (#960 <https://github.com/ros2/rviz/issues/960>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Felix Exner (fexner), mergify[bot]
```

## rviz_default_plugins

```
* Added Effort plugin (#990 <https://github.com/ros2/rviz/issues/990>) (#1010 <https://github.com/ros2/rviz/issues/1010>)
* Update Frame shortcut (#958 <https://github.com/ros2/rviz/issues/958>) (#960 <https://github.com/ros2/rviz/issues/960>)
* Fix tolerance calculation precision (#934 <https://github.com/ros2/rviz/issues/934>) (#965 <https://github.com/ros2/rviz/issues/965>)
* Fix MeshResourceMarker for mesh with color-based embedded material (#928 <https://github.com/ros2/rviz/issues/928>) (#964 <https://github.com/ros2/rviz/issues/964>)
* std::copy fix - OccupancyGridUpdate - Data is not being processed correctly (#895 <https://github.com/ros2/rviz/issues/895>) (#978 <https://github.com/ros2/rviz/issues/978>)
* Contributors: Chuanhong Guo, Daisuke Sato, mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Added Effort plugin (#990 <https://github.com/ros2/rviz/issues/990>) (#1010 <https://github.com/ros2/rviz/issues/1010>)
* Contributors: mergify[bot]
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
