### PR TITLE
ros2_controllers: 3.12.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4904,7 +4904,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 3.11.0-1
+      version: 3.12.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `3.12.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.11.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

```
* Activate AdmittanceControllerTestParameterizedInvalidParameters (#711 <https://github.com/ros-controls/ros2_controllers/issues/711>)
* Contributors: Christoph Fröhlich
```

## bicycle_steering_controller

- No changes

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* Remove reactivation test from ROS 1
* Don't test update after cleanup
* Fix namespace for parameter traits(#703 <https://github.com/ros-controls/ros2_controllers/issues/703>)
* Fixed update period computation in test (#693 <https://github.com/ros-controls/ros2_controllers/issues/693>)
* [JTC] Reject trajectories with nonzero terminal velocity (#567 <https://github.com/ros-controls/ros2_controllers/issues/567>)
* Compute velocity errors when using an effort command interface (#679 <https://github.com/ros-controls/ros2_controllers/issues/679>)
* Add test for velocity error with effort cmd interface (#690 <https://github.com/ros-controls/ros2_controllers/issues/690>)
* Revert "[JTC] Command final waypoint identically when traj_point_active_ptr_ is nullptr (#682 <https://github.com/ros-controls/ros2_controllers/issues/682>)"
* [JTC] Fix time sources and wrong checks in tests (#686 <https://github.com/ros-controls/ros2_controllers/issues/686>)
* Increase action tests timeout (#680 <https://github.com/ros-controls/ros2_controllers/issues/680>)
* [JTC] Extend tests (#612 <https://github.com/ros-controls/ros2_controllers/issues/612>)
* [JTC] Command final waypoint identically when traj_point_active_ptr_ is nullptr (#682 <https://github.com/ros-controls/ros2_controllers/issues/682>)
* Contributors: Christoph Fröhlich, Ethan Gordon, Lars Tingelstad, gwalck, Bence Magyar
```

## position_controllers

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

- No changes

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
