### PR TITLE
ros2cli: 0.18.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5701,7 +5701,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.18.6-2
+      version: 0.18.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.18.7-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.18.6-2`

## ros2action

- No changes

## ros2cli

```
* Set automatically_declare_parameters_from_overrides in DirectNode. (#813 <https://github.com/ros2/ros2cli/issues/813>) (#815 <https://github.com/ros2/ros2cli/issues/815>)
* Contributors: mergify[bot]
```

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

- No changes

## ros2interface

- No changes

## ros2lifecycle

- No changes

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

- No changes

## ros2param

```
* Update ros2 param dump dosctring. (#837 <https://github.com/ros2/ros2cli/issues/837>) (#840 <https://github.com/ros2/ros2cli/issues/840>)
* Contributors: mergify[bot]
```

## ros2pkg

```
* resolve #790 <https://github.com/ros2/ros2cli/issues/790> (#801 <https://github.com/ros2/ros2cli/issues/801>) (#832 <https://github.com/ros2/ros2cli/issues/832>)
* Contributors: mergify[bot]
```

## ros2run

- No changes

## ros2service

- No changes

## ros2topic

- No changes
