### PR TITLE
rosbag2: 0.15.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5897,7 +5897,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.15.6-1
+      version: 0.15.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.15.7-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.15.6-1`

## mcap_vendor

- No changes

## ros2bag

```
* [humble] When using sim time, wait for /clock before beginning recording (backport #1378 <https://github.com/ros2/rosbag2/issues/1378>) (#1392 <https://github.com/ros2/rosbag2/issues/1392>)
* Contributors: Michael Orlov, mergify[bot]
```

## rosbag2

- No changes

## rosbag2_compression

- No changes

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Rewrite TimeControllerClockTest.unpaused_sleep_returns_true to be correct (backport #1384 <https://github.com/ros2/rosbag2/issues/1384>) (#1390 <https://github.com/ros2/rosbag2/issues/1390>)
* Contributors: Bernat, Michael Orlov, mergify[bot]
```

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_py

```
* [humble] Gracefully handle SIGINT and SIGTERM in rosbag2 recorder (backport #1301 <https://github.com/ros2/rosbag2/issues/1301>) (#1395 <https://github.com/ros2/rosbag2/issues/1395>)
* Contributors: Michael Orlov, mergify[bot]
```

## rosbag2_storage

```
* Fix missing cstdint include (#1383 <https://github.com/ros2/rosbag2/issues/1383>) (#1386 <https://github.com/ros2/rosbag2/issues/1386>)
* Contributors: Michael Orlov, mergify[bot]
```

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

```
* [humble] Don't crash when type definition cannot be found, and find srv defs if available (#1398 <https://github.com/ros2/rosbag2/issues/1398>)
* [humble] Add ROS_DISTRO metadata record to mcap file when opening for writing (backport #1371 <https://github.com/ros2/rosbag2/issues/1371>) (#1393 <https://github.com/ros2/rosbag2/issues/1393>)
* Contributors: Emerson Knapp, Michael Orlov, mergify[bot]
```

## rosbag2_storage_mcap_testdata

```
* [humble] Don't crash when type definition cannot be found, and find srv defs if available (#1398 <https://github.com/ros2/rosbag2/issues/1398>)
* Contributors: Emerson Knapp, Michael Orlov
```

## rosbag2_test_common

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

```
* [humble] Fix for possible freeze in Recorder::stop() (backport #1381 <https://github.com/ros2/rosbag2/issues/1381>) (#1388 <https://github.com/ros2/rosbag2/issues/1388>)
* [humble] Fix for rosbag2_transport::Recorder failures due to the unhandled exceptions (backport #1382 <https://github.com/ros2/rosbag2/issues/1382>) (#1403 <https://github.com/ros2/rosbag2/issues/1403>)
* [humble] When using sim time, wait for /clock before beginning recording (backport #1378 <https://github.com/ros2/rosbag2/issues/1378>) (#1392 <https://github.com/ros2/rosbag2/issues/1392>)
* Add recorder stop() API (backport #1300 <https://github.com/ros2/rosbag2/issues/1300>) (#1396 <https://github.com/ros2/rosbag2/issues/1396>)
* Contributors: Michael Orlov, mergify[bot], zeal-up
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
