### PR TITLE
Add msgsl for alpine

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4122,6 +4122,7 @@ libmpich2-dev:
   nixos: [mpich]
   ubuntu: [libmpich2-dev]
 libmsgsl-dev:
+  alpine: [msgsl]
   arch: [microsoft-gsl]
   debian: [libmsgsl-dev]
   fedora: [guidelines-support-library-devel]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

Microsoft GSL

## Package Upstream Source:

[microsoft/GSL](https://github.com/microsoft/GSL)

## Purpose of using this:

This is an existing key, I want it available on alpine. 

## Links to Distribution Packages

- Alpine: https://pkgs.alpinelinux.org/package/edge/community/x86/msgsl
  - IF AVAILABLE



# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
 
 Note: This work was done on behalf of[ AeroVironment Inc.](https://www.avinc.com/)
