### PR TITLE
depthimage_to_laserscan: 2.5.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -929,7 +929,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/depthimage_to_laserscan-release.git
-      version: 2.5.0-4
+      version: 2.5.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthimage_to_laserscan` to `2.5.1-1`:

- upstream repository: https://github.com/ros-perception/depthimage_to_laserscan.git
- release repository: https://github.com/ros2-gbp/depthimage_to_laserscan-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.5.0-4`

## depthimage_to_laserscan

```
* fix node name (#71 <https://github.com/ros-perception/depthimage_to_laserscan/issues/71>)
* Update the code to use a non-deprecated header. (#72 <https://github.com/ros-perception/depthimage_to_laserscan/issues/72>)
* Fix the style throughout the codebase to conform to ROS 2 style. (#63 <https://github.com/ros-perception/depthimage_to_laserscan/issues/63>)
* Contributors: Chris Lalancette, Josef
```
