### PR TITLE
pal_statistics: 2.1.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3309,6 +3309,24 @@ repositories:
       url: https://github.com/OUXT-Polaris/ouxt_common.git
       version: master
     status: developed
+  pal_statistics:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pal_statistics.git
+      version: humble-devel
+    release:
+      packages:
+      - pal_statistics
+      - pal_statistics_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/pal-gbp/pal_statistics-release.git
+      version: 2.1.5-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pal_statistics.git
+      version: humble-devel
+    status: maintained
   pcl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_statistics` to `2.1.5-1`:

- upstream repository: https://github.com/pal-robotics/pal_statistics.git
- release repository: https://github.com/pal-gbp/pal_statistics-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## pal_statistics

```
* miscellaneous enhancements
* refactor gtest_pal_statistics to test also lifecycle nodes
* add support for lifecycle nodes
* add namespace for StaticCircularBuffer
* Contributors: Noel Jimenez
```

## pal_statistics_msgs

```
* miscellaneous enhancements
* Contributors: Noel Jimenez
```
