### PR TITLE
pal_statistics: 1.5.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7052,6 +7052,25 @@ repositories:
       url: https://github.com/eclipse/paho.mqtt.cpp.git
       version: master
     status: maintained
+  pal_statistics:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pal_statistics.git
+      version: kinetic-devel
+    release:
+      packages:
+      - pal_carbon_collector
+      - pal_statistics
+      - pal_statistics_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/pal-gbp/pal_statistics-release.git
+      version: 1.5.1-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pal_statistics.git
+      version: kinetic-devel
+    status: maintained
   panda_moveit_config:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_statistics` to `1.5.1-1`:

- upstream repository: https://github.com/pal-robotics/pal_statistics.git
- release repository: https://github.com/pal-gbp/pal_statistics-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## pal_carbon_collector

- No changes

## pal_statistics

```
* drop c++11 compiler flag
  broke on newer systems as log4cxx requires c++17 for quite some time now.
* Contributors: v4hn
```

## pal_statistics_msgs

- No changes
