### PR TITLE
Unrelease flexbe_app from Noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2858,11 +2858,6 @@ repositories:
       version: noetic
     status: developed
   flexbe_app:
-    release:
-      tags:
-        release: release/noetic/{package}/{version}
-      url: https://github.com/flexbe/flexbe_app-release.git
-      version: 2.4.1-1
     source:
       type: git
       url: https://github.com/flexbe/flexbe_app.git


### PR DESCRIPTION
It is failing to build on all platforms, and has never succeeded in building.

Upstream issue: https://github.com/FlexBE/flexbe_app/issues/90

* https://build.ros.org/job/Nbin_uF64__flexbe_app__ubuntu_focal_amd64__binary/
* https://build.ros.org/job/Nbin_ufhf_uFhf__flexbe_app__ubuntu_focal_armhf__binary/
* https://build.ros.org/job/Nbin_ufv8_uFv8__flexbe_app__ubuntu_focal_arm64__binary/

@dcconner FYI