### PR TITLE
Unrelease google_chat_ros from Noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4269,7 +4269,6 @@ repositories:
       - ff
       - ffha
       - gdrive_ros
-      - google_chat_ros
       - google_cloud_texttospeech
       - influxdb_store
       - jsk_3rdparty


### PR DESCRIPTION
It's failing on all platforms, and has never succeeded to build.

Upstream issue: https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/482

@k-okada FYI