### PR TITLE
Unrelease moveit_calibration_gui from Noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5754,13 +5754,6 @@ repositories:
       type: git
       url: https://github.com/ros-planning/moveit_calibration.git
       version: master
-    release:
-      packages:
-      - moveit_calibration_gui
-      tags:
-        release: release/noetic/{package}/{version}
-      url: https://github.com/JStech/moveit_calibration-release.git
-      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_calibration.git


### PR DESCRIPTION
It's failing to build on all platforms, and has never succeeded.

* https://build.ros.org/job/Nbin_uF64__moveit_calibration_gui__ubuntu_focal_amd64__binary/198/console
* https://build.ros.org/job/Nbin_ufhf_uFhf__moveit_calibration_gui__ubuntu_focal_armhf__binary/
* https://build.ros.org/job/Nbin_ufv8_uFv8__moveit_calibration_gui__ubuntu_focal_arm64__binary/

Upstream issue: https://github.com/ros-planning/moveit_calibration/issues/135

@Abishalini FYI
