### PR TITLE
Set ros_tutorials release tags path to use distribution name on humble iron

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5860,7 +5860,7 @@ repositories:
       packages:
       - turtlesim
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_tutorials-release.git
       version: 1.4.2-1
     source:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5198,7 +5198,7 @@ repositories:
       packages:
       - turtlesim
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros_tutorials-release.git
       version: 1.6.1-1
     source:


### PR DESCRIPTION
Revises release tags for `turtlesim` package in `ros_tutorials` key for `humble` and `iron` to use their distribution names in the tag path (instead of rolling). Needed so that the release tags are resolved to tags that exist in the [ros_tutorials-release repository](https://github.com/ros2-gbp/ros_tutorials-release).  Fixes #38036

Note: I am not a maintainer of the package referenced above.