### PR TITLE
rplidar_ros: 2.1.3-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6128,11 +6128,15 @@ repositories:
       version: master
     status: maintained
   rplidar_ros:
+    doc:
+      type: git
+      url: https://github.com/Slamtec/rplidar_ros.git
+      version: ros2
     release:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rplidar_ros-release.git
-      version: 2.1.0-1
+      version: 2.1.3-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rplidar_ros` to `2.1.3-2`:

- upstream repository: https://github.com/Slamtec/rplidar_ros
- release repository: https://github.com/ros2-gbp/rplidar_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.0-1`

## rplidar_ros

```
* Rename SLLidar* to RPLidar* in rplidar_node.cpp
* Renaming variable m_running to is_scanning
* Update README
* Use rplidar_ros.rviz instead of rplidar.rviz
* Update source files in src directory:
  Use the source files developed by Slamtec instead of the old ones, and add the functionality of the old code.
* Modify and add launch files
* Update rplidar-sdk to 2.0.0
* Update create_udev_rules.sh
* Update description in package.xml
* Update maintainer to Wang DeYou
* Contributors: Wang DeYou
```
