### PR TITLE
pal_navigation_cfg_public: 3.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3943,7 +3943,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_navigation_cfg_public-release.git
-      version: 3.0.4-1
+      version: 3.0.5-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_navigation_cfg_public.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_navigation_cfg_public` to `3.0.5-1`:

- upstream repository: https://github.com/pal-robotics/pal_navigation_cfg_public.git
- release repository: https://github.com/pal-gbp/pal_navigation_cfg_public-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.4-1`

## pal_navigation_cfg

- No changes

## pal_navigation_cfg_bringup

```
* Fix license
* Remove pal flags dependency
* compatibility with monitor
* Contributors: Noel Jimenez, antoniobrandi
```

## pal_navigation_cfg_params

```
* Remove pal flags dependency
* compatibility with monitor
* Contributors: Noel Jimenez, antoniobrandi
```
