### PR TITLE
Removed ros2_gz_control_tests package from gz_ros2_control

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1779,7 +1779,6 @@ repositories:
       packages:
       - gz_ros2_control
       - gz_ros2_control_demos
-      - gz_ros2_control_tests
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros-controls/gz_ros2_control.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1738,7 +1738,6 @@ repositories:
       packages:
       - gz_ros2_control
       - gz_ros2_control_demos
-      - gz_ros2_control_tests
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git


### PR DESCRIPTION
[Failing in CI](https://build.ros2.org/job/Rbin_ujv8_uJv8__gz_ros2_control_tests__ubuntu_jammy_arm64__binary/2/) but we don't need to release this package. 