### PR TITLE
Added Draco to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3096,9 +3096,8 @@ libdraco:
     '*': null
     '9': [draco-devel]
   ubuntu:
-    '*': null
-    jammy: [libdraco-dev]
-    kinetic: [libdraco-dev]
+    '*': [libdraco-dev]
+    focal: null
 libdrm-dev:
   arch: [libdrm]
   debian: [libdrm-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -854,7 +854,7 @@ libdraco:
   arch: [draco]
   rhel:
     '*': null
-    '9': [draco]
+    '9': [draco-devel]
 dvipng:
   arch: [texlive-bin]
   debian: [dvipng]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -844,12 +844,15 @@ dpkg-dev:
   fedora: [dpkg-dev]
   nixos: [dpkg]
   ubuntu: [dpkg-dev]
-draco:
+libdraco:
   debian: [libdraco-dev]
   fedora: [draco-devel]
   ubuntu:
+    '*': null
     kinetic: [libdraco-dev]
     jammy: [libdraco-dev]
+  arch: [draco]
+  rhel: [draco]
 dvipng:
   arch: [texlive-bin]
   debian: [dvipng]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3092,13 +3092,13 @@ libdraco:
   arch: [draco]
   debian: [libdraco-dev]
   fedora: [draco-devel]
+  rhel:
+    '*': null
+    '9': [draco-devel]
   ubuntu:
     '*': null
     jammy: [libdraco-dev]
     kinetic: [libdraco-dev]
-  rhel:
-    '*': null
-    '9': [draco-devel]
 libdrm-dev:
   arch: [libdrm]
   debian: [libdrm-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -852,7 +852,9 @@ libdraco:
     kinetic: [libdraco-dev]
     jammy: [libdraco-dev]
   arch: [draco]
-  rhel: [draco]
+  rhel:
+    '*': null
+    '9': [draco]
 dvipng:
   arch: [texlive-bin]
   debian: [dvipng]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -847,7 +847,9 @@ dpkg-dev:
 draco:
   debian: [libdraco-dev]
   fedora: [draco-devel]
-  ubuntu: [libdraco-dev]
+  ubuntu:
+    kinetic: [libdraco-dev]
+    jammy: [libdraco-dev]
 dvipng:
   arch: [texlive-bin]
   debian: [dvipng]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -844,6 +844,10 @@ dpkg-dev:
   fedora: [dpkg-dev]
   nixos: [dpkg]
   ubuntu: [dpkg-dev]
+draco:
+  debian: [libdraco-dev]
+  fedora: [draco-devel]
+  ubuntu: [libdraco-dev]
 dvipng:
   arch: [texlive-bin]
   debian: [dvipng]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3088,7 +3088,7 @@ libdpkg-dev:
   nixos: [dpkg]
   rhel: [dpkg-devel]
   ubuntu: [libdpkg-dev]
-libdraco:
+libdraco-dev:
   arch: [draco]
   debian: [libdraco-dev]
   fedora: [draco-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -844,17 +844,6 @@ dpkg-dev:
   fedora: [dpkg-dev]
   nixos: [dpkg]
   ubuntu: [dpkg-dev]
-libdraco:
-  debian: [libdraco-dev]
-  fedora: [draco-devel]
-  ubuntu:
-    '*': null
-    kinetic: [libdraco-dev]
-    jammy: [libdraco-dev]
-  arch: [draco]
-  rhel:
-    '*': null
-    '9': [draco-devel]
 dvipng:
   arch: [texlive-bin]
   debian: [dvipng]
@@ -3099,6 +3088,17 @@ libdpkg-dev:
   nixos: [dpkg]
   rhel: [dpkg-devel]
   ubuntu: [libdpkg-dev]
+libdraco:
+  arch: [draco]
+  debian: [libdraco-dev]
+  fedora: [draco-devel]
+  ubuntu:
+    '*': null
+    jammy: [libdraco-dev]
+    kinetic: [libdraco-dev]
+  rhel:
+    '*': null
+    '9': [draco-devel]
 libdrm-dev:
   arch: [libdrm]
   debian: [libdrm-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3093,8 +3093,8 @@ libdraco:
   debian: [libdraco-dev]
   fedora: [draco-devel]
   rhel:
-    '*': null
-    '9': [draco-devel]
+    '*': [draco-devel]
+    '8': null
   ubuntu:
     '*': [libdraco-dev]
     focal: null


### PR DESCRIPTION
As part of the effort to port `point_cloud_transport` https://github.com/john-maidbot/point_cloud_transport/pull/1 from ROS to ROS 2, we want to include [draco](https://github.com/google/draco) as a dependency. It has binaries for some platforms