### PR TITLE
ros2_kortex: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4772,6 +4772,18 @@ repositories:
       type: git
       url: https://github.com/PickNikRobotics/ros2_kortex.git
       version: main
+    release:
+      packages:
+      - kinova_gen3_6dof_robotiq_2f_85_moveit_config
+      - kinova_gen3_7dof_robotiq_2f_85_moveit_config
+      - kortex_api
+      - kortex_bringup
+      - kortex_description
+      - kortex_driver
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_kortex-release.git
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/ros2_kortex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_kortex` to `0.2.0-1`:

- upstream repository: https://github.com/PickNikRobotics/ros2_kortex.git
- release repository: https://github.com/ros2-gbp/ros2_kortex-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## kinova_gen3_6dof_robotiq_2f_85_moveit_config

```
* Initial Public ROS 2 release of kinova_gen3_6dof_robotiq_2f_85_moveit_config
* Make Gripper velocity and force configurable through URDF (#137 <https://github.com/PickNikRobotics/ros2_kortex/issues/137>)
* Fault and Twist controller from new repo (#143 <https://github.com/PickNikRobotics/ros2_kortex/issues/143>)
* Update sim.launch.py (#138 <https://github.com/PickNikRobotics/ros2_kortex/issues/138>)
* add parameter to use sim time to move_group launch (#134 <https://github.com/PickNikRobotics/ros2_kortex/issues/134>)
* Add moveit config for 6dof gen 3 (#109 <https://github.com/PickNikRobotics/ros2_kortex/issues/109>)
* Contributors: Alex Moriarty, Anthony Baker
```

## kinova_gen3_7dof_robotiq_2f_85_moveit_config

```
* Initial Public ROS 2 release of kinova_gen3_7dof_robotiq_2f_85_moveit_config
* Make Gripper velocity and force configurable through URDF (#137 <https://github.com/PickNikRobotics/ros2_kortex/issues/137>)
* Fault and Twist controller from new repo (#143 <https://github.com/PickNikRobotics/ros2_kortex/issues/143>)
* Add camera to 7dof gen3 ignition sim (#141 <https://github.com/PickNikRobotics/ros2_kortex/issues/141>)
* add parameter to use sim time to move_group launch (#134 <https://github.com/PickNikRobotics/ros2_kortex/issues/134>)
* Add MoveIt Config for 7dof arm with robotiq_2f_85 gripper (#107 <https://github.com/PickNikRobotics/ros2_kortex/issues/107>)
* Contributors: Alex Moriarty, Anthony Baker
```

## kortex_api

```
* Initial Public ROS 2 Release of kortex_api
* [kortex_api] use CMake FetchContent to get API (#112 <https://github.com/PickNikRobotics/ros2_kortex/issues/112>)
  * Currently only Linux x86_64 is supported
* Contributors: Alex Moriarty
```

## kortex_bringup

```
* Initial Public ROS 2 release of kortex_bringup
* Make Gripper velocity and force configurable through URDF (#137 <https://github.com/PickNikRobotics/ros2_kortex/issues/137>)
* Fix License -> BSD and update maintainers (#146 <https://github.com/PickNikRobotics/ros2_kortex/issues/146>)
* Contributors: Alex Moriarty, Anthony Baker
```

## kortex_description

```
* Initial Public ROS 2 release of kortex_description
* Make Gripper velocity and force configurable through URDF (#137 <https://github.com/PickNikRobotics/ros2_kortex/issues/137>)
* rename kortex2 -> kortex (#144 <https://github.com/PickNikRobotics/ros2_kortex/issues/144>)
* Fault and Twist controller from new repo (#143 <https://github.com/PickNikRobotics/ros2_kortex/issues/143>)
* Add camera to 7dof gen3 ignition sim (#141 <https://github.com/PickNikRobotics/ros2_kortex/issues/141>)
* Remove circular dependency between Description and bringup package (#123 <https://github.com/PickNikRobotics/ros2_kortex/issues/123>)
* Add moveit config for 6dof gen 3 (#109 <https://github.com/PickNikRobotics/ros2_kortex/issues/109>)
* Add MoveIt Config for 7dof arm with robotiq_2f_85 gripper (#107 <https://github.com/PickNikRobotics/ros2_kortex/issues/107>)
* Convert package to use robotiq_description and update xacros (#95 <https://github.com/PickNikRobotics/ros2_kortex/issues/95>)
  * add sim_isaac arg to gen3.xacro
* Update gen3 URDF mesh path (#79 <https://github.com/PickNikRobotics/ros2_kortex/issues/79>)
* Support Gen3 lite Hardware (#73 <https://github.com/PickNikRobotics/ros2_kortex/issues/73>)
  * Improve Protective Stop Reset and General Driver Robusteness (#75 <https://github.com/PickNikRobotics/ros2_kortex/issues/75>)
* Add support for ros2_control of the kinova gen3 lite (#72 <https://github.com/PickNikRobotics/ros2_kortex/issues/72>)
* Revert joint2 limit to factory values (#70 <https://github.com/PickNikRobotics/ros2_kortex/issues/70>)
* Kortex fixes for simulations (#64 <https://github.com/PickNikRobotics/ros2_kortex/issues/64>)
* Gripper controller adaptation (#66 <https://github.com/PickNikRobotics/ros2_kortex/issues/66>)
* Remove ros1 files (#62 <https://github.com/PickNikRobotics/ros2_kortex/issues/62>)
* Add conditional finger joint import. (#57 <https://github.com/PickNikRobotics/ros2_kortex/issues/57>)
* Add default params for easier use in simulation. (#56 <https://github.com/PickNikRobotics/ros2_kortex/issues/56>)
* Changes after debugging on real hardware (#51 <https://github.com/PickNikRobotics/ros2_kortex/issues/51>)
* Additional parametrization (#47 <https://github.com/PickNikRobotics/ros2_kortex/issues/47>)
* Use gripper through internal bus extension (#38 <https://github.com/PickNikRobotics/ros2_kortex/issues/38>)
* Contributors: Alex Moriarty, Anthony Baker, Denis Štogl, Marq Rasmussen, livanov93
```

## kortex_driver

```
* Initial Public ROS 2 release of kortex_driver
* cxx: fixup compiler warnings (#148 <https://github.com/PickNikRobotics/ros2_kortex/issues/148>)
* Make Gripper velocity and force configurable through URDF (#137 <https://github.com/PickNikRobotics/ros2_kortex/issues/137>)
* Fix License -> BSD and update maintainers (#146 <https://github.com/PickNikRobotics/ros2_kortex/issues/146>)
* Contributors: Alex Moriarty, Anthony Baker, Denis Štogl
```
