### PR TITLE
picknik_controllers: 0.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4144,7 +4144,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/picknik_controllers-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/picknik_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `picknik_controllers` to `0.0.3-1`:

- upstream repository: https://github.com/PickNikRobotics/picknik_controllers.git
- release repository: https://github.com/ros2-gbp/picknik_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.2-1`

## picknik_reset_fault_controller

- No changes

## picknik_twist_controller

```
* Use Twist not TwistStamped (#11 <https://github.com/PickNikRobotics/picknik_controllers/issues/11>)
* Contributors: Alex Moriarty
```
