### PR TITLE
clearpath_simulator: 0.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -891,7 +891,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_simulator-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_simulator` to `0.0.3-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_simulator.git
- release repository: https://github.com/clearpath-gbp/clearpath_simulator-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.2-1`

## clearpath_generator_gz

```
* Linting
* Added prefix launch arg for A200
* Updated param generator 'use_sim_time' implementation
* Launch generator cleanup
* Contributors: Roni Kreinin
```

## clearpath_gz

```
* Linting
* Contributors: Roni Kreinin
```

## clearpath_simulator

```
* Linting
* Contributors: Roni Kreinin
```
