### PR TITLE
added ccid distro packages to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -465,6 +465,13 @@ cccc:
   gentoo: [dev-util/cccc]
   nixos: [cccc]
   ubuntu: [cccc]
+ccid: 
+  alpine: [ccid]
+  debian: [libccid]
+  fedora: [pcsc-lite-ccid]
+  gentoo: [app-crypt/ccid]
+  nixos: [ccid]
+  ubuntu: [libccid]
 cdk:
   debian: [libcdk5]
   fedora: [cdk]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -465,12 +465,14 @@ cccc:
   gentoo: [dev-util/cccc]
   nixos: [cccc]
   ubuntu: [cccc]
-ccid:
+libccid:
   alpine: [ccid]
+  arch: [ccid]
   debian: [libccid]
   fedora: [pcsc-lite-ccid]
   gentoo: [app-crypt/ccid]
   nixos: [ccid]
+  rhel: [pcsc-lite-ccid]
   ubuntu: [libccid]
 cdk:
   debian: [libcdk5]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -465,7 +465,7 @@ cccc:
   gentoo: [dev-util/cccc]
   nixos: [cccc]
   ubuntu: [cccc]
-ccid: 
+ccid:
   alpine: [ccid]
   debian: [libccid]
   fedora: [pcsc-lite-ccid]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -465,15 +465,6 @@ cccc:
   gentoo: [dev-util/cccc]
   nixos: [cccc]
   ubuntu: [cccc]
-libccid:
-  alpine: [ccid]
-  arch: [ccid]
-  debian: [libccid]
-  fedora: [pcsc-lite-ccid]
-  gentoo: [app-crypt/ccid]
-  nixos: [ccid]
-  rhel: [pcsc-lite-ccid]
-  ubuntu: [libccid]
 cdk:
   debian: [libcdk5]
   fedora: [cdk]
@@ -2906,6 +2897,15 @@ libccd-dev:
   openembedded: [libccd@meta-ros-common]
   rhel: [libccd-devel]
   ubuntu: [libccd-dev]
+libccid:
+  alpine: [ccid]
+  arch: [ccid]
+  debian: [libccid]
+  fedora: [pcsc-lite-ccid]
+  gentoo: [app-crypt/ccid]
+  nixos: [ccid]
+  rhel: [pcsc-lite-ccid]
+  ubuntu: [libccid]
 libcdd-dev:
   arch: [cddlib]
   debian: [libcdd-dev]


### PR DESCRIPTION
Package name:
"ccid"

Package Upstream Source:
https://ccid.apdu.fr/

Purpose of using this:
CCID is required to use smartcard readers with pcsc packages.

Distro packaging links:

Links to Distribution Packages
Debian: [](https://packages.debian.org/)
https://packages.debian.org/ja/source/sid/ccid
Ubuntu: https://packages.ubuntu.com/
https://packages.ubuntu.com/focal/libccid
Fedora: https://packages.fedoraproject.org/
https://src.fedoraproject.org/rpms/pcsc-lite-ccid
Arch: https://www.archlinux.org/packages/
https://archlinux.org/packages/extra/x86_64/ccid/
Gentoo: https://packages.gentoo.org/
https://packages.gentoo.org/packages/app-crypt/ccid
macOS: https://formulae.brew.sh/
not available
Alpine: https://pkgs.alpinelinux.org/packages
https://pkgs.alpinelinux.org/package/edge/community/x86/ccid
NixOS/nixpkgs: https://search.nixos.org/packages
https://search.nixos.org/packages?channel=23.05&show=ccid&from=0&size=50&sort=relevance&type=packages&query=ccid)
openSUSE: https://software.opensuse.org/package/
https://software.opensuse.org/package/pcsc-ccid
Please Add This Package to be indexed in the rosdistro.
ROSDISTRO NAME

The source is here:
http://sourcecode_url

Checks
 All packages have a declared license in the package.xml
 This repository has a LICENSE file
 This package is expected to build on the submitted rosdistro