### PR TITLE
microstrain_inertial: 3.1.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2681,7 +2681,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/microstrain_inertial-release.git
-      version: 3.0.1-3
+      version: 3.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `3.1.0-1`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/ros2-gbp/microstrain_inertial-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.1-3`

## microstrain_inertial_driver

```
* Adds several PRs from submodule (#263 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/263>)
* Updates submodule to fix TF warning (#262 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/262>)
* ROS Turns on antenna calibration by default, and publishes the amount corrected by (#237 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/237>)
* Feature/ros relative position base station (#235 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/235>)
* Contributors: Rob
```

## microstrain_inertial_examples

- No changes

## microstrain_inertial_msgs

```
* ROS Turns on antenna calibration by default, and publishes the amount corrected by (#237 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/237>)
  * Turns on antenna calibration by default, and publishes the amount corrected by
  * Updates submodules to main
* Contributors: Rob
```

## microstrain_inertial_rqt

```
* Installs the rqt utils package (#239 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/239>)
* Contributors: Rob
```
