### PR TITLE
qb_device: 3.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8058,7 +8058,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
-      version: 3.0.5-1
+      version: 3.1.0-1
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbdevice-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_device` to `3.1.0-1`:

- upstream repository: https://bitbucket.org/qbrobotics/qbdevice-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.0.5-1`

## qb_device

- No changes

## qb_device_bringup

- No changes

## qb_device_control

- No changes

## qb_device_description

- No changes

## qb_device_driver

```
* Updated Submodule
* FIX: submodules updated and current/deflection control mode check
* FIX: Conflict with ros-serial
* Tested code with modification and new API
```

## qb_device_gazebo

- No changes

## qb_device_hardware_interface

- No changes

## qb_device_msgs

- No changes

## qb_device_srvs

- No changes

## qb_device_utils

- No changes
