### PR TITLE
qb_move: 3.0.3-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8092,13 +8092,15 @@ repositories:
       version: production-noetic
     release:
       packages:
+      - qb_move
       - qb_move_control
       - qb_move_description
       - qb_move_gazebo
+      - qb_move_hardware_interface
       tags:
         release: release/noetic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbmove-ros-release.git
-      version: 2.2.2-1
+      version: 3.0.3-2
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbmove-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_move` to `3.0.3-2`:

- upstream repository: https://bitbucket.org/qbrobotics/qbmove-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbmove-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.2-1`

## qb_move

- No changes

## qb_move_control

- No changes

## qb_move_description

- No changes

## qb_move_gazebo

- No changes

## qb_move_hardware_interface

```
* FIX: deflection joint always updated even when its controller is not running.
```
