### PR TITLE
ros2_kortex: 0.2.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4927,7 +4927,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_kortex-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/ros2_kortex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_kortex` to `0.2.1-1`:

- upstream repository: https://github.com/PickNikRobotics/ros2_kortex.git
- release repository: https://github.com/ros2-gbp/ros2_kortex-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.0-1`

## kinova_gen3_6dof_robotiq_2f_85_moveit_config

- No changes

## kinova_gen3_7dof_robotiq_2f_85_moveit_config

```
* remove stomp for Humble from ros packages (#153 <https://github.com/PickNikRobotics/ros2_kortex/issues/153>)
  - STOMP is available if you build and use MoveIt from src but not
  if you have MoveIt installed from the ros distro
* Contributors: Alex Moriarty
```

## kortex_api

```
* Change kortex_api header and library install locations (#156 <https://github.com/PickNikRobotics/ros2_kortex/issues/156>)
  This commit does several two main things:
  1) kortex_api now only installs the header files and they now do not pollute include
  2) kortex_driver gets the binary libKortexApiCpp.a itself
  kortex_driver gets the headers from kortex_api this avoids protobuf errors because
  those header files and the libKortexApiCpp.a were generated using non-system protobuf
  kortex_api cannot install the libKortexApiCpp.a because CMake does not allow installing library which was IMPORTED
  This should fix the debian packages which are currently released
* Contributors: Alex Moriarty
```

## kortex_bringup

```
* fix missing dependencies (#152 <https://github.com/PickNikRobotics/ros2_kortex/issues/152>)
  This fixes missing dependencies which were available from source build
  but were missing from released binary
* Contributors: Alex Moriarty
```

## kortex_description

```
* fix missing dependencies (#152 <https://github.com/PickNikRobotics/ros2_kortex/issues/152>)
  This fixes missing dependencies which were available from source build
  but were missing from released binary
* Contributors: Alex Moriarty
```

## kortex_driver

```
* Change kortex_api header and library install locations (#156 <https://github.com/PickNikRobotics/ros2_kortex/issues/156>)
  This commit does several two main things:
  1) kortex_api now only installs the header files and they now do not pollute include
  2) kortex_driver gets the binary libKortexApiCpp.a itself
  kortex_driver gets the headers from kortex_api this avoids protobuf errors because
  those header files and the libKortexApiCpp.a were generated using non-system protobuf
  kortex_api cannot install the libKortexApiCpp.a because CMake does not allow installing library which was IMPORTED
  This should fix the debian packages which are currently released
* fix missing dependencies (#152 <https://github.com/PickNikRobotics/ros2_kortex/issues/152>)
  This fixes missing dependencies which were available from source build
  but were missing from released binary
* Contributors: Alex Moriarty
```
