### PR TITLE
rviz: 12.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5883,7 +5883,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 12.7.0-1
+      version: 12.8.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `12.8.0-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `12.7.0-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Remove warning in depth_cloud_mld.cpp (#1021 <https://github.com/ros2/rviz/issues/1021>)
* Added DepthCloud default plugin (#996 <https://github.com/ros2/rviz/issues/996>)
* Stop inheriting from std::iterator. (#1013 <https://github.com/ros2/rviz/issues/1013>)
  In C++17, inheriting from std::iterator has been
  deprecated: https://www.fluentcpp.com/2018/05/08/std-iterator-deprecated/
  Here, switch away from inheriting and just define the
  interface ourselves (which is the current recommended best practice).
  This removes some warnings when building with gcc 13.1.1
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```

## rviz_default_plugins

```
* Don't pass screw_display.hpp to the moc generator. (#1018 <https://github.com/ros2/rviz/issues/1018>)
  Since it isn't a Qt class, you get a warning from moc:
  Note: No relevant classes found. No output generated.
  Just skip adding it to the moc list here, which gets rid
  of the warning.
* Added DepthCloud default plugin (#996 <https://github.com/ros2/rviz/issues/996>)
* Added TwistStamped and AccelStamped default plugins (#991 <https://github.com/ros2/rviz/issues/991>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Added TwistStamped and AccelStamped default plugins (#991 <https://github.com/ros2/rviz/issues/991>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
