### PR TITLE
rviz: 12.4.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6017,7 +6017,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 12.4.1-1
+      version: 12.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `12.4.2-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `12.4.1-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Remove warning in depth_cloud_mld.cpp (#1021 <https://github.com/ros2/rviz/issues/1021>)
  (cherry picked from commit 092e3efef2f907549976ffd101e5ad8100cbea3f)
* Added DepthCloud default plugin (#996 <https://github.com/ros2/rviz/issues/996>)
  (cherry picked from commit 8f2e17e441399974ebd465a2d2ef0a3529f57f23)
* Contributors: Alejandro Hernández Cordero
```

## rviz_default_plugins

```
* Don't pass screw_display.hpp to the moc generator. (#1018 <https://github.com/ros2/rviz/issues/1018>)
  Since it isn't a Qt class, you get a warning from moc:
  Note: No relevant classes found. No output generated.
  Just skip adding it to the moc list here, which gets rid
  of the warning.
  (cherry picked from commit 071adba7fca13da7f6ba77c26e2d9cf989308ca2)
* Added DepthCloud default plugin (#996 <https://github.com/ros2/rviz/issues/996>)
  (cherry picked from commit 8f2e17e441399974ebd465a2d2ef0a3529f57f23)
* Added TwistStamped and AccelStamped default plugins (#991 <https://github.com/ros2/rviz/issues/991>) (#1015 <https://github.com/ros2/rviz/issues/1015>)
  (cherry picked from commit 9599dd488d543671121c40df9aec5533064e86fb)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Improve the compilation time of rviz_default_plugins (#1007 <https://github.com/ros2/rviz/issues/1007>) (#1009 <https://github.com/ros2/rviz/issues/1009>)
  * Cleanup rviz_visual_testing_framework CMakeLists.txt
  The main motivation here is to remove an exported absolute
  path from this package.  To do this, mark everything in
  the CMakeLists.txt private that we can.
  This ended up exposing a bunch of missing dependencies
  in rviz_default_plugins, so fix those here as well.
  (cherry picked from commit 5af8896a30311e4b8171864391d3bc2d8b81b611)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Added Effort plugin (#990 <https://github.com/ros2/rviz/issues/990>) (#1011 <https://github.com/ros2/rviz/issues/1011>)
  * Added Effort plugin
  (cherry picked from commit e3b56ed7058502d94fe3d1c27948d4f4e9be58a8)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Added TwistStamped and AccelStamped default plugins (#991 <https://github.com/ros2/rviz/issues/991>) (#1015 <https://github.com/ros2/rviz/issues/1015>)
  (cherry picked from commit 9599dd488d543671121c40df9aec5533064e86fb)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Added Effort plugin (#990 <https://github.com/ros2/rviz/issues/990>) (#1011 <https://github.com/ros2/rviz/issues/1011>)
  * Added Effort plugin
  (cherry picked from commit e3b56ed7058502d94fe3d1c27948d4f4e9be58a8)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Contributors: Alejandro Hernández Cordero
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

```
* Improve the compilation time of rviz_default_plugins (#1007 <https://github.com/ros2/rviz/issues/1007>) (#1009 <https://github.com/ros2/rviz/issues/1009>)
  * Cleanup rviz_visual_testing_frameiwork CMakeLists.txt
  The main motivation here is to remove an exported absolute
  path from this package.  To do this, mark everything in
  the CMakeLists.txt private that we can.
  This ended up exposing a bunch of missing dependencies
  in rviz_default_plugins, so fix those here as well.
  (cherry picked from commit 5af8896a30311e4b8171864391d3bc2d8b81b611)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
```
