### PR TITLE
rviz: 11.2.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6697,7 +6697,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 11.2.6-1
+      version: 11.2.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `11.2.7-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `11.2.6-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Remove warning in depth_cloud_mld.cpp (#1021 <https://github.com/ros2/rviz/issues/1021>)
  (cherry picked from commit 092e3efef2f907549976ffd101e5ad8100cbea3f)
* Added DepthCloud default plugin (#996 <https://github.com/ros2/rviz/issues/996>)
  (cherry picked from commit 8f2e17e441399974ebd465a2d2ef0a3529f57f23)
* Contributors: Alejandro Hernández Cordero
```

## rviz_default_plugins

```
* Don't pass screw_display.hpp to the moc generator. (#1018 <https://github.com/ros2/rviz/issues/1018>)
  Since it isn't a Qt class, you get a warning from moc:
  Note: No relevant classes found. No output generated.
  Just skip adding it to the moc list here, which gets rid
  of the warning.
  (cherry picked from commit 071adba7fca13da7f6ba77c26e2d9cf989308ca2)
* Added DepthCloud default plugin (#996 <https://github.com/ros2/rviz/issues/996>)
  (cherry picked from commit 8f2e17e441399974ebd465a2d2ef0a3529f57f23)
* Added TwistStamped and AccelStamped default plugins (#991 <https://github.com/ros2/rviz/issues/991>) (#1014 <https://github.com/ros2/rviz/issues/1014>)
  (cherry picked from commit 9599dd488d543671121c40df9aec5533064e86fb)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Added TwistStamped and AccelStamped default plugins (#991 <https://github.com/ros2/rviz/issues/991>) (#1014 <https://github.com/ros2/rviz/issues/1014>)
  (cherry picked from commit 9599dd488d543671121c40df9aec5533064e86fb)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Contributors: mergify[bot]
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
