### PR TITLE
Added source entries for boost_plugin_loader on humble and rolling

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -684,6 +684,11 @@ repositories:
       url: https://github.com/OUXT-Polaris/boost_geometry_util.git
       version: master
     status: developed
+  boost_plugin_loader:
+    source:
+      type: git
+      url: https://github.com/tesseract-robotics/boost_plugin_loader.git
+      version: main
   camera_ros:
     release:
       tags:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -628,6 +628,11 @@ repositories:
       url: https://github.com/OUXT-Polaris/boost_geometry_util.git
       version: master
     status: developed
+  boost_plugin_loader:
+    source:
+      type: git
+      url: https://github.com/tesseract-robotics/boost_plugin_loader.git
+      version: main
   cartographer:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

`boost_plugin_loader`

> Note: this package has already been added for `noetic`

# The source is here:

https://github.com/tesseract-robotics/boost_plugin_loader

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
