### PR TITLE
Add catch2 to rosdep rules

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -460,6 +460,15 @@ castxml:
   fedora: [castxml]
   macports: [castxml]
   ubuntu: [castxml]
+catch2:
+  arch: [catch2]
+  debian: [catch2]
+  fedora: [catch2-devel]
+  freebsd: [catch2]
+  gentoo: [catch]
+  nixos: [catch2]
+  opensuse: [Catch2]
+  ubuntu: [catch2]
 cccc:
   debian: [cccc]
   gentoo: [dev-util/cccc]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -463,7 +463,9 @@ castxml:
 catch2:
   arch: [catch2]
   debian: [catch2]
-  fedora: [catch2-devel]
+  fedora:
+    '*': [catch2-devel]
+    '37': null
   freebsd: [catch2]
   gentoo: [catch]
   nixos: [catch2]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -470,7 +470,9 @@ catch2:
   freebsd: [catch2]
   gentoo: [catch]
   nixos: [catch2]
-  ubuntu: [catch2]
+  ubuntu:
+    '*': [catch2]
+    focal: null
 cccc:
   debian: [cccc]
   gentoo: [dev-util/cccc]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -461,6 +461,7 @@ castxml:
   macports: [castxml]
   ubuntu: [castxml]
 catch2:
+  alpine: [catch2]
   arch: [catch2]
   debian: [catch2]
   fedora:
@@ -469,7 +470,6 @@ catch2:
   freebsd: [catch2]
   gentoo: [catch]
   nixos: [catch2]
-  opensuse: [Catch2]
   ubuntu: [catch2]
 cccc:
   debian: [cccc]

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -46,6 +46,10 @@ bzip2:
   osx:
     homebrew:
       packages: []
+catch2:
+  osx:
+    homebrew:
+      packages: [catch2]
 checkinstall:
   osx:
     homebrew:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name: 
catch2
## Package Upstream Source: 
https://github.com/catchorg/Catch2
## Purpose of using this:

Catch2 is an alternative to gtest

Distro packaging links:

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/catch2
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/kinetic/catch2
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/catch2/catch2-devel/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/any/catch2/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-cpp/catch
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/catch2#default
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=23.05&show=catch2&from=0&size=50&sort=relevance&type=packages&query=catch2
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/Catch2

