### PR TITLE
generate_parameter_library: 0.3.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1523,7 +1523,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 0.3.4-1
+      version: 0.3.5-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `generate_parameter_library` to `0.3.5-1`:

- upstream repository: https://github.com/PickNikRobotics/generate_parameter_library.git
- release repository: https://github.com/ros2-gbp/generate_parameter_library-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.4-1`

## generate_parameter_library

- No changes

## generate_parameter_library_example

```
* Remove documentation of deprecated validator functions (#135 <https://github.com/PickNikRobotics/generate_parameter_library/issues/135>)
* Contributors: Tyler Weaver
```

## generate_parameter_library_py

```
* Remove documentation of deprecated validator functions (#135 <https://github.com/PickNikRobotics/generate_parameter_library/issues/135>)
* Contributors: Tyler Weaver
```

## generate_parameter_module_example

```
* add dependency to python example package (#136 <https://github.com/PickNikRobotics/generate_parameter_library/issues/136>)
* Contributors: Paul Gesel
```

## parameter_traits

- No changes
