### PR TITLE
moveit: 1.1.13-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5736,7 +5736,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 1.1.13-1
+      version: 1.1.13-2
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `1.1.13-2`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.13-1`

## chomp_motion_planner

- No changes

## moveit

- No changes

## moveit_chomp_optimizer_adapter

- No changes

## moveit_commander

- No changes

## moveit_core

```
* Avoid global transforms in ``getRigidlyConnectedParentLinkModel()`` (#3470 <https://github.com/ros-planning/moveit/issues/3470>)
  
    * RobotState::setFromIK: ensure up-to-date state before calling IK solver
    * Remove unimplemented RobotState::getSubframeTransformInLinkFrame()
  
* Add missing include (#3451 <https://github.com/ros-planning/moveit/issues/3451>)
* Fix Jacobian calculation for planar joint (#3439 <https://github.com/ros-planning/moveit/issues/3439>)
* Silent "empty quaternion" warning from poseMsgToEigen() (#3435 <https://github.com/ros-planning/moveit/issues/3435>)
* Contributors: Cong Liu, Ivo Vatavuk, Robert Haschke
```

## moveit_fake_controller_manager

- No changes

## moveit_kinematics

```
* Improvements to create_ikfast_moveit_plugin.py (#3449 <https://github.com/ros-planning/moveit/issues/3449>)
  * Make SRDF sanity checks optional
  * Provide hint how to change kinematics.yaml if automatic adaption fails
  * Modernize string formatting to Python 3.x
  * Create new planning group entry in kinematics.yaml if needed
* Contributors: Robert Haschke
```

## moveit_planners

- No changes

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

- No changes

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

- No changes

## moveit_ros_move_group

- No changes

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

- No changes

## moveit_ros_planning

- No changes

## moveit_ros_planning_interface

```
* Add unittest for #3467 <https://github.com/ros-planning/moveit/issues/3467> (#3470 <https://github.com/ros-planning/moveit/issues/3470>)
* Contributors: Robert Haschke
```

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

```
* Avoid costly updates of invisible RobotInteractions on query state changes (#3478 <https://github.com/ros-planning/moveit/issues/3478>)
* Contributors: Robert Haschke
```

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_servo

- No changes

## moveit_setup_assistant

```
* Fix OMPL's TRRT parameter names (#3461 <https://github.com/ros-planning/moveit/issues/3461>)
* Contributors: VideoSystemsTech
```

## moveit_simple_controller_manager

- No changes

## pilz_industrial_motion_planner

- No changes

## pilz_industrial_motion_planner_testutils

- No changes
