### PR TITLE
generate_parameter_library: 0.3.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1523,7 +1523,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 0.3.4-1
+      version: 0.3.6-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `generate_parameter_library` to `0.3.6-1`:

- upstream repository: https://github.com/PickNikRobotics/generate_parameter_library.git
- release repository: https://github.com/ros2-gbp/generate_parameter_library-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.4-1`

## generate_parameter_library

- No changes

## generate_parameter_library_example

- No changes

## generate_parameter_library_py

- No changes

## generate_parameter_module_example

```
* Prevent module import  when running setup.py clean (#137 <https://github.com/PickNikRobotics/generate_parameter_library/issues/137>)
* Contributors: Paul Gesel
```

## parameter_traits

- No changes
