### PR TITLE
laser_filters: 2.0.7-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2234,7 +2234,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/laser_filters-release.git
-      version: 2.0.6-4
+      version: 2.0.7-1
     source:
       type: git
       url: https://github.com/ros-perception/laser_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters` to `2.0.7-1`:

- upstream repository: https://github.com/ros-perception/laser_filters.git
- release repository: https://github.com/ros2-gbp/laser_filters-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.6-4`

## laser_filters

```
* Escape invalid xml in laser_filters_plugins.xml
* Contributors: Calder Phillips-Grafflin
```
