### PR TITLE
crane_plus: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1034,6 +1034,28 @@ repositories:
       url: https://github.com/PickNikRobotics/cpp_polyfills.git
       version: main
     status: maintained
+  crane_plus:
+    doc:
+      type: git
+      url: https://github.com/rt-net/crane_plus.git
+      version: humble-devel
+    release:
+      packages:
+      - crane_plus
+      - crane_plus_control
+      - crane_plus_description
+      - crane_plus_examples
+      - crane_plus_gazebo
+      - crane_plus_moveit_config
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/crane_plus-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/rt-net/crane_plus.git
+      version: humble-devel
+    status: maintained
   create3_sim:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `crane_plus` to `2.0.0-1`:

- upstream repository: https://github.com/rt-net/crane_plus.git
- release repository: https://github.com/ros2-gbp/crane_plus-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## crane_plus

```
* Feature/support humble (#58 <https://github.com/rt-net/crane_plus/issues/58>)
* Contributors: Shota Aoki, YusukeKato
```

## crane_plus_control

```
* Feature/support humble (#58 <https://github.com/rt-net/crane_plus/issues/58>)
* Contributors: Shota Aoki, YusukeKato
```

## crane_plus_description

```
* カメラサンプルのHumble対応 (#64 <https://github.com/rt-net/crane_plus/issues/64>)
* Feature/support humble (#58 <https://github.com/rt-net/crane_plus/issues/58>)
* Contributors: Kuwamai, Shota Aoki, YusukeKato
```

## crane_plus_examples

```
* 軌道生成の失敗時にpick_and_placeを中断する機能を追加 (#65 <https://github.com/rt-net/crane_plus/issues/65>)
* カメラサンプルのHumble対応 (#64 <https://github.com/rt-net/crane_plus/issues/64>)
* Feature/support humble (#58 <https://github.com/rt-net/crane_plus/issues/58>)
* Contributors: Shota Aoki, YusukeKato
```

## crane_plus_gazebo

```
* Gazeboカメラ位置の調整 (#67 <https://github.com/rt-net/crane_plus/issues/67>)
* Feature/support humble (#58 <https://github.com/rt-net/crane_plus/issues/58>)
* Contributors: Shota Aoki, YusukeKato
```

## crane_plus_moveit_config

```
* カメラサンプルのHumble対応 (#64 <https://github.com/rt-net/crane_plus/issues/64>)
* Contributors: Shota Aoki, YusukeKato
```
