### PR TITLE
mrpt_slam: 0.1.15-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6061,7 +6061,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_slam-release.git
-      version: 0.1.14-1
+      version: 0.1.15-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_slam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_slam` to `0.1.15-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_slam.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_slam-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.14-1`

## mrpt_ekf_slam_2d

- No changes

## mrpt_ekf_slam_3d

- No changes

## mrpt_graphslam_2d

```
* Fix build errors and warnings with latest mrpt2 versions
  (Closes: #71 <https://github.com/mrpt-ros-pkg/mrpt_slam/issues/71>)
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_icp_slam_2d

```
* Fix build errors and warnings with latest mrpt2 versions
  (Closes: #71 <https://github.com/mrpt-ros-pkg/mrpt_slam/issues/71>)
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_rbpf_slam

- No changes

## mrpt_slam

- No changes
