### PR TITLE
add flexbe_behavior_engine to iron and rolling distribution.yaml prior to bloom

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1321,6 +1321,16 @@ repositories:
       url: https://github.com/introlab/find-object.git
       version: rolling-devel
     status: maintained
+  flexbe_behavior_engine:
+    doc:
+      type: git
+      url: https://github.com/flexbe/flexbe_behavior_engine.git
+      version: iron
+    source:
+      type: git
+      url: https://github.com/flexbe/flexbe_behavior_engine.git
+      version: iron
+    status: developed
   fluent_rviz:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1326,6 +1326,16 @@ repositories:
       url: https://github.com/introlab/find-object.git
       version: rolling-devel
     status: maintained
+  flexbe_behavior_engine:
+    doc:
+      type: git
+      url: https://github.com/flexbe/flexbe_behavior_engine.git
+      version: rolling
+    source:
+      type: git
+      url: https://github.com/flexbe/flexbe_behavior_engine.git
+      version: rolling
+    status: developed
   fluent_rviz:
     doc:
       type: git


### PR DESCRIPTION

# Please Add flexbe_behavior_engine  to be indexed in the rosdistro.

* iron
* rolling

# The source is here:

https://github.com/FlexBE/flexbe_behavior_engine

previously released on Noetic and now Humble

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
