### PR TITLE
nao_interfaces: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2922,7 +2922,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nao_interfaces-release.git
-      version: 0.0.4-3
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/ijnek/nao_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_interfaces` to `1.0.0-1`:

- upstream repository: https://github.com/ijnek/nao_interfaces.git
- release repository: https://github.com/ros2-gbp/nao_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.4-3`

## nao_command_msgs

```
* Deprecate nao_command_msgs, and move to nao_lola_command_msgs from the nao_lola repo instead. (#7 <https://github.com/ijnek/nao_interfaces/issues/7>)
* Contributors: Kenji Brameld
```

## nao_sensor_msgs

```
* Deprecate nao_sensor_msgs, and move to nao_lola_sensor_msgs from the nao_lola repo instead. (#7 <https://github.com/ijnek/nao_interfaces/issues/7>)
* Contributors: Kenji Brameld
```
