### PR TITLE
nao_lola: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2934,10 +2934,16 @@ repositories:
       url: https://github.com/ros-sports/nao_lola.git
       version: rolling
     release:
+      packages:
+      - nao_lola
+      - nao_lola_client
+      - nao_lola_command_msgs
+      - nao_lola_conversion
+      - nao_lola_sensor_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nao_lola-release.git
-      version: 0.3.1-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/ros-sports/nao_lola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_lola` to `1.0.0-1`:

- upstream repository: https://github.com/ros-sports/nao_lola.git
- release repository: https://github.com/ros2-gbp/nao_lola-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.1-1`

## nao_lola

```
* Deprecate nao_lola package in favor of nao_lola_client package.
* Contributors: ijnek
```

## nao_lola_client

```
* Migrate nao_lola across to nao_lola/nao_lola_client
* Contributors: ijnek
```

## nao_lola_command_msgs

```
* Migrate nao_interfaces/nao_command_msgs across to nao_lola_command_msgs
* Contributors: ijnek
```

## nao_lola_conversion

```
* Migrate nao/nao_interfaces_package to nao_lola_conversion package.
* Contributors: ijnek
```

## nao_lola_sensor_msgs

```
* Migrate nao_interfaces/nao_sensor_msgs across to nao_lola_sensor_msgs
* Contributors: ijnek
```
