### PR TITLE
add python3-sqlmodel-pip to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8580,10 +8580,11 @@ python3-sqlalchemy-utils:
   nixos: [python3Packages.sqlalchemy-utils]
   opensuse: [python3-SQLAlchemy-Utils]
   ubuntu: [python3-sqlalchemy-utils]
-python3-sqlmodel-pip:
+python3-sqlmodel:
   debian:
-    pip:
-      packages: [sqlmodel]
+    '*':
+      packages: [python3-sqlmodel]
+    buster: null
   ubuntu:
     pip:
       packages: [sqlmodel]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8582,15 +8582,18 @@ python3-sqlalchemy-utils:
   ubuntu: [python3-sqlalchemy-utils]
 python3-sqlmodel:
   debian:
-    '*':
-      packages: [python3-sqlmodel]
+    '*': [python3-sqlmodel]
     bullseye:
       pip:
         packages: [sqlmodel]
-    buster: null
   ubuntu:
-    pip:
-      packages: [sqlmodel]
+    '*': [python3-sqlmodel]
+    focal:
+      pip:
+        packages: [sqlmodel]
+    jammy:
+      pip:
+        packages: [sqlmodel]
 python3-squaternion-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8584,6 +8584,9 @@ python3-sqlmodel:
   debian:
     '*':
       packages: [python3-sqlmodel]
+    bullseye:
+      pip:
+        packages: [sqlmodel]
     buster: null
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8580,6 +8580,13 @@ python3-sqlalchemy-utils:
   nixos: [python3Packages.sqlalchemy-utils]
   opensuse: [python3-SQLAlchemy-Utils]
   ubuntu: [python3-sqlalchemy-utils]
+python3-sqlmodel-pip:
+  debian:
+    pip:
+      packages: [sqlmodel]
+  ubuntu:
+    pip:
+      packages: [sqlmodel]
 python3-squaternion-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`python3-sqlmodel-pip`

## Package Upstream Source:

https://github.com/tiangolo/sqlmodel

## Purpose of using this:

This python package provides a easy-to-use, pythonic and strongly-typed interface to various SQL databases.

SQL databases are used widely even today, and I found them to be very useful to store runtime-configurable data across reboots.
This package should facilitate storing those data.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - not available
- Ubuntu: https://packages.ubuntu.com/
  - not available

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
