### PR TITLE
qb_softhand_industry: 1.0.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8106,6 +8106,32 @@ repositories:
       url: https://bitbucket.org/qbrobotics/qbmove-ros.git
       version: production-noetic
     status: developed
+  qb_softhand_industry:
+    doc:
+      type: git
+      url: https://bitbucket.org/qbrobotics/qbshin-ros-release.git
+      version: master
+    release:
+      packages:
+      - qb_softhand_industry
+      - qb_softhand_industry_bringup
+      - qb_softhand_industry_control
+      - qb_softhand_industry_description
+      - qb_softhand_industry_driver
+      - qb_softhand_industry_hardware_interface
+      - qb_softhand_industry_msgs
+      - qb_softhand_industry_srvs
+      - qb_softhand_industry_utils
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://bitbucket.org/qbrobotics/qbshin-ros-release.git
+      version: 1.0.6-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://bitbucket.org/qbrobotics/qbshin-ros.git
+      version: production-noetic
+    status: developed
   qpoases_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_softhand_industry` to `1.0.6-1`:

- upstream repository: https://bitbucket.org/qbrobotics/qbshin-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbshin-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## qb_softhand_industry

- No changes

## qb_softhand_industry_bringup

- No changes

## qb_softhand_industry_control

- No changes

## qb_softhand_industry_description

- No changes

## qb_softhand_industry_driver

```
* qb_softhand_industry_driver version number fix
```

## qb_softhand_industry_hardware_interface

- No changes

## qb_softhand_industry_msgs

- No changes

## qb_softhand_industry_srvs

- No changes

## qb_softhand_industry_utils

- No changes
