### PR TITLE
ros2_planning_system: 2.0.11-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4967,7 +4967,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_planning_system-release.git
-      version: 2.0.10-1
+      version: 2.0.11-1
     source:
       type: git
       url: https://github.com/PlanSys2/ros2_planning_system.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_planning_system` to `2.0.11-1`:

- upstream repository: https://github.com/PlanSys2/ros2_planning_system.git
- release repository: https://github.com/ros2-gbp/ros2_planning_system-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.10-1`

## plansys2_bringup

- No changes

## plansys2_bt_actions

```
* Fix logger destruction at BTActions
* Contributors: Francisco Martín Rico
```

## plansys2_core

- No changes

## plansys2_domain_expert

- No changes

## plansys2_executor

- No changes

## plansys2_lifecycle_manager

- No changes

## plansys2_msgs

- No changes

## plansys2_pddl_parser

- No changes

## plansys2_planner

- No changes

## plansys2_popf_plan_solver

- No changes

## plansys2_problem_expert

- No changes

## plansys2_terminal

```
* Read multiple lines in terminal input
* Contributors: Francisco Martín Rico
```

## plansys2_tests

- No changes

## plansys2_tools

- No changes
