### PR TITLE
Add hebi_cpp_api to humble.yaml

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2107,6 +2107,15 @@ repositories:
       url: https://github.com/tier4/heaphook.git
       version: main
     status: maintained
+  hebi_cpp_api:
+    doc:
+      type: git
+      url: https://github.com/HebiRobotics/hebi_cpp_api_ros/
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/HebiRobotics/hebi_cpp_api_ros/
+      version: ros2
   hey5_description:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2110,11 +2110,11 @@ repositories:
   hebi_cpp_api:
     doc:
       type: git
-      url: https://github.com/HebiRobotics/hebi_cpp_api_ros/
+      url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
       version: ros2
     source:
       type: git
-      url: https://github.com/HebiRobotics/hebi_cpp_api_ros/
+      url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
       version: ros2
   hey5_description:
     doc:


### PR DESCRIPTION
Add hebi_cpp_api package to humble

<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

hebi_cpp_api

## Package Upstream Source:

https://github.com/HebiRobotics/hebi_cpp_api_ros.git

Previously released on Noetic

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
