### PR TITLE
Add vcstool on NixOS

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9020,6 +9020,7 @@ python3-vcstool:
   macports:
     pip:
       packages: [vcstool]
+  nixos: [vcstool]
   osx:
     pip:
       packages: [vcstool]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

## Package name:

vcstool

## Links to Distribution Packages

- NixOS/nixpkgs: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/vcstool/default.nix