### PR TITLE
fix: non-raw string for regex in script causing `DeprecationWarning`

### DIFF
--- a/scripts/check_rosdep.py
+++ b/scripts/check_rosdep.py
@@ -79,7 +79,7 @@ def generic_parser(buf, cb):
         if re.search(r'^\s*#', l) is not None:
             continue
         try:
-            s = re.search(r'(?!' + indent_atom + ')[^\s]', l).start()
+            s = re.search(r'(?!' + indent_atom + r')[^\s]', l).start()
         except:
             print_err("line %u: %s" % (i, l))
             raise


### PR DESCRIPTION
in scripts/check_rosdep.py, there was a normal string used with `'\s'` escape, which caused `DeprecationWarning`.
This commit fixes it by adding `r` and specifying as a raw string.
