### PR TITLE
nao_button_sim: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2904,7 +2904,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nao_button_sim-release.git
-      version: 0.1.1-4
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/ijnek/nao_button_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_button_sim` to `1.0.0-1`:

- upstream repository: https://github.com/ijnek/nao_button_sim.git
- release repository: https://github.com/ros2-gbp/nao_button_sim-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.1-4`

## nao_button_sim

```
* Migrate from nao_sensor_msgs to nao_lola_sensor_msgs (#5 <https://github.com/ijnek/nao_button_sim/issues/5>)
* Contributors: Kenji Brameld
```
