### PR TITLE
rcss3d_nao: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4167,7 +4167,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcss3d_nao-release.git
-      version: 0.1.1-2
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/ros-sports/rcss3d_nao.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcss3d_nao` to `1.0.0-1`:

- upstream repository: https://github.com/ros-sports/rcss3d_nao.git
- release repository: https://github.com/ros2-gbp/rcss3d_nao-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.1-2`

## rcss3d_nao

```
* Migrate to nao_lola_sensor_msgs and nao_lola_command_msgs (#20 <https://github.com/ros-sports/rcss3d_nao/issues/20>)
* Contributors: Kenji Brameld
```
