### PR TITLE
sick_safetyscanners_base: 1.0.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6132,6 +6132,21 @@ repositories:
       url: https://github.com/SICKAG/sick_safetyscanners2_interfaces.git
       version: master
     status: developed
+  sick_safetyscanners_base:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/sick_safetyscanners_base.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/SICKAG/sick_safetyscanners_base-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_safetyscanners_base.git
+      version: ros2
+    status: developed
   simple_actions:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safetyscanners_base` to `1.0.2-1`:

- upstream repository: https://github.com/SICKAG/sick_safetyscanners_base.git
- release repository: https://github.com/SICKAG/sick_safetyscanners_base-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## sick_safetyscanners_base

```
* Added missing 'using' statement to UDPClient.cpp
* Contributors: Lennart Puck, crown-bdee
```
