### PR TITLE
add python3-mccabe entry

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6637,6 +6637,13 @@ python3-matplotlib:
     '7': null
   slackware: [python3-matplotlib]
   ubuntu: [python3-matplotlib]
+python3-mccabe:
+  arch: [python-mccabe]
+  debian: [python3-mccabe]
+  gentoo: [dev-python/mccabe]
+  nixos: [python310Packages.mccabe]
+  opensuse: [python-mccabe]
+  ubuntu: [python3-mccabe]
 python3-mechanize:
   debian:
     '*': [python3-mechanize]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6643,7 +6643,7 @@ python3-mccabe:
   fedora: [python3-mccabe]
   gentoo: [dev-python/mccabe]
   nixos: [python310Packages.mccabe]
-  opensuse: [python-mccabe]
+  opensuse: [python3-mccabe]
   rhel: [python3-mccabe]
   ubuntu: [python3-mccabe]
 python3-mechanize:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6640,9 +6640,11 @@ python3-matplotlib:
 python3-mccabe:
   arch: [python-mccabe]
   debian: [python3-mccabe]
+  fedora: [python3-mccabe]
   gentoo: [dev-python/mccabe]
   nixos: [python310Packages.mccabe]
   opensuse: [python-mccabe]
+  rhel: [python3-mccabe]
   ubuntu: [python3-mccabe]
 python3-mechanize:
   debian:


### PR DESCRIPTION
## Package name:

python3-mccabe

## Package Upstream Source:

https://github.com/pycqa/mccabe

## Purpose of using this:

to check code complexity

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=python3-mccabe
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/focal/python3-mccabe
  - REQUIRED
- Fedora: https://packages.fedoraproject.org/
  - n/a
  - IF AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/any/python-mccabe/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/mccabe
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - n/a
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - n/a
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=23.05&show=python311Packages.mccabe&from=0&size=50&sort=relevance&type=packages&query=python+mccabe
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python-mccabe
  - IF AVAILABLE