### PR TITLE
metavision_driver: 1.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2571,6 +2571,11 @@ repositories:
       type: git
       url: https://github.com/ros-event-camera/metavision_driver.git
       version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/metavision_driver-release.git
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ros-event-camera/metavision_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `metavision_driver` to `1.0.2-1`:

- upstream repository: https://github.com/ros-event-camera/metavision_driver.git
- release repository: https://github.com/ros2-gbp/metavision_driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## metavision_driver

```
* Try to pull in OpenEB dependencies via package.xml and figure out ROS1/ROS2 via cmake
* updated links in README
* Contributors: Bernd Pfrommer, Laurent Bristiel
```
