### PR TITLE
Adding "adi_3dtof_image_stitching" to source index for Noetic.

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -75,6 +75,12 @@ repositories:
       url: https://github.com/ros/actionlib.git
       version: noetic-devel
     status: maintained
+  adi_3dtof_image_stitching:
+    source:
+      type: git
+      url: https://github.com/analogdevicesinc/adi_3dtof_image_stitching.git
+      version: v1.0.0
+    status: maintained
   agni_tf_tools:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro(for pre-release testing).

ROSDISTRO NAME 
Noetic

# The source is here:
https://github.com/analogdevicesinc/adi_3dtof_image_stitching/tree/v1.0.0


# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
