### PR TITLE
event_camera_msgs: 1.1.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1204,7 +1204,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_msgs-release.git
-      version: 1.1.2-1
+      version: 1.1.4-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `event_camera_msgs` to `1.1.4-1`:

- upstream repository: https://github.com/ros-event-camera/event_camera_msgs.git
- release repository: https://github.com/ros2-gbp/event_camera_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.2-1`

## event_camera_msgs

```
* fix cmake bug preventing bombout when ROS_VERSION was not set
* Contributors: Bernd Pfrommer
```
