### PR TITLE
Add in a set of pyside2 rosdep keys.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -289,6 +289,11 @@ jupyter-notebook:
 libgv-python:
   debian: [libgv-python]
   ubuntu: [libgv-python]
+libshiboken2-dev:
+  debian: [libshiboken2-dev]
+  fedora: [python3-shiboken2-devel]
+  rhel: [python3-shiboken2-devel]
+  ubuntu: [libshiboken2-dev]
 mcap-ros2-support:
   debian:
     pip:
@@ -7758,8 +7763,18 @@ python3-pyside2:
   fedora: [python3-pyside2, pyside2-tools, python3-pyside2-devel, python3-shiboken2, python3-shiboken2-devel, shiboken2]
   gentoo: [dev-python/pyside2, dev/python/shiboken2]
   ubuntu:
-    "*": [libpyside2-dev, libshiboken2-dev, python3-pyside2.qtcore, python3-pyside2.qtgui, python3-pyside2.qthelp, python3-pyside2.qtnetwork, python3-pyside2.qtprintsupport, python3-pyside2.qtsvg, python3-pyside2.qttest, python3-pyside2.qtwidgets, python3-pyside2.qtxml, shiboken2]
+    '*': [libpyside2-dev, libshiboken2-dev, python3-pyside2.qtcore, python3-pyside2.qtgui, python3-pyside2.qthelp, python3-pyside2.qtnetwork, python3-pyside2.qtprintsupport, python3-pyside2.qtsvg, python3-pyside2.qttest, python3-pyside2.qtwidgets, python3-pyside2.qtxml, shiboken2]
     bionic: null
+python3-pyside2.qtcore:
+  debian: [python3-pyside2.qtcore]
+  fedora: [python3-pyside2]
+  rhel: [python3-pyside2]
+  ubuntu: [python3-pyside2.qtcore]
+python3-pyside2.qtgui:
+  debian: [python3-pyside2.qtgui]
+  fedora: [python3-pyside2]
+  rhel: [python3-pyside2]
+  ubuntu: [python3-pyside2.qtgui]
 python3-pyside2.qtopengl:
   arch: [pyside2]
   debian: [python3-pyside2.qtopengl]
@@ -7778,9 +7793,16 @@ python3-pyside2.qtquick:
     bionic: null
 python3-pyside2.qtuitools:
   debian: [python3-pyside2.qtuitools]
+  fedora: [python3-pyside2]
+  rhel: [python3-pyside2]
   ubuntu:
     '*': [python3-pyside2.qtuitools]
     bionic: null
+python3-pyside2.qtwidgets:
+  debian: [python3-pyside2.qtwidgets]
+  fedora: [python3-pyside2]
+  rhel: [python3-pyside2]
+  ubuntu: [python3-pyside2.qtwidgets]
 python3-pysnmp:
   debian: [python3-pysnmp4]
   fedora: [python3-pysnmp]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -290,9 +290,13 @@ libgv-python:
   debian: [libgv-python]
   ubuntu: [libgv-python]
 libshiboken2-dev:
+  alpine: [libshiboken2-dev]
   debian: [libshiboken2-dev]
   fedora: [python3-shiboken2-devel]
-  rhel: [python3-shiboken2-devel]
+  opensuse: [python3-pyside2-devel]
+  rhel:
+    '*': [python3-shiboken2-devel]
+    '8': null
   ubuntu: [libshiboken2-dev]
 mcap-ros2-support:
   debian:
@@ -7768,12 +7772,16 @@ python3-pyside2:
 python3-pyside2.qtcore:
   debian: [python3-pyside2.qtcore]
   fedora: [python3-pyside2]
-  rhel: [python3-pyside2]
+  rhel:
+    '*': [python3-pyside2]
+    '8': null
   ubuntu: [python3-pyside2.qtcore]
 python3-pyside2.qtgui:
   debian: [python3-pyside2.qtgui]
   fedora: [python3-pyside2]
-  rhel: [python3-pyside2]
+  rhel:
+    '*': [python3-pyside2]
+    '8': null
   ubuntu: [python3-pyside2.qtgui]
 python3-pyside2.qtopengl:
   arch: [pyside2]
@@ -7794,14 +7802,18 @@ python3-pyside2.qtquick:
 python3-pyside2.qtuitools:
   debian: [python3-pyside2.qtuitools]
   fedora: [python3-pyside2]
-  rhel: [python3-pyside2]
+  rhel:
+    '*': [python3-pyside2]
+    '8': null
   ubuntu:
     '*': [python3-pyside2.qtuitools]
     bionic: null
 python3-pyside2.qtwidgets:
   debian: [python3-pyside2.qtwidgets]
   fedora: [python3-pyside2]
-  rhel: [python3-pyside2]
+  rhel:
+    '*': [python3-pyside2]
+    '8': null
   ubuntu: [python3-pyside2.qtwidgets]
 python3-pysnmp:
   debian: [python3-pysnmp4]


### PR DESCRIPTION
These keys are the necessary set to actually use the pyside2 bindings that are available in rqt.

I'll note one oddity, which is the 'libshiboken2-dev' key living in the rosdep/python.yaml file.  While that is indeed a C-style library, it's main goal in life is to bridge the C++ Qt library and Python.  So I felt like it was appropriate in the python.yaml file.  I could also be convinced to move it to base.yaml.

Please add the following dependency to the rosdep database.

## Package name:

* libshiboken2-dev
* python3-pyside2.qtcore
* python3-pyside2.qtgui
* python3-pyside2.qtwidgets

## Package Upstream Source:

https://doc.qt.io/qtforpython-5/shiboken2/gettingstarted.html (I think the sources are actually part of Qt proper)

## Purpose of using this:

If we want to stop using SIP in binding generation in Rqt, we'll instead need to use pyside2.  I think it is better to have these keys split out like this rather than the uber-key python3-pyside2.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=libshiboken2-dev&searchon=names&suite=all&section=all
  - https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=python3-pyside2.qtcore
  - https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=python3-pyside2.qtgui
  - https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=python3-pyside2.qtwidgets
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=libshiboken2-dev&searchon=names&suite=all&section=all
  - https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=python3-pyside2.qtcore&searchon=names
  - https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=python3-pyside2.qtgui&searchon=names
  - https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=python3-pyside2.qtwidgets&searchon=names
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-pyside2/python3-shiboken2-devel/
  - https://packages.fedoraproject.org/pkgs/python-pyside2/python3-pyside2/ (this covers python3-pyside2.qtcore, python3-pyside2.qtgui, and python3-pyside2.qtwidgets since Fedora does not split them out)
- RHEL: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-pyside2/python3-shiboken2-devel/
  - https://packages.fedoraproject.org/pkgs/python-pyside2/python3-pyside2/ (this covers python3-pyside2.qtcore, python3-pyside2.qtgui, and python3-pyside2.qtwidgets since RHEL/EPEL does not split them out)