### PR TITLE
Update outdated testing documentation (use pytest)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 .DS_STORE
 *.pyc
+.venv/*

--- a/.yamllint
+++ b/.yamllint
@@ -15,3 +15,6 @@ rules:
     allow-non-breakable-words: yes
     ignore: |
       rosdep/*.yaml
+
+ignore: |
+  .venv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -300,7 +300,7 @@ The unit tests enforce alphabetization of elements and a consistent formatting t
 ### Unit Testing
 
 It is recommended to use a virtual environment and pip to install the unit test dependencies.
-They are listed in tests/requirements.txt.
+The test dependencies are listed in tests/requirements.txt.
 
 ```bash
 # create the virtual environment

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -305,6 +305,20 @@ To run the tests, run `pytest` in the root of the repository.
 
 #### Test Dependencies
 
+Using a virtual environment and `pip` is recommended to install the dependencies.
+
+```bash
+# create the virtual environment
+python3 -m venv .venv
+# "activate" the virtual environment
+# this will let pip install dependencies into the virtual environment
+# use activate.zsh if you use zsh, activate.fish if you use fish, etc.
+source .venv/bin/activate
+
+# install the dependencies
+pip3 install -r test/requirements.txt
+```
+
 Tests are written using [pytest](https://docs.pytest.org/).
 These tests require several dependencies that can be installed either from the ROS repositories or via pip (list built based on the content of [test/requirements.txt](https://github.com/ros/rosdistro/blob/master/test/requirements.txt)):
 
@@ -319,20 +333,6 @@ These tests require several dependencies that can be installed either from the R
 | ros_buildfarm  | python3-ros-buildfarm              | ros-buildfarm  |
 | unidiff        | python3-unidiff (Zesty and higher) | unidiff        |
 | yamllint       | yamllint                          | yamllint       |
-
-Using a virtual environment and `pip` is recommended to install the dependencies.
-
-```bash
-# create the virtual environment
-python3 -m venv .venv
-# "activate" the virtual environment
-# this will let pip install dependencies into the virtual environment
-# use activate.zsh if you use zsh, activate.fish if you use fish, etc.
-source .venv/bin/activate
-
-# install the dependencies
-pip3 install -r test/requirements.txt
-```
 
 #### Quick testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -297,19 +297,15 @@ How to submit pull requests
 When submitting pull requests it is expected that they pass the unit tests for formatting.
 The unit tests enforce alphabetization of elements and a consistent formatting to keep merging as clean as possible.
 
-### Testing
+### Unit Testing
 
-It is highly recommended to run the tests before submitting a pull request.
-(the test will be run automatically by the CI system anyways, but it will save you time)
-To run the tests, run `pytest` in the root of the repository.
-
-#### Test Dependencies
-
-Using a virtual environment and `pip` is recommended to install the dependencies.
+It is recommended to use a virtual environment and pip to install the unit test dependencies.
+They are listed in tests/requirements.txt.
 
 ```bash
 # create the virtual environment
 python3 -m venv .venv
+
 # "activate" the virtual environment
 # this will let pip install dependencies into the virtual environment
 # use activate.zsh if you use zsh, activate.fish if you use fish, etc.
@@ -322,32 +318,6 @@ pip3 install -r test/requirements.txt
 pytest
 ```
 
-Tests are written using [pytest](https://docs.pytest.org/).
-These tests require several dependencies that can be installed either from the ROS repositories or via pip (list built based on the content of [test/requirements.txt](https://github.com/ros/rosdistro/blob/master/test/requirements.txt)):
+It is highly recommended to run the unit tests before submitting a pull request.
+(the CI system will run them anyways, but it will save you time)
 
-| Dependency   | Ubuntu package (<=22.04)| Pip package  |
-| :------------: | --------------------------------- | -------------- |
-| catkin_pkg     | python3-catkin-pkg                 | catkin-pkg     |
-| github         | python3-github                     | PyGithub       |
-| pytest         | python3-pytest                    | pytest         |
-| yaml           | python3-yaml                      | PyYAML         |
-| rosdep         | python3-rosdep                    | rosdep         |
-| rosdistro      | python3-rosdistro                  | rosdistro      |
-| ros_buildfarm  | python3-ros-buildfarm              | ros-buildfarm  |
-| unidiff        | python3-unidiff (Zesty and higher) | unidiff        |
-| yamllint       | yamllint                          | yamllint       |
-
-#### Quick testing
-
-There is a tool [scripts/check_rosdep](./scripts/check_rosdep.py) which will check most formatting errors such as alphabetization and correct formatting.
-It will not check for all errors, but it is a quick way to check for common errors.
-
-Here is a one liner to check all files in the [rosdep](./rosdep) directory:
-```bash
-for f in ./rosdep/*.yaml; do echo "$f"; ./scripts/check_rosdep.py "$f"; done
-```
-
-Or simply use `pytest` (although the output is quite verbose):
-```bash
-pytest test/rosdep_formatting_test.py
-```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -297,31 +297,41 @@ How to submit pull requests
 When submitting pull requests it is expected that they pass the unit tests for formatting.
 The unit tests enforce alphabetization of elements and a consistent formatting to keep merging as clean as possible.
 
-If you want to run the tests before submitting, first install the dependencies. Using `pip` is recommended.
+### Testing
+
+It is highly recommended to run the tests before submitting a pull request.
+(the test will be run automatically by the CI system anyways, but it will save you time)
+
+Tests are written using [pytest](https://docs.pytest.org/).
+To run the tests, first install the dependencies.
+Using a virtual environment and `pip` is recommended.
 
 ```bash
-python3 -m pip install -r test/requirements.txt
+# create the virtual environment
+python3 -m venv .venv
+# "activate" the virtual environment
+# this will let pip install dependencies into the virtual environment
+# use activate.zsh if you use zsh, activate.fish if you use fish, etc.
+source .venv/bin/activate
+
+# install the dependencies
+pip3 install -r test/requirements.txt
+
+# run the tests
+pytest
 ```
 
-To run the tests run ``nosetests`` in the root of the repository.
-These tests require several dependencies that can be installed either from the ROS repositories or via pip(list built based on the content of [.travis.yaml](https://github.com/ros/rosdistro/blob/master/.travis.yml):
-
-| Dependency   | Ubuntu package (<=20.04)| Pip package  |
-| :------------: | --------------------------------- | -------------- |
-| catkin_pkg     | python-catkin-pkg                 | catkin-pkg     |
-| github         | python-github                     | PyGithub       |
-| nose           | python-nose                       | nose           |
-| rosdistro      | python-rosdistro                  | rosdistro      |
-| ros_buildfarm  | python-ros-buildfarm              | ros-buildfarm  |
-| unidiff        | python-unidiff (Zesty and higher) | unidiff        |
-| yamllint       | yamllint                          | yamllint       |
+#### Quick testing
 
 There is a tool [scripts/check_rosdep](./scripts/check_rosdep.py) which will check most formatting errors such as alphabetization and correct formatting.
-It is recommended to run it before submitting your contribution.
+It will not check for all errors, but it is a quick way to check for common errors.
 
-For example, to check a change to `rosdep/base.yaml`:
+Here is a one liner to check all files in the [rosdep](./rosdep) directory:
 ```bash
-python3 scripts/check_rosdep.py rosdep/base.yaml
+for f in ./rosdep/*.yaml; do echo "$f"; ./scripts/check_rosdep.py "$f"; done
 ```
 
-Note: There's a [known issue](https://github.com/disqus/nose-unittest/issues/2) discovered [here](https://github.com/ros/rosdistro/issues/16336) that most tests won't run if you have the python package `nose-unitttest` installed.
+Or simply use `pytest` (although the output is quite verbose):
+```bash
+pytest test/rosdep_formatting_test.py
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -317,6 +317,9 @@ source .venv/bin/activate
 
 # install the dependencies
 pip3 install -r test/requirements.txt
+
+# run the tests!
+pytest
 ```
 
 Tests are written using [pytest](https://docs.pytest.org/).


### PR DESCRIPTION
The CONTRIBUTING.md's "How to submit pull requests" specified nosetests, which is no longer used. (see: commit id f27dfbf, github pr #36201)
This commit updates the documentation to use pytest instead, and also encourages the use of a virtual environment.

Config files are also updated to ignore the virtual environment.
