### PR TITLE
linting: modify yaml files to satisfy yamllint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,9 @@
+---
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    # only notify on security updates and not version updates.
-    open-pull-requests-limit: 0
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  # only notify on security updates and not version updates.
+  open-pull-requests-limit: 0

--- a/.github/labeler-config.yaml
+++ b/.github/labeler-config.yaml
@@ -1,38 +1,39 @@
+---
 # Add 'noetic' label if any files in noetic/ folder are changed by a PR
 noetic:
-  - noetic/*
+- noetic/*
 
 # Add 'humble' label if any files in humble/ folder are changed by a PR
 humble:
-  - humble/*
+- humble/*
 
 # Add 'iron' label if any files in iron/ folder are changed by a PR
 iron:
-  - iron/*
+- iron/*
 
 # Add 'rolling' label if any files in rolling/ folder are changed by a PR
 rolling:
-  - rolling/*
+- rolling/*
 
 # Add 'rosdep' label if any files in rosdep/ folder are changed by a PR
 rosdep:
-  - rosdep/*
+- rosdep/*
 
 # Add 'end-of-life' label if any files are in folders for versions that are no longer supported
 end-of-life:
-  # ROS 1
-  - groovy/*
-  - hydro/*
-  - indigo/*
-  - jade/*
-  - kinetic/*
-  - lunar/*
-  - melodic/*
-  # ROS 2
-  - ardent/*
-  - bouncy/*
-  - crystal/*
-  - dashing/*
-  - eloquent/*
-  - foxy/*
-  - galactic/*
+# ROS 1
+- groovy/*
+- hydro/*
+- indigo/*
+- jade/*
+- kinetic/*
+- lunar/*
+- melodic/*
+# ROS 2
+- ardent/*
+- bouncy/*
+- crystal/*
+- dashing/*
+- eloquent/*
+- foxy/*
+- galactic/*

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,23 +1,27 @@
+---
 pull_request_rules:
-  - name: Comment on PRs with an end-of-life label
-    conditions:
-      - label=end-of-life
-    actions:
-      comment:
-        message: This pull request changes files for a ROS distribution that is no longer supported (End Of Life) and the distribution will not have any future syncs to include this change.
-  - name: Close on changes only to EOL folders
-    conditions:
-      - and:
-        - label=end-of-life
-        # Active ROS 1 distros
-        - label!=melodic
-        - label!=noetic
-        # Active ROS 2 distros
-        - label!=foxy
-        - label!=galactic
-        - label!=humble
-        - label!=rolling
-        # Other labels
-        - label!=rosdep
-    actions:
-      close:
+- name: Comment on PRs with an end-of-life label
+  conditions:
+  - label=end-of-life
+  actions:
+    comment:
+      message: >
+        This pull request changes files for a ROS distribution
+        that is no longer supported (End Of Life)
+        and the distribution will not have any future syncs to include this change.
+- name: Close on changes only to EOL folders
+  conditions:
+  - and:
+    - label=end-of-life
+    # Active ROS 1 distros
+    - label!=melodic
+    - label!=noetic
+    # Active ROS 2 distros
+    - label!=foxy
+    - label!=galactic
+    - label!=humble
+    - label!=rolling
+    # Other labels
+    - label!=rosdep
+  actions:
+    close:

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -1,6 +1,7 @@
 ---
 name: Validate rosdistro
-"on":
+# this is fine since gha runs with yaml 1.2
+on:  # yamllint disable-line rule:truthy
   push:
     branches: ['master']
   pull_request:

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -1,5 +1,6 @@
+---
 name: Validate rosdistro
-on:
+"on":
   push:
     branches: ['master']
   pull_request:
@@ -22,7 +23,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Fetch upstream (to enable diff)
       run: |
-        git remote add unittest_upstream_comparison https://github.com/ros/rosdistro.git || git remote set-url unittest_upstream_comparison https://github.com/ros/rosdistro.git
+        git remote add unittest_upstream_comparison https://github.com/ros/rosdistro.git \
+        || git remote set-url unittest_upstream_comparison https://github.com/ros/rosdistro.git
         git fetch --no-tags --depth=1 unittest_upstream_comparison master
     - name: Install Dependencies
       run: |

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,6 +1,7 @@
 ---
 name: "Pull Request Labeler"
-"on":
+# this is fine since gha runs with yaml 1.2
+on:  # yamllint disable-line rule:truthy
 - pull_request_target
 
 permissions:

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,5 +1,6 @@
+---
 name: "Pull Request Labeler"
-on:
+"on":
 - pull_request_target
 
 permissions:

--- a/.github/workflows/stale_labeler.yaml
+++ b/.github/workflows/stale_labeler.yaml
@@ -1,19 +1,28 @@
+---
 name: 'Label inactive PRs as stale'
 
-on:
+"on":
   schedule:
-    - cron: '0 11 * * *'  # runs at 11am UTC every day => early morning in US
+  - cron: '0 11 * * *'  # runs at 11am UTC every day => early morning in US
 
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v8  # https://github.com/marketplace/actions/close-stale-issues
-        with:
-          stale-pr-label: 'stale'
-          stale-pr-message: "This PR hasn't been activity in 14 days. If you are still are interested in getting it merged please provide an update. Otherwise it will likely be closed by a rosdistro maintainer following our [contributing policy](https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md). It's been labeled \"stale\" for visibility to the maintainers. If this label isn't appropriate, you can ask a maintainer to remove the label and add the 'persistent' label."
-          days-before-pr-stale: 14
-          days-before-pr-close: -1     # don't close PRs automatically
-          days-before-issue-stale: -1  # don't label issues as stale
-          days-before-issue-close: -1  # don't close issues automatically
-          exempt-pr-labels: 'persistent'
+    - uses: actions/stale@v8  # https://github.com/marketplace/actions/close-stale-issues
+      with:
+        stale-pr-label: 'stale'
+        stale-pr-message: >
+          This PR hasn't been activity in 14 days.
+          If you are still are interested in getting it merged
+          please provide an update.
+          Otherwise it will likely be closed by a rosdistro maintainer
+          following our [contributing policy](https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md).
+          It's been labeled "stale" for visibility to the maintainers.
+          If this label isn't appropriate,
+          you can ask a maintainer to remove the label and add the 'persistent' label.
+        days-before-pr-stale: 14
+        days-before-pr-close: -1     # don't close PRs automatically
+        days-before-issue-stale: -1  # don't label issues as stale
+        days-before-issue-close: -1  # don't close issues automatically
+        exempt-pr-labels: 'persistent'

--- a/.github/workflows/stale_labeler.yaml
+++ b/.github/workflows/stale_labeler.yaml
@@ -1,7 +1,8 @@
 ---
 name: 'Label inactive PRs as stale'
 
-"on":
+# this is fine since gha runs with yaml 1.2
+on:  # yamllint disable-line rule:truthy
   schedule:
   - cron: '0 11 * * *'  # runs at 11am UTC every day => early morning in US
 

--- a/.yamllint
+++ b/.yamllint
@@ -1,3 +1,4 @@
+---
 extends:
   default
 
@@ -8,10 +9,10 @@ rules:
       rosdep/*.yaml
   indentation:
     spaces: consistent
-    indent-sequences: no
+    indent-sequences: false
   key-duplicates: enable
   line-length:
     max: 125
-    allow-non-breakable-words: yes
+    allow-non-breakable-words: true
     ignore: |
       rosdep/*.yaml


### PR DESCRIPTION
The files modified are:
- `.yamllint` (document-start, truthy)
- `.github/**/*.y[a]ml` (document-start, indentation, line-length, truthy)

Once this PR is merged, we can fix yamllint in github actions (#38145). (currently, it ignores hidden directories)