### PR TITLE
fix: run yamllint on all files

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -47,4 +47,4 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         pip install yamllint
     - name: Run yamllint
-      run: yamllint */
+      run: yamllint .


### PR DESCRIPTION
The current CI setup ignores hidden directories. (e.g. `.github`)
This PR fixes it.

NOTE: merge #38144 first, otherwise the CI will report errors.