### PR TITLE
raspimouse_ros2_examples: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4694,6 +4694,22 @@ repositories:
       url: https://github.com/rt-net/raspimouse_description.git
       version: humble-devel
     status: maintained
+  raspimouse_ros2_examples:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspimouse_ros2_examples.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/raspimouse_ros2_examples-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rt-net/raspimouse_ros2_examples.git
+      version: humble-devel
+    status: maintained
   rc_common_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspimouse_ros2_examples` to `2.0.0-1`:

- upstream repository: https://github.com/rt-net/raspimouse_ros2_examples.git
- release repository: https://github.com/ros2-gbp/raspimouse_ros2_examples-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## raspimouse_ros2_examples

```
* Humble対応 (#41 <https://github.com/rt-net/raspimouse_ros2_examples/issues/41>)
* Contributors: Shuhei Kozasa
```
