### PR TITLE
Please add python3-attrs to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4895,6 +4895,7 @@ python3-attrs:
   debian: [python3-attr]
   fedora: [python3-attrs]
   opensuse: [python3-attrs]
+  rhel: [python3-attrs]
   ubuntu: [python3-attr]
 python3-autobahn:
   debian: [python3-autobahn]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4891,6 +4891,11 @@ python3-asyncssh:
   debian: [python3-asyncssh]
   fedora: [python3-asyncssh]
   ubuntu: [python3-asyncssh]
+python3-attrs:
+  debian: [python3-attr]
+  fedora: [python3-attrs]
+  opensuse: [python3-attrs]
+  ubuntu: [python3-attr]
 python3-autobahn:
   debian: [python3-autobahn]
   fedora: [python3-autobahn]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-attrs

## Package Upstream Source:

https://www.attrs.org/en/stable/
https://github.com/python-attrs/attrs

## Purpose of using this:

`attrs` is a widely used library for making data-oriented classes.
It was in the list with python2, and there are packages that specify it as a dependency with python3. (e.g. `python3-twisted`)

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/python3-attr
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/jammy/python3-attr
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-attrs/python3-attrs/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/any/python-attrs/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/attrs
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://hydra.nixos.org/job/nixos/release-23.05/nixpkgs.python311Packages.attrs.x86_64-linux
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python3-attrs
