### PR TITLE
metavision_driver: 1.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3147,7 +3147,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/metavision_driver-release.git
-      version: 1.0.1-2
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/ros-event-camera/metavision_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `metavision_driver` to `1.0.3-1`:

- upstream repository: https://github.com/ros-event-camera/metavision_driver.git
- release repository: https://github.com/ros2-gbp/metavision_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.1-2`

## metavision_driver

```
* changes to build on ROS2 build farm
* Contributors: Bernd Pfrommer
```
