### PR TITLE
joint_state_publisher: 2.4.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2070,7 +2070,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/joint_state_publisher-release.git
-      version: 2.3.0-3
+      version: 2.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joint_state_publisher` to `2.4.0-1`:

- upstream repository: https://github.com/ros/joint_state_publisher.git
- release repository: https://github.com/ros2-gbp/joint_state_publisher-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.0-3`

## joint_state_publisher

```
* Support for sdformat robot descriptions (#55 <https://github.com/ros/joint_state_publisher/issues/55>)
* Refactor urdf parser function (#94 <https://github.com/ros/joint_state_publisher/issues/94>)
* Gracefully handle SIGINT (#86 <https://github.com/ros/joint_state_publisher/issues/86>)
* Contributors: Dharini Dutia, Shane Loretz, Will
```

## joint_state_publisher_gui

```
* Show 3 decimal places of joint angle (#83 <https://github.com/ros/joint_state_publisher/issues/83>)
* Contributors: Andy McEvoy
```
