### PR TITLE
rtabmap_ros: 0.21.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5983,6 +5983,35 @@ repositories:
       url: https://github.com/introlab/rtabmap.git
       version: rolling-devel
     status: maintained
+  rtabmap_ros:
+    doc:
+      type: git
+      url: https://github.com/introlab/rtabmap_ros.git
+      version: iron-devel
+    release:
+      packages:
+      - rtabmap_conversions
+      - rtabmap_demos
+      - rtabmap_examples
+      - rtabmap_launch
+      - rtabmap_msgs
+      - rtabmap_odom
+      - rtabmap_python
+      - rtabmap_ros
+      - rtabmap_rviz_plugins
+      - rtabmap_slam
+      - rtabmap_sync
+      - rtabmap_util
+      - rtabmap_viz
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/introlab/rtabmap_ros-release.git
+      version: 0.21.2-1
+    source:
+      type: git
+      url: https://github.com/introlab/rtabmap_ros.git
+      version: iron-devel
+    status: maintained
   rtcm_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap_ros` to `0.21.2-1`:

- upstream repository: https://github.com/introlab/rtabmap_ros.git
- release repository: https://github.com/introlab/rtabmap_ros-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
