### PR TITLE
rosdep: nixos: update libyamlcpp to yaml-cpp

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8388,7 +8388,7 @@ yaml-cpp:
   freebsd: [yaml-cpp]
   gentoo: [dev-cpp/yaml-cpp]
   macports: [yaml-cpp]
-  nixos: [libyamlcpp]
+  nixos: [yaml-cpp]
   openembedded: [yaml-cpp@meta-ros-common]
   opensuse: [yaml-cpp-devel]
   rhel: [yaml-cpp-devel]


### PR DESCRIPTION
libyamlcpp has been renamed to yaml-cpp in nixpkgs (https://github.com/NixOS/nixpkgs/commit/c9b4c7dccdbf196fbe1113ef27da7da17f84b994). The old name continues to work, but it should be updated.