### PR TITLE
raspimouse_slam_navigation_ros2: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4710,6 +4710,26 @@ repositories:
       url: https://github.com/rt-net/raspimouse_ros2_examples.git
       version: humble-devel
     status: maintained
+  raspimouse_slam_navigation_ros2:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspimouse_slam_navigation_ros2.git
+      version: humble-devel
+    release:
+      packages:
+      - raspimouse_navigation
+      - raspimouse_slam
+      - raspimouse_slam_navigation
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rt-net/raspimouse_slam_navigation_ros2.git
+      version: humble-devel
+    status: maintained
   rc_common_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspimouse_slam_navigation_ros2` to `2.0.0-1`:

- upstream repository: https://github.com/rt-net/raspimouse_slam_navigation_ros2.git
- release repository: https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## raspimouse_navigation

```
* Humble対応 (#6 <https://github.com/rt-net/raspimouse_slam_navigation_ros2/issues/6>)
* Contributors: Shuhei Kozasa
```

## raspimouse_slam

```
* Humble対応 (#6 <https://github.com/rt-net/raspimouse_slam_navigation_ros2/issues/6>)
* Contributors: Shuhei Kozasa
```

## raspimouse_slam_navigation

- No changes
