### PR TITLE
Unrelease qb_softhand_industry qb_softhand_industry_control qb_softhand_industry_hardware_interface

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8113,12 +8113,9 @@ repositories:
       version: production-noetic
     release:
       packages:
-      - qb_softhand_industry
       - qb_softhand_industry_bringup
-      - qb_softhand_industry_control
       - qb_softhand_industry_description
       - qb_softhand_industry_driver
-      - qb_softhand_industry_hardware_interface
       - qb_softhand_industry_msgs
       - qb_softhand_industry_srvs
       - qb_softhand_industry_utils


### PR DESCRIPTION
Unrelease 3 packages from #38153 because one fails to build on all platforms. The other two packages depend on that one.


`qb_softhand_industry_hardware_interface` is failing with: 

```
[ 50%] Building CXX object CMakeFiles/qb_softhand_industry_hardware_interface.dir/src/qb_softhand_industry_hardware_interface.cpp.o
/usr/lib/ccache/c++  -DROSCONSOLE_BACKEND_LOG4CXX -DROS_BUILD_SHARED_LIBS=1 -DROS_PACKAGE_NAME=\"qb_softhand_industry_hardware_interface\" -Dqb_softhand_industry_hardware_interface_EXPORTS -I/tmp/binarydeb/ros-noetic-qb-softhand-industry-hardware-interface-1.0.8/include -I/opt/ros/noetic/include -I/opt/ros/noetic/share/xmlrpcpp/cmake/../../../include/xmlrpcpp  -g -O2 -fdebug-prefix-map=/tmp/binarydeb/ros-noetic-qb-softhand-industry-hardware-interface-1.0.8=. -fstack-protector-strong -Wformat -Werror=format-security -DNDEBUG -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC   -std=gnu++14 -o CMakeFiles/qb_softhand_industry_hardware_interface.dir/src/qb_softhand_industry_hardware_interface.cpp.o -c /tmp/binarydeb/ros-noetic-qb-softhand-industry-hardware-interface-1.0.8/src/qb_softhand_industry_hardware_interface.cpp
In file included from /tmp/binarydeb/ros-noetic-qb-softhand-industry-hardware-interface-1.0.8/src/qb_softhand_industry_hardware_interface.cpp:28:
/tmp/binarydeb/ros-noetic-qb-softhand-industry-hardware-interface-1.0.8/include/qb_softhand_industry_hardware_interface/qb_softhand_industry_hardware_interface.h:41:10: fatal error: controller_manager/controller_manager.h: No such file or directory
   41 | #include <controller_manager/controller_manager.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

* https://build.ros.org/view/Nbin_uF64/job/Nbin_uF64__qb_softhand_industry_hardware_interface__ubuntu_focal_amd64__binary/
* https://build.ros.org/view/Nbin_ufhf_uFhf/job/Nbin_ufhf_uFhf__qb_softhand_industry_hardware_interface__ubuntu_focal_armhf__binary/
* https://build.ros.org/view/Nbin_ufv8_uFv8/job/Nbin_ufv8_uFv8__qb_softhand_industry_hardware_interface__ubuntu_focal_arm64__binary/

@GDqbrobotics FYI - I'm not able to open an issue on https://bitbucket.org/qbrobotics/qbshin-ros . Is [the issue tracker private](https://support.atlassian.com/bitbucket-cloud/docs/enable-an-issue-tracker/)?

Please bloom-release again once the build issue is fixed.