### PR TITLE
ros2_control: 3.17.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4886,7 +4886,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.16.0-1
+      version: 3.17.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.17.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.16.0-1`

## controller_interface

- No changes

## controller_manager

```
* [CM] Fixes the issue with individual controller's update rate (#1082 <https://github.com/ros-controls/ros2_control/issues/1082>)
* Fix deprecation warning (#1093 <https://github.com/ros-controls/ros2_control/issues/1093>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Add checks if hardware is initialized. (#1054 <https://github.com/ros-controls/ros2_control/issues/1054>)
* Contributors: Dr. Denis
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Add info where the pdf is saved to view_controller_chains (#1094 <https://github.com/ros-controls/ros2_control/issues/1094>)
* Contributors: Christoph Fröhlich
```

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
