### PR TITLE
metavision_driver: 1.0.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2581,7 +2581,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/metavision_driver-release.git
-      version: 1.0.3-1
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/ros-event-camera/metavision_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `metavision_driver` to `1.0.5-1`:

- upstream repository: https://github.com/ros-event-camera/metavision_driver.git
- release repository: https://github.com/ros2-gbp/metavision_driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.3-1`

## metavision_driver

```
* added dependency on hal_plugins to cause metavision plugins to be built
* remove setting of unnecessary COMPILE_3DVIEW option
* Contributors: Bernd Pfrommer
```
