### PR TITLE
rosdep: nixos: Add xtensor and libopencv-imgproc-dev library package

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8336,10 +8336,10 @@ xsltproc:
 xtensor:
   arch: [xtensor]
   fedora: [xtensor]
+  nixos: [xtensor]
   ubuntu:
     bionic: [xtensor-dev]
     jammy: [libxtensor-dev]
-  nixos: [xtensor]
 xterm:
   arch: [xterm]
   debian: [xterm]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8339,6 +8339,7 @@ xtensor:
   ubuntu:
     bionic: [xtensor-dev]
     jammy: [libxtensor-dev]
+  nixos: [xtensor]
 xterm:
   arch: [xterm]
   debian: [xterm]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4377,6 +4377,7 @@ libopencv-imgproc-dev:
   debian: [libopencv-imgproc-dev]
   fedora: [opencv-devel]
   gentoo: [media-libs/opencv]
+  nixos: [opencv]
   openembedded: [opencv@meta-oe]
   rhel: [opencv-devel]
   ubuntu: [libopencv-imgproc-dev]


### PR DESCRIPTION
This adds the NixOS package for `xtensor` and `libopencv-imgproc-dev`

cc: @lopsided98

