### PR TITLE
adding python3-nmcli-pip to python

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2485,7 +2485,7 @@ python-networkx:
   gentoo: [dev-python/networkx]
   ubuntu:
     '*': [python-networkx]
-python3-nmcli:
+python3-nmcli-pip:
   ubuntu:
     pip:
       packages: [nmcli]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2485,11 +2485,6 @@ python-networkx:
   gentoo: [dev-python/networkx]
   ubuntu:
     '*': [python-networkx]
-python3-nmcli-pip:
-  ubuntu:
-    pip:
-      depends: [network-manager]
-      packages: [nmcli]
 python-nose:
   alpine: [py-nose]
   arch: [python2-nose]
@@ -6891,6 +6886,11 @@ python3-nlopt:
   ubuntu:
     '*': [python3-nlopt]
     bionic: null
+python3-nmcli-pip:
+  ubuntu:
+    pip:
+      depends: [network-manager]
+      packages: [nmcli]
 python3-nose:
   arch: [python-nose]
   debian: [python3-nose]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2488,6 +2488,7 @@ python-networkx:
 python3-nmcli-pip:
   ubuntu:
     pip:
+      depends: [network-manager]
       packages: [nmcli]
 python-nose:
   alpine: [py-nose]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2485,6 +2485,10 @@ python-networkx:
   gentoo: [dev-python/networkx]
   ubuntu:
     '*': [python-networkx]
+python3-nmcli:
+  ubuntu:
+    pip:
+      packages: [nmcli]
 python-nose:
   alpine: [py-nose]
   arch: [python2-nose]


### PR DESCRIPTION
Allows network control using python similar to the bash nmcli package.

Two points however:
1. for the nmcli pip package to work, apt needs to install network-manager
2. The package only worked for ubuntu 20.04 and 22.04 as I tested in docker.