### PR TITLE
rosdep: nixos: Use correct package for python-bson

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -811,7 +811,7 @@ python-bson:
   debian: [python-bson]
   fedora: [python-bson]
   gentoo: [dev-python/pymongo]
-  nixos: [pythonPackages.bson]
+  nixos: [pythonPackages.pymongo]
   openembedded: ['${PYTHON_PN}-pymongo@meta-python']
   osx:
     pip:


### PR DESCRIPTION
As pointed out in https://github.com/lopsided98/nix-ros-overlay/pull/284, all the other distros use PyMongo.