### PR TITLE
fix: nixos: add xsimd package

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8333,6 +8333,7 @@ xsimd:
     bullseye: null
     buster: null
   fedora: [xsimd-devel]
+  nixos: [xsimd]
   rhel:
     '*': [xsimd-devel]
     '7': null


### PR DESCRIPTION
This adds the NixOS package for `xsimd`

cc: @lopsided98
