### PR TITLE
Add python3-waitress

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9128,6 +9128,12 @@ python3-voluptuous:
     '*': [python3-voluptuous]
     '7': null
   ubuntu: [python3-voluptuous]
+python3-waitress:
+  debian: [python3-waitress]
+  fedora: [python3-waitress]
+  gentoo: [dev-python/waitress]
+  nixos: [python3Packages.waitress]
+  ubuntu: [python3-waitress]
 python3-watchdog:
   debian: [python3-watchdog]
   fedora: [python3-watchdog]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9133,6 +9133,8 @@ python3-waitress:
   fedora: [python3-waitress]
   gentoo: [dev-python/waitress]
   nixos: [python3Packages.waitress]
+  opensuse: [python3-waitress]
+  rhel: [python3-waitress]
   ubuntu: [python3-waitress]
 python3-watchdog:
   debian: [python3-watchdog]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:
python3-waitress

## Package Upstream Source:
https://github.com/Pylons/waitress

## Purpose of using this:
Waitress is a production-quality pure-Python WSGI server with very acceptable performance.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/bookworm/python3-waitress
- Ubuntu: https://packages.ubuntu.com/jammy/python3-waitress
- Fedora: https://packages.fedoraproject.org/pkgs/python-waitress/python3-waitress/
- Gentoo: https://packages.gentoo.org/packages/dev-python/waitress
- NixOS/nixpkgs: [Link](https://search.nixos.org/packages?channel=23.05&show=python310Packages.waitress&from=0&size=50&buckets=%7B%22package_attr_set%22%3A%5B%22python310Packages%22%5D%2C%22package_license_set%22%3A%5B%5D%2C%22package_maintainers_set%22%3A%5B%5D%2C%22package_platforms%22%3A%5B%5D%7D&sort=relevance&type=packages&query=waitress)
- OpenSuse: https://software.opensuse.org/package/python3-waitress
- RHEL: No link
