### PR TITLE
ros2_kortex: 0.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4836,7 +4836,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_kortex-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/Kinovarobotics/ros2_kortex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_kortex` to `0.2.2-1`:

- upstream repository: https://github.com/PickNikRobotics/ros2_kortex.git
- release repository: https://github.com/ros2-gbp/ros2_kortex-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.1-1`

## kinova_gen3_6dof_robotiq_2f_85_moveit_config

```
* specify planning pipelines to use (#157 <https://github.com/Kinovarobotics/ros2_kortex/issues/157>)
* Refactor MoveIt Launch files (#162 <https://github.com/Kinovarobotics/ros2_kortex/issues/162>)
* Contributors: Anthony Baker
```

## kinova_gen3_7dof_robotiq_2f_85_moveit_config

```
* specify planning pipelines to use (#157 <https://github.com/Kinovarobotics/ros2_kortex/issues/157>)
* Refactor MoveIt Launch files (#162 <https://github.com/Kinovarobotics/ros2_kortex/issues/162>)
* Add use_external_cable parameter to URDF (#155 <https://github.com/Kinovarobotics/ros2_kortex/issues/155>)
* Contributors: Anthony Baker
```

## kortex_api

- No changes

## kortex_bringup

- No changes

## kortex_description

```
* Refactor MoveIt Launch files (#162 <https://github.com/Kinovarobotics/ros2_kortex/issues/162>)
* Add use_external_cable parameter to URDF (#155 <https://github.com/Kinovarobotics/ros2_kortex/issues/155>)
* Contributors: Anthony Baker
```

## kortex_driver

```
* cxx: remove unused-but-set-parameter (#164 <https://github.com/Kinovarobotics/ros2_kortex/issues/164>)
* Contributors: Alex Moriarty
```
