### PR TITLE
social_nav_ros: 0.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7155,6 +7155,25 @@ repositories:
       url: https://github.com/ijnek/soccer_visualization.git
       version: rolling
     status: developed
+  social_nav_ros:
+    doc:
+      type: git
+      url: https://github.com/MetroRobots/social_nav_ros.git
+      version: main
+    release:
+      packages:
+      - social_nav_msgs
+      - social_nav_util
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/social_nav_ros-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/MetroRobots/social_nav_ros.git
+      version: main
+    status: developed
   sol_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `social_nav_ros` to `0.1.0-1`:

- upstream repository: https://github.com/MetroRobots/social_nav_ros.git
- release repository: https://github.com/ros2-gbp/social_nav_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## social_nav_msgs

```
* Initial Messages
* Contributors: David V. Lu!!
```

## social_nav_util

```
* Visualization script
* Contributors: David V. Lu!!
```
