### PR TITLE
classic_bags: 0.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -720,6 +720,15 @@ repositories:
       version: rolling
     status: maintained
   classic_bags:
+    doc:
+      type: git
+      url: https://github.com/MetroRobots/classic_bags.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/classic_bags-release.git
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/MetroRobots/classic_bags.git


### PR DESCRIPTION
Increasing version of package(s) in repository `classic_bags` to `0.1.0-1`:

- upstream repository: https://github.com/MetroRobots/classic_bags.git
- release repository: https://github.com/ros2-gbp/classic_bags-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## classic_bags

```
* Initial package
* Contributors: David V. Lu!!
```
