### PR TITLE
rmf_ros2: 2.1.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5217,7 +5217,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 2.1.6-1
+      version: 2.1.7-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_ros2` to `2.1.7-1`:

- upstream repository: https://github.com/open-rmf/rmf_ros2.git
- release repository: https://github.com/ros2-gbp/rmf_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.6-1`

## rmf_fleet_adapter

```
* Fix comparator for direct assignment ordering (#292 <https://github.com/open-rmf/rmf_ros2/pull/292>)
* Adding initiator and request time to booking (#284 <https://github.com/open-rmf/rmf_ros2/pull/284>)
* Contributors: Aaron Chong, Yadunund
```

## rmf_fleet_adapter_python

```
* Adding initiator and request time to booking (#284 <https://github.com/open-rmf/rmf_ros2/pull/284>)
* Contributors: Aaron Chong
```

## rmf_task_ros2

```
* Adding initiator and request time to booking (#284 <https://github.com/open-rmf/rmf_ros2/pull/284>)
* Contributors: Aaron Chong
```

## rmf_traffic_ros2

- No changes

## rmf_websocket

- No changes
