### PR TITLE
rmf_ros2: 2.2.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4518,7 +4518,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 2.2.0-1
+      version: 2.2.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_ros2` to `2.2.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_ros2.git
- release repository: https://github.com/ros2-gbp/rmf_ros2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.0-1`

## rmf_fleet_adapter

```
* Fix comparator for direct assignment ordering (#291 <https://github.com/open-rmf/rmf_ros2/pull/291>)
* Adding initiator and request time to booking (#285 <https://github.com/open-rmf/rmf_ros2/pull/285>)
* Contributors: Aaron Chong, Yadunund
```

## rmf_fleet_adapter_python

```
* Adding initiator and request time to booking (#285 <https://github.com/open-rmf/rmf_ros2/pull/285>)
* Contributors: Aaron Chong, Yadunund
```

## rmf_task_ros2

```
* Adding initiator and request time to booking (#285 <https://github.com/open-rmf/rmf_ros2/pull/285>)
* Contributors: Aaron Chong, Yadunund
```

## rmf_traffic_ros2

- No changes

## rmf_websocket

- No changes
