### PR TITLE
rmf_task: 2.2.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4558,7 +4558,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
-      version: 2.2.1-1
+      version: 2.2.2-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_task.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_task` to `2.2.2-1`:

- upstream repository: https://github.com/open-rmf/rmf_task.git
- release repository: https://github.com/ros2-gbp/rmf_task-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.1-1`

## rmf_task

- No changes

## rmf_task_sequence

```
* Fix battery drain crash for GoToPlace (#95 <https://github.com/open-rmf/rmf_task/pull/95>)
* Contributors: Yadunund
```
