### PR TITLE
rmf_traffic_editor: 1.6.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5295,7 +5295,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
-      version: 1.6.1-1
+      version: 1.6.2-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic_editor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_traffic_editor` to `1.6.2-1`:

- upstream repository: https://github.com/open-rmf/rmf_traffic_editor.git
- release repository: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.6.1-1`

## rmf_building_map_tools

```
* Fix gz classic model download (#471 <https://github.com/open-rmf/rmf_traffic_editor/pull/471>)
* Contributors: Aaron Chong
```

## rmf_traffic_editor

- No changes

## rmf_traffic_editor_assets

- No changes

## rmf_traffic_editor_test_maps

```
* Fix gz classic model download (#471 <https://github.com/open-rmf/rmf_traffic_editor/pull/471>)
* Contributors: Aaron Chong
```
