### PR TITLE
rmf_traffic_editor: 1.7.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4596,7 +4596,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
-      version: 1.7.0-1
+      version: 1.7.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic_editor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_traffic_editor` to `1.7.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_traffic_editor.git
- release repository: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.7.0-1`

## rmf_building_map_tools

```
* Fix gz classic model download (#472 <https://github.com/open-rmf/rmf_traffic_editor/pull/472>)
* Contributors: Aaron Chong
```

## rmf_traffic_editor

- No changes

## rmf_traffic_editor_assets

- No changes

## rmf_traffic_editor_test_maps

```
* Fix gz classic model download (#472 <https://github.com/open-rmf/rmf_traffic_editor/pull/472>)
* Contributors: Aaron Chong
```
