### PR TITLE
rmf_ros2: 2.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4388,7 +4388,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 2.3.0-1
+      version: 2.3.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_ros2` to `2.3.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_ros2.git
- release repository: https://github.com/ros2-gbp/rmf_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.0-1`

## rmf_fleet_adapter

```
* Remove duplicate task schemas (#294 <https://github.com/open-rmf/rmf_ros2/pull/294>)
* Fix comparator for direct assignment ordering (#288 <https://github.com/open-rmf/rmf_ros2/pull/288>)
* Adding initiator and request time to booking (#267 <https://github.com/open-rmf/rmf_ros2/pull/267>)
* Contributors: Aaron Chong, Omar Hamza, Yadunund
```

## rmf_fleet_adapter_python

```
* Adding initiator and request time to booking (#267 <https://github.com/open-rmf/rmf_ros2/pull/267>)
* Contributors: Aaron Chong
```

## rmf_task_ros2

```
* Adding initiator and request time to booking (#267 <https://github.com/open-rmf/rmf_ros2/pull/267>)
* Contributors: Aaron Chong
```

## rmf_traffic_ros2

- No changes

## rmf_websocket

- No changes
