### PR TITLE
rmf_traffic_editor: 1.8.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4466,7 +4466,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
-      version: 1.8.0-1
+      version: 1.8.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic_editor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_traffic_editor` to `1.8.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_traffic_editor.git
- release repository: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.8.0-1`

## rmf_building_map_tools

```
* Fix gz classic model download (#470 <https://github.com/open-rmf/rmf_traffic_editor/pull/470>)
* Contributors: Aaron Chong
```

## rmf_traffic_editor

- No changes

## rmf_traffic_editor_assets

- No changes

## rmf_traffic_editor_test_maps

```
* Fix gz classic model download (#470 <https://github.com/open-rmf/rmf_traffic_editor/pull/470>)
* Contributors: Aaron Chong
```
