### PR TITLE
Add tshark base dependency

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7987,6 +7987,13 @@ tree:
   gentoo: [app-text/tree]
   nixos: [tree]
   ubuntu: [tree]
+tshark:
+  alpine: [tshark]
+  arch: [wireshark-cli]
+  debian: [tshark]
+  fedora: [wireshark-cli]
+  rhel: [wireshark-cli]
+  ubuntu: [tshark]
 ttf-kochi-gothic:
   arch: [ttf-togoshi-gothic]
   debian: [ttf-kochi-gothic]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

tshark (aka wireshark-cli)

## Package Upstream Source:
https://github.com/wireshark/wireshark

## Purpose of using this:

We have launch files that begin packet capture on robot bringup while in debug mode. We have this in our own rosdistro fork but it makes sense to have this here.

Distro packaging links:
https://rockylinux.pkgs.org/9/rockylinux-appstream-x86_64/wireshark-cli-3.4.10-4.el9.x86_64.rpm.html

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/tshark
- Ubuntu: https://packages.ubuntu.com/
https://packages.ubuntu.com/jammy/tshark
- Fedora: https://packages.fedoraproject.org/
https://packages.fedoraproject.org/pkgs/wireshark/wireshark-cli/index.html
- Arch: https://www.archlinux.org/packages/
https://archlinuxarm.org/packages/aarch64/wireshark-cli
- Alpine: https://pkgs.alpinelinux.org/packages
https://pkgs.alpinelinux.org/package/v3.18/community/aarch64/tshark

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

