### PR TITLE
clearpath_config: 0.0.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -826,7 +826,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 0.0.5-1
+      version: 0.0.6-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `0.0.6-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.5-1`

## clearpath_config

```
* Added all modules to setup.py
* Removed J100 bumpers from samples
* Updated sample configs
* Added posts and disks to samples
* Removed unused include
* Split tower into post and disk
* Renamed ust10 to ust
* Updated README
* Updated samples
* Removed eof line
* Fixed port paths
* Added fenders, default disabled
* Added ROS CI, issue templates and codeowners.
* Added sick stand and variable-leg tower
* Added UM7/UM6
* Contributors: Luis Camero, Tony Baltovski
```
