### PR TITLE
aws_sdk_cpp_vendor: 0.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -515,6 +515,15 @@ repositories:
       version: ros2
     status: maintained
   aws_sdk_cpp_vendor:
+    doc:
+      type: git
+      url: https://github.com/wep21/aws_sdk_cpp_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/aws_sdk_cpp_vendor-release.git
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/wep21/aws_sdk_cpp_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aws_sdk_cpp_vendor` to `0.1.0-1`:

- upstream repository: https://github.com/wep21/aws_sdk_cpp_vendor.git
- release repository: https://github.com/ros2-gbp/aws_sdk_cpp_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## aws_sdk_cpp_vendor

```
* fix: add missing dependency
* feat: initial commit
* Contributors: wep21
```
