### PR TITLE
witmotion_ros: 1.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12518,7 +12518,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/twdragon/witmotion_ros-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `witmotion_ros` to `1.3.1-1`:

- upstream repository: https://github.com/ElettraSciComp/witmotion_IMU_ros.git
- release repository: https://github.com/twdragon/witmotion_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.0-1`

## witmotion_ros

```
* Fixed GPS decoder function in the underlying library (added x10 multiplier in Degrees section)
* Version bump to 1.3.1
* Community-driven test of the library on WTGAHRS1 combined enclosed IMU/GPS sensor module <https://www.wit-motion.com/inertial-navigation/witmotion-wtgahrs1-10-axis-gps.html> by Quing Joe Wong joewong00
* Contributors: Andrey Vukolov, Quing Joe Wong
```
