### PR TITLE
rig_reconfigure: 1.2.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4421,7 +4421,7 @@ repositories:
     release:
       tags:
         release: release/iron/{package}/{version}
-      url: git@github.com:ros2-gbp/rig_reconfigure-release.git
+      url: https://github.com/ros2-gbp/rig_reconfigure-release.git
       version: 1.2.0-1
     source:
       test_pull_requests: true

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4421,8 +4421,8 @@ repositories:
     release:
       tags:
         release: release/iron/{package}/{version}
-      url: https://github.com/ros2-gbp/rig_reconfigure-release.git
-      version: 1.1.0-1
+      url: git@github.com:ros2-gbp/rig_reconfigure-release.git
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rig_reconfigure` to `1.2.0-1`:

- upstream repository: https://github.com/teamspatzenhirn/rig_reconfigure.git
- release repository: git@github.com:ros2-gbp/rig_reconfigure-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-1`

## rig_reconfigure

```
* Improvements for handling string parameters (sending update only once editing is complete)
* Add window icon
* Add desktop file
* Contributors: Dominik, Jonas Otto
```
