### PR TITLE
rig_reconfigure: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4267,7 +4267,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: git@github.com:ros2-gbp/rig_reconfigure-release.git
+      url: https://github.com/ros2-gbp/rig_reconfigure-release.git
       version: 1.2.0-1
     source:
       test_pull_requests: true

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4267,8 +4267,8 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/rig_reconfigure-release.git
-      version: 1.1.0-1
+      url: git@github.com:ros2-gbp/rig_reconfigure-release.git
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rig_reconfigure` to `1.2.0-1`:

- upstream repository: https://github.com/teamspatzenhirn/rig_reconfigure.git
- release repository: git@github.com:ros2-gbp/rig_reconfigure-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-1`

## rig_reconfigure

```
* Improvements for handling string parameters (sending update only once editing is complete)
* Add window icon
* Add desktop file
* Contributors: Dominik, Jonas Otto
```
