### PR TITLE
mvsim: 0.7.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2987,7 +2987,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/mvsim-release.git
-      version: 0.7.1-1
+      version: 0.7.2-1
     source:
       type: git
       url: https://github.com/MRPT/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.7.2-1`:

- upstream repository: https://github.com/MRPT/mvsim.git
- release repository: https://github.com/ros2-gbp/mvsim-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.1-1`

## mvsim

```
* Joystick driving: added support for direct driving the vehicles with a joystick.
* Fix rviz for ros1 demo
* Better docs and more modern RST style.
* More shadow tuning parameters.
* IMU sensor now reads real vehicle linear acceleration.
* Contributors: Jose Luis Blanco-Claraco
```
