### PR TITLE
flir_camera_driver: 2.0.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1653,7 +1653,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git
-      version: 2.0.5-1
+      version: 2.0.6-1
     source:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_camera_driver` to `2.0.6-1`:

- upstream repository: https://github.com/ros-drivers/flir_camera_driver.git
- release repository: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.5-1`

## flir_camera_description

- No changes

## flir_camera_msgs

- No changes

## spinnaker_camera_driver

```
* fix arm64 build: use correct file name when downloading spinnaker from clearpath
* fix broken build when the Spinnaker SDK is present
* allow building with older version (0.6) of yaml library
* Contributors: Bernd Pfrommer
```
