### PR TITLE
feat: add gnu octave to rosdep

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6741,6 +6741,15 @@ ocl-icd-opencl-dev:
   gentoo: [virtual/opencl]
   rhel: [ocl-icd-devel]
   ubuntu: [ocl-icd-opencl-dev]
+octave:
+  alpine: [octave]
+  arch: [octave]
+  debian: [octave]
+  fedora: [octave]
+  gentoo: [sci-mathematics/octave]
+  opensuse: [octave]
+  rhel: [octave]
+  ubuntu: [octave]
 odb:
   debian: [odb]
   ubuntu:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

octave

## Package Upstream Source:

[GNU Mercurial](https://hg.savannah.gnu.org/hgweb/octave)
[Github Mirror](https://github.com/gnu-octave/octave)

## Purpose of using this:

Octave is a (mostly MATLAB® compatible) high-level language, primarily  intended for numerical computations. It provides a convenient command-line interface for solving linear and nonlinear problems numerically.

It is an open source alternative to run code that was originally written for matlab, in and open source framework. We are using it for signal processing.

## Links to Distribution Packages

- Octave Wiki: https://wiki.octave.org/Octave_for_GNU/Linux
- Debian: https://packages.debian.org/bookworm/octave
- Ubuntu: https://packages.ubuntu.com/jammy/octave
- Fedora: https://packages.fedoraproject.org/pkgs/octave/octave/
- Arch: https://archlinux.org/packages/extra/x86_64/octave/
- Gentoo: https://packages.gentoo.org/packages/sci-mathematics/octave
- Alpine: https://pkgs.alpinelinux.org/package/edge/community/x86_64/octave
- openSUSE: https://software.opensuse.org/package/octave