### PR TITLE
feat: add pip oct2py to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6969,6 +6969,16 @@ python3-oauth2client:
     '*': [python3-oauth2client]
     '7': null
   ubuntu: [python3-oauth2client]
+python3-oct2py-pip:
+  debian:
+    pip:
+      packages: [oct2py]
+  fedor:
+    pip:
+      packages: [oct2py]
+  ubuntu:
+    pip:
+      packages: [oct2py]
 python3-odrive-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6973,7 +6973,7 @@ python3-oct2py-pip:
   debian:
     pip:
       packages: [oct2py]
-  fedor:
+  fedora:
     pip:
       packages: [oct2py]
   ubuntu:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

oct2py

## Package Upstream Source:

https://github.com/blink1073/oct2py

## Purpose of using this:

Oct2Py allows you to seamlessly call M-files and Octave functions from Python. It manages the Octave session for you, sharing data behind the scenes using MAT files. With this we can call matlab/octave functions from our python ros node. Related to #38228 

Distro packaging links:

## Links to Distribution Packages

- pypi: https://pypi.org/project/oct2py/
- Debian: not available
- Ubuntu: not available
- Fedora: not available