### PR TITLE
behaviortree_cpp_v4: 4.3.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -517,7 +517,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.2.1-1
+      version: 4.3.5-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp_v4` to `4.3.5-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.2.1-1`

## behaviortree_cpp

```
* fix issue #621 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/621>: ConsumeQueue
* feat: add template specialization for convertFromString deque (#628 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/628>)
* unit test added
* Update groot2_publisher.h (#630 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/630>)
* unit test issue #629 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/629>
* WhileDoElseNode can have 2 or 3 children (#625 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/625>)
* fix issue #624 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/624> : add TimeoutNode::halt()
* fix recording_fist_time issue on windows (#618 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/618>)
* Contributors: Aglargil, Davide Faconti, Michael Terzer, benyamin saedi, muritane
```
