### PR TITLE
feat: add 'numpy' pip install

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2531,6 +2531,19 @@ python-numpy:
   ubuntu:
     bionic: [python-numpy]
     focal: [python-numpy]
+python-numpy-pip: &migrate_eol_2025_04_30_python3_numpy_pip
+  debian:
+    pip:
+      packages: [numpy]
+  fedora:
+    pip:
+      packages: [numpy]
+  osx:
+    pip:
+      packages: [numpy]
+  ubuntu:
+    pip:
+      packages: [numpy]
 python-numpy-quaternion-pip:
   debian:
     pip:
@@ -6929,6 +6942,7 @@ python3-numpy:
   opensuse: [python3-numpy]
   rhel: ['python%{python3_pkgversion}-numpy']
   ubuntu: [python3-numpy]
+python3-numpy-pip: *migrate_eol_2025_04_30_python3_numpy_pip
 python3-numpy-stl:
   debian: [python3-numpy-stl]
   fedora: [python3-numpy-stl]


### PR DESCRIPTION
This commit adds the pip install of the NumPy package. This allows users to use more recent versions for their distro than those available through system packages.

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

Pip version of [numpy](https://pypi.org/search/?q=numpy).

## Package Upstream Source:

https://github.com/numpy/numpy

## Purpose of using this:

This dependency is needed because other items that are available in the [rosdep/python.yaml](https://github.com/ros/rosdistro/blob/b6b1a7f3d9931b19efaee421982fbca875531087/rosdep/python.yaml#L221-L233)
file that does not have a system package available throws errors when NumPy is installed. Gymnasium, for example, which I added in https://github.com/ros/rosdistro/pull/37334, requires `numpy>=1.21` since it uses the [typing module released in 1.21](https://numpy.org/devdocs/reference/typing.html), while `numpy==1.17.4` is installed on Ubuntu 20.04 (see https://pkgs.org/search/?q=python3-pandas). Allowing developers to choose the pip version of NumPy solves this issue for users.

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
