### PR TITLE
feat: add 'pandas' pip install

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2656,6 +2656,19 @@ python-pandas:
   gentoo: [dev-python/pandas]
   nixos: [pythonPackages.pandas]
   ubuntu: [python-pandas]
+python-pandas-pip: &migrate_eol_2025_04_30_python3_pandas_pip
+  debian:
+    pip:
+      packages: [pandas]
+  fedora:
+    pip:
+      packages: [pandas]
+  osx:
+    pip:
+      packages: [pandas]
+  ubuntu:
+    pip:
+      packages: [pandas]
 python-parameterized:
   debian:
     '*': [python-parameterized]
@@ -7122,6 +7135,7 @@ python3-pandas:
     '*': ['python%{python3_pkgversion}-pandas']
     '7': null
   ubuntu: [python3-pandas]
+python3-pandas-pip: *migrate_eol_2025_04_30_python3_pandas_pip
 python3-papermill-pip:
   debian:
     pip:


### PR DESCRIPTION
This commit adds the pip install of the pandas package. This allows users to use more recent versions for their distro than those available through system packages. This pull request is closely related to https://github.com/ros/rosdistro/pull/38242.

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

Pip version of [pandas](https://pypi.org/project/pandas/).

## Package Upstream Source:

https://github.com/pandas-dev/pandas

## Purpose of using this:

This dependency is needed because other items that are available in the [rosdep/python.yaml](https://github.com/ros/rosdistro/blob/b6b1a7f3d9931b19efaee421982fbca875531087/rosdep/python.yaml#L221-L233)
file which does not have a system package available throws errors when the system pandas package is installed. When for example, NumPy is installed through pip (see https://github.com/ros/rosdistro/pull/38242), it requires `pandas>=1.1.0` since the older version of pandas expects the `np.bool` to be not deprecated (see https://github.com/brightway-lca/brightway2/issues/64).

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
