### PR TITLE
feat: add 'gymnasium-robotics' pip package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6275,6 +6275,21 @@ python3-gymnasium-pip:
   ubuntu:
     '*':
       pip:
+        packages: [gymnasium]
+    focal: null
+python3-gymnasium-robotics-pip:
+  debian:
+    pip:
+      packages: [gymnasium-robotics]
+  fedora:
+    pip:
+      packages: [gymnasium-robotics]
+  osx:
+    pip:
+      packages: [gymnasium-robotics]
+  ubuntu:
+    '*':
+      pip:
         packages: [gymnasium-robotics]
     focal: null
 python3-gz-math6:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

https://pypi.org/project/gymnasium-robotics/

## Package Upstream Source:

https://github.com/Farama-Foundation/Gymnasium-Robotics

## Purpose of using this:

This package can be used to train RL on robotics systems.

Distro packaging links: N/A

## Additional comments

I omitted a [python/python3](https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#pip-1) prefix since this package is unavailable as a python2 package.

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
