### PR TITLE
added minimalmodbus from pip to ubuntu

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6697,6 +6697,10 @@ python3-meson-pip:
   ubuntu:
     pip:
       packages: [meson]
+python3-minimalmodbus-pip:
+  ubuntu:
+    pip:
+      packages: [minimalmodbus]
 python3-mistune:
   alpine:
     pip:


### PR DESCRIPTION
## Package name:

[minimalmodbus](https://pypi.org/project/minimalmodbus/)

## Package Upstream Source:

https://github.com/pyhys/minimalmodbus

## Purpose of using this:

This dependency allows for simple modbus communication.
