### PR TITLE
ros2_control: 2.30.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5644,7 +5644,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.29.0-1
+      version: 2.30.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.30.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.29.0-1`

## controller_interface

- No changes

## controller_manager

```
* [CM] Fixes the issue with individual controller's update rate (#1082 <https://github.com/ros-controls/ros2_control/issues/1082>) (#1097 <https://github.com/ros-controls/ros2_control/issues/1097>)
* Contributors: Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Add checks if hardware is initialized. (backport #1054 <https://github.com/ros-controls/ros2_control/issues/1054>) (#1081 <https://github.com/ros-controls/ros2_control/issues/1081>)
* Contributors: Denis Stogl
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Add info where the pdf is saved to view_controller_chains (#1094 <https://github.com/ros-controls/ros2_control/issues/1094>) (#1096 <https://github.com/ros-controls/ros2_control/issues/1096>)
* Contributors: Christoph Fröhlich
```

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
