### PR TITLE
marti_common: 3.5.4-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2560,7 +2560,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/marti_common-release.git
-      version: 3.5.3-1
+      version: 3.5.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `3.5.4-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/ros2-gbp/marti_common-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.5.3-1`

## swri_cli_tools

- No changes

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

- No changes

## swri_image_util

- No changes

## swri_math_util

- No changes

## swri_opencv_util

- No changes

## swri_prefix_tools

- No changes

## swri_roscpp

```
* Add publisher and subscription options to constructors (#714 <https://github.com/swri-robotics/marti_common/issues/714>)
* Use System QoS Settings as Defaults (#713 <https://github.com/swri-robotics/marti_common/issues/713>)
* Adding wrapper for unique_ptr arguments (#712 <https://github.com/swri-robotics/marti_common/issues/712>)
* Contributors: David Anthony, Veronica Knisley
```

## swri_route_util

- No changes

## swri_serial_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

- No changes
