### PR TITLE
rplidar_ros: 2.1.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6274,7 +6274,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rplidar_ros-release.git
-      version: 2.1.3-3
+      version: 2.1.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rplidar_ros` to `2.1.4-1`:

- upstream repository: https://github.com/Slamtec/rplidar_ros
- release repository: https://github.com/ros2-gbp/rplidar_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.3-3`

## rplidar_ros

```
* Update SDK.
  * UltraDense protocol support
  * support for stoppping A1 motor
  * Optimize lidar driver for switching S2E workingmode
* Bugfix:logical error
* Install udev rules via debian.
* Contributors: Tony Baltovski, deyou wang
```
