### PR TITLE
ouster-ros: 0.10.3-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3491,6 +3491,25 @@ repositories:
       url: https://github.com/osrf/osrf_testing_tools_cpp.git
       version: iron
     status: maintained
+  ouster-ros:
+    doc:
+      type: git
+      url: https://github.com/ouster-lidar/ouster-ros.wiki.git
+      version: master
+    release:
+      packages:
+      - ouster_msgs
+      - ouster_ros
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ouster-lidar/ouster-ros-release.git
+      version: 0.10.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ouster-lidar/ouster-ros.wiki.git
+      version: master
+    status: developed
   ouxt_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ouster-ros` to `0.10.3-1`:

- upstream repository: https://github.com/ouster-lidar/ouster-ros.git
- release repository: https://github.com/ouster-lidar/ouster-ros-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## ouster_msgs

```
* Add per package LICENSE file
* Contributors: Ussama Naal
```

## ouster_ros

```
* Add per package LICENSE file
* manifest symbolic links as files
* Contributors: Ussama Naal
```
