### PR TITLE
weight_scale_interfaces: 0.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8590,7 +8590,7 @@ repositories:
     source:
       type: git
       url: https://github.com/TechMagicKK/weight_scale_interfaces.git
-      version: humble
+      version: main
   wireless:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8581,6 +8581,12 @@ repositories:
       url: https://github.com/cyberbotics/webots_ros2.git
       version: master
     status: maintained
+  weight_scale_interfaces:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/TechMagicKK/weight_scale_interfaces-release.git
+      version: 0.0.1-1
   wireless:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8591,7 +8591,6 @@ repositories:
       type: git
       url: https://github.com/TechMagicKK/weight_scale_interfaces.git
       version: humble
-    status: maintained
   wireless:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8587,6 +8587,11 @@ repositories:
         release: release/humble/{package}/{version}
       url: https://github.com/TechMagicKK/weight_scale_interfaces-release.git
       version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/TechMagicKK/weight_scale_interfaces.git
+      version: humble
+    status: maintained
   wireless:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `weight_scale_interfaces` to `0.0.1-1`:

- upstream repository: https://github.com/TechMagicKK/weight_scale_interfaces.git
- release repository: https://github.com/TechMagicKK/weight_scale_interfaces-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## weight_scale_interfaces

```
* Release
* Initial commit
* Contributors: Ravi Joshi, Ryosuke Tajima, koki-ogura
```
