### PR TITLE
aerostack2: 1.0.0-3 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -97,7 +97,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/aerostack2-release.git
-      version: 1.0.0-2
+      version: 1.0.0-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aerostack2` to `1.0.0-3`:

- upstream repository: https://github.com/aerostack2/aerostack2.git
- release repository: https://github.com/ros2-gbp/aerostack2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-2`

## aerostack2

- No changes

## as2_alphanumeric_viewer

- No changes

## as2_behavior

- No changes

## as2_behavior_tree

- No changes

## as2_behaviors_motion

```
* Merge pull request #195 <https://github.com/aerostack2/aerostack2/issues/195> from aerostack2/add_follow_reference_behavior
  Follow reference typos fix
* typos fix
* Merge pull request #193 <https://github.com/aerostack2/aerostack2/issues/193> from aerostack2/add_follow_reference_behavior
  Add follow reference behavior
* clang test passes, format changes, new individual launcher
* feedback fixed
* removed gdb from compiling
* new behavior created and tested, modify tbd
* Merge pull request #176 <https://github.com/aerostack2/aerostack2/issues/176> from aerostack2/175-as2_behaviors_motion-land-behavior-not-loading-land-speed-condition-parameter
  Loading parameters in land behavior fixed
* fixes #175 <https://github.com/aerostack2/aerostack2/issues/175>
* Merge pull request #163 <https://github.com/aerostack2/aerostack2/issues/163> from aerostack2/crazyflie_swarm_demo
  Crazyflie swarm demo updates
* Merge pull request #160 <https://github.com/aerostack2/aerostack2/issues/160> from aerostack2/trajectory_generation
  Change trajectory generator name
* Demo cf swarm updates
* Change trajectory generator name
* Revert "Change trayectory generator"
  This reverts commit fe17ea3f0a5ef1eb377e0779359bd75dc8c3212d.
* Change trayectory generator
* Merge branch 'main' into aruco_detect
* Merge pull request #156 <https://github.com/aerostack2/aerostack2/issues/156> from aerostack2/go_to
  [as2_behaviors_motion] Change goto to go_to
* Change goto to go_to
* Merge pull request #152 <https://github.com/aerostack2/aerostack2/issues/152> from aerostack2/151-as2_behaviors_motion-follow-path-launch
  Stripping whitespaces in launch file name
* stripping whitespaces in launch file name
* rename movement_behavior launcher into motion_behaviors_launcher.py
* Merge pull request #125 <https://github.com/aerostack2/aerostack2/issues/125> from aerostack2/as2_behaviors
  [as2_behaviors] Reorganize behaviors
* Behaviors motion clang test
* Reorganize behaviors
* Contributors: Javilinos, Miguel Fernandez-Cortizas, RPS98, Rafael Pérez, pariaspe
```

## as2_behaviors_perception

```
* Merge branch 'main' into trajectory_generation
* Merge pull request #157 <https://github.com/aerostack2/aerostack2/issues/157> from aerostack2/aruco_detect
  [as2_behaviors_perception] Change aruco_detector to detect_aruco_marker
* Merge to main
* Merge remote-tracking branch 'origin/aruco_detect'
* Change auro detector to auro_detect
* Merge pull request #125 <https://github.com/aerostack2/aerostack2/issues/125> from aerostack2/as2_behaviors
  [as2_behaviors] Reorganize behaviors
* Reorganize behaviors
* Contributors: David Perez-Saura, Miguel Fernandez-Cortizas, RPS98, pariaspe
```

## as2_behaviors_platform

- No changes

## as2_behaviors_trajectory_generation

```
* Merge pull request #183 <https://github.com/aerostack2/aerostack2/issues/183> from aerostack2/153-as2_behaviors-extra-foreach-in-cmake
  [bug] extra foreach removed
* [bug] extra foreach removed
* Merge pull request #163 <https://github.com/aerostack2/aerostack2/issues/163> from aerostack2/crazyflie_swarm_demo
  Crazyflie swarm demo updates
* Merge pull request #160 <https://github.com/aerostack2/aerostack2/issues/160> from aerostack2/trajectory_generation
  Change trajectory generator name
* Demo cf swarm updates
* Change trajectory generator name
* Revert "Change trayectory generator"
  This reverts commit fe17ea3f0a5ef1eb377e0779359bd75dc8c3212d.
* Change trayectory generator
* Contributors: Miguel, RPS98, Rafael Pérez, pariaspe
```

## as2_cli

- No changes

## as2_core

- No changes

## as2_gazebo_classic_assets

- No changes

## as2_ign_gazebo_assets

```
* Merge pull request #174 <https://github.com/aerostack2/aerostack2/issues/174> from aerostack2/as2_simulation_assets_for_windmill_project
  [as2_simulation_assets] Windmill updates
* ground truth bridge in cmakelist was missing
* fix bug tf broadcaster
* tf broadcaster renamed to object tf broadcaster
* last changes
* stop windmill gps reference frame from rotating when blades rotate aswell
* object tf bridge added, windmill object finished
* added controller for windmill in ros2
* grass patch with sky added
* joint controller bridge added, windmill joints controllable from ros2
* added velocity controller to windmill for box
* Merge remote-tracking branch 'origin' into as2_simulation_assets_for_windmill_project
* Merge pull request #171 <https://github.com/aerostack2/aerostack2/issues/171> from aerostack2/ign_empty_gps
  [as2_ign_gazebo_assets] Add GPS coordinates to empty world
* Add GPS coordinates to empty world
* azimuth bridge added
* added gps odometry for azimuth calculation, gps bridge for windmill
* Merge pull request #145 <https://github.com/aerostack2/aerostack2/issues/145> from aerostack2/add_objects_ignition_enhancement
  Windmill + load objects with bridges
* removed windmill world
* Merge pull request #163 <https://github.com/aerostack2/aerostack2/issues/163> from aerostack2/crazyflie_swarm_demo
  Crazyflie swarm demo updates
* Demo cf swarm updates
* changes and bug fix
* deleted comments
* structural changes
* fix, check for objects in json file
* added working windmill model, added feature to load object with bridges into the world from config file
* Merge pull request #124 <https://github.com/aerostack2/aerostack2/issues/124> from aerostack2/123-ground-truth-bridge-segmentation-fault
  Ground truth bridge segmentation fault fix
* move publishers before ign subscriber
* Merge pull request #114 <https://github.com/aerostack2/aerostack2/issues/114> from aerostack2/devel
  [all] Reduce packages and update names
* Update namespace names
* Rename ignition_assets to as2_ign_gazebo_assets
* Contributors: Javier Melero, Javilinos, Miguel Fernandez-Cortizas, RPS98, pariaspe
```

## as2_keyboard_teleoperation

- No changes

## as2_motion_controller

```
* Merge branch 'main' into aruco_detect
* Merge branch 'main' into state_estimator_plugins
* Merge pull request #158 <https://github.com/aerostack2/aerostack2/issues/158> from aerostack2/motion_controller
  [as2_controller] Change as2_controller to as2_motion_controller
* Change as2_controller to as2_motion_controller
* Contributors: Miguel Fernandez-Cortizas, RPS98
```

## as2_motion_reference_handlers

- No changes

## as2_msgs

- No changes

## as2_platform_crazyflie

- No changes

## as2_platform_dji_osdk

```
* Merge pull request #149 <https://github.com/aerostack2/aerostack2/issues/149> from aerostack2/148-add-missing-licenses
  Updated liceses and description
* updated liceses and description
* Merge pull request #144 <https://github.com/aerostack2/aerostack2/issues/144> from aerostack2/136-as2_platform_dji_osdk-add-dji-m200-and-m300-support-using-dji-osdk
  as2 platform dji osdk add dji m200 and m300 support using dji osdk
* Use aerostack fork
  >
  >
  Co-authored-by: Miguel Fernandez <mailto:miferco97@gmail.com>
* Remove gps utils package dependence
* Remove GeographicLib dependence
* DJI tested in simulation
* use has_new_references attribute before sending command
* 1st integration
* first iteration before sync with main
* Contributors: Miguel, RPS98, Rafael Pérez, pariaspe
```

## as2_platform_ign_gazebo

```
* Merge pull request #145 <https://github.com/aerostack2/aerostack2/issues/145> from aerostack2/add_objects_ignition_enhancement
  Windmill + load objects with bridges
* structural changes
* added working windmill model, added feature to load object with bridges into the world from config file
* Merge pull request #114 <https://github.com/aerostack2/aerostack2/issues/114> from aerostack2/devel
  [all] Reduce packages and update names
* Update namespace names
* Rename ignition_assets to as2_ign_gazebo_assets
* Merge pull request #113 <https://github.com/aerostack2/aerostack2/issues/113> from aerostack2/as2_platforms_rename
  Rename platforms
* Rename platforms
* Contributors: Javilinos, Miguel Fernandez-Cortizas, RPS98, Rafael Pérez, pariaspe
```

## as2_platform_tello

- No changes

## as2_python_api

- No changes

## as2_realsense_interface

- No changes

## as2_state_estimator

```
* Merge branch 'main' into trajectory_generation
* Merge pull request #159 <https://github.com/aerostack2/aerostack2/issues/159> from aerostack2/state_estimator_plugins
  [as2_state_estimator] Change plugins names
* Clang format
* Chnage plugins names
* Merge pull request #137 <https://github.com/aerostack2/aerostack2/issues/137> from aerostack2/main
  Sync branch with main
* Merge pull request #134 <https://github.com/aerostack2/aerostack2/issues/134> from aerostack2/71-all-include-gps-translator-functions
  GPS behavior support
* fixing gps origin earth to map tf
* set and get origin srvs created on external_odom plugin
* Merge pull request #114 <https://github.com/aerostack2/aerostack2/issues/114> from aerostack2/devel
  [all] Reduce packages and update names
* Clang format fix
* State estimator launch config file bug fix
* Update namespace names
* Merge pull request #119 <https://github.com/aerostack2/aerostack2/issues/119> from aerostack2/as2_state_estimator_unify
  [as2_state_estimator] As2 state estimator unify
* Add license header
* Unify state estimators in one package
* Contributors: Miguel, Miguel Fernandez-Cortizas, RPS98, Rafael Pérez, pariaspe
```

## as2_usb_camera_interface

- No changes
