### PR TITLE
aerostack2: 1.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -97,7 +97,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/aerostack2-release.git
-      version: 1.0.0-2
+      version: 1.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aerostack2` to `1.0.2-1`:

- upstream repository: https://github.com/aerostack2/aerostack2.git
- release repository: https://github.com/ros2-gbp/aerostack2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-2`

## aerostack2

- No changes

## as2_alphanumeric_viewer

- No changes

## as2_behavior

- No changes

## as2_behavior_tree

```
* Merge pull request #292 <https://github.com/aerostack2/aerostack2/issues/292> from aerostack2/issue-289
  Delete install_bt_dependencies.bash
* Delete install_bt_dependencies.bash
  Closes #289 <https://github.com/aerostack2/aerostack2/issues/289>
* Merge pull request #235 <https://github.com/aerostack2/aerostack2/issues/235> from aerostack2/234-goto-bt-action-missing-frame
  [as2_behavior_tree] GoTo Bt action missing frame
* adding short sleep after takeoff
* adding earth frame
* Contributors: Javilinos, Miguel Fernandez-Cortizas, RPS98, Rafael Pérez, pariaspe
```

## as2_behaviors_motion

```
* Merge pull request #304 <https://github.com/aerostack2/aerostack2/issues/304> from aerostack2/302-parametrize_tf_threshold_time
  302-Parametrize tf timeout in go to and follow reference behavior
* parametrize tf timeout in go to and follow reference behavior
* Merge pull request #273 <https://github.com/aerostack2/aerostack2/issues/273> from aerostack2/272-add_reference_facing_mode_to_follow_reference
  follow reference with reference facing added
* add follow reference with new yaw mode
* follow reference with reference facing added
* Merge pull request #268 <https://github.com/aerostack2/aerostack2/issues/268> from aerostack2/fix_follow_path_with_reference
  follow path frame bug fixed, frame id argument added to python interface
* follow path frame bug fixed, frame id argument added to python interface
* Merge pull request #237 <https://github.com/aerostack2/aerostack2/issues/237> from aerostack2/unify_platform_launchers
  Unify launchers
* Unify as2_behaviors_motion with config files
* Contributors: Javier Melero, Javilinos, Miguel Fernandez-Cortizas, RPS98, Rafael Pérez, pariaspe
```

## as2_behaviors_perception

- No changes

## as2_behaviors_platform

- No changes

## as2_behaviors_trajectory_generation

- No changes

## as2_cli

- No changes

## as2_core

```
* Merge pull request #304 <https://github.com/aerostack2/aerostack2/issues/304> from aerostack2/302-parametrize_tf_threshold_time
  302-Parametrize tf timeout in go to and follow reference behavior
* parametrize tf timeout in go to and follow reference behavior
* Contributors: Javier Melero, Javilinos, RPS98, pariaspe
```

## as2_gazebo_classic_assets

```
* Merge pull request #238 <https://github.com/aerostack2/aerostack2/issues/238> from aerostack2/px4_gz_assets
  [as2_gazebo_classic_assets] PX4 gazebo assets update to micro dds
* fixing gz-classic scripts
* Update folders name
* Contributors: Javilinos, Miguel Fernandez-Cortizas, RPS98, pariaspe
```

## as2_ign_gazebo_assets

```
* Merge pull request #314 <https://github.com/aerostack2/aerostack2/issues/314> from aerostack2/313-payload-bridges-missing
  Payload bridges fix
* fixes issue 313: payload bridges
* Merge pull request #306 <https://github.com/aerostack2/aerostack2/issues/306> from aerostack2/as2_viz
  Added drone_viz sdf
* added drone_viz sdf
* Merge pull request #305 <https://github.com/aerostack2/aerostack2/issues/305> from aerostack2/300-add_sim_time_to_gps_bridge
  use_sim_time now works in gps bridge
* use sim time now works in gps bridge
* added grass world
* Merge pull request #295 <https://github.com/aerostack2/aerostack2/issues/295> from aerostack2/290-add_gps_origin_from_json_file
  add gps origin from json file
* now assets can be loaded from other directory
* jinja always used, if it doesn't exist, sdf is used
* add gps origin from json file
* Merge pull request #286 <https://github.com/aerostack2/aerostack2/issues/286> from aerostack2/285-fix_python_list_type
  Changed typing list to List
* changed list to List
* Merge pull request #278 <https://github.com/aerostack2/aerostack2/issues/278> from aerostack2/229-as2_simulation_assets-earth-needs-to-be-alligned-in-enu-frame
  Change 0 deg reference from North to East
* Change 0 deg reference from North to East
* Merge pull request #266 <https://github.com/aerostack2/aerostack2/issues/266> from aerostack2/add_position_plugin_to_gates
  added position plugin to gates
* added position plugin to gates
* Clean gazebo on exit
* Merge pull request #232 <https://github.com/aerostack2/aerostack2/issues/232> from aerostack2/launch_gz_v2
  Gazebo launcher engine refactored
* Change assets simulation_config_file name
* default empty value for joints and bridges
* added pydantic dep
* models splitted in several files
* updated to new model
* model refactor
* Contributors: Javilinos, Miguel Fernandez-Cortizas, RPS98, Rafael Pérez, pariaspe, rdasilva01
```

## as2_keyboard_teleoperation

- No changes

## as2_motion_controller

```
* Merge pull request #275 <https://github.com/aerostack2/aerostack2/issues/275> from aerostack2/274-as2_motion_controller-parameter-changes-are-not-applied-properly
  [as2_motion_controller] Change updateParams input from std::string to rclcpp::Parameter
* Change updateParams input from std::string to rclcpp::Parameter
* Convert motion controller params to config file
* Contributors: Javilinos, Miguel Fernandez-Cortizas, RPS98, pariaspe
```

## as2_motion_reference_handlers

```
* Merge pull request #260 <https://github.com/aerostack2/aerostack2/issues/260> from aerostack2/259-as2_motion_reference_handlers-motion-reference-handler-using-old-trajectory-topic
  [as2_motion_reference_handlers] Change JointTrajectoryPoint to TrajectoryPoint msg type
* Change JointTrajectoryPoint to TrajectoryPoint
* Contributors: RPS98, pariaspe
```

## as2_msgs

```
* Merge pull request #277 <https://github.com/aerostack2/aerostack2/issues/277> from aerostack2/276-add_yaw_to_frame_mode
  new yaw mode yaw to frame added
* add follow reference with new yaw mode
* new yaw mode yaw to frame added
* new mission update types
* follow reference with reference facing added
* Merge pull request #258 <https://github.com/aerostack2/aerostack2/issues/258> from rdasilva01/187-mission-interpreter
  [as2_python_api] Mission updates: reset, append and insert
* Add MissionUpdate message, add Append and Insert in MissionInterpreter
* Contributors: Javilinos, RPS98, Rafael Pérez, pariaspe, rdasilva01
```

## as2_platform_crazyflie

```
* Merge pull request #239 <https://github.com/aerostack2/aerostack2/issues/239> from aerostack2/cf-namespace
  [as2_crazyflie_platform] Remove namespace from launch
* Fix aideck config file in launcher
* Remove namespace from launch
  Namespace was overriding each crazyflie namespace which is intended to be set by swarm_config_file
* Merge pull request #237 <https://github.com/aerostack2/aerostack2/issues/237> from aerostack2/unify_platform_launchers
  Unify launchers
* Fix crazyflie params file read
* Unify platform launchers
* Contributors: Javilinos, Miguel Fernandez-Cortizas, RPS98, Rafael Pérez, pariaspe
```

## as2_platform_dji_osdk

```
* Merge pull request #315 <https://github.com/aerostack2/aerostack2/issues/315> from aerostack2/uplink_reliable
  [as2_platform_dji_osdk] Links qos subscritions changed to reliable
* subs qos changed to reliable
* Merge pull request #309 <https://github.com/aerostack2/aerostack2/issues/309> from aerostack2/mop_channel
  [as2_platform_dji_osdk] Mop channel communication
* Several commits
* Merge pull request #303 <https://github.com/aerostack2/aerostack2/issues/303> from aerostack2/dji_gimbal_test
  [as2_platform_dji_osdk] Add gimbal and camera trigger support
* Change camera mode
* [feat] take images
* dji gimbal topic
* Merge pull request #299 <https://github.com/aerostack2/aerostack2/issues/299> from aerostack2/298-as2_platform_dji_osdk-take-off-delay-to-wait-to-be-done
  [as2_platform_dji_osdk] Add take off sleep to wait until it has finished
* Add take off sleep
* Merge pull request #297 <https://github.com/aerostack2/aerostack2/issues/297> from aerostack2/252-as2_platform_dji_osdk-add-camera-support
  [as2_platform_dji_osdk] Add camera interface with ROS 2
* Add camera info params
* parameters for enabling camera
* image transport into the platform
* camera image obtained
* Merge pull request #237 <https://github.com/aerostack2/aerostack2/issues/237> from aerostack2/unify_platform_launchers
  Unify launchers
* Unify platform launchers
* Contributors: AGX Xavier 1, Javier Melero, Javilinos, Miguel, Miguel Fernandez-Cortizas, RPS98, Rafael Pérez, pariaspe
```

## as2_platform_ign_gazebo

```
* Merge pull request #237 <https://github.com/aerostack2/aerostack2/issues/237> from aerostack2/unify_platform_launchers
  Unify launchers
* Unify platform launchers
* Contributors: Javilinos, Miguel Fernandez-Cortizas, RPS98, pariaspe
```

## as2_platform_tello

```
* Merge pull request #237 <https://github.com/aerostack2/aerostack2/issues/237> from aerostack2/unify_platform_launchers
  Unify launchers
* Merge remote-tracking branch 'origin/unify_platform_launchers' into px4_gz_assets
* Unify platform launchers
* Contributors: Javilinos, Miguel Fernandez-Cortizas, RPS98, pariaspe
```

## as2_python_api

```
* Merge pull request #310 <https://github.com/aerostack2/aerostack2/issues/310> from aerostack2/executor_fixes
  Some Mission Control fixes
* Merge pull request #309 <https://github.com/aerostack2/aerostack2/issues/309> from aerostack2/mop_channel
  [as2_platform_dji_osdk] Mop channel communication
* Multiple commits
* Merge pull request #301 <https://github.com/aerostack2/aerostack2/issues/301> from aerostack2/257-mission-monitoring
  Mission executor
* catching execption if goal rejected while running behavior
* adding temporary abort mission
* added ros2_adapter node
* get mission item module
* feedback in interpreter status
* Merge pull request #286 <https://github.com/aerostack2/aerostack2/issues/286> from aerostack2/285-fix_python_list_type
  Changed typing list to List
* changed list to List
* Remove feedback serialization
* Merge pull request #273 <https://github.com/aerostack2/aerostack2/issues/273> from aerostack2/272-add_reference_facing_mode_to_follow_reference
  follow reference with reference facing added
* add follow reference with new yaw mode
* added feedback
* Mission default to None
* follow reference with reference facing added
* Merge pull request #268 <https://github.com/aerostack2/aerostack2/issues/268> from aerostack2/fix_follow_path_with_reference
  follow path frame bug fixed, frame id argument added to python interface
* follow path frame bug fixed, frame id argument added to python interface
* Merge pull request #267 <https://github.com/aerostack2/aerostack2/issues/267> from aerostack2/add_frame_id_argument_to_simplifications
  added frame_id argument to go_to
* Multiple commits
* Merge pull request #258 <https://github.com/aerostack2/aerostack2/issues/258> from rdasilva01/187-mission-interpreter
  [as2_python_api] Mission updates: reset, append and insert
* Merge pull request #233 <https://github.com/aerostack2/aerostack2/issues/233> from aerostack2/187-mission-interpreter
  [as2_python_api] Mission interpreter
* Multiple commits
* Contributors: Javilinos, Miguel Fernandez-Cortizas, RPS98, Rafael Pérez, Rodrigo Da Silva, pariaspe, rdasilva01
```

## as2_realsense_interface

- No changes

## as2_state_estimator

```
* Merge pull request #279 <https://github.com/aerostack2/aerostack2/issues/279> from aerostack2/230-gps_support_for_ground_truth_plugin
  Add gps support for ground truth plugin
* Change origin param
* parameters added, compiling, add origin manually working
* gps support for ground truth plugin
* Contributors: Javilinos, Miguel Fernandez-Cortizas, RPS98, pariaspe
```

## as2_usb_camera_interface

- No changes
