### PR TITLE
ros2_control: 3.18.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4779,7 +4779,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.17.0-1
+      version: 3.18.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.18.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.17.0-1`

## controller_interface

```
* add a broadcaster for range sensor (#1091 <https://github.com/ros-controls/ros2_control/issues/1091>)
* Contributors: flochre
```

## controller_manager

```
* Controller sorting and proper execution in a chain (Fixes #853 <https://github.com/ros-controls/ros2_control/issues/853>) (#1063 <https://github.com/ros-controls/ros2_control/issues/1063>)
* Contributors: Sai Kishor Kothakota, Christoph Fröhlich, Dr Denis, Bence Magyar
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
