### PR TITLE
Add package mrpt_navigation to humble for indexing

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3431,6 +3431,16 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
       version: master
     status: maintained
+  mrpt_navigation:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
+      version: ros2
+    status: developed
   mrpt_path_planning:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble

# The source is here:

https://github.com/mrpt-ros-pkg/mrpt_navigation

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
