### PR TITLE
ros_inorbit_samples: 0.4.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5637,6 +5637,14 @@ repositories:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release.git
       version: 0.4.0-1
+  ros_inorbit_samples:
+    release:
+      packages:
+      - inorbit_republisher
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/inorbit-ai/ros_inorbit_samples-release.git
+      version: 0.4.0-2
   ros_testing:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_inorbit_samples` to `0.4.0-2`:

- upstream repository: https://github.com/inorbit-ai/ros_inorbit_samples.git
- release repository: https://github.com/inorbit-ai/ros_inorbit_samples-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## inorbit_republisher

```
* First pass at porting republisher to ROS 2 (#20 <https://github.com/inorbit-ai/ros_inorbit_samples/issues/20>)
  Ported from noetic-devel
* Contributors: Julian Cerruti, Elvio Aruta
```
