### PR TITLE
Add two MetroRobots src repos to humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3168,6 +3168,18 @@ repositories:
       url: https://github.com/ros-event-camera/metavision_driver.git
       version: master
     status: developed
+  metrics_msgs:
+    source:
+      type: git
+      url: https://github.com/MetroRobots/metrics_msgs.git
+      version: main
+    status: developed
+  metro_gazebo_plugins:
+    source:
+      type: git
+      url: https://github.com/MetroRobots/metro_gazebo_plugins.git
+      version: main
+    status: developed
   micro_ros_diagnostics:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

 * [metrics_msgs](https://github.com/MetroRobots/metrics_msgs.git)
 * [metro_gazebo_plugins](https://github.com/MetroRobots/metro_gazebo_plugins.git)

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
