### PR TITLE
marti_messages: 0.12.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5245,7 +5245,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_messages-release.git
-      version: 0.12.0-1
+      version: 0.12.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_messages` to `0.12.1-1`:

- upstream repository: https://github.com/swri-robotics/marti_messages.git
- release repository: https://github.com/swri-robotics-gbp/marti_messages-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.12.0-1`

## marti_can_msgs

- No changes

## marti_common_msgs

- No changes

## marti_dbw_msgs

- No changes

## marti_introspection_msgs

- No changes

## marti_nav_msgs

- No changes

## marti_perception_msgs

- No changes

## marti_sensor_msgs

```
* Fixed number of dashes in SetExposure Service call (#130 <https://github.com/swri-robotics/marti_messages/issues/130>)
  Co-authored-by: Tyler Marr <mailto:tyler.marr@swri.org>
* Contributors: Tyler Marr
```

## marti_status_msgs

- No changes

## marti_visualization_msgs

- No changes
