### PR TITLE
rosdep: nixos: Add range-v3 package

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7302,6 +7302,7 @@ range-v3:
     stretch: null
   fedora: [range-v3-devel]
   gentoo: [dev-cpp/range-v3]
+  nixos: [range-v3]
   osx:
     homebrew:
       packages: [range-v3]


### PR DESCRIPTION
This adds the Nix package name for `range-v3`.