### PR TITLE
Please add python3-pytest-xdist to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7940,6 +7940,17 @@ python3-pytest-timeout:
   opensuse: [python3-pytest-timeout]
   rhel: ['python%{python3_pkgversion}-pytest-timeout']
   ubuntu: [python3-pytest-timeout]
+python3-pytest-xdist:
+  arch: [python-pytest-xdist]
+  debian: [python3-pytest-xdist]
+  fedora: [python3-pytest-xdist]
+  gentoo: [dev-python/pytest-xdist]
+  nixos: ['python%{python3_pkgversion}Packages.pytest-xdist']
+  opensuse: [python3-pytest-xdist]
+  rhel:
+    "*": [python3-pytest-xdist]
+    7: ['python%{python3_pkgversion}-pytest-xdist']
+  ubuntu: [python3-pytest-xdist]
 python3-pytorch-pip: *migrate_eol_2025_04_30_python3_pytorch_pip
 python3-pytrinamic-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7945,11 +7945,11 @@ python3-pytest-xdist:
   debian: [python3-pytest-xdist]
   fedora: [python3-pytest-xdist]
   gentoo: [dev-python/pytest-xdist]
-  nixos: ['python%{python3_pkgversion}Packages.pytest-xdist']
+  nixos: [python3Packages.pytest-xdist]
   opensuse: [python3-pytest-xdist]
   rhel:
     "*": [python3-pytest-xdist]
-    7: ['python%{python3_pkgversion}-pytest-xdist']
+    "7": ['python%{python3_pkgversion}-pytest-xdist']
   ubuntu: [python3-pytest-xdist]
 python3-pytorch-pip: *migrate_eol_2025_04_30_python3_pytorch_pip
 python3-pytrinamic-pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-pytest-xdist

## Package Upstream Source:

https://github.com/pytest-dev/pytest-xdist

## Purpose of using this:

`pytest` is a widely used python unit-testing library. `pytest-xdist` is an addon to it, enabling concurrent testing.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/python3-pytest-xdist
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/kinetic/python3-pytest-xdist
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-pytest-xdist/python3-pytest-xdist/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/any/python-pytest-xdist/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/pytest-xdist
- macOS: https://formulae.brew.sh/
  - NOT AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - NOT AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=23.05&show=python311Packages.pytest-xdist&from=0&size=50&sort=relevance&type=packages&query=pytest-xdist
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python3-pytest-xdist
