### PR TITLE
[rosdep] Add hddtemp for ubuntu trusty and xenial

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1851,6 +1851,8 @@ hddtemp:
   slackware: [hddtemp]
   ubuntu:
     '*': null
+    trusty: [hddtemp]
+    xenial: [hddtemp]
     bionic: [hddtemp]
     focal: [hddtemp]
 hdf5:


### PR DESCRIPTION
#33110 deleted rosdep definitions of hddtemp on ubuntu trusty and xenial, but I think they actually have hddtemp.
This PR recovers those definitions.
Without this PR, we will easily face an error in `rosdep install` after `rosdep update` on trusty and xenial.

## Package name:

hddtemp

## Package Upstream Source:

omitted since it is already present in the base.yml

## Purpose of using this:

I want to avoid an error in `rosdep install` after `rosdep update` on trusty and xenial.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - Not changed
- Ubuntu: https://launchpad.net/ubuntu/ (Sorry but I cannot find EOL distros on https://packages.ubuntu.com/)
  - https://launchpad.net/ubuntu/trusty/+source/hddtemp
  - https://launchpad.net/ubuntu/xenial/+source/hddtemp
    - (I think this PR is enough because https://launchpad.net/ubuntu/+source/hddtemp shows focal, bionic, xenial, and trusty)
- Fedora: https://packages.fedoraproject.org/
  - Not changed
- Arch: https://www.archlinux.org/packages/
  - Not changed
- Gentoo: https://packages.gentoo.org/
  - Not changed
- macOS: https://formulae.brew.sh/
  - Not changed
- Alpine: https://pkgs.alpinelinux.org/packages
  - Not changed
- NixOS/nixpkgs: https://search.nixos.org/packages
  - Not changed
- openSUSE: https://software.opensuse.org/package/
  - Not changed

## How to reproduce rosdep error

```
$ sudo docker pull osrf/ros:indigo-desktop-trusty
$ sudo docker run -it osrf/ros:indigo-desktop-trusty
# rosdep install --rosdistro ${ROS_DISTRO} -s -r -y -i --from-paths /opt/ros/${ROS_DISTRO}/share
#[apt] Installation commands:
  apt-get install -y python-coverage
  apt-get install -y libcppunit-dev
  apt-get install -y python-mock
  apt-get install -y python-pygraphviz
# rosdep update --include-eol-distros
reading in sources list data from /etc/ros/rosdep/sources.list.d
Warning: running 'rosdep update' as root is not recommended.
  You should run 'sudo rosdep fix-permissions' and invoke 'rosdep update' again without sudo.
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/osx-homebrew.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/base.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/python.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/ruby.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/releases/fuerte.yaml
Query rosdistro index https://raw.githubusercontent.com/ros/rosdistro/master/index-v4.yaml
Add distro "ardent"
Add distro "bouncy"
Add distro "crystal"
Add distro "dashing"
Add distro "eloquent"
Add distro "foxy"
Add distro "galactic"
Add distro "groovy"
Add distro "humble"
Add distro "hydro"
Add distro "indigo"
Add distro "iron"
Add distro "jade"
Add distro "kinetic"
Add distro "lunar"
Add distro "melodic"
Add distro "noetic"
Add distro "rolling"
updated cache in /root/.ros/rosdep/sources.cache
# rosdep install --rosdistro ${ROS_DISTRO} -s -r -y -i --from-paths /opt/ros/${ROS_DISTRO}/share

ERROR: Rosdep experienced an error: rosdep OS definition for [hddtemp:ubuntu] must be a dictionary, string, or list: None
Please go to the rosdep page [1] and file a bug report with the stack trace below.
[1] : http://www.ros.org/wiki/rosdep

rosdep version: 0.15.2

Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/rosdep2/main.py", line 140, in rosdep_main
    exit_code = _rosdep_main(args)
  File "/usr/lib/python2.7/dist-packages/rosdep2/main.py", line 396, in _rosdep_main
    return _package_args_handler(command, parser, options, args)
  File "/usr/lib/python2.7/dist-packages/rosdep2/main.py", line 492, in _package_args_handler
    return command_handlers[command](lookup, packages, options)
  File "/usr/lib/python2.7/dist-packages/rosdep2/main.py", line 691, in command_install
    uninstalled, errors = installer.get_uninstalled(packages, implicit=options.recursive, verbose=options.verbose)
  File "/usr/lib/python2.7/dist-packages/rosdep2/installers.py", line 445, in get_uninstalled
    resolutions, errors = self.lookup.resolve_all(resources, installer_context, implicit=implicit)
  File "/usr/lib/python2.7/dist-packages/rosdep2/lookup.py", line 401, in resolve_all
    self.resolve(rosdep_key, resource_name, installer_context)
  File "/usr/lib/python2.7/dist-packages/rosdep2/lookup.py", line 485, in resolve
    installer_key, rosdep_args_dict = definition.get_rule_for_platform(os_name, os_version, installer_keys, default_key)
  File "/usr/lib/python2.7/dist-packages/rosdep2/lookup.py", line 148, in get_rule_for_platform
    raise InvalidData('rosdep OS definition for [%s:%s] must be a dictionary, string, or list: %s' % (self.rosdep_key, os_name, data), origin=self.origin)
InvalidData: rosdep OS definition for [hddtemp:ubuntu] must be a dictionary, string, or list: None
```
First `rosdep install` shows no fatal error, but after `rosdep update`, it raises a fatal error.
This is because `osrf/ros:indigo-desktop-trusty` includes `ros-indigo-desktop` which depends on `hddtemp` but https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/base.yaml does not include `hddtemp` for trusty:
```
# dpkg -l hddtemp
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name                                     Version                   Architecture              Description
+++-========================================-=========================-=========================-=====================================================================================
ii  hddtemp                                  0.3-beta15-52             amd64                     hard drive temperature monitoring utility
# apt-cache rdepends hddtemp
hddtemp
Reverse Depends:
  ros-indigo-diagnostic-common-diagnostics
# apt-cache rdepends ros-indigo-diagnostic-common-diagnostics
ros-indigo-diagnostic-common-diagnostics
Reverse Depends:
  ros-indigo-diagnostics
# apt-cache rdepends ros-indigo-diagnostics
ros-indigo-diagnostics
Reverse Depends:
  ros-indigo-robot
# apt-cache rdepends ros-indigo-robot
ros-indigo-robot
Reverse Depends:
  ros-indigo-desktop
```