### PR TITLE
rpyutils: 0.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5478,7 +5478,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rpyutils-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rpyutils` to `0.4.1-1`:

- upstream repository: https://github.com/ros2/rpyutils.git
- release repository: https://github.com/ros2-gbp/rpyutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.0-1`

## rpyutils

```
* correct the URL and f-strings format (#11 <https://github.com/ros2/rpyutils/issues/11>)
* Contributors: Chen Lihui
```
