### PR TITLE
rosidl_python: 0.20.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5363,7 +5363,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.19.0-1
+      version: 0.20.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_python` to `0.20.0-1`:

- upstream repository: https://github.com/ros2/rosidl_python.git
- release repository: https://github.com/ros2-gbp/rosidl_python-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.19.0-1`

## rosidl_generator_py

```
* Fix: Missing dependency that causes cmake error in downstream (resolves https://github.com/ros2/rosidl_python/issues/198) (#199 <https://github.com/ros2/rosidl_python/issues/199>)
* Contributors: Isaac Saito
```
