### PR TITLE
rmw_fastrtps: 7.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4652,7 +4652,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 7.3.0-1
+      version: 7.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `7.4.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `7.3.0-1`

## rmw_fastrtps_cpp

- No changes

## rmw_fastrtps_dynamic_cpp

- No changes

## rmw_fastrtps_shared_cpp

```
* Clear out errors once we have handled them. (#701 <https://github.com/ros2/rmw_fastrtps/issues/701>)
* Instrument loaned message publication code path (#698 <https://github.com/ros2/rmw_fastrtps/issues/698>)
* Add in a missing data_reader check when creating subscription. (#697 <https://github.com/ros2/rmw_fastrtps/issues/697>)
* Contributors: Chris Lalancette, Christophe Bedard
```
