### PR TITLE
rclpy: 5.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4150,7 +4150,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 5.0.0-1
+      version: 5.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `5.0.1-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `5.0.0-1`

## rclpy

```
* Avoid generating the exception when rcl_send_response times out. (#1136 <https://github.com/ros2/rclpy/issues/1136>)
* Store time source clocks in a set (#1146 <https://github.com/ros2/rclpy/issues/1146>)
* Fix spin_once_until_future_complete to quit when the future finishes. (#1143 <https://github.com/ros2/rclpy/issues/1143>)
* Contributors: Chris Lalancette, Luca Della Vedova, Tomoya Fujita
```
