### PR TITLE
rmw_connextdds: 0.17.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4599,7 +4599,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 0.16.0-1
+      version: 0.17.0-1
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `0.17.0-1`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.16.0-1`

## rmw_connextdds

```
* Update to C++17 (#125 <https://github.com/ros2/rmw_connextdds/issues/125>)
* Contributors: Chris Lalancette
```

## rmw_connextdds_common

```
* Fix RMW_Connext_Client::is_service_available for micro (#130 <https://github.com/ros2/rmw_connextdds/issues/130>)
* Update to C++17 (#125 <https://github.com/ros2/rmw_connextdds/issues/125>)
* Pass parameters in the correct order to DDS_DataReader_read in rmw_connextdds_count_unread_samples for micro (#129 <https://github.com/ros2/rmw_connextdds/issues/129>)
* Optimize QoS to improve responsiveness of reliable endpoints (#26 <https://github.com/ros2/rmw_connextdds/issues/26>)
* Clear out errors once we have handled them. (#126 <https://github.com/ros2/rmw_connextdds/issues/126>)
* Contributors: Andrea Sorbini, Chris Lalancette, Christopher Wecht
```

## rti_connext_dds_cmake_module

- No changes
