### PR TITLE
rclcpp: 22.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4134,7 +4134,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 22.0.0-1
+      version: 22.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `22.1.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `22.0.0-1`

## rclcpp

```
* Do not crash Executor when send_response fails due to client failure. (#2276 <https://github.com/ros2/rclcpp/issues/2276>)
* Adding Custom Unknown Type Error (#2272 <https://github.com/ros2/rclcpp/issues/2272>)
* Add a pimpl inside rclcpp::Node for future distro backports (#2228 <https://github.com/ros2/rclcpp/issues/2228>)
* Remove an unused variable from the events executor tests. (#2270 <https://github.com/ros2/rclcpp/issues/2270>)
* Add spin_all shortcut (#2246 <https://github.com/ros2/rclcpp/issues/2246>)
* Adding Missing Group Exceptions (#2256 <https://github.com/ros2/rclcpp/issues/2256>)
* Change associated clocks storage to unordered_set (#2257 <https://github.com/ros2/rclcpp/issues/2257>)
* associated clocks should be protected by mutex. (#2255 <https://github.com/ros2/rclcpp/issues/2255>)
* Instrument loaned message publication code path (#2240 <https://github.com/ros2/rclcpp/issues/2240>)
* Contributors: Chris Lalancette, Christophe Bedard, Emerson Knapp, Luca Della Vedova, Lucas Wendland, Tomoya Fujita, Tony Najjar
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* Stop using constref signature of benchmark DoNotOptimize. (#2238 <https://github.com/ros2/rclcpp/issues/2238>)
* Contributors: Chris Lalancette
```
