### PR TITLE
mimick_vendor: 0.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2674,7 +2674,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mimick_vendor-release.git
-      version: 0.4.1-1
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/ros2/mimick_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mimick_vendor` to `0.5.0-1`:

- upstream repository: https://github.com/ros2/mimick_vendor.git
- release repository: https://github.com/ros2-gbp/mimick_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.1-1`

## mimick_vendor

```
* Update to the comment that fixes the executable stack. (#32 <https://github.com/ros2/mimick_vendor/issues/32>)
* Update to take advantage of TARGET_ARCH (#28 <https://github.com/ros2/mimick_vendor/issues/28>)
* Contributors: Chris Lalancette, Michael Carroll
```
