### PR TITLE
message_filters: 4.10.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2574,7 +2574,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_message_filters-release.git
-      version: 4.9.1-1
+      version: 4.10.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_filters` to `4.10.0-1`:

- upstream repository: https://github.com/ros2/message_filters.git
- release repository: https://github.com/ros2-gbp/ros2_message_filters-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.9.1-1`

## message_filters

```
* Update the HasHeader check to be more specific. (#101 <https://github.com/ros2/message_filters/issues/101>)
* TypeAdapters support (#95 <https://github.com/ros2/message_filters/issues/95>) (#96 <https://github.com/ros2/message_filters/issues/96>)
* Contributors: Chris Lalancette, Patrick Roncagliolo
```
