### PR TITLE
launch: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2302,7 +2302,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 2.2.1-1
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.0.0-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.1-1`

## launch

```
* Fix remaining occurrences of "There is no current event loop" (#723 <https://github.com/ros2/launch/issues/723>)
* Update the launch code for newer flake8 and mypy. (#719 <https://github.com/ros2/launch/issues/719>)
* Remove the deprecated some_actions_type.py (#718 <https://github.com/ros2/launch/issues/718>)
* Contributors: Chris Lalancette
```

## launch_pytest

- No changes

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
