### PR TITLE
demos: 0.31.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -937,7 +937,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.30.1-1
+      version: 0.31.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.31.0-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.30.1-1`

## action_tutorials_cpp

- No changes

## action_tutorials_interfaces

- No changes

## action_tutorials_py

- No changes

## composition

- No changes

## demo_nodes_cpp

```
* Dramatically speed up the demo_nodes_cpp tests (#641 <https://github.com/ros2/demos/issues/641>)
* Switch to using RCLCPP logging macros in the lifecycle package. (#644 <https://github.com/ros2/demos/issues/644>)
* Contributors: Chris Lalancette
```

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

- No changes

## dummy_map_server

- No changes

## dummy_robot_bringup

- No changes

## dummy_sensors

- No changes

## image_tools

- No changes

## intra_process_demo

- No changes

## lifecycle

```
* Switch to using RCLCPP logging macros in the lifecycle package. (#644 <https://github.com/ros2/demos/issues/644>)
* Contributors: Chris Lalancette
```

## lifecycle_py

- No changes

## logging_demo

- No changes

## pendulum_control

- No changes

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

```
* Cleanup the interactive quality of service demos. (#637 <https://github.com/ros2/demos/issues/637>)
* Contributors: Chris Lalancette
```

## quality_of_service_demo_py

- No changes

## topic_monitor

- No changes

## topic_statistics_demo

- No changes
