### PR TITLE
image_common: 4.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1960,7 +1960,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 4.3.0-2
+      version: 4.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `4.5.0-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.3.0-2`

## camera_calibration_parsers

- No changes

## camera_info_manager

- No changes

## image_common

- No changes

## image_transport

```
* feat: enable plugin allowlist (#264 <https://github.com/ros-perception/image_common/issues/264>)
* Expose option to set callback groups (#274 <https://github.com/ros-perception/image_common/issues/274>)
* add support for lazy subscribers (#272 <https://github.com/ros-perception/image_common/issues/272>)
* Contributors: Aditya Pande, Daisuke Nishimatsu, Michael Ferguson
```
