### PR TITLE
ament_index: 1.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -197,7 +197,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_index-release.git
-      version: 1.6.0-1
+      version: 1.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_index` to `1.7.0-1`:

- upstream repository: https://github.com/ament/ament_index.git
- release repository: https://github.com/ros2-gbp/ament_index-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.6.0-1`

## ament_index_cpp

```
* Update to C++17 (#90 <https://github.com/ament/ament_index/issues/90>)
* Contributors: Chris Lalancette
```

## ament_index_python

- No changes
