### PR TITLE
lanelet2: 1.2.1-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2229,6 +2229,7 @@ repositories:
       - lanelet2_examples
       - lanelet2_io
       - lanelet2_maps
+      - lanelet2_matching
       - lanelet2_projection
       - lanelet2_python
       - lanelet2_routing
@@ -2237,7 +2238,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/lanelet2-release.git
-      version: 1.1.1-4
+      version: 1.2.1-4
     source:
       type: git
       url: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lanelet2` to `1.2.1-4`:

- upstream repository: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git
- release repository: https://github.com/ros2-gbp/lanelet2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.1-4`

## lanelet2

- No changes

## lanelet2_core

```
* Update thirdparty deps, rework projected point, enable python 3.10/3.11 (#300 <https://github.com/immel-f/Lanelet2/issues/300>)
* Fix typos in documentation (#286 <https://github.com/immel-f/Lanelet2/issues/286>)
* Contributors: Johannes Schmitz, poggenhans
```

## lanelet2_examples

- No changes

## lanelet2_io

- No changes

## lanelet2_maps

- No changes

## lanelet2_matching

- No changes

## lanelet2_projection

- No changes

## lanelet2_python

```
* Improve python core module (#293 <https://github.com/immel-f/Lanelet2/issues/293>)
  Improve lanelet2.core python wrappers
  add docstrings, named arguments and __repr__ methods to core primitives in python, fix bugs and add more initialization options
  ---------
  Co-authored-by: Fabian Poggenhans <mailto:fabian.poggenhans@partner.kit.edu>
* Add readme to PyPi package description and fix readme icons (#283 <https://github.com/immel-f/Lanelet2/issues/283>)
* Build lanelet2 wheel and publish in GH release and PyPI (#278 <https://github.com/immel-f/Lanelet2/issues/278>)
* Contributors: Jan Rudolph, immel-f, poggenhans
```

## lanelet2_routing

```
* Update thirdparty deps, rework projected point, enable python 3.10/3.11 (#300 <https://github.com/immel-f/Lanelet2/issues/300>)
* Contributors: poggenhans
```

## lanelet2_traffic_rules

- No changes

## lanelet2_validation

- No changes
