### PR TITLE
rviz: 13.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5939,7 +5939,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 12.8.0-1
+      version: 13.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `13.0.0-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `12.8.0-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Remove unused LineEditWithButton::simulateReturnPressed() (#1040 <https://github.com/ros2/rviz/issues/1040>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_default_plugins

```
* Fixed AccelStamped, TwistStamped and Wrench icons (#1041 <https://github.com/ros2/rviz/issues/1041>)
* Fix the flakey rviz_rendering tests (#1026 <https://github.com/ros2/rviz/issues/1026>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Fix the flakey rviz_rendering tests (#1026 <https://github.com/ros2/rviz/issues/1026>)
* Contributors: Chris Lalancette
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
