### PR TITLE
rviz: 12.4.3-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6111,7 +6111,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 12.4.2-1
+      version: 12.4.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `12.4.3-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `12.4.2-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Remove unused LineEditWithButton::simulateReturnPressed() (#1040 <https://github.com/ros2/rviz/issues/1040>) (#1043 <https://github.com/ros2/rviz/issues/1043>)
* Contributors: mergify[bot]
```

## rviz_default_plugins

```
* Fixed AccelStamped, TwistStamped and Wrench icons (#1041 <https://github.com/ros2/rviz/issues/1041>) (#1047 <https://github.com/ros2/rviz/issues/1047>)
* Fix the flakey rviz_rendering tests (#1026 <https://github.com/ros2/rviz/issues/1026>) (#1031 <https://github.com/ros2/rviz/issues/1031>)
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Fix the flakey rviz_rendering tests (#1026 <https://github.com/ros2/rviz/issues/1026>) (#1031 <https://github.com/ros2/rviz/issues/1031>)
* Contributors: mergify[bot]
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
