### PR TITLE
foxglove_bridge: 0.7.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1775,7 +1775,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 0.7.0-1
+      version: 0.7.1-1
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_bridge` to `0.7.1-1`:

- upstream repository: https://github.com/foxglove/ros-foxglove-bridge.git
- release repository: https://github.com/ros2-gbp/foxglove_bridge-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.0-1`

## foxglove_bridge

```
* Communicate double / double array parameters with type info, explicitly cast when set from integer (#256 <https://github.com/foxglove/ros-foxglove-bridge/issues/256>)
* Make ROS 2 smoke tests less flaky (#260 <https://github.com/foxglove/ros-foxglove-bridge/issues/260>)
* Add debug config for ros2 smoke test (#257 <https://github.com/foxglove/ros-foxglove-bridge/issues/257>)
* Handle client disconnection in message handler thread (#259 <https://github.com/foxglove/ros-foxglove-bridge/issues/259>)
* Reduce smoke test flakiness (#258 <https://github.com/foxglove/ros-foxglove-bridge/issues/258>)
* Server code improvements (#250 <https://github.com/foxglove/ros-foxglove-bridge/issues/250>)
* Contributors: Hans-Joachim Krauch
```
