### PR TITLE
aerostack2: 1.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -97,7 +97,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/aerostack2-release.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aerostack2` to `1.0.3-1`:

- upstream repository: https://github.com/aerostack2/aerostack2.git
- release repository: https://github.com/ros2-gbp/aerostack2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.2-1`

## aerostack2

- No changes

## as2_alphanumeric_viewer

- No changes

## as2_behavior

- No changes

## as2_behavior_tree

- No changes

## as2_behaviors_motion

```
* Merge pull request #317 <https://github.com/aerostack2/aerostack2/issues/317> from aerostack2/316-tf2_geometry_msgs-dep
  Only use tf2_geometry_msgs library when needed
* only use library when needed
* Contributors: Miguel Fernandez-Cortizas, pariaspe
```

## as2_behaviors_perception

- No changes

## as2_behaviors_platform

- No changes

## as2_behaviors_trajectory_generation

- No changes

## as2_cli

- No changes

## as2_core

```
* Merge pull request #317 <https://github.com/aerostack2/aerostack2/issues/317> from aerostack2/316-tf2_geometry_msgs-dep
  Only use tf2_geometry_msgs library when needed
* revert change in include library
* only use library when needed
* Contributors: Miguel Fernandez-Cortizas, pariaspe
```

## as2_gazebo_classic_assets

- No changes

## as2_ign_gazebo_assets

- No changes

## as2_keyboard_teleoperation

- No changes

## as2_motion_controller

```
* Merge pull request #317 <https://github.com/aerostack2/aerostack2/issues/317> from aerostack2/316-tf2_geometry_msgs-dep
  Only use tf2_geometry_msgs library when needed
* only use library when needed
* Contributors: Miguel Fernandez-Cortizas, pariaspe
```

## as2_motion_reference_handlers

```
* Merge pull request #317 <https://github.com/aerostack2/aerostack2/issues/317> from aerostack2/316-tf2_geometry_msgs-dep
  Only use tf2_geometry_msgs library when needed
* only use library when needed
* Contributors: Miguel Fernandez-Cortizas, pariaspe
```

## as2_msgs

- No changes

## as2_platform_crazyflie

- No changes

## as2_platform_dji_osdk

```
* Merge pull request #317 <https://github.com/aerostack2/aerostack2/issues/317> from aerostack2/316-tf2_geometry_msgs-dep
  Only use tf2_geometry_msgs library when needed
* only use library when needed
* Contributors: Miguel Fernandez-Cortizas, pariaspe
```

## as2_platform_ign_gazebo

- No changes

## as2_platform_tello

- No changes

## as2_python_api

- No changes

## as2_realsense_interface

```
* Merge pull request #317 <https://github.com/aerostack2/aerostack2/issues/317> from aerostack2/316-tf2_geometry_msgs-dep
  Only use tf2_geometry_msgs library when needed
* only use library when needed
* Contributors: Miguel Fernandez-Cortizas, pariaspe
```

## as2_state_estimator

```
* Merge pull request #317 <https://github.com/aerostack2/aerostack2/issues/317> from aerostack2/316-tf2_geometry_msgs-dep
  Only use tf2_geometry_msgs library when needed
* only use library when needed
* Contributors: Miguel Fernandez-Cortizas, pariaspe
```

## as2_usb_camera_interface

- No changes
