### PR TITLE
Add the_navigation_gauntlet source repo to humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7500,6 +7500,12 @@ repositories:
       url: https://github.com/DLu/tf_transformations.git
       version: main
     status: maintained
+  the_navigation_gauntlet:
+    source:
+      type: git
+      url: https://github.com/MetroRobots/the_navigation_gauntlet.git
+      version: navigation_metrics
+    status: developed
   tiago_moveit_config:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7504,7 +7504,7 @@ repositories:
     source:
       type: git
       url: https://github.com/MetroRobots/the_navigation_gauntlet.git
-      version: navigation_metrics
+      version: main
     status: developed
   tiago_moveit_config:
     doc:


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

the_navigation_gauntlet

# The source is here:

https://github.com/MetroRobots/the_navigation_gauntlet.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
