### PR TITLE
gazebo_ros2_control: 0.4.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1800,7 +1800,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git
-      version: master
+      version: humble
     release:
       packages:
       - gazebo_ros2_control
@@ -1812,7 +1812,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git
-      version: master
+      version: humble
     status: developed
   gazebo_ros_pkgs:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1808,7 +1808,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.4.3-1
+      version: 0.4.4-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros2_control` to `0.4.4-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros2_control.git
- release repository: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.3-1`

## gazebo_ros2_control

```
* Catch pluginlib exceptions (backport #229 <https://github.com/ros-controls/gazebo_ros2_control/issues/229>) (#230 <https://github.com/ros-controls/gazebo_ros2_control/issues/230>)
  * Catch pluginlib exceptions (#229 <https://github.com/ros-controls/gazebo_ros2_control/issues/229>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  (cherry picked from commit f8a475d3092e67b77846d76738ffad0861c680c1)
* Set the C++ version to 17 (#221 <https://github.com/ros-controls/gazebo_ros2_control/issues/221>) (#228 <https://github.com/ros-controls/gazebo_ros2_control/issues/228>)
  (cherry picked from commit 6da415cf82a75e2a5e9f9a41400957ad45b2be84)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Removed unused var (#220 <https://github.com/ros-controls/gazebo_ros2_control/issues/220>) (#226 <https://github.com/ros-controls/gazebo_ros2_control/issues/226>)
  (cherry picked from commit 174e6b85f82774e9e802a5540382999066734421)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Remove plugin export from ROS 1 (#212 <https://github.com/ros-controls/gazebo_ros2_control/issues/212>) (#215 <https://github.com/ros-controls/gazebo_ros2_control/issues/215>)
  (cherry picked from commit c15af63cb036cd1f36cffbc56e5e5bdb5224c7e2)
  Co-authored-by: Christoph Fröhlich <mailto:christophfroehlich@users.noreply.github.com>
* Forced zero vel in position mode to avoid sagging (#213 <https://github.com/ros-controls/gazebo_ros2_control/issues/213>) (#214 <https://github.com/ros-controls/gazebo_ros2_control/issues/214>)
  (cherry picked from commit 3e950618a1f82c72097f7c90a6b5d2ea2e32b7b8)
  Co-authored-by: gwalck <mailto:guillaume.walck@stoglrobotics.de>
* Various bug fixes (#177 <https://github.com/ros-controls/gazebo_ros2_control/issues/177>) (#208 <https://github.com/ros-controls/gazebo_ros2_control/issues/208>)
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
* Add pre-commit and CI-format (#206 <https://github.com/ros-controls/gazebo_ros2_control/issues/206>) (#207 <https://github.com/ros-controls/gazebo_ros2_control/issues/207>)
  * Add pre-commit and ci-format
  (cherry picked from commit f2cf686a1a97cefc9b5e3daa115e0c4854ea5707)
  Co-authored-by: Christoph Fröhlich <mailto:christophfroehlich@users.noreply.github.com>
* Contributors: Alejandro Hernández Cordero, Christoph Fröhlich, mergify[bot]
```

## gazebo_ros2_control_demos

```
* Set the C++ version to 17 (#221 <https://github.com/ros-controls/gazebo_ros2_control/issues/221>) (#228 <https://github.com/ros-controls/gazebo_ros2_control/issues/228>)
  (cherry picked from commit 6da415cf82a75e2a5e9f9a41400957ad45b2be84)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Update diff_drive_controller.yaml (#224 <https://github.com/ros-controls/gazebo_ros2_control/issues/224>) (#225 <https://github.com/ros-controls/gazebo_ros2_control/issues/225>)
  The wrong base frame is set. The name of the link in the URDF is chassis.
  (cherry picked from commit c915939bfc13a43b2ab0e30029725f6c8023f3ca)
  Co-authored-by: David V. Lu!! <mailto:davidvlu@gmail.com>
* Add pre-commit and CI-format (#206 <https://github.com/ros-controls/gazebo_ros2_control/issues/206>) (#207 <https://github.com/ros-controls/gazebo_ros2_control/issues/207>)
  * Add pre-commit and ci-format
  (cherry picked from commit f2cf686a1a97cefc9b5e3daa115e0c4854ea5707)
  Co-authored-by: Christoph Fröhlich <mailto:christophfroehlich@users.noreply.github.com>
* Contributors: Alejandro Hernández Cordero, Christoph Fröhlich, mergify[bot]
```
