### PR TITLE
rolling: Replace mp2p_icp by its parent project

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2692,6 +2692,16 @@ repositories:
       url: https://github.com/DFKI-NI/mir_robot.git
       version: rolling
     status: developed
+  mola:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mola.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mola.git
+      version: develop
+    status: developed
   moveit:
     doc:
       type: git
@@ -2803,21 +2813,6 @@ repositories:
       url: https://github.com/ros-planning/moveit_visual_tools.git
       version: ros2
     status: maintained
-  mp2p_icp:
-    doc:
-      type: git
-      url: https://github.com/MOLAorg/mp2p_icp.git
-      version: master
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 0.1.0-1
-    source:
-      type: git
-      url: https://github.com/MOLAorg/mp2p_icp.git
-      version: master
-    status: developed
   mqtt_client:
     doc:
       type: git


### PR DESCRIPTION
mp2p_icp was actually part (git submodule) of the "MOLA" larger project, which is now converted to build using colcon and ROS 2.

This commit removes the mp2p_icp package, and adds the source and doc for MOLA. Later on, bloom releases will make mp2p_icp to appear, along with other side projects.