### PR TITLE
iron: Replace mp2p_icp by its parent project

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2760,6 +2760,16 @@ repositories:
       url: https://github.com/DFKI-NI/mir_robot.git
       version: rolling
     status: developed
+  mola:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mola.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mola.git
+      version: develop
+    status: developed
   moveit:
     doc:
       type: git
@@ -2871,21 +2881,6 @@ repositories:
       url: https://github.com/ros-planning/moveit_visual_tools.git
       version: ros2
     status: maintained
-  mp2p_icp:
-    doc:
-      type: git
-      url: https://github.com/MOLAorg/mp2p_icp.git
-      version: master
-    release:
-      tags:
-        release: release/iron/{package}/{version}
-      url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 0.1.0-1
-    source:
-      type: git
-      url: https://github.com/MOLAorg/mp2p_icp.git
-      version: master
-    status: developed
   mqtt_client:
     doc:
       type: git


### PR DESCRIPTION
mp2p_icp was actually part (git submodule) of the "MOLA" larger project, which is now converted to build using colcon and ROS 2.

This commit removes the mp2p_icp package, and adds the source and doc for MOLA. Later on, bloom releases will make mp2p_icp to appear, along with other side projects.