### PR TITLE
marti_common: 3.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2468,6 +2468,7 @@ repositories:
       version: dashing-devel
     release:
       packages:
+      - swri_cli_tools
       - swri_console_util
       - swri_dbw_interface
       - swri_geometry_util
@@ -2483,7 +2484,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/marti_common-release.git
-      version: 3.5.0-2
+      version: 3.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `3.6.0-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/ros2-gbp/marti_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.5.0-2`

## swri_cli_tools

- No changes

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

- No changes

## swri_image_util

- No changes

## swri_math_util

- No changes

## swri_opencv_util

- No changes

## swri_prefix_tools

- No changes

## swri_roscpp

```
* Rolling updates (#715 <https://github.com/swri-robotics/marti_common/issues/715>)
  - Updating code for Rolling.
  - Removing conditional compilation code related to EOL distributions.
* Contributors: David Anthony
```

## swri_route_util

```
* Rolling updates (#715 <https://github.com/swri-robotics/marti_common/issues/715>)
  - Updating code for Rolling.
  - Removing conditional compilation code related to EOL distributions.
* Contributors: David Anthony
```

## swri_serial_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

```
* Rolling updates (#715 <https://github.com/swri-robotics/marti_common/issues/715>)
  - Updating code for Rolling.
  - Removing conditional compilation code related to EOL distributions.
* Contributors: David Anthony
```
