### PR TITLE
nao_lola: 1.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2979,7 +2979,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nao_lola-release.git
-      version: 1.1.0-2
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/ros-sports/nao_lola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_lola` to `1.1.1-1`:

- upstream repository: https://github.com/ros-sports/nao_lola.git
- release repository: https://github.com/ros2-gbp/nao_lola-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-2`

## nao_lola

```
* revert msgpack-c commit to match those in the iron branch, because newer version of msgpack-c is crashing LoLA
* Contributors: ijnek
```

## nao_lola_client

```
* revert msgpack-c commit to match those in the iron branch, because newer version of msgpack-c is crashing LoLA
* Contributors: ijnek
```

## nao_lola_command_msgs

- No changes

## nao_lola_conversion

- No changes

## nao_lola_sensor_msgs

- No changes
