### PR TITLE
gazebo_ros2_control: 0.6.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1504,7 +1504,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.6.1-1
+      version: 0.6.2-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros2_control` to `0.6.2-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros2_control.git
- release repository: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.1-1`

## gazebo_ros2_control

```
* Catch pluginlib exceptions (#229 <https://github.com/ros-controls/gazebo_ros2_control/issues/229>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Set the C++ version to 17 (#221 <https://github.com/ros-controls/gazebo_ros2_control/issues/221>)
* Removed unused var (#220 <https://github.com/ros-controls/gazebo_ros2_control/issues/220>)
* Remove plugin export from ROS 1 (#212 <https://github.com/ros-controls/gazebo_ros2_control/issues/212>)
* Forced zero vel in position mode to avoid sagging (#213 <https://github.com/ros-controls/gazebo_ros2_control/issues/213>)
* Contributors: Alejandro Hernández Cordero, Christoph Fröhlich, gwalck
```

## gazebo_ros2_control_demos

```
* Set the C++ version to 17 (#221 <https://github.com/ros-controls/gazebo_ros2_control/issues/221>)
* Update diff_drive_controller.yaml (#224 <https://github.com/ros-controls/gazebo_ros2_control/issues/224>)
  The wrong base frame is set. The name of the link in the URDF is chassis.
* Contributors: Alejandro Hernández Cordero, David V. Lu!!
```
