### PR TITLE
gz_ros2_control: 1.1.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1826,10 +1826,11 @@ repositories:
       packages:
       - gz_ros2_control
       - gz_ros2_control_demos
+      - gz_ros2_control_tests
       tags:
         release: release/iron/{package}/{version}
-      url: https://github.com/ros-controls/gz_ros2_control.git
-      version: 1.1.1-1
+      url: https://github.com/ros2-gbp/ign_ros2_control-release.git
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1826,7 +1826,6 @@ repositories:
       packages:
       - gz_ros2_control
       - gz_ros2_control_demos
-      - gz_ros2_control_tests
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `1.1.2-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.1-1`

## gz_ros2_control

```
* Catch pluginlib exceptions (#175 <https://github.com/ros-controls/gz_ros2_control/issues/175>)
* Contributors: Alejandro Hernández Cordero
```

## gz_ros2_control_demos

```
* Set C++ version to 17 (#171 <https://github.com/ros-controls/gz_ros2_control/issues/171>)
* Update diff_drive_controller_velocity.yaml (#172 <https://github.com/ros-controls/gz_ros2_control/issues/172>)
* Contributors: Alejandro Hernández Cordero
```
