### PR TITLE
gz_ros2_control: 1.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1794,7 +1794,6 @@ repositories:
       packages:
       - gz_ros2_control
       - gz_ros2_control_demos
-      - gz_ros2_control_tests
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1794,10 +1794,11 @@ repositories:
       packages:
       - gz_ros2_control
       - gz_ros2_control_demos
+      - gz_ros2_control_tests
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `1.1.2-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.1-1`

## gz_ros2_control

```
* Catch pluginlib exceptions (#175 <https://github.com/ros-controls/gz_ros2_control/issues/175>)
* Contributors: Alejandro Hernández Cordero
```

## gz_ros2_control_demos

```
* Set C++ version to 17 (#171 <https://github.com/ros-controls/gz_ros2_control/issues/171>)
* Update diff_drive_controller_velocity.yaml (#172 <https://github.com/ros-controls/gz_ros2_control/issues/172>)
* Contributors: Alejandro Hernández Cordero
```
