### PR TITLE
urdf_launch: 0.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8188,6 +8188,22 @@ repositories:
       url: https://github.com/ros2/urdf.git
       version: humble
     status: maintained
+  urdf_launch:
+    doc:
+      type: git
+      url: https://github.com/MetroRobots/urdf_launch.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/urdf_launch-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/MetroRobots/urdf_launch.git
+      version: main
+    status: developed
   urdf_parser_py:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_launch` to `0.1.0-1`:

- upstream repository: https://github.com/MetroRobots/urdf_launch.git
- release repository: https://github.com/ros2-gbp/urdf_launch-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## urdf_launch

```
* Initial Package
* Contributors: David V. Lu!!
```
