### PR TITLE
ros2_tracing: 7.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4938,7 +4938,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 7.0.0-1
+      version: 7.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `7.1.0-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `7.0.0-1`

## ros2trace

```
* Create start/pause/resume/stop sub-commands for 'ros2 trace' (#70 <https://github.com/ros2/ros2_tracing/issues/70>)
* Contributors: Christophe Bedard
```

## tracetools

- No changes

## tracetools_launch

- No changes

## tracetools_read

- No changes

## tracetools_test

- No changes

## tracetools_trace

```
* Create start/pause/resume/stop sub-commands for 'ros2 trace' (#70 <https://github.com/ros2/ros2_tracing/issues/70>)
* Contributors: Christophe Bedard
```
