### PR TITLE
aerostack2: 1.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -97,7 +97,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/aerostack2-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aerostack2` to `1.0.4-1`:

- upstream repository: https://github.com/aerostack2/aerostack2.git
- release repository: https://github.com/ros2-gbp/aerostack2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.3-1`

## aerostack2

- No changes

## as2_alphanumeric_viewer

- No changes

## as2_behavior

- No changes

## as2_behavior_tree

- No changes

## as2_behaviors_motion

- No changes

## as2_behaviors_perception

- No changes

## as2_behaviors_platform

```
* Merge pull request #318 <https://github.com/aerostack2/aerostack2/issues/318> from aerostack2/jenkins-build
  fixing jenkins build failures
* fixing jenkins build failures
* Contributors: pariaspe
```

## as2_behaviors_trajectory_generation

- No changes

## as2_cli

- No changes

## as2_core

- No changes

## as2_gazebo_classic_assets

- No changes

## as2_ign_gazebo_assets

- No changes

## as2_keyboard_teleoperation

- No changes

## as2_motion_controller

- No changes

## as2_motion_reference_handlers

- No changes

## as2_msgs

- No changes

## as2_platform_crazyflie

- No changes

## as2_platform_dji_osdk

```
* Merge pull request #318 <https://github.com/aerostack2/aerostack2/issues/318> from aerostack2/jenkins-build
  fixing jenkins build failures
* fixing jenkins build failures
* Contributors: pariaspe
```

## as2_platform_ign_gazebo

- No changes

## as2_platform_tello

- No changes

## as2_python_api

- No changes

## as2_realsense_interface

```
* Merge pull request #318 <https://github.com/aerostack2/aerostack2/issues/318> from aerostack2/jenkins-build
  fixing jenkins build failures
* fixing jenkins build failures
* Contributors: pariaspe
```

## as2_state_estimator

- No changes

## as2_usb_camera_interface

- No changes
