### PR TITLE
Add metro_nav source repo to humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3186,6 +3186,12 @@ repositories:
       url: https://github.com/MetroRobots/metro_gazebo_plugins.git
       version: main
     status: developed
+  metro_nav:
+    source:
+      type: git
+      url: https://github.com/MetroRobots/metro_nav.git
+      version: main
+    status: developed
   micro_ros_diagnostics:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

metro_nav

# The source is here:

https://github.com/MetroRobots/metro_nav.git

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
