### PR TITLE
naming review rolling: add more repos for event camera support

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1225,6 +1225,16 @@ repositories:
       url: https://github.com/stack-of-tasks/eigenpy.git
       version: devel
     status: maintained
+  event_camera_codecs:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_codecs.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_codecs.git
+      version: master
+    status: developed
   event_camera_msgs:
     doc:
       type: git
@@ -1238,6 +1248,26 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_msgs.git
+      version: master
+    status: developed
+  event_camera_py:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_py.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_py.git
+      version: master
+    status: developed
+  event_camera_renderer:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_renderer.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_renderer.git
       version: master
     status: developed
   example_interfaces:


### PR DESCRIPTION
# Please Add These Packages to be indexed in the rosdistro

distro: ROLLLING

# The sources are here:

https://github.com/ros-event-camera/event_camera_codecs
https://github.com/ros-event-camera/event_camera_py
https://github.com/ros-event-camera/event_camera_renderer

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
