### PR TITLE
raspimouse2: 1.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4717,7 +4717,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/raspimouse2-release.git
-      version: 1.1.1-7
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/rt-net/raspimouse2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspimouse2` to `1.1.2-1`:

- upstream repository: https://github.com/rt-net/raspimouse2.git
- release repository: https://github.com/ros2-gbp/raspimouse2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.1-7`

## raspimouse

```
* Calculate speed from robot parameters (#50 <https://github.com/rt-net/raspimouse2/issues/50>)
* Contributors: Tatsuhiro Ikebe
```

## raspimouse_msgs

- No changes
