### PR TITLE
fix: fixes incorrect gymnasium rule

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -218,19 +218,6 @@ gym-pip:
   ubuntu:
     pip:
       packages: [gym]
-gymnasium-pip:
-  debian:
-    pip:
-      packages: [gymnasium]
-  fedora:
-    pip:
-      packages: [gymnasium]
-  osx:
-    pip:
-      packages: [gymnasium]
-  ubuntu:
-    pip:
-      packages: [gymnasium]
 imgaug-pip:
   debian:
     pip:
@@ -6232,6 +6219,21 @@ python3-grpcio:
     '*': [python3-grpcio]
     bionic: null
 python3-gurobipy-pip: *migrate_eol_2025_04_30_python3_gurobipy_pip
+python3-gymnasium-pip:
+  debian:
+    pip:
+      packages: [gymnasium]
+  fedora:
+    pip:
+      packages: [gymnasium]
+  osx:
+    pip:
+      packages: [gymnasium]
+  ubuntu:
+    '*':
+      pip:
+        packages: [gymnasium-robotics]
+    focal: null
 python3-gz-math6:
   ubuntu:
     focal: [python3-gz-math6]


### PR DESCRIPTION
> [!WARNING]
> This pull request changes an existing rule that has been in the index since May 31 see https://github.com/ros/rosdistro/pull/37334. As discussed in https://github.com/ros/rosdistro/pull/38244#issuecomment-1690622106, this needs to be done since in my previous pull request an incorrect key was introduced.

## Package name:

[gymnasium](https://gymnasium.farama.org/)

## Package Upstream Source:

https://github.com/Farama-Foundation/Gymnasium

## Purpose of using this:

The old OpenAI gym package is no longer maintained (see https://www.gymlibrary.dev/). As a result gym should be replaced with gymnasium. Gym is kept in the dependency list for back-compatibility.

Pypi packaging links:

- https://pypi.org/project/gymnasium/
