### PR TITLE
network_interface: 2003.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3657,6 +3657,12 @@ repositories:
       url: https://github.com/nerian-vision/nerian_stereo_ros2.git
       version: master
     status: developed
+  network_interface:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/astuff/network_interface-release.git
+      version: 2003.1.1-1
   nlohmann_json_schema_validator_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `network_interface` to `2003.1.1-1`:

- upstream repository: https://github.com/astuff/network_interface.git
- release repository: https://github.com/astuff/network_interface-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## network_interface

```
* Ros2 devel (#42 <https://github.com/astuff/network_interface/issues/42>)
  * changes for ros2
  * foxy ci
  * install boost library in docker container
* Contributors: cullenstoneAS
```
