### PR TITLE
Add flake8-black rosdep rule

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5792,6 +5792,22 @@ python3-flake8:
     '*': ['python%{python3_pkgversion}-flake8']
     '7': null
   ubuntu: [python3-flake8]
+python3-flake8-black:
+  arch: [python-flake8-black]
+  debian:
+    '*':
+      pip:
+        packages: [flake8-black]
+    bookworm: [python3-flake8-black]
+  fedora:
+    pip:
+      packages: [flake8-black]
+  osx:
+    pip:
+      packages: [flake8-black]
+  ubuntu:
+    pip:
+      packages: [flake8-black]
 python3-flake8-blind-except:
   opensuse: [python3-flake8-blind-except]
   ubuntu:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`flake8-black`

## Package Upstream Source:

https://github.com/peterjc/flake8-black

## Purpose of using this:

Popular python code formatter - this plugin lets flake8 check `black` formatting so we can  use it with `ament_flake8`

Distro packaging links:

## Links to Distribution Packages

PyPi: https://pypi.org/project/flake8-black/

- Debian: https://packages.debian.org/
  - REQUIRED: Bookworm - https://packages.debian.org/bookworm/python3-flake8-black
- Ubuntu: https://packages.ubuntu.com/
  - REQUIRED: pip only
- Fedora: https://packages.fedoraproject.org/
  - IF AVAILABLE: not available
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE: https://archlinux.org/packages/extra/any/python-flake8-black/
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE: not available
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE: not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE: not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL: not available
- openSUSE: https://software.opensuse.org/package/
  - IF AVAILABLE: not available