### PR TITLE
Add python3-flake8-isort rosdep rule

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5869,6 +5869,20 @@ python3-flake8-import-order-pip:
   ubuntu:
     pip:
       packages: [flake8-import-order]
+python3-flake8-isort:
+  arch: [python-flake8-isort]
+  debian:
+    pip:
+      packages: [flake8-isort]
+  fedora:
+    pip:
+      packages: [flake8-isort]
+  osx:
+    pip:
+      packages: [flake8-isort]
+  ubuntu:
+    pip:
+      packages: [flake8-isort]
 python3-flake8-quotes:
   fedora:
     '*': [python3-flake8-quotes]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`python3-flake8-isort`

## Package Upstream Source:

https://github.com/gforcada/flake8-isort

## Purpose of using this:

`isort` is a popular python formatter for sorting import statements, which pairs well with `black` style.
Its rules differ from `flake8-import-order`.
This plugin for `flake8` allows that linter to check `isort`'s style.

Distro packaging links:

## Links to Distribution Packages

PyPI: https://pypi.org/project/flake8-isort/

- Debian: https://packages.debian.org/
  - REQUIRED: not available
- Ubuntu: https://packages.ubuntu.com/
  - REQUIRED: not available
- Fedora: https://packages.fedoraproject.org/
  - IF AVAILABLE: not available
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE: not available
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE: not available
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE: not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE: not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL: not available
- openSUSE: https://software.opensuse.org/package/
  - IF AVAILABLE: not available