### PR TITLE
rmf_ros2: 2.3.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4409,7 +4409,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 2.3.1-1
+      version: 2.3.2-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_ros2` to `2.3.2-1`:

- upstream repository: https://github.com/open-rmf/rmf_ros2.git
- release repository: https://github.com/ros2-gbp/rmf_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.1-1`

## rmf_fleet_adapter

```
* Improve linking time (#297 <https://github.com/open-rmf/rmf_ros2/pull/297>)
* EasyFullControl API (#235 <https://github.com/open-rmf/rmf_ros2/pull/235>)
* Contributors: Grey, Luca Della Vedova, Xiyu, Yadunund
```

## rmf_fleet_adapter_python

```
* EasyFullControl API (#235 <https://github.com/open-rmf/rmf_ros2/pull/235>)
* Contributors: Grey, Luca Della Vedova, Xiyu, Yadunund
```

## rmf_task_ros2

```
* Improve linking time (#297 <https://github.com/open-rmf/rmf_ros2/pull/297>)
* Contributors: Grey, Luca Della Vedova
```

## rmf_traffic_ros2

```
* Improve linking time (#297 <https://github.com/open-rmf/rmf_ros2/pull/297>)
* EasyFullControl API (#235 <https://github.com/open-rmf/rmf_ros2/pull/235>)
* Remove a few warnings related to RCLCPP logger (#296 <https://github.com/open-rmf/rmf_ros2/pull/296>)
* Contributors: Arjo Chakravarty, Grey, Luca Della Vedova, Xiyu, Yadunund
```

## rmf_websocket

- No changes
