### PR TITLE
rmf_visualization: 2.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4543,7 +4543,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_visualization-release.git
-      version: 2.2.0-1
+      version: 2.2.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_visualization` to `2.2.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_visualization.git
- release repository: https://github.com/ros2-gbp/rmf_visualization-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.0-1`

## rmf_visualization

- No changes

## rmf_visualization_building_systems

- No changes

## rmf_visualization_fleet_states

```
* Improve linking times (#61 <https://github.com/open-rmf/rmf_visualization/pull/61>)
* Contributors: Grey, Luca Della Vedova
```

## rmf_visualization_floorplans

```
* Improve linking times (#61 <https://github.com/open-rmf/rmf_visualization/pull/61>)
* Contributors: Grey, Luca Della Vedova
```

## rmf_visualization_navgraphs

```
* Improve linking times (#61 <https://github.com/open-rmf/rmf_visualization/pull/61>)
* Contributors: Grey, Luca Della Vedova
```

## rmf_visualization_obstacles

```
* Improve linking times (#61 <https://github.com/open-rmf/rmf_visualization/pull/61>)
* Contributors: Grey, Luca Della Vedova
```

## rmf_visualization_rviz2_plugins

```
* Improve linking times (#61 <https://github.com/open-rmf/rmf_visualization/pull/61>)
* Contributors: Grey, Luca Della Vedova
```

## rmf_visualization_schedule

```
* Improve linking times (#61 <https://github.com/open-rmf/rmf_visualization/pull/61>)
* Contributors: Grey, Luca Della Vedova
```
