### PR TITLE
Add python3-mysqldb rosdep rule

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6816,6 +6816,13 @@ python3-mypy:
     '7': null
     '8': null
   ubuntu: [python3-mypy]
+python3-mysqldb:
+  arch: [python-mysqlclient]
+  debian: [python3-mysqldb]
+  fedora: [python3-mysql]
+  gentoo: [dev-python/mysqlclient]
+  opensuse: [python-mysqlclient]
+  ubuntu: [python3-mysqldb]
 python3-myst-parser-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-mysqldb

## Package Upstream Source:

https://github.com/PyMySQL/mysqlclient

## Purpose of using this:

This is a MySQL database connector for Python. It provides a client library for interfacing with the MySQL database server.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/bookworm/python3-mysqldb
- Ubuntu: https://packages.ubuntu.com/jammy/python3-mysqldb
- Fedora: https://packages.fedoraproject.org/pkgs/python-mysql/python3-mysql/
- Arch: https://archlinux.org/packages/extra/x86_64/python-mysqlclient/
- Gentoo: https://packages.gentoo.org/packages/dev-python/mysqlclient
- openSUSE: https://software.opensuse.org/package/python-mysqlclient

