### PR TITLE
ur_description: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6825,7 +6825,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.1.0-2
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.2.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.0-2`

## ur_description

```
* Auto-update pre-commit hooks
* Do not require upstream ws in ici
* Auto-update pre-commit hooks (#88 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/88>)
* Bump ros-tooling/setup-ros from 0.2 to 0.7 (#83 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/83>)
* Bump pat-s/always-upload-cache from 2.1.5 to 3.0.11 (#84 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/84>)
* Bump actions/checkout from 1 to 3 (#85 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/85>)
* Update README regarding distribution branches (#80 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/80>)
* Add mergify, dependabot and pre-commit update
* Switch fake to mock for ros2_control updates (#77 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/77>)
* Add iron workflow (#64 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/64>)
* Contributors: Felix Exner, Sebastian Castro, dependabot[bot], github-actions[bot]
```
