### PR TITLE
ur_robot_driver: 2.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6862,7 +6862,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.3.2-1
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.4.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.2-1`

## ur

- No changes

## ur_calibration

```
* Use mock_hardware and mock_sensor_commands instead of fake (#739 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/739>)
  * Use mock_hardware and mock_sensor_commands instead of fake
  This has been deprecated a while back and was never adapted.
  * Update documentation to mock_hardware
* Contributors: Felix Exner (fexner)
```

## ur_controllers

```
* Handle api changes related to traj_external_point_ptr_ (#779 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/779>)
  * Handle api changes related to traj_external_point_ptr_
  * Fix formatting
  ---------
  Co-authored-by: Robert Wilbrandt <mailto:wilbrandt@fzi.de>
* Contributors: Yadu
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* Use mock_hardware and mock_sensor_commands instead of fake (#739 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/739>)
  * Use mock_hardware and mock_sensor_commands instead of fake
  This has been deprecated a while back and was never adapted.
  * Update documentation to mock_hardware
* Contributors: Felix Exner (fexner)
```

## ur_robot_driver

```
* Start ursim from lib (#733 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/733>)
  * Forward start_ursim.sh to the one from the client library
  * Update docs and tests to start ursim from the ur_client_library script
* Update velocity-control on feature list (#573 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/573>)
  ros2_controllers jtc does support velocity control by now, so we should not state it doesn't.
* Introduced tf_prefix into log handler (#713 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/713>)
  * Introduced tf_prefix into log handler
  * added default argument to prefix
  ---------
  Co-authored-by: Lennart Nachtigall <mailto:firesurfer@firesurfer.de>
  Co-authored-by: Felix Exner <mailto:exner@fzi.de>
  Co-authored-by: Lennart Nachtigall <mailto:lennart.nachtigall@sci-mo.de>
* Run robot driver test also with tf_prefix (#729 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/729>)
  * Run robot driver test also with tf_prefix
  * Use tf_prefix substitution in controllers config file
  * Set default value of tf_prefix in launchfile to empty instead of '""'
  ---------
  Co-authored-by: Robert Wilbrandt <mailto:wilbrandt@fzi.de>
* Use mock_hardware and mock_sensor_commands instead of fake (#739 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/739>)
  * Use mock_hardware and mock_sensor_commands instead of fake
  This has been deprecated a while back and was never adapted.
  * Update documentation to mock_hardware
* Urscript interface (#721 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/721>)
  * Add a urscript interface node
  * Add urscript_interface to standard launchfile
  * Added documentation for urscript_interface
  * Add a notice about incorrect script code
  * Add test for urscript interface
  * Move tests to one single tests
  This should avoid that different tests run in parallel
  * Wait for IO controller before checking IOs
  * Write an initial textmessage when connecting the urscript_interface
  * Wait for controller_manager services longer
  * Make sure we have a clean robot state without any program running once we enter our test
  similar to how we did it on the robot_driver test
  * Remove unneeded Destructor definition
* Use SCHED_FIFO for controller_manager's main thread (#719 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/719>)
  Previous investigations showed that using FIFO scheduling helps keeping
  cycle times also non non-RT kernels. This combined with non-blocking read
  can result in a very stable system.
  This is, in fact, very close to what the actual controller_manager_node
  does except that we always use FIFO scheduling independent of the actual
  kernel in use.
* Contributors: Felix Exner (fexner), Lennart Nachtigall
```
