### PR TITLE
Add entries of python module to use hidapi

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6359,6 +6359,16 @@ python3-helyos_agent_sdk-pip:
   '*':
     pip:
       packages: [helyos_agent_sdk]
+python3-hidapi:
+  debian: [python3-hid]
+  fedora: [python3-hidapi]
+  rhel:
+    '*': [python3-hidapi]
+    '8': null
+  ubuntu: [python3-hid]
+python3-hidapi-cffi:
+  debian: [python3-hidapi]
+  ubuntu: [python3-hidapi]
 python3-httplib2:
   debian: [python3-httplib2]
   fedora: [python3-httplib2]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

- `python-hid`
- `python3-hid`
- `python-hidapi`
- `python3-hidapi`
- `python-hidapi-cffi`
- `python3-hidapi-cffi`

## Package Upstream Source:

The names of these python modules are extremely confusing and are organized in the table below.

|Index | Proposed rosdep name | Upstream Source                                | Name to import | Name in pypi | Name in github | Name in apt | Architecture |
| ------: | :------------------------------ | :------------------------------------------------   | :-------  | :--------------- | :---- | :-------- | :---- |
|       1 | python[3]-hid                     | https://github.com/apmorton/pyhidapi   | hid      | hid  | pyhidapi | - | ctypes          | 
|       2 | python[3]-hidapi                | https://github.com/trezor/cython-hidapi | hid or hidraw | hidapi | cython-hidapi | python[3]-hid | Cython/cython3 |
|       3 | python[3]-hidapi-cffi          | https://github.com/jbaiter/hidapi-cffi      | hidapi  | hidapi-cffi | hidapi-cffi | python[3]-hidapi | cffi or python3-cffi |

As shown in the table above, each library uses a different name depending on the context, and I proposes following naming rule for these python packages.

```text
python-<PyPi name>
```
## Purpose of using this:

These python modules provide interface to access [`hidapi`](https://github.com/libusb/hidapi).  
You can work with Human Interface Devices such as mouses and keyboards, etc.


Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

### `python[3]-hid`

- PyPi: https://pypi.org/project/hid/
- Debian: https://packages.debian.org/
  - REQUIRED: not available
- Ubuntu: https://packages.ubuntu.com/
  - REQUIRED: not available

### `python[3]-hidapi`

- Debian: https://packages.debian.org/en/buster/python3-hid, https://packages.debian.org/en/buster/python-hid
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/focal/python3-hid
  - REQUIRED

### `python[3]-hidapi-cffi`

- Debian: https://packages.debian.org/en/buster/python3-hidapi, https://packages.debian.org/en/buster/python-hidapi
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/focal/python3-hidapi
  - REQUIRED