### PR TITLE
nixos: use pythonPackages.opencv4 instead of pythonPackages.opencv3

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2594,7 +2594,7 @@ python-opencv:
   debian: [python-opencv]
   freebsd: [py27-opencv]
   gentoo: ['media-libs/opencv[python]']
-  nixos: [pythonPackages.opencv3]
+  nixos: [pythonPackages.opencv4]
   openembedded: [opencv@meta-oe]
   opensuse: [python2-opencv]
   rhel:
@@ -7059,7 +7059,7 @@ python3-opencv:
   debian: [python3-opencv]
   fedora: [python3-opencv]
   gentoo: ['media-libs/opencv[python]']
-  nixos: [python3Packages.opencv3]
+  nixos: [python3Packages.opencv4]
   openembedded: [opencv@meta-oe]
   opensuse: [python3-opencv]
   rhel:


### PR DESCRIPTION
Looks like this was left behind in #33094.
Packages that depend on both the regular and Python packages get very confused.
Melodic is no longer included in nix-ros-overlay so that is no longer of concern.