### PR TITLE
ecal: 5.12.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1088,6 +1088,15 @@ repositories:
       version: ros2
     status: maintained
   ecal:
+    doc:
+      type: git
+      url: https://github.com/eclipse-ecal/ecal.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ecal-release.git
+      version: 5.12.0-1
     source:
       type: git
       url: https://github.com/eclipse-ecal/ecal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecal` to `5.12.0-1`:

- upstream repository: https://github.com/eclipse-ecal/ecal.git
- release repository: https://github.com/ros2-gbp/ecal-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
