### PR TITLE
mola: 0.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3319,6 +3319,15 @@ repositories:
       type: git
       url: https://github.com/MOLAorg/mola.git
       version: develop
+    release:
+      packages:
+      - mola_common
+      - mola_yaml
+      - mp2p_icp
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/mola-release.git
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `0.2.0-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## mola_common

```
* First public release as ROS 2 package.
```

## mola_yaml

```
* First public release as ROS 2 package.
```

## mp2p_icp

```
* First release as MOLA submodule.
```
