### PR TITLE
gazebo_custom_sensor_preloader: 1.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3028,6 +3028,21 @@ repositories:
       url: https://github.com/locusrobotics/fuse.git
       version: devel
     status: developed
+  gazebo_custom_sensor_preloader:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/gazebo_custom_sensor_preloader.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/gazebo_custom_sensor_preloader
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/ctu-vras/gazebo_custom_sensor_preloader.git
+      version: master
+    status: maintained
   gazebo_ros_control_select_joints:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_custom_sensor_preloader` to `1.1.0-1`:

- upstream repository: https://github.com/ctu-vras/gazebo_custom_sensor_preloader
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/gazebo_custom_sensor_preloader
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## gazebo_custom_sensor_preloader

```
* Removed unnecessary pollution of gazebo plugin path.
* Simplified specifying the plugin name on the command line, cleaned up build files.
* Noetic compatibility.
* Contributors: Martin Pecka
```
