### PR TITLE
cras_relative_positional_controller: 2.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1607,6 +1607,21 @@ repositories:
       url: https://github.com/ctu-vras/cras_msgs.git
       version: master
     status: developed
+  cras_relative_positional_controller:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/cras_relative_positional_controller.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/cras_relative_positional_controller.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ctu-vras/cras_relative_positional_controller.git
+      version: master
+    status: developed
   cras_ros_utils:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_relative_positional_controller` to `2.0.0-1`:

- upstream repository: https://github.com/ctu-vras/cras_relative_positional_controller
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/cras_relative_positional_controller.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## cras_relative_positional_controller

```
* Renamed to cras_relative_positional_controller.
* Contributors: Martin Pecka
```
