### PR TITLE
metrics_msgs: 0.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3219,6 +3219,19 @@ repositories:
       version: master
     status: developed
   metrics_msgs:
+    doc:
+      type: git
+      url: https://github.com/MetroRobots/metrics_msgs.git
+      version: main
+    release:
+      packages:
+      - benchmark_msgs
+      - benchmark_utils
+      - collision_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/metrics_msgs-release.git
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/MetroRobots/metrics_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `metrics_msgs` to `0.1.0-1`:

- upstream repository: https://github.com/MetroRobots/metrics_msgs
- release repository: https://github.com/ros2-gbp/metrics_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## benchmark_msgs

```
* benchmark_msgs, benchmark_utils, collision_msgs
* Contributors: David V. Lu!!
```

## benchmark_utils

```
* Fix Compiler Warning (#2 <https://github.com/MetroRobots/metrics_msgs/issues/2>)
* benchmark_msgs, benchmark_utils, collision_msgs
* Contributors: David V. Lu!!
```

## collision_msgs

```
* benchmark_msgs, benchmark_utils, collision_msgs
* Contributors: David V. Lu!!
```
