### PR TITLE
metro_nav: 0.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3231,6 +3231,18 @@ repositories:
       version: main
     status: developed
   metro_nav:
+    doc:
+      type: git
+      url: https://github.com/MetroRobots/metro_nav.git
+      version: main
+    release:
+      packages:
+      - kinematics_2d
+      - kinematics_2d_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/metro_nav-release.git
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/MetroRobots/metro_nav.git


### PR DESCRIPTION
Increasing version of package(s) in repository `metro_nav` to `0.1.0-1`:

- upstream repository: https://github.com/MetroRobots/metro_nav.git
- release repository: https://github.com/ros2-gbp/metro_nav-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## kinematics_2d

```
* Initial kinematics_2d_msgs and kinematics_2d packages
* Contributors: David V. Lu
```

## kinematics_2d_msgs

```
* Initial kinematics_2d_msgs and kinematics_2d packages
* Contributors: David V. Lu
```
