### PR TITLE
neonavigation: 0.15.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6351,7 +6351,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.14.2-1
+      version: 0.15.0-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.15.0-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.14.2-1`

## costmap_cspace

- No changes

## joystick_interrupt

- No changes

## map_organizer

- No changes

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

- No changes

## obj_to_pointcloud

- No changes

## planner_cspace

```
* planner_cspace: enable dynamic reconfigure (#714 <https://github.com/at-wat/neonavigation/issues/714>)
* planner_space: fix segmentation fault on out-of-map (#712 <https://github.com/at-wat/neonavigation/issues/712>)
* Contributors: Atsushi Watanabe, Naotaka Hatao
```

## safety_limiter

- No changes

## track_odometry

- No changes

## trajectory_tracker

```
* trajectory_tracker: make trajectory_tracker library (#713 <https://github.com/at-wat/neonavigation/issues/713>)
* Contributors: Naotaka Hatao
```
