### PR TITLE
openzen_sensor: 1.3.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6934,7 +6934,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/lp-research/openzen_sensor-release.git
-      version: 1.2.0-1
+      version: 1.3.2-1
     source:
       type: git
       url: https://bitbucket.org/lpresearch/openzenros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openzen_sensor` to `1.3.2-1`:

- upstream repository: https://bitbucket.org/lpresearch/openzenros.git
- release repository: https://github.com/lp-research/openzen_sensor-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.0-1`

## openzen_sensor

```
* fix default gyro mapping for legacy sensor
  tested with URS2
* update ros package version to v1.3.1
* update submodule openzen to v1.3.1 to support LPMS3 sensors
* switch default gyros for different sensors
* updated OpenZen to be able to parse 16-bit data format messages for IG1
* updated to recent OpenZen to be able to directly connect to Linux device files
* added link to melodic ROS directly
* Contributors: LP-Research Inc. Team
```
