### PR TITLE
rig_reconfigure: 1.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4362,8 +4362,8 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/rig_reconfigure-release.git
-      version: 1.2.0-1
+      url: git@github.com:ros2-gbp/rig_reconfigure-release.git
+      version: 1.3.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4362,7 +4362,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: git@github.com:ros2-gbp/rig_reconfigure-release.git
+      url: https://github.com/ros2-gbp/rig_reconfigure-release.git
       version: 1.3.0-1
     source:
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rig_reconfigure` to `1.3.0-1`:

- upstream repository: https://github.com/teamspatzenhirn/rig_reconfigure.git
- release repository: https://github.com/ros2-gbp/rig_reconfigure-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.0-1`

## rig_reconfigure

```
* Only list nodes providing the parameter service (#23 <https://github.com/teamspatzenhirn/rig_reconfigure/issues/23>)
* Cleanup (#22 <https://github.com/teamspatzenhirn/rig_reconfigure/issues/22>)
* Info window (#21 <https://github.com/teamspatzenhirn/rig_reconfigure/issues/21>)
* Contributors: Dominik
```
