### PR TITLE
mvsim: 0.7.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3552,7 +3552,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mvsim-release.git
-      version: 0.7.3-1
+      version: 0.7.4-1
     source:
       type: git
       url: https://github.com/MRPT/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.7.4-1`:

- upstream repository: https://github.com/MRPT/mvsim.git
- release repository: https://github.com/ros2-gbp/mvsim-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.3-1`

## mvsim

```
* Add new LIDAR 3D models: Helios 32.
* Removed LIDAR3D fbo_nrows parameter, automatically computed now from geometry solutions.
* More optimal simulation of asymmetric 3D lidars.
* Progress with RTD documentation.
* Add proper bibliography; fix all docs warnings
* ROS 2 warehouse demo: show 2D lidar in RVIZ too; add headless launch argument
* New GUI editor feature: move sensor poses
* Contributors: Jose Luis Blanco-Claraco
```
