### PR TITLE
usb_cam: 0.7.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7306,7 +7306,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/usb_cam-release.git
-      version: 0.6.0-2
+      version: 0.7.0-1
     source:
       type: git
       url: https://github.com/ros-drivers/usb_cam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `usb_cam` to `0.7.0-1`:

- upstream repository: https://github.com/ros-drivers/usb_cam.git
- release repository: https://github.com/ros2-gbp/usb_cam-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.0-2`

## usb_cam

```
* Fix mjpeg invalid ptr and mjpeg memory leak
* Allocate unique avpacket for each frame
* Fix some minor memorly leaks for mjpeg
  Relates to #262 <https://github.com/ros-drivers/usb_cam/issues/262>
* Update docs to new launch file name
  Closes #277 <https://github.com/ros-drivers/usb_cam/issues/277>
* Only unref packet in destructor
  Closes #274 <https://github.com/ros-drivers/usb_cam/issues/274> #275 <https://github.com/ros-drivers/usb_cam/issues/275>
* Enable manaul trigger of ROS 2 CI, add Iron, deprecate Foxy
* Add Iron to CI, remove Foxy
* Enable manaul trigger of ROS 2 CI
* Fix memory leaks in mjpeg2rgb conversion
* Add SANITIZE option to package to help with debugging, document it
* Fix memory leaks caused by buffer allocation by using smart pointers
* Fix linter errors
* Update params2 file for second camera
* Fixed wrong image timestamp due to missing handling of microseconds in epoch time shift
* Removed debug output of timestamp
* Fixed wring image timestamp due to missing handling of microseconds in epoch time shift.
* Address multiple memory leak issues after ros2 rewrite
* Remove EOL Galactic distro from CI
* Address multiple memory leak issues after ros2 rewrite
* Create CameraConfig class, use it in launch file
* imports no longer needed.
* Multiple cameras + compression
* Remove debug print accidentally added
* Clean up ROS 2 node, update parameter logic
* Contributors: Boitumelo Ruf, Brendon Cintas, Evan Flynn
```
