### PR TITLE
behaviortree_cpp_v4: 4.3.6-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -561,7 +561,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.3.5-1
+      version: 4.3.6-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp_v4` to `4.3.6-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.3.5-1`

## behaviortree_cpp

```
* Simplify the visualization of custom type in Groot2 and improved tutorial 12
* fix compilation warnings
* Apply changes in ReactiveSequence to ReactiveFallback too
* test that logging works correctly with ReactiveSequence #643 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/643>
* reduce the number of times preconditions scripts are executed
* PauseWithRetry test added
* Contributors: Davide Faconti
```
