### PR TITLE
nmea_navsat_driver: 2.0.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3193,11 +3193,15 @@ repositories:
       version: ros2
     status: maintained
   nmea_navsat_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/nmea_navsat_driver.git
+      version: 2.0.1
     release:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/nmea_navsat_driver-release.git
-      version: 2.0.0-3
+      version: 2.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_navsat_driver` to `2.0.1-1`:

- upstream repository: https://github.com/ros-drivers/nmea_navsat_driver.git
- release repository: https://github.com/ros2-gbp/nmea_navsat_driver-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-3`

## nmea_navsat_driver

```
* Fix parsing of true_course field in VTG message (#165 <https://github.com/evenator/nmea_navsat_driver/issues/165>)
  Co-authored-by: Stefan Gisler <mailto:stefan.gisler@hillbot.ch>
* Fix missing return in driver.add_sentence to avoid returning None.
* Update logger definition to match ROS2 logging API.
* Add Support for TCP GNSS Sensor (#152 <https://github.com/evenator/nmea_navsat_driver/issues/152>)
  Add a new nmea_tcpclient_driver for sensors that offer a TCP interface rather than a UDP interface.
  The nmea_tcpclient_driver connects to a TCP socket and forwards the NMEA-Sentences line-by-line to the driver.
* Modify setup.cfg to remove warning when doing colcon build (#157 <https://github.com/evenator/nmea_navsat_driver/issues/157>)
* Contributors: Dunkelmann, Luca Bascetta, gislers, joeldushouyu
```
