### PR TITLE
rosdep: nixos: Add few missing rules

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1877,6 +1877,7 @@ hdf5:
   ubuntu: [libhdf5-dev]
 hdf5-tools:
   debian: [hdf5-tools]
+  nixos: [hdf5]
   ubuntu: [hdf5-tools]
 hostapd:
   arch: [hostapd]
@@ -4551,6 +4552,7 @@ libpaho-mqtt-dev:
   alpine: [paho-mqtt-c-dev]
   debian: [libpaho-mqtt-dev]
   fedora: [paho-c-devel]
+  nixos: [paho-mqtt-c]
   opensuse: [libpaho-mqtt-devel]
   ubuntu:
     '*': [libpaho-mqtt-dev]
@@ -4563,6 +4565,7 @@ libpaho-mqttpp:
     bionic: null
     focal: null
 libpaho-mqttpp-dev:
+  nixos: [paho-mqtt-cpp]
   ubuntu:
     '*': [libpaho-mqttpp-dev]
     bionic: null
@@ -5719,6 +5722,7 @@ libtins-dev:
   arch: [libtins]
   debian: [libtins-dev]
   fedora: [libtins-devel]
+  nixos: [libtins]
   opensuse: [libtins-devel]
   rhel:
     '*': [libtins-devel]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -312,6 +312,7 @@ meson:
   alpine: [meson]
   debian: [meson]
   fedora: [meson]
+  nixos: [meson]
   opensuse: [meson]
   rhel: [meson]
   ubuntu: [meson]
@@ -6899,6 +6900,7 @@ python3-myst-parser-pip:
 python3-natsort:
   debian: [python3-natsort]
   fedora: [python3-natsort]
+  nixos: [python3Packages.natsort]
   opensuse: [python3-natsort]
   rhel: [python3-natsort]
   ubuntu: [python3-natsort]
@@ -7341,6 +7343,7 @@ python3-ply:
   debian: [python3-ply]
   fedora: [python3-ply]
   gentoo: [dev-python/ply]
+  nixos: [python3Packages.ply]
   opensuse: [python3-ply]
   rhel:
     '*': [python3-ply]


### PR DESCRIPTION
Following are links to Ubuntu and NixOS package information for you to check that these are the same packages:

- hdf5-tools: [Ubuntu](https://packages.ubuntu.com/lunar/hdf5-tools) [NixOS](https://search.nixos.org/packages?channel=unstable&show=hdf5)
- libpaho-mqtt-dev: [Ubuntu](https://packages.ubuntu.com/lunar/libpaho-mqtt-dev) [NixOS](https://search.nixos.org/packages?channel=unstable&show=paho-mqtt-c)
- libpaho-mqttpp: [Ubuntu](https://packages.ubuntu.com/lunar/libpaho-mqttpp-dev) [NixOS](https://search.nixos.org/packages?channel=unstable&show=paho-mqtt-cpp)
- libtins-dev: [Ubuntu](https://packages.ubuntu.com/lunar/libtins-dev) [NixOS](https://search.nixos.org/packages?channel=unstable&show=libtins)
- meson: [Ubuntu](https://packages.ubuntu.com/lunar/meson) [NixOS](https://search.nixos.org/packages?channel=unstable&show=meson)
- python3-natsort: [Ubuntu](https://packages.ubuntu.com/lunar/python3-natsort) [NixOS](https://search.nixos.org/packages?channel=unstable&show=python311Packages.natsort)
- python3-ply: [Ubuntu](https://packages.ubuntu.com/lunar/python3-ply) [NixOS](https://search.nixos.org/packages?channel=unstable&show=python311Packages.ply)
