### PR TITLE
mvsim: 0.8.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6164,7 +6164,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
-      version: 0.7.4-1
+      version: 0.8.0-1
     source:
       type: git
       url: https://github.com/ual-arm-ros-pkg/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.8.0-1`:

- upstream repository: https://github.com/ual-arm-ros-pkg/mvsim.git
- release repository: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.4-1`

## mvsim

```
* Recursive `<include>`s are now possible.
* All vehicle and sensor definitions are now exposed in public directory 'definitions' and are safe to be included from user worlds
* ROS warehouse demos: fix wrong camera topicn ame in rviz
* Add missing ROS 2 launch demo for greenhouse world
* Add new variable: MVSIM_CURRENT_FILE_DIRECTORY
* BUGFIX: In parseVars() in the XML parser
* Debugging feature: MVSIM_VERBOSE_PARSE now also traces <variable> definitions
* Contributors: Jose Luis Blanco-Claraco
```
