### PR TITLE
mola: 0.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2766,12 +2766,15 @@ repositories:
     release:
       packages:
       - mola_common
+      - mola_input_euroc_dataset
+      - mola_input_kitti_dataset
+      - mola_kernel
       - mola_yaml
       - mp2p_icp
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `0.2.1-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.0-1`

## mola_common

- No changes

## mola_input_euroc_dataset

```
* Update to new colcon ROS2 build system
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_kitti_dataset

```
* Implement ground-truth interface for KITTI
* Update copyright date
* Update to new colcon ROS2 build system
* Contributors: Jose Luis Blanco-Claraco
```

## mola_kernel

```
* Add virtual interface for dataset groundtruth
* Update copyright date
* Update to new colcon ROS2 build system
* Contributors: Jose Luis Blanco-Claraco
```

## mola_yaml

- No changes

## mp2p_icp

```
* Update copyright date
* Update to new name of mola_common
* update ros badges
* Contributors: Jose Luis Blanco-Claraco
```
