### PR TITLE
rosdep: Add libfyaml-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3402,6 +3402,19 @@ libftgl-dev:
   fedora: [ftgl-devel]
   gentoo: [media-libs/ftgl]
   ubuntu: [libftgl-dev]
+libfyaml-dev:
+  alpine: [libfyaml-dev]
+  debian:
+    '*': [libfyaml-dev]
+    bullseye: null
+  fedora: [libfyaml-devel]
+  nixos: [libfyaml]
+  opensuse:
+    '*': [libfyaml]
+    '15.2': null
+  ubuntu:
+    '*': [libfyaml-dev]
+    focal: null
 libgazebo-dev:
   debian:
     bullseye: [libgazebo-dev]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

libfyaml-dev

## Package Upstream Source:

https://github.com/pantoniou/libfyaml

## Purpose of using this:

This dependency is used by [mrpt2](https://index.ros.org/search/?term=mrpt2) package. Currently, it fetches the copy of the library source code by cmake. However, this fails on Nix(OS), because packages are built in a sandbox without network access. Having it in rosdep allows building the package without problems.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/search?keywords=libfyaml-dev
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/search?keywords=libfyaml-dev
  - REQUIRED
- Fedora: https://packages.fedoraproject.org/ (NOT AVAILABLE)
  - IF AVAILABLE
- Arch: https://www.archlinux.org/packages/ (NOT AVAILABLE)
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/ (NOT AVAILABLE)
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/ (NOT AVAILABLE)
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/package/edge/testing/x86_64/libfyaml-dev
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=unstable&show=libfyaml
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/libfyaml
  - IF AVAILABLE
- rhel: https://rhel.pkgs.org/ (NOT AVAILABLE)
  - IF AVAILABLE
