### PR TITLE
rosdep: nixos: Update wxGTK to wxGTK32

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8276,7 +8276,7 @@ wx-common:
   debian: [wx-common]
   fedora: [wxGTK3-devel]
   gentoo: [x11-libs/wxGTK]
-  nixos: [wxGTK]
+  nixos: [wxGTK32]
   openembedded: [wxwidgets@meta-ros-common]
   rhel:
     '*': [wxGTK3-devel]
@@ -8291,7 +8291,7 @@ wxwidgets:
   freebsd: [wxgtk2]
   gentoo: [x11-libs/wxGTK]
   macports: [wxWidgets-python]
-  nixos: [wxGTK]
+  nixos: [wxGTK32]
   openembedded: [wxwidgets@meta-ros-common]
   opensuse: [wxGTK-devel]
   rhel:


### PR DESCRIPTION
wxGTK has been removed from nixpkgs. See
https://github.com/NixOS/nixpkgs/blob/5e9ff98d1dccbb391a9769b5dc660a5f6e39c18b/pkgs/top-level/aliases.nix#L1867

Currently, wxGTK31 and wxGTK32 are available:
https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=wxGTK

Choose wxGTK32 - the software I care about (mrpt2) compiles with it.
