### PR TITLE
ros_controllers: 0.21.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9132,7 +9132,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.21.1-1
+      version: 0.21.2-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.21.2-1`:

- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.21.1-1`

## ackermann_steering_controller

- No changes

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_controller

- No changes

## forward_command_controller

- No changes

## four_wheel_steering_controller

- No changes

## gripper_action_controller

- No changes

## imu_sensor_controller

- No changes

## joint_state_controller

```
* [joint_state_controller] clear joint_state_ before assignment
* Contributors: Cong Liu
```

## joint_trajectory_controller

- No changes

## position_controllers

- No changes

## ros_controllers

- No changes

## rqt_joint_trajectory_controller

```
* change to setuptools in accordance with migration guide
* Contributors: Arne Hitzmann
```

## velocity_controllers

- No changes
