### PR TITLE
Update Rolling source branch for micro_ros_msgs

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2700,7 +2700,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/micro-ROS/micro_ros_msgs.git
-      version: main
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2709,7 +2709,7 @@ repositories:
     source:
       type: git
       url: https://github.com/micro-ROS/micro_ros_msgs.git
-      version: main
+      version: rolling
     status: maintained
   microstrain_inertial:
     doc:


### PR DESCRIPTION
@jamoralp FYI

I noticed there's no `main` branch on this repo, but there is a `rolling` branch.

https://github.com/micro-ROS/micro_ros_msgs/tree/rolling