### PR TITLE
nmea_msgs: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3127,7 +3127,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nmea_msgs-release.git
-      version: 2.0.0-4
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/ros-drivers/nmea_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_msgs` to `2.1.0-1`:

- upstream repository: https://github.com/ros-drivers/nmea_msgs.git
- release repository: https://github.com/ros2-gbp/nmea_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-4`

## nmea_msgs

```
* Add GPVTG and GPZDA Sentences (#19 <https://github.com/evenator/nmea_msgs/issues/19>)
  GPVTG is useful for interpreting speed and heading.
  GPZDA is useful for syncing date and time.
* Add GPGST NMEA message (#18 <https://github.com/evenator/nmea_msgs/issues/18>)
  Add ROS2 message definition for GST NMEA sentences.
  See: #17 <https://github.com/evenator/nmea_msgs/issues/17>
  Co-authored-by: Nicolas Chleq
```
