### PR TITLE
fadecandy_ros: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1432,6 +1432,20 @@ repositories:
       url: https://github.com/ros2/examples.git
       version: foxy
     status: maintained
+  fadecandy_ros:
+    doc:
+      type: git
+      url: https://github.com/eurogroep/fadecandy_ros.git
+      version: ros2
+    release:
+      packages:
+      - fadecandy_driver
+      - fadecandy_msgs
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/eurogroep/fadecandy_ros-release.git
+      version: 1.0.0-1
+    status: maintained
   fastcdr:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `fadecandy_ros` to `1.0.0-1`:

- upstream repository: https://github.com/eurogroep/fadecandy_ros.git
- release repository: https://github.com/eurogroep/fadecandy_ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## fadecandy_driver

```
* remove time dependency
* refactor to ros2
* Contributors: Tom de Winter
```

## fadecandy_msgs

```
* refactor to ros2
* Contributors: Tom de Winter
```
