### PR TITLE
ecal: 5.12.0-2 in 'humble/distribution.yaml'

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1427,7 +1427,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ecal-release.git
-      version: 5.12.0-1
+      version: 5.12.0-2
     source:
       type: git
       url: https://github.com/eclipse-ecal/ecal.git


### PR DESCRIPTION
Increasing version of package(s) in repository ecal to 5.12.0-2:

- upstream repository: https://github.com/eclipse-ecal/ecal.git
- release repository: https://github.com/ros2-gbp/ecal-release.git
- distro file: humble/distribution.yaml

add patch to change cmake options
