### PR TITLE
remove ros2_ouster_drivers entry from rolling in preparation for replacing with the official ouster_ros package.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4941,25 +4941,6 @@ repositories:
       url: https://github.com/Kinovarobotics/ros2_kortex.git
       version: main
     status: developed
-  ros2_ouster_drivers:
-    doc:
-      type: git
-      url: https://github.com/SteveMacenski/ros2_ouster_drivers.git
-      version: foxy-devel
-    release:
-      packages:
-      - ouster_msgs
-      - ros2_ouster
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/ros2_ouster_drivers-release.git
-      version: 0.5.0-2
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/SteveMacenski/ros2_ouster_drivers.git
-      version: foxy-devel
-    status: maintained
   ros2_robotiq_gripper:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please remove the following dependency to the rosdep database.

## Package name:

ros2_ouster_drivers

## Package Upstream Source:

https://github.com/ros-drivers/ros2_ouster_drivers

## Purpose of using this:

Remove **ros2_ouster_drivers** entry from **rolling** in preparation for replacing with the official **ouster_ros** packages.

Distro packaging links:

## Links to Distribution Packageshttps://github.com/ros-drivers/ros2_ouster_drivers


## Comments to reviewers
I will have a followup pull request to add an entry to the rolling distribution list once this has been removed since bloom wouldn't allow me to create a pull request due to package name conflict for `ouster_msgs`.

I have already prepared the rolling release: https://github.com/ros2-gbp/ouster-ros-release

Should I manually add **ouster-ros** entry in this pull request? Let me know please...