### PR TITLE
aandd_ekew_driver_py: 0.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10,6 +10,22 @@ release_platforms:
   ubuntu:
   - jammy
 repositories:
+  aandd_ekew_driver_py:
+    doc:
+      type: git
+      url: https://github.com/TechMagicKK/aandd_ekew_driver_py.git
+      version: humble
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/TechMagicKK/aandd_ekew_driver_py-release.git
+      version: 0.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/TechMagicKK/aandd_ekew_driver_py.git
+      version: humble
+    status: maintained
   acado_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `aandd_ekew_driver_py` to `0.0.1-1`:

- upstream repository: https://github.com/TechMagicKK/aandd_ekew_driver_py.git
- release repository: https://github.com/TechMagicKK/aandd_ekew_driver_py-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## aandd_ekew_driver_py

```
* relesase
* Contributors: Jiaqing Lin
```
