### PR TITLE
topic_based_ros2_control: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6597,7 +6597,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/PickNikRobotics/topic_based_ros2_control-release.git
-      version: 0.1.1-1
+      version: 0.2.0-1
   topic_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_based_ros2_control` to `0.2.0-1`:

- upstream repository: https://github.com/PickNikRobotics/topic_based_ros2_control.git
- release repository: https://github.com/PickNikRobotics/topic_based_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.1-1`

## topic_based_ros2_control

```
* Check the mimicked joint interface before setting them (#13 <https://github.com/PickNikRobotics/topic_based_ros2_control/issues/13>)
* Check ros context is valid before spinning the node (#13 <https://github.com/PickNikRobotics/topic_based_ros2_control/issues/13>)
* Enable mobile base in Isaac (#12 <https://github.com/PickNikRobotics/topic_based_ros2_control/issues/12>)
* Contributors: Jafar Uruç, Marq Rasmussen
```
