### PR TITLE
ur_client_library: 1.3.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11805,7 +11805,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
-      version: 1.3.2-1
+      version: 1.3.3-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `1.3.3-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.2-1`

## ur_client_library

```
* Add support for setting socket max num tries and reconnect timeout (#172 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/172>)
* Unify socket open (#174 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/174>)
* Added handling of spline interpolation with end point velocities (#169 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/169>)
* Throws exception if the URScript file doesn't exists (#173 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/173>)
* Added check to ensure receive timeout isn't overwritten (#171 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/171>)
* Added RTDEClient constructor with vector recipes (#143 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/143>)
* Only warn if system is not setup for FIFO scheduling (#170 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/170>)
* Ensuring that the Timestamp is always in the output recipe (#168 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/168>)
* CI: Add Iron to CI tests (#167 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/167>)
* Add issue templates for bugs and features (#166 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/166>)
* Updated license (#164 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/164>)
* Bugfixes for spline interpolation (#162)
  
  Add separate rounding in the conversion from float to int32
  
  Add more debug printout for splines
  
  Add Copying flight reports if CI fails
  
  Update ursim mininum version in start_ursim.sh
* Fix the prerelease ci for Melodic (#163 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/163>)
* Contributors: Dag-Are Trydal, Felix Exner, Felix Exner (fexner), Mads Holm Peters, Michael Eriksen, RobertWilbrandt, Rune Søe-Knudsen, urmahp, urrsk
```
