### PR TITLE
boost_plugin_loader: 0.2.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -700,10 +700,16 @@ repositories:
       version: master
     status: developed
   boost_plugin_loader:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/tesseract-robotics-release/boost_plugin_loader-release.git
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/tesseract-robotics/boost_plugin_loader.git
       version: main
+    status: developed
   camera_ros:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository boost_plugin_loader to 0.2.1-1:

- upstream repository: https://github.com/tesseract-robotics/boost_plugin_loader.git
- release repository: https://github.com/tesseract-robotics-release/boost_plugin_loader-release.git
- distro file: humble/distribution.yaml
- bloom version: 0.11.2
- previous version for package: None
