### PR TITLE
rosidl: 4.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5332,7 +5332,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 4.3.1-1
+      version: 4.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `4.4.0-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.3.1-1`

## rosidl_adapter

- No changes

## rosidl_cli

- No changes

## rosidl_cmake

```
* Add rosidl_find_package_idl helper function (#754 <https://github.com/ros2/rosidl/issues/754>)
* Contributors: Mike Purvis
```

## rosidl_generator_c

```
* Add rosidl_find_package_idl helper function (#754 <https://github.com/ros2/rosidl/issues/754>)
* Contributors: Mike Purvis
```

## rosidl_generator_cpp

```
* Add rosidl_find_package_idl helper function (#754 <https://github.com/ros2/rosidl/issues/754>)
* Contributors: Mike Purvis
```

## rosidl_generator_type_description

- No changes

## rosidl_parser

- No changes

## rosidl_pycommon

- No changes

## rosidl_runtime_c

- No changes

## rosidl_runtime_cpp

- No changes

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

```
* Add rosidl_find_package_idl helper function (#754 <https://github.com/ros2/rosidl/issues/754>)
* Contributors: Mike Purvis
```

## rosidl_typesupport_introspection_cpp

```
* Add rosidl_find_package_idl helper function (#754 <https://github.com/ros2/rosidl/issues/754>)
* Contributors: Mike Purvis
```
