### PR TITLE
rclpy: 5.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4228,7 +4228,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 5.0.1-1
+      version: 5.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `5.1.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `5.0.1-1`

## rclpy

```
* Support to get remapped service name (#1156 <https://github.com/ros2/rclpy/issues/1156>)
* a couple of typo fixes. (#1158 <https://github.com/ros2/rclpy/issues/1158>)
* Fix get_type_description service bug and add a unit test (#1155 <https://github.com/ros2/rclpy/issues/1155>)
* Fix an inherent race in execution vs. destruction. (#1150 <https://github.com/ros2/rclpy/issues/1150>)
* Cleanup of test_node.py. (#1153 <https://github.com/ros2/rclpy/issues/1153>)
* Contributors: Barry Xu, Chris Lalancette, Emerson Knapp, Tomoya Fujita
```
