### PR TITLE
rclcpp: 22.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4212,7 +4212,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 22.1.0-1
+      version: 22.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `22.2.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `22.1.0-1`

## rclcpp

```
* Topic correct typeadapter deduction (#2294 <https://github.com/ros2/rclcpp/issues/2294>)
* Fix C++20 allocator construct deprecation (#2292 <https://github.com/ros2/rclcpp/issues/2292>)
* Make Rate to select the clock to work with (#2123 <https://github.com/ros2/rclcpp/issues/2123>)
* Correct the position of a comment. (#2290 <https://github.com/ros2/rclcpp/issues/2290>)
* Remove unnecessary lambda captures in the tests. (#2289 <https://github.com/ros2/rclcpp/issues/2289>)
* Add rcl_logging_interface as an explicit dependency. (#2284 <https://github.com/ros2/rclcpp/issues/2284>)
* Revamp list_parameters to be more efficient and easier to read. (#2282 <https://github.com/ros2/rclcpp/issues/2282>)
* Contributors: AiVerisimilitude, Alexey Merzlyakov, Chen Lihui, Chris Lalancette, Jiaqi Li
```

## rclcpp_action

```
* Correct the position of a comment. (#2290 <https://github.com/ros2/rclcpp/issues/2290>)
* Fix a typo in a comment. (#2283 <https://github.com/ros2/rclcpp/issues/2283>)
* doc fix: call canceled only after goal state is in canceling. (#2266 <https://github.com/ros2/rclcpp/issues/2266>)
* Contributors: Chris Lalancette, Jiaqi Li, Tomoya Fujita
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* add logger level service to lifecycle node. (#2277 <https://github.com/ros2/rclcpp/issues/2277>)
* Contributors: Tomoya Fujita
```
