### PR TITLE
rcl: 7.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4112,7 +4112,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 7.1.0-1
+      version: 7.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `7.1.1-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `7.1.0-1`

## rcl

```
* Cut down the amount of time for test_logging_rosout. (#1098 <https://github.com/ros2/rcl/issues/1098>)
* Simplify local_namespace handling in rcl_node_init. (#1097 <https://github.com/ros2/rcl/issues/1097>)
* Reduce the number of tests we run (#1096 <https://github.com/ros2/rcl/issues/1096>)
* Adding duplicate node information (#1088 <https://github.com/ros2/rcl/issues/1088>)
* Revamp the test_get_type_description_service. (#1095 <https://github.com/ros2/rcl/issues/1095>)
* Cleanup network flow endpoints test. (#1094 <https://github.com/ros2/rcl/issues/1094>)
* Reduce the failure timeout time for namespaces. (#1093 <https://github.com/ros2/rcl/issues/1093>)
* Shorten wait time for a subscription not being ready. (#1092 <https://github.com/ros2/rcl/issues/1092>)
* Contributors: Chris Lalancette, Lucas Wendland
```

## rcl_action

- No changes

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

- No changes
