### PR TITLE
launch_ros: 0.26.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2382,7 +2382,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.26.1-1
+      version: 0.26.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.26.2-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.26.1-1`

## launch_ros

```
* Create py.typed to mark this library as typed (#379 <https://github.com/ros2/launch_ros/issues/379>)
* Contributors: Jonas Otto
```

## launch_testing_ros

```
* Handle spin() ExternalShutdownException. (#378 <https://github.com/ros2/launch_ros/issues/378>)
* Increase the timeout in wait_for_topic_launch_test. (#377 <https://github.com/ros2/launch_ros/issues/377>)
* Contributors: Chris Lalancette
```

## ros2launch

- No changes
