### PR TITLE
reach_ros: 1.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8483,10 +8483,16 @@ repositories:
       version: master
     status: developed
   reach_ros:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-industrial-release/reach_ros-release.git
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/ros-industrial/reach_ros.git
       version: master
+    status: developed
   realsense2_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository reach_ros to 1.1.1-1:

- upstream repository: https://github.com/ros-industrial/reach_ros.git
- release repository: https://github.com/ros-industrial-release/reach_ros-release.git
- distro file: noetic/distribution.yaml
- bloom version: 0.11.2
- previous version for package: None