### PR TITLE
rviz: 13.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6017,7 +6017,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 13.0.0-1
+      version: 13.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `13.1.0-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `13.0.0-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Removed unused code (#1044 <https://github.com/ros2/rviz/issues/1044>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_default_plugins

```
* Improve error handling in LaserScanDisplay (#1035 <https://github.com/ros2/rviz/issues/1035>)
* Fix implicit capture of "this" warning in C++20 (#1053 <https://github.com/ros2/rviz/issues/1053>)
* Removed unused code (#1044 <https://github.com/ros2/rviz/issues/1044>)
* Contributors: AiVerisimilitude, Alejandro Hernández Cordero
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* make box-mode point cloud shader lighter on top than bottom (#1058 <https://github.com/ros2/rviz/issues/1058>)
* Removed warning when building in release mode (#1057 <https://github.com/ros2/rviz/issues/1057>)
* Fixed low FPS when sending point markers (#1049 <https://github.com/ros2/rviz/issues/1049>)
* Removed unused code (#1044 <https://github.com/ros2/rviz/issues/1044>)
* Contributors: Alejandro Hernández Cordero, Morgan Quigley
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
