### PR TITLE
mvsim: 0.8.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6164,7 +6164,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       type: git
       url: https://github.com/ual-arm-ros-pkg/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.8.1-1`:

- upstream repository: https://github.com/ual-arm-ros-pkg/mvsim.git
- release repository: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.8.0-1`

## mvsim

```
* Move the rawlog-generation option to the World global options instead of sensor-wise.
* Create CITATION.cff
* helios 32fov70 sensor.xml: Fix missing MVSIM_CURRENT_FILE_DIRECTORY tag
* Fix crash in edge case with world file path in the current directory
* Contributors: Jose Luis Blanco-Claraco
```
