### PR TITLE
rosdoc_lite: 0.2.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9552,7 +9552,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rosdoc_lite-release.git
-      version: 0.2.10-1
+      version: 0.2.11-1
     source:
       type: git
       url: https://github.com/ros-infrastructure/rosdoc_lite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosdoc_lite` to `0.2.11-1`:

- upstream repository: https://github.com/ros-infrastructure/rosdoc_lite.git
- release repository: https://github.com/ros-gbp/rosdoc_lite-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.10-1`

## rosdoc_lite

```
* add generate_treeview option (#96 <https://github.com/ros-infrastructure/rosdoc_lite/issues/96>)
  To enable the treeview set in rosdoc.yaml
  ```
  - builder: doxygen
  generate_treeview: YES
  ```
* change to setuptools in accordance with migration guide (#105 <https://github.com/ros-infrastructure/rosdoc_lite/issues/105>)
* Add option "required" to builder configs which will cause rosdoc_lite to fail if the builder fails. (#106 <https://github.com/ros-infrastructure/rosdoc_lite/issues/106>)
  * Add option "required" to builder configs which will cause rosdoc_lite to fail if the builder fails.
  * Require documentation of this package to finish properly.
  * Added documentation to the added exception from generate_docs.
* Add support for configuring INPUT_FILTER doxygen option (#103 <https://github.com/ros-infrastructure/rosdoc_lite/issues/103>)
* Add missing graphviz dep
  Used by Doxygen for inheritance diagrams.
* Read include_path from config file
  * Removes warning about non existing INCLUDE_PATH. Closes #86 <https://github.com/ros-infrastructure/rosdoc_lite/issues/86>
* Bump CMake version to avoid CMP0048
* Contributors: Alexander Gutenkunst, Arne Hitzmann, Felix Ruess, Martin Pecka, Matthijs van der Burgh, Shane Loretz, Tully Foote
```
