### PR TITLE
reach: 1.5.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8476,7 +8476,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros2-gbp/reach-release.git
-      version: 1.5.1-1
+      version: 1.5.2-1
     source:
       type: git
       url: https://github.com/ros-industrial/reach.git


### PR DESCRIPTION
Increasing version of package(s) in repository reach to 1.5.2-1:

- upstream repository: https://github.com/ros-industrial/reach.git
- release repository: https://github.com/ros2-gbp/reach-release.git
- distro file: noetic/distribution.yaml
- bloom version: 0.11.2
- previous version for package: 1.5.1-1