### PR TITLE
rqt_bag: 1.3.4-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5697,7 +5697,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
-      version: 1.3.3-1
+      version: 1.3.4-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `1.3.4-1`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros2-gbp/rqt_bag-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.3-1`

## rqt_bag

```
* Enable Save button while recording (#144 <https://github.com/ros-visualization/rqt_bag/issues/144>)
* Contributors: Emerson Knapp, Yadunund
```

## rqt_bag_plugins

- No changes
