### PR TITLE
geometry2: 0.31.5-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1643,7 +1643,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.31.4-1
+      version: 0.31.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.31.5-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.31.4-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

- No changes

## tf2_eigen

```
* Add another reference for twist transformation. Comment correction. (#622 <https://github.com/ros2/geometry2/issues/622>)
* Contributors: AndyZe
```

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

```
* Add doTransform support for Point32, Polygon and PolygonStamped (#618 <https://github.com/ros2/geometry2/issues/618>)
* Contributors: Alejandro Hernández Cordero
```

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Fix invalid timer handle exception (#613 <https://github.com/ros2/geometry2/issues/613>)
* Contributors: Cliff Wu
```

## tf2_ros_py

```
* Remove 'efficient copy' prints (#627 <https://github.com/ros2/geometry2/issues/627>)
* Contributors: Matthijs van der Burgh
```

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
