### PR TITLE
rclpy: 4.1.3-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4316,7 +4316,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 4.1.2-1
+      version: 4.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `4.1.3-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.1.2-1`

## rclpy

```
* Fix get_type_description service bug and add a unit test (#1157 <https://github.com/ros2/rclpy/issues/1157>)
* Avoid generating the exception when rcl_send_response times out. (#1151 <https://github.com/ros2/rclpy/issues/1151>)
* get_type_description service (#1140 <https://github.com/ros2/rclpy/issues/1140>)
* Contributors: Emerson Knapp, Tomoya Fujita
```
