### PR TITLE
rosidl_dynamic_typesupport: 0.1.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5492,7 +5492,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_dynamic_typesupport-release.git
-      version: 0.0.3-2
+      version: 0.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_dynamic_typesupport` to `0.1.2-1`:

- upstream repository: https://github.com/ros2/rosidl_dynamic_typesupport.git
- release repository: https://github.com/ros2-gbp/rosidl_dynamic_typesupport-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.3-2`

## rosidl_dynamic_typesupport

```
* uchar: fix conditional include/typedef (#10 <https://github.com/ros2/rosidl_dynamic_typesupport/issues/10>)
* uchar: use __has_include(..) on separate line (#8 <https://github.com/ros2/rosidl_dynamic_typesupport/issues/8>)
* Refactor the handling of nested types. (#7 <https://github.com/ros2/rosidl_dynamic_typesupport/issues/7>)
* Contributors: Chris Lalancette, G.A. vd. Hoorn
```
