### PR TITLE
rviz: 12.4.4-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6131,7 +6131,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 12.4.3-1
+      version: 12.4.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `12.4.4-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `12.4.3-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Remove warning in depth_cloud_mld.cpp (#1021 <https://github.com/ros2/rviz/issues/1021>)
* Added DepthCloud default plugin (#1017 <https://github.com/ros2/rviz/issues/1017>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```

## rviz_default_plugins

```
* Fixed AccelStamped, TwistStamped and Wrench icons (#1047 <https://github.com/ros2/rviz/issues/1047>)
* Fix the flakey rviz_rendering tests (#1031 <https://github.com/ros2/rviz/issues/1031>)
* Don't pass screw_display.hpp to the moc generator (#1020 <https://github.com/ros2/rviz/issues/1020>)
* Added DepthCloud default plugin (#996 <https://github.com/ros2/rviz/issues/996>)
* Added TwistStamped and AccelStamped default plugins (#1015 <https://github.com/ros2/rviz/issues/1015>)
* Improve the compilation time of rviz_default_plugins (#1009 <https://github.com/ros2/rviz/issues/1009>)
* Added Effort plugin (#1011 <https://github.com/ros2/rviz/issues/1011>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Fixed low FPS when sending point markers (#1056 <https://github.com/ros2/rviz/issues/1056>)
* Fixed camera default plugin crash (#1054 <https://github.com/ros2/rviz/issues/1054>)
* Fix the flakey rviz_rendering tests (#1031 <https://github.com/ros2/rviz/issues/1031>)
* Added TwistStamped and AccelStamped default plugins (#1015 <https://github.com/ros2/rviz/issues/1015>)
* Added Effort plugin (#1011 <https://github.com/ros2/rviz/issues/1011>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

```
* Improve the compilation time of rviz_default_plugins (#1009 <https://github.com/ros2/rviz/issues/1009>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```
