### PR TITLE
mola: 0.2.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3342,15 +3342,22 @@ repositories:
     release:
       packages:
       - mola_common
+      - mola_demos
+      - mola_imu_preintegration
       - mola_input_euroc_dataset
       - mola_input_kitti_dataset
+      - mola_input_rawlog
+      - mola_input_ros2
       - mola_kernel
+      - mola_launcher
+      - mola_test_datasets
+      - mola_viz
       - mola_yaml
       - mp2p_icp
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `0.2.2-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.1-1`

## mola_common

```
* Fix package name in docs
* Generate ament-correct package for ROS2 builds
* fix lib name in cmake warning message
* Contributors: Jose Luis Blanco-Claraco
```

## mola_demos

```
* Progress with demo
* Import first demo files
* Contributors: Jose Luis Blanco-Claraco
```

## mola_imu_preintegration

```
* Update copyright year
* Correct references to license
* Ported to ROS2 colcon build system
* Delete WIP files.
* first unit tests
* progress, unit tests
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_euroc_dataset

```
* Correct references to license
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_kitti_dataset

```
* Correct references to license
* Fix published ground truth axis of reference
* Fix wrong ground truth matrix indexing.
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_rawlog

```
* First complete public release
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_ros2

```
* First complete public release
* Contributors: Jose Luis Blanco-Claraco
```

## mola_kernel

```
* Correct references to the license.
* viz interface: new service update_3d_object()
* Fix const-correctness of observations
* FIX missing dependency on mrpt::gui for public header
* Contributors: Jose Luis Blanco-Claraco
```

## mola_launcher

```
* First complete public release
* Contributors: Jose Luis Blanco-Claraco
```

## mola_test_datasets

```
* Fix package name in docs
* Build as correct ament package. Add license file
* Add package.xml and reorganize data files
* fix cmake lib name
* add 2lidar+odo dataset
* add radish test datasets
* fix copyright
* import a tiny extract of Kitti00 (lidar) for unit tests
* add example 2D slam dataset
* add sample g2o dataset
* Contributors: Jose Luis Blanco-Claraco
```

## mola_viz

```
* Initial public release.
* Contributors: Jose Luis Blanco-Claraco
```

## mola_yaml

```
* Fix package name in docs
* Contributors: Jose Luis Blanco-Claraco
```

## mp2p_icp

```
* Fix missing cmake dependencies between libraries
* Update mola_common
* Refactor into a new small library mp2p_icp_map with just the metricmap_t class
* sync mola_common submodule
* Update submodule mola_common
* Remove redundant section
* Update ROS badges
* Contributors: Jose Luis Blanco-Claraco
```
