### PR TITLE
Revert "depthai-ros: 2.8.0-1 in 'humble/distribution.yaml' [bloom]"

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1280,7 +1280,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/luxonis/depthai-ros-release.git
-      version: 2.8.0-1
+      version: 2.7.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#38429

This bump causes a failure on the buildfarm because a dependency is missing:
https://build.ros2.org/view/Hbin_uJ64/job/Hbin_uJ64__depthai_bridge__ubuntu_jammy_amd64__binary/62/

FYI @Serafadam