### PR TITLE
cpr_onav_description: 0.1.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1550,7 +1550,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/cpr_onav_description-release.git
-      version: 0.1.6-1
+      version: 0.1.7-1
     source:
       type: git
       url: https://github.com/cpr-application/cpr_onav_description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_onav_description` to `0.1.7-1`:

- upstream repository: https://github.com/cpr-application/cpr_onav_description.git
- release repository: https://github.com/clearpath-gbp/cpr_onav_description-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.6-1`

## cpr_onav_description

```
* Expand the readme, add setup scripts for the starter kit on Jackal, Warthog, and Husky.
* Add setup script for the Husky Observer
* Add the RealSense gazebo plugins to the starter kit
* Contributors: Chris Iverach-Brereton
```
