### PR TITLE
metro_nav: 0.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3237,6 +3237,18 @@ repositories:
       version: main
     status: developed
   metro_nav:
+    doc:
+      type: git
+      url: https://github.com/MetroRobots/metro_nav.git
+      version: main
+    release:
+      packages:
+      - base2d_kinematics
+      - base2d_kinematics_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/metro_nav-release.git
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/MetroRobots/metro_nav.git


### PR DESCRIPTION
Increasing version of package(s) in repository `metro_nav` to `0.2.0-1`:

- upstream repository: https://github.com/MetroRobots/metro_nav.git
- release repository: https://github.com/ros2-gbp/metro_nav-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## base2d_kinematics

```
* Fix #1 <https://github.com/MetroRobots/metro_nav/issues/1> (#3 <https://github.com/MetroRobots/metro_nav/issues/3>)
* Rename packages (#2 <https://github.com/MetroRobots/metro_nav/issues/2>)
* Contributors: David V. Lu!!
```

## base2d_kinematics_msgs

```
* Rename packages (#2 <https://github.com/MetroRobots/metro_nav/issues/2>)
* Contributors: David V. Lu!!
```
