### PR TITLE
rclcpp: 23.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4212,7 +4212,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 22.2.0-1
+      version: 23.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `23.0.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `22.2.0-1`

## rclcpp

```
* Fix the return type of Rate::period. (#2301 <https://github.com/ros2/rclcpp/issues/2301>)
* Update API docs links in package READMEs (#2302 <https://github.com/ros2/rclcpp/issues/2302>)
* Cleanup flaky timers_manager tests. (#2299 <https://github.com/ros2/rclcpp/issues/2299>)
* Contributors: Chris Lalancette, Christophe Bedard
```

## rclcpp_action

```
* Update API docs links in package READMEs (#2302 <https://github.com/ros2/rclcpp/issues/2302>)
* fix(ClientGoalHandle): Made mutex recursive to prevent deadlocks (#2267 <https://github.com/ros2/rclcpp/issues/2267>)
* Contributors: Christophe Bedard, jmachowinski
```

## rclcpp_components

```
* Update API docs links in package READMEs (#2302 <https://github.com/ros2/rclcpp/issues/2302>)
* Contributors: Christophe Bedard
```

## rclcpp_lifecycle

```
* Update API docs links in package READMEs (#2302 <https://github.com/ros2/rclcpp/issues/2302>)
* Contributors: Christophe Bedard
```
