### PR TITLE
mavlink: 2023.9.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5301,7 +5301,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mavlink/mavlink-gbp-release.git
-      version: 2023.6.6-1
+      version: 2023.9.9-1
     source:
       type: git
       url: https://github.com/mavlink/mavlink-gbp-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavlink` to `2023.9.9-1`:

- upstream repository: https://github.com/mavlink/mavlink.git
- release repository: https://github.com/mavlink/mavlink-gbp-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2023.6.6-1`
