### PR TITLE
mavros: 1.17.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5322,7 +5322,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 1.16.0-1
+      version: 1.17.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `1.17.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.16.0-1`

## libmavconn

```
* Merge pull request #1865 <https://github.com/mavlink/mavros/issues/1865> from scoutdi/warnings
  Fix / suppress some build warnings
* Suppress warnings from included headers
* Contributors: Morten Fyhn Amundsen, Vladimir Ermakov
```

## mavros

```
* cog: regenerate all
* Bugfix/update map origin with home position (#1892 <https://github.com/mavlink/mavros/issues/1892>)
  * Update map origin with home position
  * Uncrustify
  * Revert "Uncrustify"
  This reverts commit f1387c79c7670cc241986586436e3da43842e877.
  * Change to relative topic
  ---------
  Co-authored-by: Natalia Molina <mailto:molina-munoz@wingcopter.com>
* Merge pull request #1865 <https://github.com/mavlink/mavros/issues/1865> from scoutdi/warnings
  Fix / suppress some build warnings
* mavros: Remove extra ';'
* Suppress warnings from included headers
* Contributors: Morten Fyhn Amundsen, Vladimir Ermakov, natmol
```

## mavros_extras

```
* Merge pull request #1865 <https://github.com/mavlink/mavros/issues/1865> from scoutdi/warnings
  Fix / suppress some build warnings
* mavros_extras: Fix some init order warnings
* Suppress warnings from included headers
* Contributors: Morten Fyhn Amundsen, Vladimir Ermakov
```

## mavros_msgs

```
* cog: regenerate all
* Contributors: Vladimir Ermakov
```

## test_mavros

```
* Merge pull request #1865 <https://github.com/mavlink/mavros/issues/1865> from scoutdi/warnings
  Fix / suppress some build warnings
* Suppress warnings from included headers
* Contributors: Morten Fyhn Amundsen, Vladimir Ermakov
```
