### PR TITLE
mavros: 2.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2611,7 +2611,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mavros-release.git
-      version: 2.4.0-2
+      version: 2.6.0-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `2.6.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/ros2-gbp/mavros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.4.0-2`

## libmavconn

```
* fix ament_cpplint
* Merge branch 'master' into ros2
  * master:
  1.17.0
  update changelog
  cog: regenerate all
  Bugfix/update map origin with home position (#1892 <https://github.com/mavlink/mavros/issues/1892>)
  mavros: Remove extra ';'
  mavros_extras: Fix some init order warnings
  Suppress warnings from included headers
  1.16.0
  update changelog
  made it such that the gp_origin topic published latched.
  use hpp instead of deprecated .h pluginlib headers
* 1.17.0
* update changelog
* Merge pull request #1865 <https://github.com/mavlink/mavros/issues/1865> from scoutdi/warnings
  Fix / suppress some build warnings
* Suppress warnings from included headers
* 1.16.0
* update changelog
* Contributors: Morten Fyhn Amundsen, Vladimir Ermakov
```

## mavros

```
* fix build warnings tf2_eigen.h
* switch to use tf2_eigen.hpp, but that drops support for EOL distros
* fix ament_cpplint
* reformat python code with black
* msgs: move generator code
* ament uncrustify
* Merge branch 'master' into ros2
  * master:
  1.17.0
  update changelog
  cog: regenerate all
  Bugfix/update map origin with home position (#1892 <https://github.com/mavlink/mavros/issues/1892>)
  mavros: Remove extra ';'
  mavros_extras: Fix some init order warnings
  Suppress warnings from included headers
  1.16.0
  update changelog
  made it such that the gp_origin topic published latched.
  use hpp instead of deprecated .h pluginlib headers
* 1.17.0
* update changelog
* cog: regenerate all
* local takeoff and land topics (#1890 <https://github.com/mavlink/mavros/issues/1890>)
  * local takeoff and land topics
  * vector3 position type, rename to TOLLocal
  * remove auto include line
* Bugfix/update map origin with home position (#1892 <https://github.com/mavlink/mavros/issues/1892>)
  * Update map origin with home position
  * Uncrustify
  * Revert "Uncrustify"
  This reverts commit f1387c79c7670cc241986586436e3da43842e877.
  * Change to relative topic
  ---------
  Co-authored-by: Natalia Molina <mailto:molina-munoz@wingcopter.com>
* Merge pull request #1865 <https://github.com/mavlink/mavros/issues/1865> from scoutdi/warnings
  Fix / suppress some build warnings
* mavros: Remove extra ';'
* Suppress warnings from included headers
* 1.16.0
* update changelog
* Merge pull request #1829 <https://github.com/mavlink/mavros/issues/1829> from snwu1996/latched_gp_origin_pub
  Made it such that the gp_origin topic publisher is latched.
* made it such that the gp_origin topic published latched.
* Merge pull request #1817 <https://github.com/mavlink/mavros/issues/1817> from lucasw/pluginlib_hpp
  use hpp instead of deprecated .h pluginlib headers
* use hpp instead of deprecated .h pluginlib headers
* Contributors: Ido Guzi, Lucas Walter, Morten Fyhn Amundsen, Shu-Nong Wu, Vladimir Ermakov, natmol
```

## mavros_extras

```
* switch to use tf2_eigen.hpp, but that drops support for EOL distros
* ament uncrustify
* cog: regenerate all
* Merge branch 'master' into ros2
  * master:
  1.17.0
  update changelog
  cog: regenerate all
  Bugfix/update map origin with home position (#1892 <https://github.com/mavlink/mavros/issues/1892>)
  mavros: Remove extra ';'
  mavros_extras: Fix some init order warnings
  Suppress warnings from included headers
  1.16.0
  update changelog
  made it such that the gp_origin topic published latched.
  use hpp instead of deprecated .h pluginlib headers
* 1.17.0
* update changelog
* Merge pull request #1889 <https://github.com/mavlink/mavros/issues/1889> from MKargus0/feature/fix_landing_target_time_conversion
  Fixed header.stamp conversion in landing target
* fixed style
* fixed header.stamp conversion in landing target
* Merge pull request #1871 <https://github.com/mavlink/mavros/issues/1871> from Vladislavert/feature/optical_flow_msg
  Addition of New OpticalFlow.msg
* Added geometry_msgs/Vector3 to OpticalFlow.msg
* Added vectors to the message OpticalFlow.msg
* Added message optical flow
* Merge pull request #1865 <https://github.com/mavlink/mavros/issues/1865> from scoutdi/warnings
  Fix / suppress some build warnings
* mavros_extras: Fix some init order warnings
* Suppress warnings from included headers
* 1.16.0
* update changelog
* Merge pull request #1817 <https://github.com/mavlink/mavros/issues/1817> from lucasw/pluginlib_hpp
  use hpp instead of deprecated .h pluginlib headers
* use hpp instead of deprecated .h pluginlib headers
* Contributors: Lucas Walter, Mikhail Kolodochka, Morten Fyhn Amundsen, Vladimir Ermakov, Vladislavert
```

## mavros_msgs

```
* msgs: move generator code
* cog: regenerate all
* Merge branch 'master' into ros2
  * master:
  1.17.0
  update changelog
  cog: regenerate all
  Bugfix/update map origin with home position (#1892 <https://github.com/mavlink/mavros/issues/1892>)
  mavros: Remove extra ';'
  mavros_extras: Fix some init order warnings
  Suppress warnings from included headers
  1.16.0
  update changelog
  made it such that the gp_origin topic published latched.
  use hpp instead of deprecated .h pluginlib headers
* 1.17.0
* update changelog
* cog: regenerate all
* local takeoff and land topics (#1890 <https://github.com/mavlink/mavros/issues/1890>)
  * local takeoff and land topics
  * vector3 position type, rename to TOLLocal
  * remove auto include line
* Merge pull request #1871 <https://github.com/mavlink/mavros/issues/1871> from Vladislavert/feature/optical_flow_msg
  Addition of New OpticalFlow.msg
* Added geometry_msgs/Vector3 to OpticalFlow.msg
* Added vectors to the message OpticalFlow.msg
* Added message optical flow
* 1.16.0
* update changelog
* Contributors: Ido Guzi, Vladimir Ermakov, Vladislavert
```
