### PR TITLE
moveit: 2.8.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2837,7 +2837,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
-      version: 2.7.4-1
+      version: 2.8.0-2
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.8.0-2`:

- upstream repository: https://github.com/ros-planning/moveit2.git
- release repository: https://github.com/ros2-gbp/moveit2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.7.4-1`

## chomp_motion_planner

```
* Always set response planner id and warn if it is not set (#2236 <https://github.com/ros-planning/moveit2/issues/2236>)
* Contributors: Sebastian Jahr
```

## moveit

- No changes

## moveit_chomp_optimizer_adapter

```
* Remove added path index from planner adapter function signature (#2285 <https://github.com/ros-planning/moveit2/issues/2285>)
* Contributors: Sebastian Jahr
```

## moveit_common

- No changes

## moveit_configs_utils

```
* Add stomp default config to moveit_config_utils (#2238 <https://github.com/ros-planning/moveit2/issues/2238>)
* Contributors: Sebastian Jahr
```

## moveit_core

```
* Add a benchmark for 'getJacobian' (#2326 <https://github.com/ros-planning/moveit2/issues/2326>)
* [TOTG] Exit loop when position can't change (#2307 <https://github.com/ros-planning/moveit2/issues/2307>)
* Remove added path index from planner adapter function signature (#2285 <https://github.com/ros-planning/moveit2/issues/2285>)
* Fix typo in error message (#2286 <https://github.com/ros-planning/moveit2/issues/2286>)
* Fix comment formatting (#2276 <https://github.com/ros-planning/moveit2/issues/2276>)
* Cleanup planning request adapter interface (#2266 <https://github.com/ros-planning/moveit2/issues/2266>)
  * Use default arguments instead of additional functions
  * Use generate param lib for default plan request adapters
  * Small cleanup of ResolveConstraintFrames
  * Remove dublicate yaml file entry
  * Move list_planning_adapter_plugins into own directory
  * Apply suggestions from code review
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  * Fix copy& paste error
  * Update parameter descriptions
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  * Apply suggestions from code review
  Co-authored-by: Kyle Cesare <mailto:kcesare@gmail.com>
  * EMPTY_PATH_INDEX_VECTOR -> empty_path_index_vector
  * Update parameter yaml
  * Make param listener unique
  * Fix build error
  * Use gt_eq instead of deprecated lower_bounds
  ---------
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  Co-authored-by: Kyle Cesare <mailto:kcesare@gmail.com>
* fix for kinematic constraints parsing (#2267 <https://github.com/ros-planning/moveit2/issues/2267>)
* Contributors: Jorge Nicho, Mario Prats, Nacho Mellado, Sebastian Jahr, Stephanie Eng
```

## moveit_hybrid_planning

```
* Replaced numbers with SystemDefaultsQos() (#2271 <https://github.com/ros-planning/moveit2/issues/2271>)
* Contributors: Shobuj Paul
```

## moveit_kinematics

```
* Fix linking error with cached_ik_kinematics_plugin (#2292 <https://github.com/ros-planning/moveit2/issues/2292>)
* Fix ikfast package template (#2195 <https://github.com/ros-planning/moveit2/issues/2195>)
* Make loggers static or move into anonymous namespace (#2184 <https://github.com/ros-planning/moveit2/issues/2184>)
  * Make loggers static or move into anonymous namespace
  * Update moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
  * Update moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
  * Move LOGGER out of class template
* Contributors: Jafar, Sebastian Jahr, Shane Loretz
```

## moveit_planners

- No changes

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

```
* Fix typo in model_based_planning_context.h (#2243 <https://github.com/ros-planning/moveit2/issues/2243>)
* Warn if optimization objective does not match expected values (#2213 <https://github.com/ros-planning/moveit2/issues/2213>)
  * Warn if optimization objective does not match expected values
  * Update moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@tuta.io>
  * Format
  ---------
* Contributors: Stephanie Eng
```

## moveit_planners_stomp

```
* Remove added path index from planner adapter function signature (#2285 <https://github.com/ros-planning/moveit2/issues/2285>)
* Always set response planner id and warn if it is not set (#2236 <https://github.com/ros-planning/moveit2/issues/2236>)
* Contributors: Sebastian Jahr
```

## moveit_plugins

- No changes

## moveit_py

```
* Fix moveit_py rclcpp::init() (#2223 <https://github.com/ros-planning/moveit2/issues/2223>)
  * Fix moveit_py rclcpp::init()
  Rclcpp has been initialized without args which was problematic
  for some use cases like clock simulation. Parameters like
  use_sim_time:=true need to be passed to rclcpp, also
  NodeOptions access the global rcl state on construction.
  Co-authored-by: Jafar Uruç <mailto:jafar.uruc@gmail.com>
* Export moveit_py_utils' cmake target (#2207 <https://github.com/ros-planning/moveit2/issues/2207>)
* fix typo in name
* Contributors: Henning Kayser, Michael Görner, Robert Haschke
```

## moveit_resources_prbt_ikfast_manipulator_plugin

- No changes

## moveit_resources_prbt_moveit_config

- No changes

## moveit_resources_prbt_pg70_support

- No changes

## moveit_resources_prbt_support

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

```
* Simplify controller manager namespacing (#2210 <https://github.com/ros-planning/moveit2/issues/2210>)
* Minor cleanup to ros_control_interface and trajectory execution (#2208 <https://github.com/ros-planning/moveit2/issues/2208>)
* Contributors: Stephanie Eng
```

## moveit_ros_move_group

```
* Replaced boost::algorithm::join with fmt::join (#2273 <https://github.com/ros-planning/moveit2/issues/2273>)
  * Replaced boost::algorithm::join with fmt::join
  * Made changes in CMakeLists.txt to accomodate fmt
  * Updated package.xml files
  * removed redundant boost dependencies
  * Rename variables -> variable
  ---------
  Co-authored-by: Sebastian Castro <4603398+sea-bass@users.noreply.github.com>
  Co-authored-by: Sebastian Jahr <sebastian.jahr@picknik.ai>
* Specify controller name in MGI execution (#2257 <https://github.com/ros-planning/moveit2/issues/2257>)
  * Specify controller name in MGI execute
  * Finish comment
  ---------
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* fix move_group capabilities loading (#2270 <https://github.com/ros-planning/moveit2/issues/2270>)
  * fix move_group capabilities loading
  * clang-format
* Cleanup move_group CMake (#2226 <https://github.com/ros-planning/moveit2/issues/2226>)
* Contributors: Shobuj Paul, Stephanie Eng, Tyler Weaver, Yang Lin
```

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

```
* Replaced numbers with SystemDefaultsQos() (#2271 <https://github.com/ros-planning/moveit2/issues/2271>)
* Use isnan in DepthImageOctomapUpdater (#2201 <https://github.com/ros-planning/moveit2/issues/2201>)
* Contributors: Ezra Brooks, Shobuj Paul
```

## moveit_ros_planning

```
* Remove added path index from planner adapter function signature (#2285 <https://github.com/ros-planning/moveit2/issues/2285>)
* Replaced boost::algorithm::join with fmt::join (#2273 <https://github.com/ros-planning/moveit2/issues/2273>)
  * Replaced boost::algorithm::join with fmt::join
  * Made changes in CMakeLists.txt to accomodate fmt
  * Updated package.xml files
  * removed redundant boost dependencies
  * Rename variables -> variable
  ---------
  Co-authored-by: Sebastian Castro <4603398+sea-bass@users.noreply.github.com>
  Co-authored-by: Sebastian Jahr <sebastian.jahr@picknik.ai>
* Replaced numbers with SystemDefaultsQos() (#2271 <https://github.com/ros-planning/moveit2/issues/2271>)
* Cleanup planning request adapter interface (#2266 <https://github.com/ros-planning/moveit2/issues/2266>)
  * Use default arguments instead of additional functions
  * Use generate param lib for default plan request adapters
  * Small cleanup of ResolveConstraintFrames
  * Remove dublicate yaml file entry
  * Move list_planning_adapter_plugins into own directory
  * Apply suggestions from code review
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  * Fix copy& paste error
  * Update parameter descriptions
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  * Apply suggestions from code review
  Co-authored-by: Kyle Cesare <mailto:kcesare@gmail.com>
  * EMPTY_PATH_INDEX_VECTOR -> empty_path_index_vector
  * Update parameter yaml
  * Make param listener unique
  * Fix build error
  * Use gt_eq instead of deprecated lower_bounds
  ---------
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  Co-authored-by: Kyle Cesare <mailto:kcesare@gmail.com>
* Prefer to use the active controller if multiple controllers apply (#2251 <https://github.com/ros-planning/moveit2/issues/2251>)
* Don't default to random algorithm if no plugin is defined (#2228 <https://github.com/ros-planning/moveit2/issues/2228>)
  * Don't default to random algorithm if no plugin is defined
  * Simplify selection logic & initialize default values in constructor
  * Increase message severity
* Always set response planner id and warn if it is not set (#2236 <https://github.com/ros-planning/moveit2/issues/2236>)
* Suppress redundant error message in CSM (#2222 <https://github.com/ros-planning/moveit2/issues/2222>)
  The CSM would spam the log if /joint_states messages
  includes unkonwn joints. RobotModel::hasJointModel()
  allows for verifying joint names in a safe way without
  the error message.
* Minor cleanup to ros_control_interface and trajectory execution (#2208 <https://github.com/ros-planning/moveit2/issues/2208>)
* Ensure that planning pipeline id is set (#2202 <https://github.com/ros-planning/moveit2/issues/2202>)
* Add @brief descriptions for plan_request_adapters (#2185 <https://github.com/ros-planning/moveit2/issues/2185>)
* Make loggers static or move into anonymous namespace (#2184 <https://github.com/ros-planning/moveit2/issues/2184>)
  * Make loggers static or move into anonymous namespace
  * Update moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
  * Update moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
  * Move LOGGER out of class template
* Contributors: Henning Kayser, Sebastian Jahr, Shobuj Paul, Stephanie Eng
```

## moveit_ros_planning_interface

```
* Specify controller name in MGI execution (#2257 <https://github.com/ros-planning/moveit2/issues/2257>)
  * Specify controller name in MGI execute
  * Finish comment
  ---------
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Remove deprecated move_group pick& place functionality + demo (#2239 <https://github.com/ros-planning/moveit2/issues/2239>)
  Co-authored-by: Jafar Uruç <mailto:cafer.abdi@gmail.com>
* Contributors: Sebastian Jahr, Stephanie Eng
```

## moveit_ros_robot_interaction

```
* Replaced numbers with SystemDefaultsQos() (#2271 <https://github.com/ros-planning/moveit2/issues/2271>)
* Contributors: Shobuj Paul
```

## moveit_ros_visualization

```
* Remove boost from motion_planning_rviz_plugin (#2308 <https://github.com/ros-planning/moveit2/issues/2308>)
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@tuta.io>
* Replaced numbers with SystemDefaultsQos() (#2271 <https://github.com/ros-planning/moveit2/issues/2271>)
* fix for not having transparency in collision scenes on rviz. (#2242 <https://github.com/ros-planning/moveit2/issues/2242>)
  Co-authored-by: Alp Akgun <mailto:samialp.akgun@ocado.com>
* Contributors: Sami Alperen Akgün, Shobuj Paul, Yang Lin
```

## moveit_ros_warehouse

```
* Replaced boost::algorithm::join with fmt::join (#2273 <https://github.com/ros-planning/moveit2/issues/2273>)
  * Replaced boost::algorithm::join with fmt::join
  * Made changes in CMakeLists.txt to accomodate fmt
  * Updated package.xml files
  * removed redundant boost dependencies
  * Rename variables -> variable
  ---------
  Co-authored-by: Sebastian Castro <4603398+sea-bass@users.noreply.github.com>
  Co-authored-by: Sebastian Jahr <sebastian.jahr@picknik.ai>
* Replaced numbers with SystemDefaultsQos() (#2271 <https://github.com/ros-planning/moveit2/issues/2271>)
* Contributors: Shobuj Paul
```

## moveit_runtime

- No changes

## moveit_servo

```
* [Servo] Fix Twist transformation  (#2311 <https://github.com/ros-planning/moveit2/issues/2311>)
* [Servo] Add additional info about twist frame conversion  (#2295 <https://github.com/ros-planning/moveit2/issues/2295>)
  * Update docstring + warning for twist frame conversion
  * Apply suggestions from code review
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * Suppress old-style-cast warnings
  ---------
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
* [Servo] Refactoring servo (#2224 <https://github.com/ros-planning/moveit2/issues/2224>)
* Replaced numbers with SystemDefaultsQos() (#2271 <https://github.com/ros-planning/moveit2/issues/2271>)
* Fix Servo suddenHalt() to halt at previous state, not current (#2229 <https://github.com/ros-planning/moveit2/issues/2229>)
* Fix the launching of Servo as a node component (#2194 <https://github.com/ros-planning/moveit2/issues/2194>)
  * Fix the launching of Servo as a node component
  * Comment improvement
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  * Add launch argument
  ---------
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
* Revert central differencing calculation in servo (#2203 <https://github.com/ros-planning/moveit2/issues/2203>)
  * Revert central differencing calculation in servo
  * current_joint_state_ to internal_joint_state_
* Fix servo speed scaling YAML parameters (#2211 <https://github.com/ros-planning/moveit2/issues/2211>)
* Reset Servo filters when starting (#2186 <https://github.com/ros-planning/moveit2/issues/2186>)
* [Servo] Move enforcePositionLimits and enforceVelocityLimits to utilities (#2180 <https://github.com/ros-planning/moveit2/issues/2180>)
  * Move limit enforcing functions to utilities
  * Fix comments
  * Make clock const
  * Remove clock from enforcePositionLimit
  * Remove clock usage from transformTwistToPlanningFrame and applyJointUpdates
  * Remove clock from vvelocityScalingFactorForSingularity
  * Fix tests
  * Cleanups + clang-tidy
  * Minor cleanups
  * Log output formatting
* Change servo collision checking parameters to dynamically update (#2183 <https://github.com/ros-planning/moveit2/issues/2183>)
* Contributors: AndyZe, Sebastian Castro, Shobuj Paul, V Mohammed Ibrahim
```

## moveit_setup_app_plugins

```
* Replaced boost::algorithm::join with fmt::join (#2273 <https://github.com/ros-planning/moveit2/issues/2273>)
  * Replaced boost::algorithm::join with fmt::join
  * Made changes in CMakeLists.txt to accomodate fmt
  * Updated package.xml files
  * removed redundant boost dependencies
  * Rename variables -> variable
  ---------
  Co-authored-by: Sebastian Castro <4603398+sea-bass@users.noreply.github.com>
  Co-authored-by: Sebastian Jahr <sebastian.jahr@picknik.ai>
* Contributors: Shobuj Paul
```

## moveit_setup_assistant

- No changes

## moveit_setup_controllers

- No changes

## moveit_setup_core_plugins

```
* Replaced boost::algorithm::join with fmt::join (#2273 <https://github.com/ros-planning/moveit2/issues/2273>)
  * Replaced boost::algorithm::join with fmt::join
  * Made changes in CMakeLists.txt to accomodate fmt
  * Updated package.xml files
  * removed redundant boost dependencies
  * Rename variables -> variable
  ---------
  Co-authored-by: Sebastian Castro <4603398+sea-bass@users.noreply.github.com>
  Co-authored-by: Sebastian Jahr <sebastian.jahr@picknik.ai>
* Contributors: Shobuj Paul
```

## moveit_setup_framework

```
* Replaced boost::algorithm::join with fmt::join (#2273 <https://github.com/ros-planning/moveit2/issues/2273>)
  * Replaced boost::algorithm::join with fmt::join
  * Made changes in CMakeLists.txt to accomodate fmt
  * Updated package.xml files
  * removed redundant boost dependencies
  * Rename variables -> variable
  ---------
  Co-authored-by: Sebastian Castro <4603398+sea-bass@users.noreply.github.com>
  Co-authored-by: Sebastian Jahr <sebastian.jahr@picknik.ai>
* Contributors: Shobuj Paul
```

## moveit_setup_srdf_plugins

- No changes

## moveit_simple_controller_manager

- No changes

## pilz_industrial_motion_planner

```
* Fx class_loader warnings in PILZ unittests (#2296 <https://github.com/ros-planning/moveit2/issues/2296>)
* Always set response planner id and warn if it is not set (#2236 <https://github.com/ros-planning/moveit2/issues/2236>)
* Pilz multi-group incompatibility (#1856 <https://github.com/ros-planning/moveit2/issues/1856>)
* Enhance PILZ service request checks (#2087 <https://github.com/ros-planning/moveit2/issues/2087>)
* Contributors: Marco Magri, Sebastian Jahr, Yang Lin
```

## pilz_industrial_motion_planner_testutils

```
* Make loggers static or move into anonymous namespace (#2184 <https://github.com/ros-planning/moveit2/issues/2184>)
  * Make loggers static or move into anonymous namespace
  * Update moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
  * Update moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
  * Move LOGGER out of class template
* Contributors: Sebastian Jahr
```
