### PR TITLE
moveit: 2.5.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3404,7 +3404,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
-      version: 2.5.4-1
+      version: 2.5.5-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.5.5-1`:

- upstream repository: https://github.com/ros-planning/moveit2.git
- release repository: https://github.com/ros2-gbp/moveit2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.5.4-1`

## chomp_motion_planner

```
* Switch to clang-format-14 (#1877 <https://github.com/ros-planning/moveit2/issues/1877>) (#1880 <https://github.com/ros-planning/moveit2/issues/1880>)
  * Switch to clang-format-14
  * Fix clang-format-14
  (cherry picked from commit 7fa5eaf1ac21ab8a99c5adae53bd0a2d4abf98f6)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Contributors: mergify[bot]
```

## moveit

- No changes

## moveit_chomp_optimizer_adapter

- No changes

## moveit_common

```
* Add -Wunused-parameter (#1756 <https://github.com/ros-planning/moveit2/issues/1756>) (#1757 <https://github.com/ros-planning/moveit2/issues/1757>)
  (cherry picked from commit be474ec5ba6d0210379d009d518bdd631cc46ad9)
  Co-authored-by: Chris Thrasher <mailto:chrisjthrasher@gmail.com>
* Add -Wunused-function (#1754 <https://github.com/ros-planning/moveit2/issues/1754>) (#1755 <https://github.com/ros-planning/moveit2/issues/1755>)
  (cherry picked from commit ed9c3317bc1335b66afb0b2e7478b95ddb5c4b33)
  Co-authored-by: Chris Thrasher <mailto:chrisjthrasher@gmail.com>
* Contributors: mergify[bot]
```

## moveit_configs_utils

```
* Do not add Pilz parameters to MoveIt Configs Utils if Pilz is not used (#1583 <https://github.com/ros-planning/moveit2/issues/1583>) (#2174 <https://github.com/ros-planning/moveit2/issues/2174>)
  (cherry picked from commit 1c7fa52edeef08bf8eb1e9cc73c1b0835aaf17e7)
  Co-authored-by: Stephanie Eng <mailto:stephanie-eng@users.noreply.github.com>
* Update default planning configs to use AddTimeOptimalParameterization (#2167 <https://github.com/ros-planning/moveit2/issues/2167>) (#2170 <https://github.com/ros-planning/moveit2/issues/2170>)
  (cherry picked from commit 895e9268bd5d9337bebdede07a7f68a99055a1df)
  Co-authored-by: Anthony Baker <mailto:abake48@users.noreply.github.com>
* Add xacro subsititution class and use it for loading urdf & srdf (backport #1805 <https://github.com/ros-planning/moveit2/issues/1805>) (#1937 <https://github.com/ros-planning/moveit2/issues/1937>)
  * Add xacro subsititution class and use it for loading urdf & srdf (#1805 <https://github.com/ros-planning/moveit2/issues/1805>)
  * Add Xacro substitution type
  * Use Xacro substitution for robot description and robot description semantic
  * Install subsititution folder
  * Default to load_xacro if there's no launch substitution specified in the mappings
  (cherry picked from commit 4bc83c3c9e6bfa9efea8c431794a630fbf27dddc)
  # Conflicts:
  #     moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
  * Fix merge conflicts
  ---------
  Co-authored-by: Jafar <mailto:cafer.abdi@gmail.com>
  Co-authored-by: Tyler Weaver <mailto:tyler@picknik.ai>
* Add support for multiple MoveItConfigBuilder instaces (#1807 <https://github.com/ros-planning/moveit2/issues/1807>) (#1808 <https://github.com/ros-planning/moveit2/issues/1808>)
  (cherry picked from commit 25d086cee9a7cf1c95a15ea12a27e5b7cbe50a1f)
  Co-authored-by: Marco Magri <mailto:94347649+MarcoMagriDev@users.noreply.github.com>
* Contributors: mergify[bot]
```

## moveit_core

```
* Don't use ament_export_targets from package sub folder (backport #1889 <https://github.com/ros-planning/moveit2/issues/1889>) (#1893 <https://github.com/ros-planning/moveit2/issues/1893>)
* Fix comment formatting (#2276 <https://github.com/ros-planning/moveit2/issues/2276>) (#2278 <https://github.com/ros-planning/moveit2/issues/2278>)
  (cherry picked from commit 83892d6a7cb2f84485ebd96d41adb3acd8c44bee)
  Co-authored-by: Stephanie Eng <mailto:stephanie-eng@users.noreply.github.com>
* fix for kinematic constraints parsing (#2267 <https://github.com/ros-planning/moveit2/issues/2267>) (#2268 <https://github.com/ros-planning/moveit2/issues/2268>)
  (cherry picked from commit b0f0f680c3f86b8074d208a1e78c92cfa75cf5ca)
  Co-authored-by: Jorge Nicho <mailto:jrgnichodevel@gmail.com>
* Added butterworth_filter_coeff parameter (#2129 <https://github.com/ros-planning/moveit2/issues/2129>)
  * Added butterworth_filter_coeff parameter
  * Added formating like in original PR #2091 <https://github.com/ros-planning/moveit2/issues/2091>
  * Update moveit_core/online_signal_smoothing/src/butterworth_filter.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * Update moveit_core/online_signal_smoothing/include/moveit/online_signal_smoothing/butterworth_filter.h
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * Alphabetized dependencies
  * Update moveit_core/package.xml
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  ---------
  Co-authored-by: andrey <>
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
* Fix ci-testing build issues (backport #1998 <https://github.com/ros-planning/moveit2/issues/1998>) (#2002 <https://github.com/ros-planning/moveit2/issues/2002>)
* Fix invalid case style for private member in RobotTrajectory
  (cherry picked from commit 31e07d3d6a6c1d59bca5876cc0acc51abb960997)
* Fix unreachable child logger instance
  (cherry picked from commit 1323d05c89a8815450f8f4edf7a1d7b520871d18)
* Fix clang compiler warnings (backport of #1712 <https://github.com/ros-planning/moveit2/issues/1712>) (#1896 <https://github.com/ros-planning/moveit2/issues/1896>)
  - Fix warning: definition of implicit copy assignment operator is deprecated
  - Fix warning: expression with side effects will be evaluated
  - Fix warning: passing by value
  - Enable -Werror
  - Fix -Wdelete-non-abstract-non-virtual-dtor
  - Fix more clang warnings
  - Modernize gtest: TYPED_TEST_CASE -> TYPED_TEST_SUITE
  - Fix GoogleTestVerification.UninstantiatedTypeParameterizedTestSuite
  - Add default copy/move constructors/assignment operators
  As a user-declared destructor deletes any implicitly-defined move constructor/assignment operator,
  we need to declared them manually. This in turn requires to declare the copy constructor/assignment as well.
  - Explicitly declare overrides
  - Add default constructors as they are not implicitly declared anymore
  - Declare selected classes as final
  - Add noexcept specifier to constructors
  - Fixup gmock/gtest warnings
* Switch to clang-format-14 (#1877 <https://github.com/ros-planning/moveit2/issues/1877>) (#1880 <https://github.com/ros-planning/moveit2/issues/1880>)
  * Switch to clang-format-14
  * Fix clang-format-14
  (cherry picked from commit 7fa5eaf1ac21ab8a99c5adae53bd0a2d4abf98f6)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Cleanup msg includes: Use C++ instead of C header (backport #1844 <https://github.com/ros-planning/moveit2/issues/1844>)
  * Cleanup msg includes: Use C++ instead of C header
  * Remove obsolete include: moveit_msgs/srv/execute_known_trajectory.hpp
* Fix moveit_core dependency on tf2_kdl (#1817 <https://github.com/ros-planning/moveit2/issues/1817>) (#1823 <https://github.com/ros-planning/moveit2/issues/1823>)
  This is a proper dependency, and not only a test dependency. It is still
  needed when building moveit_core with -DBUILD_TESTING=OFF.
  (cherry picked from commit 9f7d6df9cac9b55d10f6fee6c29e41ff1d1bf44c)
  Co-authored-by: Scott K Logan <mailto:logans@cottsay.net>
* Use <> for non-local headers (#1765 <https://github.com/ros-planning/moveit2/issues/1765>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
  (cherry picked from commit 7a1f2a101f9aeb8557e8a31656bbe1a6d53b430e)
* Add -Wunused-function (#1754 <https://github.com/ros-planning/moveit2/issues/1754>) (#1755 <https://github.com/ros-planning/moveit2/issues/1755>)
  (cherry picked from commit ed9c3317bc1335b66afb0b2e7478b95ddb5c4b33)
  Co-authored-by: Chris Thrasher <mailto:chrisjthrasher@gmail.com>
* Re-enable clang-tidy check performance-unnecessary-value-param (backport #1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Re-enable clang-tidy check performance-unnecessary-value-param (#1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: Robert Haschke <mailto:rhaschke@users.noreply.github.com>
* Contributors: Chris Thrasher, Henning Kayser, Robert Haschke, andrey-pr, mergify[bot]
```

## moveit_hybrid_planning

```
* Replaced numbers with SystemDefaultsQos() (#2271 <https://github.com/ros-planning/moveit2/issues/2271>) (#2277 <https://github.com/ros-planning/moveit2/issues/2277>)
  (cherry picked from commit 5506dd516a91bc145e462b493668ef8623d43521)
  Co-authored-by: Shobuj Paul <mailto:72087882+Shobuj-Paul@users.noreply.github.com>
* Fix clang compiler warnings (backport of #1712 <https://github.com/ros-planning/moveit2/issues/1712>) (#1896 <https://github.com/ros-planning/moveit2/issues/1896>)
  - Fix warning: definition of implicit copy assignment operator is deprecated
  - Fix warning: expression with side effects will be evaluated
  - Fix warning: passing by value
  - Enable -Werror
  - Fix -Wdelete-non-abstract-non-virtual-dtor
  - Fix more clang warnings
  - Modernize gtest: TYPED_TEST_CASE -> TYPED_TEST_SUITE
  - Fix GoogleTestVerification.UninstantiatedTypeParameterizedTestSuite
  - Add default copy/move constructors/assignment operators
  As a user-declared destructor deletes any implicitly-defined move constructor/assignment operator,
  we need to declared them manually. This in turn requires to declare the copy constructor/assignment as well.
  - Explicitly declare overrides
  - Add default constructors as they are not implicitly declared anymore
  - Declare selected classes as final
  - Add noexcept specifier to constructors
  - Fixup gmock/gtest warnings
* Cleanup msg includes: Use C++ instead of C header (backport #1844 <https://github.com/ros-planning/moveit2/issues/1844>)
  * Cleanup msg includes: Use C++ instead of C header
  * Remove obsolete include: moveit_msgs/srv/execute_known_trajectory.hpp
* Use <> for non-local headers (#1765 <https://github.com/ros-planning/moveit2/issues/1765>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
  (cherry picked from commit 7a1f2a101f9aeb8557e8a31656bbe1a6d53b430e)
* Re-enable clang-tidy check performance-unnecessary-value-param (backport #1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Re-enable clang-tidy check performance-unnecessary-value-param (#1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: Robert Haschke <mailto:rhaschke@users.noreply.github.com>
* Contributors: Chris Thrasher, Robert Haschke, mergify[bot]
```

## moveit_kinematics

```
* Fix ikfast package template (#2195 <https://github.com/ros-planning/moveit2/issues/2195>) (#2199 <https://github.com/ros-planning/moveit2/issues/2199>)
  (cherry picked from commit 21036b58e99876928b46e3cc4603a9eb9b85e11d)
  Co-authored-by: Jafar <mailto:cafer.abdi@gmail.com>
* Fix clang compiler warnings (backport of #1712 <https://github.com/ros-planning/moveit2/issues/1712>) (#1896 <https://github.com/ros-planning/moveit2/issues/1896>)
  - Fix warning: definition of implicit copy assignment operator is deprecated
  - Fix warning: expression with side effects will be evaluated
  - Fix warning: passing by value
  - Enable -Werror
  - Fix -Wdelete-non-abstract-non-virtual-dtor
  - Fix more clang warnings
  - Modernize gtest: TYPED_TEST_CASE -> TYPED_TEST_SUITE
  - Fix GoogleTestVerification.UninstantiatedTypeParameterizedTestSuite
  - Add default copy/move constructors/assignment operators
  As a user-declared destructor deletes any implicitly-defined move constructor/assignment operator,
  we need to declared them manually. This in turn requires to declare the copy constructor/assignment as well.
  - Explicitly declare overrides
  - Add default constructors as they are not implicitly declared anymore
  - Declare selected classes as final
  - Add noexcept specifier to constructors
  - Fixup gmock/gtest warnings
* Contributors: Robert Haschke, mergify[bot]
```

## moveit_planners

- No changes

## moveit_planners_chomp

```
* Re-enable clang-tidy check performance-unnecessary-value-param (backport #1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Re-enable clang-tidy check performance-unnecessary-value-param (#1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: Robert Haschke <mailto:rhaschke@users.noreply.github.com>
* Contributors: mergify[bot]
```

## moveit_planners_ompl

```
* Fix Constraint Planning Segfault (#2130 <https://github.com/ros-planning/moveit2/issues/2130>) (#2173 <https://github.com/ros-planning/moveit2/issues/2173>)
  * Fix Constraint Planning Segfault
  * Reuse planner data
  * apply clang formatting
  * apply clang formatting round 2
  * add FIXME note and verbose output of planning graph size
  ---------
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
  (cherry picked from commit 92a7951f74baaf26d07356612a2f5dca0bac5065)
  Co-authored-by: Marq Rasmussen <mailto:marq.razz@gmail.com>
* Cleanup msg includes: Use C++ instead of C header (backport #1844 <https://github.com/ros-planning/moveit2/issues/1844>)
  * Cleanup msg includes: Use C++ instead of C header
  * Remove obsolete include: moveit_msgs/srv/execute_known_trajectory.hpp
* Use <> for non-local headers (#1765 <https://github.com/ros-planning/moveit2/issues/1765>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
  (cherry picked from commit 7a1f2a101f9aeb8557e8a31656bbe1a6d53b430e)
* Re-enable clang-tidy check performance-unnecessary-value-param (backport #1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Re-enable clang-tidy check performance-unnecessary-value-param (#1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: Robert Haschke <mailto:rhaschke@users.noreply.github.com>
* Contributors: Chris Thrasher, Robert Haschke, mergify[bot]
```

## moveit_plugins

- No changes

## moveit_resources_prbt_ikfast_manipulator_plugin

```
* Used C++ style casting for int type (backport #1627 <https://github.com/ros-planning/moveit2/issues/1627>) (#1819 <https://github.com/ros-planning/moveit2/issues/1819>)
  (cherry picked from commit 1f32ab0e43f488e9c5bd1957c7677e302c406df0)
  Co-authored-by: Abhijeet Das Gupta <mailto:75399048+abhijelly@users.noreply.github.com>
* Add -Wunused-parameter (#1756 <https://github.com/ros-planning/moveit2/issues/1756>) (#1757 <https://github.com/ros-planning/moveit2/issues/1757>)
  (cherry picked from commit be474ec5ba6d0210379d009d518bdd631cc46ad9)
  Co-authored-by: Chris Thrasher <mailto:chrisjthrasher@gmail.com>
* Contributors: mergify[bot]
```

## moveit_resources_prbt_moveit_config

- No changes

## moveit_resources_prbt_pg70_support

- No changes

## moveit_resources_prbt_support

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

```
* Fix parameters for ros2_control namespaces (#1833 <https://github.com/ros-planning/moveit2/issues/1833>) (#1897 <https://github.com/ros-planning/moveit2/issues/1897>)
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  (cherry picked from commit 5838ce890975e3a058cdc9ab699b27941374c3a2)
  Co-authored-by: Pablo Iñigo Blasco <mailto:pablo.inigo.blasco@gmail.com>
* Contributors: mergify[bot]
```

## moveit_ros_move_group

```
* Re-enable clang-tidy check performance-unnecessary-value-param (backport #1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Re-enable clang-tidy check performance-unnecessary-value-param (#1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: Robert Haschke <mailto:rhaschke@users.noreply.github.com>
* Contributors: mergify[bot]
```

## moveit_ros_occupancy_map_monitor

```
* Switch to clang-format-14 (#1877 <https://github.com/ros-planning/moveit2/issues/1877>) (#1880 <https://github.com/ros-planning/moveit2/issues/1880>)
  * Switch to clang-format-14
  * Fix clang-format-14
  (cherry picked from commit 7fa5eaf1ac21ab8a99c5adae53bd0a2d4abf98f6)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Re-enable clang-tidy check performance-unnecessary-value-param (backport #1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Re-enable clang-tidy check performance-unnecessary-value-param (#1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: Robert Haschke <mailto:rhaschke@users.noreply.github.com>
* Contributors: mergify[bot]
```

## moveit_ros_perception

```
* Replaced numbers with SystemDefaultsQos() (#2271 <https://github.com/ros-planning/moveit2/issues/2271>) (#2277 <https://github.com/ros-planning/moveit2/issues/2277>)
  (cherry picked from commit 5506dd516a91bc145e462b493668ef8623d43521)
  Co-authored-by: Shobuj Paul <mailto:72087882+Shobuj-Paul@users.noreply.github.com>
* Use <> for non-local headers (#1765 <https://github.com/ros-planning/moveit2/issues/1765>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
  (cherry picked from commit 7a1f2a101f9aeb8557e8a31656bbe1a6d53b430e)
* Re-enable clang-tidy check performance-unnecessary-value-param (backport #1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Re-enable clang-tidy check performance-unnecessary-value-param (#1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: Robert Haschke <mailto:rhaschke@users.noreply.github.com>
* Contributors: Chris Thrasher, mergify[bot]
```

## moveit_ros_planning

```
* Replaced numbers with SystemDefaultsQos() (#2271 <https://github.com/ros-planning/moveit2/issues/2271>) (#2277 <https://github.com/ros-planning/moveit2/issues/2277>)
  (cherry picked from commit 5506dd516a91bc145e462b493668ef8623d43521)
  Co-authored-by: Shobuj Paul <mailto:72087882+Shobuj-Paul@users.noreply.github.com>
* Update default planning configs to use AddTimeOptimalParameterization (#2167 <https://github.com/ros-planning/moveit2/issues/2167>) (#2170 <https://github.com/ros-planning/moveit2/issues/2170>)
  (cherry picked from commit 895e9268bd5d9337bebdede07a7f68a99055a1df)
  Co-authored-by: Anthony Baker <mailto:abake48@users.noreply.github.com>
* Fix timeout in waitForCurrentState (backport #1899 <https://github.com/ros-planning/moveit2/issues/1899>) (#1938 <https://github.com/ros-planning/moveit2/issues/1938>)
  (cherry picked from commit 2c48478ac9b4ccfa6784f0e3a9cbf92ef1ecd363)
  Co-authored-by: Carlo Rizzardo <mailto:c-rizz@users.noreply.github.com>
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Switch to clang-format-14 (#1877 <https://github.com/ros-planning/moveit2/issues/1877>) (#1880 <https://github.com/ros-planning/moveit2/issues/1880>)
  * Switch to clang-format-14
  * Fix clang-format-14
  (cherry picked from commit 7fa5eaf1ac21ab8a99c5adae53bd0a2d4abf98f6)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Cleanup msg includes: Use C++ instead of C header (backport #1844 <https://github.com/ros-planning/moveit2/issues/1844>)
  * Cleanup msg includes: Use C++ instead of C header
  * Remove obsolete include: moveit_msgs/srv/execute_known_trajectory.hpp
* Use <> for non-local headers (#1765 <https://github.com/ros-planning/moveit2/issues/1765>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
  (cherry picked from commit 7a1f2a101f9aeb8557e8a31656bbe1a6d53b430e)
* Re-enable clang-tidy check performance-unnecessary-value-param (backport #1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Re-enable clang-tidy check performance-unnecessary-value-param (#1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: Robert Haschke <mailto:rhaschke@users.noreply.github.com>
* Contributors: Chris Thrasher, Robert Haschke, mergify[bot]
```

## moveit_ros_planning_interface

```
* 400% speed up to move group interface (#1865 <https://github.com/ros-planning/moveit2/issues/1865>) (#1867 <https://github.com/ros-planning/moveit2/issues/1867>)
  (cherry picked from commit 0642ef064df512566ffb171f5a889f4c7886110d)
  Co-authored-by: azalutsky <mailto:azalutsky@gmail.com>
* Cleanup msg includes: Use C++ instead of C header (backport #1844 <https://github.com/ros-planning/moveit2/issues/1844>)
  * Cleanup msg includes: Use C++ instead of C header
  * Remove obsolete include: moveit_msgs/srv/execute_known_trajectory.hpp
* Use <> for non-local headers (#1765 <https://github.com/ros-planning/moveit2/issues/1765>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
  (cherry picked from commit 7a1f2a101f9aeb8557e8a31656bbe1a6d53b430e)
* Re-enable clang-tidy check performance-unnecessary-value-param (backport #1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Re-enable clang-tidy check performance-unnecessary-value-param (#1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: Robert Haschke <mailto:rhaschke@users.noreply.github.com>
* Contributors: Chris Thrasher, Robert Haschke, mergify[bot]
```

## moveit_ros_robot_interaction

```
* Replaced numbers with SystemDefaultsQos() (#2271 <https://github.com/ros-planning/moveit2/issues/2271>) (#2277 <https://github.com/ros-planning/moveit2/issues/2277>)
  (cherry picked from commit 5506dd516a91bc145e462b493668ef8623d43521)
  Co-authored-by: Shobuj Paul <mailto:72087882+Shobuj-Paul@users.noreply.github.com>
* Use <> for non-local headers (#1765 <https://github.com/ros-planning/moveit2/issues/1765>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
  (cherry picked from commit 7a1f2a101f9aeb8557e8a31656bbe1a6d53b430e)
* Re-enable clang-tidy check performance-unnecessary-value-param (backport #1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Re-enable clang-tidy check performance-unnecessary-value-param (#1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: Robert Haschke <mailto:rhaschke@users.noreply.github.com>
* Contributors: Chris Thrasher, mergify[bot]
```

## moveit_ros_visualization

```
* Replaced numbers with SystemDefaultsQos() (#2271 <https://github.com/ros-planning/moveit2/issues/2271>) (#2277 <https://github.com/ros-planning/moveit2/issues/2277>)
  (cherry picked from commit 5506dd516a91bc145e462b493668ef8623d43521)
  Co-authored-by: Shobuj Paul <mailto:72087882+Shobuj-Paul@users.noreply.github.com>
* Doxygen tag (backport #1955 <https://github.com/ros-planning/moveit2/issues/1955>) (#1958 <https://github.com/ros-planning/moveit2/issues/1958>)
  * Generate Doxygen Tag
  * Install tagfile in output directory
  * Fix problematic override for Doxygen linking
  (cherry picked from commit 752571e9ff027b3137b9720227681ed6b57e42d6)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Use <> for non-local headers (#1765 <https://github.com/ros-planning/moveit2/issues/1765>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
  (cherry picked from commit 7a1f2a101f9aeb8557e8a31656bbe1a6d53b430e)
* Re-enable clang-tidy check performance-unnecessary-value-param (backport #1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Re-enable clang-tidy check performance-unnecessary-value-param (#1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: Robert Haschke <mailto:rhaschke@users.noreply.github.com>
* Contributors: Chris Thrasher, mergify[bot]
```

## moveit_ros_warehouse

```
* Replaced numbers with SystemDefaultsQos() (#2271 <https://github.com/ros-planning/moveit2/issues/2271>) (#2277 <https://github.com/ros-planning/moveit2/issues/2277>)
  (cherry picked from commit 5506dd516a91bc145e462b493668ef8623d43521)
  Co-authored-by: Shobuj Paul <mailto:72087882+Shobuj-Paul@users.noreply.github.com>
* Use <> for non-local headers (#1765 <https://github.com/ros-planning/moveit2/issues/1765>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
  (cherry picked from commit 7a1f2a101f9aeb8557e8a31656bbe1a6d53b430e)
* Re-enable clang-tidy check performance-unnecessary-value-param (backport #1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Re-enable clang-tidy check performance-unnecessary-value-param (#1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: Robert Haschke <mailto:rhaschke@users.noreply.github.com>
* Contributors: Chris Thrasher, mergify[bot]
```

## moveit_runtime

- No changes

## moveit_servo

```
* Replaced numbers with SystemDefaultsQos() (#2271 <https://github.com/ros-planning/moveit2/issues/2271>) (#2277 <https://github.com/ros-planning/moveit2/issues/2277>)
  (cherry picked from commit 5506dd516a91bc145e462b493668ef8623d43521)
  Co-authored-by: Shobuj Paul <mailto:72087882+Shobuj-Paul@users.noreply.github.com>
* [Servo] CI simplification (backport #1556 <https://github.com/ros-planning/moveit2/issues/1556>) (#1980 <https://github.com/ros-planning/moveit2/issues/1980>)
* Fix clang compiler warnings (backport of #1712 <https://github.com/ros-planning/moveit2/issues/1712>) (#1896 <https://github.com/ros-planning/moveit2/issues/1896>)
  - Fix warning: definition of implicit copy assignment operator is deprecated
  - Fix warning: expression with side effects will be evaluated
  - Fix warning: passing by value
  - Enable -Werror
  - Fix -Wdelete-non-abstract-non-virtual-dtor
  - Fix more clang warnings
  - Modernize gtest: TYPED_TEST_CASE -> TYPED_TEST_SUITE
  - Fix GoogleTestVerification.UninstantiatedTypeParameterizedTestSuite
  - Add default copy/move constructors/assignment operators
  As a user-declared destructor deletes any implicitly-defined move constructor/assignment operator,
  we need to declared them manually. This in turn requires to declare the copy constructor/assignment as well.
  - Explicitly declare overrides
  - Add default constructors as they are not implicitly declared anymore
  - Declare selected classes as final
  - Add noexcept specifier to constructors
  - Fixup gmock/gtest warnings
* Cleanup msg includes: Use C++ instead of C header (backport #1844 <https://github.com/ros-planning/moveit2/issues/1844>)
  * Cleanup msg includes: Use C++ instead of C header
  * Remove obsolete include: moveit_msgs/srv/execute_known_trajectory.hpp
* Use <> for non-local headers (#1765 <https://github.com/ros-planning/moveit2/issues/1765>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
  (cherry picked from commit 7a1f2a101f9aeb8557e8a31656bbe1a6d53b430e)
* Re-enable clang-tidy check performance-unnecessary-value-param (backport #1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Re-enable clang-tidy check performance-unnecessary-value-param (#1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: Robert Haschke <mailto:rhaschke@users.noreply.github.com>
* Contributors: AndyZe, Chris Thrasher, Robert Haschke, mergify[bot]
```

## moveit_setup_app_plugins

```
* add missing dependencies on config utils (backport #1962 <https://github.com/ros-planning/moveit2/issues/1962>) (#2206 <https://github.com/ros-planning/moveit2/issues/2206>)
  when installing ros-humble-moveit-setup-assistant from debs,
  the package cannot currently run due to this missing depend
  (cherry picked from commit cc635471aadfb9446398ece319ae31c6b72bec86)
  Co-authored-by: Michael Ferguson <mailto:mfergs7@gmail.com>
* Fix clang compiler warnings (backport of #1712 <https://github.com/ros-planning/moveit2/issues/1712>) (#1896 <https://github.com/ros-planning/moveit2/issues/1896>)
  - Fix warning: definition of implicit copy assignment operator is deprecated
  - Fix warning: expression with side effects will be evaluated
  - Fix warning: passing by value
  - Enable -Werror
  - Fix -Wdelete-non-abstract-non-virtual-dtor
  - Fix more clang warnings
  - Modernize gtest: TYPED_TEST_CASE -> TYPED_TEST_SUITE
  - Fix GoogleTestVerification.UninstantiatedTypeParameterizedTestSuite
  - Add default copy/move constructors/assignment operators
  As a user-declared destructor deletes any implicitly-defined move constructor/assignment operator,
  we need to declared them manually. This in turn requires to declare the copy constructor/assignment as well.
  - Explicitly declare overrides
  - Add default constructors as they are not implicitly declared anymore
  - Declare selected classes as final
  - Add noexcept specifier to constructors
  - Fixup gmock/gtest warnings
* Contributors: Robert Haschke, mergify[bot]
```

## moveit_setup_assistant

```
* Use <> for non-local headers (#1765 <https://github.com/ros-planning/moveit2/issues/1765>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
  (cherry picked from commit 7a1f2a101f9aeb8557e8a31656bbe1a6d53b430e)
* Re-enable clang-tidy check performance-unnecessary-value-param (backport #1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Re-enable clang-tidy check performance-unnecessary-value-param (#1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: Robert Haschke <mailto:rhaschke@users.noreply.github.com>
* Contributors: Chris Thrasher, mergify[bot]
```

## moveit_setup_controllers

```
* add missing dependencies on config utils (backport #1962 <https://github.com/ros-planning/moveit2/issues/1962>) (#2206 <https://github.com/ros-planning/moveit2/issues/2206>)
  when installing ros-humble-moveit-setup-assistant from debs,
  the package cannot currently run due to this missing depend
  (cherry picked from commit cc635471aadfb9446398ece319ae31c6b72bec86)
  Co-authored-by: Michael Ferguson <mailto:mfergs7@gmail.com>
* Fix clang compiler warnings (backport of #1712 <https://github.com/ros-planning/moveit2/issues/1712>) (#1896 <https://github.com/ros-planning/moveit2/issues/1896>)
  - Fix warning: definition of implicit copy assignment operator is deprecated
  - Fix warning: expression with side effects will be evaluated
  - Fix warning: passing by value
  - Enable -Werror
  - Fix -Wdelete-non-abstract-non-virtual-dtor
  - Fix more clang warnings
  - Modernize gtest: TYPED_TEST_CASE -> TYPED_TEST_SUITE
  - Fix GoogleTestVerification.UninstantiatedTypeParameterizedTestSuite
  - Add default copy/move constructors/assignment operators
  As a user-declared destructor deletes any implicitly-defined move constructor/assignment operator,
  we need to declared them manually. This in turn requires to declare the copy constructor/assignment as well.
  - Explicitly declare overrides
  - Add default constructors as they are not implicitly declared anymore
  - Declare selected classes as final
  - Add noexcept specifier to constructors
  - Fixup gmock/gtest warnings
* Re-enable clang-tidy check performance-unnecessary-value-param (backport #1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Re-enable clang-tidy check performance-unnecessary-value-param (#1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: Robert Haschke <mailto:rhaschke@users.noreply.github.com>
* Contributors: Robert Haschke, mergify[bot]
```

## moveit_setup_core_plugins

```
* Use <> for non-local headers (#1765 <https://github.com/ros-planning/moveit2/issues/1765>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
  (cherry picked from commit 7a1f2a101f9aeb8557e8a31656bbe1a6d53b430e)
* Contributors: Chris Thrasher
```

## moveit_setup_framework

```
* Fix clang compiler warnings (backport of #1712 <https://github.com/ros-planning/moveit2/issues/1712>) (#1896 <https://github.com/ros-planning/moveit2/issues/1896>)
  - Fix warning: definition of implicit copy assignment operator is deprecated
  - Fix warning: expression with side effects will be evaluated
  - Fix warning: passing by value
  - Enable -Werror
  - Fix -Wdelete-non-abstract-non-virtual-dtor
  - Fix more clang warnings
  - Modernize gtest: TYPED_TEST_CASE -> TYPED_TEST_SUITE
  - Fix GoogleTestVerification.UninstantiatedTypeParameterizedTestSuite
  - Add default copy/move constructors/assignment operators
  As a user-declared destructor deletes any implicitly-defined move constructor/assignment operator,
  we need to declared them manually. This in turn requires to declare the copy constructor/assignment as well.
  - Explicitly declare overrides
  - Add default constructors as they are not implicitly declared anymore
  - Declare selected classes as final
  - Add noexcept specifier to constructors
  - Fixup gmock/gtest warnings
* Use <> for non-local headers (#1765 <https://github.com/ros-planning/moveit2/issues/1765>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
  (cherry picked from commit 7a1f2a101f9aeb8557e8a31656bbe1a6d53b430e)
* Re-enable clang-tidy check performance-unnecessary-value-param (backport #1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Re-enable clang-tidy check performance-unnecessary-value-param (#1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: Robert Haschke <mailto:rhaschke@users.noreply.github.com>
* Contributors: Chris Thrasher, Robert Haschke, mergify[bot]
```

## moveit_setup_srdf_plugins

- No changes

## moveit_simple_controller_manager

```
* Use emulated time in action-based controller (#899 <https://github.com/ros-planning/moveit2/issues/899>) (#1743 <https://github.com/ros-planning/moveit2/issues/1743>)
  (cherry picked from commit b6fcac8055f54012dd9e698be6e06f70613a5abf)
  Co-authored-by: Gaël Écorchard <mailto:gael.ecorchard@cvut.cz>
* Re-enable clang-tidy check performance-unnecessary-value-param (backport #1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Re-enable clang-tidy check performance-unnecessary-value-param (#1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: Robert Haschke <mailto:rhaschke@users.noreply.github.com>
* Contributors: mergify[bot]
```

## pilz_industrial_motion_planner

```
* Pilz multi-group incompatibility (#1856 <https://github.com/ros-planning/moveit2/issues/1856>) (#2306 <https://github.com/ros-planning/moveit2/issues/2306>)
  (cherry picked from commit 5bbe21b3574d3e3ef2a2c681b3962f70c3db7e78)
  Co-authored-by: Marco Magri <mailto:94347649+MarcoMagriDev@users.noreply.github.com>
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Fx class_loader warnings in PILZ unittests (#2296 <https://github.com/ros-planning/moveit2/issues/2296>) (#2303 <https://github.com/ros-planning/moveit2/issues/2303>)
  (cherry picked from commit d4dcea36d9767605fc1921716a67a0c6e9be2a2e)
  Co-authored-by: Yang Lin <mailto:todoubaba@gmail.com>
* fix: resolve bugs in MoveGroupSequenceAction class (main branch) (#1797 <https://github.com/ros-planning/moveit2/issues/1797>) (#1809 <https://github.com/ros-planning/moveit2/issues/1809>)
  * fix: resolve bugs in MoveGroupSequenceAction class
  * style: adopt .clang-format
  Co-authored-by: Marco Magri <mailto:marco.magri@fraunhofer.it>
  (cherry picked from commit fca8e9bd3f41e6bff5aadbf75c494b5cc3fa25ee)
  Co-authored-by: Marco Magri <mailto:94347649+MarcoMagriDev@users.noreply.github.com>
* Use <> for non-local headers (#1765 <https://github.com/ros-planning/moveit2/issues/1765>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
  (cherry picked from commit 7a1f2a101f9aeb8557e8a31656bbe1a6d53b430e)
* Re-enable clang-tidy check performance-unnecessary-value-param (backport #1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Re-enable clang-tidy check performance-unnecessary-value-param (#1703 <https://github.com/ros-planning/moveit2/issues/1703>)
  * Fix clang-tidy issues (#1706 <https://github.com/ros-planning/moveit2/issues/1706>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
  Co-authored-by: Robert Haschke <mailto:rhaschke@users.noreply.github.com>
* Contributors: Chris Thrasher, mergify[bot]
```

## pilz_industrial_motion_planner_testutils

```
* Fix clang compiler warnings (backport of #1712 <https://github.com/ros-planning/moveit2/issues/1712>) (#1896 <https://github.com/ros-planning/moveit2/issues/1896>)
  - Fix warning: definition of implicit copy assignment operator is deprecated
  - Fix warning: expression with side effects will be evaluated
  - Fix warning: passing by value
  - Enable -Werror
  - Fix -Wdelete-non-abstract-non-virtual-dtor
  - Fix more clang warnings
  - Modernize gtest: TYPED_TEST_CASE -> TYPED_TEST_SUITE
  - Fix GoogleTestVerification.UninstantiatedTypeParameterizedTestSuite
  - Add default copy/move constructors/assignment operators
  As a user-declared destructor deletes any implicitly-defined move constructor/assignment operator,
  we need to declared them manually. This in turn requires to declare the copy constructor/assignment as well.
  - Explicitly declare overrides
  - Add default constructors as they are not implicitly declared anymore
  - Declare selected classes as final
  - Add noexcept specifier to constructors
  - Fixup gmock/gtest warnings
* Use <> for non-local headers (#1765 <https://github.com/ros-planning/moveit2/issues/1765>)
  Unless a header lives in the same or a child directory of the file
  including it, it's recommended to use <> for the #include statement.
  For more information, see the C++ Core Guidelines item SF.12
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else
  (cherry picked from commit 7a1f2a101f9aeb8557e8a31656bbe1a6d53b430e)
* Contributors: Chris Thrasher, Robert Haschke
```
