### PR TITLE
ur_description: 2.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6913,7 +6913,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.2.0-1
+      version: 2.2.1-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.2.1-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.0-1`

## ur_description

```
* Update the joint limits for UR20 (#98 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/98>)
* UR20 description and meshes (#94 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/94>)
  The UR20 meshes are added under Universal Robots A/S’
  Terms and Conditions for Use of Graphical Documentation
* Contributors: Rune Søe-Knudsen, Felix Exner
```
