### PR TITLE
ros2_control: 2.31.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5751,7 +5751,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.30.0-1
+      version: 2.31.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.31.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.30.0-1`

## controller_interface

```
* add a broadcaster for range sensor (#1091 <https://github.com/ros-controls/ros2_control/issues/1091>) (#1100 <https://github.com/ros-controls/ros2_control/issues/1100>)
* Contributors: flochre
```

## controller_manager

```
* [Docs] Fix information about activation and deactivation of chainable controllers (#1104 <https://github.com/ros-controls/ros2_control/issues/1104>) (#1106 <https://github.com/ros-controls/ros2_control/issues/1106>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
