### PR TITLE
ur_description: 2.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8210,7 +8210,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.1.1-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.0-1`

## ur_description

```
* Update the joint limits for UR20 (#99 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/99>)
* UR20 description and meshes (#94 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/94>)
  The UR20 meshes are added under Universal Robots A/S’
  Terms and Conditions for Use of Graphical Documentation
  Co-authored-by: Rune Søe-Knudsen <mailto:41109954+urrsk@users.noreply.github.com>
* Revert "Switch fake to mock for ros2_control updates (#77 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/77>)"
* Switch fake to mock for ros2_control updates (#77 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/77>)
* CI: Add iron workflow (#64 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/64>)
* Contributors: Felix Exner, Sebastian Castro, Rune Søe-Knudsen
```
