### PR TITLE
weight_scale_interfaces: 0.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8711,15 +8711,20 @@ repositories:
       version: master
     status: maintained
   weight_scale_interfaces:
+    doc:
+      type: git
+      url: https://github.com/TechMagicKK/weight_scale_interfaces.git
+      version: main
     release:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/TechMagicKK/weight_scale_interfaces-release.git
-      version: 0.0.1-1
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/TechMagicKK/weight_scale_interfaces.git
       version: main
+    status: maintained
   wireless:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `weight_scale_interfaces` to `0.0.2-1`:

- upstream repository: https://github.com/TechMagicKK/weight_scale_interfaces.git
- release repository: https://github.com/TechMagicKK/weight_scale_interfaces-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.1-1`

## weight_scale_interfaces

```
* Add builtin_interfaces dependency
* Contributors: Ryosuke Tajima
```
