### PR TITLE
foxglove_bridge: 0.7.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1451,7 +1451,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 0.7.1-1
+      version: 0.7.2-1
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_bridge` to `0.7.2-1`:

- upstream repository: https://github.com/foxglove/ros-foxglove-bridge.git
- release repository: https://github.com/ros2-gbp/foxglove_bridge-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.1-1`

## foxglove_bridge

```
* Fix invalid pointers not being caught (#265 <https://github.com/foxglove/ros-foxglove-bridge/issues/265>)
* Make ROS1 service type retrieval more robust (#263 <https://github.com/foxglove/ros-foxglove-bridge/issues/263>)
* Contributors: Hans-Joachim Krauch
```
