### PR TITLE
behaviortree_cpp_v4: 4.3.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -585,7 +585,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.3.6-2
+      version: 4.3.7-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp_v4` to `4.3.7-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.3.6-2`

## behaviortree_cpp

```
* Test and fix issue #653 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/653>: AnyTypeAllowed by default
* more time margin for Windows tests
* Add support for successful conda builds (#650 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/650>)
* fix: Update how unit tests are executed in the github workflow so they are actually run on windows (#647 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/647>)
* Add unit test related to SequenceWithMemory #636 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/636>
* Contributors: Davide Faconti, tony-p
```
