### PR TITLE
classic_bags: 0.1.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -704,6 +704,22 @@ repositories:
       url: https://github.com/ros/class_loader.git
       version: iron
     status: maintained
+  classic_bags:
+    doc:
+      type: git
+      url: https://github.com/MetroRobots/classic_bags.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/classic_bags-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/MetroRobots/classic_bags.git
+      version: main
+    status: developed
   color_names:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `classic_bags` to `0.1.0-1`:

- upstream repository: https://github.com/MetroRobots/classic_bags.git
- release repository: https://github.com/ros2-gbp/classic_bags-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## classic_bags

```
* Initial package
* Contributors: David V. Lu!!
```
