### PR TITLE
rosmobile_build_tools: 0.4.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9660,6 +9660,21 @@ repositories:
       url: https://github.com/ros/roslisp_common.git
       version: master
     status: maintained
+  rosmobile_build_tools:
+    doc:
+      type: git
+      url: https://github.com/Application-UI-UX/rosmobile_build_tools/blob/main/README.md.git
+      version: main
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: git@github.com:Application-UI-UX/rosmobile_build_tools.git
+      version: 0.4.2-1
+    source:
+      type: git
+      url: https://github.com/Application-UI-UX/rosmobile_build_tools/blob/main/README.md.git
+      version: main
+    status: maintained
   rosmon:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosmobile_build_tools` to `0.4.2-1`:

- upstream repository: git@github.com:Application-UI-UX/rosmobile_build_tools.git
- release repository: git@github.com:Application-UI-UX/rosmobile_build_tools.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## rosmobile_build_tools

```
* Fix countless bugs in the repository and recalibrate
* Release dedicated code for maven, ros, and python
* Maintainer & Contributors: Ronaldson Bellande
```
