### PR TITLE
reach_ros: 1.3.1-3 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5187,10 +5187,16 @@ repositories:
       version: master
     status: developed
   reach_ros:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/reach_ros2-release.git
+      version: 1.3.1-3
     source:
       type: git
       url: https://github.com/ros-industrial/reach_ros2.git
       version: master
+    status: developed
   realsense2_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository reach_ros to 1.3.1-3:

- upstream repository: https://github.com/ros-industrial/reach_ros2.git
- release repository: https://github.com/ros2-gbp/reach_ros2-release.git
- distro file: humble/distribution.yaml
- bloom version: 0.11.2
- previous version for package: None