### PR TITLE
rosmobile_build_tools: 0.4.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6395,6 +6395,21 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
       version: humble
     status: developed
+  rosmobile_build_tools:
+    doc:
+      type: git
+      url: https://github.com/Application-UI-UX/rosmobile_build_tools/blob/main/README.md.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: git@github.com:Application-UI-UX/rosmobile_build_tools.git
+      version: 0.4.2-1
+    source:
+      type: git
+      url: https://github.com/Application-UI-UX/rosmobile_build_tools/blob/main/README.md.git
+      version: main
+    status: maintained
   rospy_message_converter:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosmobile_build_tools` to `0.4.2-1`:

- upstream repository: git@github.com:Application-UI-UX/rosmobile_build_tools.git
- release repository: git@github.com:Application-UI-UX/rosmobile_build_tools.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## rosmobile_build_tools

```
* Fix countless bugs in the repository and recalibrate
* Release dedicated code for maven, ros, and python
* Maintainer & Contributors: Ronaldson Bellande
```
