### PR TITLE
rosmobile_build_tools: 0.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5538,7 +5538,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: git@github.com:application-ui-ux/mobile_catkin_modules_build_development_tools.git
-      version: 0.4.4
+      version: 0.4.4-1
     source:
       type: git
       url: https://github.com/application-ui-ux/mobile_catkin_modules_build_development_tools.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5529,19 +5529,19 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
       version: rolling
     status: developed
-  rosmobile_build_tools:
+  mobile_catkin_modules_build_development_tools:
     doc:
       type: git
-      url: https://github.com/Application-UI-UX/rosmobile_build_tools/blob/main/README.md.git
+      url: https://github.com/application-ui-ux/mobile_catkin_modules_build_development_tools.git
       version: main
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: git@github.com:Application-UI-UX/rosmobile_build_tools.git
+      url: git@github.com:application-ui-ux/mobile_catkin_modules_build_development_tools.git
       version: 0.4.2-1
     source:
       type: git
-      url: https://github.com/Application-UI-UX/rosmobile_build_tools/blob/main/README.md.git
+      url: https://github.com/application-ui-ux/mobile_catkin_modules_build_development_tools.git
       version: main
     status: maintained
   rospy_message_converter:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5529,6 +5529,21 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
       version: rolling
     status: developed
+  rosmobile_build_tools:
+    doc:
+      type: git
+      url: https://github.com/Application-UI-UX/rosmobile_build_tools/blob/main/README.md.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: git@github.com:Application-UI-UX/rosmobile_build_tools.git
+      version: 0.4.2-1
+    source:
+      type: git
+      url: https://github.com/Application-UI-UX/rosmobile_build_tools/blob/main/README.md.git
+      version: main
+    status: maintained
   rospy_message_converter:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5538,7 +5538,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: git@github.com:application-ui-ux/mobile_catkin_modules_build_development_tools.git
-      version: 0.4.2-1
+      version: 0.4.4
     source:
       type: git
       url: https://github.com/application-ui-ux/mobile_catkin_modules_build_development_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosmobile_build_tools` to `0.4.2-1`:

- upstream repository: git@github.com:Application-UI-UX/rosmobile_build_tools.git
- release repository: git@github.com:Application-UI-UX/rosmobile_build_tools.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## rosmobile_build_tools

```
* Fix countless bugs in the repository and recalibrate
* Release dedicated code for maven, ros, and python
* Maintainer & Contributors: Ronaldson Bellande
```
