### PR TITLE
mlx90640_thermal_camera: 1.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5599,7 +5599,7 @@ repositories:
       version: master
     release:
       packages:
-      - mlx90640-thermal-camera
+      - mlx90640_thermal_camera
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/vakshit/mlx90640_thermal_camera-release.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5592,6 +5592,24 @@ repositories:
       type: git
       url: https://github.com/221eROS/mitch_v2_driver.git
       version: main
+  mlx90640_thermal_camera:
+    doc:
+      type: git
+      url: https://github.com/vakshit/mlx90640_thermal_camera.git
+      version: master
+    release:
+      packages:
+      - mlx90640-thermal-camera
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/vakshit/mlx90640_thermal_camera-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/vakshit/mlx90640_thermal_camera.git
+      version: master
+    status: maintained
   mobile_robot_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mlx90640_thermal_camera` to `1.0.0-1`:

- upstream repository: https://github.com/vakshit/mlx90640_thermal_camera.git
- release repository: https://github.com/vakshit/mlx90640_thermal_camera-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
