### PR TITLE
Remove hebi_cpp_api_ros from Noetic.

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3544,23 +3544,6 @@ repositories:
       url: https://github.com/crigroup/handeye.git
       version: master
     status: maintained
-  hebi_cpp_api_ros:
-    doc:
-      type: git
-      url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
-      version: master
-    release:
-      packages:
-      - hebi_cpp_api
-      tags:
-        release: release/noetic/{package}/{version}
-      url: https://github.com/HebiRobotics/hebi_cpp_api_ros-release.git
-      version: 3.2.0-1
-    source:
-      type: git
-      url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
-      version: master
-    status: developed
   hector_gazebo:
     release:
       packages:


### PR DESCRIPTION
The license on the code is a non-standard license, not approved by the OSI.  Thus we can neither confirm nor deny whether we have the right to redistribute the sources and binaries contained within it.  Until that situation is clarified, we should remove it from the index.

@cwbollinger If we can quickly change the license in https://github.com/HebiRobotics/hebi_cpp_api_ros/blob/master/package.xml , then we don't need to do this revert.  If it is going to take time, however, we'll revert this for now and readd it once the license situation is cleared up.

@gbiggs @nuclearsandwich FYI.