### PR TITLE
nixos: Use generic python3Packages instead of specific python versions

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4947,7 +4947,7 @@ python3-bcrypt:
   debian: [python3-bcrypt]
   fedora: [python3-bcrypt]
   gentoo: [dev-python/bcrypt]
-  nixos: [python39Packages.bcrypt]
+  nixos: [python3Packages.bcrypt]
   opensuse: [python3-bcrypt]
   rhel: ['python%{python3_pkgversion}-bcrypt']
   ubuntu: [python3-bcrypt]
@@ -4958,7 +4958,7 @@ python3-bidict:
     buster: null
   fedora: [python3-bidict]
   freebsd: [py39-bidict]
-  nixos: [python310Packages.bidict]
+  nixos: [python3Packages.bidict]
   openembedded: [python3-bidict@meta-python]
   ubuntu:
     '*': [python3-bidict]
@@ -5197,7 +5197,7 @@ python3-cbor2:
         packages: [cbor2]
   fedora: [python3-cbor2]
   gentoo: [dev-python/cbor2]
-  nixos: [python39Packages.cbor2]
+  nixos: [python3Packages.cbor2]
   opensuse: [python-cbor2]
   osx:
     pip:
@@ -5214,7 +5214,7 @@ python3-certifi:
   debian: [python3-certifi]
   fedora: [python3-certifi]
   gentoo: [dev-python/certifi]
-  nixos: [python39Packages.certifi]
+  nixos: [python3Packages.certifi]
   opensuse: [python3-certifi]
   rhel: ['python%{python3_pkgversion}-certifi']
   ubuntu: [python3-certifi]
@@ -5926,7 +5926,7 @@ python3-flask:
   ubuntu: [python3-flask]
 python3-flask-bcrypt:
   debian: [python3-flask-bcrypt]
-  nixos: [python39Packages.flask-bcrypt]
+  nixos: [python3Packages.flask-bcrypt]
   ubuntu: [python3-flask-bcrypt]
 python3-flask-cors:
   debian: [python3-flask-cors]
@@ -5945,7 +5945,7 @@ python3-flask-jwt-extended:
       pip:
         packages: [flask-jwt-extended]
   freebsd: [py-flask-jwt-extended]
-  nixos: [python39Packages.flask-jwt-extended]
+  nixos: [python3Packages.flask-jwt-extended]
   opensuse: [python-flask-jwt-extended]
   ubuntu:
     '*': [python3-python-flask-jwt-extended]
@@ -5973,7 +5973,7 @@ python3-flask-sqlalchemy:
   debian: [python3-flask-sqlalchemy]
   fedora: [python3-flask-sqlalchemy]
   gentoo: [dev-python/flask-sqlalchemy]
-  nixos: [python39Packages.flask_sqlalchemy]
+  nixos: [python3Packages.flask_sqlalchemy]
   opensuse: [python-Flask-SQLAlchemy]
   rhel:
     '*': [python3-flask-sqlalchemy]
@@ -6229,7 +6229,7 @@ python3-graphviz:
   debian: [python3-graphviz]
   fedora: [python3-graphviz]
   gentoo: [dev-python/graphviz]
-  nixos: [python39Packages.graphviz]
+  nixos: [python3Packages.graphviz]
   opensuse: [python3-graphviz]
   ubuntu: [python3-graphviz]
 python3-grip:
@@ -6353,7 +6353,7 @@ python3-img2pdf:
   debian: [python3-img2pdf]
   fedora: [python3-img2pdf]
   gentoo: [media-gfx/img2pdf]
-  nixos: [python39Packages.img2pdf]
+  nixos: [python3Packages.img2pdf]
   opensuse: [python3-img2pdf]
   rhel:
     '*': [python3-img2pdf]
@@ -6482,7 +6482,7 @@ python3-jmespath:
   debian: [python3-jmespath]
   fedora: [python-jmespath]
   gentoo: [dev-python/jmespath]
-  nixos: [python39Packages.jmespath]
+  nixos: [python3Packages.jmespath]
   ubuntu: [python3-jmespath]
 python3-joblib:
   arch: [python-joblib]
@@ -6608,7 +6608,7 @@ python3-lockfile:
   debian: [python3-lockfile]
   fedora: [python3-lockfile]
   gentoo: [dev-python/lockfile]
-  nixos: [python39Packages.lockfile]
+  nixos: [python3Packages.lockfile]
   opensuse: [python-lockfile]
   rhel: [python3-lockfile]
   ubuntu: [python3-lockfile]
@@ -6642,7 +6642,7 @@ python3-magic:
   debian: [python3-magic]
   fedora: [python3-magic]
   gentoo: [dev-python/python-magic]
-  nixos: [python310Packages.magic]
+  nixos: [python3Packages.magic]
   opensuse: [python-magic]
   ubuntu: [python3-magic]
 python3-mako:
@@ -6685,7 +6685,7 @@ python3-marshmallow:
   debian: [python3-marshmallow]
   fedora: [python3-marshmallow]
   gentoo: [dev-python/marshmallow]
-  nixos: [python39Packages.marshmallow]
+  nixos: [python3Packages.marshmallow]
   opensuse: [python3-marshmallow]
   rhel:
     '*': ['python%{python3_pkgversion}-marshmallow']
@@ -6718,7 +6718,7 @@ python3-mccabe:
   debian: [python3-mccabe]
   fedora: [python3-mccabe]
   gentoo: [dev-python/mccabe]
-  nixos: [python310Packages.mccabe]
+  nixos: [python3Packages.mccabe]
   opensuse: [python3-mccabe]
   rhel: [python3-mccabe]
   ubuntu: [python3-mccabe]
@@ -6766,7 +6766,7 @@ python3-mistune:
   debian: [python3-mistune]
   fedora: [python3-mistune]
   gentoo: [dev-python/mistune]
-  nixos: [python39Packages.mistune]
+  nixos: [python3Packages.mistune]
   opensuse: [python3-mistune]
   osx:
     pip:
@@ -8083,7 +8083,7 @@ python3-qrcode:
   debian: [python3-qrcode]
   fedora: [python3-qrcode]
   gentoo: [dev-python/qrcode]
-  nixos: [python39Packages.qrcode]
+  nixos: [python3Packages.qrcode]
   opensuse: [python3-qrcode]
   rhel:
     '8': [python3-qrcode]
@@ -8351,7 +8351,7 @@ python3-schema:
   debian: [python3-schema]
   fedora: [python3-schema]
   freebsd: [py38-schema-0.7.5]
-  nixos: [python38Packages.schema]
+  nixos: [python3Packages.schema]
   opensuse: [python3-schema]
   osx:
     pip:
@@ -9096,7 +9096,7 @@ python3-tz:
   debian: [python3-tz]
   fedora: [python3-pytz]
   gentoo: [dev-python/pytz]
-  nixos: [python39Packages.pytz]
+  nixos: [python3Packages.pytz]
   rhel:
     '*': [python3-pytz]
     '7': null
@@ -9139,7 +9139,7 @@ python3-unidiff:
   debian: [python3-unidiff]
   fedora: [python3-unidiff]
   gentoo: [dev-python/unidiff]
-  nixos: [python39Packages.unidiff]
+  nixos: [python3Packages.unidiff]
   opensuse: [python-unidiff]
   rhel: [python3-unidiff]
   ubuntu: [python3-unidiff]
@@ -9262,7 +9262,7 @@ python3-webargs:
     buster:
       pip:
         packages: [webargs]
-  nixos: [python39Packages.webargs]
+  nixos: [python3Packages.webargs]
   ubuntu:
     '*': [python3-webargs]
     bionic:


### PR DESCRIPTION
Correct nixos packages to use the generic Python 3 package set and not tie to a specific minor version.