### PR TITLE
weight_scale_interfaces: 0.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8798,7 +8798,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/TechMagicKK/weight_scale_interfaces-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/TechMagicKK/weight_scale_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `weight_scale_interfaces` to `0.0.3-1`:

- upstream repository: https://github.com/TechMagicKK/weight_scale_interfaces.git
- release repository: https://github.com/TechMagicKK/weight_scale_interfaces-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.2-1`

## weight_scale_interfaces

```
* Added action msgs dependence
* Contributors: Jiaqing Lin
```
