### PR TITLE
neonavigation: 0.16.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6381,7 +6381,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.15.0-1
+      version: 0.16.0-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.16.0-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.15.0-1`

## costmap_cspace

```
* costmap_cspace: add linear_spread_min_cost parameter (#719 <https://github.com/at-wat/neonavigation/issues/719>)
* Contributors: Naotaka Hatao
```

## joystick_interrupt

- No changes

## map_organizer

- No changes

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

- No changes

## obj_to_pointcloud

- No changes

## planner_cspace

```
* planner_cspace: start planning from expected robot pose (#717 <https://github.com/at-wat/neonavigation/issues/717>)
* planner_cspace: add new parameters for cost function (#720 <https://github.com/at-wat/neonavigation/issues/720>)
* planner_cspace: refactor start pose building algorithm and fix finishing condition when start is relocated (#718 <https://github.com/at-wat/neonavigation/issues/718>)
* Contributors: Naotaka Hatao
```

## safety_limiter

- No changes

## track_odometry

- No changes

## trajectory_tracker

```
* planner_cspace: start planning from expected robot pose (#717 <https://github.com/at-wat/neonavigation/issues/717>)
* Contributors: Naotaka Hatao
```
