### PR TITLE
reach_ros: 1.3.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5209,7 +5209,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/reach_ros2-release.git
-      version: 1.3.1-3
+      version: 1.3.2-1
     source:
       type: git
       url: https://github.com/ros-industrial/reach_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `reach_ros` to `1.3.2-1`:

- upstream repository: https://github.com/ros-industrial/reach_ros2
- release repository: https://github.com/ros2-gbp/reach_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.1-3`

## reach_ros

```
* Updated CMake version for if STRGREATER_EQUAL command (#23 <https://github.com/marip8/reach_ros2/issues/23>)
* Contributors: Michael Ripperger
```
