### PR TITLE
dbw_polaris_ros: 1.1.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1846,7 +1846,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_polaris_ros-release.git
-      version: 1.1.0-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/dbw_polaris_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_polaris_ros` to `1.1.2-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/dbw_polaris_ros.git
- release repository: https://github.com/DataspeedInc-release/dbw_polaris_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-1`

## dbw_polaris

- No changes

## dbw_polaris_can

```
* Bump firmware versions
* Contributors: Kevin Hallenbeck
```

## dbw_polaris_description

- No changes

## dbw_polaris_joystick_demo

- No changes

## dbw_polaris_msgs

- No changes
