### PR TITLE
ecal: 5.12.0-3 in 'iron/distribution.yaml'

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1096,7 +1096,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ecal-release.git
-      version: 5.12.0-1
+      version: 5.12.0-3
     source:
       type: git
       url: https://github.com/eclipse-ecal/ecal.git


### PR DESCRIPTION
Increasing version of package(s) in repository ecal to 5.12.0-3:

upstream repository: https://github.com/eclipse-ecal/ecal.git
release repository: https://github.com/ros2-gbp/ecal-release.git
distro file: iron/distribution.yaml

- change cmake option
- disable lto to avoid [lto wrapper error](https://build.ros2.org/job/Hbin_uJ64__ecal__ubuntu_jammy_amd64__binary/15/console)