### PR TITLE
depthai-ros: 2.8.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -954,7 +954,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/luxonis/depthai-ros-release.git
-      version: 2.8.0-1
+      version: 2.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai-ros` to `2.8.1-1`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: https://github.com/luxonis/depthai-ros-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.8.0-1`

## depthai-ros

```
* Added support for OpenCV Stereo order convention
* Added disparity to depth use spec translation parameter
* Updated sensor socket logic
* Fixed issues when running robot_state_publisher as component
* Added missing tf2 dependencies
```
