### PR TITLE
ros2_controllers: 2.25.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5865,7 +5865,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.24.0-1
+      version: 2.25.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.25.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.24.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

```
* Update docs for diff drive controller (#751 <https://github.com/ros-controls/ros2_controllers/issues/751>) (#753 <https://github.com/ros-controls/ros2_controllers/issues/753>)
* Contributors: Christoph Fröhlich
```

## bicycle_steering_controller

- No changes

## diff_drive_controller

```
* removed duplicated previous_publish_timestamp_ increment by publish_period_ in diff_drive_controller.cpp (#644 <https://github.com/ros-controls/ros2_controllers/issues/644>) (#777 <https://github.com/ros-controls/ros2_controllers/issues/777>)
* Update docs for diff drive controller (#751 <https://github.com/ros-controls/ros2_controllers/issues/751>) (#753 <https://github.com/ros-controls/ros2_controllers/issues/753>)
* Contributors: Christoph Fröhlich, Jules CARPENTIER
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

```
* Use tabs (#743 <https://github.com/ros-controls/ros2_controllers/issues/743>) (#746 <https://github.com/ros-controls/ros2_controllers/issues/746>)
* Contributors: Christoph Fröhlich
```

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* [JTC] Rename parameter: normalize_error to angle_wraparound (#772 <https://github.com/ros-controls/ros2_controllers/issues/772>) (#776 <https://github.com/ros-controls/ros2_controllers/issues/776>)
* Remove wrong description (#742 <https://github.com/ros-controls/ros2_controllers/issues/742>) (#747 <https://github.com/ros-controls/ros2_controllers/issues/747>)
* [JTC] Update trajectory documentation (#714 <https://github.com/ros-controls/ros2_controllers/issues/714>) (#741 <https://github.com/ros-controls/ros2_controllers/issues/741>)
* Contributors: Christoph Fröhlich
```

## position_controllers

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

- No changes

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
