### PR TITLE
Update techmagic repositories to use ros2-gbp release repo.

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -18,7 +18,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/TechMagicKK/aandd_ekew_driver_py-release.git
+      url: https://github.com/ros2-gbp/aandd_ekew_driver_py-release.git
       version: 0.0.2-1
     source:
       test_pull_requests: true
@@ -8843,7 +8843,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/TechMagicKK/weight_scale_interfaces-release.git
+      url: https://github.com/ros2-gbp/weight_scale_interfaces-release.git
       version: 0.0.3-1
     source:
       type: git


### PR DESCRIPTION
These repositories have been mirrored into the ros2-gbp organization and the ros2-gbp copies should be used for releases going forward.

@Kansea please give a 👍🏼 or Approving review before the ROS team merges this PR.