### PR TITLE
mqtt_client: 2.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5996,7 +5996,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ika-rwth-aachen/mqtt_client-release.git
-      version: 2.0.1-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/ika-rwth-aachen/mqtt_client.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mqtt_client` to `2.1.0-1`:

- upstream repository: https://github.com/ika-rwth-aachen/mqtt_client.git
- release repository: https://github.com/ika-rwth-aachen/mqtt_client-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.1-1`

## mqtt_client

```
* Merge pull request #31 from ika-rwth-aachen/features/ros2-component
  ROS2 Component
* Merge pull request #30 from oxin-ros/ros2-add-multiple-topics
  ROS 2: add multiple topics
* Merge pull request #28 from oxin-ros/add-ALPN-protocol-support-for-aws
  Add ALPN protocol support for AWS
* Contributors: David B, David Buckman, Lennart Reiher
```

## mqtt_client_interfaces

- No changes
