### PR TITLE
point_cloud_transport: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3724,11 +3724,24 @@ repositories:
       version: rolling
     status: developed
   point_cloud_transport:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/point_cloud_transport_tutorial.git
+      version: rolling
+    release:
+      packages:
+      - point_cloud_transport
+      - point_cloud_transport_py
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/point_cloud_transport-release.git
+      version: 2.0.0-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/point_cloud_transport.git
       version: rolling
+    status: maintained
   point_cloud_transport_plugins:
     source:
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `2.0.0-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## point_cloud_transport

```
* Removed warning (#28 <https://github.com/ros-perception/point_cloud_transport/issues/28>)
* Added point_cloud_transport_py (#26 <https://github.com/ros-perception/point_cloud_transport/issues/26>)
* Bug fixes from porting tutorials (#18 <https://github.com/ros-perception/point_cloud_transport/issues/18>)
* Use whitelist instead of blacklist (#13 <https://github.com/ros-perception/point_cloud_transport/issues/13>)
* Add ThirdParty folder to support building offline without FetchContent (#12 <https://github.com/ros-perception/point_cloud_transport/issues/12>)
* Fix pointcloud-codec and python bindings (#3 <https://github.com/ros-perception/point_cloud_transport/issues/3>)
* Contributors: Alejandro Hernández Cordero, john-maidbot
```

## point_cloud_transport_py

```
* Added point_cloud_transport_py (#26 <https://github.com/ros-perception/point_cloud_transport/issues/26>)
* Contributors: Alejandro Hernández Cordero
```
