### PR TITLE
point_cloud_transport: 1.0.12-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4553,6 +4553,24 @@ repositories:
       url: https://gitlab.com/ApexAI/point_cloud_msg_wrapper
       version: rolling
     status: developed
+  point_cloud_transport:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/point_cloud_transport_tutorial.git
+      version: rolling
+    release:
+      packages:
+      - point_cloud_transport
+      - point_cloud_transport_py
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/point_cloud_transport-release.git
+      version: 1.0.12-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/point_cloud_transport.git
+      version: rolling
+    status: maintained
   pointcloud_to_laserscan:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4556,8 +4556,8 @@ repositories:
   point_cloud_transport:
     doc:
       type: git
-      url: https://github.com/ros-perception/point_cloud_transport_tutorial.git
-      version: rolling
+      url: https://github.com/ros-perception/point_cloud_transport.git
+      version: humble
     release:
       packages:
       - point_cloud_transport
@@ -4569,7 +4569,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-perception/point_cloud_transport.git
-      version: rolling
+      version: humble
     status: maintained
   pointcloud_to_laserscan:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `1.0.12-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## point_cloud_transport

```
* ROS2 port
* Contributors: Alejandro Hernández Cordero, John D'Angelo
```

## point_cloud_transport_py

```
* Added point_cloud_transport_py (#26 <https://github.com/ros-perception/point_cloud_transport/issues/26>)
* Contributors: Alejandro Hernández Cordero
```
