### PR TITLE
twist_mux: 4.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6805,7 +6805,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/twist_mux-release.git
-      version: 4.1.0-3
+      version: 4.2.0-1
     source:
       type: git
       url: https://github.com/ros-teleop/twist_mux.git


### PR DESCRIPTION
Increasing version of package(s) in repository `twist_mux` to `4.2.0-1`:

- upstream repository: https://github.com/ros-teleop/twist_mux.git
- release repository: https://github.com/ros2-gbp/twist_mux-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.1.0-3`

## twist_mux

```
* Joystick relay for ROS 2 (#43 <https://github.com/ros-teleop/twist_mux/issues/43>)
* Add CI (#47 <https://github.com/ros-teleop/twist_mux/issues/47>)
* Clean up parameter warnings for Rolling (#28 <https://github.com/ros-teleop/twist_mux/issues/28>)
* Contributors: Bence Magyar, Noel Jiménez García, Stephen Street
```
