### PR TITLE
Add some missing gentoo packages and fix wrong names for the existing ones

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -185,7 +185,7 @@ at-spi2-core:
   arch: [at-spi2-core]
   debian: [at-spi2-core]
   fedora: [at-spi2-core]
-  gentoo: [at-spi2-core]
+  gentoo: [app-accessibility/at-spi2-core]
   nixos: [at-spi2-core]
   rhel: [at-spi2-core]
   ubuntu: [at-spi2-core]
@@ -324,6 +324,7 @@ benchmark:
     '*': [libbenchmark-dev]
     stretch: null
   fedora: [google-benchmark-devel]
+  gentoo: [dev-cpp/benchmark]
   nixos: [gbenchmark]
   openembedded: [google-benchmark@meta-ros2]
   rhel: [google-benchmark-devel]
@@ -450,6 +451,7 @@ cargo:
   archlinux: [rust]
   debian: [cargo]
   fedora: [cargo]
+  gentoo: [virtual/rust]
   nixos: [cargo]
   opensuse: [cargo]
   rhel: [cargo]
@@ -468,7 +470,7 @@ catch2:
     '*': [catch2-devel]
     '37': null
   freebsd: [catch2]
-  gentoo: [catch]
+  gentoo: [dev-cpp/catch]
   nixos: [catch2]
   ubuntu:
     '*': [catch2]
@@ -962,7 +964,7 @@ exiv2:
   arch: [exiv2]
   debian: [exiv2]
   fedora: [exiv2]
-  gentoo: [exiv2]
+  gentoo: [media-gfx/exiv2]
   nixos: [exiv2]
   opensuse: [exiv2]
   osx:
@@ -1039,6 +1041,7 @@ file:
   arch: [file]
   debian: [file]
   fedora: [file]
+  gentoo: [sys-apps/file]
   nixos: [file]
   openembedded: [file@openembedded-core]
   rhel: [file]
@@ -1296,6 +1299,7 @@ gdal-bin:
 geographiclib:
   debian: [libgeographic-dev]
   fedora: [GeographicLib-devel]
+  gentoo: [sci-geosciences/GeographicLib]
   nixos: [geographiclib]
   openembedded: [geographiclib@meta-ros-common]
   rhel: [GeographicLib-devel]
@@ -1303,6 +1307,7 @@ geographiclib:
 geographiclib-tools:
   debian: [geographiclib-tools]
   fedora: [GeographicLib]
+  gentoo: [sci-geosciences/GeographicLib]
   nixos: [geographiclib]
   openembedded: [geographiclib@meta-ros-common]
   rhel: [GeographicLib]
@@ -1880,6 +1885,7 @@ hdf5:
   ubuntu: [libhdf5-dev]
 hdf5-tools:
   debian: [hdf5-tools]
+  gentoo: [sci-libs/hdf5]
   nixos: [hdf5]
   ubuntu: [hdf5-tools]
 hostapd:
@@ -1934,6 +1940,7 @@ ignition-cmake2:
   debian:
     bookworm: [libignition-cmake-dev]
     buster: [libignition-cmake2-dev]
+  gentoo: ['dev-util/ignition-cmake:2']
   nixos: [ignition.cmake2]
   ubuntu:
     focal: [libignition-cmake2-dev]
@@ -1941,6 +1948,7 @@ ignition-cmake2:
 ignition-common3:
   debian:
     buster: [libignition-common3-dev]
+  gentoo: ['sci-libs/ignition-common:3']
   nixos: [ignition.common3]
   ubuntu:
     focal: [libignition-common3-dev]
@@ -1964,6 +1972,7 @@ ignition-fortress:
 ignition-fuel-tools4:
   debian:
     buster: [libignition-fuel-tools4-dev]
+  gentoo: ['sci-libs/ignition-fuel-tools:4']
   nixos: [ignition.fuel-tools4]
   ubuntu:
     focal: [libignition-fuel-tools4-dev]
@@ -2041,6 +2050,7 @@ ignition-math6:
   debian:
     bookworm: [libignition-math-dev]
     buster: [libignition-math6-dev]
+  gentoo: ['sci-libs/ignition-math:6']
   nixos: [ignition.math6]
   ubuntu:
     focal: [libignition-math6-dev]
@@ -2048,6 +2058,7 @@ ignition-math6:
 ignition-math6-eigen3:
   debian:
     buster: [libignition-math6-eigen3-dev]
+  gentoo: ['sci-libs/ignition-math:6']
   nixos: [ignition.math6]
   ubuntu:
     focal: [libignition-math6-eigen3-dev]
@@ -2977,6 +2988,7 @@ libclang-dev:
   arch: [clang]
   debian: [libclang-dev]
   fedora: [clang-devel]
+  gentoo: [sys-devel/clang]
   nixos: [clang]
   rhel: [clang-devel]
   ubuntu: [libclang-dev]
@@ -3631,6 +3643,7 @@ libgphoto-dev:
 libgpiod-dev:
   debian: [libgpiod-dev]
   fedora: [libgpiod-devel]
+  gentoo: [dev-libs/libgpiod]
   nixos: [libgpiod]
   opensuse: [libgpiod-devel]
   rhel:
@@ -3832,6 +3845,7 @@ libignition-launch4:
 libignition-math6:
   debian:
     buster: [libignition-math6]
+  gentoo: ['sci-libs/ignition-math:6']
   nixos: [ignition.math6]
   ubuntu:
     focal: [libignition-math6]
@@ -4373,6 +4387,7 @@ libomp-dev:
   arch: [openmp]
   debian: [libomp-dev]
   fedora: [libomp-devel]
+  gentoo: [sys-libs/libomp]
   nixos: [llvmPackages.openmp]
   rhel:
     '*': [libomp-devel]
@@ -4402,6 +4417,7 @@ libopenal-dev:
 libopenblas-dev:
   debian: [libopenblas-dev]
   fedora: [openblas-devel]
+  gentoo: [sci-libs/openblas]
   nixos: [openblas]
   openembedded: [openblas@meta-ros-common]
   rhel: [openblas-devel]
@@ -5111,6 +5127,7 @@ libqd-dev:
 libqglviewer-dev-qt5:
   debian: [libqglviewer-dev-qt5]
   fedora: [libQGLViewer-qt5-devel]
+  gentoo: [x11-libs/libQGLViewer]
   nixos: [libsForQt5.libqglviewer]
   openembedded: [qtbase@meta-qt5]
   rhel:
@@ -5141,6 +5158,7 @@ libqglviewer-qt4-dev:
 libqglviewer2-qt5:
   debian: [libqglviewer2-qt5]
   fedora: [libQGLViewer-qt5]
+  gentoo: [x11-libs/libQGLViewer]
   nixos: [libsForQt5.libqglviewer]
   rhel:
     '*': [libQGLViewer-qt5]
@@ -5318,11 +5336,13 @@ libqt5-printsupport:
   ubuntu: [libqt5printsupport5]
 libqt5-qml:
   debian: [libqt5qml5]
+  gentoo: ['dev-qt/qtdeclarative:5']
   nixos: [qt5.qtdeclarative]
   rhel: [qt5-qtdeclarative]
   ubuntu: [libqt5qml5]
 libqt5-quick:
   debian: [libqt5quick5]
+  gentoo: ['dev-qt/qtdeclarative:5']
   nixos: [qt5.qtdeclarative]
   rhel: [qt5-qtdeclarative]
   ubuntu: [libqt5quick5]
@@ -5356,6 +5376,7 @@ libqt5-svg:
   arch: [qt5-svg]
   debian: [libqt5svg5]
   fedora: [qt5-qtsvg]
+  gentoo: ['dev-qt/qtsvg:5']
   nixos: [qt5.qtsvg]
   opensuse: [libqt5-qtsvg]
   rhel: [qt5-qtsvg]
@@ -5848,7 +5869,7 @@ libusb:
   arch: [libusb-compat]
   debian: [libusb-0.1-4]
   fedora: [libusb]
-  gentoo: [virtual/libusb]
+  gentoo: ['virtual/libusb:0']
   macports: [libusb]
   nixos: [libusb-compat-0_1]
   ubuntu: [libusb-0.1-4]
@@ -6021,7 +6042,7 @@ libwebsocketpp-dev:
   arch: [websocketpp]
   debian: [libwebsocketpp-dev]
   fedora: [websocketpp-devel]
-  gentoo: [websocketpp]
+  gentoo: [dev-cpp/websocketpp]
   nixos: [websocketpp]
   openembedded: [websocketpp@meta-oe]
   rhel: [websocketpp-devel]
@@ -6467,6 +6488,7 @@ mapnik-utils:
 matio:
   debian: [libmatio-dev]
   fedora: [matio-devel]
+  gentoo: [sci-libs/matio]
   nixos: [matio]
   rhel:
     '*': null
@@ -6830,6 +6852,7 @@ opencl-headers:
   arch: [opencl-headers]
   debian: [opencl-headers]
   fedora: [opencl-headers]
+  gentoo: [dev-util/opencl-headers]
   nixos: [opencl-headers]
   openembedded: [opencl-headers@meta-oe]
   rhel: [opencl-headers]
@@ -6882,7 +6905,7 @@ openni-dev:
 openocd:
   debian: [openocd]
   fedora: [openocd]
-  gentoo: [openocd]
+  gentoo: [dev-embedded/openocd]
   nixos: [openocd]
   ubuntu: [openocd]
 opensplice:
@@ -7157,12 +7180,13 @@ pstoedit:
 psutils:
   debian: [psutils]
   fedora: [psutils]
-  gentoo: [psutils]
+  gentoo: [app-text/psutils]
   nixos: [psutils]
   ubuntu: [psutils]
 pugixml-dev:
   debian: [libpugixml-dev]
   fedora: [pugixml-devel]
+  gentoo: [dev-libs/pugixml]
   nixos: [pugixml]
   openembedded: [pugixml@meta-oe]
   rhel: [pugixml-devel]
@@ -7171,6 +7195,7 @@ pybind11-dev:
   arch: [pybind11]
   debian: [pybind11-dev]
   fedora: [pybind11-devel]
+  gentoo: [dev-python/pybind11]
   nixos: [pythonPackages.pybind11]
   openembedded: [python3-pybind11@meta-python]
   rhel:
@@ -7212,6 +7237,7 @@ qml-module-qtmultimedia:
   ubuntu: [qml-module-qtmultimedia]
 qml-module-qtquick-controls:
   debian: [qml-module-qtquick-controls]
+  gentoo: [dev-qt/qtquickcontrols]
   ubuntu: [qml-module-qtquick-controls]
 qml-module-qtquick-controls2:
   debian: [qml-module-qtquick-controls2]
@@ -7221,6 +7247,7 @@ qml-module-qtquick-dialogs:
   ubuntu: [qml-module-qtquick-dialogs]
 qml-module-qtquick-extras:
   debian: [qml-module-qtquick-extras]
+  gentoo: [dev-qt/qtquickcontrols]
   ubuntu: [qml-module-qtquick-extras]
 qml-module-qtquick-layouts:
   debian: [qml-module-qtquick-layouts]
@@ -8165,7 +8192,7 @@ util-linux:
     '*': [util-linux]
     stretch: [setpriv, util-linux]
   fedora: [util-linux]
-  gentoo: [util-linux]
+  gentoo: [sys-apps/util-linux]
   macports: [util-linux]
   nixos: [util-linux]
   openembedded: [util-linux@openembedded-core]
@@ -8399,6 +8426,7 @@ xsimd:
     bullseye: null
     buster: null
   fedora: [xsimd-devel]
+  gentoo: [dev-cpp/xsimd]
   nixos: [xsimd]
   rhel:
     '*': [xsimd-devel]
@@ -8526,7 +8554,7 @@ zeromq3:
   arch: [zeromq]
   debian: [libzmq5]
   fedora: [zeromq]
-  gentoo: [zeromq]
+  gentoo: [net-libs/zeromq]
   nixos: [zeromq]
   ubuntu: [libzmq5]
 zip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5030,6 +5030,7 @@ python3-bosdyn-mission-pip:
 python3-boto3:
   debian: [python3-boto3]
   fedora: [python3-boto3]
+  gentoo: [dev-python/boto3]
   nixos: [python3Packages.boto3]
   openembedded: [python3-boto3@meta-ros-common]
   opensuse: [python3-boto3]
@@ -5259,6 +5260,7 @@ python3-collada:
     buster: null
     stretch: null
   fedora: [python3-collada]
+  gentoo: [dev-python/pycollada]
   nixos: [python3Packages.pycollada]
   rhel: ['python%{python3_pkgversion}-collada']
   ubuntu:
@@ -5405,6 +5407,7 @@ python3-dateutil:
 python3-dbus:
   debian: [python3-dbus]
   fedora: [python3-dbus]
+  gentoo: [dev-python/dbus-python]
   nixos: [python3Packages.dbus-python]
   openembedded: [python3-dbus@openembedded-core]
   rhel: [python3-dbus]
@@ -6418,7 +6421,7 @@ python3-importlib-metadata:
       pip:
         packages: [importlib-metadata]
   fedora: [python3]
-  gentoo: [dev-python/importlib_metadata]
+  gentoo: [dev-python/importlib-metadata]
   nixos: [python3Packages.importlib-metadata]
   openembedded: [python3-importlib-metadata@openembedded-core]
   osx:
@@ -6444,7 +6447,7 @@ python3-importlib-resources:
       pip:
         packages: [importlib-resources]
   fedora: [python3]
-  gentoo: [dev-python/importlib_resources]
+  gentoo: [dev-lang/python]
   nixos: [python3Packages.importlib-resources]
   openembedded: [python3@openembedded-core]
   osx:
@@ -6633,7 +6636,7 @@ python3-libgpiod:
   arch: [libgpiod]
   debian: [python3-libgpiod]
   fedora: [python3-libgpiod]
-  gentoo: [dev-libs/libgpiod]
+  gentoo: ['dev-libs/libgpiod[python]']
   nixos: [python3Packages.libgpiod]
   opensuse: [python3-gpiod]
   rhel:
@@ -6947,6 +6950,7 @@ python3-myst-parser-pip:
 python3-natsort:
   debian: [python3-natsort]
   fedora: [python3-natsort]
+  gentoo: [dev-python/natsort]
   nixos: [python3Packages.natsort]
   opensuse: [python3-natsort]
   rhel: [python3-natsort]
@@ -7030,6 +7034,7 @@ python3-nose-yanc:
 python3-ntplib:
   debian: [python3-ntplib]
   fedora: [python3-ntplib]
+  gentoo: [dev-python/ntplib]
   nixos: [python3Packages.ntplib]
   opensuse: [python3-ntplib]
   rhel:
@@ -7359,6 +7364,7 @@ python3-pip:
   alpine: [py3-pip]
   debian: [python3-pip]
   fedora: [python3-pip]
+  gentoo: [dev-python/pip]
   nixos: [python3Packages.pip]
   openembedded: [python3-pip@openembedded-core]
   opensuse: [python3-pip]
@@ -7875,6 +7881,7 @@ python3-pyqt5.qtquick:
 python3-pyqt5.qtwebengine:
   debian: [python3-pyqt5.qtwebengine]
   fedora: [python3-qt5-webengine]
+  gentoo: [dev-python/PyQtWebEngine]
   nixos: [python3Packages.pyqtwebengine]
   openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
   opensuse: [python3-qtwebengine-qt5]
@@ -8231,12 +8238,14 @@ python3-reportlab:
 python3-requests:
   debian: [python3-requests]
   fedora: [python3-requests]
+  gentoo: [dev-python/requests]
   nixos: [python3Packages.requests]
   openembedded: [python3-requests@meta-python]
   rhel: ['python%{python3_pkgversion}-requests']
   ubuntu: [python3-requests]
 python3-requests-futures:
   debian: [python3-requests-futures]
+  gentoo: [dev-python/requests-futures]
   opensuse: [python3-requests-futures]
   ubuntu: [python3-requests-futures]
 python3-requests-oauthlib:
@@ -8374,6 +8383,7 @@ python3-rospkg-modules:
 python3-rtree:
   debian: [python3-rtree]
   fedora: [python3-rtree]
+  gentoo: [sci-libs/rtree]
   nixos: [python3Packages.Rtree]
   rhel:
     '*': [python3-rtree]
@@ -8495,6 +8505,7 @@ python3-sense-hat-pip:
 python3-serial:
   debian: [python3-serial]
   fedora: [python3-pyserial]
+  gentoo: [dev-python/pyserial]
   nixos: [python3Packages.pyserial]
   openembedded: [python3-pyserial@meta-python]
   rhel:
@@ -8726,6 +8737,7 @@ python3-sparkfun-ublox-gps-pip:
 python3-sphinx:
   debian: [python3-sphinx]
   fedora: [python3-sphinx]
+  gentoo: [dev-python/sphinx]
   nixos: [python3Packages.sphinx]
   openembedded: [python3-sphinx@meta-ros-common]
   opensuse: [python3-Sphinx]
@@ -8734,6 +8746,7 @@ python3-sphinx:
 python3-sphinx-argparse:
   debian: [python3-sphinx-argparse]
   fedora: [python3-sphinx-argparse]
+  gentoo: [dev-python/sphinx-argparse]
   nixos: [python3Packages.sphinx-argparse]
   ubuntu: [python3-sphinx-argparse]
 python3-sphinx-autoapi-pip:
@@ -8970,6 +8983,7 @@ python3-timm-pip:
 python3-tk:
   debian: [python3-tk]
   fedora: [python3-tkinter]
+  gentoo: ['dev-lang/python[tk]']
   nixos: [python3Packages.tkinter]
   openembedded: [python3-tkinter@openembedded-core]
   opensuse: [python3-tk]
@@ -9101,6 +9115,7 @@ python3-typeguard:
   arch: [python-typeguard]
   debian: [python3-typeguard]
   fedora: [python3-typeguard]
+  gentoo: [dev-python/typeguard]
   nixos: [python3Packages.typeguard]
   osx:
     pip:
@@ -9245,6 +9260,7 @@ python3-vedo-pip:
 python3-venv:
   debian: [python3-venv]
   fedora: [python3-libs]
+  gentoo: [dev-lang/python]
   nixos: [python3]
   opensuse: [python3-virtualenv]
   osx:


### PR DESCRIPTION
Please update gentoo package names for the following dependencies in the rosdep database.

## Base

|Rosdep package name|Gentoo package name|
|----------------------------|----------------------------------|
|`at-spi2-core`         |Add category: `at-spi2-core` -> [`app-accessibility/at-spi2-core`](https://packages.gentoo.org/packages/app-accessibility/at-spi2-core)|
|`benchmark`            |[`dev-cpp/benchmark`](https://packages.gentoo.org/packages/dev-cpp/benchmark)|
|`cargo`                |[`virtual/rust`](https://packages.gentoo.org/packages/virtual/rust)|
|`catch2`               |Add category: `catch` -> [`dev-cpp/catch`](https://packages.gentoo.org/packages/dev-cpp/catch)|
|`exiv2`                |Add category: `exiv2` -> [`media-gfx/exiv2`](https://packages.gentoo.org/packages/media-gfx/exiv2)|
|`file`                 |[`sys-apps/file`](https://packages.gentoo.org/packages/sys-apps/file)|
|`geographiclib`        |[`sci-geosciences/GeographicLib`](https://packages.gentoo.org/packages/sci-geosciences/GeographicLib)|
|`geographiclib-tools`  |[`sci-geosciences/GeographicLib`](https://packages.gentoo.org/packages/sci-geosciences/GeographicLib)|
|`hdf5-tools`           |[`sci-libs/hdf5`](https://packages.gentoo.org/packages/sci-libs/hdf5)|
|`ignition-cmake2`      |[`'dev-util/ignition-cmake:2'`](https://packages.gentoo.org/packages/dev-util/ignition-cmake)|
|`ignition-common3`     |[`'sci-libs/ignition-common:3'`](https://packages.gentoo.org/packages/sci-libs/ignition-common)|
|`ignition-fuel-tools4` |[`'sci-libs/ignition-fuel-tools:4'`](https://packages.gentoo.org/packages/sci-libs/ignition-fuel-tools)|
|`ignition-math6`       |[`'sci-libs/ignition-math:6'`](https://packages.gentoo.org/packages/sci-libs/ignition-math)|
|`ignition-math6-eigen3`|[`'sci-libs/ignition-math:6'`](https://packages.gentoo.org/packages/sci-libs/ignition-math)|
|`libclang-dev`         |[`sys-devel/clang`](https://packages.gentoo.org/packages/sys-devel/clang)|
|`libgpiod-dev`         |[`dev-libs/libgpiod`](https://packages.gentoo.org/packages/dev-libs/libgpiod)|
|`libignition-math6`    |[`'sci-libs/ignition-math:6'`](https://packages.gentoo.org/packages/sci-libs/ignition-math)|
|`libomp-dev`           |[`sys-libs/libomp`](https://packages.gentoo.org/packages/sys-libs/libomp)|
|`libopenblas-dev`      |[`sci-libs/openblas`](https://packages.gentoo.org/packages/sci-libs/openblas)|
|`ibqglviewer-dev-qt5`  |[`x11-libs/libQGLViewer`](https://packages.gentoo.org/packages/x11-libs/libQGLViewer)|
|`libqglviewer2-qt5`    |[`x11-libs/libQGLViewer`](https://packages.gentoo.org/packages/x11-libs/libQGLViewer)|
|`libqt5-qml`           |[`'dev-qt/qtdeclarative:5'`](https://packages.gentoo.org/packages/dev-qt/qtdeclarative)|
|`libqt5-quick`         |[`'dev-qt/qtdeclarative:5'`](https://packages.gentoo.org/packages/dev-qt/qtdeclarative)|
|`libqt5-svg`           |[`'dev-qt/qtsvg:5'`](https://packages.gentoo.org/packages/dev-qt/qtsvg)|
|`libusb`               |Add slot: `virtual/libusb` -> [`'virtual/libusb:0'`](https://packages.gentoo.org/packages/virtual/libusb)|
|`libwebsocketpp-dev`   |Add category: `websocketpp` -> [`dev-cpp/websocketpp`](https://packages.gentoo.org/packages/dev-cpp/websocketpp)|
|`matio`                |[`sci-libs/matio`](https://packages.gentoo.org/packages/sci-libs/matio)|
|`opencl-headers`       |[`dev-util/opencl-headers`](https://packages.gentoo.org/packages/dev-util/opencl-headers)|
|`openocd`              |Add category: `openocd` -> [`dev-embedded/openocd`](https://packages.gentoo.org/packages/dev-embedded/openocd)|
|`psutils`              |Add category: `psutils` -> [`app-text/psutils`](https://packages.gentoo.org/packages/app-text/psutils)|
|`pugixml-dev`          |[`dev-libs/pugixml`](https://packages.gentoo.org/packages/dev-libs/pugixml)|
|`pybind11-dev`         |[`dev-python/pybind11`](https://packages.gentoo.org/packages/dev-python/pybind11)|
|`qml-module-qtquick-controls`|[`dev-qt/qtquickcontrols`](https://packages.gentoo.org/packages/dev-qt/qtquickcontrols)|
|`qml-module-qtquick-extras`|[`dev-qt/qtquickcontrols`](https://packages.gentoo.org/packages/dev-qt/qtquickcontrols)|
|`util-linux`           |Add category: `util-linux` -> [`sys-apps/util-linux`](https://packages.gentoo.org/packages/sys-apps/util-linux)|
|`xsimd`                |[`dev-cpp/xsimd`](https://packages.gentoo.org/packages/dev-cpp/xsimd)|
|`zeromq`|Add category: `zeromq` -> [`net-libs/zeromq`](https://packages.gentoo.org/packages/net-libs/zeromq)|

## Python
|Rosdep package name|Gentoo package name|
|----------------------------|----------------------------------|
|`python3-boto3`|[`dev-python/boto3`](https://packages.gentoo.org/packages/dev-python/boto3)|
|`python3-collada`|[`dev-python/pycollada`](https://packages.gentoo.org/packages/dev-python/pycollada)|
|`python3-importlib-metadata`|Rename: `dev-python/importlib_metadata` -> [`dev-python/importlib-metadata`](https://packages.gentoo.org/packages/dev-python/importlib-metadata)|
|`python3-importlib-resources`|Removed. Is now part of [`dev-lang/python`](https://packages.gentoo.org/packages/dev-lang/python)|
|`python3-libgpiod`|Add useflag: [`'dev-libs/libgpiod[python]'`](https://packages.gentoo.org/packages/dev-libs/libgpiod)|
|`python3-natsort`|[`dev-python/natsort`](https://packages.gentoo.org/packages/dev-python/natsort)|
|`python3-ntplib`|[`dev-python/ntplib`](https://packages.gentoo.org/packages/dev-python/ntplib)|
|`python3-pip`|[`dev-python/pip`](https://packages.gentoo.org/packages/dev-python/pip)|
|`python3-pyqt5.qtwebengine`|[`dev-python/PyQtWebEngine`](https://packages.gentoo.org/packages/dev-python/PyQtWebEngine)|
|`python3-requests`|[`dev-python/requests`](https://packages.gentoo.org/packages/dev-python/requests)|
|`python3-requests-futures`|[`dev-python/requests-futures`](https://packages.gentoo.org/packages/dev-python/requests-futures)|
|`python3-rtree`|[`sci-libs/rtree`](https://packages.gentoo.org/packages/sci-libs/rtree)|
|`python3-serial`|[`dev-python/pyserial`](https://packages.gentoo.org/packages/dev-python/pyserial)|
|`python3-sphinx`|[`dev-python/sphinx`](https://packages.gentoo.org/packages/dev-python/sphinx)|
|`python3-sphinx-argparse`|[`dev-python/sphinx-argparse`](https://packages.gentoo.org/packages/dev-python/sphinx-argparse)|
|`python3-tk`|[`'dev-lang/python[tk]'`](https://packages.gentoo.org/packages/dev-lang/python)|
|`python3-typeguard`|[`dev-python/typeguard`](https://packages.gentoo.org/packages/dev-python/typeguard)|
|`python3-venv`|[`dev-lang/python`](https://packages.gentoo.org/packages/dev-lang/python)|
