### PR TITLE
launch_ros: 0.19.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2801,7 +2801,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.19.5-2
+      version: 0.19.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.19.6-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.19.5-2`

## launch_ros

```
* Implement None check for ComposableNodeContainer (#341 <https://github.com/ros2/launch_ros/issues/341>) (#371 <https://github.com/ros2/launch_ros/issues/371>)
* Contributors: mergify[bot]
```

## launch_testing_ros

- No changes

## ros2launch

- No changes
