### PR TITLE
rclcpp: 16.0.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5124,7 +5124,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 16.0.5-2
+      version: 16.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `16.0.6-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `16.0.5-2`

## rclcpp

```
* Topic correct typeadapter deduction (#2294 <https://github.com/ros2/rclcpp/issues/2294>) (#2297 <https://github.com/ros2/rclcpp/issues/2297>)
* check thread whether joinable before join (#2019 <https://github.com/ros2/rclcpp/issues/2019>) (#2275 <https://github.com/ros2/rclcpp/issues/2275>)
* Do not crash Executor when send_response fails due to client failure. (#2276 <https://github.com/ros2/rclcpp/issues/2276>) (#2280 <https://github.com/ros2/rclcpp/issues/2280>)
* Contributors: mergify[bot]
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* Switch lifecycle to use the RCLCPP macros Signed-off-by: Tony Najjar <mailto:tony.najjar.1997@gmail.com> (#2234 <https://github.com/ros2/rclcpp/issues/2234>)
* Contributors: Tony Najjar
```
