### PR TITLE
geometry2: 0.25.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2017,7 +2017,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.25.3-1
+      version: 0.25.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.25.4-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.25.3-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

- No changes

## tf2_eigen

```
* Add another reference for twist transformation. Comment correction. (#620 <https://github.com/ros2/geometry2/issues/620>) (#621 <https://github.com/ros2/geometry2/issues/621>)
* Contributors: mergify[bot]
```

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

```
* Fixed Windows warnings (#623 <https://github.com/ros2/geometry2/issues/623>)
* Add doTransform support for Point32, Polygon and PolygonStamped (#616 <https://github.com/ros2/geometry2/issues/616>)
* Contributors: Alejandro Hernández Cordero, Guillaume Doisy
```

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Suppress spam from calling canTransform (#529 <https://github.com/ros2/geometry2/issues/529>) (#615 <https://github.com/ros2/geometry2/issues/615>)
* Fix invalid timer handle exception (#474 <https://github.com/ros2/geometry2/issues/474>) (#614 <https://github.com/ros2/geometry2/issues/614>)
* Contributors: mergify[bot]
```

## tf2_ros_py

```
* Remove 'efficient copy' prints (#625 <https://github.com/ros2/geometry2/issues/625>) (#626 <https://github.com/ros2/geometry2/issues/626>)
* Contributors: mergify[bot]
```

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
