### PR TITLE
rviz: 11.2.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6986,7 +6986,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 11.2.7-1
+      version: 11.2.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `11.2.8-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `11.2.7-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Remove unused LineEditWithButton::simulateReturnPressed() (#1040 <https://github.com/ros2/rviz/issues/1040>) (#1042 <https://github.com/ros2/rviz/issues/1042>)
* Contributors: mergify[bot]
```

## rviz_default_plugins

```
* Fixed AccelStamped, TwistStamped and Wrench icons (#1041 <https://github.com/ros2/rviz/issues/1041>) (#1046 <https://github.com/ros2/rviz/issues/1046>)
* Fix the flakey rviz_rendering tests (#1026 <https://github.com/ros2/rviz/issues/1026>) (#1030 <https://github.com/ros2/rviz/issues/1030>)
* point_marker: fix bug where the number of rendered points accumulates over time (#949 <https://github.com/ros2/rviz/issues/949>) (#1029 <https://github.com/ros2/rviz/issues/1029>)
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

```
* Make resource file paths relative (#862 <https://github.com/ros2/rviz/issues/862>) (#867 <https://github.com/ros2/rviz/issues/867>)
* Contributors: mergify[bot]
```

## rviz_rendering

```
* Removed warning when building in release mode (#1057 <https://github.com/ros2/rviz/issues/1057>) (#1059 <https://github.com/ros2/rviz/issues/1059>)
* Fixed low FPS when sending point markers (#1049 <https://github.com/ros2/rviz/issues/1049>) (#1055 <https://github.com/ros2/rviz/issues/1055>)
* Fix the flakey rviz_rendering tests (#1026 <https://github.com/ros2/rviz/issues/1026>) (#1030 <https://github.com/ros2/rviz/issues/1030>)
* Contributors: mergify[bot]
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
