### PR TITLE
simple_actions: 0.3.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6299,7 +6299,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/simple_actions-release.git
-      version: 0.2.2-2
+      version: 0.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_actions` to `0.3.0-1`:

- upstream repository: https://github.com/DLu/simple_actions.git
- release repository: https://github.com/ros2-gbp/simple_actions-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.2-2`
