### PR TITLE
event_camera_py: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1274,6 +1274,11 @@ repositories:
       type: git
       url: https://github.com/ros-event-camera/event_camera_py.git
       version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/event_camera_py-release.git
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_py.git


### PR DESCRIPTION
Increasing version of package(s) in repository `event_camera_py` to `1.0.1-1`:

- upstream repository: https://github.com/ros-event-camera/event_camera_py.git
- release repository: https://github.com/ros2-gbp/event_camera_py-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## event_camera_py

```
* Initial release
* Contributors: Bernd Pfrommer, Fernando Cladera, k-chaney
```
