### PR TITLE
Fixed documentation link in point_cloud_transport

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3731,7 +3731,7 @@ repositories:
   point_cloud_transport:
     doc:
       type: git
-      url: https://github.com/ros-perception/point_cloud_transport_tutorial.git
+      url: https://github.com/ros-perception/point_cloud_transport.git
       version: rolling
     release:
       packages:


### PR DESCRIPTION
Fixed documentation link in `point_cloud_transport`. Related to this comment https://github.com/ros/rosdistro/pull/38572#discussion_r1328934656