### PR TITLE
rmf_ros2: 2.2.3-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4610,7 +4610,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 2.2.2-1
+      version: 2.2.3-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_ros2` to `2.2.3-1`:

- upstream repository: https://github.com/open-rmf/rmf_ros2.git
- release repository: https://github.com/ros2-gbp/rmf_ros2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.2-1`

## rmf_fleet_adapter

```
* EasyFullControl API (#302 <https://github.com/open-rmf/rmf_ros2/pull/302>)
* Contributors: Luca Della Vedova, Michael X. Grey, Xiyu, Yadunund
```

## rmf_fleet_adapter_python

```
* EasyFullControl API (#302 <https://github.com/open-rmf/rmf_ros2/pull/302>)
* Contributors: Luca Della Vedova, Michael X. Grey, Xiyu, Yadunund
```

## rmf_task_ros2

- No changes

## rmf_traffic_ros2

```
* EasyFullControl API (#302 <https://github.com/open-rmf/rmf_ros2/pull/302>)
* Contributors: Luca Della Vedova, Michael X. Grey, Xiyu, Yadunund
```

## rmf_websocket

- No changes
