### PR TITLE
point_cloud_transport: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3750,7 +3750,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 2.0.0-1
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `3.0.0-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-1`

## point_cloud_transport

```
* feat: replace third party expected with ros package (#32 <https://github.com/ros-perception/point_cloud_transport/issues/32>)
* fix: modify wrong install for header (#30 <https://github.com/ros-perception/point_cloud_transport/issues/30>)
* Contributors: Daisuke Nishimatsu
```

## point_cloud_transport_py

- No changes
