### PR TITLE
point_cloud_transport_plugins: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3758,11 +3758,27 @@ repositories:
       version: rolling
     status: maintained
   point_cloud_transport_plugins:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/point_cloud_transport_plugins.git
+      version: rolling
+    release:
+      packages:
+      - draco_point_cloud_transport
+      - point_cloud_interfaces
+      - point_cloud_transport_plugins
+      - zlib_point_cloud_transport
+      - zstd_point_cloud_transport
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/point_cloud_transport_plugins.git
       version: rolling
+    status: maintained
   point_cloud_transport_tutorial:
     source:
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport_plugins` to `3.0.0-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport_plugins
- release repository: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## draco_point_cloud_transport

```
* feat: use tl_expected of ros package (#22 <https://github.com/ros-perception/point_cloud_transport_plugins/issues/22>)
* Contributors: Daisuke Nishimatsu
```

## point_cloud_interfaces

- No changes

## point_cloud_transport_plugins

- No changes

## zlib_point_cloud_transport

- No changes

## zstd_point_cloud_transport

- No changes
