### PR TITLE
swri_console: 2.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6413,7 +6413,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/swri_console-release.git
-      version: 2.0.3-2
+      version: 2.0.4-1
     source:
       type: git
       url: https://github.com/swri-robotics/swri_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_console` to `2.0.4-1`:

- upstream repository: https://github.com/swri-robotics/swri_console.git
- release repository: https://github.com/ros2-gbp/swri_console-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.3-2`

## swri_console

```
* Adding missing dependency needed by build farm (#58 <https://github.com/swri-robotics/swri_console/issues/58>)
* Contributors: David Anthony
```
