### PR TITLE
ros2_controllers: 3.16.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4970,7 +4970,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 3.15.0-1
+      version: 3.16.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `3.16.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.15.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

- No changes

## bicycle_steering_controller

- No changes

## diff_drive_controller

- No changes

## effort_controllers

```
* [Doc] Add specific documentation on the available fw cmd controllers (#765 <https://github.com/ros-controls/ros2_controllers/issues/765>)
* Contributors: Christoph Fröhlich
```

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

```
* [Doc] Add specific documentation on the available fw cmd controllers (#765 <https://github.com/ros-controls/ros2_controllers/issues/765>)
* Contributors: Christoph Fröhlich
```

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* [Docs] Improve interface description of JTC (#770 <https://github.com/ros-controls/ros2_controllers/issues/770>)
* [JTC] Add time-out for trajectory interfaces (#609 <https://github.com/ros-controls/ros2_controllers/issues/609>)
* [JTC] Rename parameter: normalize_error to angle_wraparound (#772 <https://github.com/ros-controls/ros2_controllers/issues/772>)
* [JTC] Fix hold position mode with goal_time>0 (#758 <https://github.com/ros-controls/ros2_controllers/issues/758>)
* [JTC] Add note on goal_time=0 in docs (#773 <https://github.com/ros-controls/ros2_controllers/issues/773>)
* Contributors: Christoph Fröhlich
```

## position_controllers

```
* [Doc] Add specific documentation on the available fw cmd controllers (#765 <https://github.com/ros-controls/ros2_controllers/issues/765>)
* Contributors: Christoph Fröhlich
```

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

- No changes

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

```
* [Doc] Add specific documentation on the available fw cmd controllers (#765 <https://github.com/ros-controls/ros2_controllers/issues/765>)
* Contributors: Christoph Fröhlich
```
