### PR TITLE
ur_robot_driver: 2.3.4-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7193,7 +7193,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.3.3-1
+      version: 2.3.4-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.3.4-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.3-1`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* Update sjtc to newest upstream API (#813 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/813>)
* Contributors: Felix Exner
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* Added support for UR20 (#806 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/806>)
* Contributors: Felix Exner
```

## ur_robot_driver

```
* Added a test that sjtc correctly aborts on violation of constraints (#813 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/813>)
* Added support for UR20 (#806 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/806>)
* Introduced tf_prefix into log handler (#713 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/713>)
* Contributors: Felix Exner, Lennart Nachtigall
```
