### PR TITLE
ur_robot_driver: 2.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7013,7 +7013,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.4.0-1
+      version: 2.4.1-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.4.1-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.4.0-1`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* Update sjtc to newest upstream API (#810 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/810>)
* Contributors: Felix Exner
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* Added support for UR20 (#797 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/797>)
* Contributors: Felix Exner
```

## ur_robot_driver

```
* Added a test that sjtc correctly aborts on violation of constraints (#810 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/810>)
* Added support for UR20 (#797 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/797>)
* Contributors: Felix Exner
```
