### PR TITLE
fadecandy_ros: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1656,7 +1656,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/eurogroep/fadecandy_ros-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/eurogroep/fadecandy_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fadecandy_ros` to `1.0.1-1`:

- upstream repository: https://github.com/eurogroep/fadecandy_ros.git
- release repository: https://github.com/eurogroep/fadecandy_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-1`

## fadecandy_driver

- No changes

## fadecandy_msgs

```
* fix(msgs): depends + cmake
* Contributors: Rein Appeldoorn
```
