### PR TITLE
robotraconteur: 0.18.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4977,6 +4977,11 @@ repositories:
       version: iron
     status: maintained
   robotraconteur:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/robotraconteur-packaging/robotraconteur-ros2-release.git
+      version: 0.18.0-1
     source:
       type: git
       url: https://github.com/robotraconteur/robotraconteur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotraconteur` to `0.18.0-1`:

- upstream repository: https://github.com/robotraconteur/robotraconteur.git
- release repository: https://github.com/robotraconteur-packaging/robotraconteur-ros2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
