### PR TITLE
event_camera_renderer: 1.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1583,7 +1583,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_renderer-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_renderer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `event_camera_renderer` to `1.1.2-1`:

- upstream repository: https://github.com/ros-event-camera/event_camera_renderer.git
- release repository: https://github.com/ros2-gbp/event_camera_renderer-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.1-1`

## event_camera_renderer

```
* added dependency on ament_cmake_clang_format
* Contributors: Bernd Pfrommer
```
