### PR TITLE
event_camera_py: 1.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1278,7 +1278,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_py-release.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_py.git


### PR DESCRIPTION
Increasing version of package(s) in repository `event_camera_py` to `1.0.3-1`:

- upstream repository: https://github.com/ros-event-camera/event_camera_py.git
- release repository: https://github.com/ros2-gbp/event_camera_py-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.2-1`

## event_camera_py

```
* improved README, fixed python test dependencies
* Contributors: Bernd Pfrommer
```
