### PR TITLE
mobile_catkin_modules_build_development_tools: 0.4.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2796,7 +2796,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/Robotics-Sensors/mobile_catkin_modules_build_development_tools.git
+      url: https://github.com/ros2-gbp/mobile_catkin_modules_build_development_tools.git
       version: 0.4.4-1
     source:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2781,7 +2781,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: git@github.com:Application-UI-UX/mobile_catkin_modules_build_development_tools.git
+      url: https://github.com/Robotics-Sensors/mobile_catkin_modules_build_development_tools.git
       version: 0.4.4-1
     source:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2773,6 +2773,21 @@ repositories:
       url: https://github.com/DFKI-NI/mir_robot.git
       version: rolling
     status: developed
+  mobile_catkin_modules_build_development_tools:
+    doc:
+      type: git
+      url: https://github.com/Application-UI-UX/mobile_catkin_modules_build_development_tools.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: git@github.com:Application-UI-UX/mobile_catkin_modules_build_development_tools.git
+      version: 0.4.4-1
+    source:
+      type: git
+      url: https://github.com/Application-UI-UX/mobile_catkin_modules_build_development_tools.git
+      version: main
+    status: maintained
   mola:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mobile_catkin_modules_build_development_tools` to `0.4.4-1`:

- upstream repository: https://github.com/Application-UI-UX/mobile_catkin_modules_build_development_tools.git
- release repository: git@github.com:Application-UI-UX/mobile_catkin_modules_build_development_tools.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## mobile_catkin_modules_build_development_tools

```
* Fix countless bugs in the repository
* Rerelease dedicated code for maven, ros, and python
* Change name for more discriptions a take down old publish namees
* Make repository compatible with ROS2 and will now be compatible for ROS1 and ROS2
* Upgrade version of all builds and make it more compatible
* Maintainer & Contributors & Aurthor: Ronaldson Bellande
```

Resubmission of: https://github.com/ros/rosdistro/pull/38536