### PR TITLE
aandd_ekew_driver_py: 0.0.2-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -19,7 +19,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/TechMagicKK/aandd_ekew_driver_py-release.git
-      version: 0.0.2-1
+      version: 0.0.2-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aandd_ekew_driver_py` to `0.0.2-2`:

- upstream repository: https://github.com/TechMagicKK/aandd_ekew_driver_py.git
- release repository: https://github.com/TechMagicKK/aandd_ekew_driver_py-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.2-1`

## aandd_ekew_driver_py

```
* Added author info
* Contributors: Jiaqing Lin
```
