### PR TITLE
ur_client_library: 1.3.4-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7167,7 +7167,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
-      version: 1.3.3-1
+      version: 1.3.4-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `1.3.4-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.3-1`

## ur_client_library

```
* Make depreaction warning for keepalive_counter a warning instead of error (#182 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/182>)
* Added watchdog configuration for the reverse socket (#178 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/178>)
* Add support for ur20 in start_ursim script (#179 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/179>)
* Use pre-commit for clang-format (#175 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/175>)
* Make tcp_server retry binding the socket (#176 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/176>)
* Contributors: Felix Exner, Mads Holm Peters
```
