### PR TITLE
aws_sdk_cpp_vendor: 0.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -596,7 +596,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/aws_sdk_cpp_vendor-release.git
-      version: 0.1.1-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/wep21/aws_sdk_cpp_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aws_sdk_cpp_vendor` to `0.2.0-1`:

- upstream repository: https://github.com/wep21/aws_sdk_cpp_vendor.git
- release repository: https://github.com/ros2-gbp/aws_sdk_cpp_vendor-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.1-1`

## aws_sdk_cpp_vendor

```
* feat: update sdk version and cmake options
* Contributors: wep21
```
