### PR TITLE
navigation2: 1.2.3-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3134,7 +3134,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/SteveMacenski/navigation2-release.git
-      version: 1.2.2-2
+      version: 1.2.3-1
     source:
       type: git
       url: https://github.com/ros-planning/navigation2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation2` to `1.2.3-1`:

- upstream repository: https://github.com/ros-planning/navigation2.git
- release repository: https://github.com/SteveMacenski/navigation2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.2-2`
