### PR TITLE
reach_ros: 1.3.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5281,7 +5281,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/reach_ros2-release.git
-      version: 1.3.2-2
+      version: 1.3.4-1
     source:
       type: git
       url: https://github.com/ros-industrial/reach_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `reach_ros` to `1.3.4-1`:

- upstream repository: https://github.com/ros-industrial/reach_ros2
- release repository: https://github.com/ros2-gbp/reach_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.2-2`

## reach_ros

```
* Python CMake Update (#27 <https://github.com/marip8/reach_ros2/issues/27>)
  * Ensure PYTHON_INSTALL_DIR is set by ament
  * Replace ROS version compile definition with preprocessor check
* CI Update (#26 <https://github.com/marip8/reach_ros2/issues/26>)
  * Push docker image on ref_type tag
  * Added AFTER_SCRIPT to CI
* Contributors: Michael Ripperger
```
