### PR TITLE
rosdep: nixos: Use tbb_2021_8

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7946,7 +7946,7 @@ tbb:
   fedora: [tbb-devel]
   gentoo: [dev-cpp/tbb]
   macports: [tbb]
-  nixos: [tbb]
+  nixos: [tbb_2021_8]
   openembedded: [tbb@meta-oe]
   opensuse: [tbb-devel]
   rhel: [tbb-devel]


### PR DESCRIPTION
As of https://github.com/NixOS/nixpkgs/commit/cc541cb750a3468fbc5a75ecd6ef8d9e7402e490, `tbb` is an alias of `tbb_2020_3`. Packages such as [Slam Toolbox](https://github.com/SteveMacenski/slam_toolbox) often expect a newer version.