### PR TITLE
rosbridge_suite: 1.3.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6347,7 +6347,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 1.3.1-1
+      version: 1.3.2-1
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `1.3.2-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.1-1`

## rosapi

```
* Fix ROS2 CI for iron & rolling (#875 <https://github.com/RobotWebTools/rosbridge_suite/issues/875>)
* Contributors: Hans-Joachim Krauch
```

## rosapi_msgs

- No changes

## rosbridge_library

```
* Interpret call_services_in_new_thread as boolean (#857 <https://github.com/RobotWebTools/rosbridge_suite/issues/857>)
* Add option to call services in a separate thread (#847 <https://github.com/RobotWebTools/rosbridge_suite/issues/847>)
* fix memory leak on service call (#774 <https://github.com/RobotWebTools/rosbridge_suite/issues/774>)
* Contributors: Sebastian Castro, hiroyuki obinata, rwhitney456
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* Add option to call services in a separate thread (#847 <https://github.com/RobotWebTools/rosbridge_suite/issues/847>)
* Contributors: Sebastian Castro
```

## rosbridge_suite

```
* rosbridge_suite: depend on ament_cmake (#848 <https://github.com/RobotWebTools/rosbridge_suite/issues/848>)
* Contributors: Jochen Sprickerhof
```

## rosbridge_test_msgs

- No changes
