### PR TITLE
Added libhpptools-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3777,6 +3777,9 @@ libhidapi-dev:
   gentoo: [dev-libs/hidapi]
   nixos: [hidapi]
   ubuntu: [libhidapi-dev]
+libhpptools-dev:
+  debian: [libhpptools-dev]
+  ubuntu: [libhpptools-dev]
 libi2c-dev:
   arch: [linux-api-headers]
   debian: [libi2c-dev]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

libhpptools-dev

## Package Upstream Source:

https://github.com/mateidavid/hpptools

## Purpose of using this:

Various handy utilities, e.g. a simple thread-pool implementation for C++.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/sid/libhpptools-dev
- Ubuntu: https://packages.ubuntu.com/focal/libhpptools-dev
- Fedora: N/A
- Arch: N/A
- Gentoo: N/A
- macOS: N/A
- Alpine: N/A
- NixOS/nixpkgs: N/A
- openSUSE: N/A
- rhel: N/A
