### PR TITLE
rosmon: 2.5.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9690,7 +9690,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/xqms/rosmon-release.git
-      version: 2.5.0-2
+      version: 2.5.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosmon` to `2.5.1-2`:

- upstream repository: https://github.com/xqms/rosmon.git
- release repository: https://github.com/xqms/rosmon-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.5.0-2`

## rosmon

- No changes

## rosmon_core

```
* Fix state machine for multiple colored sections (Issue #178, PR #179)
  Something like "e[33m First e[0m and e[32m second e[0m" would
  lead to rosmon only outputting "First".
  This also adds a corresponding test case.
* Contributors: Max Schwarz
```

## rosmon_msgs

- No changes

## rqt_rosmon

- No changes
