### PR TITLE
Adding python-gsmmodem-new

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1881,11 +1881,13 @@ python-grpcio:
       pip: [grpcio]
 python-gsmmodem-pip: &migrate_eol_2025_04_30_python3_gsmmodem_pip
   debian:
-    pip:
-      packages: [python-gsmmodem-new]
+    '*':
+      pip:
+        packages: [python-gsmmodem-new]
   ubuntu:
-    pip:
-      packages: [python-gsmmodem-new]
+    '*':
+      pip:
+        packages: [python-gsmmodem-new]
 python-gst:
   arch: [gstreamer0.10-python]
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1880,6 +1880,9 @@ python-grpcio:
     bionic:
       pip: [grpcio]
 python-gsmmodem-pip: &migrate_eol_2025_04_30_python3_gsmmodem_pip
+  debian:
+    pip:
+      packages: [python-gsmmodem-new]
   ubuntu:
     pip:
       packages: [python-gsmmodem-new]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1879,6 +1879,10 @@ python-grpcio:
     '*': [python-grpcio]
     bionic:
       pip: [grpcio]
+python-gsmmodem-pip: &migrate_eol_2025_04_30_python3_gsmmodem_pip
+  ubuntu:
+    pip:
+      packages: [python-gsmmodem-new]
 python-gst:
   arch: [gstreamer0.10-python]
   debian:
@@ -6319,6 +6323,7 @@ python3-grpcio:
   ubuntu:
     '*': [python3-grpcio]
     bionic: null
+python3-gsmmodem-pip: *migrate_eol_2025_04_30_python3_gsmmodem_pip
 python3-gurobipy-pip: *migrate_eol_2025_04_30_python3_gurobipy_pip
 python3-gymnasium-pip:
   debian:


### PR DESCRIPTION
added python-gsmmodem-new

<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python-gsmmodem-new

## Package Upstream Source:

https://github.com/babca/python-gsmmodem/tree/master

## Purpose of using this:

Control an attached GSM modem: send/receive SMS messages, handle calls, etc

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - Pip: https://pypi.org/project/python-gsmmodem-new/
- Ubuntu: https://packages.ubuntu.com/
  - Pip: https://pypi.org/project/python-gsmmodem-new/
