### PR TITLE
rqt_runtime_monitor: 0.5.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10254,7 +10254,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_runtime_monitor-release.git
-      version: 0.5.9-1
+      version: 0.5.10-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_runtime_monitor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_runtime_monitor` to `0.5.10-1`:

- upstream repository: https://github.com/ros-visualization/rqt_runtime_monitor.git
- release repository: https://github.com/ros-gbp/rqt_runtime_monitor-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.5.9-1`

## rqt_runtime_monitor

```
* Import setup from setuptools instead of distutils.core
* added LICENSE file
```
