### PR TITLE
rqt_logger_level: 0.4.12-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10017,7 +10017,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_logger_level-release.git
-      version: 0.4.11-1
+      version: 0.4.12-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_logger_level.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_logger_level` to `0.4.12-1`:

- upstream repository: https://github.com/ros-visualization/rqt_logger_level.git
- release repository: https://github.com/ros-gbp/rqt_logger_level-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.11-1`

## rqt_logger_level

```
* added LICENSE
* Import setup from setuptools instead of distutils.core
* Add xml-model
```
