### PR TITLE
rqt_tf_tree: 0.6.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10330,7 +10330,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_tf_tree-release.git
-      version: 0.6.3-1
+      version: 0.6.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_tf_tree` to `0.6.4-1`:

- upstream repository: https://github.com/ros-visualization/rqt_tf_tree.git
- release repository: https://github.com/ros-gbp/rqt_tf_tree-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.3-1`

## rqt_tf_tree

```
* Fix dot save according to the PyQt5 (#28 <https://github.com/ros-visualization/rqt_tf_tree/issues/28>)
* Import setup from setuptools instead of distutils.core (#45 <https://github.com/ros-visualization/rqt_tf_tree/issues/45>)
* Add xml-model
* Add LICENSE file
```
