### PR TITLE
simple_launch: 1.7.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6187,7 +6187,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/simple_launch-release.git
-      version: 1.7.0-2
+      version: 1.7.2-1
     source:
       type: git
       url: https://github.com/oKermorgant/simple_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_launch` to `1.7.2-1`:

- upstream repository: https://github.com/oKermorgant/simple_launch.git
- release repository: https://github.com/ros2-gbp/simple_launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.7.0-2`

## simple_launch

```
* simplify logic of try_perform
* Merge pull request #5 <https://github.com/oKermorgant/simple_launch/issues/5> from okvik/devel
  Fix string-valued launch argument substitution
* slight refactor to prepare wrapping Delays
* Contributors: Olivier Kermorgant, Viktor Pocedulic
* slight refactor to prepare wrapping Delays
* Contributors: Olivier Kermorgant
```
