### PR TITLE
metrics_msgs: 0.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3303,6 +3303,19 @@ repositories:
       version: master
     status: developed
   metrics_msgs:
+    doc:
+      type: git
+      url: https://github.com/MetroRobots/metrics_msgs.git
+      version: main
+    release:
+      packages:
+      - collision_log_msgs
+      - metro_benchmark_msgs
+      - metro_benchmark_pub
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/metrics_msgs-release.git
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/MetroRobots/metrics_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `metrics_msgs` to `0.1.1-1`:

- upstream repository: https://github.com/MetroRobots/metrics_msgs
- release repository: https://github.com/ros2-gbp/metrics_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## collision_log_msgs

```
* Rename collision_msgs -> collision_log_msgs (#3 <https://github.com/Metrorobots/metrics_msgs/issues/3>)
* Contributors: David V. Lu!!
```

## metro_benchmark_msgs

```
* Rename benchmark_msgs -> metro_benchmark_msgs (#3 <https://github.com/Metrorobots/metrics_msgs/issues/3>)
* Contributors: David V. Lu!!
```

## metro_benchmark_pub

```
* Rename benchmark_utils -> metro_benchmark_pub (#3 <https://github.com/Metrorobots/metrics_msgs/issues/3>)
* Contributors: David V. Lu!!
```
