### PR TITLE
rtctree: 3.0.1-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10470,6 +10470,21 @@ repositories:
       url: https://github.com/tilk/rtcm_msgs.git
       version: master
     status: maintained
+  rtctree:
+    doc:
+      type: git
+      url: https://github.com/tork-a/rtctree-release.git
+      version: release/hydro/rtctree
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/tork-a/rtctree-release.git
+      version: 3.0.1-3
+    source:
+      type: git
+      url: https://github.com/gbiggs/rtctree.git
+      version: master
+    status: maintained
   ruckig:
     release:
       tags:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10483,6 +10483,8 @@ repositories:
     source:
       type: git
       url: https://github.com/gbiggs/rtctree.git
+      version: master
+    status: maintained
   rtsprofile:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtctree` to `3.0.1-3`:

- upstream repository: https://github.com/gbiggs/rtctree.git
- release repository: https://github.com/tork-a/rtctree-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
