### PR TITLE
urdf_tutorial: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8493,7 +8493,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/urdf_tutorial-release.git
-      version: 1.0.0-3
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_tutorial` to `1.1.0-1`:

- upstream repository: https://github.com/ros/urdf_tutorial
- release repository: https://github.com/ros2-gbp/urdf_tutorial-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-3`

## urdf_tutorial

```
* Precommit configuration (#64 <https://github.com/ros/urdf_tutorial/issues/64>)
* Use urdf_launch package (#65 <https://github.com/ros/urdf_tutorial/issues/65>)
* Add gazebo export to package.xml and tidy up package.xml (#63 <https://github.com/ros/urdf_tutorial/issues/63>)
* More reasonable inertia values. (#58 <https://github.com/ros/urdf_tutorial/issues/58>)
* upgrade dae files (#60 <https://github.com/ros/urdf_tutorial/issues/60>) (#61 <https://github.com/ros/urdf_tutorial/issues/61>)
* Add in a LICENSE file. (#57 <https://github.com/ros/urdf_tutorial/issues/57>)
* Contributors: Andreas Bihlmaier, Chris Lalancette, David V. Lu!!
```
