### PR TITLE
Add urdf_sim_tutorial source repo to humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8482,6 +8482,13 @@ repositories:
       url: https://github.com/ros/urdf_parser_py.git
       version: ros2
     status: maintained
+  urdf_sim_tutorial:
+    source:
+      type: git
+      url: https://github.com/ros/urdf_sim_tutorial.git
+      version: license
+      test_pull_requests: true
+    status: developed
   urdf_test:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

urdf_sim_tutorial

# The source is here:

https://github.com/ros/urdf_sim_tutorial.git

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
