### PR TITLE
Add urdf_sim_tutorial source repo to humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8484,10 +8484,10 @@ repositories:
     status: maintained
   urdf_sim_tutorial:
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/urdf_sim_tutorial.git
       version: ros2
-      test_pull_requests: true
     status: developed
   urdf_test:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8482,6 +8482,13 @@ repositories:
       url: https://github.com/ros/urdf_parser_py.git
       version: ros2
     status: maintained
+  urdf_sim_tutorial:
+    source:
+      type: git
+      url: https://github.com/ros/urdf_sim_tutorial.git
+      version: ros2
+      test_pull_requests: true
+    status: developed
   urdf_test:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

urdf_sim_tutorial

# The source is here:

https://github.com/ros/urdf_sim_tutorial.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
