### PR TITLE
ros2_control: 3.19.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5022,7 +5022,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.18.0-1
+      version: 3.19.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.19.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.18.0-1`

## controller_interface

```
* Enable services for setting the log-level in controller per default (#1102 <https://github.com/ros-controls/ros2_control/issues/1102>)
* Contributors: Dr. Denis
```

## controller_manager

```
* Proper controller update rate (#1105 <https://github.com/ros-controls/ros2_control/issues/1105>)
* Fix multiple calls to export reference interfaces (#1108 <https://github.com/ros-controls/ros2_control/issues/1108>)
* [Docs] Fix information about activation and deactivation of chainable controllers (#1104 <https://github.com/ros-controls/ros2_control/issues/1104>)
* Contributors: Dr. Denis, Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* [MockHardware] Added dynamic simulation functionality. (#1028 <https://github.com/ros-controls/ros2_control/issues/1028>)
* Add GPIO tag description to docs (#1109 <https://github.com/ros-controls/ros2_control/issues/1109>)
* Contributors: Christoph Fröhlich, Dr. Denis
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
