### PR TITLE
ros2_controllers: 2.26.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5951,6 +5951,7 @@ repositories:
       - joint_state_broadcaster
       - joint_trajectory_controller
       - position_controllers
+      - range_sensor_broadcaster
       - ros2_controllers
       - ros2_controllers_test_nodes
       - rqt_joint_trajectory_controller
@@ -5961,7 +5962,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.25.0-1
+      version: 2.26.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.26.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.25.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

- No changes

## bicycle_steering_controller

- No changes

## diff_drive_controller

- No changes

## effort_controllers

```
* [Doc] Add specific documentation on the available fw cmd controllers (#765 <https://github.com/ros-controls/ros2_controllers/issues/765>) (#778 <https://github.com/ros-controls/ros2_controllers/issues/778>)
* Contributors: mergify[bot]
```

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

```
* [Doc] Add specific documentation on the available fw cmd controllers (#765 <https://github.com/ros-controls/ros2_controllers/issues/765>) (#778 <https://github.com/ros-controls/ros2_controllers/issues/778>)
* Contributors: mergify[bot]
```

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

- No changes

## position_controllers

```
* [Doc] Add specific documentation on the available fw cmd controllers (#765 <https://github.com/ros-controls/ros2_controllers/issues/765>) (#778 <https://github.com/ros-controls/ros2_controllers/issues/778>)
* Contributors: mergify[bot]
```

## range_sensor_broadcaster

```
* add a broadcaster for range sensor (backport #725 <https://github.com/ros-controls/ros2_controllers/issues/725>) (#766 <https://github.com/ros-controls/ros2_controllers/issues/766>)
* Contributors: mergify[bot]
```

## ros2_controllers

```
* add a broadcaster for range sensor (backport #725 <https://github.com/ros-controls/ros2_controllers/issues/725>) (#766 <https://github.com/ros-controls/ros2_controllers/issues/766>)
* Contributors: mergify[bot]
```

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

- No changes

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

```
* [Doc] Add specific documentation on the available fw cmd controllers (#765 <https://github.com/ros-controls/ros2_controllers/issues/765>) (#778 <https://github.com/ros-controls/ros2_controllers/issues/778>)
* Contributors: mergify[bot]
```
