### PR TITLE
ros2_control: 2.32.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5926,7 +5926,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.31.0-1
+      version: 2.32.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.32.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.31.0-1`

## controller_interface

- No changes

## controller_manager

```
* Fix multiple calls to export reference interfaces (backport #1108 <https://github.com/ros-controls/ros2_control/issues/1108>) (#1114 <https://github.com/ros-controls/ros2_control/issues/1114>)
* Contributors: Sai Kishor Kothakota, Dr Denis
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Add GPIO tag description to docs (#1109 <https://github.com/ros-controls/ros2_control/issues/1109>) (#1120 <https://github.com/ros-controls/ros2_control/issues/1120>)
* Contributors: Christoph Froehlich
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
