### PR TITLE
reach: 1.6.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5294,7 +5294,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/reach-release.git
-      version: 1.5.2-1
+      version: 1.6.0-1
     source:
       type: git
       url: https://github.com/ros-industrial/reach.git


### PR DESCRIPTION
Increasing version of package(s) in repository `reach` to `1.6.0-1`:

- upstream repository: https://github.com/ros-industrial/reach
- release repository: https://github.com/ros2-gbp/reach-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.5.2-1`

## reach

```
* Add seed state checks (#66 <https://github.com/marip8/reach/issues/66>)
  * Added utility from reach_ros for getting subset of joint state
  * Added check to ensure seed state parameter is set correctly
  * Updated function name
  * Run format jobs on 20.04
  * Clang format
* Contributors: Michael Ripperger
```
