### PR TITLE
rmw_fastrtps: 7.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4799,7 +4799,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 7.5.0-1
+      version: 7.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `7.6.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `7.5.0-1`

## rmw_fastrtps_cpp

```
* Add rmw_count clients,services impl (#641 <https://github.com/ros2/rmw_fastrtps/issues/641>)
* Improve node graph delivery by using a unique listening port (#711 <https://github.com/ros2/rmw_fastrtps/issues/711>)
* Contributors: Miguel Company, Minju, Lee
```

## rmw_fastrtps_dynamic_cpp

```
* Account for alignment on is_plain calculations. (#716 <https://github.com/ros2/rmw_fastrtps/issues/716>)
* Add rmw_count clients,services impl (#641 <https://github.com/ros2/rmw_fastrtps/issues/641>)
* Improve node graph delivery by using a unique listening port (#711 <https://github.com/ros2/rmw_fastrtps/issues/711>)
* Contributors: Chris Lalancette, Miguel Company, Minju, Lee
```

## rmw_fastrtps_shared_cpp

```
* Add rmw_count clients,services impl (#641 <https://github.com/ros2/rmw_fastrtps/issues/641>)
* Contributors: Minju, Lee
```
