### PR TITLE
rclpy: 5.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4297,7 +4297,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 5.2.0-1
+      version: 5.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `5.3.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `5.2.0-1`

## rclpy

```
* 1105 parameter event handler (#1135 <https://github.com/ros2/rclpy/issues/1135>)
* unregister_sigterm_signal_handler should be called. (#1170 <https://github.com/ros2/rclpy/issues/1170>)
* Handle take failure in wait_for_message (#1172 <https://github.com/ros2/rclpy/issues/1172>)
* Decouple rosout publisher init from node init. (#1121 <https://github.com/ros2/rclpy/issues/1121>)
* Fix _list_parameters_callback & test (#1161 <https://github.com/ros2/rclpy/issues/1161>)
* Contributors: EsipovPA, Minju, Lee, Tomoya Fujita, mhidalgo-bdai
```
