### PR TITLE
launch: 3.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2362,7 +2362,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.1.0-1
+      version: 3.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.2.0-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.1.0-1`

## launch

```
* Add conditional substitution (#734 <https://github.com/ros2/launch/issues/734>)
* Contributors: Nick Lamprianidis
```

## launch_pytest

- No changes

## launch_testing

```
* to open expected outpout file with an encoding parameter (#717 <https://github.com/ros2/launch/issues/717>)
* Contributors: Chen Lihui
```

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
