### PR TITLE
geometry2: 0.33.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1692,7 +1692,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.33.1-1
+      version: 0.33.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.33.2-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.33.1-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

- No changes

## tf2_eigen

```
* Fix clang build warnings. (#628 <https://github.com/ros2/geometry2/issues/628>)
* Contributors: Chris Lalancette
```

## tf2_eigen_kdl

```
* Fix clang build warnings. (#628 <https://github.com/ros2/geometry2/issues/628>)
* Contributors: Chris Lalancette
```

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

- No changes

## tf2_ros_py

- No changes

## tf2_sensor_msgs

```
* Fix clang build warnings. (#628 <https://github.com/ros2/geometry2/issues/628>)
* Contributors: Chris Lalancette
```

## tf2_tools

- No changes
