### PR TITLE
reach_ros: 1.4.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5305,7 +5305,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/reach_ros2-release.git
-      version: 1.3.4-1
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/ros-industrial/reach_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `reach_ros` to `1.4.0-1`:

- upstream repository: https://github.com/ros-industrial/reach_ros2
- release repository: https://github.com/ros2-gbp/reach_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.4-1`

## reach_ros

```
* IK Solver Update (#30 <https://github.com/marip8/reach_ros2/issues/30>)
  * Migrate utility function to reach
  * Replace deprecated function
  * Check that IK solver has been loaded for move group
  * Run format jobs on 20.04
  * Ran clang format
* Contributors: Michael Ripperger
```
