### PR TITLE
clearpath_simulator: 0.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -953,7 +953,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_simulator-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_simulator` to `0.1.2-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_simulator.git
- release repository: https://github.com/clearpath-gbp/clearpath_simulator-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.1-1`

## clearpath_generator_gz

```
* Initial addition of Blackfly (#19 <https://github.com/clearpathrobotics/clearpath_simulator/issues/19>)
  * Initial addition of Blackfly
* Contributors: Hilary Luo
```

## clearpath_gz

- No changes

## clearpath_simulator

- No changes
