### PR TITLE
urdf_sim_tutorial: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8484,6 +8484,15 @@ repositories:
       version: ros2
     status: maintained
   urdf_sim_tutorial:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf_sim_tutorial.git
+      version: ros2
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros-gbp/urdf_sim_tutorial-release.git
+      version: 1.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_sim_tutorial` to `1.0.1-1`:

- upstream repository: https://github.com/ros/urdf_sim_tutorial.git
- release repository: https://github.com/ros-gbp/urdf_sim_tutorial-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
