### PR TITLE
clearpath_desktop: 0.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -901,7 +901,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_desktop-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_desktop` to `0.1.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_desktop.git
- release repository: https://github.com/clearpath-gbp/clearpath_desktop-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.0-1`

## clearpath_config_live

```
* [clearpath_config_live] Removed unused import.
* [clearpath_config_live] Added periods to all comments for pep257.
* Contributors: Tony Baltovski
```

## clearpath_desktop

```
* Added config live dependency
* Contributors: Roni Kreinin
```

## clearpath_viz

- No changes
