### PR TITLE
Add robot_module_msgs and digital_interface_msgs

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1977,6 +1977,16 @@ repositories:
       url: https://github.com/ros-mobile-robots/diffbot.git
       version: noetic-devel
     status: developed
+  digital_interface_msgs:
+    doc:
+      type: git
+      url: https://github.com/ReconCycle/digital_interface_msgs
+      version: release
+    source:
+      type: git
+      url: https://github.com/ReconCycle/digital_interface_msgs
+      version: release
+    status: maintained
   dingo:
     doc:
       type: git
@@ -8781,6 +8791,16 @@ repositories:
       url: https://github.com/cra-ros-pkg/robot_localization.git
       version: noetic-devel
     status: developed
+  robot_module_msgs:
+    doc:
+      type: git
+      url: https://github.com/ReconCycle/robot_module_msgs.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/ReconCycle/robot_module_msgs.git
+      version: release
+    status: maintained
   robot_navigation:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1980,11 +1980,11 @@ repositories:
   digital_interface_msgs:
     doc:
       type: git
-      url: https://github.com/ReconCycle/digital_interface_msgs
+      url: https://github.com/ReconCycle/digital_interface_msgs.git
       version: release
     source:
       type: git
-      url: https://github.com/ReconCycle/digital_interface_msgs
+      url: https://github.com/ReconCycle/digital_interface_msgs.git
       version: release
     status: maintained
   dingo:


### PR DESCRIPTION
## Package name:

1. robot_module_msgs
2. digital_interface_msgs

## Package Upstream Source:

1. https://github.com/ReconCycle/robot_module_msgs
2. https://github.com/ReconCycle/digital_interface_msgs

## Purpose of using this:

1. Provides message, service, and action definitions for general purpose robot-agnostic controllers. Notably, it includes JointCommand.msg and CartesianCommand.msg, which include fields to specify positions, velocities, accelerations and additional force applied by the robot as well as an option to set robot compliance. it is used in https://github.com/abr-ijs/ijs_controllers
3. Provides message and service definitions for controlling GPIO pins. It is used for https://github.com/ReconCycle/raspi_ros and https://github.com/ReconCycle/rqt_raspi_ros

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
