### PR TITLE
mvsim: 0.8.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3671,7 +3671,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mvsim-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       type: git
       url: https://github.com/MRPT/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.8.2-1`:

- upstream repository: https://github.com/MRPT/mvsim.git
- release repository: https://github.com/ros2-gbp/mvsim-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.8.1-1`

## mvsim

```
* 3D LIDARs: Bilinear interpolation (when it makes sense) to obtain much smoother point cloud simulations
* Add missing build dep on python3-pip.
  This was triggering errors on ROS 1 build farm dev builds.
* Contributors: Jose Luis Blanco-Claraco
```
