### PR TITLE
ur_robot_driver: 2.2.9-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8424,7 +8424,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.2.8-1
+      version: 2.2.9-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.2.9-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.8-1`

## ur

- No changes

## ur_bringup

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* Update sjtc to newest upstream API
* Contributors: Felix Exner
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* Added support for UR20 (#805 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/805>)
* Contributors: mergify[bot], Felix Exner
```

## ur_robot_driver

```
* Added a test that sjtc correctly aborts on violation of constraints
* Added support for UR20 (#805 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/805>)
* Introduced tf_prefix into log handler (#713 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/713>)
* Start ursim from lib (#733 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/733>)
* Run robot driver test also with tf_prefix (#729 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/729>)
* Urscript interface (#721 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/721>) (#742 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/742>)
* Contributors: Felix Exner, Lennart Nachtigall, mergify[bot]
```
