### PR TITLE
behaviortree_cpp_v4: 4.3.8-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -561,7 +561,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.3.7-1
+      version: 4.3.8-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp_v4` to `4.3.8-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.3.7-1`

## behaviortree_cpp

```
* ReactiveSequence and ReactiveFallback will behave more similarly to 3.8
* bug fix in wakeUpSignal
* ignore newlines in script
* stop ordering ports in TreeNodesModel
* add a specific tutorial for plugins
* Contributors: Davide Faconti
```
