### PR TITLE
point_cloud_transport_tutorial: 0.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3787,7 +3787,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/ros-perception/point_cloud_transport_tutorial.git
+      url: https://github.com/ros2-gbp/point_cloud_transport_tutorial-release.git
       version: 0.0.1-1
     source:
       test_pull_requests: true

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3780,11 +3780,21 @@ repositories:
       version: rolling
     status: maintained
   point_cloud_transport_tutorial:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/point_cloud_transport_tutorial.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros-perception/point_cloud_transport_tutorial.git
+      version: 0.0.1-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/point_cloud_transport_tutorial.git
       version: rolling
+    status: maintained
   pointcloud_to_laserscan:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport_tutorial` to `0.0.1-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport_tutorial
- release repository: https://github.com/ros-perception/point_cloud_transport_tutorial.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## point_cloud_transport_tutorial

```
* Added CI (#7 <https://github.com/ros-perception/point_cloud_transport_tutorial/issues/7>)
* Installed scripts, some minor fixes and warnings (#6 <https://github.com/ros-perception/point_cloud_transport_tutorial/issues/6>)
* ROS2 Port (#2 <https://github.com/ros-perception/point_cloud_transport_tutorial/issues/2>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Report log messages from transport C API.
* Added encoder/decoder tutorial.
* Initial cleanup before releasing. No substantial changes made.
* Contributors: Alejandro Hernández Cordero, john-maidbot
```
