### PR TITLE
rclcpp: 23.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4281,7 +4281,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 23.1.0-1
+      version: 23.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `23.2.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `23.1.0-1`

## rclcpp

```
* add clients & services count (#2072 <https://github.com/ros2/rclcpp/issues/2072>)
* remove invalid sized allocation test for SerializedMessage. (#2330 <https://github.com/ros2/rclcpp/issues/2330>)
* Adding API to copy all parameters from one node to another (#2304 <https://github.com/ros2/rclcpp/issues/2304>)
* Contributors: Minju, Lee, Steve Macenski, Tomoya Fujita
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* add clients & services count (#2072 <https://github.com/ros2/rclcpp/issues/2072>)
* Contributors: Minju, Lee
```
