### PR TITLE
rviz: 13.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6087,7 +6087,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 13.1.1-1
+      version: 13.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `13.1.2-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `13.1.1-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

- No changes

## rviz_default_plugins

```
* Fix ODR violations in interactive_marker displays. (#1068 <https://github.com/ros2/rviz/issues/1068>)
* Contributors: Chris Lalancette
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* RVIZ_RENDERING_PUBLIC to export class RenderSystem (#1072 <https://github.com/ros2/rviz/issues/1072>)
* Restore the maybe-uninitialized flag in covariance_visual.hpp (#1071 <https://github.com/ros2/rviz/issues/1071>)
* Fix up warnings when building with clang. (#1070 <https://github.com/ros2/rviz/issues/1070>)
* Contributors: Chris Lalancette, Felix F Xu
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
