### PR TITLE
urdf_sim_tutorial: 1.0.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7278,6 +7278,22 @@ repositories:
       url: https://github.com/ros/urdf_parser_py.git
       version: ros2
     status: maintained
+  urdf_sim_tutorial:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf_sim_tutorial.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros-gbp/urdf_sim_tutorial-release.git
+      version: 1.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/urdf_sim_tutorial.git
+      version: ros2
+    status: developed
   urdf_tutorial:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_sim_tutorial` to `1.0.1-1`:

- upstream repository: https://github.com/ros/urdf_sim_tutorial.git
- release repository: https://github.com/ros-gbp/urdf_sim_tutorial-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
