### PR TITLE
rclpy: 5.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4297,7 +4297,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 5.3.0-1
+      version: 5.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `5.4.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `5.3.0-1`

## rclpy

```
* Fix to issue https://github.com/ros2/rclpy/issues/1179 (#1180 <https://github.com/ros2/rclpy/issues/1180>)
* Add count services, clients & test (#1024 <https://github.com/ros2/rclpy/issues/1024>)
* Contributors: KKSTB, Minju, Lee
```
