### PR TITLE
Adding vizanti to documentation index for humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8786,6 +8786,16 @@ repositories:
       url: https://github.com/ros-acceleration/vitis_common.git
       version: rolling
     status: developed
+  vizanti:
+    doc:
+      type: git
+      url: https://github.com/MoffKalast/vizanti.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/MoffKalast/vizanti.git
+      version: ros2
+    status: maintained
   vrpn:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

Humble

# The source is here:

https://github.com/MoffKalast/vizanti/tree/ros2

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
