### PR TITLE
joystick_drivers: 3.2.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2183,7 +2183,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/joystick_drivers-release.git
-      version: 3.1.0-4
+      version: 3.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joystick_drivers` to `3.2.0-1`:

- upstream repository: https://github.com/ros-drivers/joystick_drivers.git
- release repository: https://github.com/ros2-gbp/joystick_drivers-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.1.0-4`

## joy

```
* Remove ament target deps for the new game_controller node. (#272 <https://github.com/ros-drivers/joystick_drivers/issues/272>)
* Use the SDL2 Game Controller API (#258 <https://github.com/ros-drivers/joystick_drivers/issues/258>)
* fix autorepeat not being triggered when inside deadzone (#261 <https://github.com/ros-drivers/joystick_drivers/issues/261>)
* Linter fix.
* fix high CPU usage (#247 <https://github.com/ros-drivers/joystick_drivers/issues/247>)
* Contributors: Chris Lalancette, Joshua Whitley, Marco Boneberger, Roderick Taylor, Tony Najjar
```

## joy_linux

```
* Remove the last use of ament_target_dependencies. (#264 <https://github.com/ros-drivers/joystick_drivers/issues/264>)
* Contributors: Chris Lalancette
```

## sdl2_vendor

- No changes

## spacenav

```
* add option to use TwistStamped (#251 <https://github.com/ros-drivers/joystick_drivers/issues/251>)
* Changed name of executable in launch files to match installed node (#230 <https://github.com/ros-drivers/joystick_drivers/issues/230>)
* Fix publishing of spacenav button values (#243 <https://github.com/ros-drivers/joystick_drivers/issues/243>)
* Fix from-source build with missing dependencies (#242 <https://github.com/ros-drivers/joystick_drivers/issues/242>)
* Installing libspacenav.so to lib/ for spacenav_node execution via ros2 run (#229 <https://github.com/ros-drivers/joystick_drivers/issues/229>)
* Contributors: Borong Yuan, Stefan Scherzinger, chriseichmann
```

## wiimote

```
* Revert "Fix dependency issues." (#259 <https://github.com/ros-drivers/joystick_drivers/issues/259>)
* Fix dependency issues.
* Contributors: Chris Lalancette, Joshua Whitley
```

## wiimote_msgs

```
* Remove trailing whitespace from .msg files. (#237 <https://github.com/ros-drivers/joystick_drivers/issues/237>)
* Contributors: Chris Lalancette
```
