### PR TITLE
ament_black: 0.2.2-2 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -105,7 +105,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/botsandus/ament_black-release.git
-      version: 0.2.2-1
+      version: 0.2.2-2
     source:
       type: git
       url: https://github.com/botsandus/ament_black.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_black` to `0.2.2-2`:

- upstream repository: https://github.com/botsandus/ament_black.git
- release repository: https://github.com/botsandus/ament_black-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.2-1`

## ament_black

```
* Nacho/fix ci tests (#5 <https://github.com/botsandus/ament_black/issues/5>)
  * Add missing test dependency
  * pre-commit
  * Add pre-commit workflow
  * Add CLI test to make sure the package has been properly installed
  * Remove ament hooks
  * Add missing apt-python dependency
  Not sure if it's necessary ...
  * Fix CI pre-commit
  The CI error was fixed in: https://github.com/psf/black/issues/2964
  Thus, we need black >22.3.0
* Contributors: Ignacio Vizzo
```

## ament_cmake_black

```
* Nacho/fix ci tests (#5 <https://github.com/botsandus/ament_black/issues/5>)
  * Add missing test dependency
  * pre-commit
  * Add pre-commit workflow
  * Add CLI test to make sure the package has been properly installed
  * Remove ament hooks
  * Add missing apt-python dependency
  Not sure if it's necessary ...
  * Fix CI pre-commit
  The CI error was fixed in: https://github.com/psf/black/issues/2964
  Thus, we need black >22.3.0
* Contributors: Ignacio Vizzo
```
