### PR TITLE
Add uvloop to python rosdep index

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9272,8 +9272,6 @@ python3-uvloop:
   fedora: [python3-uvloop]
   gentoo: [dev-python/uvloop]
   nixos: [python3Packages.uvloop]
-  opensuse: [python-uvloop]
-  rhel: [python3-uvloop]
   ubuntu: [python3-uvloop]
 python3-vcstool:
   alpine: [vcstool]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9266,15 +9266,15 @@ python3-uvicorn:
     bionic:
       pip:
         packages: [uvicorn]
-python3-uvtool:
-  arch: [python-uvtool]
-  debian: [python3-uvtool]
-  fedora: [python3-uvtool]
-  gentoo: [dev-python/uvtool]
-  nixos: [python3Packages.uvtool]
-  opensuse: [python-uvtool]
-  rhel: [python3-uvtool]
-  ubuntu: [python3-uvtool]
+python3-uvloop:
+  arch: [python-uvloop]
+  debian: [python3-uvloop]
+  fedora: [python3-uvloop]
+  gentoo: [dev-python/uvloop]
+  nixos: [python3Packages.uvloop]
+  opensuse: [python-uvloop]
+  rhel: [python3-uvloop]
+  ubuntu: [python3-uvloop]
 python3-vcstool:
   alpine: [vcstool]
   debian: [python3-vcstool]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9266,6 +9266,15 @@ python3-uvicorn:
     bionic:
       pip:
         packages: [uvicorn]
+python3-uvtool:
+  arch: [python-uvtool]
+  debian: [python3-uvtool]
+  fedora: [python3-uvtool]
+  gentoo: [dev-python/uvtool]
+  nixos: [python3Packages.uvtool]
+  opensuse: [python-uvtool]
+  rhel: [python3-uvtool]
+  ubuntu: [python3-uvtool]
 python3-vcstool:
   alpine: [vcstool]
   debian: [python3-vcstool]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-uvloop

## Package Upstream Source:

https://github.com/MagicStack/uvloop

## Purpose of using this:

Dependency to be used by the new version of `ament-black`. `uvtool` is required to fix a concurrency problem on `--reformat`, this was solved in https://github.com/botsandus/ament_black/pull/4

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  -[ REQUIRED](https://packages.debian.org/bookworm/python3-uvloop)
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/jammy/python3-uvloop
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-uvloop/python3-uvloop/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/python-uvloop/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/uvloop
- macOS: https://formulae.brew.sh/
  - NOT AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - NOT AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=23.05&from=0&size=50&sort=relevance&type=packages&query=uvloop
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python-uvloop
- rhel: https://rhel.pkgs.org/
  - Ihttps://pkgs.org/search/?q=uvloop

