### PR TITLE
ublox_dgnss: 0.5.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7124,7 +7124,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ublox_dgnss-release.git
-      version: 0.4.4-1
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/aussierobots/ublox_dgnss.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ublox_dgnss` to `0.5.0-1`:

- upstream repository: https://github.com/aussierobots/ublox_dgnss
- release repository: https://github.com/ros2-gbp/ublox_dgnss-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.4-1`

## ntrip_client_node

- No changes

## ublox_dgnss

```
* Merge branch 'main' of github.com:aussierobots/ublox_dgnss
* Merge pull request #12 <https://github.com/aussierobots/ublox_dgnss/issues/12> from gsokoll/main
  Add multiple device support, and moving base+rover example
* Add multiple device support, and moving base+rover example
* Contributors: Geoff Sokoll, Nick Hortovanyi
```

## ublox_dgnss_node

```
* code formatting issues
* fixed line length
* Merge branch 'main' of github.com:aussierobots/ublox_dgnss
* Merge pull request #12 <https://github.com/aussierobots/ublox_dgnss/issues/12> from gsokoll/main
  Add multiple device support, and moving base+rover example
* Added new messages for satellite data & security
* increase buffer size
* Add multiple device support, and moving base+rover example
* Contributors: Geoff Sokoll, Nick Hortovanyi
```

## ublox_nav_sat_fix_hp_node

- No changes

## ublox_ubx_interfaces

- No changes

## ublox_ubx_msgs

```
* Added new messages for satellite data & security
* Contributors: Nick Hortovanyi
```
