### PR TITLE
ublox_dgnss: 0.5.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6904,7 +6904,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ublox_dgnss-release.git
-      version: 0.4.4-1
+      version: 0.5.1-1
     source:
       type: git
       url: https://github.com/aussierobots/ublox_dgnss.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ublox_dgnss` to `0.5.1-1`:

- upstream repository: https://github.com/aussierobots/ublox_dgnss
- release repository: https://github.com/ros2-gbp/ublox_dgnss-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.4-1`

## ntrip_client_node

```
* Merge branch 'aussierobots:main' into main
* Contributors: Geoff Sokoll
```

## ublox_dgnss

```
* Merge branch 'aussierobots:main' into main
* Contributors: Geoff Sokoll
```

## ublox_dgnss_node

```
* Merge branch 'aussierobots:main' into main
* Contributors: Geoff Sokoll
```

## ublox_nav_sat_fix_hp_node

```
* fixed formatting
* Merge pull request #14 <https://github.com/aussierobots/ublox_dgnss/issues/14> from gsokoll/main
  Remove check for nav_sat_stat and nav_sat_cov from nav_sat_fix node
* Merge branch 'aussierobots:main' into main
* Removed check for nav_sat_stat and _cov
* Contributors: Geoff Sokoll, Nick Hortovanyi
```

## ublox_ubx_interfaces

```
* Merge branch 'aussierobots:main' into main
* Contributors: Geoff Sokoll
```

## ublox_ubx_msgs

```
* Merge branch 'aussierobots:main' into main
* Contributors: Geoff Sokoll
```
