### PR TITLE
ament_black: 0.2.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -153,8 +153,8 @@ repositories:
       - ament_cmake_black
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/Timple/ament_black-release.git
-      version: 0.1.0-1
+      url: https://github.com/botsandus/ament_black-release.git
+      version: 0.2.3-1
     source:
       type: git
       url: https://github.com/Timple/ament_black.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_black` to `0.2.3-1`:

- upstream repository: https://github.com/botsandus/ament_black.git
- release repository: https://github.com/botsandus/ament_black-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.0-1`

## ament_black

```
* Add python3-uvloop as dependency https://github.com/ros/rosdistro/pull/38754
* Contributors: Ignacio Vizzo
```

## ament_cmake_black

```
* Fix amenx_xmllint test
* Contributors: Ignacio Vizzo
```
