### PR TITLE
ament_black: 0.2.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -104,7 +104,7 @@ repositories:
       - ament_cmake_black
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/botsandus/ament_black-release.git
+      url: https://github.com/ros2-gbp/ament_black-release.git
       version: 0.2.3-1
     source:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -97,6 +97,15 @@ repositories:
       url: https://github.com/ros-acceleration/ament_acceleration.git
       version: rolling
     status: developed
+  ament_black:
+    release:
+      packages:
+      - ament_black
+      - ament_cmake_black
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/botsandus/ament_black-release.git
+      version: 0.2.3-1
   ament_cmake:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -106,6 +106,11 @@ repositories:
         release: release/rolling/{package}/{version}
       url: https://github.com/botsandus/ament_black-release.git
       version: 0.2.3-1
+    source:
+      type: git
+      url: https://github.com/botsandus/ament_black.git
+      version: main
+    status: maintained
   ament_cmake:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_black` to `0.2.3-1`:

- upstream repository: https://github.com/botsandus/ament_black.git
- release repository: https://github.com/botsandus/ament_black-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## ament_black

```
* Add python3-uvloop as dependency https://github.com/ros/rosdistro/pull/38754
* Contributors: Ignacio Vizzo
```

## ament_cmake_black

```
* Fix amenx_xmllint test
* Contributors: Ignacio Vizzo
```
