### PR TITLE
geometry2: 0.7.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3293,7 +3293,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/geometry2-release.git
-      version: 0.7.6-1
+      version: 0.7.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.7.7-1`:

- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry2-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.6-1`

## geometry2

- No changes

## tf2

```
* fix extra comma that gives annoying build warnings with -Wall and -Wpedantic with g++-9 and assuming most other compilers (#550 <https://github.com/ros/geometry2/issues/550>)
* Add parent frame to warning logs (#533 <https://github.com/ros/geometry2/issues/533>)
* Contributors: Jack Zender, Stephan
```

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

```
* Fix(tf2_py) potential memory leak (#544 <https://github.com/ros/geometry2/issues/544>)
* Contributors: Matthijs van der Burgh
```

## tf2_ros

- No changes

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
