### PR TITLE
clearpath_desktop: 0.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -916,7 +916,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_desktop-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_desktop` to `0.1.2-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_desktop.git
- release repository: https://github.com/clearpath-gbp/clearpath_desktop-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.1-1`

## clearpath_config_live

```
* Pass setup path to clearpath_config
* Contributors: Luis Camero
```

## clearpath_desktop

- No changes

## clearpath_viz

```
* rqt_robot_monitor dep
* View diagnostics
  Added license
* Pass setup path to clearpath_config
* Contributors: Luis Camero, Roni Kreinin
```
