### PR TITLE
Add leo_simulator repository

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2349,6 +2349,16 @@ repositories:
       url: https://github.com/LeoRover/leo_robot-ros2.git
       version: humble
     status: maintained
+  leo_simulator:
+    doc:
+      type: git
+      url: https://github.com/LeoRover/leo_simulator-ros2.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/LeoRover/leo_simulator-ros2.git
+      version: humble
+    status: maintained
   lgsvl_msgs:
     release:
       tags:


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

Humble

# The source is here:

https://github.com/LeoRover/leo_simulator-ros2/tree/humble

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
