### PR TITLE
behaviortree_cpp_v4: 4.4.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -684,7 +684,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.3.8-1
+      version: 4.4.0-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp_v4` to `4.4.0-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.3.8-1`

## behaviortree_cpp

```
* Update ex05_subtree_model.cpp
* added any::stringToNumber
* added SubTree model example
* unit test for issue 660
* adding SubTree model
* minor changes
* change blackboard entry
* Update simple_string.hpp
* SimpleString: fix warning by checking upper size limit (#666 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/666>)
* Contributors: Adam Boseley, Davide Faconti
```
