### PR TITLE
Adding sick_scan_xd to documentation index for distro noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10864,6 +10864,11 @@ repositories:
       url: https://github.com/SICKAG/sick_scan.git
       version: master
     status: developed
+  sick_scan_xd:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/sick_scan_xd.git
+      version: master
   sick_tim:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

ROSDISTRO noetic

# The source is here:

https://github.com/SICKAG/sick_scan_xd

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
