### PR TITLE
sick_safevisionary_ros1: 1.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10849,6 +10849,24 @@ repositories:
       url: https://github.com/SICKAG/sick_safetyscanners.git
       version: master
     status: developed
+  sick_safevisionary_ros1:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/sick_safevisionary_ros1.git
+      version: main
+    release:
+      packages:
+      - sick_safevisionary_driver
+      - sick_safevisionary_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/SICKAG/sick_safevisionary_ros1-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_safevisionary_ros1.git
+      version: main
+    status: developed
   sick_scan:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safevisionary_ros1` to `1.0.1-1`:

- upstream repository: https://github.com/SICKAG/sick_safevisionary_ros1.git
- release repository: https://github.com/SICKAG/sick_safevisionary_ros1-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## sick_safevisionary_driver

```
* Add a minimal readme to the driver package
* Added doxygen comments
* Added licensing and maintainer infos
* Updated msg names and included header
* Check intensity and point vector size for mismatch
* Split into driver and publisher class
* Removed unnecessary info from cmake and package files
* renamed variables
* Renamed classes and files
* Contributors: Marvin Große Besselmann, Stefan Scherzinger
```

## sick_safevisionary_msgs

```
* Add a minimal readme to the messages package
* Added pre-commit config and removed eof whitespaces
* Added licensing and maintainer infos
* Updated msg names and included header
* Removed unnecessary info from cmake and package files
* Renaming of msgs
* Added message definitions for status, io, roi, fields
* Transformed package into meta package and added driver specific msg package
* Contributors: Marvin Große Besselmann, Stefan Scherzinger
```
