### PR TITLE
libstatistics_collector: 1.6.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2460,7 +2460,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libstatistics_collector-release.git
-      version: 1.6.2-1
+      version: 1.6.3-1
     source:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libstatistics_collector` to `1.6.3-1`:

- upstream repository: https://github.com/ros-tooling/libstatistics_collector.git
- release repository: https://github.com/ros2-gbp/libstatistics_collector-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.6.2-1`

## libstatistics_collector

```
* Bump actions/checkout from 3 to 4 (#169 <https://github.com/ros-tooling/libstatistics_collector/issues/169>)
* Add API to use message_info instead unserialized message (#170 <https://github.com/ros-tooling/libstatistics_collector/issues/170>)
* Bump codecov/codecov-action from 3.1.3 to 3.1.4
* Contributors: Lucas Wendland, Michael Orlov, dependabot[bot]
```
- Relates https://github.com/ros2/rclcpp/pull/2337