### PR TITLE
Remove apex containers from rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -311,21 +311,6 @@ repositories:
       url: https://github.com/ros/angles.git
       version: ros2
     status: maintained
-  apex_containers:
-    doc:
-      type: git
-      url: https://gitlab.com/ApexAI/apex_containers.git
-      version: rolling
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/apex_containers-release.git
-      version: 0.0.4-4
-    source:
-      type: git
-      url: https://gitlab.com/ApexAI/apex_containers.git
-      version: rolling
-    status: developed
   apex_test_tools:
     doc:
       type: git


### PR DESCRIPTION
Removing apex_containers from rolling since it is no longer maintained.