### PR TITLE
mrpt2: 2.11.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2966,7 +2966,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt2-release.git
-      version: 2.10.2-1
+      version: 2.11.0-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt2` to `2.11.0-1`:

- upstream repository: https://github.com/MRPT/mrpt.git
- release repository: https://github.com/ros2-gbp/mrpt2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.10.2-1`
