### PR TITLE
gnsstk: 14.0.0-7 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3359,6 +3359,21 @@ repositories:
       url: https://github.com/adler-1994/gmcl.git
       version: master
     status: developed
+  gnsstk:
+    doc:
+      type: git
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/gnsstk-release.git
+      version: release/noetic/gnsstk
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/gnsstk-release.git
+      version: 14.0.0-7
+    source:
+      type: git
+      url: https://github.com/SGL-UT/gnsstk.git
+      version: stable
+    status: maintained
   gpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gnsstk` to `14.0.0-7`:

- upstream repository: https://github.com/SGL-UT/gnsstk.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/gnsstk-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
