### PR TITLE
locator_ros_bridge: 1.0.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5085,7 +5085,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/locator_ros_bridge-release.git
-      version: 1.0.9-3
+      version: 1.0.10-1
     source:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `locator_ros_bridge` to `1.0.10-1`:

- upstream repository: https://github.com/boschglobal/locator_ros_bridge.git
- release repository: https://github.com/ros-gbp/locator_ros_bridge-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.9-3`

## bosch_locator_bridge

```
* Update to ROKIT Locator version 1.6
* Document the map expansion workflow
* Add rviz config files for map expansion
* Add services and interfaces for map expansion
* Add expandmap_state in control mode
* Remove field distanceToLastLC in ClientLocalizationVisualizationDatagram
* Introduce parameter odometry_velocity_set of odometry message
* Configurable Locator ports
* Contributors: Sheung Ying Yuen-Wille
```
