### PR TITLE
catch_ros2: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -711,7 +711,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/catch_ros2-release.git
-      version: 0.1.0-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/ngmor/catch_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catch_ros2` to `0.2.0-1`:

- upstream repository: https://github.com/ngmor/catch_ros2.git
- release repository: https://github.com/ros2-gbp/catch_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.0-1`

## catch_ros2

```
* Updated to Catch2 v3.4.0
* Add launch_catch_ros2 Python package to the launch.frontend.launch_extension group
* Expose launch_catch_ros2 items to frontend (XML/YAML) launch files
* Update documentation
* Contributors: Nick Morales
```
