### PR TITLE
clearpath_msgs: 0.9.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -827,6 +827,32 @@ repositories:
       url: https://github.com/ros/class_loader.git
       version: noetic-devel
     status: maintained
+  clearpath_msgs:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_msgs.git
+      version: noetic-devel
+    release:
+      packages:
+      - clearpath_configuration_msgs
+      - clearpath_control_msgs
+      - clearpath_dock_msgs
+      - clearpath_localization_msgs
+      - clearpath_mission_manager_msgs
+      - clearpath_mission_scheduler_msgs
+      - clearpath_msgs
+      - clearpath_navigation_msgs
+      - clearpath_platform_msgs
+      - clearpath_safety_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/clearpath_msgs-release.git
+      version: 0.9.4-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_msgs.git
+      version: noetic-devel
+    status: maintained
   clober:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_msgs` to `0.9.4-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_msgs.git
- release repository: https://github.com/clearpath-gbp/clearpath_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## clearpath_configuration_msgs

- No changes

## clearpath_control_msgs

- No changes

## clearpath_dock_msgs

- No changes

## clearpath_localization_msgs

- No changes

## clearpath_mission_manager_msgs

- No changes

## clearpath_mission_scheduler_msgs

- No changes

## clearpath_msgs

```
* Remove dependencies on packages not released to OSRF
* Contributors: Chris Iverach-Brereton
```

## clearpath_navigation_msgs

- No changes

## clearpath_platform_msgs

- No changes

## clearpath_safety_msgs

- No changes
