### PR TITLE
Add gazebo_video_monitors in humble and iron

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1970,6 +1970,16 @@ repositories:
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
       version: ros2
     status: maintained
+  gazebo_video_monitors:
+    doc:
+      type: git
+      url: https://github.com/nlamprian/gazebo_video_monitors.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/nlamprian/gazebo_video_monitors.git
+      version: ros2
+    status: maintained
   gc_spl:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1572,6 +1572,16 @@ repositories:
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
       version: ros2
     status: maintained
+  gazebo_video_monitors:
+    doc:
+      type: git
+      url: https://github.com/nlamprian/gazebo_video_monitors.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/nlamprian/gazebo_video_monitors.git
+      version: ros2
+    status: maintained
   gc_spl:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3131,7 +3131,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/nlamprian/gazebo_video_monitors.git
-      version: master
+      version: ros1
     release:
       packages:
       - gazebo_video_monitor_msgs
@@ -3145,7 +3145,7 @@ repositories:
     source:
       type: git
       url: https://github.com/nlamprian/gazebo_video_monitors.git
-      version: master
+      version: ros1
     status: maintained
   gencpp:
     doc:


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

Humble and Iron

# The source is here:

https://github.com/nlamprian/gazebo_video_monitors

# Checks
 - [x] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
