### PR TITLE
Remove apex_containers from Iron

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -325,21 +325,6 @@ repositories:
       url: https://github.com/ros/angles.git
       version: ros2
     status: maintained
-  apex_containers:
-    doc:
-      type: git
-      url: https://gitlab.com/ApexAI/apex_containers.git
-      version: rolling
-    release:
-      tags:
-        release: release/iron/{package}/{version}
-      url: https://github.com/ros2-gbp/apex_containers-release.git
-      version: 0.0.4-5
-    source:
-      type: git
-      url: https://gitlab.com/ApexAI/apex_containers.git
-      version: rolling
-    status: developed
   apex_test_tools:
     doc:
       type: git


### PR DESCRIPTION
Removing apex_containers from iron since it is no longer maintained.
