### PR TITLE
Revert "openzen_sensor: 1.3.2-1 in 'noetic/distribution.yaml' [bloom]"

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7030,7 +7030,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/lp-research/openzen_sensor-release.git
-      version: 1.3.2-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://bitbucket.org/lpresearch/openzenros.git


### PR DESCRIPTION
Reverts ros/rosdistro#38372

This appears to be failing on all platforms since this release. I'm not sure why it wasn't listed as a regression last sync.

@ykchong45 FYI

https://bitbucket.org/lpresearch/openzenros/issues/11/noetic-all-builds-of-openzen_sensor