### PR TITLE
openni2_camera: 1.6.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6964,7 +6964,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/openni2_camera-release.git
-      version: 1.6.0-1
+      version: 1.6.1-1
     source:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_camera` to `1.6.1-1`:

- upstream repository: https://github.com/ros-drivers/openni2_camera.git
- release repository: https://github.com/ros-gbp/openni2_camera-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.6.0-1`

## openni2_camera

```
* Fix: make subprocess output a string instead of bytes, needed in python 3.7 #113 <https://github.com/ros-drivers/openni2_camera/issues/113>
```

## openni2_launch

```
* Fix: make subprocess output a string instead of bytes, needed in python 3.7 #113 <https://github.com/ros-drivers/openni2_camera/issues/113>
```
