### PR TITLE
foxglove_bridge: 0.7.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2988,7 +2988,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/foxglove/ros_foxglove_bridge-release.git
-      version: 0.7.2-1
+      version: 0.7.3-1
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_bridge` to `0.7.3-1`:

- upstream repository: https://github.com/foxglove/ros-foxglove-bridge.git
- release repository: https://github.com/foxglove/ros_foxglove_bridge-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.2-1`

## foxglove_bridge

```
* Fix asset_uri_whitelist regex backtracking issue, add more extensions (#270 <https://github.com/foxglove/ros-foxglove-bridge/issues/270>)
* [ROS1] Fix callback accessing invalid reference to promise (#268 <https://github.com/foxglove/ros-foxglove-bridge/issues/268>)
* Contributors: Hans-Joachim Krauch
```
