### PR TITLE
gazebo_video_monitors: 0.7.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3141,7 +3141,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/nlamprian/gazebo_video_monitors-release.git
-      version: 0.7.0-1
+      version: 0.7.1-1
     source:
       type: git
       url: https://github.com/nlamprian/gazebo_video_monitors.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_video_monitors` to `0.7.1-1`:

- upstream repository: https://github.com/nlamprian/gazebo_video_monitors.git
- release repository: https://github.com/nlamprian/gazebo_video_monitors-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.0-1`

## gazebo_video_monitor_msgs

- No changes

## gazebo_video_monitor_plugins

- No changes

## gazebo_video_monitor_utils

- No changes

## gazebo_video_monitors

```
* Add missing dependency
* Contributors: Nick Lamprianidis
```
