### PR TITLE
leo_common: 2.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4846,7 +4846,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_common-release.git
-      version: 2.2.0-1
+      version: 2.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_common` to `2.3.0-1`:

- upstream repository: https://github.com/LeoRover/leo_common.git
- release repository: https://github.com/fictionlab-gbp/leo_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.0-1`

## leo

- No changes

## leo_description

```
* Add mecanum wheels to description package (#5 <https://github.com/LeoRover/leo_common/issues/5>)
* Contributors: Aleksander Szymański
```

## leo_msgs

```
* Add WheelOdomMecanum message type (#3 <https://github.com/LeoRover/leo_common/issues/3>)
* Contributors: Aleksander Szymański
```

## leo_teleop

```
* Expand joy teleop config to support the mecanum wheels (#4 <https://github.com/LeoRover/leo_common/issues/4>)
* Contributors: Aleksander Szymański
```
