### PR TITLE
joystick_drivers: 3.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2634,7 +2634,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/joystick_drivers-release.git
-      version: 3.2.0-1
+      version: 3.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joystick_drivers` to `3.3.0-1`:

- upstream repository: https://github.com/ros-drivers/joystick_drivers.git
- release repository: https://github.com/ros2-gbp/joystick_drivers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.2.0-1`

## joy

```
* Fix compatibility with SDL versions below 2.0.18 (#273 <https://github.com/ros-drivers/joystick_drivers/issues/273>)
* Contributors: Johannes Meyer
```

## joy_linux

- No changes

## sdl2_vendor

```
* Upgrade to SDL2.0.20 (#270 <https://github.com/ros-drivers/joystick_drivers/issues/270>)
* Contributors: Patrick Roncagliolo
```

## spacenav

- No changes

## wiimote

- No changes

## wiimote_msgs

- No changes
