### PR TITLE
locator_ros_bridge: 2.1.10-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2489,7 +2489,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/locator_ros_bridge-release.git
-      version: 2.1.9-2
+      version: 2.1.10-1
     source:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `locator_ros_bridge` to `2.1.10-1`:

- upstream repository: https://github.com/boschglobal/locator_ros_bridge.git
- release repository: https://github.com/ros2-gbp/locator_ros_bridge-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.9-2`

## bosch_locator_bridge

```
* update compatible Locator version to 1.8
* Document the map expansion workflow
* Add rviz config files for map expansion
* Add services and interfaces for map expansion
* Add expandmap_state in control mode
* Remove field distanceToLastLC in ClientLocalizationVisualizationDatagram
* Introduce parameter odometry_velocity_set of odometry message
* Configurable Locator ports
* Contributors: Sheung Ying Yuen-Wille, Stefan Laible
```
