### PR TITLE
leo_desktop: 0.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4884,7 +4884,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_desktop-release.git
-      version: 0.2.3-1
+      version: 0.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_desktop` to `0.3.0-1`:

- upstream repository: https://github.com/LeoRover/leo_desktop.git
- release repository: https://github.com/fictionlab-gbp/leo_desktop-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.3-1`

## leo_desktop

```
* Update author and maintainer info
* Contributors: Błażej Sowa
```

## leo_viz

```
* Add mecanum_wheels argument to view_model.launch (#1 <https://github.com/LeoRover/leo_desktop/issues/1>)
* Add xacro as exec dependency
* Update author and maintainer info
* Contributors: Aleksander Szymański, Błażej Sowa
```
