### PR TITLE
leo_robot: 2.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4924,7 +4924,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_robot-release.git
-      version: 2.3.0-1
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_robot` to `2.4.0-1`:

- upstream repository: https://github.com/LeoRover/leo_robot.git
- release repository: https://github.com/fictionlab-gbp/leo_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.0-1`

## leo_bringup

```
* Update author info
* Remove old deprecated firmware parameters
* Override firmware/mecanum_wheels parameter when mecanum_wheels argument is set
* Add mecanum_wheels argument to leo_bringup.launch (#14 <https://github.com/LeoRover/leo_robot/issues/14>)
* Mecanum wheels handling in merged odometry (#10 <https://github.com/LeoRover/leo_robot/issues/10>)
* Contributors: Aleksander Szymański, Błażej Sowa
```

## leo_fw

```
* Update firmware binaries
* Update author info
* Mecanum wheels handling in merged odometry (#10 <https://github.com/LeoRover/leo_robot/issues/10>)
* added std_srvs to package dependencies (#13 <https://github.com/LeoRover/leo_robot/issues/13>)
* Add merged odometry to firmware_message_converter (#11 <https://github.com/LeoRover/leo_robot/issues/11>)
* CI improvements and format fixes (#12 <https://github.com/LeoRover/leo_robot/issues/12>)
* Contributors: Aleksander Szymański, Błażej Sowa
```

## leo_robot

- No changes
