### PR TITLE
clearpath_onav_examples: 0.0.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -866,7 +866,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_onav_examples-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/cpr-application/clearpath_onav_examples.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_onav_examples` to `0.0.3-1`:

- upstream repository: https://github.com/cpr-application/clearpath_onav_examples.git
- release repository: https://github.com/clearpath-gbp/clearpath_onav_examples-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.2-1`

## clearpath_onav_api_examples

- No changes

## clearpath_onav_api_examples_lib

```
* Added instructions for generating docs for clearpath_onav_api_examples_lib
* Review fixes
* Fix typos
* Added a tasks class and modified Mission to include the onstart onstop tasks
* Contributors: José Mastrangelo, Jason Higgins
```

## clearpath_onav_examples

- No changes
