### PR TITLE
ros2_control: 3.20.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5046,7 +5046,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.19.1-1
+      version: 3.20.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.20.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.19.1-1`

## controller_interface

- No changes

## controller_manager

```
* Update spawner to accept controllers list and start them in sequence (#1139 <https://github.com/ros-controls/ros2_control/issues/1139>)
* [ResourceManager] deactivate hardware from read/write return value (#884 <https://github.com/ros-controls/ros2_control/issues/884>)
* Export of the get_cm_node_options() from robostack (#1129 <https://github.com/ros-controls/ros2_control/issues/1129>)
* Contributors: Felix Exner (fexner), Olivier Stasse, Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* [ResourceManager] deactivate hardware from read/write return value (#884 <https://github.com/ros-controls/ros2_control/issues/884>)
* Contributors: Felix Exner (fexner)
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

```
* [ResourceManager] deactivate hardware from read/write return value (#884 <https://github.com/ros-controls/ros2_control/issues/884>)
* Contributors: Felix Exner (fexner)
```

## ros2controlcli

```
* Fix doc of load_controller (#1132 <https://github.com/ros-controls/ros2_control/issues/1132>)
* Contributors: Christoph Fröhlich
```

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
