### PR TITLE
ros2_controllers: 3.17.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5007,7 +5007,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 3.16.0-1
+      version: 3.17.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `3.17.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.16.0-1`

## ackermann_steering_controller

```
* Improve docs (#785 <https://github.com/ros-controls/ros2_controllers/issues/785>)
* Contributors: Christoph Fröhlich
```

## admittance_controller

- No changes

## bicycle_steering_controller

```
* Improve docs (#785 <https://github.com/ros-controls/ros2_controllers/issues/785>)
* Contributors: Christoph Fröhlich
```

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* Cleanup comments and unnecessary checks (#803 <https://github.com/ros-controls/ros2_controllers/issues/803>)
* Update requirements of state interfaces (#798 <https://github.com/ros-controls/ros2_controllers/issues/798>)
* [JTC] Add tests for acceleration command interface (#752 <https://github.com/ros-controls/ros2_controllers/issues/752>)
* Contributors: Christoph Fröhlich
```

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

```
* [TestNodes] Optimize output about setup of JTC publisher (#792 <https://github.com/ros-controls/ros2_controllers/issues/792>)
* Contributors: Dr. Denis
```

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Steering controllers library: fix open loop mode (#793 <https://github.com/ros-controls/ros2_controllers/issues/793>)
  * set last*velocity variables for open loop odometry
  * Make function arguments const
  * Update function in header file too
* Improve docs (#785 <https://github.com/ros-controls/ros2_controllers/issues/785>)
* Contributors: Christoph Fröhlich
```

## tricycle_controller

- No changes

## tricycle_steering_controller

```
* Improve docs (#785 <https://github.com/ros-controls/ros2_controllers/issues/785>)
* Contributors: Christoph Fröhlich
```

## velocity_controllers

- No changes
