### PR TITLE
ouster_ros: 0.11.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3479,6 +3479,21 @@ repositories:
       url: https://github.com/osrf/osrf_testing_tools_cpp.git
       version: rolling
     status: maintained
+  ouster_ros:
+    release:
+      packages:
+      - ouster_ros
+      - ouster_sensor_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ouster-ros-release.git
+      version: 0.11.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ouster-lidar/ouster-ros.git
+      version: rolling-devel
+    status: developed
   ouxt_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ouster_ros` to `0.11.1-1`:

- upstream repository: https://github.com/ouster-lidar/ouster-ros.git
- release repository: https://github.com/ros2-gbp/ouster-ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## ouster_ros

```
* breaking: rename ouster_msgs to ouster_sensor_msgs
* shutdown the driver when unable to connect to the sensor on startup
```

## ouster_sensor_msgs

```
* breaking: rename ouster_msgs to ouster_sensor_msgs
```
