### PR TITLE
ouster-ros: 0.11.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3571,12 +3571,12 @@ repositories:
       version: master
     release:
       packages:
-      - ouster_msgs
       - ouster_ros
+      - ouster_sensor_msgs
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ouster-ros-release.git
-      version: 0.10.4-1
+      version: 0.11.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ouster-ros` to `0.11.1-1`:

- upstream repository: https://github.com/ouster-lidar/ouster-ros.git
- release repository: https://github.com/ros2-gbp/ouster-ros-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.10.4-1`

## ouster_ros

```
* breaking: rename ouster_msgs to ouster_sensor_msgs
* shutdown the driver when unable to connect to the sensor on startup
```

## ouster_sensor_msgs

```
* breaking: rename ouster_msgs to ouster_sensor_msgs
```
