### PR TITLE
Add xtensor rule for RHEL 9 and fix Fedora rule

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8461,8 +8461,11 @@ xsltproc:
   ubuntu: [xsltproc]
 xtensor:
   arch: [xtensor]
-  fedora: [xtensor]
+  fedora: [xtensor-devel]
   nixos: [xtensor]
+  rhel:
+    '*': [xtensor-devel]
+    '8': null
   ubuntu:
     bionic: [xtensor-dev]
     jammy: [libxtensor-dev]


### PR DESCRIPTION
The Ubuntu rule references the `-dev` subpackage, so should Fedora/RHEL.

This package was recently made available to RHEL 9 via EPEL, and should unblock the nav2 repository from releasing.

https://packages.fedoraproject.org/pkgs/xtensor/xtensor-devel/