### PR TITLE
sick_scan_xd: 3.0.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10972,6 +10972,16 @@ repositories:
       type: git
       url: https://github.com/SICKAG/sick_scan_xd.git
       version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/SICKAG/sick_scan_xd-release.git
+      version: 3.0.3-1
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_scan_xd.git
+      version: master
+    status: developed
   sick_tim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_scan_xd` to `3.0.3-1`:

- upstream repository: https://github.com/SICKAG/sick_scan_xd.git
- release repository: https://github.com/SICKAG/sick_scan_xd-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
