### PR TITLE
ros_gz: 0.247.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5332,7 +5332,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 0.245.0-1
+      version: 0.247.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `0.247.0-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.245.0-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* Fix double wait in ros_gz_bridge (#347 <https://github.com/gazebosim/ros_gz/issues/347>) (#449 <https://github.com/gazebosim/ros_gz/issues/449>)
  Co-authored-by: ymd-stella <mailto:7959916+ymd-stella@users.noreply.github.com>
* [backport iron] SensorNoise msg bridging (#417 <https://github.com/gazebosim/ros_gz/issues/417>) (#425 <https://github.com/gazebosim/ros_gz/issues/425>)
  Co-authored-by: Aditya Pande <mailto:aditya050995@gmail.com>
* Merge pull request #420 <https://github.com/gazebosim/ros_gz/issues/420> from gazebosim/ahcorde/iron/backport/411
  [backport iron] Update README.md (#411 <https://github.com/gazebosim/ros_gz/issues/411>)
* Merge branch 'iron' into ahcorde/iron/backport/411
* [backport Iron] Added Altimeter msg bridging (#413 <https://github.com/gazebosim/ros_gz/issues/413>) (#414 <https://github.com/gazebosim/ros_gz/issues/414>)
  Co-authored-by: Aditya Pande <mailto:aditya050995@gmail.com>
* Update README.md (#411 <https://github.com/gazebosim/ros_gz/issues/411>)
  The ROS type for gz.msgs.NavSat messages should be **sensor_msgs/msg/NavSatFix** instead of **sensor_msgs/msg/NavSatFixed**
* Contributors: Alejandro Hernández Cordero, Arjun K Haridas
```

## ros_gz_image

```
* Fix double wait in ros_gz_bridge (#347 <https://github.com/gazebosim/ros_gz/issues/347>) (#449 <https://github.com/gazebosim/ros_gz/issues/449>)
  Co-authored-by: ymd-stella <mailto:7959916+ymd-stella@users.noreply.github.com>
* Contributors: Alejandro Hernández Cordero
```

## ros_gz_interfaces

```
* [backport iron] SensorNoise msg bridging (#417 <https://github.com/gazebosim/ros_gz/issues/417>) (#425 <https://github.com/gazebosim/ros_gz/issues/425>)
  Co-authored-by: Aditya Pande <mailto:aditya050995@gmail.com>
* Merge branch 'iron' into ahcorde/iron/backport/411
* [backport Iron] Added Altimeter msg bridging (#413 <https://github.com/gazebosim/ros_gz/issues/413>) (#414 <https://github.com/gazebosim/ros_gz/issues/414>)
  Co-authored-by: Aditya Pande <mailto:aditya050995@gmail.com>
* Contributors: Alejandro Hernández Cordero
```

## ros_gz_sim

```
* set on_exit_shutdown argument for gz-sim ExecuteProcess (#355 <https://github.com/gazebosim/ros_gz/issues/355>) (#452 <https://github.com/gazebosim/ros_gz/issues/452>)
  Co-authored-by: andermi <mailto:anderson@mbari.org>
* Contributors: Michael Carroll
```

## ros_gz_sim_demos

```
* Merge branch 'iron' into ahcorde/iron/backport/411
* Added more topic to the bridge (#422 <https://github.com/gazebosim/ros_gz/issues/422>) (#423 <https://github.com/gazebosim/ros_gz/issues/423>)
* Fix incorrect subscription on demo (#405 <https://github.com/gazebosim/ros_gz/issues/405>) (#407 <https://github.com/gazebosim/ros_gz/issues/407>)
  Co-authored-by: Arjo Chakravarty <mailto:arjoc@intrinsic.ai>
* Contributors: Alejandro Hernández Cordero
```

## ros_ign

- No changes

## ros_ign_bridge

- No changes

## ros_ign_gazebo

- No changes

## ros_ign_gazebo_demos

- No changes

## ros_ign_image

- No changes

## ros_ign_interfaces

- No changes
