### PR TITLE
leo_common: 1.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2886,7 +2886,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/leo_common-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_common-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_common` to `1.2.0-1`:

- upstream repository: https://github.com/LeoRover/leo_common-ros2.git
- release repository: https://github.com/ros2-gbp/leo_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-1`

## leo

- No changes

## leo_description

```
* Update author and copyright info
* Add mecanum wheels to description package (#6 <https://github.com/LeoRover/leo_common-ros2/issues/6>)
* Ci updates (#7 <https://github.com/LeoRover/leo_common-ros2/issues/7>)
* Adjust description package to work in new Gazebo simulation (#5 <https://github.com/LeoRover/leo_common-ros2/issues/5>)
* Contributors: Aleksander Szymański, Błażej Sowa, Jan Hernas
```

## leo_msgs

```
* Update author and copyright info
* Ci updates (#7 <https://github.com/LeoRover/leo_common-ros2/issues/7>)
* Mecanum Wheel Odom message (#3 <https://github.com/LeoRover/leo_common-ros2/issues/3>)
* Contributors: Aleksander Szymański, Błażej Sowa
```

## leo_teleop

```
* Increase joystick deadzone
* Switch to using joy_linux package instead of joy
* Update author and copyright info
* Ci updates (#7 <https://github.com/LeoRover/leo_common-ros2/issues/7>)
* Adapt joy_config to mecanum wheels (#4 <https://github.com/LeoRover/leo_common-ros2/issues/4>)
* Contributors: Aleksander Szymański, Błażej Sowa
```
