### PR TITLE
clearpath_common: 0.1.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -882,7 +882,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 0.1.2-1
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `0.1.3-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.2-1`

## clearpath_common

- No changes

## clearpath_control

- No changes

## clearpath_description

- No changes

## clearpath_generator_common

- No changes

## clearpath_mounts_description

```
* Load bracket XYZ from block
* Contributors: Luis Camero
```

## clearpath_platform

- No changes

## clearpath_platform_description

```
* [clearpath_platform_description] Removed un-used ros2_control params.
* Contributors: Tony Baltovski
```

## clearpath_sensors_description

- No changes
