### PR TITLE
marti_messages: 0.12.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5345,7 +5345,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_messages-release.git
-      version: 0.12.1-1
+      version: 0.12.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_messages` to `0.12.2-1`:

- upstream repository: https://github.com/swri-robotics/marti_messages.git
- release repository: https://github.com/swri-robotics-gbp/marti_messages-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.12.1-1`

## marti_can_msgs

- No changes

## marti_common_msgs

- No changes

## marti_dbw_msgs

```
* Added constant for reverse_low gear string (#131 <https://github.com/swri-robotics/marti_messages/issues/131>)
* Contributors: Robert Brothers
```

## marti_introspection_msgs

- No changes

## marti_nav_msgs

- No changes

## marti_perception_msgs

- No changes

## marti_sensor_msgs

- No changes

## marti_status_msgs

- No changes

## marti_visualization_msgs

- No changes
