### PR TITLE
ublox_dgnss: 0.5.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7134,7 +7134,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ublox_dgnss-release.git
-      version: 0.5.1-1
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/aussierobots/ublox_dgnss.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ublox_dgnss` to `0.5.2-1`:

- upstream repository: https://github.com/aussierobots/ublox_dgnss
- release repository: https://github.com/ros2-gbp/ublox_dgnss-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.5.1-1`

## ntrip_client_node

- No changes

## ublox_dgnss

- No changes

## ublox_dgnss_node

```
* removed saving of read serial str in connection
* uncrustify format issue
* fixed error messages
* added rc logic and throws
* Contributors: Nick Hortovanyi
```

## ublox_nav_sat_fix_hp_node

- No changes

## ublox_ubx_interfaces

- No changes

## ublox_ubx_msgs

- No changes
