### PR TITLE
Add pep8-naming

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7347,16 +7347,10 @@ python3-pep8:
     pip:
       packages: [pep8]
   ubuntu: [python3-pep8]
-python3-pep8-naming-pip:
-  debian:
-    pip:
-      packages: [pep8-naming]
-  fedora:
-    pip:
-      packages: [pep8-naming]
-  ubuntu:
-    pip:
-      packages: [pep8-naming]
+python3-pep8-naming:
+  debian: [python3-pep8-naming]
+  fedora: [python3-pep8-naming]
+  ubuntu: [python3-pep8-naming]
 python3-petact-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7347,6 +7347,13 @@ python3-pep8:
     pip:
       packages: [pep8]
   ubuntu: [python3-pep8]
+python3-pep8-naming:
+  debian:
+    pip:
+      packages: [pep8-naming]
+  ubuntu:
+    pip:
+      packages: [pep8-naming]
 python3-petact-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7347,8 +7347,11 @@ python3-pep8:
     pip:
       packages: [pep8]
   ubuntu: [python3-pep8]
-python3-pep8-naming:
+python3-pep8-naming-pip:
   debian:
+    pip:
+      packages: [pep8-naming]
+  fedora:
     pip:
       packages: [pep8-naming]
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7350,6 +7350,7 @@ python3-pep8:
 python3-pep8-naming:
   debian: [python3-pep8-naming]
   fedora: [python3-pep8-naming]
+  opensuse: [python3-pep8-naming]
   ubuntu: [python3-pep8-naming]
 python3-petact-pip:
   debian:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

pep8-naming

## Package Upstream Source:

https://github.com/PyCQA/pep8-naming

## Purpose of using this:

Python naming convention linting.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://pypi.org/project/pep8-naming/
- Ubuntu: https://packages.ubuntu.com/
  - https://pypi.org/project/pep8-naming/
- Fedora: https://packages.fedoraproject.org/
  - https://pypi.org/project/pep8-naming/