### PR TITLE
Adding raspimouse and raspimouse_description to documentation index for noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8342,6 +8342,11 @@ repositories:
       url: https://github.com/NewEagleRaptor/raptor-dbw-ros.git
       version: master
     status: maintained
+  raspimouse:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspimouse.git
+      version: noetic-devel
   razor_imu_9dof:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8347,6 +8347,11 @@ repositories:
       type: git
       url: https://github.com/rt-net/raspimouse.git
       version: noetic-devel
+  raspimouse_description:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspimouse_description.git
+      version: noetic-devel
   razor_imu_9dof:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

Noetic

# The source is here:

* https://github.com/rt-net/raspimouse
* https://github.com/rt-net/raspimouse_description

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
