### PR TITLE
cob_common: 0.7.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1067,7 +1067,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_common-release.git
-      version: 0.7.8-1
+      version: 0.7.9-1
     source:
       type: git
       url: https://github.com/ipa320/cob_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `0.7.9-1`:

- upstream repository: https://github.com/ipa320/cob_common.git
- release repository: https://github.com/ipa320/cob_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.8-1`

## cob_actions

- No changes

## cob_common

- No changes

## cob_description

- No changes

## cob_msgs

```
* Merge pull request #301 <https://github.com/ipa320/cob_common/issues/301> from omar-ihab-ali/update/emergency_stop_state_msg
  update EmergencyStopState Msg to include other states sent from PLC
* update EmergencyStopState Msg to include other states sent from PLC
* Contributors: Benjamin Maidel, omar-ihab-ali
```

## cob_srvs

- No changes

## raw_description

- No changes
