### PR TITLE
cob_command_tools: 0.6.33-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1045,7 +1045,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_command_tools-release.git
-      version: 0.6.32-1
+      version: 0.6.33-1
     source:
       type: git
       url: https://github.com/ipa320/cob_command_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.33-1`:

- upstream repository: https://github.com/ipa320/cob_command_tools.git
- release repository: https://github.com/ipa320/cob_command_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.32-1`

## cob_command_gui

- No changes

## cob_command_tools

- No changes

## cob_dashboard

- No changes

## cob_helper_tools

- No changes

## cob_interactive_teleop

- No changes

## cob_monitoring

```
* Merge pull request #335 <https://github.com/ipa320/cob_command_tools/issues/335> from benmaidel/fix/em_topic_based_em_stop_mon
  fixed em topic based emergency_stop_monitor
* fix melodic compatibility
* fixed em topic based emergency_stop_monitor
* Merge pull request #334 <https://github.com/ipa320/cob_command_tools/issues/334> from HannesBachter/feature/topic_emergency_stop_monitor
  set light based on emergency stop topic
* log em-stop only after issuing
* set light based on emergency stop topic
* Merge pull request #333 <https://github.com/ipa320/cob_command_tools/issues/333> from benmaidel/feature/battery_monitor_params
  extend battery_monitor with additional rosparams
* fix default values
* extend battery_monitor with additional rosparams
* Contributors: Benjamin Maidel, Felix Messmer, HannesBachter
```

## cob_script_server

```
* Merge pull request #331 <https://github.com/ipa320/cob_command_tools/issues/331> from benmaidel/feature/allow_bigger_rel_rotation
  allow max relative rotation of pi*2+0.1
* allow max relative rotation of pi*2+0.1
* Contributors: Felix Messmer, mailto:bnm@mrl-2
```

## cob_teleop

- No changes

## generic_throttle

- No changes

## scenario_test_tools

- No changes

## service_tools

- No changes
