### PR TITLE
Update ament-black release repository

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -153,11 +153,11 @@ repositories:
       - ament_cmake_black
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/botsandus/ament_black-release.git
+      url: https://github.com/ros2-gbp/ament_black-release.git
       version: 0.2.3-1
     source:
       type: git
-      url: https://github.com/Timple/ament_black.git
+      url: https://github.com/botsandus/ament_black.git
       version: main
     status: maintained
   ament_cmake:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -104,7 +104,7 @@ repositories:
       - ament_cmake_black
       tags:
         release: release/iron/{package}/{version}
-      url: https://github.com/botsandus/ament_black-release.git
+      url: https://github.com/ros2-gbp/ament_black-release.git
       version: 0.2.3-1
     source:
       type: git


### PR DESCRIPTION
A short follow-up from #38762 to use the `ros2-gbp` upstream for the release repository

Please correct me if I'm wrong, but I guess this is the common "pattern". Having the source code in a self-managed repo, in my case that would be https://github.com/botsandus/ament_black, which is the source of the package and maintaining a `ros2-gbp` release repo: https://github.com/ros2-gbp/ament_black-release