### PR TITLE
cob_driver: 0.7.15-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1136,7 +1136,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_driver-release.git
-      version: 0.7.14-1
+      version: 0.7.15-1
     source:
       type: git
       url: https://github.com/ipa320/cob_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_driver` to `0.7.15-1`:

- upstream repository: https://github.com/ipa320/cob_driver.git
- release repository: https://github.com/ipa320/cob_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.14-1`

## cob_base_drive_chain

- No changes

## cob_bms_driver

- No changes

## cob_canopen_motor

- No changes

## cob_driver

- No changes

## cob_elmo_homing

- No changes

## cob_generic_can

- No changes

## cob_light

```
* Merge pull request #441 <https://github.com/ipa320/cob_driver/issues/441> from muritane/motion_monitor
  [motion_monitor] adjust turn indicator
* [motion_monitor] reverse led quarters for left and right turn indication
* [motion_monitor] add comments which leds are used for left and right turn
* [motion_monitor] change turn indicator to flash
* Contributors: Benjamin Maidel, Daniel Azanov
```

## cob_mimic

- No changes

## cob_phidget_em_state

- No changes

## cob_phidget_power_state

- No changes

## cob_phidgets

- No changes

## cob_relayboard

- No changes

## cob_scan_unifier

```
* Merge pull request #440 <https://github.com/ipa320/cob_driver/issues/440> from benmaidel/feature/angle_increment_independend
  remove hardcoded angle_increment value
* make cob_scan_unifier angle_increment independet by using the info from the input scan
* Contributors: Benjamin Maidel
```

## cob_sick_lms1xx

- No changes

## cob_sick_s300

- No changes

## cob_sound

- No changes

## cob_undercarriage_ctrl

- No changes

## cob_utilities

- No changes

## cob_voltage_control

- No changes

## laser_scan_densifier

- No changes
