### PR TITLE
rviz: 13.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6122,7 +6122,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 13.1.2-1
+      version: 13.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `13.2.0-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `13.1.2-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

- No changes

## rviz_default_plugins

```
* (robot) fix styling of log msg (#1080 <https://github.com/ros2/rviz/issues/1080>)
* Fix image display wrapping (#1038 <https://github.com/ros2/rviz/issues/1038>)
* removed enableInteraction reference (#1075 <https://github.com/ros2/rviz/issues/1075>)
* Contributors: Alejandro Hernández Cordero, Lewe Christiansen, Matthijs van der Burgh
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Include MeshShape class (#1064 <https://github.com/ros2/rviz/issues/1064>)
* Use assimp to load stl (#1063 <https://github.com/ros2/rviz/issues/1063>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_rendering_tests

```
* Use assimp to load stl (#1063 <https://github.com/ros2/rviz/issues/1063>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_visual_testing_framework

- No changes
