### PR TITLE
ros2cli: 0.30.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5168,7 +5168,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.29.1-1
+      version: 0.30.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.30.0-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.29.1-1`

## ros2action

- No changes

## ros2cli

```
* Add ros2 service info (#771 <https://github.com/ros2/ros2cli/issues/771>)
* Contributors: Minju, Lee
```

## ros2cli_test_interfaces

- No changes

## ros2component

```
* Warning: get_parameter_value() is deprecated. (#866 <https://github.com/ros2/ros2cli/issues/866>)
* Contributors: Tomoya Fujita
```

## ros2doctor

```
* (ros2doctor) fix PackageCheck (#860 <https://github.com/ros2/ros2cli/issues/860>)
  * (ros2doctor)(package) improve result string generation
* Contributors: Matthijs van der Burgh
```

## ros2interface

- No changes

## ros2lifecycle

- No changes

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

- No changes

## ros2param

```
* Warning: get_parameter_value() is deprecated. (#866 <https://github.com/ros2/ros2cli/issues/866>)
* Contributors: Tomoya Fujita
```

## ros2pkg

- No changes

## ros2run

- No changes

## ros2service

```
* Add ros2 service info (#771 <https://github.com/ros2/ros2cli/issues/771>)
* Contributors: Minju, Lee
```

## ros2topic

- No changes
