### PR TITLE
rmw_fastrtps: 8.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4834,7 +4834,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 7.6.0-1
+      version: 8.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `8.0.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `7.6.0-1`

## rmw_fastrtps_cpp

```
* avoid using dds common public mutex directly (#725 <https://github.com/ros2/rmw_fastrtps/issues/725>)
* Contributors: Chen Lihui
```

## rmw_fastrtps_dynamic_cpp

```
* avoid using dds common public mutex directly (#725 <https://github.com/ros2/rmw_fastrtps/issues/725>)
* Contributors: Chen Lihui
```

## rmw_fastrtps_shared_cpp

```
* Quiet compiler warning in Release mode. (#730 <https://github.com/ros2/rmw_fastrtps/issues/730>)
* avoid using dds common public mutex directly (#725 <https://github.com/ros2/rmw_fastrtps/issues/725>)
* Contributors: Chen Lihui, Chris Lalancette
```
