### PR TITLE
rmw_connextdds: 0.19.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4781,7 +4781,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 0.18.0-1
+      version: 0.19.0-1
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `0.19.0-1`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.18.0-1`

## rmw_connextdds

- No changes

## rmw_connextdds_common

```
* avoid using dds common public mutex directly (#134 <https://github.com/ros2/rmw_connextdds/issues/134>)
* Fix a couple of warnings pointed out by clang. (#133 <https://github.com/ros2/rmw_connextdds/issues/133>)
* Contributors: Chen Lihui, Chris Lalancette
```

## rti_connext_dds_cmake_module

- No changes
