### PR TITLE
rclpy: 6.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4332,7 +4332,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 5.4.0-1
+      version: 6.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `6.0.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `5.4.0-1`

## rclpy

```
* Adjust python usage of the type_description service API (#1192 <https://github.com/ros2/rclpy/issues/1192>)
* Document that spin_once() should not be called from multiple threads (#1079 <https://github.com/ros2/rclpy/issues/1079>)
* making optional things Optional (#1182 <https://github.com/ros2/rclpy/issues/1182>)
* Use timeout object to avoid callback losing in wait_for_ready_callbacks (#1165 <https://github.com/ros2/rclpy/issues/1165>)
* Contributors: AndyZe, Anton Kesy, Barry Xu, Michael Carroll
```
