### PR TITLE
rclcpp: 24.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4316,7 +4316,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 23.2.0-1
+      version: 24.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `24.0.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `23.2.0-1`

## rclcpp

```
* fix (signal_handler.hpp): spelling (#2356 <https://github.com/ros2/rclcpp/issues/2356>)
* Updates to not use std::move in some places. (#2353 <https://github.com/ros2/rclcpp/issues/2353>)
* rclcpp::Time::max() clock type support. (#2352 <https://github.com/ros2/rclcpp/issues/2352>)
* Serialized Messages with Topic Statistics (#2274 <https://github.com/ros2/rclcpp/issues/2274>)
* Add a custom deleter when constructing rcl_service_t (#2351 <https://github.com/ros2/rclcpp/issues/2351>)
* Disable the loaned messages inside the executor. (#2335 <https://github.com/ros2/rclcpp/issues/2335>)
* Use message_info in SubscriptionTopicStatistics instead of typed message (#2337 <https://github.com/ros2/rclcpp/issues/2337>)
* Add missing 'enable_rosout' comments (#2345 <https://github.com/ros2/rclcpp/issues/2345>)
* Adjust rclcpp usage of type description service (#2344 <https://github.com/ros2/rclcpp/issues/2344>)
* address rate related flaky tests. (#2329 <https://github.com/ros2/rclcpp/issues/2329>)
* Fixes pointed out by the clang analyzer. (#2339 <https://github.com/ros2/rclcpp/issues/2339>)
* Remove useless ROSRate class (#2326 <https://github.com/ros2/rclcpp/issues/2326>)
* Contributors: Alexey Merzlyakov, Chris Lalancette, Jiaqi Li, Lucas Wendland, Michael Carroll, Michael Orlov, Tomoya Fujita, Zard-C
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* Fix rclcpp_lifecycle inclusion on Windows. (#2331 <https://github.com/ros2/rclcpp/issues/2331>)
* Contributors: Chris Lalancette
```
