### PR TITLE
rcl: 8.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4216,7 +4216,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 7.3.0-1
+      version: 8.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `8.0.0-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `7.3.0-1`

## rcl

```
* Set disable loan to on by default. (#1110 <https://github.com/ros2/rcl/issues/1110>)
* Return service from node_type_description_service_init (#1112 <https://github.com/ros2/rcl/issues/1112>)
* next_call_time will always be greater than now after calling rcl_timer_call. (#1089 <https://github.com/ros2/rcl/issues/1089>)
* Contributors: Chris Lalancette, Michael Carroll, Thiemo Kohrt
```

## rcl_action

- No changes

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

- No changes
