### PR TITLE
image_common: 5.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2018,7 +2018,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 4.5.1-1
+      version: 5.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `5.0.0-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.5.1-1`

## camera_calibration_parsers

```
* Removed C headers: camera_info_manager camera_calibration_parsers (#290 <https://github.com/ros-perception/image_common/issues/290>)
* Contributors: Alejandro Hernández Cordero
```

## camera_info_manager

```
* Removed C headers: camera_info_manager camera_calibration_parsers (#290 <https://github.com/ros-perception/image_common/issues/290>)
* Contributors: Alejandro Hernández Cordero
```

## image_common

- No changes

## image_transport

```
* Advertize and subscribe with custom qos (#288 <https://github.com/ros-perception/image_common/issues/288>)
* Removed C headers (#289 <https://github.com/ros-perception/image_common/issues/289>)
* Contributors: Alejandro Hernández Cordero
```
