### PR TITLE
ros2_control: 3.21.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5046,7 +5046,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.20.0-1
+      version: 3.21.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5030,7 +5030,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/ros2_control.git
-      version: master
+      version: iron
     release:
       packages:
       - controller_interface
@@ -5050,7 +5050,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git
-      version: master
+      version: iron
     status: developed
   ros2_controllers:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.21.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.20.0-1`

## controller_interface

- No changes

## controller_manager

```
* Sort controllers while configuring instead of while activating (#1107 <https://github.com/ros-controls/ros2_control/issues/1107>)
* Contributors: Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* [MockHardware] Fix the issues where hardware with multiple interfaces can not be started because of a logical bug added when adding dynamics calculation functionality. (#1151 <https://github.com/ros-controls/ros2_control/issues/1151>)
* Fix potential deadlock in ResourceManager (#925 <https://github.com/ros-controls/ros2_control/issues/925>)
* Contributors: Christopher Wecht, Dr. Denis
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
