### PR TITLE
ros2_control: 3.21.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4985,7 +4985,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.20.0-1
+      version: 3.21.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.21.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.20.0-1`

## controller_interface

- No changes

## controller_manager

```
* Sort controllers while configuring instead of while activating (#1107 <https://github.com/ros-controls/ros2_control/issues/1107>)
* Contributors: Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* [MockHardware] Fix the issues where hardware with multiple interfaces can not be started because of a logical bug added when adding dynamics calculation functionality. (#1151 <https://github.com/ros-controls/ros2_control/issues/1151>)
* Fix potential deadlock in ResourceManager (#925 <https://github.com/ros-controls/ros2_control/issues/925>)
* Contributors: Christopher Wecht, Dr. Denis
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
