### PR TITLE
ament_cmake: 2.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -143,7 +143,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 2.3.0-1
+      version: 2.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake` to `2.3.1-1`:

- upstream repository: https://github.com/ament/ament_cmake.git
- release repository: https://github.com/ros2-gbp/ament_cmake-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.0-1`

## ament_cmake

- No changes

## ament_cmake_auto

```
* Add ament_auto_add_gmock to ament_cmake_auto (#482 <https://github.com/ament/ament_cmake/issues/482>)
* Contributors: Jordan Palacios
```

## ament_cmake_core

```
* Use CMAKE_CURRENT_BINARY_DIR instead of CMAKE_BINARY_DIR  in ament_generate_environment (#485 <https://github.com/ament/ament_cmake/issues/485>)
* Fix CMake error when entire ament projects are added via add_subdirectory (#484 <https://github.com/ament/ament_cmake/issues/484>)
* Contributors: Silvio Traversaro
```

## ament_cmake_export_definitions

- No changes

## ament_cmake_export_dependencies

- No changes

## ament_cmake_export_include_directories

- No changes

## ament_cmake_export_interfaces

- No changes

## ament_cmake_export_libraries

- No changes

## ament_cmake_export_link_flags

- No changes

## ament_cmake_export_targets

- No changes

## ament_cmake_gen_version_h

```
* Update to C++17 (#488 <https://github.com/ament/ament_cmake/issues/488>)
* Contributors: Chris Lalancette
```

## ament_cmake_gmock

- No changes

## ament_cmake_google_benchmark

- No changes

## ament_cmake_gtest

- No changes

## ament_cmake_include_directories

- No changes

## ament_cmake_libraries

- No changes

## ament_cmake_pytest

- No changes

## ament_cmake_python

- No changes

## ament_cmake_target_dependencies

- No changes

## ament_cmake_test

- No changes

## ament_cmake_vendor_package

- No changes

## ament_cmake_version

- No changes
