### PR TITLE
neonavigation: 0.17.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6467,7 +6467,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.16.0-1
+      version: 0.17.0-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.17.0-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.16.0-1`

## costmap_cspace

```
* costmap_3d: avoid unnecessary grid expansions (#726 <https://github.com/at-wat/neonavigation/issues/726>)
* Contributors: Naotaka Hatao
```

## joystick_interrupt

- No changes

## map_organizer

- No changes

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

- No changes

## obj_to_pointcloud

- No changes

## planner_cspace

```
* planner_3d: add an option to trigger planning by costmap updates (#727 <https://github.com/at-wat/neonavigation/issues/727>)
* planner_3d: fix cost calculation bug on in-place turning (#725 <https://github.com/at-wat/neonavigation/issues/725>)
* Contributors: Naotaka Hatao
```

## safety_limiter

- No changes

## track_odometry

- No changes

## trajectory_tracker

- No changes
