### PR TITLE
raspimouse_ros2_examples: 2.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5023,7 +5023,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/raspimouse_ros2_examples-release.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspimouse_ros2_examples` to `2.1.0-1`:

- upstream repository: https://github.com/rt-net/raspimouse_ros2_examples.git
- release repository: https://github.com/ros2-gbp/raspimouse_ros2_examples-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-1`

## raspimouse_ros2_examples

```
* READMEにGazeboでも実行できることを追記 (#44 <https://github.com/rt-net/raspimouse_ros2_examples/issues/44>)
* object_trackingにおいて画像トピックをサブスクライブするように変更 (#43 <https://github.com/rt-net/raspimouse_ros2_examples/issues/43>)
* Contributors: YusukeKato
```
