### PR TITLE
naoqi_libqi: 3.0.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3110,6 +3110,21 @@ repositories:
       url: https://github.com/ros-sports/nao_lola.git
       version: iron
     status: developed
+  naoqi_libqi:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/libqi.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros-naoqi/libqi-release.git
+      version: 3.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/libqi.git
+      version: ros2
+    status: maintained
   navigation2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_libqi` to `3.0.0-1`:

- upstream repository: https://github.com/ros-naoqi/libqi.git
- release repository: https://github.com/ros-naoqi/libqi-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## naoqi_libqi

```
* Add iron workflow for CI
* Restore GitHub workflows
* Contributors: Victor Paléologue
* Update README
* Avoid boost bind global placeholders
  Finally, at last.
* Use .value() when getting a service
* Fix usage of boost::asio for 1.74
* Use explicit placeholders
* Port to ROS 2 restarted from version qi-framework-v1.8.7
```
