### PR TITLE
cob_common: 2.7.9-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -974,6 +974,25 @@ repositories:
       url: https://github.com/clearpathrobotics/clearpath_simulator.git
       version: main
     status: developed
+  cob_common:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_common.git
+      version: foxy
+    release:
+      packages:
+      - cob_actions
+      - cob_msgs
+      - cob_srvs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ipa320/cob_common-release.git
+      version: 2.7.9-1
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_common.git
+      version: foxy
+    status: maintained
   color_names:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `2.7.9-1`:

- upstream repository: https://github.com/ipa320/cob_common.git
- release repository: https://github.com/ipa320/cob_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## cob_actions

- No changes

## cob_msgs

```
* Merge pull request #303 <https://github.com/ipa320/cob_common/issues/303> from omar-ihab-ali/update/emergency_stop_state_msg_foxy
  update EmergencyStopState Msg to include other states sent by PLC
* update implementation for EmergencyStopState Msg to include other states sent by PLC
* Contributors: Benjamin Maidel, omar-ihab-ali
```

## cob_srvs

- No changes
