### PR TITLE
Change rqt_image_view humble branch to 'humble-devel'.

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6738,7 +6738,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_image_view.git
-      version: rolling-devel
+      version: humble-devel
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -6748,7 +6748,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_image_view.git
-      version: rolling-devel
+      version: humble-devel
     status: maintained
   rqt_moveit:
     doc:


### PR DESCRIPTION
That's because there are breaking changes about to be introduced to the 'rolling-devel' branch.