### PR TITLE
added libcaer_driver repository to humble and rolling

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2978,6 +2978,16 @@ repositories:
       type: git
       url: https://github.com/lgsvl/lgsvl_msgs.git
       version: foxy-devel
+  libcaer_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/libcaer_driver.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/libcaer_driver.git
+      version: master
+    status: developed
   libcamera:
     release:
       tags:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2448,6 +2448,16 @@ repositories:
       type: git
       url: https://github.com/lgsvl/lgsvl_msgs.git
       version: foxy-devel
+  libcaer_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/libcaer_driver.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/libcaer_driver.git
+      version: master
+    status: developed
   libg2o:
     release:
       tags:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

# Please Add This Package to be indexed in the rosdistro.
ROSDISTRO NAME: libcaer_driver

# The source is here: https://github.com/ros-event-camera/libcaer_driver

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
