### PR TITLE
release event based camera packages on iron

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1250,6 +1250,46 @@ repositories:
       url: https://github.com/stack-of-tasks/eigenpy.git
       version: devel
     status: maintained
+  event_camera_codecs:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_codecs.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_codecs.git
+      version: master
+    status: developed
+  event_camera_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_msgs.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_msgs.git
+      version: master
+    status: developed
+  event_camera_py:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_py.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_py.git
+      version: master
+    status: developed
+  event_camera_renderer:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_renderer.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_renderer.git
+      version: master
+    status: developed
   example_interfaces:
     doc:
       type: git
@@ -2455,6 +2495,16 @@ repositories:
       type: git
       url: https://github.com/lgsvl/lgsvl_msgs.git
       version: foxy-devel
+  libcaer_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/libcaer_driver.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/libcaer_driver.git
+      version: master
+    status: developed
   libcreate:
     doc:
       type: git
@@ -2749,6 +2799,16 @@ repositories:
       url: https://github.com/ika-rwth-aachen/message_tf_frame_transformer.git
       version: main
     status: maintained
+  metavision_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/metavision_driver.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/metavision_driver.git
+      version: master
+    status: developed
   micro_ros_diagnostics:
     doc:
       type: git


### PR DESCRIPTION

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.
PACKAGE NAMES:
libcaer_driver
metavision_driver
event_camera_codecs
event_camera_msgs
event_camera_py
event_camera_renderer

ROSDISTRO NAME: iron

# The source is here:
This PR covers multiple packages release in multiple repositories. They are already in humble and rolling (except for libcaer_driver), and now are added to iron as well.

Here are the upstream sources:
https://github.com/ros-event-camera/libcaer_driver.git
https://github.com/ros-event-camera/metavision_driver.git
 https://github.com/ros-event-camera/event_camera_codecs.git
https://github.com/ros-event-camera/event_camera_msgs.git
https://github.com/ros-event-camera/event_camera_py.git
https://github.com/ros-event-camera/event_camera_renderer.git

# Checks
 - [x ] All packages have a declared license in the package.xml
 - [x ] This repository has a LICENSE file
 - [x ] This package is expected to build on the submitted rosdistro
