### PR TITLE
ros2_control: 2.34.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6000,7 +6000,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.33.0-1
+      version: 2.34.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.34.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.33.0-1`

## controller_interface

- No changes

## controller_manager

```
* [Humble] Controller sorting (#1157 <https://github.com/ros-controls/ros2_control/issues/1157>)
* Update spawner to accept controllers list and start them in sequence (backport #1139 <https://github.com/ros-controls/ros2_control/issues/1139>) (#1149 <https://github.com/ros-controls/ros2_control/issues/1149>)
* Create doc file for chained controllers (backport #985 <https://github.com/ros-controls/ros2_control/issues/985>) (#1131 <https://github.com/ros-controls/ros2_control/issues/1131>)
* Contributors: Sai Kishor Kothakota, mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
