### PR TITLE
turtlebot4: 1.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8155,7 +8155,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot4.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4` to `1.0.4-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4.git
- release repository: https://github.com/ros2-gbp/turtlebot4-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.3-1`

## turtlebot4_description

- No changes

## turtlebot4_msgs

- No changes

## turtlebot4_navigation

```
* Use opaque function to allow for remapping of scan topics (<https://github.com/turtlebot/turtlebot4/issues/293>)
* Contributors: Hilary Luo
```

## turtlebot4_node

- No changes
