### PR TITLE
turtlebot4_simulator: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8229,7 +8229,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4_simulator-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot4_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4_simulator` to `1.0.1-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4_simulator.git
- release repository: https://github.com/ros2-gbp/turtlebot4_simulator-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-1`

## turtlebot4_ignition_bringup

```
* Merge pull request <https://github.com/turtlebot/turtlebot4_simulator/issues/57>
* Merge pull request <https://github.com/turtlebot/turtlebot4_simulator/issues/58>
* Remove outdated world
* Don't push namespace to nav, it is handled in the nav launch files
* Contributors: Hilary Luo
```

## turtlebot4_ignition_gui_plugins

- No changes

## turtlebot4_ignition_toolbox

- No changes

## turtlebot4_simulator

- No changes
