### PR TITLE
Add raspimouse_sim repository

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5069,6 +5069,16 @@ repositories:
       url: https://github.com/rt-net/raspimouse_ros2_examples.git
       version: humble-devel
     status: maintained
+  raspimouse_sim:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspimouse_sim.git
+      version: humble-devel
+    source:
+      type: git
+      url: https://github.com/rt-net/raspimouse_sim.git
+      version: humble-devel
+    status: maintained
   raspimouse_slam_navigation_ros2:
     doc:
       type: git


### PR DESCRIPTION
<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

Humble

# The source is here:

https://github.com/rt-net/raspimouse_sim/tree/humble-devel

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
