### PR TITLE
jsk_common: 2.2.13-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4412,6 +4412,7 @@ repositories:
       - jsk_common
       - jsk_data
       - jsk_network_tools
+      - jsk_rosbag_tools
       - jsk_tilt_laser
       - jsk_tools
       - jsk_topic_tools
@@ -4420,7 +4421,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 2.2.12-1
+      version: 2.2.13-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `2.2.13-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.12-1`

## audio_video_recorder

- No changes

## dynamic_tf_publisher

```
* add test to check if dynamic_tf_publisher/sample/sample.launch works (#1788 <https://github.com/jsk-ros-pkg/jsk_common/issues/1788>)
  
    * fixed to import roslib.message explicitly
    * add test to check if dynamic_tf_publisher/sample/sample.launch works
  
* [dynamic_tf_publisher] Fix Python shebang for Noetic (#1775 <https://github.com/jsk-ros-pkg/jsk_common/issues/1775>)
* Contributors: Kei Okada, Shingo Kitagawa, Wolfgang Merkt, Koki Amabe
```

## image_view2

```
* Fix for Noetic (#1774 <https://github.com/jsk-ros-pkg/jsk_common/issues/1774>)
  
    * test/publish_mouse_event.py: value of MouseEvent  must be integer
  
* add test to compile on 22.04, see #1770 <https://github.com/jsk-ros-pkg/jsk_common/issues/1770> (#1773 <https://github.com/jsk-ros-pkg/jsk_common/issues/1773>)
  
    * revert code before C++11
    * avoid boost::bind (esp. global _1)
      it's deprecated to use global _1 from boost for a while now
      and the Debian ROS packages do not provide it anymore.
    * do not specify c++ standard
      it break with current log4cxx which requires c++17.
      No, going forward it's no option to specify the standard anymore.
      And it's not necessary either.
  
* Fixed typo of Software License Agreement. and/o2r to and/or (#1764 <https://github.com/jsk-ros-pkg/jsk_common/issues/1764>)
* Contributors: Kei Okada, Shingo Kitagawa, Iory Yanokura, v4hn
```

## jsk_common

```
* Add jsk_rosbag_tools package (#1738 <https://github.com/jsk-ros-pkg/jsk_common/issues/1738>)
* Contributors: Kei Okada, Shingo Kitagawa, Iory Yanokura
```

## jsk_data

```
* [jsk_data/download_data.py] Add timeout argument to download() for wget (#1771 <https://github.com/jsk-ros-pkg/jsk_common/issues/1771>)
  
    * add  2 blank lines before function definition ros roslint
      ```
      src/jsk_data/download_data.py:120:1: E302 expected 2 blank lines, found 1
      ```
    * Add timeout argument to download() for wget
  
* Contributors: Aoi Nakane, Kei Okada, Shingo Kitagawa
```

## jsk_network_tools

```
* add test to compile on 22.04, see #1770 <https://github.com/jsk-ros-pkg/jsk_common/issues/1770> (#1773 <https://github.com/jsk-ros-pkg/jsk_common/issues/1773>)
  
    * use setuptools
      setup from distutils is deprecated and will be removed eventually.
  
* Fixed typo of Software License Agreement. and/o2r to and/or (#1764 <https://github.com/jsk-ros-pkg/jsk_common/issues/1764>)
  Fixed typo of Software License Agreement. and/o2r to and/or
* Contributors: Kei Okada, Shingo Kitagawa, Iory Yanokura, v4hn
```

## jsk_rosbag_tools

```
* [jsk_rosbag_tools] Use python3-catkin-pkg-modules when python3 is used (#1784 <https://github.com/jsk-ros-pkg/jsk_common/issues/1784>)
  
    * [jsk_rosbag_tools] Use python3-catkin-pkg-modules when python3 is used
  
* set python2 for jsk_rosbag_tools (#1781 <https://github.com/jsk-ros-pkg/jsk_common/issues/1781>)
  
    * set numpy version for python3
    * split requirements.in for python2 and 3
    * set scipy<1.9.0 to avoid build error with openblas
      https://github.com/scipy/scipy/issues/16308
    * install scipy to avoid numpy attribute error
  
* catch StopIteration when all images do not have stamp (#1767 <https://github.com/jsk-ros-pkg/jsk_common/issues/1767>)
* jsk_rosbag_tools: version of jsk_common is 2.2.12 (#1751 <https://github.com/jsk-ros-pkg/jsk_common/issues/1751>)
* [jsk_rosbag_tools] Fixed a bug when the specified fps is less than the fps of the topic in rosbag. (#1750 <https://github.com/jsk-ros-pkg/jsk_common/issues/1750>)
* Add jsk_rosbag_tools package (#1738 <https://github.com/jsk-ros-pkg/jsk_common/issues/1738>)
* [jsk_rosbag_tools] Add descriptions for static_tf_republisher.py.
* [jsk_rosbag_tools] Enable catkin_virtualenv for pip dependencies
* [jsk_rosbag_tools] Specify python version
* [jsk_rosbag_tools] logerr subprocess command if failed
* [jsk_rosbag_tools] Split test to avoid indigo's error
* [jsk_rosbag_tools] Drop installation of requirements.in and requirements.txt
* [jsk_rosbag_tools] Add dependencies of download data
* [jsk_rosbag_tools] Refactor test to print command log
* [jsk_rosbag_tools] Avoid raise ValueError on invalid compressed format.
* [jsk_rosbag_tools] Add resize_keeping_aspect_ratio_wrt_target_size to fix video
* [jsk_rosbag_tools] Fixed W503 line break before binary operator
* [jsk_rosbag_tools] Fixed E226 missing whitespace around arithmetic operator
* [jsk_rosbag_tools] Add show_progress_bar option
* [jsk_rosbag_tools] Add .wav ext
* [jsk_rosbag_tools] Add fps option
* [jsk_rosbag_tools] Add message to raise
* [jsk_rosbag_tools] Resize every frame
* [jsk_rosbag_tools] Fix bug when saving to local path with --image-topic
* [jsk_rosbag_tools] Allow to record mono8 topics for mask images
* [jsk_rosbag_tools] Fixed compr_type condition
* [jsk_rosbag_tools] Check topic exists
* [jsk_rosbag_tools] Fixed W503 line break before binary operator
* [jsk_rosbag_tools] Rename extract_audio to bag_to_audio
* [jsk_rosbag_tools] Fixed E225 missing whitespace around operator
* [jsk_rosbag_tools] Decompress as much as possible
* [jsk_rosbag_tools] Refactor dependencies
* [jsk_rosbag_tools] Enable python2 compatibility
* [jsk_rosbag_tools] Add shebang
* [jsk_rosbag_tools] chmod u+x test_jsk_rosbag_tools.py
* [jsk_rosbag_tools] Add bag_to_audio.py
* [jsk_rosbag_tools] Makedirs in extract_audio
* [jsk_rosbag_tools] Include AudioFileClip and VideoFileClip to prevent calling pygame.init()
* [jsk_rosbag_tools] chmod u+x
* [jsk_rosbag_tools] Fixed sample docs
* [jsk_rosbag_tools] Fixed bag to video docs
* [jsk_rosbag_tools] Import AudioFileClip and VideoFileClip
* [jsk_rosbag_tools] Use library's function
* [jsk_rosbag_tools] Seperate bag_to_video function as library
* [jsk_rosbag_tools] Add topic_name_to_file_name
* [jsk_rosbag_tools] Add makedirs library for python2
* [jsk_rosbag_tools] Set time-limit to 360.0
* [jsk_rosbag_tools] Modified sample bagfile to reduce test time
* [jsk_rosbag_tools] Set version to 2.2.11
* [jsk_rosbag_tools] Drop catkin virtualenv
* Add jsk_rosbag_tools package
* Contributors: Guilherme Affonso, Kei Okada, Naoto Tsukamoto, Shingo Kitagawa, Iory Yanokura
```

## jsk_tilt_laser

```
* add test to check c++14/C++11/C++0x (#1785 <https://github.com/jsk-ros-pkg/jsk_common/issues/1785>)
  
    * auto lambda for c++14
  
* add test to compile on 22.04, see #1770 <https://github.com/jsk-ros-pkg/jsk_common/issues/1770> (#1773 <https://github.com/jsk-ros-pkg/jsk_common/issues/1773>)
  
    * revert code before C++11
    * avoid boost::bind (esp. global _1)
      it's deprecated to use global _1 from boost for a while now
      and the Debian ROS packages do not provide it anymore.
  
* Fixed typo of Software License Agreement. and/o2r to and/or (#1764 <https://github.com/jsk-ros-pkg/jsk_common/issues/1764>)
* Contributors: Kei Okada, Shingo Kitagawa, Iory Yanokura, v4hn
```

## jsk_tools

```
* [test_topic_published.py, boolean_node.py] Enable importing modules (#1760 <https://github.com/jsk-ros-pkg/jsk_common/issues/1760>)
* fix: make battery_capacity_summary compatible with python3 (#1763 <https://github.com/jsk-ros-pkg/jsk_common/issues/1763>)
  
    * fix(battery_capacity_summary): avoid usin keys[i]
    * [jsk_tools/test_topic_published] Fixed E402 (module level import not at top of file) error
    * [jsk_tools/test_topic_published] Use eval_utils module and enabled import moduels for input_condition
  
* [jsk_tools/sanity_diagnostics.py] Modified the timing of updating (#1756 <https://github.com/jsk-ros-pkg/jsk_common/issues/1756>)
  
    * [jsk_tools/sanity_diagnostics.py] Modified the timing of updating timestamp and states for each topic and each node.
  
* [jsk_tools] Seperate sanity check frequency and diagnostics publish frequency (#1745 <https://github.com/jsk-ros-pkg/jsk_common/issues/1745>)
  
    * Publish diagnostics at more than 1Hz, but check sanity at 0.1 Hz
    * [jsk_tools] Change function name
    * [jsk_tools] Seperate sanity check frequency and diagnostics publish frequency
  
* [jsk_tools/test_topic_published.py] Add condition_%d option for checking topic value (#1744 <https://github.com/jsk-ros-pkg/jsk_common/issues/1744>)
  
    * [jsk_tools/test_topic_published.py] Fixed E131 continuation line unaligned for hanging indent
    * [jsk_tools/test_topic_published.py] Add document for escape sequence.
    * [jsk_tools/test_topic_published.py] Changed the output error message based on negative and condition.
    * [jsk_tools/test_topic_published.py] Add test for condition option
    * [jsk_tools/test_topic_published.py] Add condition_%d option for checking topic value
  
* Contributors: Hiro Ishida, Iori Yanokura, Kei Okada, Naoya Yamaguchi, Shingo Kitagawa
```

## jsk_topic_tools

```
* use hpp instead of deprecated .h pluginlib headers (#1777 <https://github.com/jsk-ros-pkg/jsk_common/issues/1777>)
* Fix for noetic (#1774 <https://github.com/jsk-ros-pkg/jsk_common/issues/1774>)
  
    * test/test_transform_wrench.test: retry=3, time-limit=15
  
* add test to check c++14/C++11/C++0x (#1785 <https://github.com/jsk-ros-pkg/jsk_common/issues/1785>)
  
    * auto lambda for c++14
  
* add test to compile on 22.04, see #1770 <https://github.com/jsk-ros-pkg/jsk_common/issues/1770> (#1773 <https://github.com/jsk-ros-pkg/jsk_common/issues/1773>)
  
    * revert code before C++11
    * <mutex> requries -std=c++11 compile options, but it is not used in source tree
    * avoid boost::bind (esp. global _1)
      it's deprecated to use global _1 from boost for a while now
      and the Debian ROS packages do not provide it anymore.
    * do not specify c++ standard
      it break with current log4cxx which requires c++17.
      No, going forward it's no option to specify the standard anymore.
      And it's not necessary either.
      same fix as https://github.com/jsk-ros-pkg/jsk_common/pull/1773/commits/18e200ca51ac035af3e8ab5955cde2b76fc9c980
    * fixup documentation
      this confused me when I looked through the code.
    * avoid boost::bind (esp. global _1)
      it's deprecated to use global _1 from boost for a while now
      and the Debian ROS packages do not provide it anymore.
    * update pluginlib includes
      the non-hpp headers are deprecated since kinetic
  
* [test_topic_published.py, boolean_node.py] Enable importing modules (#1760 <https://github.com/jsk-ros-pkg/jsk_common/issues/1760>)
* [jsk_topic_tools/DiagnosticNodelet] Use node name for diagnostic message (#1762 <https://github.com/jsk-ros-pkg/jsk_common/issues/1762>)
  
    * [jsk_topic_tools/DiagnosticNodelet] Use %.1f for readability
    * [jsk_topic_tools/DiagnosticNodelet] Use node name for diagnostic message
  
* [jsk_topic_tools] Eval at every timer callback (#1758 <https://github.com/jsk-ros-pkg/jsk_common/issues/1758>)
* Add ConstantRateThrottle Nodelet (#1748 <https://github.com/jsk-ros-pkg/jsk_common/issues/1748>)
  
    * [jsk_topic_tools] fix timer start flag of ConstantRateThrottleNodelet
    * [jsk_topic_tools] add a test for ConstantRateThrottle
    * [jsk_topic_tools] enalbe c++11 support
    * [jsk_topic_tools] add ConstantRateThrottleNodelet and sample/docs for it.
      [jsk_topic_tools] add constant_rate_throttle_node files
      [jsk_topic_tools] update for constant_rate_throttle_nodelet
      [jsk_topic_tools] add compiling of constant_rate_throttle_nodelet
      [jsk_topic_tools] update constatn_rate_throttle_nodelet
      [jsk_topic_tools] fix class name for ConstantRateThrottle
      [jsk_topic_tools] fix plugin build
      [jsk_topic_tools] update sample for constant_rate_nodelet
      [jsk_topic_tools] fix bugs
      [jsk_topic_tools] add constant_rate_throttle_nodelet docs
  
* Fixed typo of Software License Agreement. and/o2r to and/or (#1764 <https://github.com/jsk-ros-pkg/jsk_common/issues/1764>)
* [jsk_topic_tools/DiagnosticsNodelet] Enable constructor without name argument (#1761 <https://github.com/jsk-ros-pkg/jsk_common/issues/1761>)
  
    * [jsk_topic_tools/boolean_node] Use eval_utils's expr_eval and enable import options
    * [jsk_topic_tools] Add eval_utils module to eval Python expression
    * [jsk_topic_tools] Eval at every timer callback
  
* [jsk_topic_tools/version] Generate jsk_topic_tools_version.h without calling catkin_package_xml. (#1755 <https://github.com/jsk-ros-pkg/jsk_common/issues/1755>)
* [jsk_topic_tools/timered_diagnostics_updater] Use force_update instead of update because of update called using TimeredDiagnosticUpdater's timer (#1752 <https://github.com/jsk-ros-pkg/jsk_common/issues/1752>)
* [jsk_topic_tools/HzMeasureNodelet] Added measure_time param and modified to measure hz in the updateDiagnostics function. (#1754 <https://github.com/jsk-ros-pkg/jsk_common/issues/1754>)
  
    * [jsk_topic_tools/HzMeasureNodelet] Modified to measure hz in the updateDiagnostics function.
      The hz calculation will be correct even if the topic does not come.
    * [jsk_topic_tools/DiagnosticsNodelet] Enable constructor without name argument
    * [jsk_topic_tools/HzMeasureNodelet] Fixed calculation for hz.
    * [jsk_topic_tools/HzMeasureNodelet] Call popBufferQueue in calculateHz
    * [jsk_topic_tools/HzMeasureNodelet] Fixed timing of scoped_lock to publish /diagnostics. Also, added test for diagnostics
    * [jsk_topic_tools/HzMeasureNodelet] Add test for ~measure_time and ~message_num
    * [jsk_topic_tools/HzMeasureNodelet] Enable ~measure_time param to calculate hz from the number of topics received in time in ~measure_time
    * [jsk_topic_tools/HzMeasureNodelet] Fixed calculation of average_time (buffer_.size() - 1) to buffer_.size()
    * [jsk_topic_tools/HzMeasureNodelet] Fixed calculating hz condition
  
* [jsk_topic_tools] Add header file to check jsk_topic_tools' version (#1753 <https://github.com/jsk-ros-pkg/jsk_common/issues/1753>)
  
    * [jsk_topic_tools] Don't install *_version.h.in files using FILES_MATCHING PATTERN
    * [jsk_topic_tools] Add header file to check jsk_topic_tools' version
  
* [jsk_topic_tools] merge topic_buffer tests and loose conditions (#1739 <https://github.com/jsk-ros-pkg/jsk_common/issues/1739>)
  
    * [jsk_topic_tools] Rename dropped test_topic_buffer's extention to launch
    * [jsk_topic_tools] Commented out test_topic_buffer to loose test conditions
  
* Add boolean operation nodes (and, or, not) (#1706 <https://github.com/jsk-ros-pkg/jsk_common/issues/1706>)
* [jsk_topic_tools/HzMeasureNodelet] Add diagnostics to monitor hz (#1743 <https://github.com/jsk-ros-pkg/jsk_common/issues/1743>)
* Contributors: Iori Yanokura, Kei Okada, Koki Shinjo, Lucas Walter, Shingo Kitagawa, Yoshiki Obinata, v4hn
```

## multi_map_server

- No changes

## virtual_force_publisher

- No changes
