### PR TITLE
leo_desktop: 2.0.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2485,6 +2485,24 @@ repositories:
       url: https://github.com/LeoRover/leo_common-ros2.git
       version: iron
     status: maintained
+  leo_desktop:
+    doc:
+      type: git
+      url: https://github.com/LeoRover/leo_desktop-ros2.git
+      version: iron
+    release:
+      packages:
+      - leo_desktop
+      - leo_viz
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/leo_desktop-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/LeoRover/leo_desktop-ros2.git
+      version: iron
+    status: maintained
   lgsvl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_desktop` to `2.0.0-1`:

- upstream repository: https://github.com/LeoRover/leo_desktop-ros2.git
- release repository: https://github.com/ros2-gbp/leo_desktop-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## leo_desktop

- No changes

## leo_viz

```
* CI update
* Contributors: Błażej Sowa
```
