### PR TITLE
Add fonts-roboto entry

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1137,6 +1137,10 @@ fonts-noto:
   fedora: [google-noto-sans-mono-fonts, google-noto-serif-fonts]
   gentoo: [media-fonts/noto]
   ubuntu: [fonts-noto]
+fonts-roboto:
+  debian: [fonts-roboto-hinted, fonts-roboto-unhinted]
+  fedora: [google-roboto-fonts, google-roboto-condensed-fonts]
+  ubuntu: [fonts-roboto-hinted, fonts-roboto-unhinted]
 fping:
   arch: [fping]
   debian: [fping]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1138,6 +1138,7 @@ fonts-noto:
   gentoo: [media-fonts/noto]
   ubuntu: [fonts-noto]
 fonts-roboto:
+  arch: [ttf-roboto]
   debian: [fonts-roboto-hinted, fonts-roboto-unhinted]
   fedora: [google-roboto-fonts, google-roboto-condensed-fonts]
   ubuntu: [fonts-roboto-hinted, fonts-roboto-unhinted]


### PR DESCRIPTION
Add entry to install `fonts-roboto` on `arch`, `debian`, `fedora`,  `ubuntu`.

