### PR TITLE
Update distribution.yaml

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -705,6 +705,15 @@ repositories:
       url: https://github.com/flynneva/bno055.git
       version: main
     status: maintained
+  boeing_gazebo_model_attachment_plugin:
+    doc:
+      type: git
+      url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
+      version: humble
   bond_core:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -714,6 +714,15 @@ repositories:
       type: git
       url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
       version: humble
+  boeing_gazebo_set_joint_positions_plugin:
+    doc:
+      type: git
+      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      version: humble
   bond_core:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -526,11 +526,11 @@ repositories:
   boeing_gazebo_model_attachment_plugin:
     doc:
       type: git
-      url: https://github.com/Boeing/gazebo_model_attachment_plugin
+      url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
       version: noetic
     source:
       type: git
-      url: https://github.com/Boeing/gazebo_model_attachment_plugin
+      url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
       version: noetic
   bond_core:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -523,6 +523,15 @@ repositories:
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
       version: master
     status: developed
+  boeing_gazebo_model_attachment_plugin:
+    doc:
+      type: git
+      url: https://github.com/Boeing/gazebo_model_attachment_plugin
+      version: noetic
+    source:
+      type: git
+      url: https://github.com/Boeing/gazebo_model_attachment_plugin
+      version: noetic
   bond_core:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -532,6 +532,15 @@ repositories:
       type: git
       url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
       version: noetic
+  boeing_gazebo_set_joint_positions_plugin:
+    doc:
+      type: git
+      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      version: noetic
+    source:
+      type: git
+      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      version: noetic
   bond_core:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

boeing_gazebo_model_attachment_plugin (humble entry)
boeing_set_joint_positions_plugin

## Package Upstream Source:

https://github.com/Boeing/gazebo_model_attachment_plugin
https://github.com/Boeing/gazebo_set_joint_positions_plugin

## Purpose of using this:

This package allows for models to be linked and un linked during runtime using a ros service
Provides 

This plugin sets a RobotModel's joint values to the latest published values on a speicifed JointState topic from ROS.

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro