### PR TITLE
jsk_recognition: 1.2.16-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4533,10 +4533,11 @@ repositories:
       - jsk_recognition_msgs
       - jsk_recognition_utils
       - resized_image_transport
+      - sound_classification
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 1.2.15-1
+      version: 1.2.16-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `1.2.16-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.15-1`

## audio_to_spectrogram

```
* [audio_to_spectrogram, sound_classification] Add data_to_spectrogram (#2767 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2767>)
* [audio_to_spectrogram] Enable to change spectrum plot from rosparam (#2760 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2760>)
* Fix audio to spectrogram plot and add test (#2764 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2764>)
* [audio_to_spectrogram] Add AudioAmplitudePlot node to visualize audio amplitude #2657 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2657> (#2755 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2755>)
* [audio_to_spectrogram] Enable publishing frequency vs amplitude plot (#2654 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2654>)
* use catkin_install_python to install python scripts under node_scripts/ scripts/ (#2743 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2743>)
* Contributors: Kei Okada, Naoto Tsukamoto, Shingo Kitagawa, Shun Hasegawa, Yoshiki Obinata, Iory Yanokura
```

## checkerboard_detector

```
* Fixed typo of Software License Agreement. and/o2r to and/or (#2727 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2727>)
* use %f instead of %d (#2708 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2708>)
* Contributors: Amir Tulegenov, Ravi Joshi, Iory Yanokura
```

## imagesift

```
* add noetic build test (#2756 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2756>)
  
    * imagesift/test/test_imagesift.test: retry 3
  
* Fixed typo of Software License Agreement. and/o2r to and/or (#2727 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2727>)
* Add reset sync policy in destructor and add a test (#2681 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2681>)
  
    * [imagesift] Add test for sync policy in destructor.
    * [imagesift] Reset sync policy in destructor.
  
* add doc about ~image_transport and examples (#2558 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2558>)
* Contributors: Aoi Nakane, Iori Yanokura, Kei Okada, Naoto Tsukamoto, Shingo Kitagawa, Yoshiki Obinata, Iory Yanokura
```

## jsk_pcl_ros

```
* add noetic build test (#2756 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2756>)
* [jsk_pcl_ros] to avoid invalid access, use getGridCoordinates+getCenroidIndexAt function instead of getCentroidIndex. (#2748 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2748>)
* add relay new baxter_realsense_l515.bag (#2749 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2749>)
* [jsk_pcl_ros] fix data link in install_sample_data.py (#2733 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2733>)
* Fix #2737 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2737> (#2739 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2739>)
* Fixed typo of Software License Agreement. and/o2r to and/or (#2727 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2727>)
* [feature] container occupancy detector nodelet (#2696 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2696>)
* [jsk_pcl_ros/organized_multi_plane_segmentation_nodelet] Poke when start subscribing (#2710 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2710>)
* Add reset sync policy in destructor and add a test (#2681 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2681>)
* [jsk_pcl_ros/octomap_server_contact_nodelet.cpp] fix memory leak of colors pointer (#2661 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2661>)
* use default value for param (#2663 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2663>)
* work around permission issue / integrate all yaml to one (#2677 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2677>)
* [jsk_perception][jsk_pcl_ros_utils][jsk_pcl_ros] Fix download links (#2632 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2632>)
* check more python3 compatibility (#2614 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2614>)
* [jsk_pcl_ros] ExtractIndices debug (#2628 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2628>)
* add missing build_depend dynamic_reconfigure in jsk_pcl_ros (#2619 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2619>
* [jsk_pcl_ros] Stop tf when segmented cloud size is zero using cluster point indices decomposer (#2599 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2599>)
* add organized statistical removal test (#2602 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2602>)
* [jsk_pcl_ros] fix bug of lookuptransform in heightmapconverter (#2572 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2572>)
* [jsk_pcl_ros] add z range option to heightmap converter (#2564 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2564>)
* [DepthImageCreator] print more rosparm info on startup (#2543 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2543>)
* add sample_plane_extraction.launch , plane_extraction.launch (#2551 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2551>)
* [jsk_pcl_ros] set larger min_size limit for organized multiplane segmentation (#2571 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2571>)
* [jsk_pcl_ros/line_segment_detector] LineList needs colors aligning with points (#2562 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2562>)
* [jsk_pcl_ros] support including tabletop_object_detector.launch file in any name space (#2539 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2539>)
* Update depth_image_creator.md (#2557 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2557>)
* [jsk_pcl_ros] remove wrong launch_manager in tabletop_object_detector.launch (#2568 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2568>)
* [jsk_pcl_ros] remove wrong launch_manager in tabletop_object_detector.launch (#2546 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2546>)
* Contributors: Aoi Nakane, Guilherme Affonso, Iori Yanokura, Kei Okada, Koki Shinjo, Miyabi Tanemoto, Naoki Hiraoka, Naoto Tsukamoto, Shingo Kitagawa, Shumpei Wakabayashi, Yutaro Matsuura, Yasuhiro Ishiguro, Yoshiki Obinata,
```

## jsk_pcl_ros_utils

```
* [jsk_pcl_ros_utils] use nodelet logger and fix logging info (#2774 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2774>)
* Save point cloud data as pcd format through ROS service. (#2773 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2773>)
* add noetic build test (#2756 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2756>)
* Add size check in ClusterPointIndicesLabelFilter (#2740 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2740>)
* Force plane coefficient to direct origin in plane concatinator (#2658 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2658>)
* Fixed typo of Software License Agreement. and/o2r to and/or (#2727 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2727>)
* [jsk_perception][jsk_pcl_ros_utils][resized_image_transport] Call onInitPostProcess() (#2719 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2719>)
* Add reset sync policy in destructor and add a test (#2681 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2681>)
* work around permission issue / integrate all yaml to one (#2677 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2677>)
* [jsk_perception][jsk_pcl_ros_utils][jsk_pcl_ros] Fix download links (#2632 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2632>)
* add node that convert 3D coordinate to 2D coordinate (#2549 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2549>)
* Add cluster point indices label filter (#2468 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2468>)
* Contributors: Aoi Nakane, Guilherme Affonso, Iori Yanokura, Kei Okada, Koki Shinjo, Miyabi Tanemoto, Naoto Tsukamoto, Shingo Kitagawa, Tatsuro Sakaguchi, Yukina Iwata, Yoshiki Obinata
```

## jsk_perception

```
* [AWS] use logdebug when detect face (#2766 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2766>)
* Aws face update (#2744 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2744>)
* [jsk_perception] Add invert_mask_image nodelet (#2726 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2726>)
* [jsk_perception] Support compressed type image in vil_inference_client.py (#2800 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2800>)
* [jsk_perception] Fix Cosine Similarity description in visualize  string msg of classification_node (#2794 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2794>)
* fix ofa docker build (#2784 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2784>)
* [jsk_perception][insta360][dual_fisheye_to_panorama] Add always subscribe arg (#2777 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2777>)
* [feature] VQA using Large-Scale Vision and Language model (#2730 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2730>)
* [jsk_perception] Fix nodehandle in point_pose_extractor (#2779 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2779>)
* [jsk_perception] Use cpp version of split_image in sample_insta360_air.launch (#2772 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2772>)
* [split_image] add cpp version of split_image (#2770 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2770>)
* add video to scene (#2736 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2736>)
* [jsk_perception/point_pose_extractor] Use DiagnosticNodelet to improve subscribing (#2722 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2722>)
* [jsk_perception] Poke in dual_fisheye_to_panorama for DiagnosticNodelet (#2734 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2734>)
* add image_height and image_width in PanoramaInfo (#2753 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2753>)
* [jsk_perception] Add header to output/vis (#2758 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2758>)
* add noetic build test (#2756 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2756>)
* [jsk_perception] support image_transport in DualFisheyeToPanorama (#2745 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2745>)
* [jsk_perception/dualfisheye_panorama] poke in callback (#2690 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2690>)
* use catkin_install_python to install python scripts under node_scripts/ scripts/ (#2743 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2743>)
* [feature] removing blurred frames node (#2718 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2718>)
* Parameterize DualFisheyeToPanorama node (#2642 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2642>)
* [jsk_perception/apply_mask] Avoid error in cvtColor when masked_image is empty (#2725 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2725>)
* Fixed typo of Software License Agreement. and/o2r to and/or (#2727 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2727>)
* [jsk_perception/mask_image_to_rect] Add rect_type option to publish rects containing each contour of mask image (#2728 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2728>)
* [jsk_perception/VirtualCameraMono] Add queue_size param (#2724 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2724>)
* [jsk_perception][jsk_pcl_ros_utils][resized_image_transport] Call onInitPostProcess() (#2719 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2719>)
* [jsk_perception] return when camera info message is None (#2676 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2676>)
* [jsk_perception/aws_auto_checkin_app] Use search_faces_by_image() of Amazon Rekognition (#2716 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2716>)
* [jsk_perception/robot_to_mask_image] Fix image size considering binning (#2713 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2713>)
* [jsk_perception/image_publisher.py] Support bgr16, rgb16, bgra16 and rgba16 encodings  and compressedDepth for 32FC1 depth image (#2714 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2714>)
* [jsk_perception] Use logdebug when height for label is not specified (#2709 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2709>)
* [jsk_perception/virtual_camera_mono] Use DiagnosticNodelet to start subscribing topics when camera_info is subscribed (#2711 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2711>)
* Add reset sync policy in destructor and add a test (#2681 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2681>)
* Add CRAFT character detection node and OCR node. (#2650 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2650>)
* [jsk_perception] Exclude depth z=0 (#2701 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2701>)
* [jsk_perception] Fix depth_img.shape index (#2689 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2689>)
* [jsk_perception/aws_detect_faces] Publish visualized image when use_image is False case (#2697 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2697>)
* image_publisher, enable to publish exif information (#2640 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2640>)
* publish boundingboxarray in paper_finder.py (#2679 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2679>)
* work around permission issue / integrate all yaml to one (#2677 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2677>)
* Enable 3d hand pose detection (#2672 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2672>)
* [jsk_perception] Fix NoRegionError in aws_detect_faces.py (#2671 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2671>)
* [jsk_perception] Add libuvc_camera to dependency for sample_insta360_air.launch (#2669 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2669>)
* Add modified version of draw rects for non ascii characters (#2648 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2648>)
* [jsk_perception] Add depth image filter (#2645 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2645>)
* Add paper_finder (#2542 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2542>)
* enable to publish comprssed image if required (#2637 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2637>)
* relax test_draw_classification_result (#2639 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2639>)
* fix human_mesh_recovery (#2636 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2636>)
* [jsk_perception][jsk_pcl_ros_utils][jsk_pcl_ros] Fix download links (#2632 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2632>)
* [jsk_perception] add frame_id args to libuvc_camera and usb_cam launch (#2629 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2629>)
* check more python3 compatibility (#2614 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2614>)
* [jsk_perception] add tf broadcaster to point pose extractor (#2622 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2622>)
* add AWS DetectFaces ROS node (#2615 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2615>)
* [jsk_perception] Add label_array_to_mask_image (#2624 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2624>)
* Enable to throttle insta360 image to reduce dual_fisheye_to_panorama CPU load (#2596 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2596>)
* [jsk_perception] Add approximate sync true in sample mask rcnn instance segmentation (#2623 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2623>)
* Add hand pose estimation (#2601 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2601>)
* [jsk_perception] add max_interval_duration for apply_mask_image (#2620 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2620>)
* add aws_auto_checkin_app, see https://aws.amazon.com/jp/builders-flash/202004/auto-checkin-app/ and https://github.com/jsk-ros-pkg/jsk_demos/pull/1325 (#2583 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2583>)
* [jsk_perception] add rect_array_in_panorama_to_bounding_box_array node (#2581 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2581>)
* if we install cupy with pip install cupy, instead of pip install  cupy-cudaXXX, the package name is cupy (#2611 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2611>)
* add max_num and score_threshold param in bing (#2598 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2598>)
* [jsk_perception] support sensor_msgs/PanoramaInfo with adding a publisher to DualFisheyeToPanorama node (#2579 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2579>)
* [jsk_perception] add message size check to deep_sort_tracker_node.py (#2577 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2577>)
* if we install cupy with pip install cupy, instead of pip install cupy-cudaXXX, the package name is cupy (#2610 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2610>)
* update install_trained_data url (#2604 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2604>)
* Set default brightness to insta360 (#2575 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2575>)
* Add brightness arg to camera launchs
* Add sample to calibrate and rectify insta360 air image (#2555 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2555>)
* random_forest_sample.launch : do not use xterm -e when gui is false (#2574 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2574>)
* Add LabelArray to ssd object detector (#2473 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2473>)
* [jsk_perception] apply_mask_image publish roi (#2476 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2476>)
* Change default value of resolution_factor in DrawRects.cfg (#2538 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2538>)
* Add node to split image vertically and horizontally (#2553 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2553>)
* add more debug info for virtual_camera_info (#2563 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2563>)
* [jsk_perception] do not exit if cupy is not installed (#2566 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2566>)
* [jsk_perception] Support chainercv mask rcnn (#2435 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2435>)
* Use use_cam.launch in sample_insta360_air.launch (#2544 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2544>)
* [doc] Add elp camera doc (#2545 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2545>)
* Contributors: Aoi Nakane, Guilherme Affonso, Iori Yanokura, Kanazawa Naoaki, Kei Okada, Koki Shinjo, Liqi Wu, Naoto Tsukamoto, Naoya Yamaguchi, Shingo Kitagawa, Shumpei Wakabayashi, Yukina Iwata, Yoshiki Obinata, Kosuke Takeuchi
, Tatsuya Nakao, Akihiro Miki
```

## jsk_recognition

- No changes

## jsk_recognition_msgs

```
* [feature] VQA using Large-Scale Vision and Language model (#2730 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2730>)
  
    * add ClassificationTask.action, VQATask.action, ClipResult.msg,  QuaryANdProbability.msg, QuestionAndAnswerText.msg, VQAResult.msg
  
* 
  
    * add image_height and image_width in PanoramaInfo.msg #2753 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2753> from knorth55/panorama-info-image-shape
  
* add noetic build test (#2756 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2756>)
* jsk_recognition_msgs : setup.py need src/jsk_recognition_msgs (#2749 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2749>)
  
    * with out this fix, master branch fails with
      ```
      error: package directory 'jsk_recognition_msgs' does not exist
      error: package directory 'src/jsk_recognition_msgs' does not exist
      ```
      Not sure why CI passed
  
* use catkin_install_python to install python scripts under node_scripts/ scripts/ (#2743 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2743>)
* image_publisher, enable to publish exif information (#2640 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2640>)
  
    * add ExifGPSInfo.msg, ExifTags.msg
  
* Add hand pose estimation (#2601 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2601>)
  
    * add HandPose.msg, HandPoseArray.msg
  
* [jsk_recognition_msgs] add PanoramaInfo.msg (#2579 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2579>)add PanoramaInfo on jsk_recognition_msgs until https://github.com/ros/common_msgs/pull/171 merged
* Contributors: Iori Yanokura, Kei Okada, Koki Shinjo, Shingo Kitagawa, Wu Liqi, Yoshiki Obinata
```

## jsk_recognition_utils

```
* [jsk_recognition_utils] add cython3 depend when ROS_PYTHON_VERSION==3 (#2771 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2771>)
* use python3-shapely for ROS_PHTHON_VERSION==3 (#2756 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2756>)
* use catkin_install_python to install python scripts under node_scripts/ scripts/ (#2743 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2743>)
* Fixed typo of Software License Agreement. and/o2r to and/or (#2727 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2727>)
* [jsk_perception/mask_image_to_rect] Add rect_type option to publish rects containing each contour of mask image (#2728 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2728>)
* [jsk_recognition_utils] Add jsk_topic_tools header file to check jsk_topic_tools' version (#2721 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2721>)
* [jsk_perception/image_publisher.py] Support bgr16, rgb16, bgra16 and rgba16 encodings and compressedDepth for 32FC1 depth image (#2714 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2714>)
* Add CRAFT character detection node and OCR node. (#2650 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2650>)
* work around permission issue / integrate all yaml to one (#2677 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2677>)
* [jsk_recognition_utils] Add polygon_array_to_box_array node (#2647 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2647>)
* Add modified version of draw rects for non ascii characters (#2648 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2648>)
* [jsk_recognition_utils] Enable publishing coefficients array (#2646 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2646>)
* Replace color.pyx with color.py for better compatibility (#2633 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2633>)
* Using pcl::Vertices instead of std::vector since type of point indices changes between PCL versions. (#2627 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2627>)
* support ~image_transport for static_virtual_camera (#2569 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2569>)
* [jsk_recognition_utils] use try to import chainer depend modules (#2565 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2565>)
* Contributors: Aoi Nakane, Baltashov Ilia, Iori Yanokura, Kei Okada, Kentaro Wada, Naoto Tsukamoto, Naoya Yamaguchi, Shingo Kitagawa, Yoshiki Obinata
```

## resized_image_transport

```
* [jsk_perception][jsk_pcl_ros_utils][resized_image_transport] Call onInitPostProcess() (#2719 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2719>)
* Contributors: Aoi Nakane, Kei Okada, Naoto Tsukamoto, Shingo Kitagawa
```

## sound_classification

```
* [audio_to_spectrogram, sound_classification] Add data_to_spectrogram (#2767 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2767>)
* use catkin_install_python to install python scripts under node_scripts/ scripts/ (#2743 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2743>)
* [sound_classification] Update setup doc on READMEt( #2732 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2732>)
* [sound_classification] Enable to pass all arguments of audio_to_spectrogram.launch from upper launches (#2731 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2731>)
* [sound_classification] Fix pactl option to list up input devices (#2715 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2715>)
* [sound_classification] set default as python2 in sound_classification (#2698 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2698>)
* chmod -x sound_classification scripts for catkin_virtualenv (#2659 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2659>)
* Add sound classification (#2635 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2635>)
  
    * copy from https://github.com/708yamaguchi/sound_classification
  
* Contributors: Iori Yanokura, Kei Okada, Naoto Tsukamoto, Naoya Yamaguchi, Shingo Kitagawa, Shun Hasegawa
```
