### PR TITLE
naoqi_bridge_msgs2: 2.1.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3213,6 +3213,20 @@ repositories:
       url: https://github.com/ros-sports/nao_lola.git
       version: iron
     status: developed
+  naoqi_bridge_msgs2:
+    release:
+      packages:
+      - naoqi_bridge_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros-naoqi/naoqi_bridge_msgs2-release.git
+      version: 2.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_bridge_msgs2.git
+      version: main
+    status: maintained
   naoqi_libqi:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_bridge_msgs2` to `2.1.0-1`:

- upstream repository: https://github.com/ros-naoqi/naoqi_bridge_msgs2.git
- release repository: https://github.com/ros-naoqi/naoqi_bridge_msgs2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## naoqi_bridge_msgs

```
* Update maintainers
* New "Listen" action
* Restore action messages
* Contributors: Victor Paléologue
```
