### PR TITLE
Add rosdep key for python3-pyinotify

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7746,6 +7746,18 @@ python3-pygraphviz:
   rhel: ['python%{python3_pkgversion}-pygraphviz']
   slackware: [pygraphviz]
   ubuntu: [python3-pygraphviz]
+python3-pyinotify:
+  alpine: [py3-inotify]
+  arch: [python-pyinotify]
+  debian: [python3-pyinotify]
+  fedora: [python3-inotify]
+  gentoo: [dev-python/pyinotify]
+  nixos: [python3Packages.pyinotify]
+  opensuse: [python3-pyinotify]
+  osx:
+    pip:
+      packages: [pyinotify]
+  ubuntu: [python3-pyinotify]
 python3-pykdl:
   debian:
     '*': [python3-pykdl]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7757,6 +7757,7 @@ python3-pyinotify:
   osx:
     pip:
       packages: [pyinotify]
+  rhel: [python3-inotify]
   ubuntu: [python3-pyinotify]
 python3-pykdl:
   debian:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`python3-pyinotify`

## Package Upstream Source:

https://github.com/seb-m/pyinotify

## Purpose of using this:

To use Python scripts to watch directories for changes. In this particular case, to see rosbags as they are split in order to upload them to cloud storage.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/python3-pyinotify
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/jammy/python3-pyinotify
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-inotify/python3-inotify/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/any/python-pyinotify/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/pyinotify
- macOS: https://formulae.brew.sh/
  - pip
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/community/x86_64/py3-inotify
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=23.05&show=python311Packages.pyinotify
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python3-pyinotify