### PR TITLE
twist_mux: 4.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6919,7 +6919,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/twist_mux-release.git
-      version: 4.2.0-1
+      version: 4.3.0-1
     source:
       type: git
       url: https://github.com/ros-teleop/twist_mux.git


### PR DESCRIPTION
Increasing version of package(s) in repository `twist_mux` to `4.3.0-1`:

- upstream repository: https://github.com/ros-teleop/twist_mux.git
- release repository: https://github.com/ros2-gbp/twist_mux-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.2.0-1`

## twist_mux

```
* Add use_sim_time param for joystick_relay (#48 <https://github.com/ros-teleop/twist_mux/issues/48>)
* Add use_sim_time param to launchfile (#41 <https://github.com/ros-teleop/twist_mux/issues/41>)
* Contributors: Noel Jiménez García, Steven Palma
```
