### PR TITLE
humanoid_robot_framework: 0.3.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3821,6 +3821,26 @@ repositories:
       url: https://github.com/ros4hri/human_description.git
       version: main
     status: developed
+  humanoid_robot_framework:
+    doc:
+      type: git
+      url: https://github.com/Robotics-Sensors/humanoid_robot_framework.git
+      version: main
+    release:
+      packages:
+      - humanoid_robot_controller
+      - humanoid_robot_device
+      - humanoid_robot_framework
+      - humanoid_robot_framework_common
+      tags:
+        release: release/noetic/{package}/{version}
+      url: git@github.com:Robotics-Sensors/humanoid_robot_framework-release.git
+      version: 0.3.2-1
+    source:
+      type: git
+      url: https://github.com/Robotics-Sensors/humanoid_robot_framework.git
+      version: main
+    status: developed
   husky:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3834,7 +3834,7 @@ repositories:
       - humanoid_robot_framework_common
       tags:
         release: release/noetic/{package}/{version}
-      url: git@github.com:Robotics-Sensors/humanoid_robot_framework-release.git
+      url: https://github.com/Robotics-Sensors/humanoid_robot_framework-release.git
       version: 0.3.2-1
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `humanoid_robot_framework` to `0.3.2-1`:

- upstream repository: https://github.com/Robotics-Sensors/humanoid_robot_framework.git
- release repository: https://github.com/Robotics-Sensors/humanoid_robot_framework-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## humanoid_robot_controller

```
* Make it compatible for ROS1/ROS2
* Fix bugs
* Update package.xml and CMakeList.txt for to the latest versions
* Contributors & Maintainer: Ronaldson Bellande
```

## humanoid_robot_device

```
* Make it compatible for ROS1/ROS2
* Fix bugs
* Update package.xml and CMakeList.txt for to the latest versions
* Contributors & Maintainer: Ronaldson Bellande
```

## humanoid_robot_framework

```
* Make it compatible for ROS1/ROS2
* Fix bugs
* Update package.xml and CMakeList.txt for to the latest versions
* Contributors & Maintainer: Ronaldson Bellande
```

## humanoid_robot_framework_common

```
* Make it compatible for ROS1/ROS2
* Fix bugs
* Update package.xml and CMakeList.txt for to the latest versions
* Contributors & Maintainer: Ronaldson Bellande
```
