### PR TITLE
humanoid_robot_utility: 0.3.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3821,6 +3821,25 @@ repositories:
       url: https://github.com/ros4hri/human_description.git
       version: main
     status: developed
+  humanoid_robot_utility:
+    doc:
+      type: git
+      url: https://github.com/Robotics-Sensors/humanoid_robot_utility.git
+      version: main
+    release:
+      packages:
+      - humanoid_robot_math
+      - humanoid_robot_utility
+      - ros_madplay_player
+      tags:
+        release: release/noetic/{package}/{version}
+      url: git@github.com:Robotics-Sensors/humanoid_robot_utility-release.git
+      version: 0.3.2-1
+    source:
+      type: git
+      url: https://github.com/Robotics-Sensors/humanoid_robot_utility.git
+      version: main
+    status: developed
   husky:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3833,7 +3833,7 @@ repositories:
       - ros_madplay_player
       tags:
         release: release/noetic/{package}/{version}
-      url: git@github.com:Robotics-Sensors/humanoid_robot_utility-release.git
+      url: https://github.com/Robotics-Sensors/humanoid_robot_utility-release.git
       version: 0.3.2-1
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `humanoid_robot_utility` to `0.3.2-1`:

- upstream repository: https://github.com/Robotics-Sensors/humanoid_robot_utility.git
- release repository: https://github.com/Robotics-Sensors/humanoid_robot_utility-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## humanoid_robot_math

```
* Make it compatible for ROS1/ROS2
* Fix bugs
* Update package.xml and CMakeList.txt for to the latest versions
* Contributors & Maintainer: Ronaldson Bellande
```

## humanoid_robot_utility

```
* Make it compatible for ROS1/ROS2
* Fix bugs
* Update package.xml and CMakeList.txt for to the latest versions
* Contributors & Maintainer: Ronaldson Bellande
```

## ros_madplay_player

```
* Make it compatible for ROS1/ROS2
* Fix bugs
* Update package.xml and CMakeList.txt for to the latest versions
* Contributors & Maintainer: Ronaldson Bellande
```
