### PR TITLE
gazebo_video_monitors: 0.8.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1612,6 +1612,16 @@ repositories:
       type: git
       url: https://github.com/nlamprian/gazebo_video_monitors.git
       version: ros2
+    release:
+      packages:
+      - gazebo_video_monitor_interfaces
+      - gazebo_video_monitor_plugins
+      - gazebo_video_monitor_utils
+      - gazebo_video_monitors
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/gazebo_video_monitors-release.git
+      version: 0.8.0-1
     source:
       type: git
       url: https://github.com/nlamprian/gazebo_video_monitors.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_video_monitors` to `0.8.0-1`:

- upstream repository: https://github.com/nlamprian/gazebo_video_monitors.git
- release repository: https://github.com/ros2-gbp/gazebo_video_monitors-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## gazebo_video_monitor_interfaces

```
* Migrate interfaces package
* Contributors: Nick Lamprianidis
```

## gazebo_video_monitor_plugins

```
* Migrate plugins package
* Contributors: Nick Lamprianidis
```

## gazebo_video_monitor_utils

```
* Migrate utils package
* Contributors: Nick Lamprianidis
```

## gazebo_video_monitors

```
* Migrate metapackage
* Contributors: Nick Lamprianidis
```
