### PR TITLE
event_camera_renderer: 1.2.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1295,6 +1295,11 @@ repositories:
       type: git
       url: https://github.com/ros-event-camera/event_camera_renderer.git
       version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/event_camera_renderer-release.git
+      version: 1.2.2-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_renderer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `event_camera_renderer` to `1.2.2-1`:

- upstream repository: https://github.com/ros-event-camera/event_camera_renderer.git
- release repository: https://github.com/ros2-gbp/event_camera_renderer-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## event_camera_renderer

```
* initial release
* Contributors: Bernd Pfrommer
```
