### PR TITLE
metavision_driver: 1.0.8-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2749,7 +2749,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/metavision_driver-release.git
-      version: 1.0.6-1
+      version: 1.0.8-1
     source:
       type: git
       url: https://github.com/ros-event-camera/metavision_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `metavision_driver` to `1.0.8-1`:

- upstream repository: https://github.com/ros-event-camera/metavision_driver.git
- release repository: https://github.com/ros2-gbp/metavision_driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.6-1`

## metavision_driver

```
* fix broken build on galactic
* more fixes to make flake8 happy
* reformat python code as "black" and fix import order
* Modify launch file to accept params as args.
* support mipi frame period configuration for Gen3.1
* changed viewer -> renderer
* ignore python cache files in launch directory
* ability to set mipi_frame_period
* Contributors: Bernd Pfrommer, agaidev
```
