### PR TITLE
Add adi_tmcl to humble index

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -79,6 +79,16 @@ repositories:
       url: https://github.com/ros-acceleration/adaptive_component.git
       version: rolling
     status: developed
+  adi_tmcl:
+    doc:
+      type: git
+      url: https://github.com/analogdevicesinc/tmcl_ros2.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/analogdevicesinc/tmcl_ros2.git
+      version: humble
+    status: maintained
   aerostack2:
     doc:
       type: git
@@ -8017,16 +8027,6 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/tlsf.git
-      version: humble
-    status: maintained
-  tmcl_ros2:
-    doc:
-      type: git
-      url: https://github.com/analogdevicesinc/tmcl_ros2.git
-      version: humble
-    source:
-      type: git
-      url: https://github.com/analogdevicesinc/tmcl_ros2.git
       version: humble
     status: maintained
   topic_based_ros2_control:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7991,6 +7991,16 @@ repositories:
       url: https://github.com/ros2/tlsf.git
       version: humble
     status: maintained
+  tmcl_ros2:
+    doc:
+      type: git
+      url: https://github.com/analogdevicesinc/tmcl_ros2.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/analogdevicesinc/tmcl_ros2.git
+      version: humble
+    status: maintained
   topic_based_ros2_control:
     release:
       tags:


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble

# The source is here:

https://github.com/analogdevicesinc/tmcl_ros2

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
