### PR TITLE
naoqi_libqi: 3.0.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3227,7 +3227,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros-naoqi/libqi-release.git
-      version: 3.0.1-1
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/ros-naoqi/libqi.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_libqi` to `3.0.2-1`:

- upstream repository: https://github.com/ros-naoqi/libqi.git
- release repository: https://github.com/ros-naoqi/libqi-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.1-1`

## naoqi_libqi

```
* ROS-compatible automated test
* Contributors: Victor Paléologue
```
