### PR TITLE
python_qt_binding: 1.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4966,7 +4966,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/python_qt_binding-release.git
-      version: 1.1.1-3
+      version: 1.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `1.1.2-1`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros2-gbp/python_qt_binding-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.1-3`

## python_qt_binding

```
* Fix to allow ninja to use make for generators (#123 <https://github.com/ros-visualization/python_qt_binding/issues/123>) (#128 <https://github.com/ros-visualization/python_qt_binding/issues/128>)
* Contributors: Yasushi SHOJI
```
