### PR TITLE
rclcpp: 16.0.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5342,7 +5342,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 16.0.6-1
+      version: 16.0.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `16.0.7-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `16.0.6-1`

## rclcpp

```
* Disable the loaned messages inside the executor. (backport #2335 <https://github.com/ros2/rclcpp/issues/2335>) (#2364 <https://github.com/ros2/rclcpp/issues/2364>)
* Add missing 'enable_rosout' comments (#2345 <https://github.com/ros2/rclcpp/issues/2345>) (#2347 <https://github.com/ros2/rclcpp/issues/2347>)
* address rate related flaky tests. (#2329 <https://github.com/ros2/rclcpp/issues/2329>) (#2342 <https://github.com/ros2/rclcpp/issues/2342>)
* Update SignalHandler get_global_signal_handler to avoid complex types in static memory (#2316 <https://github.com/ros2/rclcpp/issues/2316>) (#2321 <https://github.com/ros2/rclcpp/issues/2321>)
* Fix C++20 allocator construct deprecation (#2292 <https://github.com/ros2/rclcpp/issues/2292>) (#2319 <https://github.com/ros2/rclcpp/issues/2319>)
* Contributors: mergify[bot]
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
