### PR TITLE
rosidl_typesupport_fastrtps: 2.2.2-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6636,7 +6636,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-      version: 2.2.1-1
+      version: 2.2.2-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_fastrtps` to `2.2.2-2`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.1-1`

## fastrtps_cmake_module

- No changes

## rosidl_typesupport_fastrtps_c

```
* Account for alignment on is_plain calculations (#108 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/108>) (#110 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/110>)
* Contributors: mergify[bot]
```

## rosidl_typesupport_fastrtps_cpp

```
* Account for alignment on is_plain calculations (#108 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/108>) (#110 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/110>)
* Contributors: mergify[bot]
```
