### PR TITLE
gazebo_video_monitors: 0.8.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2003,7 +2003,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_video_monitors-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       type: git
       url: https://github.com/nlamprian/gazebo_video_monitors.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_video_monitors` to `0.8.1-1`:

- upstream repository: https://github.com/nlamprian/gazebo_video_monitors.git
- release repository: https://github.com/ros2-gbp/gazebo_video_monitors-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.8.0-1`

## gazebo_video_monitor_interfaces

```
* Add missing test dependency
* Contributors: Nick Lamprianidis
```

## gazebo_video_monitor_plugins

- No changes

## gazebo_video_monitor_utils

- No changes

## gazebo_video_monitors

- No changes
