### PR TITLE
naoqi_libqicore: 3.0.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3233,6 +3233,21 @@ repositories:
       url: https://github.com/ros-naoqi/libqi.git
       version: ros2
     status: maintained
+  naoqi_libqicore:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/libqicore.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros-naoqi/libqicore-release.git
+      version: 3.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/libqicore.git
+      version: ros2
+    status: maintained
   navigation2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_libqicore` to `3.0.0-1`:

- upstream repository: https://github.com/ros-naoqi/libqicore.git
- release repository: https://github.com/ros-naoqi/libqicore-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## naoqi_libqicore

```
* Remove rolling CI
* Add more testing workflows
* Add Victor as maintainer
* Merge pull request #1 <https://github.com/ros-naoqi/libqicore/issues/1> from victorpaleologue/ros2
  Fixes for Ubuntu jammy's boost 1.74 (humble, iron)
* Build explicitly for C++11
* Fix placeholders for boost 1.74
* Dev container to work on sources
  At this stage it's checking out an unofficial libQi
* Remove spurious badge from README
* Add proper ROS2 CI tests, update the README accordingly
```
