### PR TITLE
jsk_recognition: 1.2.17-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4533,10 +4533,11 @@ repositories:
       - jsk_recognition_msgs
       - jsk_recognition_utils
       - resized_image_transport
+      - sound_classification
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 1.2.15-1
+      version: 1.2.17-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `1.2.17-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.15-1`

## audio_to_spectrogram

- No changes

## checkerboard_detector

- No changes

## imagesift

- No changes

## jsk_pcl_ros

- No changes

## jsk_pcl_ros_utils

- No changes

## jsk_perception

- No changes

## jsk_recognition

- No changes

## jsk_recognition_msgs

- No changes

## jsk_recognition_utils

```
* https://github.com/jsk-ros-pkg/jsk_recognition/pull/2648 requires jsk_data package (#2805 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2805>)
* Contributors: Kei Okada
```

## resized_image_transport

- No changes

## sound_classification

- No changes
