### PR TITLE
ros2_control: 2.35.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6053,7 +6053,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.34.0-1
+      version: 2.35.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.35.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.34.0-1`

## controller_interface

- No changes

## controller_manager

```
* Fix the controller sorting bug when the interfaces are not configured (fixes #1164 <https://github.com/ros-controls/ros2_control/issues/1164>) (#1165 <https://github.com/ros-controls/ros2_control/issues/1165>) (#1166 <https://github.com/ros-controls/ros2_control/issues/1166>)
* [CM] Use robot_description topic instead of parameter and don't crash on empty URDF 🦿 (backport #940 <https://github.com/ros-controls/ros2_control/issues/940>) (#1052 <https://github.com/ros-controls/ros2_control/issues/1052>)
* Contributors: Sai Kishor Kothakota, Denis Stogl
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* [CM] Use robot_description topic instead of parameter and don't crash on empty URDF 🦿 (backport #940 <https://github.com/ros-controls/ros2_control/issues/940>) (#1052 <https://github.com/ros-controls/ros2_control/issues/1052>)
* Contributors: mergify[bot]
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
