### PR TITLE
ros2_controllers: 2.27.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6089,7 +6089,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.26.0-1
+      version: 2.27.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.27.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.26.0-1`

## ackermann_steering_controller

```
* Improve docs (#785 <https://github.com/ros-controls/ros2_controllers/issues/785>) (#786 <https://github.com/ros-controls/ros2_controllers/issues/786>)
* Contributors: mergify[bot]
```

## admittance_controller

- No changes

## bicycle_steering_controller

```
* Improve docs (#785 <https://github.com/ros-controls/ros2_controllers/issues/785>) (#786 <https://github.com/ros-controls/ros2_controllers/issues/786>)
* Contributors: mergify[bot]
```

## diff_drive_controller

```
* [diff_drive_controller] Fixed typos in diff_drive_controller_parameter.yaml. (#822 <https://github.com/ros-controls/ros2_controllers/issues/822>) (#823 <https://github.com/ros-controls/ros2_controllers/issues/823>)
* Contributors: Tony Baltovski
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Steering controllers library: fix open loop mode (#793 <https://github.com/ros-controls/ros2_controllers/issues/793>) (#800 <https://github.com/ros-controls/ros2_controllers/issues/800>)
* Improve docs (#785 <https://github.com/ros-controls/ros2_controllers/issues/785>) (#786 <https://github.com/ros-controls/ros2_controllers/issues/786>)
* Contributors: mergify[bot]
```

## tricycle_controller

- No changes

## tricycle_steering_controller

```
* Improve docs (#785 <https://github.com/ros-controls/ros2_controllers/issues/785>) (#786 <https://github.com/ros-controls/ros2_controllers/issues/786>)
* Contributors: mergify[bot]
```

## velocity_controllers

- No changes
