### PR TITLE
ros2_control: 3.21.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5169,7 +5169,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.21.0-1
+      version: 3.21.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.21.1-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.21.0-1`

## controller_interface

- No changes

## controller_manager

```
* Fix the controller sorting bug when the interfaces are not configured (fixes #1164 <https://github.com/ros-controls/ros2_control/issues/1164>) (#1165 <https://github.com/ros-controls/ros2_control/issues/1165>) (#1167 <https://github.com/ros-controls/ros2_control/issues/1167>)
* Contributors: Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
