### PR TITLE
gnss-info: 1.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3404,6 +3404,25 @@ repositories:
       url: https://github.com/adler-1994/gmcl.git
       version: master
     status: developed
+  gnss-info:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/gnss-info.git
+      version: master
+    release:
+      packages:
+      - gnss_info
+      - gnss_info_msgs
+      - gnsstk_ros
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/gnss-info.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ctu-vras/gnss-info.git
+      version: master
+    status: developed
   gnsstk:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gnss-info` to `1.0.1-1`:

- upstream repository: https://github.com/ctu-vras/gnss-info.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/gnss-info.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## gnss_info

```
* Added support for plotting GPSFix messages.
* Added tests.
* Refactored out NavLibraryOrbitalDataProvider.
* Extracted CacheIndex class.
* Extracted cache validity checking.
* Switched to std::filesystem.
* Extracted common functionality.
* Add computation of ECEF position covariance.
* Refactor out gnsstk_ros package.
* Added sky view and sky plot publishers.
* Initial commit
* Contributors: Martin Pecka
```

## gnss_info_msgs

```
* Added sky view and sky plot publishers.
* Fixed a few issues with block-signal assignment.
* gnss_info_msgs: Fixed SkyView message build.
* Initial commit
* Contributors: Martin Pecka
```

## gnsstk_ros

```
* Add computation of ECEF position covariance.
* Refactor out gnsstk_ros package.
* Contributors: Martin Pecka
```
