### PR TITLE
mcl_3dl: 0.6.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5408,7 +5408,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/at-wat/mcl_3dl-release.git
-      version: 0.6.1-1
+      version: 0.6.2-1
     source:
       type: git
       url: https://github.com/at-wat/mcl_3dl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mcl_3dl` to `0.6.2-1`:

- upstream repository: https://github.com/at-wat/mcl_3dl.git
- release repository: https://github.com/at-wat/mcl_3dl-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.1-1`

## mcl_3dl

```
* Fix reported entropy (#408 <https://github.com/at-wat/mcl_3dl/issues/408>)
* Update assets to v0.6.1 (#407 <https://github.com/at-wat/mcl_3dl/issues/407>)
* Update assets to v0.6.0 (#406 <https://github.com/at-wat/mcl_3dl/issues/406>)
* Update assets to v0.5.2 (#405 <https://github.com/at-wat/mcl_3dl/issues/405>)
* Update assets to v0.5.1 (#404 <https://github.com/at-wat/mcl_3dl/issues/404>)
* Update assets to v0.4.2 (#402 <https://github.com/at-wat/mcl_3dl/issues/402>)
* Contributors: Atsushi Watanabe, f-fl0
```
