### PR TITLE
Update distribution.yaml with rrt_planner

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6225,6 +6225,22 @@ repositories:
       url: https://github.com/ros-visualization/rqt_topic.git
       version: iron
     status: maintained
+  rrt_planner:
+    doc:
+      type: git
+      url: https://github.com/daviddorf2023/rrt_planner.git
+      version: iron
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/daviddorf2023/rrt_planner.git
+      version: 1.0.0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/daviddorf2023/rrt_planner.git
+      version: iron
+    status: maintained
   rsl:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

rrt_planner

## Package Upstream Source:

https://github.com/daviddorf2023/rrt_planner.git

## Purpose of using this:

There used to be a package in ROS 1 for doing path planning with Rapidly Exploring Random Trees (RRTs), called rrt_exploration. That package has not been added to ROS 2, and features such as 3D path planning and marker obstacle avoidance. These features are present in rrt_planner, where a user can publish an occupancy grid or marker in 2D or 3D, and the algorithm will avoid the walls/obstacles. It then publishes the nodes as markers during runtime, and publishes a path if one is found within the node limit.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://github.com/daviddorf2023/rrt_planner.git
- Ubuntu: https://packages.ubuntu.com/
  - https://github.com/daviddorf2023/rrt_planner.git
- Fedora: https://packages.fedoraproject.org/
  - not available
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available
- openSUSE: https://software.opensuse.org/package/
  - not available
- rhel: https://rhel.pkgs.org/
  - not available

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

Iron

# The source is here:

https://github.com/daviddorf2023/rrt_planner.git

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
