### PR TITLE
fields2cover: 1.2.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1802,12 +1802,21 @@ repositories:
       version: master
     status: developed
   fields2cover:
+    doc:
+      type: git
+      url: https://github.com/Fields2Cover/fields2cover.git
+      version: main
     release:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/Fields2Cover/fields2cover-release.git
       version: 1.2.1-1
-      status: developed
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/Fields2Cover/fields2cover.git
+      version: main
+    status: developed
   filters:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1733,6 +1733,13 @@ repositories:
       url: https://github.com/eProsima/Fast-DDS.git
       version: 2.6.x
     status: maintained
+  fields2cover:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/Fields2Cover/fields2cover-release.git
+      version: 1.2.1-1
+    status: developed
   filters:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fields2cover` to `1.2.1-1`:

- upstream repository: https://github.com/Fields2Cover/fields2cover.git
- release repository: https://github.com/Fields2Cover/fields2cover-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
