### PR TITLE
fields2cover: 1.2.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1385,6 +1385,13 @@ repositories:
       url: https://github.com/eProsima/Fast-DDS.git
       version: 2.10.x
     status: maintained
+  fields2cover:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/Fields2Cover/fields2cover-release.git
+      version: 1.2.1-1
+    status: developed
   filters:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fields2cover` to `1.2.1-1`:

- upstream repository: https://github.com/Fields2Cover/fields2cover.git
- release repository: https://github.com/Fields2Cover/fields2cover-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
