### PR TITLE
fields2cover: 1.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2795,6 +2795,13 @@ repositories:
       url: https://github.com/UbiquityRobotics/fiducials.git
       version: noetic-devel
     status: maintained
+  fields2cover:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/Fields2Cover/fields2cover-release.git
+      version: 1.2.1-1
+    status: developed
   fields2cover_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fields2cover` to `1.2.1-1`:

- upstream repository: https://github.com/Fields2Cover/fields2cover.git
- release repository: https://github.com/Fields2Cover/fields2cover-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
