### PR TITLE
cras_joy_tools: 1.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1631,6 +1631,21 @@ repositories:
       url: https://github.com/ctu-vras/cras_imu_tools.git
       version: master
     status: maintained
+  cras_joy_tools:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/cras_joy_tools.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/cras_joy_tools.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ctu-vras/cras_joy_tools.git
+      version: master
+    status: maintained
   cras_laser_geometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_joy_tools` to `1.0.1-1`:

- upstream repository: https://github.com/ctu-vras/cras_joy_tools
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/cras_joy_tools.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## cras_joy_tools

```
* Prepared the package for release.
* Make compatible with renamed cras_relative_position_controller
* Noetic compatibility.
* Added stamps
* Added positional joy commander
* Initial commit
* Contributors: Martin Pecka
```
