### PR TITLE
fields2cover: 1.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1383,6 +1383,13 @@ repositories:
       url: https://github.com/eProsima/Fast-DDS.git
       version: 2.11.x
     status: maintained
+  fields2cover:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/Fields2Cover/Fields2Cover-release.git
+      version: 1.2.1-1
+    status: developed
   filters:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fields2cover` to `1.2.1-1`:

- upstream repository: https://github.com/Fields2Cover/fields2cover.git
- release repository: https://github.com/Fields2Cover/Fields2Cover-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
