### PR TITLE
add new packages ffmpeg_image_transport,  ffmpeg_image_transport_msgs

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1743,6 +1743,26 @@ repositories:
       url: https://github.com/eProsima/Fast-DDS.git
       version: 2.6.x
     status: maintained
+  ffmpeg_image_transport:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git
+      version: master
+    status: developed
+  ffmpeg_image_transport_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git
+      version: master
+    status: developed
   filters:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1390,6 +1390,26 @@ repositories:
       url: https://github.com/eProsima/Fast-DDS.git
       version: 2.10.x
     status: maintained
+  ffmpeg_image_transport:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git
+      version: master
+    status: developed
+  ffmpeg_image_transport_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git
+      version: master
+    status: developed
   fields2cover:
     release:
       tags:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1383,6 +1383,26 @@ repositories:
       url: https://github.com/eProsima/Fast-DDS.git
       version: 2.11.x
     status: maintained
+  ffmpeg_image_transport:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git
+      version: master
+    status: developed
+  ffmpeg_image_transport_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git
+      version: master
+    status: developed
   fields2cover:
     release:
       tags:


### PR DESCRIPTION
# Please add ffmpeg_image_transport_msgs and ffmpeg_image_transport to rosdistro
rosdistros: humble, iron, rolling
names:
- ffmpeg_image_transport
- ffmpeg_image_transport_msgs


# The source is here:
- [ffmpeg_image_transport](https://github.com/ros-misc-utilities/ffmpeg_image_transport)
- [ffmpeg_image_transport_msgs](https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs)


# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
