### PR TITLE
ur_description: 2.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7064,7 +7064,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.2.1-1
+      version: 2.2.2-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.2.2-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.1-1`

## ur_description

```
* Default to non_blocking_read=true (#111 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/pull/111>)
* Add license comment to package.xml (#107 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/107>)
* License update for README (#108 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/108>)
* added possibility to change reverse_port, script_sender_port and trajectory_port (#105 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/105>)
* Contributors: Felix Durchdewald, Felix Exner, Rune Søe-Knudsen, dependabot[bot], github-actions[bot]
```
