### PR TITLE
kinematics_interface: 0.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2706,7 +2706,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git
-      version: master
+      version: humble
     release:
       packages:
       - kinematics_interface
@@ -2718,7 +2718,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git
-      version: master
+      version: humble
     status: developed
   kobuki_ros_interfaces:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2714,7 +2714,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
-      version: 0.1.0-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematics_interface` to `0.2.0-1`:

- upstream repository: https://github.com/ros-controls/kinematics_interface.git
- release repository: https://github.com/ros2-gbp/kinematics_interface-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.0-1`

## kinematics_interface

- No changes

## kinematics_interface_kdl

```
* 🤔 Remove compile warnings and unify for-loop syntax. (#15 <https://github.com/ros-controls/kinematics_interface/issues/15>)
* Contributors: Dr. Denis, Bence Magyar, Paul Gesel
```
