### PR TITLE
kinematics_interface: 1.0.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2294,7 +2294,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
-      version: 0.1.0-3
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematics_interface` to `1.0.0-1`:

- upstream repository: https://github.com/ros-controls/kinematics_interface.git
- release repository: https://github.com/ros2-gbp/kinematics_interface-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.0-3`

## kinematics_interface

```
* Use a dynamic library instead of header-only (#21 <https://github.com/ros-controls/kinematics_interface/issues/21>)
* Contributors: Thibault Poignonec
```

## kinematics_interface_kdl

```
* 🤔 Remove compile warnings and unify for-loop syntax. (#15 <https://github.com/ros-controls/kinematics_interface/issues/15>)
* Contributors: Dr. Denis, Bence Magyar, Paul Gesel
```
