### PR TITLE
rcl: 6.0.4-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4409,7 +4409,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 6.0.3-1
+      version: 6.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `6.0.4-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `6.0.3-1`

## rcl

```
* Set disable loan to on by default. (#1117 <https://github.com/ros2/rcl/issues/1117>)
* Contributors: Chris Lalancette
```

## rcl_action

- No changes

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

- No changes
