### PR TITLE
rclcpp: 21.0.4-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4509,7 +4509,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 21.0.3-1
+      version: 21.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `21.0.4-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `21.0.3-1`

## rclcpp

```
* Disable the loaned messages inside the executor. (#2365 <https://github.com/ros2/rclcpp/issues/2365>)
* Add missing 'enable_rosout' comments (#2346 <https://github.com/ros2/rclcpp/issues/2346>)
* Address rate related flaky tests. (#2341 <https://github.com/ros2/rclcpp/issues/2341>)
* Add missing stdexcept include (#2333 <https://github.com/ros2/rclcpp/issues/2333>)
* Update SignalHandler get_global_signal_handler to avoid complex types in static memory (#2322 <https://github.com/ros2/rclcpp/issues/2322>)
* Fix C++20 allocator construct deprecation (#2318 <https://github.com/ros2/rclcpp/issues/2318>)
* Topic correct typeadapter deduction (#2298 <https://github.com/ros2/rclcpp/issues/2298>)
* Contributors: AiVerisimilitude, Chen Lihui, Chris Lalancette, Jiaqi Li, Øystein Sture, Tomoya Fujita, William Woodall
```

## rclcpp_action

- No changes

## rclcpp_components

```
* Add missing header required by the rclcpp::NodeOptions type (#2325 <https://github.com/ros2/rclcpp/issues/2325>)
* Contributors: Ignacio Vizzo
```

## rclcpp_lifecycle

- No changes
