### PR TITLE
rmw_fastrtps: 7.1.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5036,7 +5036,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 7.1.1-2
+      version: 7.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `7.1.2-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `7.1.1-2`

## rmw_fastrtps_cpp

- No changes

## rmw_fastrtps_dynamic_cpp

```
* Account for alignment on is_plain calculations. (#731 <https://github.com/ros2/rmw_fastrtps/issues/731>)
* Contributors: Chris Lalancette
```

## rmw_fastrtps_shared_cpp

```
* Use DataWriter Qos to configure max_blocking_time on rmw_send_response (#708 <https://github.com/ros2/rmw_fastrtps/issues/708>)
* Contributors: Miguel Company
```
