### PR TITLE
rosidl_dynamic_typesupport: 0.0.5-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5707,7 +5707,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_dynamic_typesupport-release.git
-      version: 0.0.4-1
+      version: 0.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_dynamic_typesupport` to `0.0.5-1`:

- upstream repository: https://github.com/ros2/rosidl_dynamic_typesupport.git
- release repository: https://github.com/ros2-gbp/rosidl_dynamic_typesupport-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.4-1`

## rosidl_dynamic_typesupport

```
* uchar: use __has_include(..) on separate line (#9 <https://github.com/ros2/rosidl_dynamic_typesupport/issues/9>)
* Contributors: G.A. vd. Hoorn
```
