### PR TITLE
leo_robot: 1.4.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2513,6 +2513,25 @@ repositories:
       url: https://github.com/LeoRover/leo_desktop-ros2.git
       version: iron
     status: maintained
+  leo_robot:
+    doc:
+      type: git
+      url: https://github.com/LeoRover/leo_robot-ros2.git
+      version: iron
+    release:
+      packages:
+      - leo_bringup
+      - leo_fw
+      - leo_robot
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/leo_robot-release.git
+      version: 1.4.0-1
+    source:
+      type: git
+      url: https://github.com/LeoRover/leo_robot-ros2.git
+      version: iron
+    status: maintained
   lgsvl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_robot` to `1.4.0-1`:

- upstream repository: https://github.com/LeoRover/leo_robot-ros2.git
- release repository: https://github.com/ros2-gbp/leo_robot-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## leo_bringup

```
* Add firmware parameter bridge (#4 <https://github.com/LeoRover/leo_robot-ros2/issues/4>)
* Update mecanum_wheels description
* Use tf_frame_prefix for camera frame
* Add spawn_state_publisher argument
* Sort dependencies in package.xml
* Add mecanum_wheels argument to leo_bringup launch file (#6 <https://github.com/LeoRover/leo_robot-ros2/issues/6>)
* Use ament cmake tests via colcon (#7 <https://github.com/LeoRover/leo_robot-ros2/issues/7>)
* Mecanum Wheel Odometry in firmware_message_converter (#5 <https://github.com/LeoRover/leo_robot-ros2/issues/5>)
* Contributors: Aleksander Szymański, Błażej Sowa
```

## leo_fw

```
* Update firmware binaries
* Move ImuCalibrator node into leo_fw package (#8 <https://github.com/LeoRover/leo_robot-ros2/issues/8>)
* Add firmware parameter bridge (#4 <https://github.com/LeoRover/leo_robot-ros2/issues/4>)
* Sort dependencies in package.xml
* Update copyright notices in source files
* Use ament cmake tests via colcon (#7 <https://github.com/LeoRover/leo_robot-ros2/issues/7>)
* Mecanum Wheel Odometry in firmware_message_converter (#5 <https://github.com/LeoRover/leo_robot-ros2/issues/5>)
* Reformat code
* Remove redundant imports from calibrate_imu script
* Contributors: Aleksander Szymański, Błażej Sowa
```

## leo_robot

- No changes
