### PR TITLE
Set topic_tools branches to distro branches

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8029,7 +8029,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git
-      version: main
+      version: humble
     release:
       packages:
       - topic_tools
@@ -8041,7 +8041,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git
-      version: main
+      version: humble
     status: developed
   tracetools_acceleration:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7028,7 +7028,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git
-      version: main
+      version: iron
     release:
       packages:
       - topic_tools
@@ -7040,7 +7040,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git
-      version: main
+      version: iron
     status: developed
   tracetools_acceleration:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6763,7 +6763,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git
-      version: main
+      version: rolling
     release:
       packages:
       - topic_tools
@@ -6775,7 +6775,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git
-      version: main
+      version: rolling
     status: developed
   tracetools_acceleration:
     doc:


### PR DESCRIPTION
We're switching from using a `main` branch for all distros to using distro-specific branches, like `humble`, `iron`, and `rolling`. See https://github.com/ros-tooling/topic_tools/issues/62. The branches all currently have the same version (and tag) and have not really diverged. New releases will be made soon to make new improvements available.

I've updated the branch names in the release repo: https://github.com/ros2-gbp/topic_tools-release/commit/6ae603ac0b5ecd039e99839aceae646da3ddfa5a