### PR TITLE
septentrio_gnss_driver: 1.3.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6429,7 +6429,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release.git
-      version: 1.3.1-3
+      version: 1.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `septentrio_gnss_driver` to `1.3.2-1`:

- upstream repository: https://github.com/septentrio-gnss/septentrio_gnss_driver
- release repository: https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.1-3`

## septentrio_gnss_driver

```
* Merge pull request #106 <https://github.com/septentrio-gnss/septentrio_gnss_driver/issues/106> from thomasemter/dev/next2
  Fix IMU units
* Fix topics namespace
* Fix units of imu angular rates
* Merge pull request #96 <https://github.com/septentrio-gnss/septentrio_gnss_driver/issues/96> from septentrio-gnss/dev2
  Dev2
* Contributors: Thomas Emter, Tibor Dome, septentrio-users
```
