### PR TITLE
raspimouse_sim: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5117,6 +5117,15 @@ repositories:
       type: git
       url: https://github.com/rt-net/raspimouse_sim.git
       version: humble-devel
+    release:
+      packages:
+      - raspimouse_fake
+      - raspimouse_gazebo
+      - raspimouse_sim
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/raspimouse_sim-release.git
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/rt-net/raspimouse_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspimouse_sim` to `2.0.0-1`:

- upstream repository: https://github.com/rt-net/raspimouse_sim.git
- release repository: https://github.com/ros2-gbp/raspimouse_sim-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## raspimouse_fake

```
* シミュレータ環境に擬似的なラズパイマウスノードを追加 (#69 <https://github.com/rt-net/raspimouse_sim/issues/69>)
  Co-authored-by: Shota Aoki <mailto:s.aoki@rt-net.jp>
* ROS 2 Humble環境のraspimouse_with_emptyworld.launch.pyを実装 (#66 <https://github.com/rt-net/raspimouse_sim/issues/66>)
* Contributors: YusukeKato
```

## raspimouse_gazebo

```
* Gazebo上で画像トピックを配信できるようにbridgeを設定 (#71 <https://github.com/rt-net/raspimouse_sim/issues/71>)
* カメラサンプル用のcolor_objects_worldを作成 (#70 <https://github.com/rt-net/raspimouse_sim/issues/70>)
* シミュレータ環境に擬似的なラズパイマウスノードを追加 (#69 <https://github.com/rt-net/raspimouse_sim/issues/69>)
  Co-authored-by: Shota Aoki <mailto:s.aoki@rt-net.jp>
* controller managerノードにプラグインを追加するように変更 (#68 <https://github.com/rt-net/raspimouse_sim/issues/68>)
* robot_description_lodarを使用するように変更 (#67 <https://github.com/rt-net/raspimouse_sim/issues/67>)
* ROS 2 Humble環境のraspimouse_with_emptyworld.launch.pyを実装 (#66 <https://github.com/rt-net/raspimouse_sim/issues/66>)
* Contributors: YusukeKato
```

## raspimouse_sim

```
* ROS 2 Humble環境のraspimouse_with_emptyworld.launch.pyを実装 (#66 <https://github.com/rt-net/raspimouse_sim/issues/66>)
* Contributors: YusukeKato
```
