### PR TITLE
rplidar_ros: 2.1.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9915,8 +9915,8 @@ repositories:
     release:
       tags:
         release: release/noetic/{package}/{version}
-      url: https://github.com/nobleo/rplidar_ros-release.git
-      version: 2.0.0-1
+      url: https://github.com/Slamtec/rplidar_ros-release.git
+      version: 2.1.5-1
     source:
       type: git
       url: https://github.com/Slamtec/rplidar_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rplidar_ros` to `2.1.5-1`:

- upstream repository: https://github.com/Slamtec/rplidar_ros.git
- release repository: https://github.com/Slamtec/rplidar_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-1`

## rplidar_ros

```
* Update RPLIDAR SDK to 2.1.0
  * Support RPLIDAR C1 (#142 <https://github.com/Slamtec/rplidar_ros/issues/142>)
  * Re-implemented the data retrieving logic based on async fetching and decoding mechanism to improve performance
  * UltraDense protocol support
  * support for stoppping A1 motor
  * bugfix:start/stop_motor(service) cause lidar to stop scanning
* Fix build with C++14 && --march=native
* scan frequency configuration support
* Add launch file for RPLIDAR a2m*,C1
* Install udev rules via debian. (#126 <https://github.com/Slamtec/rplidar_ros/issues/126>)
* Bugfix:create_udev_rules.sh dose not take effect immediately.
* When node starts to reset rplidar, if rplidar info is not obtained within 15 seconds, rplidar reset fails
* Add initial_reset option to reset rplidar on node start
* Compilation optimization
* Contributors: Babak-SSh, Tim Clephas, Tony Baltovski, Ubuntu248, Victor Belov, Wang DeYou, WubinXia, kint, yzx
```
