### PR TITLE
simple_launch: 1.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6275,7 +6275,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/simple_launch-release.git
-      version: 1.7.2-1
+      version: 1.8.0-1
     source:
       type: git
       url: https://github.com/oKermorgant/simple_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_launch` to `1.8.0-1`:

- upstream repository: https://github.com/oKermorgant/simple_launch.git
- release repository: https://github.com/ros2-gbp/simple_launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.7.2-1`

## simple_launch

```
* sync documentation and examples
* when instead of after for events
* scoped events
* add event wrapper
* Contributors: Olivier Kermorgant
```
