### PR TITLE
nao_meshes: 2.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3809,6 +3809,21 @@ repositories:
       url: https://github.com/ros-sports/nao_lola.git
       version: humble
     status: developed
+  nao_meshes:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/nao_meshes2.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros-naoqi/nao_meshes-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/nao_meshes2.git
+      version: main
+    status: maintained
   naoqi_bridge_msgs2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_meshes` to `2.1.0-1`:

- upstream repository: https://github.com/ros-naoqi/nao_meshes2.git
- release repository: https://github.com/ros-naoqi/nao_meshes-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## nao_meshes

```
* Workaround running installer in CI
* Fix build on GitHub Actions
* Add CI
* Interactive agreement by default
  Explicit option in command line to agree to license.
  Improved interaction and messages.
* Update maintainers
* Rename README to README.md
* Fix error in CMakeLists.txt
* Upgrade nao_meshes package for ROS2
* Contributors: Maxime Busy, Victor Paleologue, Victor Paléologue, mbusy
```
