### PR TITLE
ros2_control: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5057,7 +5057,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.21.0-1
+      version: 4.0.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.0.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.21.0-1`

## controller_interface

```
* Pass controller manager update rate on the init of the controller interface  (#1141 <https://github.com/ros-controls/ros2_control/issues/1141>)
* Pass URDF to controllers on init (#1088 <https://github.com/ros-controls/ros2_control/issues/1088>)
* Contributors: Bence Magyar, Sai Kishor Kothakota
```

## controller_manager

```
* Pass controller manager update rate on the init of the controller interface  (#1141 <https://github.com/ros-controls/ros2_control/issues/1141>)
* Fix the controller sorting bug when the interfaces are not configured (fixes #1164 <https://github.com/ros-controls/ros2_control/issues/1164>) (#1165 <https://github.com/ros-controls/ros2_control/issues/1165>)
* Pass URDF to controllers on init (#1088 <https://github.com/ros-controls/ros2_control/issues/1088>)
* Remove deprecation warning (#1101 <https://github.com/ros-controls/ros2_control/issues/1101>)
* Contributors: Bence Magyar, Christoph Fröhlich, Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* [MockHardware] Remove all deprecated options and deprecated plugins from the library. (#1150 <https://github.com/ros-controls/ros2_control/issues/1150>)
* Contributors: Dr. Denis
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
