### PR TITLE
ros2_controllers: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5093,7 +5093,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 3.17.0-1
+      version: 4.0.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `4.0.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.17.0-1`

## ackermann_steering_controller

```
* fix tests for API break of passing controller manager update rate in init method (#854 <https://github.com/ros-controls/ros2_controllers/issues/854>)
* Adjust tests after passing URDF to controllers (#817 <https://github.com/ros-controls/ros2_controllers/issues/817>)
* Contributors: Bence Magyar, Sai Kishor Kothakota
```

## admittance_controller

```
* fix tests for API break of passing controller manager update rate in init method (#854 <https://github.com/ros-controls/ros2_controllers/issues/854>)
* Adjust tests after passing URDF to controllers (#817 <https://github.com/ros-controls/ros2_controllers/issues/817>)
* Contributors: Bence Magyar, Sai Kishor Kothakota
```

## bicycle_steering_controller

```
* fix tests for API break of passing controller manager update rate in init method (#854 <https://github.com/ros-controls/ros2_controllers/issues/854>)
* Adjust tests after passing URDF to controllers (#817 <https://github.com/ros-controls/ros2_controllers/issues/817>)
* Contributors: Bence Magyar, Sai Kishor Kothakota
```

## diff_drive_controller

```
* fix tests for API break of passing controller manager update rate in init method (#854 <https://github.com/ros-controls/ros2_controllers/issues/854>)
* [diff_drive_controller] Fixed typos in diff_drive_controller_parameter.yaml. (#822 <https://github.com/ros-controls/ros2_controllers/issues/822>)
* [diff_drive_controller] Remove non-stamped Twist option (#812 <https://github.com/ros-controls/ros2_controllers/issues/812>)
* Adjust tests after passing URDF to controllers (#817 <https://github.com/ros-controls/ros2_controllers/issues/817>)
* Contributors: Bence Magyar, Sai Kishor Kothakota, Tony Baltovski
```

## effort_controllers

```
* fix tests for API break of passing controller manager update rate in init method (#854 <https://github.com/ros-controls/ros2_controllers/issues/854>)
* Adjust tests after passing URDF to controllers (#817 <https://github.com/ros-controls/ros2_controllers/issues/817>)
* Contributors: Bence Magyar, Sai Kishor Kothakota
```

## force_torque_sensor_broadcaster

```
* fix tests for API break of passing controller manager update rate in init method (#854 <https://github.com/ros-controls/ros2_controllers/issues/854>)
* Adjust tests after passing URDF to controllers (#817 <https://github.com/ros-controls/ros2_controllers/issues/817>)
* Contributors: Bence Magyar, Sai Kishor Kothakota
```

## forward_command_controller

```
* fix tests for API break of passing controller manager update rate in init method (#854 <https://github.com/ros-controls/ros2_controllers/issues/854>)
* Resort overview page (#846 <https://github.com/ros-controls/ros2_controllers/issues/846>)
* Adjust tests after passing URDF to controllers (#817 <https://github.com/ros-controls/ros2_controllers/issues/817>)
* Contributors: Bence Magyar, Christoph Fröhlich, Sai Kishor Kothakota
```

## gripper_controllers

```
* fix tests for API break of passing controller manager update rate in init method (#854 <https://github.com/ros-controls/ros2_controllers/issues/854>)
* Adjust tests after passing URDF to controllers (#817 <https://github.com/ros-controls/ros2_controllers/issues/817>)
* Contributors: Bence Magyar, Sai Kishor Kothakota
```

## imu_sensor_broadcaster

```
* fix tests for API break of passing controller manager update rate in init method (#854 <https://github.com/ros-controls/ros2_controllers/issues/854>)
* Adjust tests after passing URDF to controllers (#817 <https://github.com/ros-controls/ros2_controllers/issues/817>)
* Contributors: Bence Magyar, Sai Kishor Kothakota
```

## joint_state_broadcaster

```
* fix tests for API break of passing controller manager update rate in init method (#854 <https://github.com/ros-controls/ros2_controllers/issues/854>)
* Adjust tests after passing URDF to controllers (#817 <https://github.com/ros-controls/ros2_controllers/issues/817>)
* Contributors: Bence Magyar, Sai Kishor Kothakota
```

## joint_trajectory_controller

```
* fix tests for API break of passing controller manager update rate in init method (#854 <https://github.com/ros-controls/ros2_controllers/issues/854>)
* [JTC] Fix dynamic reconfigure of tolerances (#849 <https://github.com/ros-controls/ros2_controllers/issues/849>)
* [JTC] Remove unused home pose (#845 <https://github.com/ros-controls/ros2_controllers/issues/845>)
* [JTC] Activate update of dynamic parameters (#761 <https://github.com/ros-controls/ros2_controllers/issues/761>)
* [JTC] Fix tests when state offset is used (#797 <https://github.com/ros-controls/ros2_controllers/issues/797>)
* [JTC] Remove deprecation warnings, set allow_nonzero_velocity_at_trajectory_end default false (#834 <https://github.com/ros-controls/ros2_controllers/issues/834>)
* Adjust tests after passing URDF to controllers (#817 <https://github.com/ros-controls/ros2_controllers/issues/817>)
* Contributors: Bence Magyar, Christoph Fröhlich, Sai Kishor Kothakota, Dr Denis
```

## position_controllers

```
* fix tests for API break of passing controller manager update rate in init method (#854 <https://github.com/ros-controls/ros2_controllers/issues/854>)
* Adjust tests after passing URDF to controllers (#817 <https://github.com/ros-controls/ros2_controllers/issues/817>)
* Contributors: Bence Magyar, Sai Kishor Kothakota
```

## range_sensor_broadcaster

```
* fix tests for API break of passing controller manager update rate in init method (#854 <https://github.com/ros-controls/ros2_controllers/issues/854>)
* Adjust tests after passing URDF to controllers (#817 <https://github.com/ros-controls/ros2_controllers/issues/817>)
* Contributors: Bence Magyar, Sai Kishor Kothakota
```

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* fix tests for API break of passing controller manager update rate in init method (#854 <https://github.com/ros-controls/ros2_controllers/issues/854>)
* Adjust tests after passing URDF to controllers (#817 <https://github.com/ros-controls/ros2_controllers/issues/817>)
* Contributors: Bence Magyar, Sai Kishor Kothakota
```

## tricycle_controller

```
* fix tests for API break of passing controller manager update rate in init method (#854 <https://github.com/ros-controls/ros2_controllers/issues/854>)
* Adjust tests after passing URDF to controllers (#817 <https://github.com/ros-controls/ros2_controllers/issues/817>)
* Contributors: Bence Magyar, Sai Kishor Kothakota
```

## tricycle_steering_controller

```
* fix tests for API break of passing controller manager update rate in init method (#854 <https://github.com/ros-controls/ros2_controllers/issues/854>)
* Adjust tests after passing URDF to controllers (#817 <https://github.com/ros-controls/ros2_controllers/issues/817>)
* Contributors: Bence Magyar, Sai Kishor Kothakota
```

## velocity_controllers

```
* fix tests for API break of passing controller manager update rate in init method (#854 <https://github.com/ros-controls/ros2_controllers/issues/854>)
* Adjust tests after passing URDF to controllers (#817 <https://github.com/ros-controls/ros2_controllers/issues/817>)
* Contributors: Bence Magyar, Sai Kishor Kothakota
```
