### PR TITLE
[rosdep] Add python3-adafruit-circuitpython-lsm9ds0-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4758,6 +4758,16 @@ python3-adafruit-circuitpython-bno08x-pip:
   ubuntu:
     pip:
       packages: [adafruit-circuitpython-bno08x]
+python3-adafruit-circuitpython-lsm9ds0-pip:
+  debian:
+    pip:
+      packages: [adafruit-circuitpython-lsm9ds0]
+  fedora:
+    pip:
+      packages: [adafruit-circuitpython-lsm9ds0]
+  ubuntu:
+    pip:
+      packages: [adafruit-circuitpython-lsm9ds0]
 python3-adafruit-circuitpython-mcp230xx-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`adafruit-circuitpython-lsm9ds0`

## Package Upstream Source:

https://pypi.org/project/adafruit-circuitpython-lsm9ds0

## Purpose of using this:

Allows to use the Python interface for the Adafruit LSM9DS0 module.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- pip:
  - https://pypi.org/project/adafruit-circuitpython-lsm9ds0
- Debian: https://packages.debian.org/
  - Use `pip` package linked above. Not available in the Debian repositories
- Ubuntu: https://packages.ubuntu.com/
  - Use `pip` package linked above. Not available in the Ubuntu repositories
- Fedora: https://packages.fedoraproject.org/
  - NOT AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - NOT AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - NOT AVAILABLE
- macOS: https://formulae.brew.sh/
  - NOT AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - NOT AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - NOT AVAILABLE
- openSUSE: https://software.opensuse.org/package/
  - NOT AVAILABLE
- rhel: https://rhel.pkgs.org/
  - NOT AVAILABLE

