### PR TITLE
sick_safevisionary_base: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6276,6 +6276,21 @@ repositories:
       url: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
       version: ros2
     status: maintained
+  sick_safevisionary_base:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/sick_safevisionary_base.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/sick_safevisionary_base-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_safevisionary_base.git
+      version: main
+    status: developed
   simple_actions:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safevisionary_base` to `1.0.1-1`:

- upstream repository: https://github.com/SICKAG/sick_safevisionary_base.git
- release repository: https://github.com/ros2-gbp/sick_safevisionary_base-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## sick_safevisionary_base

```
* Update top-level readme with build instructions (#2 <https://github.com/SICKAG/sick_safevisionary_base/issues/2>)
  * Update top-level readme with build instructions
  * Mention the *send when* option in the safety designer
  * Extended tutorial on initial safety designer setup
  * Fix duplicate .png extension
  * Added structure and fixed minor errors
  ---------
  Co-authored-by: Marvin Große Besselmann <mailto:grosse@fzi.de>
* Deactivate the CI pipelines for testing
* Add CI pipelines for ROS2 Iron and Rolling
* Add build and license badges to top-level readme
* Add CI pipeline for Noetic and Humble
* Fixed License file and added maintainer in package xml
* Updated license
* Changed ci to master branch
* Added ci script
* clang formate/tidy
* Adjusted CMakeList file to support client library function
* Moved header into seperate include folder
* fixed package name
* Removed old copied files
* Initial commit
* Contributors: Jochen Lienhart, Marvin Große Besselmann, Stefan Scherzinger
```
