### PR TITLE
Update distribution.yaml with multidim_rrt_planner

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3201,6 +3201,16 @@ repositories:
       url: https://github.com/KIT-MRT/mrt_cmake_modules.git
       version: master
     status: maintained
+  multidim_rrt_planner:
+    doc:
+      type: git
+      url: https://github.com/daviddorf2023/multidim_rrt_planner/tree/iron
+      version: iron
+    source:
+      type: git
+      url: https://github.com/daviddorf2023/multidim_rrt_planner/tree/iron
+      version: iron
+    status: maintained
   mvsim:
     doc:
       type: git
@@ -6329,7 +6339,7 @@ repositories:
       type: git
       url: https://github.com/ros-visualization/rqt_topic.git
       version: iron
-    status: maintained
+    status: maintained  
   rsl:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6339,7 +6339,7 @@ repositories:
       type: git
       url: https://github.com/ros-visualization/rqt_topic.git
       version: iron
-    status: maintained  
+    status: maintained
   rsl:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3204,11 +3204,11 @@ repositories:
   multidim_rrt_planner:
     doc:
       type: git
-      url: https://github.com/daviddorf2023/multidim_rrt_planner/tree/iron
+      url: https://github.com/daviddorf2023/multidim_rrt_planner.git
       version: iron
     source:
       type: git
-      url: https://github.com/daviddorf2023/multidim_rrt_planner/tree/iron
+      url: https://github.com/daviddorf2023/multidim_rrt_planner.git
       version: iron
     status: maintained
   mvsim:


### PR DESCRIPTION
## Package name:

multidim_rrt_planner

## Package Upstream Source:

https://github.com/daviddorf2023/multidim_rrt_planner/tree/iron

## Purpose of using this:

There is no replacement for the RRT planner from ROS 1 (rrt_exploration). This package has both 2D and 3D RRT path and live node publishing in RViz that can go around markers within the confines of an occupancy grid.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://github.com/daviddorf2023/multidim_rrt_planner/tree/iron
- Ubuntu: https://packages.ubuntu.com/
  - https://github.com/daviddorf2023/multidim_rrt_planner/tree/iron
- Fedora: https://packages.fedoraproject.org/
  - not available
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available
- openSUSE: https://software.opensuse.org/package/
  - not available
- rhel: https://rhel.pkgs.org/
  - not available

# Please Add This Package to be indexed in the rosdistro.

Iron

# The source is here:

https://github.com/daviddorf2023/multidim_rrt_planner/tree/iron

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
