### PR TITLE
pepper_meshes: 3.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4438,6 +4438,21 @@ repositories:
       url: https://github.com/ros-perception/pcl_msgs.git
       version: ros2
     status: maintained
+  pepper_meshes:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/pepper_meshes2.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros-naoqi/pepper_meshes2-release.git
+      version: 3.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/pepper_meshes2.git
+      version: main
+    status: maintained
   perception_open3d:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_meshes` to `3.0.0-1`:

- upstream repository: https://github.com/ros-naoqi/pepper_meshes2.git
- release repository: https://github.com/ros-naoqi/pepper_meshes2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## pepper_meshes

```
* Update status badges
* Add CI
* Interactive agreement by default
  Explicit option in command line to agree to license.
  Improved interaction and messages.
* Improved detection of the platform
* Update maintainers
* Contributors: Victor Paléologue
```
