### PR TITLE
pepper_meshes: 3.0.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3834,7 +3834,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros-naoqi/pepper_meshes2-release.git
-      version: 2.0.1-1
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/ros-naoqi/pepper_meshes2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_meshes` to `3.0.0-1`:

- upstream repository: https://github.com/ros-naoqi/pepper_meshes2.git
- release repository: https://github.com/ros-naoqi/pepper_meshes2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.1-1`

## pepper_meshes

```
* Update status badges
* Add CI
* Interactive agreement by default
  Explicit option in command line to agree to license.
  Improved interaction and messages.
* Improved detection of the platform
* Update maintainers
* Contributors: Victor Paléologue
```
