### PR TITLE
nao_meshes: 2.1.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3264,6 +3264,21 @@ repositories:
       url: https://github.com/ros-sports/nao_lola.git
       version: iron
     status: developed
+  nao_meshes:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/nao_meshes2.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros-naoqi/nao_meshes-release.git
+      version: 2.1.1-1
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/nao_meshes2.git
+      version: main
+    status: maintained
   naoqi_bridge_msgs2:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_meshes` to `2.1.1-1`:

- upstream repository: https://github.com/ros-naoqi/nao_meshes2.git
- release repository: https://github.com/ros-naoqi/nao_meshes-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## nao_meshes

```
* Download and install directly in bin dir
* Update status badges
* Contributors: Victor Paléologue
```
