### PR TITLE
plotjuggler: 3.8.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3996,7 +3996,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.7.1-2
+      version: 3.8.0-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.8.0-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/ros2-gbp/plotjuggler-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.7.1-2`

## plotjuggler

```
* data_tamer updated
  This reverts commit 4ba24c591a9a84fbfb6c0329b787d73f98a2b23b.
* CI updated
* qwt updated
* Merge pull request #869 <https://github.com/facontidavide/PlotJuggler/issues/869> from zdavkeos/step_interpolation
  Add "Steps" when drawing curves
* Merge pull request #870 <https://github.com/facontidavide/PlotJuggler/issues/870> from MirkoFerrati/patch-3
  Fix missing '22' in the new snap core22 workflow
* Fix missing '22' in the new snap core22 workflow
* Merge pull request #849 <https://github.com/facontidavide/PlotJuggler/issues/849> from MirkoFerrati/mirko/core22_snap
  update to core22, remove ros1, enable humble instead of foxy
* Add "Steps" when drawing curves
* Remove deprecated messages from foxy
* Skip git security check for git owner inside the snap container
* Adapt to new snapcraft syntax for core22, sort stage-packages
* swap default snap with core22 snap for ros humble
* duplicate the snap github action to publish new humble track
* add snap for core22, remove ros1, enable humble
* Merge pull request #853 <https://github.com/facontidavide/PlotJuggler/issues/853> from MirkoFerrati/mirko/fix_snap
  remove deprecated msg from snapcraft
* Merge pull request #846 <https://github.com/facontidavide/PlotJuggler/issues/846> from locusrobotics/fix-catkin-build
  Use a more reliable method to select buildtool
* fix
* MCAP loader is not faster for large files
* fix parsers names
* extend the Toolbox plugin interface
* mcap updated
* remove deprecated msg from snapcraft
* Use a more reliable method to select buildtool
* Merge pull request #843 <https://github.com/facontidavide/PlotJuggler/issues/843> from faisal-shah/date-time-format-urls
  Add link to QDate format string
* Add 'tab' as a separator in the CSV loader
* Add link to QDate format string
  A link to QTime format string was there, but not QDate
* Merge pull request #840 <https://github.com/facontidavide/PlotJuggler/issues/840> from jbendes/zcm-improvements
  Zcm improvements
* Moved away from std function for speed
* Fixed loading of selected channels from layout
* Merge pull request #827 <https://github.com/facontidavide/PlotJuggler/issues/827> from jbendes/zcm
  Added zcm streaming support
* Merge pull request #834 <https://github.com/facontidavide/PlotJuggler/issues/834> from rinnaz/fix-protobuf-parser-leak
  Fix memory leak in protobuf parser
* Made transport text box wider
* Looking for zcm in alternate directory first
* A bit more stable
* Serializing and deserializing dataloader for zcm in layout
* fix: memory leak in protobuf parser
* Reverted change
* Changed to ZCM_DEFAULT_URL
* ZCM refactored
* ZCM works, with single type file
* Cleaner loading dialogs
* Added progress dialog
* Added channel selection
* Added data loading from files
* A bit of simplification and bug fix
* Added zcm streaming support
* Add missing cstdint include
* Contributors: Davide Faconti, Faisal Shah, Jonathan Bendes, Mirko Ferrati, Paul Bovbel, Rinat Nazarov, Zach Davis, joajfreitas
```
