### PR TITLE
prbt_grippers: EOL in 'noetic/distribution.yaml'

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8025,7 +8025,7 @@ repositories:
       type: git
       url: https://github.com/PilzDE/prbt_grippers.git
       version: kinetic-devel
-    status: maintained
+    status: end-of-life
   prosilica_driver:
     doc:
       type: git


### PR DESCRIPTION
Change status to end-of-life.