### PR TITLE
mobile_catkin_modules_build_development_tools: 0.4.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5720,6 +5720,21 @@ repositories:
       url: https://github.com/vakshit/mlx90640_thermal_camera.git
       version: master
     status: maintained
+  mobile_catkin_modules_build_development_tools:
+    doc:
+      type: git
+      url: https://github.com/Application-UI-UX/mobile_catkin_modules_build_development_tools.git
+      version: main
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: git@github.com:Application-UI-UX/mobile_catkin_modules_build_development_tools-release.git
+      version: 0.4.4-1
+    source:
+      type: git
+      url: https://github.com/Application-UI-UX/mobile_catkin_modules_build_development_tools.git
+      version: main
+    status: developed
   mobile_robot_simulator:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5728,7 +5728,7 @@ repositories:
     release:
       tags:
         release: release/noetic/{package}/{version}
-      url: git@github.com:Application-UI-UX/mobile_catkin_modules_build_development_tools-release.git
+      url: https://github.com/Application-UI-UX/mobile_catkin_modules_build_development_tools-release.git
       version: 0.4.4-1
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mobile_catkin_modules_build_development_tools` to `0.4.4-1`:

- upstream repository: https://github.com/Application-UI-UX/mobile_catkin_modules_build_development_tools.git
- release repository: https://github.com/Application-UI-UX/mobile_catkin_modules_build_development_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## mobile_catkin_modules_build_development_tools

```
* Fix countless bugs in the repository
* Rerelease dedicated code for maven, ros, and python
* Change name for more discriptions a take down old publish namees
* Make repository compatible with ROS2 and will now be compatible for ROS1 and ROS2
* Upgrade version of all builds and make it more compatible
* Maintainer & Contributors & Aurthor: Ronaldson Bellande
```
