### PR TITLE
sick_safevisionary_ros2: 1.0.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6601,6 +6601,25 @@ repositories:
       url: https://github.com/SICKAG/sick_safevisionary_base.git
       version: main
     status: developed
+  sick_safevisionary_ros2:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/sick_safevisionary_ros2.git
+      version: main
+    release:
+      packages:
+      - sick_safevisionary_driver
+      - sick_safevisionary_interfaces
+      - sick_safevisionary_tests
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/sick_safevisionary_ros2-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_safevisionary_ros2.git
+      version: main
+    status: developed
   simple_actions:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safevisionary_ros2` to `1.0.1-1`:

- upstream repository: https://github.com/SICKAG/sick_safevisionary_ros2.git
- release repository: https://github.com/ros2-gbp/sick_safevisionary_ros2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## sick_safevisionary_driver

```
* Update maintainer tags
* Transition from configuring to active by itself once on launch (#2 <https://github.com/SICKAG/sick_safevisionary_ros2/issues/2>)
  * Transition from configuring to active by itself once on launch
  * Initially deactivate and cleanup node during integration test
  * Added additional comments to clarify launch file
  Co-authored-by: Stefan Scherzinger <mailto:scherzin@fzi.de>
  * Updated ReadMe for auto lifecycle configuration
  * Updated driver ReadMe for auto lifecycle configuration
  Co-authored-by: Stefan Scherzinger <mailto:scherzin@fzi.de>
* Add a readme for the driver package
  Also rename the sensor in the tests package for consistency.
* Add a launch file parameter for CI testing
  We now use a launch file parameter to specify if we are running as part
  of a CI pipeline and don't check the UDP connection if that's the case.
  Also provide the port and frame_id as launch file parameters.
* Add configure check for the UDP connection
  The configure lifecycle transition now fails if there's no incoming
  sensor data, i.e. if something's wrong with the connection.
* Changed doxygen indentation
* Added doxygen comments
* Initialize shared pointer correctly
* Added license and maintainer infos
* Message variable cleanup
* added header to custom msgs
* Put pointcloud publisher to the end since its non const
* Check if intensity and points vector match
* Publish topics in node namespace
* Fixed dependency issues
* Publish depth,intensity and state map
* Publish field information
* Publish region of interest
* Publish ios
* Publish device status
* Naming consistency
* Publish Pointcloud
* Publish IMU data
* Only publish with a non-zero subscription count
  This keeps the driver's computations lean if nobody is listening.
* Make frame_id a parameter
  This allows users to set the frame_id of the published messages at
  runtime via the node's parameter interfaces.
* Use a unique pointer for the compound publisher
  That's cleaner and makes sure that the compound publisher is valid after construction.
* Add a publisher for camera info
  We use a separate class to encapsulate the different publishers so that
  the lifecycle part stays nice and clean.
* Format launch file with black
* Add an integration test for repetitive driver resets
* Add boilerplate code for integration tests
* Adjust includes from previous move
* Move relevant files into a subfolder
* Contributors: Marvin Große Besselmann, Stefan Scherzinger
```

## sick_safevisionary_interfaces

```
* Update maintainer tags
* Add a minimal readme for the interfaces package
* Added license and maintainer infos
* added header to custom msgs
* Added interfaces for internal sensor data
* Contributors: Marvin Große Besselmann, Stefan Scherzinger
```

## sick_safevisionary_tests

```
* Update maintainer tags
* Transition from configuring to active by itself once on launch (#2 <https://github.com/SICKAG/sick_safevisionary_ros2/issues/2>)
  * Transition from configuring to active by itself once on launch
  * Initially deactivate and cleanup node during integration test
  * Added additional comments to clarify launch file
  Co-authored-by: Stefan Scherzinger <mailto:scherzin@fzi.de>
  * Updated ReadMe for auto lifecycle configuration
  * Updated driver ReadMe for auto lifecycle configuration
  Co-authored-by: Stefan Scherzinger <mailto:scherzin@fzi.de>
* Use rclpy node features to list topics
* Add a readme for the driver package
  Also rename the sensor in the tests package for consistency.
* Add a launch file parameter for CI testing
  We now use a launch file parameter to specify if we are running as part
  of a CI pipeline and don't check the UDP connection if that's the case.
  Also provide the port and frame_id as launch file parameters.
* Added license and maintainer infos
* Fixed topic names in integration test
* Publish topics in node namespace
* Fixed error in unit test
* Add integration test for the publishers
* Add an integration test for repetitive driver resets
* Implement an integration test for lifecycle behavior
* Add readme on launching tests locally
* Add boilerplate code for integration tests
* Contributors: Marvin Große Besselmann, Stefan Scherzinger
```
