### PR TITLE
Add rosdep key for python3-flask-restful

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6001,6 +6001,8 @@ python3-flask:
   nixos: [python3Packages.flask]
   rhel: [python3-flask]
   ubuntu: [python3-flask]
+python3-flask-restful:
+  ubuntu: [python3-flask-restful]
 python3-flask-bcrypt:
   debian: [python3-flask-bcrypt]
   nixos: [python3Packages.flask-bcrypt]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6003,7 +6003,6 @@ python3-flask:
   ubuntu: [python3-flask]
 python3-flask-restful:
   debian: [python3-flask-restful]
-  fedora: [python3-flask-restful]
   ubuntu: [python3-flask-restful]
 python3-flask-bcrypt:
   debian: [python3-flask-bcrypt]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6003,6 +6003,7 @@ python3-flask:
   ubuntu: [python3-flask]
 python3-flask-restful:
   debian: [python3-flask-restful]
+  fedora: [python3-flask-restful]
   ubuntu: [python3-flask-restful]
 python3-flask-bcrypt:
   debian: [python3-flask-bcrypt]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6002,6 +6002,7 @@ python3-flask:
   rhel: [python3-flask]
   ubuntu: [python3-flask]
 python3-flask-restful:
+  debian: [python3-flask-restful]
   ubuntu: [python3-flask-restful]
 python3-flask-bcrypt:
   debian: [python3-flask-bcrypt]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:
python3-flask-restful

## Package Upstream Source:
https://packages.ubuntu.com/jammy/python3-flask-restful

## Purpose of using this:
Flask-RESTful is an extension for Flask that adds support for quickly building REST APIs.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.ubuntu.com/jammy/python3-flask-restful
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.debian.org/bookworm/python3-flask-restful
- Fedora: https://packages.fedoraproject.org/
  - not available
- Arch: https://www.archlinux.org/packages/
  -  not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available'
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available'
- openSUSE: https://software.opensuse.org/package/
  - not available'
- rhel: https://rhel.pkgs.org/
  - not available'
