### PR TITLE
naoqi_driver: 2.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3862,7 +3862,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_driver2-release.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_driver2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_driver` to `2.1.0-1`:

- upstream repository: https://github.com/ros-naoqi/naoqi_driver2.git
- release repository: https://github.com/ros-naoqi/naoqi_driver2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-1`

## naoqi_driver

```
* New "Listen" action
* Remove usages of BOOST_FOREACH
* New qi_listen_url option and update README
* Track ros2 branch of nao_meshes
* Get odom at the same time as joint states
* No need to register the driver as a NAOqi service
* Simplify starting and stopping the node
  An extra thread is not required anymore to run the ROS loop.
* Safer unsubscription from ALMemory
* Switch to NAOqi 2 subscribers for touch events
* Fix build warnings
  * libqi-related warningsUse .value() when getting a Qi service
  
    * Fix lack of return value in camera.cpp
    * Fix deprecated include to image_transport.h
    * Remove unused mentions to behavior trees
  
* Better error messages
  * Transform computation
* Experimental running the driver and for dev
  Adapted from https://github.com/sea-bass/turtlebot3_behavior_demos
* Support NAOqi 2.8 (NAO v6)
  * Repair audio
* Support for humble & iron
  * RViz files converted to RViz2 ones
  * Update use of placeholders
  * Update robot description code
  * Remove mentions to catkin
* Update README:
  * New details about building meshes
  * How to build from source now
* Remove dependence to orocos-kdl
* Contributors: Maxime Busy, Victor Paleologue, Victor Paléologue
```
