### PR TITLE
pal_urdf_utils: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4458,6 +4458,21 @@ repositories:
       url: https://github.com/pal-robotics/pal_statistics.git
       version: humble-devel
     status: maintained
+  pal_urdf_utils:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pal_urdf_utils.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/pal_urdf_utils-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pal_urdf_utils.git
+      version: humble-devel
+    status: developed
   pcl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_urdf_utils` to `2.0.0-1`:

- upstream repository: https://github.com/pal-robotics/pal_urdf_utils.git
- release repository: https://github.com/pal-gbp/pal_urdf_utils-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## pal_urdf_utils

```
* Merge branch 'port-to-ros2' into 'humble-devel'
  Port package.xml and CMakeLists.txt
  See merge request robots/pal_urdf_utils!2
* Change branch name in contributing
* add contributing.md
* Add licence
* Update extensions of files to .urdf.xacro
* Remove ament python dependency
* Port package.xml and CMakeLists.txt
* Contributors: David ter Kuile, davidterkuile
```
