### PR TITLE
simple_launch: 1.9.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6660,7 +6660,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/simple_launch-release.git
-      version: 1.7.2-1
+      version: 1.9.0-1
     source:
       type: git
       url: https://github.com/oKermorgant/simple_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_launch` to `1.9.0-1`:

- upstream repository: https://github.com/oKermorgant/simple_launch.git
- release repository: https://github.com/ros2-gbp/simple_launch-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.7.2-1`

## simple_launch

```
* update documentation
* warnings/errors on misuse of GazeboBridge
* move example executable to share directory
* dict cannot be updated with | in Foxy, fallback to dict.update
* absolute container name when loading in existing container
* py_eval can now handle conditions
* Contributors: Olivier Kermorgant
```
