### PR TITLE
data_tamer: 0.6.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1233,6 +1233,24 @@ repositories:
       url: https://github.com/eclipse-cyclonedds/cyclonedds.git
       version: releases/0.10.x
     status: maintained
+  data_tamer:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/data_tamer.git
+      version: main
+    release:
+      packages:
+      - data_tamer
+      - data_tamer_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/facontidavide/data_tamer-release.git
+      version: 0.6.1-1
+    source:
+      type: git
+      url: https://github.com/facontidavide/data_tamer.git
+      version: main
+    status: developed
   dataspeed_can:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `data_tamer` to `0.6.1-1`:

- upstream repository: https://github.com/facontidavide/data_tamer.git
- release repository: https://github.com/facontidavide/data_tamer-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
