### PR TITLE
ur_robot_driver: 2.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7161,7 +7161,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.4.1-1
+      version: 2.4.2-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.4.2-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.4.1-1`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* Update read_state_from_hardware
* Renamed normalize_joint_error to joints_angle_wraparound
* Remove noisy controller log message
* Contributors: Felix Exner, Robert Wilbrandt
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* moveit_servo package executable name has changed (#854 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/854>)
* Contributors: Felix Durchdewald
```

## ur_robot_driver

```
* [README] Move installation instructions to subpage (#870 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/870>)
* Add backward_ros to driver (#872 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/872>)
* Simplify tests (#849 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/849>)
* Port configuration  (#835 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/835>)
  Added possibility to change the reverse_port, script_sender_port and trajectory_port
* [README] Update link to MoveIt! documentation
* Do not start urscipt_interface when using mock hardware
* Contributors: Felix Durchdewald, Felix Exner, RobertWilbrandt
```
