### PR TITLE
paho-mqtt-cpp: 1.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7189,11 +7189,15 @@ repositories:
       version: master
     status: maintained
   paho-mqtt-cpp:
+    doc:
+      type: git
+      url: https://github.com/eclipse/paho.mqtt.cpp.git
+      version: master
     release:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/nobleo/paho.mqtt.cpp-release.git
-      version: 1.2.0-4
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/eclipse/paho.mqtt.cpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `paho-mqtt-cpp` to `1.3.1-1`:

- upstream repository: https://github.com/eclipse/paho.mqtt.cpp.git
- release repository: https://github.com/nobleo/paho.mqtt.cpp-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.0-4`
