### PR TITLE
add flir_camera_driver repo to iron

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1453,6 +1453,16 @@ repositories:
       url: https://github.com/flexbe/flexbe_behavior_engine.git
       version: iron
     status: developed
+  flir_camera_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/flir_camera_driver.git
+      version: humble-devel
+    source:
+      type: git
+      url: https://github.com/ros-drivers/flir_camera_driver.git
+      version: humble-devel
+    status: maintained
   fluent_rviz:
     doc:
       type: git


### PR DESCRIPTION
# Please add flir_camera_driver to be indexed in Iron
ROSDISTRO NAME: Iron
Note: already exists in Humble under same name
# The source is here:
https://github.com/ros-drivers/flir_camera_driver.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
