### PR TITLE
robot_calibration: 0.8.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5993,7 +5993,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/robot_calibration-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       type: git
       url: https://github.com/mikeferguson/robot_calibration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_calibration` to `0.8.1-1`:

- upstream repository: https://github.com/mikeferguson/robot_calibration.git
- release repository: https://github.com/ros2-gbp/robot_calibration-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.8.0-1`

## robot_calibration

```
* update to tinyxml2 (#159 <https://github.com/mikeferguson/robot_calibration/issues/159>)
  * proper depends, rather than hijacking urdfdom
  * less control over formatting, had to update tests
* fix checkerboard parameter name (#154 <https://github.com/mikeferguson/robot_calibration/issues/154>)
  recently fixed this parameter to actually work, but the
  name is still different from ROS1.
* implement chain3d_to_camera2d error block (#153 <https://github.com/mikeferguson/robot_calibration/issues/153>)
  Second part of #41 <https://github.com/mikeferguson/robot_calibration/issues/41>, adds error block to use data from #152 <https://github.com/mikeferguson/robot_calibration/issues/152>
* Add finder for 2d checkerboard (#152 <https://github.com/mikeferguson/robot_calibration/issues/152>)
  This is the first step towards completing #41 <https://github.com/mikeferguson/robot_calibration/issues/41>
  * Refactors checkerboard finder to be templated on data type.
  * Uses template specialization to make 2d and 3d variants.
  * Updates test to load both variants.
* properly namespace parameters (#151 <https://github.com/mikeferguson/robot_calibration/issues/151>)
  These issues were apparently an oversight during the ROS2 port.
* better messages for error_block errors (#150 <https://github.com/mikeferguson/robot_calibration/issues/150>)
* add warning if checkerboard is symmetric (#147 <https://github.com/mikeferguson/robot_calibration/issues/147>)
* fixes for base_calibration based on testing (#138 <https://github.com/mikeferguson/robot_calibration/issues/138>)
* Contributors: Michael Ferguson
```

## robot_calibration_msgs

- No changes
