### PR TITLE
[base.yaml] add protobuf-compiler-grpc

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7178,6 +7178,11 @@ protobuf:
     bionic: [libprotobuf10]
     focal: [libprotobuf17]
     jammy: [libprotobuf23]
+protobuf-compiler-grpc:
+  debian: [protobuf-compiler-grpc]
+  fedora: [grpc-plugins]
+  rhel: [grpc-plugins]
+  ubuntu: [protobuf-compiler-grpc]
 protobuf-dev:
   arch: [protobuf]
   debian: [libprotobuf-dev, protobuf-compiler, libprotoc-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7181,7 +7181,9 @@ protobuf:
 protobuf-compiler-grpc:
   debian: [protobuf-compiler-grpc]
   fedora: [grpc-plugins]
-  rhel: [grpc-plugins]
+  rhel:
+    '8': null
+    '9': [grpc-plugins]
   ubuntu: [protobuf-compiler-grpc]
 protobuf-dev:
   arch: [protobuf]


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

- protobuf-compiler-grpc

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/stable/protobuf-compiler-grpc
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/focal/libs/protobuf-compiler-grpc
  - https://packages.ubuntu.com/jammy/libs/protobuf-compiler-grpc
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/grpc/grpc-plugins/
- rhel: https://rhel.pkgs.org/
  - https://rhel.pkgs.org/8/synergy-x86_64/grpc-plugins-1.17.1-3.el8.x86_64.rpm.html
  - https://rhel.pkgs.org/9/epel-x86_64/grpc-plugins-1.46.7-10.el9.x86_64.rpm.html