### PR TITLE
Add myactuator_rmd to ROS 2 Humble index

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3771,6 +3771,16 @@ repositories:
       url: https://github.com/MRPT/mvsim.git
       version: develop
     status: developed
+  myactuator_rmd:
+    doc:
+      type: git
+      url: https://github.com/2b-t/myactuator_rmd.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/2b-t/myactuator_rmd.git
+      version: main
+    status: developed
   nao_button_sim:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble

# The source is here:

https://github.com/2b-t/myactuator_rmd

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
