### PR TITLE
register sick_visionary_ros node

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11064,6 +11064,21 @@ repositories:
       url: https://github.com/uos/sick_tim.git
       version: noetic
     status: developed
+  sick_visionary_ros:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/sick_visionary_ros.git
+      version: main
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/SICKAG/sick_visionary_ros-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_visionary_ros.git
+      version: main
+    status: developed
   simple_grasping:
     doc:
       type: git


### PR DESCRIPTION

Please add the following dependency to the rosdep database.

## Package name:

sick_visionary_ros

## Package Upstream Source:

https://github.com/SICKAG/sick_visionary_ros.git

## release is done via bloom but this merge request created manually

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
