### PR TITLE
behaviortree_cpp_v4: 4.4.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -560,7 +560,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.4.1-1
+      version: 4.4.2-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp_v4` to `4.4.2-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.4.1-1`

## behaviortree_cpp

```
* fix issue #702 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/702> : output ports require {}
* Merge pull request #691 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/691> from galou/small_refactor_and_doc
  Small code refactor, log- and doc changes
* Merge pull request #701 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/701> from tony-p/fix/file-loggers-protected
  fix: ensure public get config overload is used
* ci: use pixi github action
* fix: ensure public get config overload is used
* Small code refactor, log- and doc changes
* Contributors: Davide Faconti, Gaël Écorchard, Tony Paulussen
```
