### PR TITLE
topic_tools: 1.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8189,7 +8189,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/topic_tools-release.git
-      version: 1.0.0-2
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_tools` to `1.1.1-1`:

- upstream repository: https://github.com/ros-tooling/topic_tools.git
- release repository: https://github.com/ros2-gbp/topic_tools-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-2`

## topic_tools

```
* Apply race condition fix to mux (#78 <https://github.com/ros-tooling/topic_tools/issues/78>) (#79 <https://github.com/ros-tooling/topic_tools/issues/79>)
* Fix windows warnings (backport #71 <https://github.com/ros-tooling/topic_tools/issues/71>) (#73 <https://github.com/ros-tooling/topic_tools/issues/73>)
* Make compatible with windows (#68 <https://github.com/ros-tooling/topic_tools/issues/68>) (#70 <https://github.com/ros-tooling/topic_tools/issues/70>)
* Unit tests for all nodes (#61 <https://github.com/ros-tooling/topic_tools/issues/61>)
* Contributors: andrewbest-tri, anrp-tri, Emerson Knapp, Martin Llofriu
```

## topic_tools_interfaces

- No changes
