### PR TITLE
topic_tools: 1.2.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7190,7 +7190,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/topic_tools-release.git
-      version: 1.0.0-3
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_tools` to `1.2.0-1`:

- upstream repository: https://github.com/ros-tooling/topic_tools.git
- release repository: https://github.com/ros2-gbp/topic_tools-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-3`

## topic_tools

```
* Apply race condition fix to mux (#78 <https://github.com/ros-tooling/topic_tools/issues/78>) (#88 <https://github.com/ros-tooling/topic_tools/issues/88>)
* Fix windows warnings (#71 <https://github.com/ros-tooling/topic_tools/issues/71>) (#74 <https://github.com/ros-tooling/topic_tools/issues/74>)
* Make compatible with windows (#68 <https://github.com/ros-tooling/topic_tools/issues/68>) (#69 <https://github.com/ros-tooling/topic_tools/issues/69>)
* Unit tests for all nodes (#61 <https://github.com/ros-tooling/topic_tools/issues/61>)
* Contributors: andrewbest-tri, anrp-tri, Emerson Knapp, Martin Llofriu
```

## topic_tools_interfaces

- No changes
