### PR TITLE
topic_tools: 1.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6831,7 +6831,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/topic_tools-release.git
-      version: 1.0.0-2
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_tools` to `1.3.0-1`:

- upstream repository: https://github.com/ros-tooling/topic_tools.git
- release repository: https://github.com/ros2-gbp/topic_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-2`

## topic_tools

```
* Apply race condition fix to mux (#78 <https://github.com/ros-tooling/topic_tools/issues/78>)
* Fix windows warnings (#71 <https://github.com/ros-tooling/topic_tools/issues/71>)
* Make compatible with windows (#68 <https://github.com/ros-tooling/topic_tools/issues/68>)
* Unit tests for all nodes (#61 <https://github.com/ros-tooling/topic_tools/issues/61>)
* Contributors: andrewbest-tri, anrp-tri, Emerson Knapp, Martin Llofriu
```

## topic_tools_interfaces

- No changes
