### PR TITLE
sick_safevisionary_ros2: 1.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7531,7 +7531,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/sick_safevisionary_ros2-release.git
-      version: 1.0.1-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_safevisionary_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safevisionary_ros2` to `1.0.3-1`:

- upstream repository: https://github.com/SICKAG/sick_safevisionary_ros2.git
- release repository: https://github.com/ros2-gbp/sick_safevisionary_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.1-1`

## sick_safevisionary_driver

```
* Use ROS version-dependent cv_bridge include
* Contributors: Stefan Scherzinger
```

## sick_safevisionary_interfaces

- No changes

## sick_safevisionary_tests

- No changes
