### PR TITLE
Add adi_tmcl to noetic index

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -75,6 +75,16 @@ repositories:
       url: https://github.com/ros/actionlib.git
       version: noetic-devel
     status: maintained
+  adi_tmcl:
+    doc:
+      type: git
+      url: https://github.com/analogdevicesinc/tmcl_ros.git
+      version: noetic
+    source:
+      type: git
+      url: https://github.com/analogdevicesinc/tmcl_ros.git
+      version: noetic
+    status: maintained
   agni_tf_tools:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

noetic

# The source is here:

https://github.com/analogdevicesinc/tmcl_ros

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
