### PR TITLE
jsk_model_tools: 0.4.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4532,7 +4532,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tork-a/jsk_model_tools-release.git
-      version: 0.4.4-2
+      version: 0.4.5-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_model_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_model_tools` to `0.4.5-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_model_tools
- release repository: https://github.com/tork-a/jsk_model_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.4-2`

## eus_assimp

- No changes

## euscollada

```
* [collada2eus_urdfmodel.cpp] print links in the order of link names (#252 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/252>)
* enable to read custom limb name from .yaml file (fix for #249 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/249>) (#250 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/250>)
  
    * [collada2eus_urdfmodel.cpp] refactor code
    * [euscollada] add generate-pr2-custom-limb-test
    * [collada2eus_urdfmodel.cpp] fix comment. fix indent
    * [collada2eus_urdfmodel.cpp] support multiple config_files
    * enable to read custom limb name from .yaml file: ignore sensors key. ignore limb with invalid joint
    * [collada2eus_urdfmodel.cpp] change duplicated variable name
    * enable to read custom limb name from .yaml file: if the limb name is other than head,torso,larm,rarm,lleg,rleg, we set limb name to robot models
  
* On Noetic build environment, only python3 is available (#247 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/247>)
* Contributors: Kei Okada, Naoki-Hiraoka
```

## eusurdf

- No changes

## jsk_model_tools

- No changes
