### PR TITLE
aruco_opencv: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -201,7 +201,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fictionlab-gbp/aruco_opencv-release.git
-      version: 0.3.1-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/fictionlab/aruco_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_opencv` to `0.4.0-1`:

- upstream repository: https://github.com/fictionlab/aruco_opencv.git
- release repository: https://github.com/fictionlab-gbp/aruco_opencv-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.1-1`

## aruco_opencv

```
* Support rectified images
* Support different distortion models
* Contributors: Błażej Sowa
```

## aruco_opencv_msgs

- No changes
