### PR TITLE
python-omniorb is not available on debian, use omniorb, see https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=omniidl

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2562,7 +2562,7 @@ python-objectpath-pip:
       packages: [objectpath]
 python-omniorb:
   arch: [omniorbpy]
-  debian: [python-omniorb, python-omniorb-omg, omniidl-python]
+  debian: [omniorb, omniidl]
   fedora: [python-omniORB, omniORB-devel]
   gentoo: ['net-misc/omniORB[python]']
   ubuntu:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python-omniorb

## Package Upstream Source:

`[python-omniorb, python-omniorb-omg, omniidl-python]` is not avilable on debian.

https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=omniidl

This fix should resolve build failure on https://build.ros.org/job/Nbin_db_dB64__openhrp3__debian_buster_amd64__binary/289/console ()
