### PR TITLE
ros2_control: 4.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5074,7 +5074,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.0.0-1
+      version: 4.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.1.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.0-1`

## controller_interface

```
* Add few warning compiler options to error (#1181 <https://github.com/ros-controls/ros2_control/issues/1181>)
* [ControllerInterface] Avoid warning about conversion from int64_t to unsigned int (#1173 <https://github.com/ros-controls/ros2_control/issues/1173>)
* Contributors: Dr. Denis, Sai Kishor Kothakota
```

## controller_manager

```
* Add few warning compiler options to error (#1181 <https://github.com/ros-controls/ros2_control/issues/1181>)
* [ControllerManager] Fix all warnings from the latets features. (#1174 <https://github.com/ros-controls/ros2_control/issues/1174>)
* Compute the actual update period for each controller (#1140 <https://github.com/ros-controls/ros2_control/issues/1140>)
* Contributors: Dr. Denis, Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Add few warning compiler options to error (#1181 <https://github.com/ros-controls/ros2_control/issues/1181>)
* Contributors: Sai Kishor Kothakota
```

## joint_limits

```
* Add few warning compiler options to error (#1181 <https://github.com/ros-controls/ros2_control/issues/1181>)
* Contributors: Sai Kishor Kothakota
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

```
* Add few warning compiler options to error (#1181 <https://github.com/ros-controls/ros2_control/issues/1181>)
* Contributors: Sai Kishor Kothakota
```
