### PR TITLE
ess_imu_driver: 1.0.1-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2526,6 +2526,21 @@ repositories:
       url: https://github.com/bostoncleek/ergodic_exploration.git
       version: noetic-devel
     status: developed
+  ess_imu_driver:
+    doc:
+      type: git
+      url: https://github.com/cubicleguy/ess_imu_driver.git
+      version: noetic
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/cubicleguy/ess_imu_driver-release.git
+      version: 1.0.1-3
+    source:
+      type: git
+      url: https://github.com/cubicleguy/ess_imu_driver.git
+      version: noetic
+    status: maintained
   ess_imu_ros1_uart_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ess_imu_driver` to `1.0.1-3`:

- upstream repository: https://github.com/cubicleguy/ess_imu_driver.git
- release repository: https://github.com/cubicleguy/ess_imu_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## ess_imu_driver

- No changes
