### PR TITLE
Update python.yaml - Add Kaitaistruct python runtime

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6612,6 +6612,9 @@ python3-jupyros-pip:
     pip:
       packages: [jupyros]
 python3-kaitaistruct:
+  debian: [python3-kaitaistruct]
+  fedora: [python3-kaitaistruct]
+  opensuse: [python3-kaitaistruct]
   ubuntu:
     pip: [kaitaistruct]
 python3-kitchen:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6611,6 +6611,9 @@ python3-jupyros-pip:
   ubuntu:
     pip:
       packages: [jupyros]
+python3-kaitaistruct:
+  ubuntu:
+    pip: [kaitaistruct]
 python3-kitchen:
   arch: [python-kitchen]
   debian: [python3-kitchen]


### PR DESCRIPTION
added kaitaistruct to rosdep

<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-kaitaistruct

## Package Upstream Source:
https://pypi.org/project/kaitaistruct/

## Purpose of using this:

This dependency is used as the Kaitai Struct declarative parser generator for binary data: runtime library for Python. It is used as the runtime for python kaitaistruct generated binary parsers.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - [REQUIRED](https://pypi.org/project/kaitaistruct/)
- Ubuntu: https://packages.ubuntu.com/
  - [REQUIRED](https://pypi.org/project/kaitaistruct/)

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

GALACTIC

# The source is here:
https://github.com/kaitai-io/kaitai_struct_python_runtime

# Checks
 - [ YES] All packages have a declared license in the package.xml
 - [YES ] This repository has a LICENSE file
 - [YES ] This package is expected to build on the submitted rosdistro
