### PR TITLE
sick_scan_xd: 3.1.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11042,7 +11042,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/SICKAG/sick_scan_xd-release.git
-      version: 3.1.1-1
+      version: 3.1.3-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_scan_xd.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_scan_xd` to `3.1.3-1`:

- upstream repository: https://github.com/SICKAG/sick_scan_xd.git
- release repository: https://github.com/SICKAG/sick_scan_xd-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.1.1-1`

## sick_scan_xd

```
* 3.1.1
* Update CHANGELOG.rst
* Build options for bloom release, merge bugfix updates (mrs1xxx_init, tim240_protocol_switch, nav350_imk), documentation update (msgpack11 removed)
* Contributors: rostest
```
