### PR TITLE
ros2_controllers: 3.19.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5363,7 +5363,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 3.18.0-1
+      version: 3.19.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `3.19.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.18.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

- No changes

## bicycle_steering_controller

- No changes

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

```
* Increase test coverage of interface configuration getters (backport #856 <https://github.com/ros-controls/ros2_controllers/issues/856>)
* Contributors: Christoph Froehlich
```

## forward_command_controller

```
* Increase test coverage of interface configuration getters (backport #856 <https://github.com/ros-controls/ros2_controllers/issues/856>)
* Contributors: Christoph Froehlich
```

## gripper_controllers

```
* Increase test coverage of interface configuration getters (backport #856 <https://github.com/ros-controls/ros2_controllers/issues/856>)
* Contributors: Christoph Froehlich
```

## imu_sensor_broadcaster

```
* Increase test coverage of interface configuration getters (backport #856 <https://github.com/ros-controls/ros2_controllers/issues/856>)
* Contributors: Christoph Froehlich
```

## joint_state_broadcaster

```
* Increase test coverage of interface configuration getters (backport #856 <https://github.com/ros-controls/ros2_controllers/issues/856>)
* joint_state_broadcaster: Add proper subscription to TestCustomInterfaceMappingUpdate (#859 <https://github.com/ros-controls/ros2_controllers/issues/859>) (#864 <https://github.com/ros-controls/ros2_controllers/issues/864>)
* Contributors: Christoph Froehlich, mergify[bot]
```

## joint_trajectory_controller

```
* [JTC] Activate checks for parameter validation (backport #857 <https://github.com/ros-controls/ros2_controllers/issues/857>) (#873 <https://github.com/ros-controls/ros2_controllers/issues/873>)
* [JTC] Improve update methods for tests (backport #858 <https://github.com/ros-controls/ros2_controllers/issues/858>)
* [JTC] Fix dynamic reconfigure of tolerances (backport #849 <https://github.com/ros-controls/ros2_controllers/issues/849>)
* [JTC] Fix tests when state offset is used (backport #797 <https://github.com/ros-controls/ros2_controllers/issues/797>)
* [JTC] Set allow_nonzero_velocity_at_trajectory_end default false and rename class variables (backport #834 <https://github.com/ros-controls/ros2_controllers/issues/834>) (#843 <https://github.com/ros-controls/ros2_controllers/issues/843>)
* [JTC] Remove unused home pose (#845 <https://github.com/ros-controls/ros2_controllers/issues/845>) (#852 <https://github.com/ros-controls/ros2_controllers/issues/852>)
* Contributors: Christoph Fröhlich, Dr Denis, Bence Magyar
```

## position_controllers

- No changes

## range_sensor_broadcaster

```
* Increase test coverage of interface configuration getters (backport #856 <https://github.com/ros-controls/ros2_controllers/issues/856>)
* Contributors: Christoph Froehlich
```

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

- No changes

## tricycle_controller

```
* Increase test coverage of interface configuration getters (backport #856 <https://github.com/ros-controls/ros2_controllers/issues/856>)
* Contributors: Christoph Froehlich
```

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
