### PR TITLE
ros2_controllers: 4.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5110,7 +5110,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 4.0.0-1
+      version: 4.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `4.1.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

- No changes

## bicycle_steering_controller

- No changes

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

```
* Increase test coverage of interface configuration getters (#856 <https://github.com/ros-controls/ros2_controllers/issues/856>)
* Contributors: Christoph Fröhlich
```

## forward_command_controller

```
* Increase test coverage of interface configuration getters (#856 <https://github.com/ros-controls/ros2_controllers/issues/856>)
* Contributors: Christoph Fröhlich
```

## gripper_controllers

```
* Increase test coverage of interface configuration getters (#856 <https://github.com/ros-controls/ros2_controllers/issues/856>)
* Contributors: Christoph Fröhlich
```

## imu_sensor_broadcaster

```
* Increase test coverage of interface configuration getters (#856 <https://github.com/ros-controls/ros2_controllers/issues/856>)
* Contributors: Christoph Fröhlich
```

## joint_state_broadcaster

```
* Increase test coverage of interface configuration getters (#856 <https://github.com/ros-controls/ros2_controllers/issues/856>)
* joint_state_broadcaster: Add proper subscription to TestCustomInterfaceMappingUpdate (#859 <https://github.com/ros-controls/ros2_controllers/issues/859>)
* Contributors: Christoph Fröhlich
```

## joint_trajectory_controller

```
* [JTC] Continue with last trajectory-point on success (#842 <https://github.com/ros-controls/ros2_controllers/issues/842>)
* [JTC] Remove start_with_holding option (#839 <https://github.com/ros-controls/ros2_controllers/issues/839>)
* [JTC] Activate checks for parameter validation (#857 <https://github.com/ros-controls/ros2_controllers/issues/857>)
* [JTC] Improve update methods for tests (#858 <https://github.com/ros-controls/ros2_controllers/issues/858>)
* Contributors: Christoph Fröhlich
```

## position_controllers

- No changes

## range_sensor_broadcaster

```
* Increase test coverage of interface configuration getters (#856 <https://github.com/ros-controls/ros2_controllers/issues/856>)
* Contributors: Christoph Fröhlich
```

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

- No changes

## tricycle_controller

```
* Increase test coverage of interface configuration getters (#856 <https://github.com/ros-controls/ros2_controllers/issues/856>)
* Contributors: Christoph Fröhlich
```

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
