### PR TITLE
mqtt_client: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3023,7 +3023,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ika-rwth-aachen/mqtt_client-release.git
-      version: 2.1.0-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/ika-rwth-aachen/mqtt_client.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mqtt_client` to `2.2.0-1`:

- upstream repository: https://github.com/ika-rwth-aachen/mqtt_client.git
- release repository: https://github.com/ika-rwth-aachen/mqtt_client-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.0-1`

## mqtt_client

```
* Merge pull request #35 <https://github.com/ika-rwth-aachen/mqtt_client/issues/35> from mvccogo/main
  Dynamic registration of topics
* Merge pull request #36 <https://github.com/ika-rwth-aachen/mqtt_client/issues/36> from ika-rwth-aachen/fix/ros1-latencies
  Fix bug in ros1 latency deserialization
* Contributors: Lennart Reiher, Matheus V. C. Cogo, mvccogo
```

## mqtt_client_interfaces

```
* Merge pull request #35 <https://github.com/ika-rwth-aachen/mqtt_client/issues/35> from mvccogo/main
  Dynamic registration of topics
* Contributors: Lennart Reiher, Matheus V. C. Cogo, mvccogo
```
