### PR TITLE
Adding ess_imu_driver2 to documentation index for humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1584,6 +1584,16 @@ repositories:
       url: https://github.com/stack-of-tasks/eigenpy.git
       version: devel
     status: maintained
+  ess_imu_driver2:
+    doc:
+      type: git
+      url: https://github.com/cubicleguy/ess_imu_driver2.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/cubicleguy/ess_imu_driver2.git
+      version: humble
+    status: maintained
   etsi_its_messages:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

ess_imu_driver2

## Package Upstream Source:

https://github.com/cubicleguy/ess_imu_driver2.git

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

humble

# The source is here:

http://github.com/cubicleguy/ess_imu_driver2.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
