### PR TITLE
Perform debian repo checks on the current stable distribution.

### DIFF
--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -61,7 +61,7 @@ supported_versions:
   arch:
   - ''
   debian:
-  - bullseye
+  - bookworm
   fedora:
   - '37'
   - '38'


### PR DESCRIPTION
Bookworm has been out for some time. If we had added bookworm when it first released I would be tempted to thread them in rather than immediately dropping buster. However since we no longer build any active rosdistro on buster I think it's time to drop this.