### PR TITLE
udp_msgs: 0.0.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11964,6 +11964,17 @@ repositories:
       url: https://github.com/continental/udp_com.git
       version: main
     status: maintained
+  udp_msgs:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/flynneva/udp_msgs-release.git
+      version: 0.0.4-1
+    source:
+      type: git
+      url: https://github.com/flynneva/udp_msgs.git
+      version: main
+    status: maintained
   ueye_cam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `udp_msgs` to `0.0.4-1`:

- upstream repository: git@github.com:flynneva/udp_msgs.git
- release repository: https://github.com/flynneva/udp_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## udp_msgs

```
* Merge pull request #14 <https://github.com/flynneva/udp_msgs/issues/14> from ika-rwth-aachen/feature/ros-noetic
* adding ci for ROS noetic
* add ros noetic support
* Contributors: Evan Flynn, Jean-Pierre Busch
```
