### PR TITLE
iceoryx: 2.0.5-3 in 'rolling/distribution.yaml'

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1963,11 +1963,12 @@ repositories:
       packages:
       - iceoryx_binding_c
       - iceoryx_hoofs
+      - iceoryx_introspection
       - iceoryx_posh
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/iceoryx-release.git
-      version: 2.0.3-3
+      version: 2.0.5-3
     source:
       type: git
       url: https://github.com/eclipse-iceoryx/iceoryx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `iceoryx` to `2.0.5-3`:

* upstream repository: https://github.com/eclipse-iceoryx/iceoryx.git
* release repository: https://github.com/ros2-gbp/iceoryx-release.git
* distro file: rolling/distribution.yaml
* bloom version: `0.11.2`
* previous version for package: `2.0.3-3`

