### PR TITLE
rsl: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7236,7 +7236,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/RSL-release.git
-      version: 0.2.2-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/RSL.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rsl` to `1.0.0-1`:

- upstream repository: https://github.com/PickNikRobotics/RSL.git
- release repository: https://github.com/ros2-gbp/RSL-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.2-1`

## rsl

```
* Add rsl::StrongType
* Quote values in error messages
* Make doxygen a weak dependency
* Mark git as a test dependency
* Contributors: Andrew, Chris Thrasher, Michael Carroll, Tyler Weaver, andrea
```
