### PR TITLE
etsi_its_messages: 1.0.0-2 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1272,7 +1272,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ika-rwth-aachen/etsi_its_messages-release.git
-      version: 1.0.0-1
+      version: 1.0.0-2
     source:
       type: git
       url: https://github.com/ika-rwth-aachen/etsi_its_messages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `etsi_its_messages` to `1.0.0-2`:

- upstream repository: https://github.com/ika-rwth-aachen/etsi_its_messages.git
- release repository: https://github.com/ika-rwth-aachen/etsi_its_messages-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-1`
