### PR TITLE
iceoryx: 2.0.5-1 in 'humble/distribution.yaml'

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2465,11 +2465,12 @@ repositories:
       packages:
       - iceoryx_binding_c
       - iceoryx_hoofs
+      - iceoryx_introspection
       - iceoryx_posh
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/iceoryx-release.git
-      version: 2.0.3-1
+      version: 2.0.5-1
     source:
       type: git
       url: https://github.com/eclipse-iceoryx/iceoryx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `iceoryx` to `2.0.5-1`:

* upstream repository: https://github.com/eclipse-iceoryx/iceoryx.git
* release repository: https://github.com/ros2-gbp/iceoryx-release.git
* distro file: humble/distribution.yaml
* bloom version: `0.11.2`
* previous version for package: `2.0.3-1`