### PR TITLE
mvsim: 0.8.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3139,7 +3139,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mvsim-release.git
-      version: 0.8.2-1
+      version: 0.8.3-1
     source:
       type: git
       url: https://github.com/MRPT/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.8.3-1`:

- upstream repository: https://github.com/MRPT/mvsim.git
- release repository: https://github.com/ros2-gbp/mvsim-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.8.2-1`

## mvsim

```
* Generate ground truth trajectory files in the TUM format
* ROS nodes: add a timeout for cmd_vel commands, so the robots stop if input messages stop
* Add rviz_plugin_tutorials dependency for ROS1
* Contributors: Jose Luis Blanco-Claraco, Michael Grupp
```
