### PR TITLE
naoqi_driver: 2.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3940,7 +3940,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_driver2-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_driver2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_driver` to `2.1.1-1`:

- upstream repository: https://github.com/ros-naoqi/naoqi_driver2.git
- release repository: https://github.com/ros-naoqi/naoqi_driver2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.0-1`

## naoqi_driver

```
* Drop testing of foxy and galactic
* README: remove extraneous args in example
* Update code and instructions about Docker
* Fix build for humble
* Improve README about audio service
* Contributors: Victor Paléologue
```
