### PR TITLE
phidgets_drivers: 2.3.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4029,7 +4029,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/phidgets_drivers-release.git
-      version: 2.3.1-3
+      version: 2.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `2.3.2-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros2-gbp/phidgets_drivers-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.1-3`

## libphidget22

- No changes

## phidgets_accelerometer

- No changes

## phidgets_analog_inputs

- No changes

## phidgets_analog_outputs

- No changes

## phidgets_api

```
* added new parameters for spatial precision MOT0109 onwards
* added support for phidget spatial onboard orientation estimation
* Contributors: Malte kl. Piening, Martin Günther
```

## phidgets_digital_inputs

- No changes

## phidgets_digital_outputs

- No changes

## phidgets_drivers

- No changes

## phidgets_gyroscope

- No changes

## phidgets_high_speed_encoder

- No changes

## phidgets_ik

- No changes

## phidgets_magnetometer

- No changes

## phidgets_motors

- No changes

## phidgets_msgs

- No changes

## phidgets_spatial

```
* Only set magnetometer gain if param is set (#169 <https://github.com/ros-drivers/phidgets_drivers/issues/169>)
* added new parameters for spatial precision MOT0109 onwards
* added support for phidget spatial onboard orientation estimation
* Contributors: Malte kl. Piening, Martin Günther
```

## phidgets_temperature

- No changes
