### PR TITLE
phidgets_drivers: 1.0.8-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7429,7 +7429,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
-      version: 1.0.7-1
+      version: 1.0.8-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `1.0.8-2`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.7-1`

## libphidget22

- No changes

## phidgets_accelerometer

- No changes

## phidgets_analog_inputs

- No changes

## phidgets_analog_outputs

- No changes

## phidgets_api

- No changes

## phidgets_digital_inputs

- No changes

## phidgets_digital_outputs

- No changes

## phidgets_drivers

- No changes

## phidgets_gyroscope

- No changes

## phidgets_high_speed_encoder

- No changes

## phidgets_ik

- No changes

## phidgets_magnetometer

- No changes

## phidgets_motors

- No changes

## phidgets_msgs

- No changes

## phidgets_spatial

```
* Only set magnetometer gain if param is set (#170 <https://github.com/ros-drivers/phidgets_drivers/issues/170>)
* Contributors: Martin Günther
```

## phidgets_temperature

- No changes
