### PR TITLE
Switch the RHEL-9 python3-qt5-bindings key to SIP.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8241,7 +8241,7 @@ python3-qt5-bindings:
   openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python3-qt5]
   rhel:
-    '*': [clang, python3-devel, python3-qt5-devel, python3-sip-devel]
+    '*': [python3-qt5-devel, python3-sip-devel, libXext-devel]
     '7': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
     '8': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
   slackware: [python3-PyQt5]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8241,7 +8241,7 @@ python3-qt5-bindings:
   openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python3-qt5]
   rhel:
-    '*': [clang, python3-devel, python3-pyside2-devel, python3-shiboken2-devel]
+    '*': [clang, python3-devel, python3-qt5-devel, python3-sip-devel]
     '7': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
     '8': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
   slackware: [python3-PyQt5]


### PR DESCRIPTION
Pyside2 no longer works on RHEL, so instead switch to SIP, which now works.

This is the last piece of switching RHEL-9 to using SIP, after https://github.com/ros2/ci/pull/730, https://github.com/ros-visualization/python_qt_binding/pull/129, and https://github.com/ros2/ci/pull/732 .

Marked as a draft for now; I'd like to get @cottsay's approval before we merge this.