### PR TITLE
Remove the python-omniorb key.

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -659,10 +659,6 @@ python-cairo:
   osx:
     homebrew:
       packages: [py2cairo]
-python-omniorb:
-  osx:
-    homebrew:
-      packages: [omniorb]
 python-opencv:
   osx:
     homebrew:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2561,13 +2561,6 @@ python-objectpath-pip:
   ubuntu:
     pip:
       packages: [objectpath]
-python-omniorb:
-  arch: [omniorbpy]
-  debian: [python-omniorb, python-omniorb-omg, omniidl-python]
-  fedora: [python-omniORB, omniORB-devel]
-  gentoo: ['net-misc/omniORB[python]']
-  ubuntu:
-    '*': [python-omniorb, python-omniorb-omg, omniidl-python]
 python-open3d-pip:
   debian:
     pip:


### PR DESCRIPTION
As far as we can tell, there are no active distributions that have this package.  So there is no reason to have it in the rosdep database.

See https://github.com/ros/rosdistro/pull/39111/files#r1412492457 for some of the details.