### PR TITLE
Add python3-inflection

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6500,6 +6500,14 @@ python3-importlib-resources:
     bionic:
       pip:
         packages: [importlib-resources]
+python3-inflection:
+  arch: [python-inflection]
+  debian: [python3-inflection]
+  fedora: [python3-inflection]
+  gentoo: [dev-python/inflection]
+  nixos: [python3Packages.inflection]
+  opensuse: [python3-inflection]
+  ubuntu: [python3-inflection]
 python3-inflection-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-inflection

## Package Upstream Source:

https://github.com/jpvanhal/inflection

## Purpose of using this:

A port of Ruby on Rails' inflector to Python, properly packaged for binary releases (unlike `python3-inflection-pip`).

## Links to Distribution Packages

- Debian: https://packages.debian.org/search?keywords=python3-inflection&searchon=names&suite=all&section=all
- Ubuntu: https://packages.ubuntu.com/search?keywords=python3-inflection&searchon=names&suite=all&section=all
- Fedora: https://packages.fedoraproject.org/pkgs/python-inflection/python3-inflection/
- Arch: https://archlinux.org/packages/extra/any/python-inflection/
- Gentoo: https://packages.gentoo.org/packages/dev-python/inflection
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=23.11&from=0&size=50&sort=relevance&type=packages&query=inflection
- openSUSE: https://software.opensuse.org/search?baseproject=ALL&q=inflection