### PR TITLE
nao_lola: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3188,12 +3188,11 @@ repositories:
       - nao_lola
       - nao_lola_client
       - nao_lola_command_msgs
-      - nao_lola_conversion
       - nao_lola_sensor_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nao_lola-release.git
-      version: 1.1.1-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/ros-sports/nao_lola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_lola` to `1.2.0-1`:

- upstream repository: https://github.com/ros-sports/nao_lola.git
- release repository: https://github.com/ros2-gbp/nao_lola-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.1-1`

## nao_lola

```
* Don't process JointPositions and JointStiffnesses message if message is invalid. This prevents segmentation faults.
* Contributors: ijnek
```

## nao_lola_client

```
* Publish imu and joint state messages. These features are enabled by default, but can optionally be disabled through the "publish_imu" and "publish_joint_states" parameters.
* Modify nao_lola_client node to be an rclcpp component to allow composition.
* Allow socket connection to retry until it connects, to allow nao_lola_client to be launched before the Lola agent itself. This is useful when bringing up simulation (eg. webots) after nao_lola_client.
* Prevent segmentation faults caused by invalid JointPositions and JointStiffnesses incoming messages.
* Contributors: Kenji Brameld, ijnek
```

## nao_lola_command_msgs

- No changes

## nao_lola_sensor_msgs

- No changes
