### PR TITLE
add Pangolin to humble and rolling

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4583,6 +4583,11 @@ repositories:
       url: https://github.com/pal-robotics/pal_urdf_utils.git
       version: humble-devel
     status: developed
+  pangolin:
+    source:
+      type: git
+      url: https://github.com/stevenlovegrove/Pangolin.git
+      version: master
   pcl_msgs:
     release:
       tags:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3653,6 +3653,11 @@ repositories:
       url: https://github.com/pal-robotics/pal_statistics.git
       version: humble-devel
     status: maintained
+  pangolin:
+    source:
+      type: git
+      url: https://github.com/stevenlovegrove/Pangolin.git
+      version: master
   pcl_msgs:
     release:
       tags:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

pangolin

## Package Upstream Source:

https://github.com/stevenlovegrove/Pangolin.git

## Purpose of using this:

Pangolin is a UI toolkit that is widely used in the robotics and specifically the SLAM community to render user interfaces.


# Please Add This Package to be indexed in the rosdistro.

`humble`, `rolling`

# The source is here:

https://github.com/stevenlovegrove/Pangolin.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
