### PR TITLE
rosbag_rviz_panel: 0.1.9-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9619,6 +9619,11 @@ repositories:
       version: 0.5.4-1
     status: maintained
   rosbag_rviz_panel:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/fada-catec/rosbag_rviz_panel-release.git
+      version: 0.1.9-2
     source:
       type: git
       url: https://github.com/fada-catec/rosbag_rviz_panel.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag_rviz_panel` to `0.1.9-2`:

- upstream repository: https://github.com/fada-catec/rosbag_rviz_panel.git
- release repository: https://github.com/fada-catec/rosbag_rviz_panel-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## rosbag_rviz_panel

```
* Added CHANGELOG.rst
* Prepare package for release
```
