### PR TITLE
robot_localization: 2.7.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8947,7 +8947,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/cra-ros-pkg/robot_localization-release.git
-      version: 2.7.4-1
+      version: 2.7.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `2.7.5-1`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/cra-ros-pkg/robot_localization-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.7.4-1`

## robot_localization

```
* Fix/set utm map frame change (#830 <https://github.com/cra-ros-pkg/robot_localization/issues/830>)
  * Fix utm service properly resetting transforms and fix test for this
  ---------
  Co-authored-by: Ferry Schoenmakers <mailto:ferry.schoenmakers@nobleo.nl>
* Add flag to invert published transform (#827 <https://github.com/cra-ros-pkg/robot_localization/issues/827>)
* fix bracket missing bug ekf nodelet template noetic (#823 <https://github.com/cra-ros-pkg/robot_localization/issues/823>)
* Noetic devel (#775 <https://github.com/cra-ros-pkg/robot_localization/issues/775>)
  * fixed missing silent flag
  * removed debug statement
  * replace tabs with blanks
* Contributors: Carlos Mendes, ChenHehe, CyberNet, Ferry Schoenmakers
```
