### PR TITLE
Adding sick_scan_xd to documentation index for distro humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7599,6 +7599,12 @@ repositories:
       url: https://github.com/SICKAG/sick_safevisionary_ros2.git
       version: main
     status: developed
+  sick_scan_xd:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/sick_scan_xd.git
+      version: master
+    status: developed
   sicks300_2:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble

# The source is here:

https://github.com/SICKAG/sick_scan_xd

# Checks
 - [x ] All packages have a declared license in the package.xml
 - [x ] This repository has a LICENSE file
 - [x ] This package is expected to build on the submitted rosdistro
