### PR TITLE
control_toolbox: 3.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -864,7 +864,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 3.1.0-1
+      version: 3.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `3.2.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.1.0-1`

## control_toolbox

```
* [CI] fix source build (#168 <https://github.com/ros-controls/control_toolbox/issues/168>)
* Bump actions/setup-python from 4 to 5 (#167 <https://github.com/ros-controls/control_toolbox/issues/167>)
* [CI] Touchups (#166 <https://github.com/ros-controls/control_toolbox/issues/166>)
* [PID] Update documentation to reflect ROS 2 usage of time (#165 <https://github.com/ros-controls/control_toolbox/issues/165>)
* Bump actions/checkout from 3 to 4 (#163 <https://github.com/ros-controls/control_toolbox/issues/163>)
* Bump ros-tooling/setup-ros from 0.6 to 0.7 (#161 <https://github.com/ros-controls/control_toolbox/issues/161>)
* Add filters structure and lowpass filter (#152 <https://github.com/ros-controls/control_toolbox/issues/152>)
* Bump codecov/codecov-action from 3.1.2 to 3.1.4 (#160 <https://github.com/ros-controls/control_toolbox/issues/160>)
* Contributors: Christoph Fröhlich, GuiHome, Patrick Roncagliolo
```
