### PR TITLE
ros2_control: 2.36.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6243,7 +6243,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.35.1-1
+      version: 2.36.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.36.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.35.1-1`

## controller_interface

- No changes

## controller_manager

```
* Fix controller sorting issue while loading large number of controllers (#1180 <https://github.com/ros-controls/ros2_control/issues/1180>) (#1186 <https://github.com/ros-controls/ros2_control/issues/1186>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Cleanup Resource Manager a bit to increase clarity. (backport #816 <https://github.com/ros-controls/ros2_control/issues/816>) (#1191 <https://github.com/ros-controls/ros2_control/issues/1191>)
* Handle hardware errors in Resource Manager (#805 <https://github.com/ros-controls/ros2_control/issues/805>) (#837 <https://github.com/ros-controls/ros2_control/issues/837>) #ABI-breaking
* Contributors: mergify[bot]
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
