### PR TITLE
ros2_controllers: 4.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5137,6 +5137,7 @@ repositories:
       - imu_sensor_broadcaster
       - joint_state_broadcaster
       - joint_trajectory_controller
+      - pid_controller
       - position_controllers
       - range_sensor_broadcaster
       - ros2_controllers
@@ -5149,7 +5150,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 4.1.0-1
+      version: 4.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `4.2.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.1.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

- No changes

## bicycle_steering_controller

- No changes

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* Cleanup package.xml und clarify tests of JTC. (#889 <https://github.com/ros-controls/ros2_controllers/issues/889>)
* Fix floating point comparison in JTC (#879 <https://github.com/ros-controls/ros2_controllers/issues/879>)
* Contributors: Abishalini Sivaraman, Dr. Denis
```

## pid_controller

```
* 🚀 Add PID controller 🎉 (#434 <https://github.com/ros-controls/ros2_controllers/issues/434>)
* Contributors: Dr. Denis
```

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

```
* 🚀 Add PID controller 🎉 (#434 <https://github.com/ros-controls/ros2_controllers/issues/434>)
* Contributors: Dr. Denis
```

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

```
* Fix rqt jtc bugs for continuous joints and other minor bugs (#890 <https://github.com/ros-controls/ros2_controllers/issues/890>)
* Contributors: Sai Kishor Kothakota
```

## steering_controllers_library

- No changes

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
