### PR TITLE
ros2_control: 4.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5113,7 +5113,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.1.0-1
+      version: 4.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.2.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.1.0-1`

## controller_interface

- No changes

## controller_manager

```
* [CM] Linting if/else statements (#1193 <https://github.com/ros-controls/ros2_control/issues/1193>)
* Reformat with braces added (#1209 <https://github.com/ros-controls/ros2_control/issues/1209>)
* Report inactive controllers as a diagnostics ok instead of an error (#1184 <https://github.com/ros-controls/ros2_control/issues/1184>)
* Fix controller sorting issue while loading large number of controllers (#1180 <https://github.com/ros-controls/ros2_control/issues/1180>)
* Contributors: Bence Magyar, Dr. Denis, Lennart Nachtigall, Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
