### PR TITLE
ur_description: 2.1.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7571,7 +7571,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.1.1-1
+      version: 2.1.2-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.1.2-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.1-1`

## ur_description

```
* Add license comment to package.xml (#107 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/107>)
* License update for README (#108 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/108>)
* Default to non_blocking_read=true (#115 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/115>)
* added possibility to change reverse_port, script_sender_port and trajectory_port (#105 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/105>) (#106 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/106>)
* Update README regarding distribution branches (#80 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/80>) (#86 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/86>)
* Contributors: Felix Exner, Rune Søe-Knudsen, mergify[bot]
```
