### PR TITLE
Update sick visionary ros

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11139,7 +11139,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/SICKAG/sick_visionary_ros-release.git
-      version: 1.0.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_visionary_ros.git


### PR DESCRIPTION
Please update the following dependency in the rosdep database.

## Package name: sick_visionary_ros

## Purpose of using this: bump version to 1.1.1-1 to make new release available.

ROSDISTRO NOETIC

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
