### PR TITLE
Add mp2p_icp for indexing

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3431,6 +3431,16 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
       version: master
     status: maintained
+  mrpt_navigation:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
+      version: ros2
+    status: developed
   mrpt_path_planning:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3032,6 +3032,16 @@ repositories:
       url: https://github.com/ros-planning/moveit_visual_tools.git
       version: ros2
     status: maintained
+  mp2p_icp:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mp2p_icp.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mp2p_icp.git
+      version: master
+    status: developed
   mqtt_client:
     doc:
       type: git


### PR DESCRIPTION
Add mp2p_icp for indexing

# Please Add This Package to be indexed in the rosdistro.

rolling

# The source is here:

https://github.com/MOLAorg/mp2p_icp

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro

NOTE: This package is right now already published within another package ("mola") but in the next release it will be released as an independently package & git repository, hence this PR.
