### PR TITLE
ros_gz: 0.244.12-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6571,7 +6571,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 0.244.11-1
+      version: 0.244.12-1
     source:
       type: git
       url: https://github.com/gazebosim/ros_gz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `0.244.12-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.244.11-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* Backport: Add conversion for geometry_msgs/msg/TwistStamped <-> gz.msgs.Twist (#468 <https://github.com/gazebosim/ros_gz/issues/468>) (#470 <https://github.com/gazebosim/ros_gz/issues/470>)
* Add support for Harmonic/Humble pairing (#462 <https://github.com/gazebosim/ros_gz/issues/462>)
* Added messages for 2D Bounding Boxes to ros_gz_bridge (#458 <https://github.com/gazebosim/ros_gz/issues/458>)
* Fix double wait in ros_gz_bridge (#347 <https://github.com/gazebosim/ros_gz/issues/347>) (#450 <https://github.com/gazebosim/ros_gz/issues/450>)
* [backport humble] SensorNoise msg bridging (#417 <https://github.com/gazebosim/ros_gz/issues/417>)
* [backport humble] Added Altimeter msg bridging (#413 <https://github.com/gazebosim/ros_gz/issues/413>) (#414 <https://github.com/gazebosim/ros_gz/issues/414>) (#426 <https://github.com/gazebosim/ros_gz/issues/426>)
* [backport humble] Update README.md (#411 <https://github.com/gazebosim/ros_gz/issues/411>)
  The ROS type for gz.msgs.NavSat messages should be **sensor_msgs/msg/NavSatFix** instead of **sensor_msgs/msg/NavSatFixed**
* Contributors: Addisu Z. Taddese, Alejandro Hernández Cordero, Arjun K Haridas, wittenator
```

## ros_gz_image

```
* Add support for Harmonic/Humble pairing (#462 <https://github.com/gazebosim/ros_gz/issues/462>)
* Fix double wait in ros_gz_bridge (#347 <https://github.com/gazebosim/ros_gz/issues/347>) (#450 <https://github.com/gazebosim/ros_gz/issues/450>)
* Contributors: Addisu Z. Taddese, Alejandro Hernández Cordero
```

## ros_gz_interfaces

```
* [backport humble] SensorNoise msg bridging (#417 <https://github.com/gazebosim/ros_gz/issues/417>)
* [backport humble] Added Altimeter msg bridging (#413 <https://github.com/gazebosim/ros_gz/issues/413>) (#414 <https://github.com/gazebosim/ros_gz/issues/414>) (#426 <https://github.com/gazebosim/ros_gz/issues/426>)
* Contributors: Alejandro Hernández Cordero
```

## ros_gz_sim

```
* Add support for Harmonic/Humble pairing (#462 <https://github.com/gazebosim/ros_gz/issues/462>)
* Set on_exit_shutdown argument for gz-sim ExecuteProcess (#355 <https://github.com/gazebosim/ros_gz/issues/355>) (#451 <https://github.com/gazebosim/ros_gz/issues/451>)
* Contributors: Addisu Z. Taddese, Michael Carroll
```

## ros_gz_sim_demos

```
* [backport Humble] Added more topic to the bridge (#422 <https://github.com/gazebosim/ros_gz/issues/422>)
* Added more topic to the bridge (#422 <https://github.com/gazebosim/ros_gz/issues/422>)
* Fix incorrect subscription on demo (#405 <https://github.com/gazebosim/ros_gz/issues/405>)
* Contributors: Alejandro Hernández Cordero, Arjo Chakravarty
```

## ros_ign

- No changes

## ros_ign_bridge

- No changes

## ros_ign_gazebo

```
* Add support for Harmonic/Humble pairing (#462 <https://github.com/gazebosim/ros_gz/issues/462>)
* Contributors: Addisu Z. Taddese
```

## ros_ign_gazebo_demos

- No changes

## ros_ign_image

- No changes

## ros_ign_interfaces

- No changes
