### PR TITLE
change status to "unmaintained" for ess_imu_ros1_uart_driver (superceded by ess_imu_driver)

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2574,7 +2574,7 @@ repositories:
       type: git
       url: https://github.com/cubicleguy/ess_imu_ros1_uart_driver.git
       version: main
-    status: maintained
+    status: unmaintained
   ethercat_grant:
     doc:
       type: git


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

ess_imu_ros1_uart_driver

## Package Upstream Source:

https://github.com/cubicleguy/ess_imu_ros1_uart_driver.git

## Purpose of using this:

Change dev status to unmaintained

