### PR TITLE
Revert "Remove the python-omniorb key."

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -659,6 +659,10 @@ python-cairo:
   osx:
     homebrew:
       packages: [py2cairo]
+python-omniorb:
+  osx:
+    homebrew:
+      packages: [omniorb]
 python-opencv:
   osx:
     homebrew:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2562,12 +2562,10 @@ python-objectpath-pip:
     pip:
       packages: [objectpath]
 python-omniorb:
-  arch: [omniorbpy]
-  debian: [python-omniorb, python-omniorb-omg, omniidl-python]
   fedora: [python-omniORB, omniORB-devel]
   gentoo: ['net-misc/omniORB[python]']
   ubuntu:
-    '*': [python-omniorb, python-omniorb-omg, omniidl-python]
+    'focal': [python-omniorb, python-omniorb-omg, omniidl-python]
 python-open3d-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2561,6 +2561,13 @@ python-objectpath-pip:
   ubuntu:
     pip:
       packages: [objectpath]
+python-omniorb:
+  arch: [omniorbpy]
+  debian: [python-omniorb, python-omniorb-omg, omniidl-python]
+  fedora: [python-omniORB, omniORB-devel]
+  gentoo: ['net-misc/omniORB[python]']
+  ubuntu:
+    '*': [python-omniorb, python-omniorb-omg, omniidl-python]
 python-open3d-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2565,7 +2565,7 @@ python-omniorb:
   fedora: [python-omniORB, omniORB-devel]
   gentoo: ['net-misc/omniORB[python]']
   ubuntu:
-    'focal': [python-omniorb, python-omniorb-omg, omniidl-python]
+    focal: [python-omniorb, python-omniorb-omg, omniidl-python]
 python-open3d-pip:
   debian:
     pip:


### PR DESCRIPTION
Reverts ros/rosdistro#39174

@clalancette python-omniorb is removed from debian, but not from ubuntu yet.
- ubuntu: https://packages.ubuntu.com/focal/python-omniorb
- gento: https://packages.gentoo.org/packages/net-misc/omniORB
- fedora : https://packages.fedoraproject.org/pkgs/omniORBpy/python3-omniORB/ (removed...)
- arch: https://aur.archlinux.org/packages/omniorbpy