### PR TITLE
sick_visionary_ros: 1.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11139,7 +11139,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/SICKAG/sick_visionary_ros-release.git
-      version: 1.0.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_visionary_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_visionary_ros` to `1.1.1-1`:

- upstream repository: https://github.com/SICKAG/sick_visionary_ros.git
- release repository: https://github.com/SICKAG/sick_visionary_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-1`

## sick_visionary_ros

```
* fix: bump package.xml version
* add tags to package.xml for ros-index
```
