### PR TITLE
python3-mypy: change Ubuntu rule to use pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6980,7 +6980,9 @@ python3-mypy:
     '*': [python3-mypy]
     '7': null
     '8': null
-  ubuntu: [python3-mypy]
+  ubuntu:
+    pip:
+      packages: [mypy]
 python3-mysqldb:
   arch: [python-mysqlclient]
   debian: [python3-mysqldb]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please change the `python3-mypy` dependency in the rosdep database.

## Package name:

python3-mypy

## Package Upstream Source:

https://pypi.org/project/mypy/

## Purpose of using this:

Initially explained in #39208:
Currently, the rule for Ubuntu is to use the system's package [python3-mypy](https://packages.ubuntu.com/jammy/python3-mypy), which has a `mypy` in version `0.942` (on Ubuntu 22.04). That version contains a bug (https://github.com/python/mypy/issues/13627, fixed in `0.981`) that appears with Python's versions `>=3.10.7` (current Python's version on Ubuntu 22.04 is `3.10.12`). On PyPI, `mypy` version is the newest `1.7.1`.

Because of that mypy's bug, `ament_mypy` is crashing on my ROS packages (but works after installing `mypy` from `pip`).

This PR changes rosdep rule for Ubuntu only to use `pip` instead of the system package in order to use the latest version and ensure this and other bug fixes are implemented.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Ubuntu: https://packages.ubuntu.com/
  - ~https://packages.ubuntu.com/jammy/python3-mypy~
  - https://pypi.org/project/mypy/
- Other
  - not changed
