### PR TITLE
Add mola_common for indexing (source and doc)

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3663,6 +3663,16 @@ repositories:
       url: https://github.com/MOLAorg/mola.git
       version: develop
     status: developed
+  mola_common:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mola_common.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mola_common.git
+      version: develop
+    status: developed
   moveit:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3070,6 +3070,16 @@ repositories:
       url: https://github.com/MOLAorg/mola.git
       version: develop
     status: developed
+  mola_common:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mola_common.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mola_common.git
+      version: develop
+    status: developed
   moveit:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2921,6 +2921,16 @@ repositories:
       url: https://github.com/MOLAorg/mola.git
       version: develop
     status: developed
+  mola_common:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mola_common.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mola_common.git
+      version: develop
+    status: developed
   moveit:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

ROS distros: iron / humble / rolling

# The source is here:

https://github.com/MOLAorg/mola_common

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro

Note: This package was formerly already released within another repo (`mola`), but it will be released as a standalone package in the near future. Should I also open a PR to manually remove the `release: packages:  ...` part of `mola` to prevent the same released package to (temporarily) show up twice? Thanks.