### PR TITLE
pal_hey5: 4.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2463,7 +2463,8 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/hey5_description.git
       version: humble-devel
-    status: maintained
+    status: end-of-life
+    status_description: Deprecated by package pal_hey5_description
   hls_lfcd_lds_driver:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4549,6 +4549,25 @@ repositories:
       url: https://github.com/pal-robotics/pal_gripper.git
       version: humble-devel
     status: developed
+  pal_hey5:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pal_hey5.git
+      version: humble-devel
+    release:
+      packages:
+      - pal_hey5
+      - pal_hey5_controller_configuration
+      - pal_hey5_description
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/pal_hey5-release.git
+      version: 4.0.0-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pal_hey5.git
+      version: humble-devel
+    status: maintained
   pal_navigation_cfg_public:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_hey5` to `4.0.0-1`:

- upstream repository: https://github.com/pal-robotics/pal_hey5.git
- release repository: https://github.com/pal-gbp/pal_hey5-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## pal_hey5

```
* removing test dependencies && unneeded compiling options
* creating the metapackage for pal_hey5
* Contributors: Aina Irisarri
* removing test dependencies && unneeded compiling options
* creating the metapackage for pal_hey5
* Contributors: Aina Irisarri
```

## pal_hey5_controller_configuration

```
* rename pal_hey_controllers.yaml into pal_hey_controller.yaml
* creating the pal_hey5_controller_configuration package
* Contributors: Aina Irisarri
* rename pal_hey_controllers.yaml into pal_hey_controller.yaml
* creating the pal_hey5_controller_configuration package
* Contributors: Aina Irisarri
```

## pal_hey5_description

```
* updating CHANGELOG package name
* updating version to 3.8
* deleting duplicated xacro dependency
* Changing structure of pal_hey5 gripper repo
* Contributors: Aina Irisarri
```
