### PR TITLE
Add python3-cvxopt

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5399,6 +5399,11 @@ python3-cryptography:
   rhel: ['python%{python3_pkgversion}-cryptography']
   ubuntu: [python3-cryptography]
 python3-cvxopt:
+  arch: [python-cvxopt]
+  debian: [python3-cvxopt]
+  fedora: [python-cvxopt]
+  gentoo: [dev-python/cvxopt]
+  nixos: [python311Packages.cvxopt]
   ubuntu: [python3-cvxopt]
 python3-cvxpy-pip: *migrate_eol_2025_04_30_python3_cvxpy_pip
 python3-cycler:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5398,6 +5398,8 @@ python3-cryptography:
   opensuse: [python3-cryptography]
   rhel: ['python%{python3_pkgversion}-cryptography']
   ubuntu: [python3-cryptography]
+python3-cvxopt:
+  ubuntu: [python3-cvxopt]
 python3-cvxpy-pip: *migrate_eol_2025_04_30_python3_cvxpy_pip
 python3-cycler:
   arch: [python-cycler]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

cvxopt

## Package Upstream Source:

[https://github.com/cvxopt/cvxopt](https://github.com/cvxopt/cvxopt)

## Purpose of using this:
Convex optimization python3 library for robot control.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/search?searchon=names&keywords=python3-cvxopt
- Ubuntu: https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=python3-cvxopt&searchon=names
- Fedora: https://src.fedoraproject.org/rpms/python-cvxopt
- Arch: https://archlinux.org/packages/extra/x86_64/python-cvxopt/
- Gentoo: https://packages.gentoo.org/packages/dev-python/cvxopt
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=23.11&show=python311Packages.cvxopt&from=0&size=50&sort=relevance&type=packages&query=cvxopt
