### PR TITLE
foxglove_bridge: 0.7.4-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1595,7 +1595,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 0.7.3-1
+      version: 0.7.4-1
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_bridge` to `0.7.4-1`:

- upstream repository: https://github.com/foxglove/ros-foxglove-bridge.git
- release repository: https://github.com/ros2-gbp/foxglove_bridge-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.3-1`

## foxglove_bridge

```
* Solved bug with incompatible QoS policies
* added explicit call to ParameterValue() to avoid clang error (#277 <https://github.com/foxglove/ros-foxglove-bridge/issues/277>)
* Add iron release badge to readme (#271 <https://github.com/foxglove/ros-foxglove-bridge/issues/271>)
* Contributors: Hans-Joachim Krauch, Ted
```
