### PR TITLE
Added python3-build

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5104,6 +5104,19 @@ python3-bson:
       packages: [bson]
   rhel: ['python%{python3_pkgversion}-bson']
   ubuntu: [python3-bson]
+python3-build:
+  alpine: [py3-build]
+  arch: [python-build]
+  debian: [python3-build]
+  fedora: [python3-build]
+  gentoo: [dev-python/build]
+  osx: [python-build]
+  rhel:
+    '*': [python3-build]
+    '8': null
+  ubuntu:
+    '*': [python3-build]
+    focal: null
 python3-cairo:
   arch: [python-cairo]
   debian: [python3-cairo]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-build

## Package Upstream Source:

https://github.com/pypa/build

## Purpose of using this:

This dependency is being used for a package that makes it easier to add python code to an  ament_cmake project.
It may be use to others who want to work on various python-related build processes with ROS.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/main/python3-build
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/jammy/python3-build
  - Not available in focal or earlier, added pip dependency
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-build/python3-build/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/any/python-build/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/build
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/python-build
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/community/x86_64/py3-build
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/
  - IF AVAILABLE
- rhel: https://rhel.pkgs.org/
  - IF AVAILABLE


