### PR TITLE
pick_ik: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3780,7 +3780,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pick_ik-release.git
-      version: 1.1.0-2
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/pick_ik.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3780,7 +3780,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pick_ik-release.git
-      version: 1.0.1-1
+      version: 1.1.0-2
     source:
       type: git
       url: https://github.com/PickNikRobotics/pick_ik.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pick_ik` to `1.1.0-1`:

- upstream repository: https://github.com/PickNikRobotics/pick_ik.git
- release repository: https://github.com/ros2-gbp/pick_ik-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.1-1`

## pick_ik

```
* Support continuous (unbounded) joints properly (#59 <https://github.com/PickNikRobotics/pick_ik/pull/59>)
* Run elite gradient descent in separate threads (#61 <https://github.com/PickNikRobotics/pick_ik/pull/61>)
* Contributors: Sebastian Castro
```
