### PR TITLE
launch_pal: 0.0.14-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2993,7 +2993,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/launch_pal-release.git
-      version: 0.0.8-2
+      version: 0.0.14-1
     source:
       type: git
       url: https://github.com/pal-robotics/launch_pal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_pal` to `0.0.14-1`:

- upstream repository: https://github.com/pal-robotics/launch_pal.git
- release repository: https://github.com/pal-gbp/launch_pal-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.8-2`

## launch_pal

```
* Update style errors
* fix typo and add type hint
* update typo
* Update configuration file keywords
* Enable autocomplete for robot arguments
* Use assertDictEqual in test
* Type hint and use get_share_directory function
* update readme
* Add tests
* Update include scoped launch for more intuitive use
* Contributors: David ter Kuile
```
