### PR TITLE
universal_robots: 1.3.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12118,6 +12118,7 @@ repositories:
       - ur10_moveit_config
       - ur10e_moveit_config
       - ur16e_moveit_config
+      - ur20_moveit_config
       - ur3_moveit_config
       - ur3e_moveit_config
       - ur5_moveit_config
@@ -12127,7 +12128,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-industrial-release/universal_robot-release.git
-      version: 1.3.1-1
+      version: 1.3.2-1
     source:
       type: git
       url: https://github.com/ros-industrial/universal_robot.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12111,7 +12111,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-industrial/universal_robot.git
-      version: melodic
+      version: noetic
     release:
       packages:
       - universal_robots
@@ -12132,7 +12132,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-industrial/universal_robot.git
-      version: melodic-devel
+      version: noetic-devel
     status: developed
   ur_client_library:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `universal_robots` to `1.3.2-1`:

- upstream repository: https://github.com/ros-industrial/universal_robot.git
- release repository: https://github.com/ros-industrial-release/universal_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.1-1`

## universal_robots

```
* UR20 description and meshes (#657 <https://github.com/ros-industrial/universal_robot/issues/657>)
* Contributors: Rune Søe-Knudsen
```

## ur10_moveit_config

- No changes

## ur10e_moveit_config

- No changes

## ur16e_moveit_config

- No changes

## ur20_moveit_config

```
* UR20 description and meshes (#657 <https://github.com/ros-industrial/universal_robot/issues/657>)
* Contributors: Rune Søe-Knudsen
```

## ur3_moveit_config

- No changes

## ur3e_moveit_config

- No changes

## ur5_moveit_config

- No changes

## ur5e_moveit_config

- No changes

## ur_description

```
* UR20 description and meshes (#657 <https://github.com/ros-industrial/universal_robot/issues/657>)
* Contributors: Rune Søe-Knudsen
```

## ur_gazebo

```
* UR20 description and meshes (#657 <https://github.com/ros-industrial/universal_robot/issues/657>)
* Contributors: Rune Søe-Knudsen
```
