### PR TITLE
tiago_navigation: 4.0.9-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8219,7 +8219,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_navigation-release.git
-      version: 4.0.5-1
+      version: 4.0.9-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_navigation` to `4.0.9-1`:

- upstream repository: https://github.com/pal-robotics/tiago_navigation.git
- release repository: https://github.com/pal-gbp/tiago_navigation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.5-1`

## tiago_2dnav

- No changes

## tiago_laser_sensors

```
* Bump module names
* Contributors: Noel Jimenez
```

## tiago_navigation

- No changes
