### PR TITLE
pmb2_simulation: 4.0.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4940,7 +4940,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_simulation-release.git
-      version: 4.0.4-1
+      version: 4.0.6-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_simulation` to `4.0.6-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_simulation.git
- release repository: https://github.com/pal-gbp/pmb2_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.4-1`

## pmb2_gazebo

```
* Add website tag
* Contributors: Noel Jimenez
```

## pmb2_simulation

```
* Add website tag
* Contributors: Noel Jimenez
```
