### PR TITLE
pmb2_navigation: 4.0.9-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4902,7 +4902,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_navigation-gbp.git
-      version: 4.0.5-1
+      version: 4.0.9-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_navigation` to `4.0.9-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_navigation.git
- release repository: https://github.com/pal-gbp/pmb2_navigation-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.5-1`

## pmb2_2dnav

```
* Merge branch 'fix/clean' into 'humble-devel'
  Clean old scripts
  See merge request robots/pmb2_navigation!77
* Clean old scripts
* Contributors: Noel Jimenez, antoniobrandi
```

## pmb2_laser_sensors

- No changes

## pmb2_maps

- No changes

## pmb2_navigation

- No changes
