### PR TITLE
play_motion2: 0.0.13-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4821,7 +4821,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/play_motion2-release.git
-      version: 0.0.10-1
+      version: 0.0.13-1
     source:
       type: git
       url: https://github.com/pal-robotics/play_motion2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `play_motion2` to `0.0.13-1`:

- upstream repository: https://github.com/pal-robotics/play_motion2.git
- release repository: https://github.com/pal-gbp/play_motion2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.10-1`

## play_motion2

```
* Rename launch argument for motions config
* Add default approach_planner config
* Add launch argument for approach_planner config
* Fix approach planner parameters check condition
* Avoid installing test configuration files
* Join test config files
* Fix motion_loader_test node name and params file
* Fix parameters node names
* Simplify controllers usage for testing
* Create MotionLoader to replace helpers
* Contributors: Noel Jimenez
```

## play_motion2_msgs

- No changes
