### PR TITLE
tiago_moveit_config: 3.0.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8200,7 +8200,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_moveit_config-release.git
-      version: 3.0.2-1
+      version: 3.0.7-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_moveit_config` to `3.0.7-1`:

- upstream repository: https://github.com/pal-robotics/tiago_moveit_config.git
- release repository: https://github.com/pal-gbp/tiago_moveit_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.2-1`

## tiago_moveit_config

```
* Add if statement for moveit sensor manager
* Newline at the end of the file
* Add moveit sensor params
* Contributors: David ter Kuile, Noel Jimenez
```
