### PR TITLE
ur_robot_driver: 2.1.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12176,7 +12176,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release.git
-      version: 2.1.2-1
+      version: 2.1.3-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.1.3-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver.git
- release repository: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.2-1`

## ur_calibration

```
* Bump cmake minimum version for all packages in repo
* Contributors: Felix Exner
```

## ur_dashboard_msgs

```
* Bump cmake minimum version for all packages in repo
* Contributors: Felix Exner
```

## ur_robot_driver

```
* Added support for UR20 (#659 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/659>)
* Update documentation (#655 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/655>)
* Bump required cmake version to fix the CMake warning about CMP0048
* Change initializer list ordering to match declaration in header file
* Implemented spline interpolation in joint space (#543 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/543>)
* Use dedicated build for noetic main (#640 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/640>)
* fix typo and use ros logging
* Contributors: Felix Exner, Felix Exner (fexner), Mads Holm Peters, RobertWilbrandt, Simon Schmeisser
```
