### PR TITLE
add motion_capture_tracking to humble/iron/rolling

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3693,6 +3693,16 @@ repositories:
       url: https://github.com/MOLAorg/mola.git
       version: develop
     status: developed
+  motion_capture_tracking:
+    doc:
+      type: git
+      url: https://github.com/IMRCLab/motion_capture_tracking.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/IMRCLab/motion_capture_tracking.git
+      version: ros2
+    status: developed
   moveit:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3070,6 +3070,16 @@ repositories:
       url: https://github.com/MOLAorg/mola.git
       version: develop
     status: developed
+  motion_capture_tracking:
+    doc:
+      type: git
+      url: https://github.com/IMRCLab/motion_capture_tracking.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/IMRCLab/motion_capture_tracking.git
+      version: ros2
+    status: developed
   moveit:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2921,6 +2921,16 @@ repositories:
       url: https://github.com/MOLAorg/mola.git
       version: develop
     status: developed
+  motion_capture_tracking:
+    doc:
+      type: git
+      url: https://github.com/IMRCLab/motion_capture_tracking.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/IMRCLab/motion_capture_tracking.git
+      version: ros2
+    status: developed
   moveit:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

Humble, Iron, Rolling

# The source is here:

https://github.com/IMRCLab/motion_capture_tracking/tree/ros2

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
