### PR TITLE
gazebo_model_attachment_plugin: 1.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2081,6 +2081,15 @@ repositories:
       url: https://github.com/foxglove/schemas.git
       version: main
     status: developed
+  gazebo_model_attachment_plugin:
+    release:
+      packages:
+      - gazebo_model_attachment_plugin
+      - gazebo_model_attachment_plugin_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/boeing_gazebo_model_attachement_plugin-release.git
+      version: 1.0.3-1
   gazebo_ros2_control:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_model_attachment_plugin` to `1.0.3-1`:

- upstream repository: https://github.com/Boeing/gazebo_model_attachment_plugin.git
- release repository: https://github.com/ros2-gbp/boeing_gazebo_model_attachement_plugin-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
