### PR TITLE
gazebo_model_attachment_plugin: 1.0.2-4 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3168,6 +3168,15 @@ repositories:
       url: https://github.com/ctu-vras/gazebo_custom_sensor_preloader.git
       version: master
     status: maintained
+  gazebo_model_attachment_plugin:
+    release:
+      packages:
+      - gazebo_model_attachment_plugin
+      - gazebo_model_attachment_plugin_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros2-gbp/boeing_gazebo_model_attachement_plugin-release.git
+      version: 1.0.2-4
   gazebo_ros_control_select_joints:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_model_attachment_plugin` to `1.0.2-4`:

- upstream repository: https://github.com/Boeing/gazebo_model_attachment_plugin.git
- release repository: https://github.com/ros2-gbp/boeing_gazebo_model_attachement_plugin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
