### PR TITLE
rmf_internal_msgs: 3.0.4 in humble/distribution.yaml

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5857,7 +5857,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
-      version: 3.0.3-1
+      version: 3.0.4-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_internal_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_internal_msgs` to `3.0.4-1`:

- upstream repository: https://github.com/open-rmf/rmf_internal_msgs.git
- release repository: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.3-1`

## rmf_charger_msgs

- No changes

## rmf_dispenser_msgs

- No changes

## rmf_door_msgs

- No changes

## rmf_fleet_msgs

```
* Delivery alerts and beacons (#60 <https://github.com/open-rmf/rmf_internal_msgs/pull/60>)
* Mutex groups and dynamic charging (#59 <https://github.com/open-rmf/rmf_internal_msgs/pull/59>)
```

## rmf_ingestor_msgs

- No changes

## rmf_lift_msgs

- No changes

## rmf_obstacle_msgs

- No changes

## rmf_scheduler_msgs

- No changes

## rmf_site_map_msgs

- No changes

## rmf_task_msgs

- No changes

## rmf_traffic_msgs

- No changes

## rmf_workcell_msgs

- No changes
