### PR TITLE
rmf_ros2: 2.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4724,6 +4724,7 @@ repositories:
       version: main
     release:
       packages:
+      - rmf_charging_schedule
       - rmf_fleet_adapter
       - rmf_fleet_adapter_python
       - rmf_task_ros2
@@ -4732,7 +4733,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 2.3.2-1
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_ros2` to `2.4.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_ros2.git
- release repository: https://github.com/ros2-gbp/rmf_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.2-1`

## rmf_charging_schedule

```
* First release
```

## rmf_fleet_adapter

```
* Mutex Groups, localization hook, dynamic charging, and new graph elements (#310 <https://github.com/open-rmf/rmf_ros2/pull/310>)
```

## rmf_fleet_adapter_python

- No changes

## rmf_task_ros2

- No changes

## rmf_traffic_ros2

- No changes

## rmf_websocket

- No changes
