### PR TITLE
rmf_ros2: 2.1.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5878,7 +5878,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 2.1.7-1
+      version: 2.1.8-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_ros2` to `2.1.8-1`:

- upstream repository: https://github.com/open-rmf/rmf_ros2.git
- release repository: https://github.com/ros2-gbp/rmf_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.7-1`

## rmf_fleet_adapter

```
* Cancel automatic pending tasks that are removed during new assignments (#301 <https://github.com/open-rmf/rmf_ros2/pull/303>)
* Contributors: Aaron Chong
```

## rmf_fleet_adapter_python

- No changes

## rmf_task_ros2

- No changes

## rmf_traffic_ros2

- No changes

## rmf_websocket

- No changes
