### PR TITLE
rmf_task: 2.2.3-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5059,7 +5059,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
-      version: 2.2.2-1
+      version: 2.2.3-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_task.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_task` to `2.2.3-1`:

- upstream repository: https://github.com/open-rmf/rmf_task.git
- release repository: https://github.com/ros2-gbp/rmf_task-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.2-1`

## rmf_task

```
* Allow charging tasks to run indefinitely (#99 <https://github.com/open-rmf/rmf_task/pull/99>, #100 <https://github.com/open-rmf/rmf_task/pull/100>)
```

## rmf_task_sequence

```
* Fix edge case for task sequences (#102 <https://github.com/open-rmf/rmf_task/pull/102>)
```
