### PR TITLE
rmf_task: 2.1.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5918,7 +5918,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
-      version: 2.1.6-1
+      version: 2.1.7-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_task.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_task` to `2.1.7-1`:

- upstream repository: https://github.com/open-rmf/rmf_task.git
- release repository: https://github.com/ros2-gbp/rmf_task-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.6-1`

## rmf_task

```
* Fix race condition risk for task sequences (#102 <https://github.com/open-rmf/rmf_task/pull/102>)
* Allow charging tasks to run indefinitely (#99 <https://github.com/open-rmf/rmf_task/pull/99>, #100 <https://github.com/open-rmf/rmf_task/pull/100>)
```

## rmf_task_sequence

```
* Fix race condition risk for task sequences (#102 <https://github.com/open-rmf/rmf_task/pull/102>)
```
