### PR TITLE
behaviortree_cpp_v4: 4.4.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -527,7 +527,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.4.2-1
+      version: 4.4.3-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp_v4` to `4.4.3-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.4.2-1`

## behaviortree_cpp

```
* fix issue #725 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/725> : SetBlackboard can copy entries
* add more unit tests
* fix typos #721 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/721>
* fix: guard macro declaration to prevent redefinition warning
* fix: Rename scoped lock so it doesn't hide the outer lock triggering a compiler warning
* add private ports to exclude from autoremapping #706 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/706>
* fix issue #713 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/713>:  getNodesByPath should be const
* Contributors: Davide Faconti, Nestor Gonzalez, Tony Paulussen
```
