### PR TITLE
boeing_gazebo_model_attachment_plugin: 1.0.3-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -720,10 +720,19 @@ repositories:
       type: git
       url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
       version: humble
+    release:
+      packages:
+      - gazebo_model_attachment_plugin
+      - gazebo_model_attachment_plugin_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/boeing_gazebo_model_attachement_plugin-release.git
+      version: 1.0.3-2
     source:
       type: git
       url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
       version: humble
+    status: maintained
   boeing_gazebo_set_joint_positions_plugin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `boeing_gazebo_model_attachment_plugin` to `1.0.3-2`:

- upstream repository: https://github.com/Boeing/gazebo_model_attachment_plugin.git
- release repository: https://github.com/ros2-gbp/boeing_gazebo_model_attachement_plugin-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
