### PR TITLE
boeing_gazebo_model_attachment_plugin: 1.0.2-5 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -538,10 +538,18 @@ repositories:
       type: git
       url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
       version: noetic
+    release:
+      packages:
+      - gazebo_model_attachment_plugin
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros2-gbp/boeing_gazebo_model_attachement_plugin-release.git
+      version: 1.0.2-5
     source:
       type: git
       url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
       version: noetic
+    status: maintained
   boeing_gazebo_set_joint_positions_plugin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `boeing_gazebo_model_attachment_plugin` to `1.0.2-5`:

- upstream repository: https://github.com/Boeing/gazebo_model_attachment_plugin.git
- release repository: https://github.com/ros2-gbp/boeing_gazebo_model_attachement_plugin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
