### PR TITLE
rmf_traffic: 3.1.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5078,7 +5078,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic-release.git
-      version: 3.1.0-1
+      version: 3.1.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_traffic` to `3.1.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_traffic.git
- release repository: https://github.com/ros2-gbp/rmf_traffic-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.1.0-1`

## rmf_traffic

```
* New graph elements and various fixes (#103 <https://github.com/open-rmf/rmf_traffic/pull/103>)
```

## rmf_traffic_examples

```
* New graph elements and various fixes (#103 <https://github.com/open-rmf/rmf_traffic/pull/103>)
```
