### PR TITLE
rmf_traffic_editor: 1.8.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4811,7 +4811,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
-      version: 1.8.1-1
+      version: 1.8.2-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic_editor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_traffic_editor` to `1.8.2-1`:

- upstream repository: https://github.com/open-rmf/rmf_traffic_editor.git
- release repository: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.8.1-1`

## rmf_building_map_tools

```
* Export door information to nav graphs (#479 <https://github.com/open-rmf/rmf_traffic_editor/pull/479>)
* Export lift information to nav graphs (#478 <https://github.com/open-rmf/rmf_traffic_editor/pull/478>)
```

## rmf_traffic_editor

```
* Merge radius property (#480 <https://github.com/open-rmf/rmf_traffic_editor/pull/480>)
* Mutex group property (#477 <https://github.com/open-rmf/rmf_traffic_editor/pull/477>)
```

## rmf_traffic_editor_assets

- No changes

## rmf_traffic_editor_test_maps

- No changes
