### PR TITLE
robot_localization: 3.5.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6202,7 +6202,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/robot_localization-release.git
-      version: 3.5.1-2
+      version: 3.5.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `3.5.2-1`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/ros2-gbp/robot_localization-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.5.1-2`

## robot_localization

```
* fix header timestamp (#852 <https://github.com/cra-ros-pkg/robot_localization/issues/852>)
  Co-authored-by: Luke Chang <mailto:luke@boxfish.nz>
* Wait for odometry message before setting manual datum so that the base and world frame names can be set. (#835 <https://github.com/cra-ros-pkg/robot_localization/issues/835>)
  * wait for odom msg before setting manual datum
* Utm using geographiclib humble branch (#834 <https://github.com/cra-ros-pkg/robot_localization/issues/834>)
  * Add single test for navsat_conversions
  * Add a southern point to the navsat_transform test
  * LLtoUTM using GeographicLib
  * Use GeographicLib for UTMtoLL conversions
  * Linting
  * Forgot include
  * Fix compilation
  * Calculate gamma because it's a function output and was supplied before
  * Also test for gamma conversion
  * Align naming and install
* Contributors: Luke Chang, Tim Clephas, Tom Greier
```
