### PR TITLE
add ethtool

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -943,6 +943,15 @@ enet:
   gentoo: [net-libs/enet]
   nixos: [enet]
   ubuntu: [libenet-dev]
+ethtool:
+  alpine: [ethtool]
+  arch: [ethtool]
+  debian: [ethtool]
+  fedora: [ethtool]
+  gentoo: [ethtool]
+  nixos: [ethtool]
+  opensuse: [ethtool]
+  ubuntu: [ethtool]
 espeak:
   debian: [espeak]
   fedora: [espeak]


### PR DESCRIPTION
## Package name:
ethtool

## Package Upstream Source:
- https://github.com/serhepopovych/ethtool
- 
## Purpose of using this:
This dependency is being used for manipulating and displaying network interface. 

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?searchon=contents&keywords=ethtool&mode=path&suite=stable&arch=any
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?searchon=contents&keywords=ethtool&mode=exactfilename&suite=kinetic&arch=any
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/search?query=ethtool
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/?sort=&q=ethtool&maintainer=&flagged=
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/search?q=ethtool
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/packages?name=ethtool&branch=edge&repo=&arch=&maintainer=
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=23.11&from=0&size=50&sort=relevance&type=packages&query=ethtool
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/search?baseproject=ALL&q=ethtool

# Please Add This Package to be indexed in the rosdistro.

HUMBLE
# The source is here:

https://github.com/ros/rosdistro/tree/master/humble
