### PR TITLE
tiago_simulation: 4.0.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8257,7 +8257,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_simulation-release.git
-      version: 4.0.5-1
+      version: 4.0.6-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_simulation` to `4.0.6-1`:

- upstream repository: https://github.com/pal-robotics/tiago_simulation
- release repository: https://github.com/pal-gbp/tiago_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.5-1`

## tiago_gazebo

```
* move world_name to pal_gazebo_worlds
* Disable tuck_arm_test
* Contributors: Noel Jimenez, antoniobrandi
```

## tiago_simulation

- No changes
