### PR TITLE
pybind11_json_vendor: 3.0.1-1 in 'iron/distribution.yaml'

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4376,7 +4376,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/pybind11_json_vendor-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/open-rmf/pybind11_json_vendor.git


### PR DESCRIPTION
Manually opening this PR since `bloom-release` encountered an error when automating this step.

Release repo: https://github.com/ros2-gbp/pybind11_json_vendor-release