### PR TITLE
add ethtool

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -949,6 +949,16 @@ espeak:
   gentoo: [app-accessibility/espeak]
   nixos: [espeak]
   ubuntu: [espeak]
+ethtool:
+  alpine: [ethtool]
+  arch: [ethtool]
+  debian: [ethtool]
+  fedora: [ethtool]
+  gentoo: [ethtool]
+  nixos: [ethtool]
+  opensuse: [ethtool]
+  rhel: [ethtool]
+  ubuntu: [ethtool]
 exfat-fuse:
   debian: [exfat-fuse]
   gentoo: [sys-fs/fuse-exfat]


### PR DESCRIPTION
## Package name:
ethtool

## Package Upstream Source:
- https://github.com/serhepopovych/ethtool
- 
## Purpose of using this:
This dependency is being used for manipulating and displaying network interface. 

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?searchon=contents&keywords=ethtool&mode=path&suite=stable&arch=any
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?searchon=contents&keywords=ethtool&mode=exactfilename&suite=kinetic&arch=any
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/search?query=ethtool
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/?sort=&q=ethtool&maintainer=&flagged=
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/search?q=ethtool
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/packages?name=ethtool&branch=edge&repo=&arch=&maintainer=
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=23.11&from=0&size=50&sort=relevance&type=packages&query=ethtool
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/search?baseproject=ALL&q=ethtool
  - rhel: https://almalinux.pkgs.org/9/almalinux-baseos-aarch64/
  - https://almalinux.pkgs.org/9/almalinux-baseos-aarch64/ethtool-6.2-1.el9.aarch64.rpm.html

# Please Add This Package to be indexed in the rosdistro.

HUMBLE
# The source is here:

https://github.com/ros/rosdistro/tree/master/humble
