### PR TITLE
rmf_utils: 1.5.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5113,7 +5113,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_utils-release.git
-      version: 1.5.0-1
+      version: 1.5.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_utils` to `1.5.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_utils.git
- release repository: https://github.com/ros2-gbp/rmf_utils-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.5.0-1`

## rmf_utils

- No changes
