### PR TITLE
rmf_battery: 0.2.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4930,7 +4930,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_battery-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_battery.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_battery` to `0.2.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_battery.git
- release repository: https://github.com/ros2-gbp/rmf_battery-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.0-1`

## rmf_battery

- No changes
