### PR TITLE
Temporarily remove 'mola' package (transitional)

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3673,35 +3673,6 @@ repositories:
       url: https://github.com/OrebroUniversity/mod.git
       version: master
     status: developed
-  mola:
-    doc:
-      type: git
-      url: https://github.com/MOLAorg/mola.git
-      version: develop
-    release:
-      packages:
-      - mola_common
-      - mola_demos
-      - mola_imu_preintegration
-      - mola_input_euroc_dataset
-      - mola_input_kitti_dataset
-      - mola_input_rawlog
-      - mola_input_ros2
-      - mola_kernel
-      - mola_launcher
-      - mola_test_datasets
-      - mola_viz
-      - mola_yaml
-      - mp2p_icp
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/ros2-gbp/mola-release.git
-      version: 0.2.2-1
-    source:
-      type: git
-      url: https://github.com/MOLAorg/mola.git
-      version: develop
-    status: developed
   mola_common:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3056,35 +3056,6 @@ repositories:
       url: https://github.com/DFKI-NI/mir_robot.git
       version: rolling
     status: developed
-  mola:
-    doc:
-      type: git
-      url: https://github.com/MOLAorg/mola.git
-      version: develop
-    release:
-      packages:
-      - mola_common
-      - mola_demos
-      - mola_imu_preintegration
-      - mola_input_euroc_dataset
-      - mola_input_kitti_dataset
-      - mola_input_rawlog
-      - mola_input_ros2
-      - mola_kernel
-      - mola_launcher
-      - mola_test_datasets
-      - mola_viz
-      - mola_yaml
-      - mp2p_icp
-      tags:
-        release: release/iron/{package}/{version}
-      url: https://github.com/ros2-gbp/mola-release.git
-      version: 0.2.2-1
-    source:
-      type: git
-      url: https://github.com/MOLAorg/mola.git
-      version: develop
-    status: developed
   mola_common:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2892,35 +2892,6 @@ repositories:
       url: https://github.com/DFKI-NI/mir_robot.git
       version: rolling
     status: developed
-  mola:
-    doc:
-      type: git
-      url: https://github.com/MOLAorg/mola.git
-      version: develop
-    release:
-      packages:
-      - mola_common
-      - mola_demos
-      - mola_imu_preintegration
-      - mola_input_euroc_dataset
-      - mola_input_kitti_dataset
-      - mola_input_rawlog
-      - mola_input_ros2
-      - mola_kernel
-      - mola_launcher
-      - mola_test_datasets
-      - mola_viz
-      - mola_yaml
-      - mp2p_icp
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/mola-release.git
-      version: 0.2.2-1
-    source:
-      type: git
-      url: https://github.com/MOLAorg/mola.git
-      version: develop
-    status: developed
   mola_common:
     doc:
       type: git


### PR DESCRIPTION
This PR removes the entire section for the `mola` package (and all their released packages), as a transition towards the new organization of packages as discussed in https://github.com/ros/rosdistro/pull/39209

Once this one is merged, I'll open new PRs for the corresponding new packages, now without risk of conflicts of packages with the same name coexisting.