### PR TITLE
bcr_bot: 0.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -501,6 +501,21 @@ repositories:
       url: https://github.com/uos/basler_tof.git
       version: noetic
     status: developed
+  bcr_bot:
+    doc:
+      type: git
+      url: https://github.com/blackcoffeerobotics/bcr_bot.git
+      version: ros1
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/blackcoffeerobotics/bcr_bot-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/blackcoffeerobotics/bcr_bot.git
+      version: ros1
+    status: developed
   behaviortree_cpp_v3:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -510,7 +510,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/blackcoffeerobotics/bcr_bot-release.git
-      version: 0.0.1-1
+      version: 0.0.1-4
     source:
       type: git
       url: https://github.com/blackcoffeerobotics/bcr_bot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bcr_bot` to `0.0.1-4`:

- upstream repository: https://github.com/blackcoffeerobotics/bcr_bot.git
- release repository: https://github.com/blackcoffeerobotics/bcr_bot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## bcr_bot

```
* added stereo camera
* New Chassis, Updated URDF, new small_warehouse World, Updated readme
* Conveyor
* odom topic as argument
* Gazebo plugin publishing joint states
* Added Kinect Plugin
* Added saved map
* Added cartographer
* Added visualization
* changes in modelling, improved velocity response
* Added collision
* Added LiDAR and IMU
* Shifted traction to middle wheels
* Added robot
* Initial commit
* Contributors: Devanshu Sharma, Gaurav Gupta, Kvk Praneeth, Leander Stephen D'Souza, praneeth_bcr
```
