### PR TITLE
rsl: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7355,7 +7355,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/RSL-release.git
-      version: 1.0.1-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/RSL.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rsl` to `1.1.0-1`:

- upstream repository: https://github.com/PickNikRobotics/RSL.git
- release repository: https://github.com/ros2-gbp/RSL-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.1-1`

## rsl

```
* Fix ament_target_dependencies integration
* Add rsl::maybe_error
* Disable tests by default
* Stop using non-standard M_PI
* Contributors: Chris Thrasher
```
