### PR TITLE
rmf_building_map_msgs: 1.3.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4955,7 +4955,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_building_map_msgs-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_building_map_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_building_map_msgs` to `1.3.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_building_map_msgs.git
- release repository: https://github.com/ros2-gbp/rmf_building_map_msgs-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.0-1`

## rmf_building_map_msgs

- No changes
