### PR TITLE
bcr_bot: 1.0.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -672,16 +672,16 @@ repositories:
     doc:
       type: git
       url: https://github.com/blackcoffeerobotics/bcr_bot.git
-      version: 1.0.1
+      version: ros2
     release:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/blackcoffeerobotics/bcr_bot_ros2-release.git
-      version: 1.0.1-2
+      version: 1.0.1-3
     source:
       type: git
       url: https://github.com/blackcoffeerobotics/bcr_bot.git
-      version: 1.0.1
+      version: ros2
     status: developed
   behaviortree_cpp_v3:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -668,6 +668,21 @@ repositories:
       url: https://github.com/wep21/bag2_to_image.git
       version: main
     status: maintained
+  bcr_bot:
+    doc:
+      type: git
+      url: https://github.com/blackcoffeerobotics/bcr_bot.git
+      version: 1.0.1
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/blackcoffeerobotics/bcr_bot_ros2-release.git
+      version: 1.0.1-2
+    source:
+      type: git
+      url: https://github.com/blackcoffeerobotics/bcr_bot.git
+      version: 1.0.1
+    status: developed
   behaviortree_cpp_v3:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bcr_bot` to `1.0.1-3`:

- upstream repository: https://github.com/blackcoffeerobotics/bcr_bot.git
- release repository: https://github.com/blackcoffeerobotics/bcr_bot_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## bcr_bot

```
* added ground truth odometry
* added stereo_cam to bcr_bot
* Modified chassis desgin, Updated URDF, all the sensors working, namespace done
* Gz addition
* Conveyor
* odom topic as argument
* Added Kinect Plugin
* Added visualization
* changes in modelling, improved velocity response
* Added LiDAR and IMU
* Shifted traction to middle wheels
* Added robot
* Initial commit
* Contributors: Arthur Gomes, Devanshu Sharma, Gaurav Gupta, Kvk Praneeth, Leander Stephen D'Souza, praneeth_bcr
```
