### PR TITLE
ros2_controllers: 2.30.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6356,7 +6356,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.29.0-1
+      version: 2.30.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.30.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.29.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

- No changes

## bicycle_steering_controller

- No changes

## diff_drive_controller

```
* [DiffDriveController] Optional tf namespace prefixes instead of using node namespace (backport #533 <https://github.com/ros-controls/ros2_controllers/issues/533>) (#726 <https://github.com/ros-controls/ros2_controllers/issues/726>)
* Contributors: mergify[bot]
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* Fix floating point comparison in JTC (backport #879 <https://github.com/ros-controls/ros2_controllers/issues/879>)
* [JTC] Continue with last trajectory-point on success (backport #842 <https://github.com/ros-controls/ros2_controllers/issues/842>)
* [JTC] Remove start_with_holding option (backport #839 <https://github.com/ros-controls/ros2_controllers/issues/839>)
* [JTC] Activate checks for parameter validation backport (#857 <https://github.com/ros-controls/ros2_controllers/issues/857>)
* [JTC] Improve update methods for tests (backport #858 <https://github.com/ros-controls/ros2_controllers/issues/858>)
* [JTC] Fix dynamic reconfigure of tolerances (backport #849 <https://github.com/ros-controls/ros2_controllers/issues/849>)
* [JTC] Remove unused home pose (backport #845 <https://github.com/ros-controls/ros2_controllers/issues/845>)
* [JTC] Activate update of dynamic parameters (backport #761 <https://github.com/ros-controls/ros2_controllers/issues/761>)
* [JTC] Fix tests when state offset is used (backport #797 <https://github.com/ros-controls/ros2_controllers/issues/797>)
* Rename wraparound class variables (backport #834 <https://github.com/ros-controls/ros2_controllers/issues/834>)
* Update requirements of state interfaces (backport #798 <https://github.com/ros-controls/ros2_controllers/issues/798>)
* [JTC] Fix typos, implicit cast, const member functions (backport #748 <https://github.com/ros-controls/ros2_controllers/issues/748>)
* Cleanup comments and unnecessary checks (backport #803 <https://github.com/ros-controls/ros2_controllers/issues/803>)
* [JTC] Add tests for acceleration command interface (backport #752 <https://github.com/ros-controls/ros2_controllers/issues/752>)
* [Docs] Improve interface description of JTC (backport #770 <https://github.com/ros-controls/ros2_controllers/issues/770>)
* [JTC] Add time-out for trajectory interfaces (backport #609 <https://github.com/ros-controls/ros2_controllers/issues/609>)
* [JTC] Fix hold position mode with goal_time>0 (backport #758 <https://github.com/ros-controls/ros2_controllers/issues/758>)
* [JTC] Add note on goal_time=0 in docs (backport #773 <https://github.com/ros-controls/ros2_controllers/issues/773>)
* [JTC] Make most parameters read-only (backport #771 <https://github.com/ros-controls/ros2_controllers/issues/771>)
* [JTC] Tolerance tests + Hold on time violation (backport #613 <https://github.com/ros-controls/ros2_controllers/issues/613>)
* [JTC] Explicitly set hold position (backport #558 <https://github.com/ros-controls/ros2_controllers/issues/558>)
* [Doc] Fix links (backport #715 <https://github.com/ros-controls/ros2_controllers/issues/715>)
* Contributors: Christoph Fröhlich, Dr Denis Stogl, Bence Magyar, Abishalini Sivaraman
```

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

```
* Fix rqt jtc bugs for continuous joints and other minor bugs (#890 <https://github.com/ros-controls/ros2_controllers/issues/890>) (#897 <https://github.com/ros-controls/ros2_controllers/issues/897>)
* Adapted rqt_jtc to newest control_msgs for jtc (#643 <https://github.com/ros-controls/ros2_controllers/issues/643>) (#659 <https://github.com/ros-controls/ros2_controllers/issues/659>)
* Contributors: Guillaume Walck, Sai Kishor Kothakota
```

## steering_controllers_library

```
* Changing default int values to double in steering controller's yaml file (#927 <https://github.com/ros-controls/ros2_controllers/issues/927>) (#928 <https://github.com/ros-controls/ros2_controllers/issues/928>)
* Contributors: mergify[bot]
```

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
