### PR TITLE
Add mp2p_icp for indexing in humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3791,6 +3791,16 @@ repositories:
       url: https://github.com/ros-planning/moveit_visual_tools.git
       version: ros2
     status: maintained
+  mp2p_icp:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mp2p_icp.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mp2p_icp.git
+      version: master
+    status: developed
   mqtt_client:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble 

# The source is here:

https://github.com/MOLAorg/mp2p_icp

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro


Follow up of #39211 