### PR TITLE
pal_hey5: 4.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4593,7 +4593,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_hey5-release.git
-      version: 4.0.0-1
+      version: 4.0.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_hey5.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_hey5` to `4.0.1-1`:

- upstream repository: https://github.com/pal-robotics/pal_hey5.git
- release repository: https://github.com/pal-gbp/pal_hey5-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.0-1`

## pal_hey5

- No changes

## pal_hey5_controller_configuration

- No changes

## pal_hey5_description

```
* Move include of materials.urdf.xacro
* Use pal_urdf_utils materials and deg_to_rad
* Contributors: Noel Jimenez
```
