### PR TITLE
tiago_robot: 4.0.28-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8264,7 +8264,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_robot-release.git
-      version: 4.0.27-1
+      version: 4.0.28-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_robot` to `4.0.28-1`:

- upstream repository: https://github.com/pal-robotics/tiago_robot
- release repository: https://github.com/pal-gbp/tiago_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.27-1`

## tiago_bringup

- No changes

## tiago_controller_configuration

```
* adding pal_hey5 as dependency
* removing temporal exception for hey5 gripper
* relocate the pal-hey5 configuration and launch files
* Contributors: Aina Irisarri
```

## tiago_description

```
* renaming hey5 package and the xacro files into pal_hey5
* Contributors: Aina Irisarri
```

## tiago_robot

- No changes
