### PR TITLE
keys for GCC 10

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1190,6 +1190,12 @@ fxload:
   debian: [fxload]
   fedora: [fxload]
   ubuntu: [fxload]
+g++-10:
+  debian:
+    bullseye: [g++-10]
+  ubuntu:
+    focal: [g++-10]
+    jammy: [g++-10]
 g++-5-arm-linux-gnueabihf:
   ubuntu: [g++-5-arm-linux-gnueabihf]
 g++-5-multilib:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

g++10

## Purpose of using this:

GNU C and C++ compiler for packages that do not support newer (default) compiler.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/g%2B%2B-10
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/jammy/g++-10
