### PR TITLE
urdf: 2.10.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7226,7 +7226,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdf-release.git
-      version: 2.9.0-1
+      version: 2.10.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf` to `2.10.0-1`:

- upstream repository: https://github.com/ros2/urdf.git
- release repository: https://github.com/ros2-gbp/urdf-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.9.0-1`

## urdf

```
* Switch to target_link_libraries (#36 <https://github.com/ros2/urdf/issues/36>)
* Contributors: Chris Lalancette
```

## urdf_parser_plugin

```
* Switch to target_link_libraries (#36 <https://github.com/ros2/urdf/issues/36>)
* Contributors: Chris Lalancette
```
