### PR TITLE
rmw_fastrtps: 8.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4954,7 +4954,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 8.0.0-1
+      version: 8.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `8.1.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `8.0.0-1`

## rmw_fastrtps_cpp

```
* Switch to target_link_libraries for linking. (#734 <https://github.com/ros2/rmw_fastrtps/issues/734>)
* Contributors: Chris Lalancette
```

## rmw_fastrtps_dynamic_cpp

```
* Switch to target_link_libraries for linking. (#734 <https://github.com/ros2/rmw_fastrtps/issues/734>)
* Contributors: Chris Lalancette
```

## rmw_fastrtps_shared_cpp

```
* Switch to target_link_libraries for linking. (#734 <https://github.com/ros2/rmw_fastrtps/issues/734>)
* Contributors: Chris Lalancette
```
