### PR TITLE
rcutils: 6.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4518,7 +4518,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 6.4.1-1
+      version: 6.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `6.5.0-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `6.4.1-1`

## rcutils

```
* Remove two last uses of ament_target_dependencies. (#440 <https://github.com/ros2/rcutils/issues/440>)
* time_win32: Update dead link (#438 <https://github.com/ros2/rcutils/issues/438>)
* Contributors: Chris Lalancette, Silvio Traversaro
```
