### PR TITLE
rclpy: 7.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4451,7 +4451,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 6.0.0-1
+      version: 7.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `7.0.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `6.0.0-1`

## rclpy

```
* Add doc-string warnings for destroy methods for services. (#1205 <https://github.com/ros2/rclpy/issues/1205>)
* Add doc-string warnings for destroy() methods (#1204 <https://github.com/ros2/rclpy/issues/1204>)
* Add an optional timeout_sec input to Client.call() to fix issue https://github.com/ros2/rclpy/issues/1181 (#1188 <https://github.com/ros2/rclpy/issues/1188>)
* aligh with rcl that a rosout publisher of a node might not exist (#1196 <https://github.com/ros2/rclpy/issues/1196>)
* call ok() to see if rclpy and context is initialized. (#1198 <https://github.com/ros2/rclpy/issues/1198>)
* Contributors: Chen Lihui, KKSTB, Steve Peters, Tomoya Fujita
```
