### PR TITLE
rclcpp: 25.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4435,7 +4435,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 24.0.0-1
+      version: 25.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `25.0.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `24.0.0-1`

## rclcpp

```
* Updated GenericSubscription to AnySubscriptionCallback (#1928 <https://github.com/ros2/rclcpp/issues/1928>)
* make type support helper supported for service (#2209 <https://github.com/ros2/rclcpp/issues/2209>)
* Adding QoS to subscription options (#2323 <https://github.com/ros2/rclcpp/issues/2323>)
* Switch to target_link_libraries. (#2374 <https://github.com/ros2/rclcpp/issues/2374>)
* aligh with rcl that a rosout publisher of a node might not exist (#2357 <https://github.com/ros2/rclcpp/issues/2357>)
* Fix data race in EventHandlerBase (#2349 <https://github.com/ros2/rclcpp/issues/2349>)
* Support users holding onto shared pointers in the message memory pool (#2336 <https://github.com/ros2/rclcpp/issues/2336>)
* Contributors: Chen Lihui, Chris Lalancette, DensoADAS, Lucas Wendland, mauropasse
```

## rclcpp_action

```
* Switch to target_link_libraries. (#2374 <https://github.com/ros2/rclcpp/issues/2374>)
* Contributors: Chris Lalancette
```

## rclcpp_components

```
* Switch to target_link_libraries. (#2374 <https://github.com/ros2/rclcpp/issues/2374>)
* feat(rclcpp_components): support events executor in node main template (#2366 <https://github.com/ros2/rclcpp/issues/2366>)
* fix(rclcpp_components): increase the service queue sizes in component_container (#2363 <https://github.com/ros2/rclcpp/issues/2363>)
* Contributors: Chris Lalancette, Daisuke Nishimatsu, M. Fatih Cırıt
```

## rclcpp_lifecycle

- No changes
