### PR TITLE
rcl_logging: 2.7.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4382,7 +4382,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 2.7.0-1
+      version: 2.7.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `2.7.1-1`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.7.0-1`

## rcl_logging_interface

```
* Migrate to std::filesystem (#104 <https://github.com/ros2/rcl_logging/issues/104>)
* Contributors: Kenta Yonekura
```

## rcl_logging_noop

- No changes

## rcl_logging_spdlog

```
* Migrate to std::filesystem (#104 <https://github.com/ros2/rcl_logging/issues/104>)
* Contributors: Kenta Yonekura
```
