### PR TITLE
launch_ros: 0.26.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2439,7 +2439,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.26.2-1
+      version: 0.26.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.26.3-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.26.2-1`

## launch_ros

- No changes

## launch_testing_ros

```
* added type hinting to launch_testing_ros/test/examples (#386 <https://github.com/ros2/launch_ros/issues/386>)
* Contributors: Yaswanth
```

## ros2launch

- No changes
