### PR TITLE
geometry2: 0.35.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1718,7 +1718,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.34.0-1
+      version: 0.35.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.35.0-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.34.0-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* Update the tf2 documentation (#638 <https://github.com/ros2/geometry2/issues/638>)
* Contributors: Chris Lalancette
```

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

```
* Remove unnecessary use of ament_target_dependencies. (#637 <https://github.com/ros2/geometry2/issues/637>)
  We can just use target_link_libraries instead.
* Contributors: Chris Lalancette
```

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Avoid unecessary time conversions. (#635 <https://github.com/ros2/geometry2/issues/635>)
* Contributors: AiVerisimilitude
```

## tf2_ros_py

- No changes

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
