### PR TITLE
ros_tutorials: 1.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5444,7 +5444,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_tutorials-release.git
-      version: 1.7.4-1
+      version: 1.8.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_tutorials` to `1.8.0-1`:

- upstream repository: https://github.com/ros/ros_tutorials.git
- release repository: https://github.com/ros2-gbp/ros_tutorials-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.7.4-1`

## turtlesim

```
* Remove all uses of ament_target_dependencies. (#159 <https://github.com/ros/ros_tutorials/issues/159>)
* Contributors: Chris Lalancette
```
