### PR TITLE
resource_retriever: 3.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4581,7 +4581,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 3.3.1-1
+      version: 3.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `3.4.0-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros2-gbp/resource_retriever-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.3.1-1`

## libcurl_vendor

- No changes

## resource_retriever

```
* Switch to target_link_libraries. (#89 <https://github.com/ros/resource_retriever/issues/89>)
* Update to C++17 (#88 <https://github.com/ros/resource_retriever/issues/88>)
* Contributors: Chris Lalancette
```
