### PR TITLE
class_loader: 2.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -725,7 +725,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/class_loader-release.git
-      version: 2.6.0-1
+      version: 2.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `2.7.0-1`:

- upstream repository: https://github.com/ros/class_loader.git
- release repository: https://github.com/ros2-gbp/class_loader-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.6.0-1`

## class_loader

```
* Remove all uses of ament_target_dependencies. (#210 <https://github.com/ros/class_loader/issues/210>)
* Update to C++17 (#209 <https://github.com/ros/class_loader/issues/209>)
* Contributors: Chris Lalancette
```
