### PR TITLE
python_qt_binding: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4125,7 +4125,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/python_qt_binding-release.git
-      version: 1.3.0-1
+      version: 2.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `2.0.0-1`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros2-gbp/python_qt_binding-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.0-1`

## python_qt_binding

```
* Cleanup of the sip_configure.py file. (#131 <https://github.com/ros-visualization/python_qt_binding/issues/131>)
* Update the SIP support so we can deal with a broken RHEL-9. (#129 <https://github.com/ros-visualization/python_qt_binding/issues/129>)
* Contributors: Chris Lalancette
```
