### PR TITLE
Revert "fastrtps: 2.12.1-1 in 'rolling/distribution.yaml' [bloom] (#3…

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1375,7 +1375,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fastrtps-release.git
-      version: 2.12.1-1
+      version: 2.11.2-1
     source:
       test_commits: true
       test_pull_requests: false


### PR DESCRIPTION
…9106)"

This reverts commit 0f27389b2d3b2ab43c1f42bc05810e25d1a18a8c.

This is because we are still using 2.11.x in CI on https://ci.ros2.org, and also because 2.12.x can't currently compile on RHEL-9.  If we want to update to the 2.12 series, we'll first have to fix the CMake dependency (RHEL-9 only has CMake 3.20), and we'll also have to update https://github.com/ros2/ros2/blob/rolling/ros2.repos .

@MiguelCompany FYI