### PR TITLE
rig_reconfigure: 1.4.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4890,7 +4890,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rig_reconfigure-release.git
-      version: 1.3.2-1
+      version: 1.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rig_reconfigure` to `1.4.0-1`:

- upstream repository: https://github.com/teamspatzenhirn/rig_reconfigure.git
- release repository: https://github.com/ros2-gbp/rig_reconfigure-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.2-1`

## rig_reconfigure

```
* Add dependency on ament_index_cpp to fix build on rolling (#29 <https://github.com/teamspatzenhirn/rig_reconfigure/issues/29>)
* Place imgui.ini within users home directory (#28 <https://github.com/teamspatzenhirn/rig_reconfigure/issues/28>)
* improved input handling of numeric values (#27 <https://github.com/teamspatzenhirn/rig_reconfigure/issues/27>)
* Contributors: Chris Lalancette, Dominik
```
