### PR TITLE
split off r2r_spl iron branch

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4473,7 +4473,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-sports/r2r_spl.git
-      version: rolling
+      version: iron
     release:
       packages:
       - r2r_spl_7
@@ -4486,7 +4486,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-sports/r2r_spl.git
-      version: rolling
+      version: iron
     status: developed
   radar_msgs:
     release:


### PR DESCRIPTION
Splits off [iron branch](https://github.com/ros-sports/r2r_spl/tree/iron) for r2r_spl.