### PR TITLE
Magladko rosdep base qtwebengine5 dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7425,20 +7425,12 @@ qttools5-dev-tools:
   rhel: [qt5-qttools-devel]
   ubuntu: [qttools5-dev-tools]
 qtwebengine5-dev:
-  alpine: null
-  arch: null
   debian: [qtwebengine5-dev]
-  fedora: [qt5-qtwebengine]
+  fedora: [qt5-qtwebengine-devel]
   gentoo: [dev-qt/qtwebengine-5.15.11_p20231120]
   nixos: [libsForQt5.qt5.qtwebengine]
-  opensuse: null
-  osx: null
-  rhel: qt5-qtwebengine-dev
-  ubuntu: 
-    '*': [qtwebengine5-dev]
-    bionic: null
-    trusty: null
-    xenial: null
+  rhel: [qt5-qtwebengine-devel]
+  ubuntu: [qtwebengine5-dev]
 r-base:
   debian: [r-base]
   fedora: [R]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7424,6 +7424,14 @@ qttools5-dev-tools:
   openembedded: [qttools@meta-qt5]
   rhel: [qt5-qttools-devel]
   ubuntu: [qttools5-dev-tools]
+qtwebengine5-dev:
+  arch: [qt5-webengine]
+  debian: [qtwebengine5-dev]
+  ubuntu: 
+    '*': [qtwebengine5-dev]
+    bionic: null
+    trusty: null
+    xenial: null
 r-base:
   debian: [r-base]
   fedora: [R]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7425,8 +7425,15 @@ qttools5-dev-tools:
   rhel: [qt5-qttools-devel]
   ubuntu: [qttools5-dev-tools]
 qtwebengine5-dev:
-  arch: [qt5-webengine]
+  alpine: null
+  arch: null
   debian: [qtwebengine5-dev]
+  fedora: [qt5-qtwebengine]
+  gentoo: [dev-qt/qtwebengine-5.15.11_p20231120]
+  nixos: [libsForQt5.qt5.qtwebengine]
+  opensuse: null
+  osx: null
+  rhel: qt5-qtwebengine-dev
   ubuntu: 
     '*': [qtwebengine5-dev]
     bionic: null

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7427,7 +7427,7 @@ qttools5-dev-tools:
 qtwebengine5-dev:
   debian: [qtwebengine5-dev]
   fedora: [qt5-qtwebengine-devel]
-  gentoo: [dev-qt/qtwebengine-5.15.11_p20231120]
+  gentoo: [dev-qt/qtwebengine]
   nixos: [libsForQt5.qt5.qtwebengine]
   rhel: [qt5-qtwebengine-devel]
   ubuntu: [qtwebengine5-dev]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

qtwebengine5-dev

## Package Upstream Source:

https://github.com/qt/qtwebengine

## Purpose of using this:

Support for Qt5 Webengine utilities to make it possible to work with the Qt5 GUI application project using the webengine utilities.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/qtwebengine5-dev
- Ubuntu: https://packages.ubuntu.com/ [available only from focal onwards, added nulls only for current distros]
  - https://packages.ubuntu.com/jammy/qtwebengine5-dev
  - https://packages.ubuntu.com/search?keywords=qtwebengine5-dev&searchon=names&suite=all&section=all
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/qt5-qtwebengine/qt5-qtwebengine/
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-qt/qtwebengine
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=23.11&show=libsForQt5.qt5.qtwebengine&from=0&size=50&sort=relevance&type=packages&query=webengine
- openSUSE: https://software.opensuse.org/package/
  - not available
- rhel: https://rhel.pkgs.org/
  - https://alpine.pkgs.org/3.18/alpine-community-aarch64/qt5-qtwebengine-dev-5.15.13-r13.apk.html
