### PR TITLE
fix python3-psycopg2 for jammy

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2912,10 +2912,11 @@ python-psycopg2:
   debian: [python-psycopg2]
   fedora: [python-psycopg2]
   gentoo: [=dev-python/psycopg-2*]
-  ubuntu:
-    '*': [python-psycopg2]
-    focal: [python3-psycopg2]
-    jammy: [python3-psycopg2]
+  ubuntu: [python-psycopg2]
+python3-psycopg2:
+  debian: [python3-psycopg2]
+  fedora: [python3-psycopg2]
+  ubuntu: [python3-psycopg2]
 python-pulsectl-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2913,10 +2913,6 @@ python-psycopg2:
   fedora: [python-psycopg2]
   gentoo: [=dev-python/psycopg-2*]
   ubuntu: [python-psycopg2]
-python3-psycopg2:
-  debian: [python3-psycopg2]
-  fedora: [python3-psycopg2]
-  ubuntu: [python3-psycopg2]
 python-pulsectl-pip:
   debian:
     pip:
@@ -7617,6 +7613,10 @@ python3-psutil:
   rhel: ['python%{python3_pkgversion}-psutil']
   slackware: [psutil]
   ubuntu: [python3-psutil]
+python3-psycopg2:
+  debian: [python3-psycopg2]
+  fedora: [python3-psycopg2]
+  ubuntu: [python3-psycopg2]
 python3-py3exiv2-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2912,7 +2912,6 @@ python-psycopg2:
   debian: [python-psycopg2]
   fedora: [python-psycopg2]
   gentoo: [=dev-python/psycopg-2*]
-  ubuntu: [python-psycopg2]
 python-pulsectl-pip:
   debian:
     pip:
@@ -7617,6 +7616,8 @@ python3-psycopg2:
   debian: [python3-psycopg2]
   fedora: [python3-psycopg2]
   ubuntu: [python3-psycopg2]
+  opensuse: [python3-psycopg2]
+  rhel: [python3-psycopg2]
 python3-py3exiv2-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7614,7 +7614,7 @@ python3-psutil:
   ubuntu: [python3-psutil]
 python3-psycopg2:
   debian: [python3-psycopg2]
-  fedora: [python3-psycopg2]  
+  fedora: [python3-psycopg2]
   opensuse: [python3-psycopg2]
   rhel: [python3-psycopg2]
   ubuntu: [python3-psycopg2]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7614,10 +7614,10 @@ python3-psutil:
   ubuntu: [python3-psutil]
 python3-psycopg2:
   debian: [python3-psycopg2]
-  fedora: [python3-psycopg2]
-  ubuntu: [python3-psycopg2]
+  fedora: [python3-psycopg2]  
   opensuse: [python3-psycopg2]
   rhel: [python3-psycopg2]
+  ubuntu: [python3-psycopg2]
 python3-py3exiv2-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2915,6 +2915,7 @@ python-psycopg2:
   ubuntu:
     '*': [python-psycopg2]
     focal: [python3-psycopg2]
+    jammy: [python3-psycopg2]
 python-pulsectl-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-psycopg2

## Package Upstream Source:
https://pypi.org/project/psycopg2/

## Purpose of using this:

Add python3-psycopg2 for jammy instead of default python-psycopg2 as this results in following error:

```
E: Unable to locate package python-psycopg2
ERROR: the following rosdeps failed to install
  apt: command [apt-get install -y python-psycopg2] failed
```

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/python3-psycopg2
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/focal/python3-psycopg2
  - https://packages.ubuntu.com/jammy/python3-psycopg2
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python3-psycopg2/python3-psycopg2/
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/
  - IF AVAILABLE
- rhel: https://rhel.pkgs.org/
  - IF AVAILABLE
