### PR TITLE
bagger: 0.1.5-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -469,7 +469,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/squarerobot/bagger-release.git
-      version: 0.1.4-1
+      version: 0.1.5-2
     source:
       type: git
       url: https://github.com/squarerobot/bagger.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bagger` to `0.1.5-2`:

- upstream repository: https://github.com/squarerobot/bagger.git
- release repository: https://github.com/squarerobot/bagger-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.4-1`

## bagger

```
* Downgrade the ROS message severity of all warnings having to do with
  recording states not changing due to them already being in the
  requested state
* Contributors: Brenden Gibbons
```
