### PR TITLE
ros2_controllers: 3.20.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5430,7 +5430,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 3.19.2-1
+      version: 3.20.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `3.20.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.19.2-1`

## ackermann_steering_controller

- No changes

## admittance_controller

- No changes

## bicycle_steering_controller

- No changes

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* [JTC] Cleanup includes (#943 <https://github.com/ros-controls/ros2_controllers/issues/943>) (#960 <https://github.com/ros-controls/ros2_controllers/issues/960>)
* Add rqt_JTC to docs (#950 <https://github.com/ros-controls/ros2_controllers/issues/950>) (#953 <https://github.com/ros-controls/ros2_controllers/issues/953>)
* [JTC] Add console output for tolerance checks (#932 <https://github.com/ros-controls/ros2_controllers/issues/932>) (#939 <https://github.com/ros-controls/ros2_controllers/issues/939>)
* Contributors: mergify[bot]
```

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

```
* Add rqt_JTC to docs (#950 <https://github.com/ros-controls/ros2_controllers/issues/950>) (#953 <https://github.com/ros-controls/ros2_controllers/issues/953>)
* Contributors: mergify[bot]
```

## steering_controllers_library

```
* Changing default int values to double in steering controller's yaml file (#927 <https://github.com/ros-controls/ros2_controllers/issues/927>) (#929 <https://github.com/ros-controls/ros2_controllers/issues/929>)
* Contributors: mergify[bot]
```

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
