### PR TITLE
add imu_pipeline to rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2100,6 +2100,11 @@ repositories:
       url: https://github.com/ros-perception/image_transport_plugins.git
       version: rolling
     status: maintained
+  imu_pipeline:
+    source:
+      type: git
+      url: https://github.com/ros-perception/imu_pipeline.git
+      version: ros2
   imu_tools:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

Rolling

# The source is here:

https://github.com/ros-perception/imu_pipeline/tree/ros2

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file (NOTE: LICENSE files are within the individual packages - since there are different license for different packages)
 - [x] This package is expected to build on the submitted rosdistro
