### PR TITLE
ign_ros2_control: 0.7.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2579,12 +2579,13 @@ repositories:
       version: humble
     release:
       packages:
+      - gz_ros2_control_tests
       - ign_ros2_control
       - ign_ros2_control_demos
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 0.7.1-1
+      version: 0.7.4-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2579,7 +2579,6 @@ repositories:
       version: humble
     release:
       packages:
-      - gz_ros2_control_tests
       - ign_ros2_control
       - ign_ros2_control_demos
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ign_ros2_control` to `0.7.4-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.1-1`
