### PR TITLE
gazebo_ros2_control: 0.6.3-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1650,7 +1650,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git
-      version: master
+      version: iron
     release:
       packages:
       - gazebo_ros2_control
@@ -1662,7 +1662,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git
-      version: master
+      version: iron
     status: developed
   gazebo_ros_pkgs:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1658,7 +1658,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.6.2-1
+      version: 0.6.3-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros2_control` to `0.6.3-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros2_control.git
- release repository: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.2-1`

## gazebo_ros2_control

```
* Fix stuck passive joints (#237 <https://github.com/ros-controls/gazebo_ros2_control/issues/237>)
* Contributors: Johannes Huemer
```

## gazebo_ros2_control_demos

```
* Rename cartpole (#252 <https://github.com/ros-controls/gazebo_ros2_control/issues/252>) (#253 <https://github.com/ros-controls/gazebo_ros2_control/issues/253>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  (cherry picked from commit b39074a4a1adf8a9319a6d4378ac26e2aa9e298a)
  Co-authored-by: Christoph Fröhlich <mailto:christophfroehlich@users.noreply.github.com>
* Replace double quotes with single ones (#243 <https://github.com/ros-controls/gazebo_ros2_control/issues/243>)
* Cleanup controller config (#232 <https://github.com/ros-controls/gazebo_ros2_control/issues/232>)
  * Remove wrong yaml entries
  * Rename effort_controller
* Contributors: Christoph Fröhlich, mergify[bot]
```
