### PR TITLE
gazebo_ros2_control: 0.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1589,7 +1589,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.6.2-1
+      version: 0.7.0-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros2_control` to `0.7.0-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros2_control.git
- release repository: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.2-1`

## gazebo_ros2_control

```
* Add hold_joints parameter (#251 <https://github.com/ros-controls/gazebo_ros2_control/issues/251>)
* Fix stuck passive joints (#237 <https://github.com/ros-controls/gazebo_ros2_control/issues/237>)
* Contributors: Christoph Fröhlich, Johannes Huemer
```

## gazebo_ros2_control_demos

```
* replace Twist with TwistStamped (#249 <https://github.com/ros-controls/gazebo_ros2_control/issues/249>)
* Rename cartpole (#252 <https://github.com/ros-controls/gazebo_ros2_control/issues/252>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Replace double quotes with single ones (#243 <https://github.com/ros-controls/gazebo_ros2_control/issues/243>)
* Cleanup controller config (#232 <https://github.com/ros-controls/gazebo_ros2_control/issues/232>)
  * Remove wrong yaml entries
  * Rename effort_controller
* Contributors: Alejandro Hernández Cordero, Christoph Fröhlich
```
