### PR TITLE
rtabmap: 0.21.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7440,7 +7440,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rtabmap-release.git
-      version: 0.21.1-1
+      version: 0.21.3-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap` to `0.21.3-1`:

- upstream repository: https://github.com/introlab/rtabmap.git
- release repository: https://github.com/ros2-gbp/rtabmap-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.21.1-1`
