### PR TITLE
clearpath_common: 0.2.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -964,7 +964,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `0.2.2-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.1-1`

## clearpath_common

- No changes

## clearpath_control

- No changes

## clearpath_description

- No changes

## clearpath_generator_common

```
* Enable extras urdf and meshes to be linked by package (#53 <https://github.com/clearpathrobotics/clearpath_common/issues/53>)
* Contributors: Hilary Luo
```

## clearpath_mounts_description

- No changes

## clearpath_platform

```
* Fixed status topic names
* Contributors: Roni Kreinin
```

## clearpath_platform_description

- No changes

## clearpath_sensors_description

- No changes
