### PR TITLE
Add rosdep keys for patchelf

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7001,6 +7001,23 @@ pandoc:
   nixos: [pandoc]
   rhel: [pandoc]
   ubuntu: [pandoc]
+patchelf:
+  alpine: [patchelf]
+  arch: [patchelf]
+  debian: [patchelf]
+  fedora: [patchelf]
+  freebsd: [sysutils/patchelf]
+  gentoo: [dev-util/patchelf]
+  macports: [patchelf]
+  nixos: [patchelf]
+  openembedded: [patchelf@openembedded-core]
+  opensuse: [patchelf]
+  osx:
+    homebrew:
+      packages: [patchelf]
+  rhel: [patchelf]
+  slackware: [patchelf]
+  ubuntu: [patchelf]
 pcre:
   alpine: [pcre-dev]
   arch: [pcre]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

patchelf

## Package Upstream Source:

https://github.com/NixOS/patchelf

## Purpose of using this:

PatchELF is a simple utility for modifying existing ELF executables and libraries. It can help to customize `RPATHs` or `DT_NEEDED`, `SONAME` and other metadata in the binaries.

This is specially helpful for modifying binaries to be adapted to a different location than the one where they were installed/compiled initially if the binary ELF metadata contains hardcoded paths. If I'm not wrong, the Drake projects [is using it](https://github.com/RobotLocomotion/drake/blob/659cf702dff93ea20ee87b18e77169be404568ef/tools/install/installer.py#L331) to help adapting a Bazel build to be installed similarly to what the usual `install` targets do in a CMake+Make project changing the binaries metadata using patchelf.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/source/patchelf
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/jammy/patchelf
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/patchelf/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/patchelf/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-util/patchelf
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/patchelf
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/v3.18/main/x86_64/patchelf
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://github.com/NixOS/nixpkgs/blob/release-23.11/pkgs/development/tools/misc/patchelf/default.nix
- openSUSE: https://software.opensuse.org/package/
  - https://build.opensuse.org/package/show/openSUSE:Leap:42.3:Update/patchelf
- rhel: https://rhel.pkgs.org/
  - https://rhel.pkgs.org/8/epel-x86_64/patchelf-0.12-1.el8.x86_64.rpm.html