### PR TITLE
Unrelease rtctree from Noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10700,11 +10700,6 @@ repositories:
       type: git
       url: https://github.com/tork-a/rtctree-release.git
       version: release/hydro/rtctree
-    release:
-      tags:
-        release: release/noetic/{package}/{version}
-      url: https://github.com/tork-a/rtctree-release.git
-      version: 3.0.1-3
     source:
       type: git
       url: https://github.com/gbiggs/rtctree.git


### PR DESCRIPTION
It appears it's never successfully built on any platform. https://github.com/tork-a/rtctree-release/issues/3

@k-okada FYI
