### PR TITLE
Unrelease rtsprofile from Noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10710,11 +10710,6 @@ repositories:
       type: git
       url: https://github.com/gbiggs/rtsprofile.git
       version: master
-    release:
-      tags:
-        release: release/noetic/{package}/{version}
-      url: https://github.com/tork-a/rtsprofile-release.git
-      version: 2.0.0-3
     source:
       type: git
       url: https://github.com/gbiggs/rtsprofile.git


### PR DESCRIPTION
It's never successfully built on any platform.
https://github.com/tork-a/rtsprofile-release/issues/1

@k-okada  FYI