### PR TITLE
Unrelease sound_classification from Noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4652,7 +4652,6 @@ repositories:
       - jsk_recognition_msgs
       - jsk_recognition_utils
       - resized_image_transport
-      - sound_classification
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git


### PR DESCRIPTION
It appears to have never successfully built on any platform. https://github.com/jsk-ros-pkg/jsk_recognition/issues/2810

@k-okada FYI