### PR TITLE
imu_pipeline: 0.4.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2236,6 +2236,25 @@ repositories:
       url: https://github.com/ros-perception/image_transport_plugins.git
       version: rolling
     status: maintained
+  imu_pipeline:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/imu_pipeline.git
+      version: ros2
+    release:
+      packages:
+      - imu_pipeline
+      - imu_processors
+      - imu_transformer
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/imu_pipeline-release.git
+      version: 0.4.1-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/imu_pipeline.git
+      version: ros2
+    status: maintained
   imu_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_pipeline` to `0.4.1-1`:

- upstream repository: https://github.com/ros-perception/imu_pipeline
- release repository: https://github.com/ros2-gbp/imu_pipeline-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## imu_pipeline

- No changes

## imu_processors

```
* update dependency tf->tf2_ros (#22 <https://github.com/ros-perception/imu_pipeline/issues/22>)
  found this when trying to do first release...
* Contributors: Michael Ferguson
```

## imu_transformer

- No changes
