### PR TITLE
Wayland build and runtime dependencies

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8347,6 +8347,18 @@ vorbis-tools:
   gentoo: [media-sound/vorbis-tools]
   nixos: [vorbis-tools]
   ubuntu: [vorbis-tools]
+wayland:
+  arch: [wayland]
+  debian: [libwayland-client0, libwayland-cursor0, libwayland-egl1]
+  fedora: [libwayland-client, libwayland-cursor, libwayland-egl]
+  rhel: [libwayland-client, libwayland-cursor, libwayland-egl]
+  ubuntu: [libwayland-client0, libwayland-cursor0, libwayland-egl1]
+wayland-dev:
+  arch: [wayland, wayland-protocols]
+  debian: [libwayland-dev, wayland-protocols]
+  fedora: [wayland-devel, wayland-protocols-devel]
+  rhel: [wayland-devel, wayland-protocols-devel]
+  ubuntu: [libwayland-dev, wayland-protocols]
 wget:
   arch: [wget]
   debian: [wget]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Purpose of using this:

Wayland is a protocol to communicate with display serves on modern Linux distributions.

## Links to Distribution Packages

I am listing the source packages here, from where where the build and runtime packages are generated

- Debian: https://packages.debian.org/
  - https://packages.debian.org/source/bookworm/wayland
  - https://packages.debian.org/source/bookworm/wayland-protocols
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/source/jammy/wayland
  - https://packages.ubuntu.com/source/jammy/wayland-protocols
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/wayland/
  - https://packages.fedoraproject.org/pkgs/wayland-protocols/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/wayland/
  - https://archlinux.org/packages/extra/any/wayland-protocols/
- rhel: https://rhel.pkgs.org/
  - same as `fedora`
