### PR TITLE
ffmpeg_image_transport_msgs: 1.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1398,6 +1398,11 @@ repositories:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git
       version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ffmpeg_image_transport_msgs-release.git
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ffmpeg_image_transport_msgs` to `1.0.2-1`:

- upstream repository: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git
- release repository: https://github.com/ros2-gbp/ffmpeg_image_transport_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
