### PR TITLE
Update repo url

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -705,6 +705,15 @@ repositories:
       url: https://github.com/flynneva/bno055.git
       version: main
     status: maintained
+  boeing_gazebo_model_attachment_plugin:
+    doc:
+      type: git
+      url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
+      version: humble
   bond_core:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -751,11 +751,11 @@ repositories:
   boeing_gazebo_set_joint_positions_plugin:
     doc:
       type: git
-      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      url: https://github.com/Boeing/boeing_gazebo_set_joint_positions_plugin.git
       version: humble
     source:
       type: git
-      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      url: https://github.com/Boeing/boeing_gazebo_set_joint_positions_plugin.git
       version: humble
   bond_core:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -714,6 +714,15 @@ repositories:
       type: git
       url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
       version: humble
+  boeing_gazebo_set_joint_positions_plugin:
+    doc:
+      type: git
+      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      version: humble
   bond_core:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -568,11 +568,11 @@ repositories:
   boeing_gazebo_set_joint_positions_plugin:
     doc:
       type: git
-      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      url: https://github.com/Boeing/boeing_gazebo_set_joint_positions_plugin.git
       version: noetic
     source:
       type: git
-      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      url: https://github.com/Boeing/boeing_gazebo_set_joint_positions_plugin.git
       version: noetic
   bond_core:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -526,11 +526,11 @@ repositories:
   boeing_gazebo_model_attachment_plugin:
     doc:
       type: git
-      url: https://github.com/Boeing/gazebo_model_attachment_plugin
+      url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
       version: noetic
     source:
       type: git
-      url: https://github.com/Boeing/gazebo_model_attachment_plugin
+      url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
       version: noetic
   bond_core:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -523,6 +523,15 @@ repositories:
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
       version: master
     status: developed
+  boeing_gazebo_model_attachment_plugin:
+    doc:
+      type: git
+      url: https://github.com/Boeing/gazebo_model_attachment_plugin
+      version: noetic
+    source:
+      type: git
+      url: https://github.com/Boeing/gazebo_model_attachment_plugin
+      version: noetic
   bond_core:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -532,6 +532,15 @@ repositories:
       type: git
       url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
       version: noetic
+  boeing_gazebo_set_joint_positions_plugin:
+    doc:
+      type: git
+      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      version: noetic
+    source:
+      type: git
+      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      version: noetic
   bond_core:
     doc:
       type: git


### PR DESCRIPTION
Please update the source url for the following packages.

## Package name:

boeing_gazebo_set_joint_positions_plugin

## Package Upstream Source:

[boeing_gazebo_set_joint_positions_plugin](https://github.com/Boeing/boeing_gazebo_set_joint_positions_plugin)


# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
