### PR TITLE
ffmpeg_image_transport_msgs: 1.2.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1434,6 +1434,11 @@ repositories:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git
       version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ffmpeg_image_transport_msgs-release.git
+      version: 1.2.2-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ffmpeg_image_transport_msgs` to `1.2.2-1`:

- upstream repository: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git
- release repository: https://github.com/ros2-gbp/ffmpeg_image_transport_msgs-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## ffmpeg_image_transport_msgs

```
* initial release
* Contributors: Bernd Pfrommer
```
