### PR TITLE
libcaer: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2537,6 +2537,11 @@ repositories:
       type: git
       url: https://github.com/ros-event-camera/libcaer.git
       version: ros_event_camera
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/libcaer-release.git
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libcaer` to `1.0.1-1`:

- upstream repository: https://github.com/ros-event-camera/libcaer.git
- release repository: https://github.com/ros2-gbp/libcaer-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## libcaer

```
* libcaer: initial release as a ROS package
* Contributors: Bernd Pfrommer, Carsten L. Nielsen, Carsten Nielsen, David Wright, Federico Corradi, Felix Schwitzer, Jonathan Müller, Luca Longinotti, Marek Otahal, Reda, Rokas Jurevicius, Thomas Debrunner, clauniel, federicohyo, reda.fornera
```
