### PR TITLE
libcaer: 1.2.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2672,6 +2672,11 @@ repositories:
       type: git
       url: https://github.com/ros-event-camera/libcaer.git
       version: ros_event_camera
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/libcaer-release.git
+      version: 1.2.1-1
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libcaer` to `1.2.1-1`:

- upstream repository: https://github.com/ros-event-camera/libcaer.git
- release repository: https://github.com/ros2-gbp/libcaer-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## libcaer

```
* initial release of libcaer as ROS package
* Contributors: Bernd Pfrommer, Carsten L. Nielsen, Carsten Nielsen, David Wright, Federico Corradi, Felix Schwitzer, Jonathan Müller, Luca Longinotti, Marek Otahal, Reda, Rokas Jurevicius, Thomas Debrunner, clauniel, federicohyo, reda.fornera
```
