### PR TITLE
adi_tmcl: 4.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -80,6 +80,11 @@ repositories:
       type: git
       url: https://github.com/analogdevicesinc/tmcl_ros.git
       version: noetic
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros2-gbp/adi_tmcl-release.git
+      version: 4.0.0-1
     source:
       type: git
       url: https://github.com/analogdevicesinc/tmcl_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `adi_tmcl` to `4.0.0-1`:

- upstream repository: https://github.com/analogdevicesinc/tmcl_ros.git
- release repository: https://github.com/ros2-gbp/adi_tmcl-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## adi_tmcl

```
* Updated README.md to mention both tmcl_ros (previous package name) and adi_tmcl
* Updated package name and transforms
  
    * Updated package name in compliance to official ROS release, and updated transforms for multi-axes TMCs
  
* Contributors: mmaralit-adi, jmacagba
```
