### PR TITLE
rtctree: 3.0.1-4 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10724,6 +10724,11 @@ repositories:
       type: git
       url: https://github.com/tork-a/rtctree-release.git
       version: release/hydro/rtctree
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/tork-a/rtctree-release.git
+      version: 3.0.1-4
     source:
       type: git
       url: https://github.com/gbiggs/rtctree.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtctree` to `3.0.1-4`:

- upstream repository: https://github.com/gbiggs/rtctree.git
- release repository: https://github.com/tork-a/rtctree-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
