### PR TITLE
rtsprofile: 2.0.0-4 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10734,6 +10734,11 @@ repositories:
       type: git
       url: https://github.com/gbiggs/rtsprofile.git
       version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/tork-a/rtsprofile-release.git
+      version: 2.0.0-4
     source:
       type: git
       url: https://github.com/gbiggs/rtsprofile.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtsprofile` to `2.0.0-4`:

- upstream repository: https://github.com/gbiggs/rtsprofile.git
- release repository: https://github.com/tork-a/rtsprofile-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
