### PR TITLE
clearpath_config: 0.2.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -979,7 +979,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `0.2.2-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.1-1`

## clearpath_config

```
* Fix how blank urdf extras is handled
* Contributors: Hilary Luo
```
