### PR TITLE
ros2_control: 2.36.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6386,7 +6386,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.36.0-1
+      version: 2.36.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.36.1-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.36.0-1`

## controller_interface

- No changes

## controller_manager

```
* [docs] Remove joint_state_controller (#1263 <https://github.com/ros-controls/ros2_control/issues/1263>) (#1264 <https://github.com/ros-controls/ros2_control/issues/1264>)
* [CI] Increase timeout for controller_managers_srv test (backport #1224 <https://github.com/ros-controls/ros2_control/issues/1224>) (#1225 <https://github.com/ros-controls/ros2_control/issues/1225>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* [ResourceManager] adds test for uninitialized hardware (#1243 <https://github.com/ros-controls/ros2_control/issues/1243>) (#1274 <https://github.com/ros-controls/ros2_control/issues/1274>)
* Use portable version for string-to-double conversion (backport #1257 <https://github.com/ros-controls/ros2_control/issues/1257>) (#1268 <https://github.com/ros-controls/ros2_control/issues/1268>)
* Fix typo in docs (#1219 <https://github.com/ros-controls/ros2_control/issues/1219>) (#1221 <https://github.com/ros-controls/ros2_control/issues/1221>)
* Contributors: Christoph Fröhlich, mergify[bot]
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

```
* [ResourceManager] adds test for uninitialized hardware (#1243 <https://github.com/ros-controls/ros2_control/issues/1243>) (#1274 <https://github.com/ros-controls/ros2_control/issues/1274>)
* Contributors: mergify[bot]
```

## ros2controlcli

```
* [docs] Remove joint_state_controller (#1263 <https://github.com/ros-controls/ros2_control/issues/1263>) (#1264 <https://github.com/ros-controls/ros2_control/issues/1264>)
* Contributors: mergify[bot]
```

## rqt_controller_manager

- No changes

## transmission_interface

```
* Improve transmission tests (#1238 <https://github.com/ros-controls/ros2_control/issues/1238>) (#1241 <https://github.com/ros-controls/ros2_control/issues/1241>)
* Contributors: mergify[bot]
```
