### PR TITLE
foo: 0.0.3-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1570,6 +1570,23 @@ repositories:
       url: https://github.com/boschresearch/fmilibrary_vendor.git
       version: rolling
     status: maintained
+  foo:
+    doc:
+      type: git
+      url: https://github.com/MOCAP4ROS2-Project/mocap_msgs.git
+      version: master
+    release:
+      packages:
+      - mocap_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/MOCAP4ROS2-Project/mocap_msgs-release.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/MOCAP4ROS2-Project/mocap_msgs.git
+      version: master
+    status: developed
   foonathan_memory_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `foo` to `0.0.3-1`:

- upstream repository: https://github.com/MOCAP4ROS2-Project/mocap_msgs.git
- release repository: https://github.com/MOCAP4ROS2-Project/mocap_msgs-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## mocap_msgs

```
* Change license
* Update README.md
* Contributors: Francisco Martín Rico
```
