### PR TITLE
foo: 0.0.3-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2039,6 +2039,23 @@ repositories:
       url: https://github.com/BerkeleyAutomation/FogROS2.git
       version: humble
     status: developed
+  foo:
+    doc:
+      type: git
+      url: https://github.com/MOCAP4ROS2-Project/mocap_msgs.git
+      version: master
+    release:
+      packages:
+      - mocap_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/MOCAP4ROS2-Project/mocap_msgs-release.git
+      version: 0.0.3-2
+    source:
+      type: git
+      url: https://github.com/MOCAP4ROS2-Project/mocap_msgs.git
+      version: master
+    status: developed
   foonathan_memory_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `foo` to `0.0.3-2`:

- upstream repository: https://github.com/MOCAP4ROS2-Project/mocap_msgs.git
- release repository: https://github.com/MOCAP4ROS2-Project/mocap_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## mocap_msgs

```
* Change license
* Update README.md
* Contributors: Francisco Martín Rico
```
