### PR TITLE
mocap: 0.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3707,6 +3707,30 @@ repositories:
       url: https://github.com/DFKI-NI/mir_robot.git
       version: humble
     status: developed
+  mocap:
+    doc:
+      type: git
+      url: https://github.com/MOCAP4ROS2-Project/mocap.git
+      version: humble-devel
+    release:
+      packages:
+      - mocap_control
+      - mocap_control_msgs
+      - mocap_marker_publisher
+      - mocap_marker_viz
+      - mocap_marker_viz_srvs
+      - mocap_robot_gt
+      - mocap_robot_gt_msgs
+      - rqt_mocap_control
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/MOCAP4ROS2-Project/mocap-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/MOCAP4ROS2-Project/mocap.git
+      version: humble-devel
+    status: developed
   mod:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `mocap` to `0.0.2-1`:

- upstream repository: https://github.com/MOCAP4ROS2-Project/mocap.git
- release repository: https://github.com/MOCAP4ROS2-Project/mocap-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## mocap_control

```
* Added node_options parameter to constructor with default value, to be used with mocap4ros2 vicon driver
* Initial commit
* Contributors: Francisco Martín Rico, MFernandezCarmona
```

## mocap_control_msgs

```
* Initial commit
* Contributors: Francisco Martín Rico
```

## mocap_marker_publisher

```
* Update to msgs changes
* Initial commit
* Contributors: Francisco Martín Rico
```

## mocap_marker_viz

```
* Add launch rviz
* Multiple rigid bodies and launcher
* Adding rigid body and setting markers axis
* Fix header
* Initial commit
* Contributors: Francisco Martín Rico, Juancams, jmguerreroh
```

## mocap_marker_viz_srvs

```
* Initial commit
* Contributors: Francisco Martín Rico
```

## mocap_robot_gt

```
* Multiple rigid bodies and launcher
* Param to mocap frame
* Package for GT services
* Contributors: Francisco Martín Rico, jmguerreroh
```

## mocap_robot_gt_msgs

```
* Package for GT services
* Contributors: Francisco Martín Rico
```

## rqt_mocap_control

```
* Initial commit
* Contributors: Francisco Martín Rico, jmguerreroh
```
