### PR TITLE
mocap_msgs: 0.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3707,6 +3707,21 @@ repositories:
       url: https://github.com/DFKI-NI/mir_robot.git
       version: humble
     status: developed
+  mocap_msgs:
+    doc:
+      type: git
+      url: https://github.com/MOCAP4ROS2-Project/mocap_msgs.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/MOCAP4ROS2-Project/mocap_msgs-release.git
+      version: 0.0.4-1
+    source:
+      type: git
+      url: https://github.com/MOCAP4ROS2-Project/mocap_msgs.git
+      version: master
+    status: developed
   mod:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `mocap_msgs` to `0.0.4-1`:

- upstream repository: https://github.com/MOCAP4ROS2-Project/mocap_msgs.git
- release repository: https://github.com/MOCAP4ROS2-Project/mocap_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## mocap_msgs

```
* new message for multiple rigid bodies
* Fix Markers to Marker
* Proposal with both
* Proposal for definitive format
* Change idx (int) to name (string)
* Add markers indexes
* Add Rigid Body description
* Contributors: Francisco Martín Rico, José Miguel Guerrero, jmguerreroh
```
