### PR TITLE
mocap_msgs: 0.0.4-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3086,6 +3086,21 @@ repositories:
       url: https://github.com/DFKI-NI/mir_robot.git
       version: rolling
     status: developed
+  mocap_msgs:
+    doc:
+      type: git
+      url: https://github.com/MOCAP4ROS2-Project/mocap_msgs.git
+      version: iron-devel
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/MOCAP4ROS2-Project/mocap_msgs-release.git
+      version: 0.0.4-1
+    source:
+      type: git
+      url: https://github.com/MOCAP4ROS2-Project/mocap_msgs.git
+      version: master
+    status: developed
   mola_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mocap_msgs` to `0.0.4-1`:

- upstream repository: https://github.com/MOCAP4ROS2-Project/mocap_msgs.git
- release repository: https://github.com/MOCAP4ROS2-Project/mocap_msgs-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## mocap_msgs

```
* new message for multiple rigid bodies
* Fix Markers to Marker
* Proposal with both
* Proposal for definitive format
* Change idx (int) to name (string)
* Add markers indexes
* Add Rigid Body description
* Contributors: Francisco Martín Rico, José Miguel Guerrero, jmguerreroh
```
