### PR TITLE
plotjuggler: 3.8.6-2 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4150,7 +4150,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.8.3-1
+      version: 3.8.6-2
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.8.6-2`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/ros2-gbp/plotjuggler-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.8.3-1`

## plotjuggler

```
* fix issue #906 <https://github.com/facontidavide/PlotJuggler/issues/906>: support nanoseconds timestamp in csv
* fix issue #904 <https://github.com/facontidavide/PlotJuggler/issues/904>: wring ROS odometry parsing
* add moving variance
* Contributors: Davide Faconti
```
