### PR TITLE
rqt_gauges: 0.0.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6208,6 +6208,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_console.git
       version: iron
     status: maintained
+  rqt_gauges:
+    doc:
+      type: git
+      url: https://github.com/ToyotaResearchInstitute/gauges2.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_gauges-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/ToyotaResearchInstitute/gauges2.git
+      version: main
+    status: maintained
   rqt_graph:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_gauges` to `0.0.1-1`:

- upstream repository: https://github.com/ToyotaResearchInstitute/gauges2
- release repository: https://github.com/ros2-gbp/rqt_gauges-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## rqt_gauges

```
* Rename to rqt_gauges (#23 <https://github.com/ekumenlabs/gauges2//issues/23>)
* Fixed steering wheel range (#24 <https://github.com/ekumenlabs/gauges2//issues/24>)
* Fixed resize (#22 <https://github.com/ekumenlabs/gauges2//issues/22>)
* Fix some crashes (#21 <https://github.com/ekumenlabs/gauges2//issues/21>)
* utils.py to include common code and fixed merge (#20 <https://github.com/ekumenlabs/gauges2//issues/20>)
* Added xmllint and fleka8  (#19 <https://github.com/ekumenlabs/gauges2//issues/19>)
* Fixed runtime error (#12 <https://github.com/ekumenlabs/gauges2//issues/12>)
* Added documentation (#17 <https://github.com/ekumenlabs/gauges2//issues/17>)
* Setup CI (#16 <https://github.com/ekumenlabs/gauges2//issues/16>)
* Added .gitignore (#13 <https://github.com/ekumenlabs/gauges2//issues/13>)
* Creates the Steering Wheel Widget (#10 <https://github.com/ekumenlabs/gauges2//issues/10>)
  Co-authored-by: Franco Cipollone <mailto:franco.c@ekumenlabs.com>
* Creates the Throttle and Brake pedals Widget (#7 <https://github.com/ekumenlabs/gauges2//issues/7>)
* Creates the Speedometer Widget UI and Funtionality  (#4 <https://github.com/ekumenlabs/gauges2//issues/4>)
* Makes the plugin package discoverable (#3 <https://github.com/ekumenlabs/gauges2//issues/3>)
* Creates a discoverable rqt plugin within the package (#2 <https://github.com/ekumenlabs/gauges2//issues/2>)
* Initial commit.
* Contributors: Alejandro Hernández Cordero, Eloy Briceno, Franco Cipollone
```
