### PR TITLE
cras_ros_utils: 2.3.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1753,7 +1753,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
-      version: 2.3.5-1
+      version: 2.3.7-1
     source:
       type: git
       url: https://github.com/ctu-vras/ros-utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_ros_utils` to `2.3.7-1`:

- upstream repository: https://github.com/ctu-vras/ros-utils
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.5-1`

## cras_cpp_common

```
* node_from_nodelet: Fix syntax for Melodic.
* node_from_nodelet: Implemented a simplified version that doesn't need the nodelet header file.
* node_from_nodelet: Fixed a bug with missing return 0 at the end of main.
* Contributors: Martin Pecka
```

## cras_docs_common

- No changes

## cras_py_common

- No changes

## cras_topic_tools


*     Made use of the simplified syntax of node_from_nodelet.
*    Contributors: Martin Pecka


## image_transport_codecs

- No changes
