### PR TITLE
nodelet_core: 1.11.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6755,7 +6755,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/nodelet_core-release.git
-      version: 1.10.2-1
+      version: 1.11.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.11.0-2`:

- upstream repository: https://github.com/ros/nodelet_core.git
- release repository: https://github.com/ros-gbp/nodelet_core-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.10.2-1`

## nodelet

```
* Don't install version.h.in (#113 <https://github.com/ros/nodelet_core/issues/113>)
* Fix use-after-free when a nodelet throws on initialization (#122 <https://github.com/ros/nodelet_core/issues/122>)
* Update package maintainers (#114 <https://github.com/ros/nodelet_core/issues/114>)
* Reduce boost dependency scope (#118 <https://github.com/ros/nodelet_core/issues/118>)
* Switch to new boost/bind/bind.hpp (#117 <https://github.com/ros/nodelet_core/issues/117>)
* show warning in every 10 seconds when manager is not found (#115 <https://github.com/ros/nodelet_core/issues/115>)
* Contributors: Geoffrey Biggs, Hugal31, Jochen Sprickerhof, Shingo Kitagawa, Stephan
```

## nodelet_core

```
* Update package maintainers (#114 <https://github.com/ros/nodelet_core/issues/114>)
* Contributors: Geoffrey Biggs
```

## nodelet_topic_tools

```
* Update package maintainers (#114 <https://github.com/ros/nodelet_core/issues/114>)
* Reduce boost dependency scope (#118 <https://github.com/ros/nodelet_core/issues/118>)
* Switch to new boost/bind/bind.hpp (#117 <https://github.com/ros/nodelet_core/issues/117>)
* Contributors: Geoffrey Biggs, Jochen Sprickerhof, Stephan
```
