### PR TITLE
ypspur_ros: 0.3.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -13060,7 +13060,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/openspur/ypspur_ros-release.git
-      version: 0.3.5-1
+      version: 0.3.6-1
     source:
       type: git
       url: https://github.com/openspur/ypspur_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ypspur_ros` to `0.3.6-1`:

- upstream repository: https://github.com/openspur/ypspur_ros.git
- release repository: https://github.com/openspur/ypspur_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.5-1`

## ypspur_ros

```
* Avoid publishing joint messages with duplicate stamps (#115 <https://github.com/openspur/ypspur_ros/issues/115>)
* Update assets to v0.6.2 (#114 <https://github.com/openspur/ypspur_ros/issues/114>)
* Update assets to v0.6.1 (#113 <https://github.com/openspur/ypspur_ros/issues/113>)
* Update assets to v0.6.0 (#112 <https://github.com/openspur/ypspur_ros/issues/112>)
* Update assets to v0.5.2 (#111 <https://github.com/openspur/ypspur_ros/issues/111>)
* Update assets to v0.5.1 (#110 <https://github.com/openspur/ypspur_ros/issues/110>)
* Update assets to v0.5.0 (#109 <https://github.com/openspur/ypspur_ros/issues/109>)
* Update assets to v0.4.2 (#108 <https://github.com/openspur/ypspur_ros/issues/108>)
* Update assets to v0.4.1 (#107 <https://github.com/openspur/ypspur_ros/issues/107>)
* Update assets to v0.4.0 (#106 <https://github.com/openspur/ypspur_ros/issues/106>)
* Update assets to v0.3.4 (#102 <https://github.com/openspur/ypspur_ros/issues/102>)
* Update assets to v0.3.3 (#101 <https://github.com/openspur/ypspur_ros/issues/101>)
* Update assets to v0.3.2 (#100 <https://github.com/openspur/ypspur_ros/issues/100>)
* Contributors: Atsushi Watanabe, Mark Hedley Jones
```
