### PR TITLE
fields2cover: 1.2.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1893,7 +1893,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/Fields2Cover/fields2cover-release.git
-      version: 1.2.1-1
+      version: 1.2.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository fields2cover to 1.2.1-2:

    upstream repository: https://github.com/Fields2Cover/fields2cover.git
    release repository: https://github.com/Fields2Cover/fields2cover-release.git
    distro file: humble/distribution.yaml
    bloom version: 0.11.2
    previous version for package: 1.2.1-1

