### PR TITLE
 fields2cover: 1.2.1-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1413,7 +1413,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/Fields2Cover/Fields2Cover-release.git
-      version: 1.2.1-1
+      version: 1.2.1-2
     status: developed
   filters:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository fields2cover to 1.2.1-2:

upstream repository: https://github.com/Fields2Cover/fields2cover.git
release repository: https://github.com/Fields2Cover/fields2cover-release.git
distro file: rolling/distribution.yaml
bloom version: 0.11.2
previous version for package: 1.2.1-1
