### PR TITLE
tf2_server: 1.1.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11797,7 +11797,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/peci1/tf2_server-release.git
-      version: 1.1.2-1
+      version: 1.1.3-1
     source:
       type: git
       url: https://github.com/peci1/tf2_server.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf2_server` to `1.1.3-1`:

- upstream repository: https://github.com/peci1/tf2_server.git
- release repository: https://github.com/peci1/tf2_server-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.2-1`

## tf2_server

```
* Fixed errors printed by pluginlib when tf2_server is installed
* Contributors: Martin Pecka
```
