### PR TITLE
behaviortree_cpp_v4: 4.5.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -714,7 +714,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.4.3-2
+      version: 4.5.0-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp_v4` to `4.5.0-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.4.3-2`

## behaviortree_cpp

```
* fix typo in unit test #733 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/733>
* allow Input/Output ports with type Any
* Merge pull request #703 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/703> from galou/export_xsd
  Implement writeTreeXSD() to generate an XSD
* Any::isType() will return the original type. Cherry picking from #708 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/708>
* fix #734 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/734>
* remove unneeded includes
* add Any::castPtr
* add alias KeyValueVector
* Merge pull request #730 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/730> from adlarkin/add_metadata
  Add optional metadata to TreeNodeManifest
* Contributors: Ashton Larkin, Davide Faconti, Gaël Écorchard
```
