### PR TITLE
ess_imu_driver2: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1666,6 +1666,11 @@ repositories:
       type: git
       url: https://github.com/cubicleguy/ess_imu_driver2.git
       version: humble
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/ess_imu_driver2-release.git
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/cubicleguy/ess_imu_driver2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ess_imu_driver2` to `1.0.1-1`:

- upstream repository: https://github.com/cubicleguy/ess_imu_driver2.git
- release repository: https://github.com/ros2-gbp/ess_imu_driver2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
