### PR TITLE
Add `python-ifaddr`

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1941,6 +1941,13 @@ python-hypothesis:
   gentoo: [dev-python/hypothesis]
   ubuntu:
     '*': [python-hypothesis]
+python-ifaddr:
+  alpine: [py3-ifaddr]
+  arch: [python-ifaddr]
+  debian: [python3-ifaddr]
+  fedora: [python3-ifaddr]
+  ubuntu:
+    '*': [python3-ifaddr]
 python-imageio:
   debian:
     buster: [python-imageio]


### PR DESCRIPTION
Please add `python-ifaddr` to the rosdep database.
Needed in https://github.com/ros2/ros2cli/pull/875

## Package name:

python-ifaddr

## Package Upstream Source:

https://github.com/pydron/ifaddr

## Purpose of using this:

`python-netifaces` (https://github.com/al45tair/netifaces) is unmaintained: https://github.com/al45tair/netifaces/issues/78. ifaddr is an alternative.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/bookworm/python3-ifaddr
- Ubuntu: https://packages.ubuntu.com/source/jammy/python-ifaddr
- Fedora: https://packages.fedoraproject.org/pkgs/python-ifaddr/python3-ifaddr/index.html
- Arch: https://archlinux.org/packages/extra/any/python-ifaddr/
- Alpine: https://pkgs.alpinelinux.org/package/v3.18/community/x86_64/py3-ifaddr
