### PR TITLE
add serl_franka_controllers to rosdistro

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11079,6 +11079,21 @@ repositories:
       url: https://github.com/wjwwood/serial.git
       version: main
     status: maintained
+  serl_franka_controller:
+    doc:
+      type: git
+      url: https://github.com//rail-berkeley/serl_franka_controller.git
+      version: main
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com//rail-berkeley/serl_franka_controller.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com//rail-berkeley/serl_franka_controller.git
+      version: main
+    status: maintained
   sick_ldmrs_laser:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11079,19 +11079,19 @@ repositories:
       url: https://github.com/wjwwood/serial.git
       version: main
     status: maintained
-  serl_franka_controller:
+  serl_franka_controllers:
     doc:
       type: git
-      url: https://github.com//rail-berkeley/serl_franka_controller.git
+      url: https://github.com//rail-berkeley/serl_franka_controllers.git
       version: main
     release:
       tags:
         release: release/noetic/{package}/{version}
-      url: https://github.com//rail-berkeley/serl_franka_controller.git
+      url: https://github.com//rail-berkeley/serl_franka_controllers.git
       version: 0.1.0-1
     source:
       type: git
-      url: https://github.com//rail-berkeley/serl_franka_controller.git
+      url: https://github.com//rail-berkeley/serl_franka_controllers.git
       version: main
     status: maintained
   sick_ldmrs_laser:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11082,16 +11082,11 @@ repositories:
   serl_franka_controllers:
     doc:
       type: git
-      url: https://github.com//rail-berkeley/serl_franka_controllers.git
+      url: https://github.com/rail-berkeley/serl_franka_controllers.git
       version: main
-    release:
-      tags:
-        release: release/noetic/{package}/{version}
-      url: https://github.com//rail-berkeley/serl_franka_controllers.git
-      version: 0.1.0-1
     source:
       type: git
-      url: https://github.com//rail-berkeley/serl_franka_controllers.git
+      url: https://github.com/rail-berkeley/serl_franka_controllers.git
       version: main
     status: maintained
   sick_ldmrs_laser:


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

Package name: `serl_franka_controllers`

This package is a franka controller for a newly release paper of https://serl-robot.github.io/ (SERL: A Software Suite for Sample-Efficient Robotic Reinforcement Learning). 

# The source is here:

https://github.com/rail-berkeley/serl_franka_controllers

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
