### PR TITLE
wrapyfi_ros2_interfaces: 0.4.30-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9520,6 +9520,21 @@ repositories:
       url: https://github.com/clearpathrobotics/wireless.git
       version: foxy-devel
     status: maintained
+  wrapyfi_ros2_interfaces:
+    doc:
+      type: git
+      url: https://github.com/modular-ml/wrapyfi_ros2_interfaces.git
+      version: master
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/modular-ml/wrapyfi_ros2_interfaces-release.git
+      version: 0.4.30-1
+    source:
+      type: git
+      url: https://github.com/modular-ml/wrapyfi_ros2_interfaces.git
+      version: master
+    status: developed
   xacro:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wrapyfi_ros2_interfaces` to `0.4.30-1`:

- upstream repository: https://github.com/modular-ml/wrapyfi_ros2_interfaces.git
- release repository: https://github.com/modular-ml/wrapyfi_ros2_interfaces-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
