### PR TITLE
wrapyfi_ros_interfaces: 0.4.30-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12946,6 +12946,21 @@ repositories:
       url: https://github.com/ElettraSciComp/witmotion_IMU_ros.git
       version: main
     status: maintained
+  wrapyfi_ros_interfaces:
+    doc:
+      type: git
+      url: https://github.com/modular-ml/wrapyfi_ros_interfaces.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/modular-ml/wrapyfi_ros_interfaces-release.git
+      version: 0.4.30-1
+    source:
+      type: git
+      url: https://github.com/modular-ml/wrapyfi_ros_interfaces.git
+      version: master
+    status: developed
   wu_ros_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wrapyfi_ros_interfaces` to `0.4.30-1`:

- upstream repository: https://github.com/modular-ml/wrapyfi_ros_interfaces.git
- release repository: https://github.com/modular-ml/wrapyfi_ros_interfaces-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
