### PR TITLE
ros2_controllers: 2.31.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6457,7 +6457,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.30.0-1
+      version: 2.31.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.31.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.30.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

- No changes

## bicycle_steering_controller

- No changes

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* [JTC] Remove read_only from 'joints', 'state_interfaces' and 'command_interfaces' parameters (#967 <https://github.com/ros-controls/ros2_controllers/issues/967>) (#968 <https://github.com/ros-controls/ros2_controllers/issues/968>)
* [JTC] Add console output for tolerance checks (backport #932 <https://github.com/ros-controls/ros2_controllers/issues/932>) (#938 <https://github.com/ros-controls/ros2_controllers/issues/938>)
* [JTC] Cleanup includes (#943 <https://github.com/ros-controls/ros2_controllers/issues/943>) (#959 <https://github.com/ros-controls/ros2_controllers/issues/959>)
* Fix whitespace
* Add rqt_JTC to docs (#950 <https://github.com/ros-controls/ros2_controllers/issues/950>) (#952 <https://github.com/ros-controls/ros2_controllers/issues/952>)
* Contributors: Bence Magyar, mergify[bot]
```

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

```
* Add rqt_JTC to docs (#950 <https://github.com/ros-controls/ros2_controllers/issues/950>) (#952 <https://github.com/ros-controls/ros2_controllers/issues/952>)
* Contributors: mergify[bot]
```

## steering_controllers_library

```
* Fix ackermann steering odometry (#921 <https://github.com/ros-controls/ros2_controllers/issues/921>) (#955 <https://github.com/ros-controls/ros2_controllers/issues/955>)
* Contributors: mergify[bot]
```

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
