### PR TITLE
moveit_msgs: 2.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3012,7 +3012,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_msgs-release.git
-      version: 2.3.0-1
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_msgs` to `2.4.0-1`:

- upstream repository: https://github.com/ros-planning/moveit_msgs.git
- release repository: https://github.com/ros2-gbp/moveit_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.0-1`

## moveit_msgs

```
* Add error message string to MoveItErrorCode msg (#171 <https://github.com/ros-planning/moveit_msgs/issues/171>)
  * Add error message string to MoveItErrorCode msg
  * Add error source string
  * Add comments
  * Update msg/MoveItErrorCodes.msg
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@tuta.io>
  * Update msg/MoveItErrorCodes.msg
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
  ---------
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Defined UNDEFINED (#172 <https://github.com/ros-planning/moveit_msgs/issues/172>)
* Add PipelineState msg
* Merge CI updates from branch 'master' into ros2
* CI: Update GHA (#166 <https://github.com/ros-planning/moveit_msgs/issues/166>)
* Merge CI updates from branch 'master' into ros2
* CI: Update .pre-commit-config.yaml (#163 <https://github.com/ros-planning/moveit_msgs/issues/163>)
* CI format.yml: Update GHA
* 0.11.4
* Add more MoveItErrorCodes to match all OMPL codes (#147 <https://github.com/ros-planning/moveit_msgs/issues/147>)
* Contributors: Abishalini Sivaraman, AndyZe, Robert Haschke, Sebastian Jahr, mosfet80
```
