### PR TITLE
cras_joy_tools: 1.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1687,7 +1687,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/cras_joy_tools.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ctu-vras/cras_joy_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_joy_tools` to `1.0.2-1`:

- upstream repository: https://github.com/ctu-vras/cras_joy_tools
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/cras_joy_tools.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.1-1`

## cras_joy_tools

```
* Fixed installation of the package shared files.
* Contributors: Martin Pecka
```
