### PR TITLE
imu_tools: 1.2.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4147,7 +4147,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/uos-gbp/imu_tools-release.git
-      version: 1.2.5-1
+      version: 1.2.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `1.2.6-1`:

- upstream repository: https://github.com/ccny-ros-pkg/imu_tools.git
- release repository: https://github.com/uos-gbp/imu_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.5-1`

## imu_complementary_filter

```
* complementary filter launch: Remove outdated phidgets_imu nodelet
  The phidgets_imu package was renamed to phidgets_spatial. To avoid
  adding a dependency on phidgets_spatial, this commit removes the include
  of that nodelet altogether.
  If launching the phidgets driver is desired, it should be done like in
  this launch file:
  https://github.com/ros-drivers/phidgets_drivers/blob/20512def27a74666aeb2eb2d31ff2faf45062c35/phidgets_spatial/launch/spatial.launch
  Fixes #186 <https://github.com/CCNYRoboticsLab/imu_tools/issues/186>.
* add complementary_filter_nodelet (#181 <https://github.com/CCNYRoboticsLab/imu_tools/issues/181>)
* Contributors: Borong Yuan, Martin Günther
```

## imu_filter_madgwick

```
* Merge pull request #192 <https://github.com/CCNYRoboticsLab/imu_tools/issues/192> from enwaytech/av/remove_launchers
  Increase max stddev, add pose visualization, fix error messages
* add timeout to lookupTransform
  Otherwise there are a lot of warnings of lookup would require extrapolation into the future
* publish orientation as Pose to vis on rviz
* show correct topics even if remapped
* increase max covariance
* Contributors: Adi Vardi, Martin Günther
```

## imu_tools

- No changes

## rviz_imu_plugin

- No changes
