### PR TITLE
generate_parameter_library: 0.3.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2214,6 +2214,7 @@ repositories:
       version: main
     release:
       packages:
+      - cmake_generate_parameter_module_example
       - generate_parameter_library
       - generate_parameter_library_example
       - generate_parameter_library_py
@@ -2222,7 +2223,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 0.3.6-1
+      version: 0.3.7-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `generate_parameter_library` to `0.3.7-1`:

- upstream repository: https://github.com/PickNikRobotics/generate_parameter_library.git
- release repository: https://github.com/ros2-gbp/generate_parameter_library-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.6-1`

## cmake_generate_parameter_module_example

```
* Enable generate_parameter_module through ament_cmake_python (#161 <https://github.com/PickNikRobotics/generate_parameter_library/issues/161>)
* Contributors: Paul Gesel
```

## generate_parameter_library

```
* Enable generate_parameter_module through ament_cmake_python (#161 <https://github.com/PickNikRobotics/generate_parameter_library/issues/161>)
* Contributors: Paul Gesel
```

## generate_parameter_library_example

```
* Split example/README.md into C++ and Python version; updated content (#138 <https://github.com/PickNikRobotics/generate_parameter_library/issues/138>)
* Contributors: chriseichmann
```

## generate_parameter_library_py

```
* fix Python runtime parameters bug (#165 <https://github.com/PickNikRobotics/generate_parameter_library/issues/165>)
* markdown/rst: Support __map_ and nested parameters (#164 <https://github.com/PickNikRobotics/generate_parameter_library/issues/164>)
  * Support nested parameters and maps for RST
  * Add read_only info to RST template
  * Use map parameters for AutoDocumentation
  * Add test for markdown generation
  * Use jinja indentation instead of regex
  * Add dynamic_parameters also to DefaultConfig
  * Proper fromat of default yaml config
  * Proper format of the default yaml file
  * Fix imported function names
  * Add a jinja2 filter to create valid multiline c++ string literals
  * Handle empty strings for descriptions
* parse_yaml.py: keep the trailing newline (#159 <https://github.com/PickNikRobotics/generate_parameter_library/issues/159>)
* Fix rolling CI (#162 <https://github.com/PickNikRobotics/generate_parameter_library/issues/162>)
* parse_yaml.py: fix issue with typeguard (#154 <https://github.com/PickNikRobotics/generate_parameter_library/issues/154>)
* Bugfixes on Python code generation (#152 <https://github.com/PickNikRobotics/generate_parameter_library/issues/152>)
  * Fix raising of validation error
  * Fix inverse logic of 'unique' validator
* Fix sentence for size_lt (#150 <https://github.com/PickNikRobotics/generate_parameter_library/issues/150>)
* Fix typeguard error (#149 <https://github.com/PickNikRobotics/generate_parameter_library/issues/149>)
  For typeguard==3.0.2, default_value: any raised a TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union during colcon build of a Python node using this library.
  Using the Any from the typing module fixed this issue.
  Yes, this problem does not occur with the typeguard version provided by apt (2.2.2), but could also occur if Ubuntu bumps that version or for other users with a newer local pip install of typeguard.
* Remove my_parameter from python template (#146 <https://github.com/PickNikRobotics/generate_parameter_library/issues/146>)
* Contributors: Bruno-Pier, Christoph Fröhlich, Jan Gutsche, Matthias Schoepfer, Paul Gesel, agonzat
* fix Python runtime parameters bug (#165 <https://github.com/PickNikRobotics/generate_parameter_library/issues/165>)
* markdown/rst: Support __map_ and nested parameters (#164 <https://github.com/PickNikRobotics/generate_parameter_library/issues/164>)
  * Support nested parameters and maps for RST
  * Add read_only info to RST template
  * Use map parameters for AutoDocumentation
  * Add test for markdown generation
  * Use jinja indentation instead of regex
  * Add dynamic_parameters also to DefaultConfig
  * Proper fromat of default yaml config
  * Proper format of the default yaml file
  * Fix imported function names
  * Add a jinja2 filter to create valid multiline c++ string literals
  * Handle empty strings for descriptions
* parse_yaml.py: keep the trailing newline (#159 <https://github.com/PickNikRobotics/generate_parameter_library/issues/159>)
* Fix rolling CI (#162 <https://github.com/PickNikRobotics/generate_parameter_library/issues/162>)
* parse_yaml.py: fix issue with typeguard (#154 <https://github.com/PickNikRobotics/generate_parameter_library/issues/154>)
* Bugfixes on Python code generation (#152 <https://github.com/PickNikRobotics/generate_parameter_library/issues/152>)
  * Fix raising of validation error
  * Fix inverse logic of 'unique' validator
* Fix sentence for size_lt (#150 <https://github.com/PickNikRobotics/generate_parameter_library/issues/150>)
* Fix typeguard error (#149 <https://github.com/PickNikRobotics/generate_parameter_library/issues/149>)
  For typeguard==3.0.2, default_value: any raised a TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union during colcon build of a Python node using this library.
  Using the Any from the typing module fixed this issue.
  Yes, this problem does not occur with the typeguard version provided by apt (2.2.2), but could also occur if Ubuntu bumps that version or for other users with a newer local pip install of typeguard.
* Remove my_parameter from python template (#146 <https://github.com/PickNikRobotics/generate_parameter_library/issues/146>)
* Contributors: Bruno-Pier, Christoph Fröhlich, Jan Gutsche, Matthias Schoepfer, Paul Gesel, agonzat
```

## generate_parameter_module_example

```
* Fix rolling CI (#162 <https://github.com/PickNikRobotics/generate_parameter_library/issues/162>)
* Split example/README.md into C++ and Python version; updated content (#138 <https://github.com/PickNikRobotics/generate_parameter_library/issues/138>)
* Contributors: Paul Gesel, chriseichmann
```

## parameter_traits

- No changes
