### PR TITLE
Revert "Adding noble to rosdep_repo_check targets"

### DIFF
--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -73,7 +73,6 @@ supported_versions:
   ubuntu:
   - focal
   - jammy
-  - noble
 
 supported_arches:
   alpine:


### PR DESCRIPTION
Reverts ros/rosdistro#39514

To get CI working again until the noble support is added to our repos.