### PR TITLE
Re-add Noble support for rolling

### DIFF
--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -73,6 +73,7 @@ supported_versions:
   ubuntu:
   - focal
   - jammy
+  - noble
 
 supported_arches:
   alpine:


### PR DESCRIPTION
This restores "Adding noble to rosdep_repo_check targets"" https://github.com/ros/rosdistro/pull/39514

This was merged before the repos were setup and the rosdep CI started erroring. Hold this until noble is avaialble in our default repos. 

@nuclearsandwich Assigning to you for timing. 