### PR TITLE
generate_parameter_library: remove example packages

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2224,11 +2224,8 @@ repositories:
       version: main
     release:
       packages:
-      - cmake_generate_parameter_module_example
       - generate_parameter_library
-      - generate_parameter_library_example
       - generate_parameter_library_py
-      - generate_parameter_module_example
       - parameter_traits
       tags:
         release: release/humble/{package}/{version}

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1745,11 +1745,8 @@ repositories:
       version: main
     release:
       packages:
-      - cmake_generate_parameter_module_example
       - generate_parameter_library
-      - generate_parameter_library_example
       - generate_parameter_library_py
-      - generate_parameter_module_example
       - parameter_traits
       tags:
         release: release/iron/{package}/{version}

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1664,7 +1664,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 0.3.7-1
+      version: 0.3.7-2
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1655,11 +1655,8 @@ repositories:
       version: main
     release:
       packages:
-      - cmake_generate_parameter_module_example
       - generate_parameter_library
-      - generate_parameter_library_example
       - generate_parameter_library_py
-      - generate_parameter_module_example
       - parameter_traits
       tags:
         release: release/rolling/{package}/{version}

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1661,7 +1661,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 0.3.7-2
+      version: 0.3.7-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git


### PR DESCRIPTION
Dropping example packages from the distribution. There was no good reason for these to be packaged. I tried putting ignored files in the release repo and running a release but that didn't seem to work as I expected.