### PR TITLE
libxkbcommon-dev on RHEL 8

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6186,6 +6186,7 @@ libxinerama-dev:
 libxkbcommon-dev:
   debian: [libxkbcommon-dev]
   fedora: [libxkbcommon-devel]
+  rhel: [libxkbcommon-devel]
   ubuntu: [libxkbcommon-dev]
 libxml++-2.6:
   arch: [libxml++]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

libxkbcommon-dev

Distro packaging links:

## Links to Distribution Packages

- rhel: https://rhel.pkgs.org/
  - https://rhel.pkgs.org/8/okey-x86_64/libxkbcommon-devel-0.8.2-1.el8.x86_64.rpm.html
