### PR TITLE
pangolin: 0.9.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4765,10 +4765,16 @@ repositories:
       version: humble-devel
     status: developed
   pangolin:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/Pangolin-release.git
+      version: 0.9.0-1
     source:
       type: git
       url: https://github.com/stevenlovegrove/Pangolin.git
       version: master
+    status: maintained
   pcl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pangolin` to `0.9.0-1`:

- upstream repository: https://github.com/stevenlovegrove/Pangolin.git
- release repository: https://github.com/ros2-gbp/Pangolin-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
