### PR TITLE
Add python3-ruff-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8530,6 +8530,13 @@ python3-ruamel.yaml:
   openembedded: [python3-ruamel-yaml@meta-python]
   rhel: ['python%{python3_pkgversion}-ruamel-yaml']
   ubuntu: [python3-ruamel.yaml]
+python3-ruff-pip:
+  debian:
+    pip:
+      packages: [ruff]
+  ubuntu:
+    pip:
+      packages: [ruff]
 python3-sbp-pip: *migrate_eol_2027_04_30_python3_sbp_pip
 python3-schedule:
   debian: [python3-schedule]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`ruff`

## Package Upstream Source:

https://pypi.org/project/ruff/

## Purpose of using this:

Ruff is a python linter and formatter.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- pip: https://pypi.org/project/ruff/
- Debian: https://packages.debian.org/
  - Use `pip` package linked above. Not available in the Debian repositories
- Ubuntu: https://packages.ubuntu.com/
  - Use `pip` package linked above. Not available in the Debian repositories
- Fedora: https://packages.fedoraproject.org/
  - NOT AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - NOT AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - NOT AVAILABLE
- macOS: https://formulae.brew.sh/
  - NOT AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - NOT AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - NOT AVAILABLE
- openSUSE: https://software.opensuse.org/package/
  - NOT AVAILABLE
- rhel: https://rhel.pkgs.org/
  - NOT AVAILABLE
