### PR TITLE
sick_scan_xd: 3.1.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7830,7 +7830,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/sick_scan_xd-release.git
-      version: 3.1.7-2
+      version: 3.1.8-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_scan_xd.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_scan_xd` to `3.1.8-1`:

- upstream repository: https://github.com/SICKAG/sick_scan_xd.git
- release repository: https://github.com/ros2-gbp/sick_scan_xd-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.1.7-2`

## sick_scan_xd

```
* Removed pthread dependency under ROS-2
* Contributors: rostest
```
