### PR TITLE
libcaer: 1.2.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2684,7 +2684,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/libcaer-release.git
-      version: 1.2.1-1
+      version: 1.2.2-1
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libcaer` to `1.2.2-1`:

- upstream repository: https://github.com/ros-event-camera/libcaer.git
- release repository: https://github.com/ros2-gbp/libcaer-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.1-1`

## libcaer

```
* added dependency on cmake
* Contributors: Bernd Pfrommer
```
