### PR TITLE
Remove "boeing" prefix from released gazebo packages

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -705,6 +705,15 @@ repositories:
       url: https://github.com/flynneva/bno055.git
       version: main
     status: maintained
+  boeing_gazebo_model_attachment_plugin:
+    doc:
+      type: git
+      url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
+      version: humble
   bond_core:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -735,7 +735,7 @@ repositories:
       url: https://github.com/flynneva/bno055.git
       version: main
     status: maintained
-  boeing_gazebo_model_attachment_plugin:
+  gazebo_model_attachment_plugin:
     doc:
       type: git
       url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
@@ -753,14 +753,14 @@ repositories:
       url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
       version: humble
     status: maintained
-  boeing_gazebo_set_joint_positions_plugin:
+  gazebo_set_joint_positions_plugin:
     doc:
       type: git
-      url: https://github.com/Boeing/boeing_gazebo_set_joint_positions_plugin.git
+      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
       version: humble
     source:
       type: git
-      url: https://github.com/Boeing/boeing_gazebo_set_joint_positions_plugin.git
+      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
       version: humble
   bond_core:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -751,11 +751,11 @@ repositories:
   boeing_gazebo_set_joint_positions_plugin:
     doc:
       type: git
-      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      url: https://github.com/Boeing/boeing_gazebo_set_joint_positions_plugin.git
       version: humble
     source:
       type: git
-      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      url: https://github.com/Boeing/boeing_gazebo_set_joint_positions_plugin.git
       version: humble
   bond_core:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -714,6 +714,15 @@ repositories:
       type: git
       url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
       version: humble
+  boeing_gazebo_set_joint_positions_plugin:
+    doc:
+      type: git
+      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      version: humble
   bond_core:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -735,33 +735,6 @@ repositories:
       url: https://github.com/flynneva/bno055.git
       version: main
     status: maintained
-  gazebo_model_attachment_plugin:
-    doc:
-      type: git
-      url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
-      version: humble
-    release:
-      packages:
-      - gazebo_model_attachment_plugin
-      - gazebo_model_attachment_plugin_msgs
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/ros2-gbp/boeing_gazebo_model_attachement_plugin-release.git
-      version: 1.0.3-2
-    source:
-      type: git
-      url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
-      version: humble
-    status: maintained
-  gazebo_set_joint_positions_plugin:
-    doc:
-      type: git
-      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
-      version: humble
-    source:
-      type: git
-      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
-      version: humble
   bond_core:
     doc:
       type: git
@@ -2136,6 +2109,24 @@ repositories:
       url: https://github.com/foxglove/schemas.git
       version: main
     status: developed
+  gazebo_model_attachment_plugin:
+    doc:
+      type: git
+      url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
+      version: humble
+    release:
+      packages:
+      - gazebo_model_attachment_plugin
+      - gazebo_model_attachment_plugin_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/boeing_gazebo_model_attachement_plugin-release.git
+      version: 1.0.3-2
+    source:
+      type: git
+      url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
+      version: humble
+    status: maintained
   gazebo_ros2_control:
     doc:
       type: git
@@ -2176,6 +2167,15 @@ repositories:
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
       version: ros2
     status: maintained
+  gazebo_set_joint_positions_plugin:
+    doc:
+      type: git
+      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      version: humble
   gazebo_video_monitors:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -568,11 +568,11 @@ repositories:
   boeing_gazebo_set_joint_positions_plugin:
     doc:
       type: git
-      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      url: https://github.com/Boeing/boeing_gazebo_set_joint_positions_plugin.git
       version: noetic
     source:
       type: git
-      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      url: https://github.com/Boeing/boeing_gazebo_set_joint_positions_plugin.git
       version: noetic
   bond_core:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -553,7 +553,7 @@ repositories:
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
       version: master
     status: developed
-  boeing_gazebo_model_attachment_plugin:
+  gazebo_model_attachment_plugin:
     doc:
       type: git
       url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
@@ -570,14 +570,14 @@ repositories:
       url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
       version: noetic
     status: maintained
-  boeing_gazebo_set_joint_positions_plugin:
+  gazebo_set_joint_positions_plugin:
     doc:
       type: git
-      url: https://github.com/Boeing/boeing_gazebo_set_joint_positions_plugin.git
+      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
       version: noetic
     source:
       type: git
-      url: https://github.com/Boeing/boeing_gazebo_set_joint_positions_plugin.git
+      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
       version: noetic
   bond_core:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -526,11 +526,11 @@ repositories:
   boeing_gazebo_model_attachment_plugin:
     doc:
       type: git
-      url: https://github.com/Boeing/gazebo_model_attachment_plugin
+      url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
       version: noetic
     source:
       type: git
-      url: https://github.com/Boeing/gazebo_model_attachment_plugin
+      url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
       version: noetic
   bond_core:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -523,6 +523,15 @@ repositories:
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
       version: master
     status: developed
+  boeing_gazebo_model_attachment_plugin:
+    doc:
+      type: git
+      url: https://github.com/Boeing/gazebo_model_attachment_plugin
+      version: noetic
+    source:
+      type: git
+      url: https://github.com/Boeing/gazebo_model_attachment_plugin
+      version: noetic
   bond_core:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -553,32 +553,6 @@ repositories:
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
       version: master
     status: developed
-  gazebo_model_attachment_plugin:
-    doc:
-      type: git
-      url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
-      version: noetic
-    release:
-      packages:
-      - gazebo_model_attachment_plugin
-      tags:
-        release: release/noetic/{package}/{version}
-      url: https://github.com/ros2-gbp/boeing_gazebo_model_attachement_plugin-release.git
-      version: 1.0.2-5
-    source:
-      type: git
-      url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
-      version: noetic
-    status: maintained
-  gazebo_set_joint_positions_plugin:
-    doc:
-      type: git
-      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
-      version: noetic
-    source:
-      type: git
-      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
-      version: noetic
   bond_core:
     doc:
       type: git
@@ -3221,6 +3195,21 @@ repositories:
       url: https://github.com/ctu-vras/gazebo_custom_sensor_preloader.git
       version: master
     status: maintained
+  gazebo_model_attachment_plugin:
+    doc:
+      type: git
+      url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
+      version: noetic
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros2-gbp/boeing_gazebo_model_attachement_plugin-release.git
+      version: 1.0.2-5
+    source:
+      type: git
+      url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
+      version: noetic
+    status: maintained
   gazebo_ros_control_select_joints:
     release:
       tags:
@@ -3255,6 +3244,15 @@ repositories:
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
       version: noetic-devel
     status: maintained
+  gazebo_set_joint_positions_plugin:
+    doc:
+      type: git
+      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      version: noetic
+    source:
+      type: git
+      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      version: noetic
   gazebo_video_monitors:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -532,6 +532,15 @@ repositories:
       type: git
       url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
       version: noetic
+  boeing_gazebo_set_joint_positions_plugin:
+    doc:
+      type: git
+      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      version: noetic
+    source:
+      type: git
+      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      version: noetic
   bond_core:
     doc:
       type: git


### PR DESCRIPTION
Updating the repository name by removing the entity prefix.

## Package name:

gazebo_set_joint_positions_plugin
gazebo_model_attachment_plugin

## Package Upstream Source:

[gazebo_set_joint_positions_plugin](https://github.com/Boeing/gazebo_set_joint_positions_plugin)
[gazebo_model_attachment_plugin](https://github.com/Boeing/gazebo_model_attachment_plugin)

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
