### PR TITLE
plotjuggler: 3.8.7-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4170,7 +4170,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.8.6-2
+      version: 3.8.7-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.8.7-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/ros2-gbp/plotjuggler-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.8.6-2`

## plotjuggler

```
* add "prefix and merge" checkbox
* fix warning "transparent.png"
* fix issue #912 <https://github.com/facontidavide/PlotJuggler/issues/912>
* Contributors: Davide Faconti
```
