### PR TITLE
Add choreography packages to python3-bosdyn-*-pip rules

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5025,17 +5025,17 @@ python3-bokeh-pip:
 python3-bosdyn-api-pip:
   debian:
     pip:
-      packages: [bosdyn-api]
+      packages: [bosdyn-api, bosdyn-choreography-protos]
   ubuntu:
     pip:
-      packages: [bosdyn-api]
+      packages: [bosdyn-api, bosdyn-choreography-protos]
 python3-bosdyn-client-pip:
   debian:
     pip:
-      packages: [bosdyn-client]
+      packages: [bosdyn-client, bosdyn-choreography-client]
   ubuntu:
     pip:
-      packages: [bosdyn-client]
+      packages: [bosdyn-client, bosdyn-choreography-client]
 python3-bosdyn-core-pip:
   debian:
     pip:


### PR DESCRIPTION
Please update the following dependencies in the rosdep database.

## Package name:

`bosdyn-choreography-protos` and `bosdyn-choreography-client`

## Package Upstream Source:

https://github.com/boston-dynamics/spot-sdk

## Purpose of using this:

The rationale for updating existing keys rather than adding new ones is the implicit dependency `bosdyn-choreograph-*` packages have on core `bosdyn-*` packages. It is beyond me why these were released separately. 

## Links to Distribution Packages

These packages only exist on PyPi:

- [`bosdyn-choreography-protos`](https://pypi.org/project/bosdyn-choreography-protos)
- [`bosdyn-choreography-client`](https://pypi.org/project/bosdyn-choreography-client)