### PR TITLE
boost_plugin_loader: 0.2.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -803,7 +803,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/tesseract-robotics-release/boost_plugin_loader-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/tesseract-robotics/boost_plugin_loader.git


### PR DESCRIPTION
Increasing version of package(s) in repository `boost_plugin_loader` to `0.2.2-1`:

- upstream repository: git@github.com:tesseract-robotics/boost_plugin_loader.git
- release repository: https://github.com/tesseract-robotics-release/boost_plugin_loader-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.1-1`

## boost_plugin_loader

```
* Catch exceptions when enumerating possible symbols and sections (#17 <https://github.com/marip8/boost_plugin_loader/issues/17>)
* CI Update (#12 <https://github.com/marip8/boost_plugin_loader/issues/12>)
* Change CI to run on Ubuntu 20.04 (#15 <https://github.com/marip8/boost_plugin_loader/issues/15>)
* Contributors: Michael Ripperger
```
