### PR TITLE
libcaer_driver: 1.2.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2695,6 +2695,11 @@ repositories:
       type: git
       url: https://github.com/ros-event-camera/libcaer_driver.git
       version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/libcaer_driver-release.git
+      version: 1.2.1-1
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libcaer_driver` to `1.2.1-1`:

- upstream repository: https://github.com/ros-event-camera/libcaer_driver.git
- release repository: https://github.com/ros2-gbp/libcaer_driver-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## libcaer_driver

```
* initial release of ROS2 package
* Contributors: Bernd Pfrommer, Thies Lennart Alff
```
