### PR TITLE
pangolin: 0.9.0-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4784,7 +4784,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/Pangolin-release.git
-      version: 0.9.0-1
+      version: 0.9.0-2
     source:
       type: git
       url: https://github.com/stevenlovegrove/Pangolin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pangolin` to `0.9.0-2`:

- upstream repository: https://github.com/stevenlovegrove/Pangolin.git
- release repository: https://github.com/ros2-gbp/Pangolin-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.9.0-1`
