### PR TITLE
sync_parameter_server: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8214,6 +8214,17 @@ repositories:
       type: git
       url: https://github.com/Tacha-S/sync_parameter_server.git
       version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/sync_parameter_server-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/Tacha-S/sync_parameter_server.git
+      version: main
+    status: developed
   system_fingerprint:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sync_parameter_server` to `1.0.0-1`:

- upstream repository: https://github.com/Tacha-S/sync_parameter_server.git
- release repository: https://github.com/ros2-gbp/sync_parameter_server-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## sync_parameter_server

```
* Add scale and offset to integer
* Add document
* Add sync parameter server node
* Initial commit
* Contributors: Tatsuro Sakaguchi
```
