### PR TITLE
pal_robotiq_gripper: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4746,6 +4746,25 @@ repositories:
       url: https://github.com/pal-robotics/pal_navigation_cfg_public.git
       version: humble-devel
     status: developed
+  pal_robotiq_gripper:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pal_robotiq_gripper.git
+      version: humble-devel
+    release:
+      packages:
+      - pal_robotiq_controller_configuration
+      - pal_robotiq_description
+      - pal_robotiq_gripper
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/pal_robotiq_gripper-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pal_robotiq_gripper.git
+      version: humble-devel
+    status: developed
   pal_statistics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_robotiq_gripper` to `2.0.0-1`:

- upstream repository: https://github.com/pal-robotics/pal_robotiq_gripper.git
- release repository: https://github.com/pal-gbp/pal_robotiq_gripper-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## pal_robotiq_controller_configuration

```
* updating license to apache
* linters
* fix config yaml file error
* changing the type of the controllers according to ros2
* deleting the installation of the home_gripper script
* adapting pal_robotiq_controller_configuration package to ros 2
* adapting launch files into the new launch files structure
* deleting unused home_gripper script
* adding myself as maintainer
* home_gripper ported but still need to check if necessary
* controller configuration package ported
* Cmake changes
* Contributors: Aina Irisarri
```

## pal_robotiq_description

```
* updating the package.xml version
* removing empty choice for end_effector
* renaming xacro files into the end_effector name
* merging show launch files into one
* updating license to apache
* linters
* deleting transmition from the grippers urdfs
* adding mimic joints by hand, as result of no library for mimic gazebo
* changes related on deleting mimic library for gazebo
* adding the correct .rviz files for 85 and 140 robotiq gripper and its launch files
* merging the 85 and 140 package into pal_robotiq_description
* Contributors: Aina Irisarri
* updating the package.xml version
* removing empty choice for end_effector
* renaming xacro files into the end_effector name
* merging show launch files into one
* updating license to apache
* linters
* deleting transmition from the grippers urdfs
* adding mimic joints by hand, as result of no library for mimic gazebo
* changes related on deleting mimic library for gazebo
* adding the correct .rviz files for 85 and 140 robotiq gripper and its launch files
* merging the 85 and 140 package into pal_robotiq_description
* Contributors: Aina Irisarri
```

## pal_robotiq_gripper

```
* updating license to apache
* merging the 85 and 140 package into pal_robotiq_description
* adapting package.xml & Cmake to the new structure
* adding myself as maintainer
* basic ros to ros2 changes
* Cmake changes
* Contributors: Aina Irisarri
```
