### PR TITLE
plotjuggler: 3.8.8-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7638,7 +7638,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.8.7-1
+      version: 3.8.8-3
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.8.8-3`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.8.7-1`

## plotjuggler

```
* new update screen
* Update README.md
* dig diagnostic messages
* fix snap in CI
* Contributors: Davide Faconti
```
