### PR TITLE
clearpath_simulator: 0.2.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1028,7 +1028,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_simulator-release.git
-      version: 0.2.2-1
+      version: 0.2.3-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_simulator` to `0.2.3-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_simulator.git
- release repository: https://github.com/clearpath-gbp/clearpath_simulator-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.2-1`

## clearpath_generator_gz

```
* Removed print
* Removed namespaced tf_static
* 0.2.2
* Changes.
* 0.2.1
* Changes.
* Added all dingo to generator
* 0.2.0
* Changes.
* Added Warthog and Dingo to generator
* Added Generic robot components
* Sensor static tf should use robot namespace
* Contributors: Luis Camero, Roni Kreinin, Tony Baltovski, luis-camero
```

## clearpath_gz

```
* 0.2.2
* Changes.
* Add all sourced ros packages to gazebo resource path to address user workspaces with custom meshes
* 0.2.1
* Changes.
* 0.2.0
* Changes.
* Lifted platform to 0.3 m
* Updated links in the warehouse
* Contributors: Hilary Luo, Luis Camero, Tony Baltovski
```

## clearpath_simulator

```
* 0.2.2
* Changes.
* 0.2.1
* Changes.
* 0.2.0
* Changes.
* Contributors: Tony Baltovski
```
