### PR TITLE
pal_gripper: 3.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4720,7 +4720,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_gripper-release.git
-      version: 3.0.7-1
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_gripper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_gripper` to `3.1.0-1`:

- upstream repository: https://github.com/pal-robotics/pal_gripper.git
- release repository: https://github.com/pal-gbp/pal_gripper-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.7-1`

## pal_gripper

```
* Merge branch 'tiago-dual' into 'humble-devel'
  Adapted pal_gripper_controller_configuration to ros2
  See merge request robots/pal_gripper!32
* CMake version to 3.8
* Contributors: David ter Kuile, davidterkuile
```

## pal_gripper_controller_configuration

```
* Merge branch 'tiago-dual' into 'humble-devel'
  Adapted pal_gripper_controller_configuration to ros2
  See merge request robots/pal_gripper!32
* CMake version to 3.8
* Update variable name of gripper_prefix
* Change to ee_suffix
* Default side argument set to empty
* combine gripper controller params in single file with parametrization
* Contributors: David ter Kuile, davidterkuile
```

## pal_gripper_description

```
* Merge branch 'tiago-dual' into 'humble-devel'
  Adapted pal_gripper_controller_configuration to ros2
  See merge request robots/pal_gripper!32
* CMake version to 3.8
* Contributors: David ter Kuile, davidterkuile
```
