### PR TITLE
pal_hey5: 4.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4739,7 +4739,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_hey5-release.git
-      version: 4.0.1-1
+      version: 4.1.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_hey5.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_hey5` to `4.1.0-1`:

- upstream repository: https://github.com/pal-robotics/pal_hey5.git
- release repository: https://github.com/pal-gbp/pal_hey5-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.1-1`

## pal_hey5

- No changes

## pal_hey5_controller_configuration

```
* Merge branch 'tiago-dual-ros2' into 'humble-devel'
  Add parametric yaml file and end_effector side for tiago dual
  See merge request robots/pal_hey5!4
* Update variable name of gripper_prefix
* fix typo
* Change to ee_suffix
* Add parametric yaml file and gripper side for tiago dual
* Contributors: David ter Kuile, davidterkuile
```

## pal_hey5_description

- No changes
