### PR TITLE
tiago_robot: 4.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8471,7 +8471,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_robot-release.git
-      version: 4.0.28-1
+      version: 4.1.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_robot` to `4.1.1-1`:

- upstream repository: https://github.com/pal-robotics/tiago_robot
- release repository: https://github.com/pal-gbp/tiago_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.28-1`

## tiago_bringup

```
* adding the config files needed for robotiq
* fix prepare_grasp motion
* Contributors: Aina Irisarri
```

## tiago_controller_configuration

```
* adding the config files needed for robotiq
* modifying where to find the urdfs for robotiq
* updating the necessary dependencies for robotiq
* Contributors: Aina Irisarri
```

## tiago_description

```
* epick end effector commented
* differentiating macros for robotiq-85 & robotiq-140
* removing epick as posible end_effector for now
* modifying where to find the urdfs for robotiq
* updating the necessary dependencies for robotiq
* adding robotiq_grippers as possibles end_effectors
* Contributors: Aina Irisarri
```

## tiago_robot

- No changes
