### PR TITLE
ament_black: 0.2.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -169,7 +169,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ament_black-release.git
-      version: 0.2.3-1
+      version: 0.2.4-1
     source:
       type: git
       url: https://github.com/botsandus/ament_black.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_black` to `0.2.4-1`:

- upstream repository: https://github.com/botsandus/ament_black.git
- release repository: https://github.com/ros2-gbp/ament_black-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.3-1`

## ament_black

```
* Nacho/fix rolling build (#9 <https://github.com/botsandus/ament_black/issues/9>)
* Nacho/fix xunit report (#8 <https://github.com/botsandus/ament_black/issues/8>)
* Contributors: Ignacio Vizzo
```

## ament_cmake_black

- No changes
