### PR TITLE
rviz: 13.3.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6324,7 +6324,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 13.3.0-1
+      version: 13.3.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `13.3.0-2`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `13.3.0-1`

## rviz2

```
* Add "R" key as shortcut for resetTime (#1088 <https://github.com/ros2/rviz/issues/1088>)
* Switch to target_link_libraries. (#1098 <https://github.com/ros2/rviz/issues/1098>)
* Contributors: Chris Lalancette, Paul Erik Frivold
```

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Implement reset time service (#1109 <https://github.com/ros2/rviz/issues/1109>)
* Add "R" key as shortcut for resetTime (#1088 <https://github.com/ros2/rviz/issues/1088>)
* Add fullscreen startup option (#1097 <https://github.com/ros2/rviz/issues/1097>)
* Switch to target_link_libraries. (#1098 <https://github.com/ros2/rviz/issues/1098>)
* Initialize more of the visualization_manager members. (#1090 <https://github.com/ros2/rviz/issues/1090>)
* Explicit time conversions and comparisons (#1087 <https://github.com/ros2/rviz/issues/1087>)
* Rolling namespace in title (#1074 <https://github.com/ros2/rviz/issues/1074>)
* Contributors: AiVerisimilitude, Chris Lalancette, Hyunseok, Markus Bader, Paul Erik Frivold
```

## rviz_default_plugins

```
* Fix typo (#1104 <https://github.com/ros2/rviz/issues/1104>)
* Fix potencial leak / seg fault (#726 <https://github.com/ros2/rviz/issues/726>)
* Fixed screw display (#1093 <https://github.com/ros2/rviz/issues/1093>)
* Explicit time conversions and comparisons (#1087 <https://github.com/ros2/rviz/issues/1087>)
* Handle missing effort limit in URDF (#1084 <https://github.com/ros2/rviz/issues/1084>)
* Contributors: AiVerisimilitude, Alejandro Hernández Cordero, Christoph Fröhlich, Patrick Roncagliolo
```

## rviz_ogre_vendor

```
* Suppress a couple more of clang warnings in rviz_ogre_vendor. (#1102 <https://github.com/ros2/rviz/issues/1102>)
* Contributors: Chris Lalancette
```

## rviz_rendering

```
* Switch to target_link_libraries. (#1098 <https://github.com/ros2/rviz/issues/1098>)
* Update rviz_rendering and rviz_rendering_tests to C++17. (#1096 <https://github.com/ros2/rviz/issues/1096>)
* Contributors: Chris Lalancette
```

## rviz_rendering_tests

```
* Update rviz_rendering and rviz_rendering_tests to C++17. (#1096 <https://github.com/ros2/rviz/issues/1096>)
* Contributors: Chris Lalancette
```

## rviz_visual_testing_framework

- No changes
