### PR TITLE
rviz: 12.4.5-2 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6661,7 +6661,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 12.4.5-1
+      version: 12.4.5-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `12.4.5-2`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `12.4.5-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Initialize more of the visualization_manager members. (#1092 <https://github.com/ros2/rviz/issues/1092>)
* Contributors: Chris Lalancette
```

## rviz_default_plugins

```
* Handle missing effort limit in URDF (#1086 <https://github.com/ros2/rviz/issues/1086>)
* Contributors: Chris Lalancette, Patrick Roncagliolo
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Removed warning when building in release mode (#1060 <https://github.com/ros2/rviz/issues/1060>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
