### PR TITLE
mola_test_datasets: 0.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2949,6 +2949,11 @@ repositories:
       type: git
       url: https://github.com/MOLAorg/mola_test_datasets.git
       version: develop
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/mola_test_datasets-release.git
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_test_datasets.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_test_datasets` to `0.3.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_test_datasets.git
- release repository: https://github.com/ros2-gbp/mola_test_datasets-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## mola_test_datasets

```
* clarify copyright notices.
* add file attribute to <license> tag
* minor fixes
* Contributors: Jose Luis Blanco-Claraco
```
