### PR TITLE
ros2_control: 4.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5171,7 +5171,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.2.0-1
+      version: 4.3.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.3.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.2.0-1`

## controller_interface

```
* Issue 695: Changing 'namespace_' variables to 'node_namespace' to make it more explicit (#1239 <https://github.com/ros-controls/ros2_control/issues/1239>)
* Contributors: bailaC
```

## controller_manager

```
* [CM] Better readability and maintainability: rename variables, move code to more logical places 🔧 (#1227 <https://github.com/ros-controls/ros2_control/issues/1227>)
* Initialize the controller manager services after initializing resource manager (#1271 <https://github.com/ros-controls/ros2_control/issues/1271>)
* Issue 695: Changing 'namespace_' variables to 'node_namespace' to make it more explicit (#1239 <https://github.com/ros-controls/ros2_control/issues/1239>)
* Fix rqt controller manager crash on ros2_control restart (#1273 <https://github.com/ros-controls/ros2_control/issues/1273>)
* [docs] Remove joint_state_controller (#1263 <https://github.com/ros-controls/ros2_control/issues/1263>)
* controller_manager: Add space to string literal concatenation (#1245 <https://github.com/ros-controls/ros2_control/issues/1245>)
* Try using SCHED_FIFO on any kernel (#1142 <https://github.com/ros-controls/ros2_control/issues/1142>)
* [CM] Set chained controller interfaces 'available' for activated controllers (#1098 <https://github.com/ros-controls/ros2_control/issues/1098>)
* [CM] Increase tests timeout (#1224 <https://github.com/ros-controls/ros2_control/issues/1224>)
* Contributors: Christoph Fröhlich, Dr. Denis, Felix Exner (fexner), Sai Kishor Kothakota, Yasushi SHOJI, bailaC
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* [RM] Fix crash for missing urdf in resource manager (#1301 <https://github.com/ros-controls/ros2_control/issues/1301>)
* Add additional checks for non existing and not available interfaces. (#1218 <https://github.com/ros-controls/ros2_control/issues/1218>)
* Adding backward compatibility for string-to-double conversion (#1284 <https://github.com/ros-controls/ros2_control/issues/1284>)
* [Doc] Make interface comments clearer in the doc strings. (#1288 <https://github.com/ros-controls/ros2_control/issues/1288>)
* Fix return of ERROR and calls of cleanup when system is unconfigured of finalized (#1279 <https://github.com/ros-controls/ros2_control/issues/1279>)
* fix the multiple definitions of lexical casts methods (#1281 <https://github.com/ros-controls/ros2_control/issues/1281>)
* [ResourceManager] adds test for uninitialized hardware (#1243 <https://github.com/ros-controls/ros2_control/issues/1243>)
* Use portable version for string-to-double conversion (#1257 <https://github.com/ros-controls/ros2_control/issues/1257>)
* Fix typo in docs (#1219 <https://github.com/ros-controls/ros2_control/issues/1219>)
* Contributors: Christoph Fröhlich, Dr. Denis, Maximilian Schik, Sai Kishor Kothakota, Stephanie Eng, bailaC
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

```
* [ResourceManager] adds test for uninitialized hardware (#1243 <https://github.com/ros-controls/ros2_control/issues/1243>)
* Contributors: Maximilian Schik
```

## ros2controlcli

```
* [docs] Remove joint_state_controller (#1263 <https://github.com/ros-controls/ros2_control/issues/1263>)
* Contributors: Christoph Fröhlich
```

## rqt_controller_manager

```
* Fix rqt controller manager crash on ros2_control restart (#1273 <https://github.com/ros-controls/ros2_control/issues/1273>)
* Contributors: Sai Kishor Kothakota
```

## transmission_interface

```
* Improve transmission tests (#1238 <https://github.com/ros-controls/ros2_control/issues/1238>)
* Contributors: Maximilian Schik
```
