### PR TITLE
ros2_control: 3.22.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5469,7 +5469,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.21.2-1
+      version: 3.22.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.22.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.21.2-1`

## controller_interface

- No changes

## controller_manager

```
* Add additional checks for non existing and not available interfaces. (backport #1218 <https://github.com/ros-controls/ros2_control/issues/1218>) (#1292 <https://github.com/ros-controls/ros2_control/issues/1292>)
* [ControllerManager] Fix all warnings from the latets features. (backport #1174 <https://github.com/ros-controls/ros2_control/issues/1174>) (#1308 <https://github.com/ros-controls/ros2_control/issues/1308>)
* Reformat with braces added (backport #1209 <https://github.com/ros-controls/ros2_control/issues/1209>) (#1307 <https://github.com/ros-controls/ros2_control/issues/1307>)
* Initialize the controller manager services after initializing resource manager (backport #1271 <https://github.com/ros-controls/ros2_control/issues/1271>) (#1278 <https://github.com/ros-controls/ros2_control/issues/1278>)
* Fix rqt controller manager crash on ros2_control restart (#1273 <https://github.com/ros-controls/ros2_control/issues/1273>) (#1276 <https://github.com/ros-controls/ros2_control/issues/1276>)
* [docs] Remove joint_state_controller (#1263 <https://github.com/ros-controls/ros2_control/issues/1263>) (#1265 <https://github.com/ros-controls/ros2_control/issues/1265>)
* controller_manager: Add space to string literal concatenation (#1245 <https://github.com/ros-controls/ros2_control/issues/1245>) (#1249 <https://github.com/ros-controls/ros2_control/issues/1249>)
* [CM] Increase tests timeout (#1224 <https://github.com/ros-controls/ros2_control/issues/1224>) (#1226 <https://github.com/ros-controls/ros2_control/issues/1226>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* [RM] Fix crash for missing urdf in resource manager (#1301 <https://github.com/ros-controls/ros2_control/issues/1301>) (#1313 <https://github.com/ros-controls/ros2_control/issues/1313>)
* Add additional checks for non existing and not available interfaces. (backport #1218 <https://github.com/ros-controls/ros2_control/issues/1218>) (#1292 <https://github.com/ros-controls/ros2_control/issues/1292>)
* Adding backward compatibility for string-to-double conversion (#1284 <https://github.com/ros-controls/ros2_control/issues/1284>) (#1289 <https://github.com/ros-controls/ros2_control/issues/1289>)
* Fix return of ERROR and calls of cleanup when system is unconfigured of finalized (#1279 <https://github.com/ros-controls/ros2_control/issues/1279>) (#1287 <https://github.com/ros-controls/ros2_control/issues/1287>)
* fix the multiple definitions of lexical casts methods (#1281 <https://github.com/ros-controls/ros2_control/issues/1281>) (#1283 <https://github.com/ros-controls/ros2_control/issues/1283>)
* Use portable version for string-to-double conversion (backport #1257 <https://github.com/ros-controls/ros2_control/issues/1257>) (#1269 <https://github.com/ros-controls/ros2_control/issues/1269>)
* [ResourceManager] adds test for uninitialized hardware (#1243 <https://github.com/ros-controls/ros2_control/issues/1243>) (#1270 <https://github.com/ros-controls/ros2_control/issues/1270>)
* Fix typo in docs (#1219 <https://github.com/ros-controls/ros2_control/issues/1219>) (#1222 <https://github.com/ros-controls/ros2_control/issues/1222>)
* Contributors: mergify[bot]
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

```
* [ResourceManager] adds test for uninitialized hardware (#1243 <https://github.com/ros-controls/ros2_control/issues/1243>) (#1270 <https://github.com/ros-controls/ros2_control/issues/1270>)
* Contributors: mergify[bot]
```

## ros2controlcli

```
* [docs] Remove joint_state_controller (#1263 <https://github.com/ros-controls/ros2_control/issues/1263>) (#1265 <https://github.com/ros-controls/ros2_control/issues/1265>)
* Contributors: mergify[bot]
```

## rqt_controller_manager

```
* Fix rqt controller manager crash on ros2_control restart (#1273 <https://github.com/ros-controls/ros2_control/issues/1273>) (#1276 <https://github.com/ros-controls/ros2_control/issues/1276>)
* Contributors: mergify[bot]
```

## transmission_interface

```
* Improve transmission tests (#1238 <https://github.com/ros-controls/ros2_control/issues/1238>) (#1242 <https://github.com/ros-controls/ros2_control/issues/1242>)
* Contributors: mergify[bot]
```
