### PR TITLE
ros2_controllers: 2.32.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6533,7 +6533,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.31.0-1
+      version: 2.32.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.32.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.31.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

- No changes

## bicycle_steering_controller

- No changes

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

```
* Increase test coverage of interface configuration getters (#856 <https://github.com/ros-controls/ros2_controllers/issues/856>) (#865 <https://github.com/ros-controls/ros2_controllers/issues/865>)
* Contributors: mergify[bot]
```

## forward_command_controller

```
* Increase test coverage of interface configuration getters (#856 <https://github.com/ros-controls/ros2_controllers/issues/856>) (#865 <https://github.com/ros-controls/ros2_controllers/issues/865>)
* Contributors: mergify[bot]
```

## gripper_controllers

```
* Increase test coverage of interface configuration getters (#856 <https://github.com/ros-controls/ros2_controllers/issues/856>) (#865 <https://github.com/ros-controls/ros2_controllers/issues/865>)
* Contributors: mergify[bot]
```

## imu_sensor_broadcaster

```
* Increase test coverage of interface configuration getters (#856 <https://github.com/ros-controls/ros2_controllers/issues/856>) (#865 <https://github.com/ros-controls/ros2_controllers/issues/865>)
* Contributors: mergify[bot]
```

## joint_state_broadcaster

```
* Increase test coverage of interface configuration getters (#856 <https://github.com/ros-controls/ros2_controllers/issues/856>) (#865 <https://github.com/ros-controls/ros2_controllers/issues/865>)
* Contributors: mergify[bot]
```

## joint_trajectory_controller

```
* Cleanup package.xml und clarify tests of JTC. (backport #889 <https://github.com/ros-controls/ros2_controllers/issues/889>) (#924 <https://github.com/ros-controls/ros2_controllers/issues/924>)
* [JTC] Remove deprecation from parameters validation file. (#476 <https://github.com/ros-controls/ros2_controllers/issues/476>) (#926 <https://github.com/ros-controls/ros2_controllers/issues/926>)
* [JTC] Cancel goal in on_deactivate (#962 <https://github.com/ros-controls/ros2_controllers/issues/962>) (#970 <https://github.com/ros-controls/ros2_controllers/issues/970>)
* Contributors: mergify[bot]
```

## position_controllers

- No changes

## range_sensor_broadcaster

```
* Increase test coverage of interface configuration getters (#856 <https://github.com/ros-controls/ros2_controllers/issues/856>) (#865 <https://github.com/ros-controls/ros2_controllers/issues/865>)
* Contributors: mergify[bot]
```

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Update ci-ros-lint.yml and copyright format (backport #720 <https://github.com/ros-controls/ros2_controllers/issues/720>) (#918 <https://github.com/ros-controls/ros2_controllers/issues/918>)
* Contributors: mergify[bot]
```

## tricycle_controller

```
* Increase test coverage of interface configuration getters (#856 <https://github.com/ros-controls/ros2_controllers/issues/856>) (#865 <https://github.com/ros-controls/ros2_controllers/issues/865>)
* Contributors: mergify[bot]
```

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
