### PR TITLE
ros2_control: 2.37.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6497,7 +6497,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.36.1-1
+      version: 2.37.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.37.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.36.1-1`

## controller_interface

- No changes

## controller_manager

```
* Add additional checks for non existing and not available interfaces. (backport #1218 <https://github.com/ros-controls/ros2_control/issues/1218>) (#1291 <https://github.com/ros-controls/ros2_control/issues/1291>)
* [ControllerManager] Fix all warnings from the latets features. (backport #1174 <https://github.com/ros-controls/ros2_control/issues/1174>) (#1309 <https://github.com/ros-controls/ros2_control/issues/1309>)
* Reformat with braces added (backport #1209 <https://github.com/ros-controls/ros2_control/issues/1209>) (#1306 <https://github.com/ros-controls/ros2_control/issues/1306>)
* Add spawner for hardware (backport #941 <https://github.com/ros-controls/ros2_control/issues/941>) (#1216 <https://github.com/ros-controls/ros2_control/issues/1216>)
* Initialize the controller manager services after initializing resource manager (#1272 <https://github.com/ros-controls/ros2_control/issues/1272>)
* Fix rqt controller manager crash on ros2_control restart (#1273 <https://github.com/ros-controls/ros2_control/issues/1273>) (#1280 <https://github.com/ros-controls/ros2_control/issues/1280>)
* Contributors: David Yackzan, Sai Kishor Kothakota, mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* [RM] Fix crash for missing urdf in resource manager (#1301 <https://github.com/ros-controls/ros2_control/issues/1301>) (#1316 <https://github.com/ros-controls/ros2_control/issues/1316>)
* Add additional checks for non existing and not available interfaces. (backport #1218 <https://github.com/ros-controls/ros2_control/issues/1218>) (#1291 <https://github.com/ros-controls/ros2_control/issues/1291>)
* Fix return of ERROR and calls of cleanup when system is unconfigured of finalized (#1279 <https://github.com/ros-controls/ros2_control/issues/1279>) (#1286 <https://github.com/ros-controls/ros2_control/issues/1286>)
* fix the multiple definitions of lexical casts methods (#1281 <https://github.com/ros-controls/ros2_control/issues/1281>) (#1282 <https://github.com/ros-controls/ros2_control/issues/1282>)
* Contributors: Sai Kishor Kothakota, mergify[bot]
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

```
* Fix rqt controller manager crash on ros2_control restart (#1273 <https://github.com/ros-controls/ros2_control/issues/1273>) (#1280 <https://github.com/ros-controls/ros2_control/issues/1280>)
* Contributors: Sai Kishor Kothakota
```

## transmission_interface

- No changes
