### PR TITLE
gc_spl: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1634,7 +1634,11 @@ repositories:
       version: rolling
     release:
       packages:
+      - game_controller_spl
+      - game_controller_spl_interfaces
+      - gc_spl
       - gc_spl_2022
+      - gc_spl_interfaces
       - rcgcd_spl_14
       - rcgcd_spl_14_conversion
       - rcgcrd_spl_4
@@ -1642,7 +1646,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gc_spl-release.git
-      version: 3.0.0-3
+      version: 4.0.0-1
     source:
       type: git
       url: https://github.com/ros-sports/gc_spl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gc_spl` to `4.0.0-1`:

- upstream repository: https://github.com/ros-sports/gc_spl.git
- release repository: https://github.com/ros2-gbp/gc_spl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.0-3`

## game_controller_spl

```
* Add package (#79 <https://github.com/ros-sports/gc_spl/issues/79>)
* Contributors: Florian Vahl, Kenji Brameld
```

## game_controller_spl_interfaces

```
* Add package (#79 <https://github.com/ros-sports/gc_spl/issues/79>)
* Contributors: Florian Vahl, Kenji Brameld
```

## gc_spl

```
* Deprecate package (#79 <https://github.com/ros-sports/gc_spl/issues/79>)
* Add package (#58 <https://github.com/ros-sports/gc_spl/issues/58>)
* Contributors: Florian Vahl, Kenji Brameld
```

## gc_spl_2022

```
* Deprecate package(#81 <https://github.com/ros-sports/gc_spl/issues/81>)
* Contributors: Kenji Brameld
```

## gc_spl_interfaces

```
* Deprecate package (#79 <https://github.com/ros-sports/gc_spl/issues/79>)
* Add package (#58 <https://github.com/ros-sports/gc_spl/issues/58>)
* Contributors: Florian Vahl, Kenji Brameld
```

## rcgcd_spl_14

```
* Deprecate package(#81 <https://github.com/ros-sports/gc_spl/issues/81>)
* Contributors: Kenji Brameld
```

## rcgcd_spl_14_conversion

```
* Deprecate package(#81 <https://github.com/ros-sports/gc_spl/issues/81>)
* Contributors: Kenji Brameld
```

## rcgcrd_spl_4

```
* Deprecate package(#81 <https://github.com/ros-sports/gc_spl/issues/81>)
* change default fallen to 0
* Contributors: Kenji Brameld
```

## rcgcrd_spl_4_conversion

```
* Deprecate package(#81 <https://github.com/ros-sports/gc_spl/issues/81>)
* Contributors: Kenji Brameld
```
