### PR TITLE
motion_capture_tracking: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3830,6 +3830,14 @@ repositories:
       type: git
       url: https://github.com/IMRCLab/motion_capture_tracking.git
       version: ros2
+    release:
+      packages:
+      - motion_capture_tracking
+      - motion_capture_tracking_interfaces
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/motion_capture_tracking-release.git
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/IMRCLab/motion_capture_tracking.git


### PR DESCRIPTION
Increasing version of package(s) in repository `motion_capture_tracking` to `1.0.1-1`:

- upstream repository: https://github.com/IMRCLab/motion_capture_tracking.git
- release repository: https://github.com/ros2-gbp/motion_capture_tracking-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## motion_capture_tracking

```
* initial release
* Contributors: Wolfgang Hönig
```

## motion_capture_tracking_interfaces

```
* initial motion_capture_tracking_interfaces package
* Contributors: Wolfgang Hoenig
```
