### PR TITLE
mocap4r2_msgs: 0.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3753,6 +3753,21 @@ repositories:
       url: https://github.com/DFKI-NI/mir_robot.git
       version: humble
     status: developed
+  mocap4r2_msgs:
+    doc:
+      type: git
+      url: https://github.com/MOCAP4ROS2-Project/mocap4r2_msgs.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/MOCAP4ROS2-Project/mocap4r2_msgs-release.git
+      version: 0.0.5-1
+    source:
+      type: git
+      url: https://github.com/MOCAP4ROS2-Project/mocap4r2_msgs.git
+      version: humble-devel
+    status: developed
   mocap_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mocap4r2_msgs` to `0.0.5-1`:

- upstream repository: https://github.com/MOCAP4ROS2-Project/mocap4r2_msgs.git
- release repository: https://github.com/MOCAP4ROS2-Project/mocap4r2_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## mocap4r2_msgs

```
* Rename mocap to mocap4r2 to meet with REP 144
* Contributors: Francisco Martín Rico
```
