### PR TITLE
mocap4r2: 0.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3753,6 +3753,30 @@ repositories:
       url: https://github.com/DFKI-NI/mir_robot.git
       version: humble
     status: developed
+  mocap4r2:
+    doc:
+      type: git
+      url: https://github.com/MOCAP4ROS2-Project/mocap4r2.git
+      version: humble-devel
+    release:
+      packages:
+      - mocap4r2_control
+      - mocap4r2_control_msgs
+      - mocap4r2_marker_publisher
+      - mocap4r2_marker_viz
+      - mocap4r2_marker_viz_srvs
+      - mocap4r2_robot_gt
+      - mocap4r2_robot_gt_msgs
+      - rqt_mocap4r2_control
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/MOCAP4ROS2-Project/mocap4r2-release.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/MOCAP4ROS2-Project/mocap4r2.git
+      version: humble-devel
+    status: developed
   mocap_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mocap4r2` to `0.0.3-1`:

- upstream repository: https://github.com/MOCAP4ROS2-Project/mocap4r2.git
- release repository: https://github.com/MOCAP4ROS2-Project/mocap4r2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## mocap4r2_control

```
* Rename mocap to mocap4r2 to meet with REP 144
* Contributors: Francisco Martín Rico
```

## mocap4r2_control_msgs

```
* Rename mocap to mocap4r2 to meet with REP 144
* Contributors: Francisco Martín Rico
```

## mocap4r2_marker_publisher

```
* Rename mocap to mocap4r2 to meet with REP 144
* Contributors: Francisco Martín Rico
```

## mocap4r2_marker_viz

```
* Rename mocap to mocap4r2 to meet with REP 144
* Contributors: Francisco Martín Rico
```

## mocap4r2_marker_viz_srvs

```
* Rename mocap to mocap4r2 to meet with REP 144
* Contributors: Francisco Martín Rico
```

## mocap4r2_robot_gt

```
* Rename mocap to mocap4r2 to meet with REP 144
* Contributors: Francisco Martín Rico
```

## mocap4r2_robot_gt_msgs

```
* Rename mocap to mocap4r2 to meet with REP 144
* Contributors: Francisco Martín Rico
```

## rqt_mocap4r2_control

```
* Rename mocap to mocap4r2 to meet with REP 144
* Contributors: Francisco Martín Rico
```
