### PR TITLE
Remove mocap packages (REP 144 Fix)

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3134,6 +3134,17 @@ repositories:
       url: https://github.com/DFKI-NI/mir_robot.git
       version: foxy
     status: developed
+  mocap_msgs:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/MOCAP4ROS2-Project/mocap_msgs-release.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/MOCAP4ROS2-Project/mocap_msgs.git
+      version: master
+    status: developed
   moveit:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3134,17 +3134,6 @@ repositories:
       url: https://github.com/DFKI-NI/mir_robot.git
       version: foxy
     status: developed
-  mocap_msgs:
-    release:
-      tags:
-        release: release/foxy/{package}/{version}
-      url: https://github.com/MOCAP4ROS2-Project/mocap_msgs-release.git
-      version: 0.0.3-1
-    source:
-      type: git
-      url: https://github.com/MOCAP4ROS2-Project/mocap_msgs.git
-      version: master
-    status: developed
   moveit:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3753,21 +3753,6 @@ repositories:
       url: https://github.com/DFKI-NI/mir_robot.git
       version: humble
     status: developed
-  mocap_msgs:
-    doc:
-      type: git
-      url: https://github.com/MOCAP4ROS2-Project/mocap_msgs.git
-      version: humble-devel
-    release:
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/MOCAP4ROS2-Project/mocap_msgs-release.git
-      version: 0.0.4-1
-    source:
-      type: git
-      url: https://github.com/MOCAP4ROS2-Project/mocap_msgs.git
-      version: master
-    status: developed
   mocap_optitrack:
     doc:
       type: git


### PR DESCRIPTION
Packages removed to meet with REP 144 (https://github.com/ros/rosdistro/pull/39475#issuecomment-1894443133), replaced by https://github.com/ros/rosdistro/pull/39615 and https://github.com/ros/rosdistro/pull/39616

