### PR TITLE
multidim_rrt_planner-release: 0.0.6-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3392,24 +3392,16 @@ repositories:
       version: iron
     release:
       packages:
-      - rrt_planner
-      tags:
-        release: release/iron/{package}/{version}
-      url: https://github.com/ros2-gbp/multidim_rrt_planner-release.git
-      version: 0.0.4-1
-    source:
-      type: git
-      url: https://github.com/daviddorf2023/multidim_rrt_planner.git
-      version: iron
-    status: maintained
-  multidim_rrt_planner-release:
-    release:
-      packages:
       - multidim_rrt_planner
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/multidim_rrt_planner-release.git
       version: 0.0.6-1
+    source:
+      type: git
+      url: https://github.com/daviddorf2023/multidim_rrt_planner.git
+      version: iron
+    status: maintained
   mvsim:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3391,8 +3391,6 @@ repositories:
       url: https://github.com/daviddorf2023/multidim_rrt_planner.git
       version: iron
     release:
-      packages:
-      - multidim_rrt_planner
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/multidim_rrt_planner-release.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3402,6 +3402,14 @@ repositories:
       url: https://github.com/daviddorf2023/multidim_rrt_planner.git
       version: iron
     status: maintained
+  multidim_rrt_planner-release:
+    release:
+      packages:
+      - multidim_rrt_planner
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/multidim_rrt_planner-release.git
+      version: 0.0.6-1
   mvsim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `multidim_rrt_planner-release` to `0.0.6-1`:

- upstream repository: https://github.com/ros2-gbp/multidim_rrt_planner-release.git
- release repository: https://github.com/ros2-gbp/multidim_rrt_planner-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
