### PR TITLE
mocap4r2: 0.0.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3775,7 +3775,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/MOCAP4ROS2-Project/mocap4r2-release.git
-      version: 0.0.3-1
+      version: 0.0.6-1
     source:
       type: git
       url: https://github.com/MOCAP4ROS2-Project/mocap4r2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mocap4r2` to `0.0.6-1`:

- upstream repository: https://github.com/MOCAP4ROS2-Project/mocap4r2.git
- release repository: https://github.com/MOCAP4ROS2-Project/mocap4r2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.3-1`

## mocap4r2_control

- No changes

## mocap4r2_control_msgs

- No changes

## mocap4r2_marker_publisher

- No changes

## mocap4r2_marker_viz

- No changes

## mocap4r2_marker_viz_srvs

- No changes

## mocap4r2_robot_gt

- No changes

## mocap4r2_robot_gt_msgs

- No changes

## rqt_mocap4r2_control

- No changes
