### PR TITLE
behaviortree_cpp_v4: 4.5.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -584,7 +584,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.5.0-1
+      version: 4.5.1-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp_v4` to `4.5.1-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.5.0-1`

## behaviortree_cpp

```
* Support enums and real numbers in Node Switch
* improve Any::castPtr and add example
* fix issue #748 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/748> : static error messages
* Merge pull request #746 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/746> from galou/snprintf
  Use snprintf instead of sprintf
* Use snprintf instead of sprintf
  - Augment the buffer size on doc error.
  - Let sprintf in switch_node.h since the max. string length is known.
* Contributors: Davide Faconti, Gaël Écorchard
```
