### PR TITLE
nerian_stereo_ros2: 1.2.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3626,6 +3626,19 @@ repositories:
       url: https://github.com/neobotix/neo_simulation2.git
       version: rolling
     status: maintained
+  nerian_stereo_ros2:
+    release:
+      packages:
+      - nerian_stereo
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/nerian-vision/nerian_stereo_ros2-release.git
+      version: 1.2.1-1
+    source:
+      type: git
+      url: https://github.com/nerian-vision/nerian_stereo_ros2.git
+      version: default
+    status: developed
   nlohmann_json_schema_validator_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nerian_stereo_ros2` to `1.2.1-1`:

- upstream repository: https://github.com/nerian-vision/nerian_stereo_ros2.git
- release repository: https://github.com/nerian-vision/nerian_stereo_ros2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
