### PR TITLE
nerian_stereo_ros2: 1.2.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4332,7 +4332,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/nerian-vision/nerian_stereo_ros2-release.git
-      version: 1.2.0-1
+      version: 1.2.1-2
     source:
       type: git
       url: https://github.com/nerian-vision/nerian_stereo_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nerian_stereo_ros2` to `1.2.1-2`:

- upstream repository: https://github.com/nerian-vision/nerian_stereo_ros2.git
- release repository: https://github.com/nerian-vision/nerian_stereo_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.0-1`

## nerian_stereo

```
* Updated vision transfer to version 10.6.0
* Migration to git submodule in lieu of src release archive
* Support for setting ROS-overridden device parameters after connection
* Contributors: Konstantin Schauwecker, Ramin Yaghoubzadeh Torky
```
