### PR TITLE
qbshin-ros: 2.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5444,6 +5444,20 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: humble
     status: maintained
+  qbshin-ros:
+    release:
+      packages:
+      - qb_softhand_industry
+      - qb_softhand_industry_description
+      - qb_softhand_industry_driver
+      - qb_softhand_industry_msgs
+      - qb_softhand_industry_ros2_control
+      - qb_softhand_industry_srvs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://GiulianoDami@bitbucket.org/qbrobotics/qbshin-ros2-release.git
+      version: 2.1.2-1
+    status: developed
   qpoases_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `qbshin-ros` to `2.1.2-1`:

- upstream repository: https://GiulianoDami@bitbucket.org/qbrobotics/qbshin-ros.git
- release repository: https://GiulianoDami@bitbucket.org/qbrobotics/qbshin-ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## qb_softhand_industry

- No changes

## qb_softhand_industry_description

- No changes

## qb_softhand_industry_driver

- No changes

## qb_softhand_industry_msgs

- No changes

## qb_softhand_industry_ros2_control

- No changes

## qb_softhand_industry_srvs

- No changes
