### PR TITLE
ros2_tracing: 8.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5320,6 +5320,7 @@ repositories:
       version: rolling
     release:
       packages:
+      - lttngpy
       - ros2trace
       - tracetools
       - tracetools_launch
@@ -5329,7 +5330,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 7.1.0-1
+      version: 8.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `8.0.0-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `7.1.0-1`

## lttngpy

```
* Fix Python not being found for lttngpy in Windows debug mode (#87 <https://github.com/ros2/ros2_tracing/issues/87>)
* Switch to custom lttng-ctl Python bindings (#81 <https://github.com/ros2/ros2_tracing/issues/81>)
* Contributors: Christophe Bedard
```

## ros2trace

- No changes

## tracetools

```
* Add timestamp to rmw_publish tracepoint (#74 <https://github.com/ros2/ros2_tracing/issues/74>)
* Contributors: Christopher Wecht
```

## tracetools_launch

```
* Remove extra single quote in LdPreload debug log (#79 <https://github.com/ros2/ros2_tracing/issues/79>)
* Contributors: Christophe Bedard
```

## tracetools_read

- No changes

## tracetools_test

```
* Fix use of mutable default arg in tracetools_test (#84 <https://github.com/ros2/ros2_tracing/issues/84>)
* Contributors: Christophe Bedard
```

## tracetools_trace

```
* Switch to custom lttng-ctl Python bindings (#81 <https://github.com/ros2/ros2_tracing/issues/81>)
* Contributors: Christophe Bedard
```
