### PR TITLE
Add linux_isolate_process package to be indexed for rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2638,6 +2638,16 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: rolling
     status: maintained
+  linux_isolate_process:
+    doc:
+      type: git
+      url: https://github.com/adityapande-1995/linux_isolate_process.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/adityapande-1995/linux_isolate_process.git
+      version: main
+    status: maintained
   locator_ros_bridge:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

ROSDISTRO NAME : rolling
package name : linux_isolate_process

Making a preliminary PR as per : https://docs.ros.org/en/foxy/How-To-Guides/Releasing/Release-Team-Repository.html#join-a-release-team, will add the release section once this is approved.

Addressed original comments in https://github.com/ros/rosdistro/pull/39418 and converted this to a ROS package instead of a pip package.

# The source is here:

https://github.com/adityapande-1995/linux_isolate_process.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
