### PR TITLE
pangolin: 0.9.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3727,10 +3727,16 @@ repositories:
       version: humble-devel
     status: maintained
   pangolin:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/Pangolin-release.git
+      version: 0.9.1-1
     source:
       type: git
       url: https://github.com/stevenlovegrove/Pangolin.git
       version: master
+    status: maintained
   pcl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pangolin` to `0.9.1-1`:

- upstream repository: https://github.com/stevenlovegrove/Pangolin.git
- release repository: https://github.com/ros2-gbp/Pangolin-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
