### PR TITLE
opennav_coverage: 0.0.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3897,6 +3897,24 @@ repositories:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
       version: 1.5.2-4
+  opennav_coverage:
+    release:
+      packages:
+      - opennav_coverage
+      - opennav_coverage_bt
+      - opennav_coverage_demo
+      - opennav_coverage_msgs
+      - opennav_coverage_navigator
+      - opennav_row_coverage
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/open-navigation/opennav_coverage-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/open-navigation/opennav_coverage.git
+      version: iron
+    status: developed
   openni2_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `opennav_coverage` to `0.0.1-1`:

- upstream repository: https://github.com/open-navigation/opennav_coverage.git
- release repository: https://github.com/open-navigation/opennav_coverage-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
