### PR TITLE
vision_msgs: 4.1.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -8011,7 +8011,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/vision_msgs-release.git
-      version: 4.1.0-3
+      version: 4.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_msgs` to `4.1.1-1`:

- upstream repository: https://github.com/ros-perception/vision_msgs.git
- release repository: https://github.com/ros2-gbp/vision_msgs-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.1.0-3`
