### PR TITLE
ament_cmake: 1.3.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -208,7 +208,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 1.3.6-1
+      version: 1.3.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake` to `1.3.7-1`:

- upstream repository: https://github.com/ament/ament_cmake.git
- release repository: https://github.com/ros2-gbp/ament_cmake-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.6-1`

## ament_cmake

- No changes

## ament_cmake_auto

```
* Add ament_auto_add_gmock to ament_cmake_auto (#482 <https://github.com/ament/ament_cmake/issues/482>) (#493 <https://github.com/ament/ament_cmake/issues/493>)
* Contributors: mergify[bot]
```

## ament_cmake_core

- No changes

## ament_cmake_export_definitions

- No changes

## ament_cmake_export_dependencies

- No changes

## ament_cmake_export_include_directories

- No changes

## ament_cmake_export_interfaces

- No changes

## ament_cmake_export_libraries

- No changes

## ament_cmake_export_link_flags

- No changes

## ament_cmake_export_targets

- No changes

## ament_cmake_gen_version_h

- No changes

## ament_cmake_gmock

```
* Fix compiler warnings related to gtest/gmock (#408 <https://github.com/ament/ament_cmake/issues/408>) (#495 <https://github.com/ament/ament_cmake/issues/495>)
* Contributors: atzaros
```

## ament_cmake_google_benchmark

- No changes

## ament_cmake_gtest

```
* Fix compiler warnings related to gtest/gmock (#408 <https://github.com/ament/ament_cmake/issues/408>) (#495 <https://github.com/ament/ament_cmake/issues/495>)
* Contributors: atzaros
```

## ament_cmake_include_directories

- No changes

## ament_cmake_libraries

- No changes

## ament_cmake_nose

- No changes

## ament_cmake_pytest

- No changes

## ament_cmake_python

- No changes

## ament_cmake_target_dependencies

- No changes

## ament_cmake_test

- No changes

## ament_cmake_vendor_package

- No changes

## ament_cmake_version

- No changes
