### PR TITLE
robot_state_publisher: 3.0.3-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6455,7 +6455,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/robot_state_publisher-release.git
-      version: 3.0.2-2
+      version: 3.0.3-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `3.0.3-2`:

- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros2-gbp/robot_state_publisher-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.2-2`

## robot_state_publisher

```
* Fix reload after a description with a mimic joint (#212 <https://github.com/ros/robot_state_publisher/issues/212>) (#214 <https://github.com/ros/robot_state_publisher/issues/214>)
* Contributors: mergify[bot]
```
