### PR TITLE
launch_ros: 0.19.7-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3122,7 +3122,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.19.6-1
+      version: 0.19.7-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.19.7-2`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.19.6-1`

## launch_ros

- No changes

## launch_testing_ros

```
* WaitForTopics: get content of messages for each topic (backport #353 <https://github.com/ros2/launch_ros/issues/353>) (#389 <https://github.com/ros2/launch_ros/issues/389>)
* Contributors: mergify[bot]
```

## ros2launch

- No changes
