### PR TITLE
image_common: 3.1.8-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2706,7 +2706,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 3.1.7-1
+      version: 3.1.8-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `3.1.8-2`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.1.7-1`

## camera_calibration_parsers

- No changes

## camera_info_manager

- No changes

## image_common

- No changes

## image_transport

```
* implement CameraSubscriber::getNumPublishers (#297 <https://github.com/ros-perception/image_common/issues/297>) (#298 <https://github.com/ros-perception/image_common/issues/298>)
* Add missing definition for CameraPublisher::publish overload (#278 <https://github.com/ros-perception/image_common/issues/278>) (#294 <https://github.com/ros-perception/image_common/issues/294>)
* Contributors: Alejandro Hernández Cordero
```
