### PR TITLE
rqt: 1.1.6-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7222,7 +7222,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
-      version: 1.1.5-2
+      version: 1.1.6-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `1.1.6-2`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros2-gbp/rqt-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.5-2`

## rqt

- No changes

## rqt_gui

- No changes

## rqt_gui_cpp

- No changes

## rqt_gui_py

```
* Merge pull request #296 <https://github.com/ros-visualization/rqt/issues/296> from daisukes/humble-backport-291
* fix an exception raised while press ctrl+c to exit (#291 <https://github.com/ros-visualization/rqt/issues/291>)
* Contributors: Chen Lihui, Dharini Dutia
```

## rqt_py_common

- No changes
