### PR TITLE
Add libjchar2d-java rosdep key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3974,6 +3974,9 @@ libjansson-dev:
   ubuntu: [libjansson-dev]
 libjaxp1.3-java:
   debian: [libjaxp1.3-java]
+libjchart2d-java:
+  debian: [libjchart2d-java]
+  ubuntu: [libjchart2d-java]
 libjpeg:
   arch: [libjpeg-turbo]
   debian: [libjpeg-dev]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

libjchart2d-java

## Package Upstream Source:

http://jchart2d.sourceforge.net/

## Purpose of using this:

This is a dependency for drake which is working to be packaged. https://github.com/RobotLocomotion/ros-drake-vendor/issues/3

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/trixie/libjchart2d-java
- Ubuntu: https://packages.ubuntu.com/noble/libjchart2d-java

- Fedora: https://packages.fedoraproject.org/
  - Not found
- Arch: https://www.archlinux.org/packages/
  - Not found
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - Not found
- Alpine: https://pkgs.alpinelinux.org/packages
  - Not found
- NixOS/nixpkgs: https://search.nixos.org/packages
  - Not found
- openSUSE: https://software.opensuse.org/package/
  - Not found
- rhel: https://rhel.pkgs.org/
  - Not found
