### PR TITLE
plotjuggler: 3.8.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7638,7 +7638,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.8.8-3
+      version: 3.8.9-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.8.9-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.8.8-3`

## plotjuggler

```
* fix bug #924 <https://github.com/facontidavide/PlotJuggler/issues/924> (messages with no fields)
* Bugfix: Wrong curvestyle is preselected (#921 <https://github.com/facontidavide/PlotJuggler/issues/921>)
* Contributors: Davide Faconti, Simon Sagmeister
```
