### PR TITLE
plotjuggler: 3.8.9-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4212,7 +4212,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.8.7-1
+      version: 3.8.9-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.8.9-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/ros2-gbp/plotjuggler-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.8.7-1`

## plotjuggler

```
* fix bug #924 <https://github.com/facontidavide/PlotJuggler/issues/924> (messages with no fields)
* Bugfix: Wrong curvestyle is preselected (#921 <https://github.com/facontidavide/PlotJuggler/issues/921>)
* Contributors: Davide Faconti, Simon Sagmeister
```
