### PR TITLE
ign_ros2_control: 0.7.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2630,7 +2630,6 @@ repositories:
       version: humble
     release:
       packages:
-      - gz_ros2_control_tests
       - ign_ros2_control
       - ign_ros2_control_demos
       tags:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2630,12 +2630,13 @@ repositories:
       version: humble
     release:
       packages:
+      - gz_ros2_control_tests
       - ign_ros2_control
       - ign_ros2_control_demos
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 0.7.4-1
+      version: 0.7.5-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ign_ros2_control` to `0.7.5-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.4-1`

## ign_ros2_control

```
* Load the URDF to the resource_manager before parsing it to CM (#222 <https://github.com/ros-controls/gz_ros2_control/issues/222>) (#225 <https://github.com/ros-controls/gz_ros2_control/issues/225>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  (cherry picked from commit 5a948050563881dba20effec3ccb678e4f375529)
  Co-authored-by: Sai Kishor Kothakota <mailto:saisastra3@gmail.com>
* Contributors: mergify[bot]
```
