### PR TITLE
gazebo_ros2_control: 0.6.4-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1684,7 +1684,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.6.3-1
+      version: 0.6.4-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros2_control` to `0.6.4-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros2_control.git
- release repository: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.3-1`

## gazebo_ros2_control

```
* Load the URDF to the resource_manager before parsing it to CM  (#262 <https://github.com/ros-controls/gazebo_ros2_control//issues/262>) (#267 <https://github.com/ros-controls/gazebo_ros2_control//issues/267>)
  * Load the URDF to the resource_manager before parsing it to CM constructor (fixes https://github.com/ros-controls/ros2_control/issues/1299)
  (cherry picked from commit f5baf71c4c7cb3c0a0af52f988c107b356c95ed0)
  Co-authored-by: Sai Kishor Kothakota <mailto:saisastra3@gmail.com>
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Fix links in documentation (#263 <https://github.com/ros-controls/gazebo_ros2_control//issues/263>) (#265 <https://github.com/ros-controls/gazebo_ros2_control//issues/265>)
  (cherry picked from commit d44b879615a539fc7c6c53707ec518df7bfd4f47)
  Co-authored-by: Silvio Traversaro <mailto:silvio@traversaro.it>
* Contributors: mergify[bot]
```

## gazebo_ros2_control_demos

- No changes
