### PR TITLE
gz_ros2_control: 1.1.4-2 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2042,10 +2042,11 @@ repositories:
       packages:
       - gz_ros2_control
       - gz_ros2_control_demos
+      - gz_ros2_control_tests
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 1.1.3-1
+      version: 1.1.4-2
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2042,7 +2042,6 @@ repositories:
       packages:
       - gz_ros2_control
       - gz_ros2_control_demos
-      - gz_ros2_control_tests
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `1.1.4-2`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.3-1`

## gz_ros2_control

```
* Load the URDF to the resource_manager before parsing it to CM (#222 <https://github.com/ros-controls/gz_ros2_control/issues/222>) (#226 <https://github.com/ros-controls/gz_ros2_control/issues/226>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  (cherry picked from commit 5a948050563881dba20effec3ccb678e4f375529)
  Co-authored-by: Sai Kishor Kothakota <mailto:saisastra3@gmail.com>
* Contributors: mergify[bot]
```

## gz_ros2_control_demos

- No changes

## gz_ros2_control_tests

```
* Include testing packages on CI (#223 <https://github.com/ros-controls/gz_ros2_control/issues/223>) (#224 <https://github.com/ros-controls/gz_ros2_control/issues/224>)
  (cherry picked from commit 42a34daea74325443b6dfa759724f099b3c4e3af)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```
