### PR TITLE
gazebo_ros2_control: 0.7.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1599,7 +1599,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.7.0-1
+      version: 0.7.1-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros2_control` to `0.7.1-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros2_control.git
- release repository: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.0-1`

## gazebo_ros2_control

```
* Load the URDF to the resource_manager before parsing it to CM  (#262 <https://github.com/ros-controls/gazebo_ros2_control//issues/262>)
  * Load the URDF to the resource_manager before parsing it to CM constructor (fixes https://github.com/ros-controls/ros2_control/issues/1299)
* Use lexical casts (#260 <https://github.com/ros-controls/gazebo_ros2_control//issues/260>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Fix links in documentation (#263 <https://github.com/ros-controls/gazebo_ros2_control//issues/263>)
* Added controller manager xml argument (#255 <https://github.com/ros-controls/gazebo_ros2_control//issues/255>)
* Contributors: Alejandro Hernández Cordero, Christoph Fröhlich, Sai Kishor Kothakota, Silvio Traversaro
```

## gazebo_ros2_control_demos

- No changes
