### PR TITLE
gz_ros2_control: 1.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1891,7 +1891,6 @@ repositories:
       packages:
       - gz_ros2_control
       - gz_ros2_control_demos
-      - gz_ros2_control_tests
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1891,10 +1891,11 @@ repositories:
       packages:
       - gz_ros2_control
       - gz_ros2_control_demos
+      - gz_ros2_control_tests
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 1.2.0-1
+      version: 1.2.1-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `1.2.1-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.0-1`

## gz_ros2_control

```
* Load the URDF to the resource_manager before parsing it to CM (#222 <https://github.com/ros-controls/gz_ros2_control/issues/222>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Use own implementation of stod() (#220 <https://github.com/ros-controls/gz_ros2_control/issues/220>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## gz_ros2_control_demos

```
* Use parameters with ros_gz_sim::Create (#211 <https://github.com/ros-controls/gz_ros2_control/issues/211>)
  Co-authored-by: Christoph Fröhlich <mailto:christophfroehlich@users.noreply.github.com>
* Contributors: Alejandro Hernández Cordero
```

## gz_ros2_control_tests

```
* Include testing packages on CI (#223 <https://github.com/ros-controls/gz_ros2_control/issues/223>)
* Contributors: Alejandro Hernández Cordero
```
