### PR TITLE
image_pipeline: 3.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2732,7 +2732,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 3.0.0-1
+      version: 3.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `3.0.3-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.0-1`

## camera_calibration

```
* [backport humble] ROS 2: Added more aruco dicts, fixed aruco linerror bug (#873 <https://github.com/ros-perception/image_pipeline/issues/873>) (#889 <https://github.com/ros-perception/image_pipeline/issues/889>)
  backport #873 <https://github.com/ros-perception/image_pipeline/issues/873>
* [backport humble] ROS 2: Fixing thrown Exception in camerachecker.py (#871 <https://github.com/ros-perception/image_pipeline/issues/871>) (#887 <https://github.com/ros-perception/image_pipeline/issues/887>)
  backport #871 <https://github.com/ros-perception/image_pipeline/issues/871>
* Contributors: Alejandro Hernández Cordero
```

## depth_image_proc

```
* [backport humble] upport rgba8 and bgra8 encodings by skipping alpha channel (#869 <https://github.com/ros-perception/image_pipeline/issues/869>) (#895 <https://github.com/ros-perception/image_pipeline/issues/895>)
  backport #869 <https://github.com/ros-perception/image_pipeline/issues/869>
* [backport humble] ROS 2: Add option to use the RGB image timestamp for the registered depth image (#872 <https://github.com/ros-perception/image_pipeline/issues/872>) (#893 <https://github.com/ros-perception/image_pipeline/issues/893>)
  backport #872 <https://github.com/ros-perception/image_pipeline/issues/872>
* [backport Humble] Support MONO16 image encodings: point_cloud_xyz (#868 <https://github.com/ros-perception/image_pipeline/issues/868>) (#881 <https://github.com/ros-perception/image_pipeline/issues/881>)
  backport Humble #868 <https://github.com/ros-perception/image_pipeline/issues/868>
* [backport humble] ROS 2: depth_image_proc/point_cloud_xyzi_radial Add intensity conversion (copy) for float (#867 <https://github.com/ros-perception/image_pipeline/issues/867>) (#879 <https://github.com/ros-perception/image_pipeline/issues/879>)
  backport #867 <https://github.com/ros-perception/image_pipeline/issues/867>
* allow use as component or node (#859 <https://github.com/ros-perception/image_pipeline/issues/859>)
  backport #852 <https://github.com/ros-perception/image_pipeline/issues/852> to humble
* Contributors: Alejandro Hernández Cordero, Michael Ferguson
```

## image_pipeline

- No changes

## image_proc

```
* [backport Humble] Removed cfg files related with ROS 1 parameters (#911 <https://github.com/ros-perception/image_pipeline/issues/911>) (#913 <https://github.com/ros-perception/image_pipeline/issues/913>)
  Removed cfg files related with ROS 1 parameters. Backport
  https://github.com/ros-perception/image_pipeline/pull/911
* [backport humble] ROS 2: Merged resize.cpp: fix memory leak (#874 <https://github.com/ros-perception/image_pipeline/issues/874>) (#891 <https://github.com/ros-perception/image_pipeline/issues/891>)
  backport #874 <https://github.com/ros-perception/image_pipeline/issues/874>
* allow use as component or node (#859 <https://github.com/ros-perception/image_pipeline/issues/859>)
  backport #852 <https://github.com/ros-perception/image_pipeline/issues/852> to humble
* Contributors: Alejandro Hernández Cordero, Michael Ferguson
```

## image_publisher

```
* [backport Humble] Removed cfg files related with ROS 1 parameters (#911 <https://github.com/ros-perception/image_pipeline/issues/911>) (#913 <https://github.com/ros-perception/image_pipeline/issues/913>)
  Removed cfg files related with ROS 1 parameters. Backport
  https://github.com/ros-perception/image_pipeline/pull/911
* ROS 2: Fixed CMake (#899 <https://github.com/ros-perception/image_pipeline/issues/899>) (#901 <https://github.com/ros-perception/image_pipeline/issues/901>)
  backport #899 <https://github.com/ros-perception/image_pipeline/issues/899>
* Contributors: Alejandro Hernández Cordero
```

## image_rotate

```
* [backport Humble] Removed cfg files related with ROS 1 parameters (#911 <https://github.com/ros-perception/image_pipeline/issues/911>) (#913 <https://github.com/ros-perception/image_pipeline/issues/913>)
  Removed cfg files related with ROS 1 parameters. Backport
  https://github.com/ros-perception/image_pipeline/pull/911
* load image_rotate::ImageRotateNode as component (#857 <https://github.com/ros-perception/image_pipeline/issues/857>)
  This is a fixed version of #820 <https://github.com/ros-perception/image_pipeline/issues/820> - targeting humble
* Contributors: Alejandro Hernández Cordero, Michael Ferguson
```

## image_view

```
* [backport Humble] Removed cfg files related with ROS 1 parameters (#911 <https://github.com/ros-perception/image_pipeline/issues/911>) (#913 <https://github.com/ros-perception/image_pipeline/issues/913>)
  Removed cfg files related with ROS 1 parameters. Backport
  https://github.com/ros-perception/image_pipeline/pull/911
* [backport humble] enable autosize parameter in disparity view (#875 <https://github.com/ros-perception/image_pipeline/issues/875>) (#897 <https://github.com/ros-perception/image_pipeline/issues/897>)
  backport #875 <https://github.com/ros-perception/image_pipeline/issues/875>
  Co-authored-by: Michael Ferguson <mailto:mfergs7@gmail.com>
* [backport humble] ROS 2: Add option to prepend timestamp to image filename in image_saver node (#870 <https://github.com/ros-perception/image_pipeline/issues/870>) (#885 <https://github.com/ros-perception/image_pipeline/issues/885>)
  backport #870 <https://github.com/ros-perception/image_pipeline/issues/870>
* [backport humble] Add support for floating point fps (#866 <https://github.com/ros-perception/image_pipeline/issues/866>) (#877 <https://github.com/ros-perception/image_pipeline/issues/877>)
  Backport #866 <https://github.com/ros-perception/image_pipeline/issues/866>
* [backport Humble] use cv::DestroyAllWindows (#863 <https://github.com/ros-perception/image_pipeline/issues/863>) (#864 <https://github.com/ros-perception/image_pipeline/issues/864>)
  This ports #816 <https://github.com/ros-perception/image_pipeline/issues/816> to ROS 2 and prevents weird exit conditions if you
  already closed the window
  backport https://github.com/ros-perception/image_pipeline/pull/863
  Co-authored-by: Michael Ferguson <mailto:mfergs7@gmail.com>
* Contributors: Alejandro Hernández Cordero
```

## stereo_image_proc

```
* [backport humble] stereo_image_proc: cleanup cmake (#904 <https://github.com/ros-perception/image_pipeline/issues/904>) (#907 <https://github.com/ros-perception/image_pipeline/issues/907>)
  This was supposed to be switched over when e-turtle rolled out. J-turtle
  ain't that late...
  Backported https://github.com/ros-perception/image_pipeline/pull/904
  Co-authored-by: Michael Ferguson <mailto:mfergs7@gmail.com>
* [backport humble] upport rgba8 and bgra8 encodings by skipping alpha channel (#869 <https://github.com/ros-perception/image_pipeline/issues/869>) (#895 <https://github.com/ros-perception/image_pipeline/issues/895>)
  backport #869 <https://github.com/ros-perception/image_pipeline/issues/869>
* allow use as component or node (#859 <https://github.com/ros-perception/image_pipeline/issues/859>)
  backport #852 <https://github.com/ros-perception/image_pipeline/issues/852> to humble
* Contributors: Alejandro Hernández Cordero, Michael Ferguson
```

## tracetools_image_pipeline

```
* ROS 2: Fixed CMake (#899 <https://github.com/ros-perception/image_pipeline/issues/899>) (#901 <https://github.com/ros-perception/image_pipeline/issues/901>)
  backport #899 <https://github.com/ros-perception/image_pipeline/issues/899>
* Contributors: Alejandro Hernández Cordero
```
