### PR TITLE
image_pipeline: 4.0.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2235,7 +2235,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 3.0.1-3
+      version: 4.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `4.0.0-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.1-3`

## camera_calibration

```
* [backport iron] ROS 2: Added more aruco dicts, fixed aruco linerror bug (#873 <https://github.com/ros-perception/image_pipeline/issues/873>) (#890 <https://github.com/ros-perception/image_pipeline/issues/890>)
  backport #873 <https://github.com/ros-perception/image_pipeline/issues/873>
* [backport iron] ROS 2: Fixing thrown Exception in camerachecker.py (#871 <https://github.com/ros-perception/image_pipeline/issues/871>) (#888 <https://github.com/ros-perception/image_pipeline/issues/888>)
  backport #`#871 <https://github.com/ros-perception/image_pipeline/issues/871>`_
* add myself as a maintainer (#846 <https://github.com/ros-perception/image_pipeline/issues/846>)
* fix threading shutdown
* use correct synchronous service call
* use remap rules instead of parameters for services
* remove duplicated definition of on_model_change
* fix service check
* remove commented code
* Fix QoS incompatibility camera_calibration ROS2
* perform calibration in another thread
* Contributors: Alejandro Hernández Cordero, Christian Rauch, Kenji Brameld, Michael Ferguson, Michal Wojcik
```

## depth_image_proc

```
* [backport iron] support rgba8 and bgra8 encodings by skipping alpha channel (#869 <https://github.com/ros-perception/image_pipeline/issues/869>) (#896 <https://github.com/ros-perception/image_pipeline/issues/896>)
  backport #869 <https://github.com/ros-perception/image_pipeline/issues/869>
* [backport iron] ROS 2: Add option to use the RGB image timestamp for the registered depth image (#872 <https://github.com/ros-perception/image_pipeline/issues/872>) (#894 <https://github.com/ros-perception/image_pipeline/issues/894>)
  backport #872 <https://github.com/ros-perception/image_pipeline/issues/872>
* [backport Iron] Support MONO16 image encodings: point_cloud_xyz (#868 <https://github.com/ros-perception/image_pipeline/issues/868>) (#882 <https://github.com/ros-perception/image_pipeline/issues/882>)
  backport Iron #868 <https://github.com/ros-perception/image_pipeline/issues/868>
* [backport iron] ROS 2: depth_image_proc/point_cloud_xyzi_radial Add intensity conversion (copy) for float (#867 <https://github.com/ros-perception/image_pipeline/issues/867>) (#880 <https://github.com/ros-perception/image_pipeline/issues/880>)
  Backport #867 <https://github.com/ros-perception/image_pipeline/issues/867>
* allow use as component or node (#858 <https://github.com/ros-perception/image_pipeline/issues/858>)
  Backport #852 <https://github.com/ros-perception/image_pipeline/issues/852> to Iron
* add myself as a maintainer (#846 <https://github.com/ros-perception/image_pipeline/issues/846>)
* Depth image transport configure susbcribers (#844 <https://github.com/ros-perception/image_pipeline/issues/844>) (#845 <https://github.com/ros-perception/image_pipeline/issues/845>)
* Updated depth_image_proc for ros2
  Instantiated template for convertDepth, added options to register, and
  changed register from a class loader to an RCLPP component.
* Contributors: Alejandro Hernández Cordero, Michael Ferguson, ksommerkohrt
```

## image_pipeline

```
* add myself as a maintainer (#846 <https://github.com/ros-perception/image_pipeline/issues/846>)
* Contributors: Michael Ferguson
```

## image_proc

```
* [backport iron] Removed cfg files related with ROS 1 parameters (#911 <https://github.com/ros-perception/image_pipeline/issues/911>) (#914 <https://github.com/ros-perception/image_pipeline/issues/914>)
  Removed cfg files related with ROS 1 parameters. Backport
  https://github.com/ros-perception/image_pipeline/pull/911
* [backport iron] ROS 2: Merged resize.cpp: fix memory leak (#874 <https://github.com/ros-perception/image_pipeline/issues/874>) (#892 <https://github.com/ros-perception/image_pipeline/issues/892>)
  backport #874 <https://github.com/ros-perception/image_pipeline/issues/874>
* allow use as component or node (#858 <https://github.com/ros-perception/image_pipeline/issues/858>)
  Backport #852 <https://github.com/ros-perception/image_pipeline/issues/852> to Iron
* add myself as a maintainer (#846 <https://github.com/ros-perception/image_pipeline/issues/846>)
* Use the same QoS profiles as publishers in image_proc
* fix to allow remapping resize and image topics
* Contributors: Alejandro Hernández Cordero, Joe Schornak, Michael Ferguson, Michal Wojcik
```

## image_publisher

```
* [backport iron] Removed cfg files related with ROS 1 parameters (#911 <https://github.com/ros-perception/image_pipeline/issues/911>) (#914 <https://github.com/ros-perception/image_pipeline/issues/914>)
  Removed cfg files related with ROS 1 parameters. Backport
  https://github.com/ros-perception/image_pipeline/pull/911
* ROS 2: Fixed CMake (#899 <https://github.com/ros-perception/image_pipeline/issues/899>) (#902 <https://github.com/ros-perception/image_pipeline/issues/902>)
  #backport #899 <https://github.com/ros-perception/image_pipeline/issues/899>
* add myself as a maintainer (#846 <https://github.com/ros-perception/image_pipeline/issues/846>)
* Contributors: Alejandro Hernández Cordero, Michael Ferguson
```

## image_rotate

```
* [backport iron] Removed cfg files related with ROS 1 parameters (#911 <https://github.com/ros-perception/image_pipeline/issues/911>) (#914 <https://github.com/ros-perception/image_pipeline/issues/914>)
  Removed cfg files related with ROS 1 parameters. Backport
  https://github.com/ros-perception/image_pipeline/pull/911
* load image_rotate::ImageRotateNode as component (#856 <https://github.com/ros-perception/image_pipeline/issues/856>)
  This is a fixed version of #820 <https://github.com/ros-perception/image_pipeline/issues/820> - targeting iron
* add myself as a maintainer (#846 <https://github.com/ros-perception/image_pipeline/issues/846>)
* Contributors: Alejandro Hernández Cordero, Michael Ferguson
```

## image_view

```
* [backport iron] Removed cfg files related with ROS 1 parameters (#911 <https://github.com/ros-perception/image_pipeline/issues/911>) (#914 <https://github.com/ros-perception/image_pipeline/issues/914>)
  Removed cfg files related with ROS 1 parameters. Backport
  https://github.com/ros-perception/image_pipeline/pull/911
* [backport iron] enable autosize parameter in disparity view (#875 <https://github.com/ros-perception/image_pipeline/issues/875>) (#898 <https://github.com/ros-perception/image_pipeline/issues/898>)
  backport #875 <https://github.com/ros-perception/image_pipeline/issues/875>
  Co-authored-by: Michael Ferguson <mailto:mfergs7@gmail.com>
* [backport iron] ROS 2: Add option to prepend timestamp to image filename in image_saver node (#870 <https://github.com/ros-perception/image_pipeline/issues/870>) (#886 <https://github.com/ros-perception/image_pipeline/issues/886>)
  backport #870 <https://github.com/ros-perception/image_pipeline/issues/870>
* [backport Iron] Add support for floating point fps (#866 <https://github.com/ros-perception/image_pipeline/issues/866>) (#878 <https://github.com/ros-perception/image_pipeline/issues/878>)
  Backport #866 <https://github.com/ros-perception/image_pipeline/issues/866>
* [backport Iron] use cv::DestroyAllWindows (#863 <https://github.com/ros-perception/image_pipeline/issues/863>) (#865 <https://github.com/ros-perception/image_pipeline/issues/865>)
  This ports #816 <https://github.com/ros-perception/image_pipeline/issues/816> to ROS 2 and prevents weird exit conditions if you
  already closed the window
  backport https://github.com/ros-perception/image_pipeline/pull/863
  Co-authored-by: Michael Ferguson <mailto:mfergs7@gmail.com>
* add myself as a maintainer (#846 <https://github.com/ros-perception/image_pipeline/issues/846>)
* feat: image_saver reports an error on file save
* Contributors: Alejandro Hernández Cordero, Michael Ferguson, Russ Webber
```

## stereo_image_proc

```
* [backport iron] stereo_image_proc: cleanup cmake (#904 <https://github.com/ros-perception/image_pipeline/issues/904>) (#908 <https://github.com/ros-perception/image_pipeline/issues/908>)
  This was supposed to be switched over when e-turtle rolled out. J-turtle
  ain't that late...
  backport https://github.com/ros-perception/image_pipeline/pull/904
  Co-authored-by: Michael Ferguson <mailto:mfergs7@gmail.com>
* [backport iron] support rgba8 and bgra8 encodings by skipping alpha channel (#869 <https://github.com/ros-perception/image_pipeline/issues/869>) (#896 <https://github.com/ros-perception/image_pipeline/issues/896>)
  backport #869 <https://github.com/ros-perception/image_pipeline/issues/869>
* allow use as component or node (#858 <https://github.com/ros-perception/image_pipeline/issues/858>)
  Backport #852 <https://github.com/ros-perception/image_pipeline/issues/852> to Iron
* fix: change type for epsilon (#822 <https://github.com/ros-perception/image_pipeline/issues/822>) (#849 <https://github.com/ros-perception/image_pipeline/issues/849>)
  Co-authored-by: Daisuke Nishimatsu <mailto:42202095+wep21@users.noreply.github.com>
* add myself as a maintainer (#846 <https://github.com/ros-perception/image_pipeline/issues/846>)
* Contributors: Alejandro Hernández Cordero, Michael Ferguson
```

## tracetools_image_pipeline

```
* ROS 2: Fixed CMake (#899 <https://github.com/ros-perception/image_pipeline/issues/899>) (#902 <https://github.com/ros-perception/image_pipeline/issues/902>)
  #backport #899 <https://github.com/ros-perception/image_pipeline/issues/899>
* add myself as a maintainer (#846 <https://github.com/ros-perception/image_pipeline/issues/846>)
* Contributors: Alejandro Hernández Cordero, Michael Ferguson
```
