### PR TITLE
image_pipeline: 5.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2084,7 +2084,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 3.0.1-2
+      version: 5.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `5.0.0-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.1-2`

## camera_calibration

```
* ROS 2: Added more aruco dicts, fixed aruco linerror bug (#873 <https://github.com/ros-perception/image_pipeline/issues/873>)
  Related with this PR in ROS 1
  https://github.com/ros-perception/image_pipeline/pull/795
* ROS 2: Fixing thrown Exception in camerachecker.py (#871 <https://github.com/ros-perception/image_pipeline/issues/871>)
  Related with this PR in ROS 1
  https://github.com/ros-perception/image_pipeline/pull/812
* add myself as a maintainer (#846 <https://github.com/ros-perception/image_pipeline/issues/846>)
* fix threading shutdown
* use correct synchronous service call
* use remap rules instead of parameters for services
* remove duplicated definition of on_model_change
* fix service check
* remove commented code
* Fix QoS incompatibility camera_calibration ROS2
* perform calibration in another thread
* Contributors: Alejandro Hernández Cordero, Christian Rauch, Kenji Brameld, Michael Ferguson, Michal Wojcik
```

## depth_image_proc

```
* radial nodes: should all sub to raw topics (#906 <https://github.com/ros-perception/image_pipeline/issues/906>)
  Per findings in
  https://github.com/ros-perception/image_pipeline/issues/388#issuecomment-1902487162
  - instead of renaming xyz_radial and xyzi_radial to image_rect, I should
  have made the xyzrgb_radial use image_raw (since these nodes use
  matrices K & D):
  * Revert the change in xyzi_radial - topic is depth/image_raw as it has
  always been
  * Revert the change in xyz_radial, although it is still changed slightly
  from the old "image_raw" -> "depth/image_raw" for consistency with the
  other nodes.
  * Update xyzrgb_radial:
  * depth_registered/image_rect -> depth/image_raw
  * rgb/image_rect_color -> rgb/image_raw
  * update launch files accordingly (and remove camera_info since it no
  longer needs to be renamed, happens automagically). Note: these launch
  files are probably epically bad since realsense doesn't output radial
  images... but we'll leave them as documentation for these nodes.
* depth_image_proc: update launch files (#905 <https://github.com/ros-perception/image_pipeline/issues/905>)
  * follow up to #900 <https://github.com/ros-perception/image_pipeline/issues/900> - had not noticed these launch files at the time
  * remove camera_info topics that auto remap now
* depth_image_proc: consistent image_transport (#900 <https://github.com/ros-perception/image_pipeline/issues/900>)
  * all node support image_transport and/or depth_image_transport parameters.
  * point cloud nodes use depth_image_transport parameter for all depth inputs
  * fixes so that remapping works appropriately for image topics, even when using transports other than raw
  * fixes so that remapping works appropriately for image_transport outputs (crop/convert nodes)
  * support remapping camera_info topics
* support rgba8 and bgra8 encodings by skipping alpha channel (#869 <https://github.com/ros-perception/image_pipeline/issues/869>)
  Related with the change in ROS 1
  https://github.com/ros-perception/image_pipeline/pull/671/files
  ---------
* ROS 2: Add option to use the RGB image timestamp for the registered depth image (#872 <https://github.com/ros-perception/image_pipeline/issues/872>)
  Related with this PR in ROS 1
  https://github.com/ros-perception/image_pipeline/pull/871
* Support MONO16 image encodings: point_cloud_xyz (#868 <https://github.com/ros-perception/image_pipeline/issues/868>)
  Related with this change in ROS 1
  https://github.com/ros-perception/image_pipeline/pull/630
* ROS 2: depth_image_proc/point_cloud_xyzi_radial Add intensity conversion (copy) for float (#867 <https://github.com/ros-perception/image_pipeline/issues/867>)
  Ported from ROS 1
  https://github.com/ros-perception/image_pipeline/pull/336/files
* make remaining components lazy (#853 <https://github.com/ros-perception/image_pipeline/issues/853>)
  missed a few components in #815 <https://github.com/ros-perception/image_pipeline/issues/815>
* allow use as component or node (#852 <https://github.com/ros-perception/image_pipeline/issues/852>)
  This addresses
  https://github.com/ros-perception/image_pipeline/issues/823:
  * depth_image_proc was never implemented properly this way
  * image_proc might have once worked this way, but it appears upstream
  has changed over time and it was no longer doing the job.
  * stereo_image_proc is actually implemented correctly - I just added a
  comment
  With this PR:
  ```
  $ ros2 pkg executables image_proc
  image_proc crop_decimate_node
  image_proc crop_non_zero_node
  image_proc debayer_node
  image_proc image_proc
  image_proc rectify_node
  image_proc resize_node
  ```
  ```
  $ ros2 pkg executables depth_image_proc
  depth_image_proc convert_metric_node
  depth_image_proc crop_foremost_node
  depth_image_proc disparity_node
  depth_image_proc point_cloud_xyz_node
  depth_image_proc point_cloud_xyz_radial_node
  depth_image_proc point_cloud_xyzi_node
  depth_image_proc point_cloud_xyzi_radial_node
  depth_image_proc point_cloud_xyzrgb_node
  depth_image_proc point_cloud_xyzrgb_radial_node
  depth_image_proc register_node
  ```
* add support for lazy subscribers (#815 <https://github.com/ros-perception/image_pipeline/issues/815>)
  This implements #780 <https://github.com/ros-perception/image_pipeline/issues/780> for ROS 2 distributions after Iron, where we have:
  * Connect/disconnect callbacks, per https://github.com/ros2/rmw/issues/330 (this made it into Iron)
  * Updated APIs in https://github.com/ros-perception/image_common/pull/272 (this is only in Rolling currently)
* add myself as a maintainer (#846 <https://github.com/ros-perception/image_pipeline/issues/846>)
* Depth image transport configure susbcribers (#844 <https://github.com/ros-perception/image_pipeline/issues/844>) (#845 <https://github.com/ros-perception/image_pipeline/issues/845>)
* Updated depth_image_proc for ros2
  Instantiated template for convertDepth, added options to register, and
  changed register from a class loader to an RCLPP component.
* Contributors: Alejandro Hernández Cordero, Michael Ferguson, ksommerkohrt
```

## image_pipeline

```
* add myself as a maintainer (#846 <https://github.com/ros-perception/image_pipeline/issues/846>)
* Contributors: Michael Ferguson
```

## image_proc

```
* Port image_proc test to ROS 2 (#910 <https://github.com/ros-perception/image_pipeline/issues/910>)
* Removed cfg files related with ROS 1 parameters (#911 <https://github.com/ros-perception/image_pipeline/issues/911>)
  Removed cfg files related with ROS 1 parameters
* image_proc: consistent image_transport (#884 <https://github.com/ros-perception/image_pipeline/issues/884>)
  * consistent image_transport parameter for crop_decimate, crop_non_zero
  and debayer nodes
  * consistent remapping support for compressed/etc topics in all three
  nodes
  * add lazy subscription support to crop_non_zero
  Additional minor fixes:
  * put the getTopicQosProfile() for publisher right in front of publisher
  declaration for clarity
* resize/recify: consistent image_transport (#883 <https://github.com/ros-perception/image_pipeline/issues/883>)
  * support image_transport parameter
  * proper renaming so compressed/etc topics work as expected
  Additional minor fixes:
  * rename interpolation -> interpolation_ for consistency
  * move parameter declaration BEFORE we create a publisher (and possibly
  get a subscriber created in connect callback)
  * put the getTopicQosProfile() for publisher right in front of publisher
  declaration for clarity
* ROS 2: Merged resize.cpp: fix memory leak (#874 <https://github.com/ros-perception/image_pipeline/issues/874>)
  Related with this PR in ROS 1
  https://github.com/ros-perception/image_pipeline/pull/489
* allow use as component or node (#852 <https://github.com/ros-perception/image_pipeline/issues/852>)
  This addresses
  https://github.com/ros-perception/image_pipeline/issues/823:
  * depth_image_proc was never implemented properly this way
  * image_proc might have once worked this way, but it appears upstream
  has changed over time and it was no longer doing the job.
  * stereo_image_proc is actually implemented correctly - I just added a
  comment
  With this PR:
  ```
  $ ros2 pkg executables image_proc
  image_proc crop_decimate_node
  image_proc crop_non_zero_node
  image_proc debayer_node
  image_proc image_proc
  image_proc rectify_node
  image_proc resize_node
  ```
  ```
  $ ros2 pkg executables depth_image_proc
  depth_image_proc convert_metric_node
  depth_image_proc crop_foremost_node
  depth_image_proc disparity_node
  depth_image_proc point_cloud_xyz_node
  depth_image_proc point_cloud_xyz_radial_node
  depth_image_proc point_cloud_xyzi_node
  depth_image_proc point_cloud_xyzi_radial_node
  depth_image_proc point_cloud_xyzrgb_node
  depth_image_proc point_cloud_xyzrgb_radial_node
  depth_image_proc register_node
  ```
* add support for lazy subscribers (#815 <https://github.com/ros-perception/image_pipeline/issues/815>)
  This implements #780 <https://github.com/ros-perception/image_pipeline/issues/780> for ROS 2 distributions after Iron, where we have:
  * Connect/disconnect callbacks, per https://github.com/ros2/rmw/issues/330 (this made it into Iron)
  * Updated APIs in https://github.com/ros-perception/image_common/pull/272 (this is only in Rolling currently)
* add myself as a maintainer (#846 <https://github.com/ros-perception/image_pipeline/issues/846>)
* Use the same QoS profiles as publishers in image_proc
* fix to allow remapping resize and image topics
* Contributors: Alejandro Hernández Cordero, Joe Schornak, Michael Ferguson, Michal Wojcik
```

## image_publisher

```
* Removed cfg files related with ROS 1 parameters (#911 <https://github.com/ros-perception/image_pipeline/issues/911>)
  Removed cfg files related with ROS 1 parameters
* ROS 2: Fixed CMake (#899 <https://github.com/ros-perception/image_pipeline/issues/899>)
* image_publisher: functional component (#861 <https://github.com/ros-perception/image_pipeline/issues/861>)
  * filename now functions when using a component
  * parameter callback gets called at startup when using the component
  * cleanup a bit of the logging
  * add launch file to test component more easily
* properly remap compressed topics (#851 <https://github.com/ros-perception/image_pipeline/issues/851>)
  ## Before:
  Pushing into namespace is broken, only image_raw changes (camera_info
  and transport topics should change):
  ```
  ros2 run image_publisher image_publisher_node --ros-args -p filename:=test.png -r image_raw:=foo/image_raw
  ---
  ros2 topic list
  /camera_info
  /foo/image_raw
  /image_raw/compressed
  /image_raw/compressedDepth
  /image_raw/theora
  ```
  ## After:
  Pushing into namespace now works:
  ```
  ros2 run image_publisher image_publisher_node --ros-args -p filename:=test.png -r image_raw:=foo/image_raw
  ---
  ros2 topic list
  /foo/camera_info
  /foo/image_raw
  /foo/image_raw/compressed
  /foo/image_raw/compressedDepth
  /foo/image_raw/theora
  ```
* add myself as a maintainer (#846 <https://github.com/ros-perception/image_pipeline/issues/846>)
* Contributors: Alejandro Hernández Cordero, Michael Ferguson
```

## image_rotate

```
* Removed cfg files related with ROS 1 parameters (#911 <https://github.com/ros-perception/image_pipeline/issues/911>)
  Removed cfg files related with ROS 1 parameters
* image_rotate: clean up (#862 <https://github.com/ros-perception/image_pipeline/issues/862>)
  This is the first component/node with a cleanup pass to be fully
  implemented:
  * Fix #740 <https://github.com/ros-perception/image_pipeline/issues/740> by initializing vectors. Do this by declaring parameters
  AFTER we define the callback
  * Implement lazy subscribers (I missed this in the earlier PRs)
  * Add image_transport parameter so we can specify that desired transport
  of our subscriptions
  * Update how we test for connectivity (and update the debug message -
  has nothing to do with whether we are remapped, it's really about
  whether we are connected)
* load image_rotate::ImageRotateNode as component (#855 <https://github.com/ros-perception/image_pipeline/issues/855>)
  This is a fixed version of #820 <https://github.com/ros-perception/image_pipeline/issues/820> - targeting rolling
* add myself as a maintainer (#846 <https://github.com/ros-perception/image_pipeline/issues/846>)
* Contributors: Alejandro Hernández Cordero, Michael Ferguson
```

## image_view

```
* remove the last bit of boost (#912 <https://github.com/ros-perception/image_pipeline/issues/912>)
  Last bit of #407 <https://github.com/ros-perception/image_pipeline/issues/407> - every other occurrence of "boost" when grepping the
  repo is in the changelog
* Removed Boost dependency (#909 <https://github.com/ros-perception/image_pipeline/issues/909>)
  Removed Boost dependency. Related with
  https://github.com/ros-perception/image_pipeline/issues/407
  ---------
* Removed cfg files related with ROS 1 parameters (#911 <https://github.com/ros-perception/image_pipeline/issues/911>)
  Removed cfg files related with ROS 1 parameters
* image_view: consistent image_transport (#876 <https://github.com/ros-perception/image_pipeline/issues/876>)
  All of these nodes already have the proper remapping support - but
  image_transport parameter support was scattered
* enable autosize parameter in disparity view (#875 <https://github.com/ros-perception/image_pipeline/issues/875>)
  appears to be bug left over from ROS 2 port
* ROS 2: Add option to prepend timestamp to image filename in image_saver node (#870 <https://github.com/ros-perception/image_pipeline/issues/870>)
  Related to this PR in ROS 1
  https://github.com/ros-perception/image_pipeline/pull/806/files
  ---------
* Add support for floating point fps (#866 <https://github.com/ros-perception/image_pipeline/issues/866>)
  Related with this PR
  https://github.com/ros-perception/image_pipeline/pull/723
  ---------
* use cv::DestroyAllWindows (#863 <https://github.com/ros-perception/image_pipeline/issues/863>)
  This ports #816 <https://github.com/ros-perception/image_pipeline/issues/816> to ROS 2 and prevents weird exit conditions if you
  already closed the window
* properly remap compressed topics (#851 <https://github.com/ros-perception/image_pipeline/issues/851>)
  ## Before:
  Pushing into namespace is broken, only image_raw changes (camera_info
  and transport topics should change):
  ```
  ros2 run image_publisher image_publisher_node --ros-args -p filename:=test.png -r image_raw:=foo/image_raw
  ---
  ros2 topic list
  /camera_info
  /foo/image_raw
  /image_raw/compressed
  /image_raw/compressedDepth
  /image_raw/theora
  ```
  ## After:
  Pushing into namespace now works:
  ```
  ros2 run image_publisher image_publisher_node --ros-args -p filename:=test.png -r image_raw:=foo/image_raw
  ---
  ros2 topic list
  /foo/camera_info
  /foo/image_raw
  /foo/image_raw/compressed
  /foo/image_raw/compressedDepth
  /foo/image_raw/theora
  ```
* image_view: fix encoding, help string (#850 <https://github.com/ros-perception/image_pipeline/issues/850>)
  * encoding shouldn't be hard coded, pull it from the message
  * help string needs to be updated to proper parameter format
* Improved Image view dynamic parameters description (#829 <https://github.com/ros-perception/image_pipeline/issues/829>)
* add myself as a maintainer (#846 <https://github.com/ros-perception/image_pipeline/issues/846>)
* feat: image_saver reports an error on file save
* Contributors: Alejandro Hernández Cordero, Michael Ferguson, Russ Webber
```

## stereo_image_proc

```
* stereo_image_proc: cleanup cmake (#904 <https://github.com/ros-perception/image_pipeline/issues/904>)
  This was supposed to be switched over when e-turtle rolled out. J-turtle
  ain't that late...
* stereo_image_proc: consistent image_transport (#903 <https://github.com/ros-perception/image_pipeline/issues/903>)
  * make image_transport work
  * make remap work as expected with image_transport
  * make subscribers lazy
* support rgba8 and bgra8 encodings by skipping alpha channel (#869 <https://github.com/ros-perception/image_pipeline/issues/869>)
  Related with the change in ROS 1
  https://github.com/ros-perception/image_pipeline/pull/671/files
  ---------
* allow use as component or node (#852 <https://github.com/ros-perception/image_pipeline/issues/852>)
  This addresses
  https://github.com/ros-perception/image_pipeline/issues/823:
  * depth_image_proc was never implemented properly this way
  * image_proc might have once worked this way, but it appears upstream
  has changed over time and it was no longer doing the job.
  * stereo_image_proc is actually implemented correctly - I just added a
  comment
  With this PR:
  ```
  $ ros2 pkg executables image_proc
  image_proc crop_decimate_node
  image_proc crop_non_zero_node
  image_proc debayer_node
  image_proc image_proc
  image_proc rectify_node
  image_proc resize_node
  ```
  ```
  $ ros2 pkg executables depth_image_proc
  depth_image_proc convert_metric_node
  depth_image_proc crop_foremost_node
  depth_image_proc disparity_node
  depth_image_proc point_cloud_xyz_node
  depth_image_proc point_cloud_xyz_radial_node
  depth_image_proc point_cloud_xyzi_node
  depth_image_proc point_cloud_xyzi_radial_node
  depth_image_proc point_cloud_xyzrgb_node
  depth_image_proc point_cloud_xyzrgb_radial_node
  depth_image_proc register_node
  ```
* fix: change type for epsilon (#822 <https://github.com/ros-perception/image_pipeline/issues/822>)
* add myself as a maintainer (#846 <https://github.com/ros-perception/image_pipeline/issues/846>)
* Contributors: Alejandro Hernández Cordero, Daisuke Nishimatsu, Michael Ferguson
```

## tracetools_image_pipeline

```
* ROS 2: Fixed CMake (#899 <https://github.com/ros-perception/image_pipeline/issues/899>)
* add myself as a maintainer (#846 <https://github.com/ros-perception/image_pipeline/issues/846>)
* Contributors: Alejandro Hernández Cordero, Michael Ferguson
```
