### PR TITLE
revert locator_ros_bridge 2.1.10-1 in rolling/distribution.yaml

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2647,24 +2647,7 @@ repositories:
       type: git
       url: https://github.com/adityapande-1995/linux_isolate_process.git
       version: main
-    status: maintained
-  locator_ros_bridge:
-    doc:
-      type: git
-      url: https://github.com/boschglobal/locator_ros_bridge.git
-      version: humble
-    release:
-      packages:
-      - bosch_locator_bridge
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/locator_ros_bridge-release.git
-      version: 2.1.10-1
-    source:
-      type: git
-      url: https://github.com/boschglobal/locator_ros_bridge.git
-      version: humble
-    status: maintained
+    status: maintained 
   log_view:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2647,7 +2647,7 @@ repositories:
       type: git
       url: https://github.com/adityapande-1995/linux_isolate_process.git
       version: main
-    status: maintained 
+    status: maintained
   log_view:
     doc:
       type: git


### PR DESCRIPTION
locator_ros_bridge will not be maintained in rolling. 
Failed build https://build.ros2.org/job/Rdev__locator_ros_bridge__ubuntu_jammy_amd64/40/