### PR TITLE
rviz: 13.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6363,7 +6363,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 13.3.0-2
+      version: 13.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `13.3.1-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `13.3.0-2`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Append measured subscription frequency to topic status (#1113 <https://github.com/ros2/rviz/issues/1113>)
* Contributors: Yadu
```

## rviz_default_plugins

```
* Fix time-syncing message (#1121 <https://github.com/ros2/rviz/issues/1121>)
* Switch from ROS_TIME to SYSTEM_TIME on rclcpp::Time construction (#1117 <https://github.com/ros2/rviz/issues/1117>)
* Append measured subscription frequency to topic status (#1113 <https://github.com/ros2/rviz/issues/1113>)
* Contributors: Alejandro Hernández Cordero, Austin Moore, Yadu
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* fixed MovableText::getWorldTransforms transform (#1118 <https://github.com/ros2/rviz/issues/1118>)
* Contributors: Yaswanth
```

## rviz_rendering_tests

```
* Remove the loading_ascii_stl_files_fail (#1125 <https://github.com/ros2/rviz/issues/1125>)
* Contributors: Chris Lalancette
```

## rviz_visual_testing_framework

- No changes
