### PR TITLE
rmw_connextdds: 0.20.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5000,7 +5000,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 0.19.0-1
+      version: 0.20.0-1
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `0.20.0-1`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.19.0-1`

## rmw_connextdds

- No changes

## rmw_connextdds_common

```
* Add ros2_tracing tracepoints (#120 <https://github.com/ros2/rmw_connextdds/issues/120>)
* Contributors: Christopher Wecht
```

## rti_connext_dds_cmake_module

- No changes
