### PR TITLE
rclcpp: 26.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4534,7 +4534,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 25.0.0-1
+      version: 26.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `26.0.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `25.0.0-1`

## rclcpp

```
* Increase the cppcheck timeout to 600 seconds. (#2409 <https://github.com/ros2/rclcpp/issues/2409>)
* Add transient local durability support to publisher and subscriptions when using intra-process communication (#2303 <https://github.com/ros2/rclcpp/issues/2303>)
* Stop storing the context in the guard condition. (#2400 <https://github.com/ros2/rclcpp/issues/2400>)
* Contributors: Chris Lalancette, Jeffery Hsu
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* Increase timeout for rclcpp_lifecycle to 360 (#2395 <https://github.com/ros2/rclcpp/issues/2395>)
* Contributors: Jorge Perez
```
