### PR TITLE
rcl_logging: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4481,7 +4481,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 2.7.1-1
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `3.0.0-1`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.7.1-1`

## rcl_logging_interface

```
* add file_name_prefix parameter to external log configuration. (#109 <https://github.com/ros2/rcl_logging/issues/109>)
* Contributors: Tomoya Fujita
```

## rcl_logging_noop

```
* add file_name_prefix parameter to external log configuration. (#109 <https://github.com/ros2/rcl_logging/issues/109>)
* Contributors: Tomoya Fujita
```

## rcl_logging_spdlog

```
* add file_name_prefix parameter to external log configuration. (#109 <https://github.com/ros2/rcl_logging/issues/109>)
* Contributors: Tomoya Fujita
```
