### PR TITLE
orocos_kdl_vendor: 0.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3628,7 +3628,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
-      version: 0.4.1-1
+      version: 0.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_kdl_vendor` to `0.5.0-1`:

- upstream repository: https://github.com/ros2/orocos_kdl_vendor.git
- release repository: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.1-1`

## orocos_kdl_vendor

```
* Update to the latest orocos_kdl_kinematics commit. (#25 <https://github.com/ros2/orocos_kdl_vendor/issues/25>)
* Contributors: Chris Lalancette
```

## python_orocos_kdl_vendor

```
* Update to the latest orocos_kdl_kinematics commit. (#25 <https://github.com/ros2/orocos_kdl_vendor/issues/25>)
* Contributors: Chris Lalancette
```
