### PR TITLE
launch: 3.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2435,7 +2435,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.2.1-1
+      version: 3.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.3.0-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.2.1-1`

## launch

```
* Let XML executables/nodes be "required" (like in ROS 1) (#751 <https://github.com/ros2/launch/issues/751>)
* Contributors: Matthew Elwin
```

## launch_pytest

- No changes

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* Let XML executables/nodes be "required" (like in ROS 1) (#751 <https://github.com/ros2/launch/issues/751>)
  * Let XML nodes be "required"
  Essentially on_exit="shutdown" is equivalent to ROS 1 required="true".
  This feature is implemented using the python launchfile on_exit mechanism.
  Right now "shutdown" is the only action accepted by on_exit,
  but theoretically more "on_exit" actions could be added later.
  Example:
  <executable cmd="ls" on_exit="shutdown"/>
  * Added tests for yaml
* Contributors: Matthew Elwin
```

## launch_yaml

```
* Let XML executables/nodes be "required" (like in ROS 1) (#751 <https://github.com/ros2/launch/issues/751>)
  * Let XML nodes be "required"
  Essentially on_exit="shutdown" is equivalent to ROS 1 required="true".
  This feature is implemented using the python launchfile on_exit mechanism.
  Right now "shutdown" is the only action accepted by on_exit,
  but theoretically more "on_exit" actions could be added later.
  Example:
  <executable cmd="ls" on_exit="shutdown"/>
  * Added tests for yaml
* Contributors: Matthew Elwin
```
