### PR TITLE
image_common: 5.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2058,7 +2058,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 5.0.0-1
+      version: 5.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `5.1.0-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `5.0.0-1`

## camera_calibration_parsers

- No changes

## camera_info_manager

- No changes

## image_common

- No changes

## image_transport

```
* Add QoS option reliability to republisher qos params (#296 <https://github.com/ros-perception/image_common/issues/296>)
* implement CameraSubscriber::getNumPublishers (#297 <https://github.com/ros-perception/image_common/issues/297>)
* Add missing definition for CameraPublisher::publish overload (#278 <https://github.com/ros-perception/image_common/issues/278>)
* Contributors: Carlos Andrés Álvarez Restrepo, Michael Ferguson, s-hall
```
