### PR TITLE
ament_package: 0.16.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -286,7 +286,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_package-release.git
-      version: 0.16.2-1
+      version: 0.16.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_package` to `0.16.3-1`:

- upstream repository: https://github.com/ament/ament_package.git
- release repository: https://github.com/ros2-gbp/ament_package-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.16.2-1`

## ament_package

```
* Migrate from legacy importlib-resources (#143 <https://github.com/ament/ament_package/issues/143>)
* Contributors: Isabel Paredes
```
