### PR TITLE
depthai-ros: 2.9.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2005,7 +2005,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/luxonis/depthai-ros-release.git
-      version: 2.8.2-1
+      version: 2.9.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai-ros` to `2.9.0-1`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: https://github.com/luxonis/depthai-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.8.2-1`

## depthai-ros

```
* New documentation homepage
* Updated support for LR and SR cameras
* Added parameter to toggle restart on logging error
* Changed argument for camera.launch file from pass_tf_args_as_params to publish_tf_from_calibration to be more explicit
* Added the option to run NN as part of sensor node
* Added option to run Spatial NN as part of stereo node
```
