### PR TITLE
mocap4r2: 0.0.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3766,6 +3766,7 @@ repositories:
       packages:
       - mocap4r2_control
       - mocap4r2_control_msgs
+      - mocap4r2_dummy_driver
       - mocap4r2_marker_publisher
       - mocap4r2_marker_viz
       - mocap4r2_marker_viz_srvs
@@ -3775,7 +3776,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/MOCAP4ROS2-Project/mocap4r2-release.git
-      version: 0.0.6-1
+      version: 0.0.7-1
     source:
       type: git
       url: https://github.com/MOCAP4ROS2-Project/mocap4r2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mocap4r2` to `0.0.7-1`:

- upstream repository: https://github.com/MOCAP4ROS2-Project/mocap4r2.git
- release repository: https://github.com/MOCAP4ROS2-Project/mocap4r2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.6-1`

## mocap4r2_control

- No changes

## mocap4r2_control_msgs

- No changes

## mocap4r2_dummy_driver

```
* Dummy driver initial version
* Contributors: Francisco Martín Rico
```

## mocap4r2_marker_publisher

- No changes

## mocap4r2_marker_viz

- No changes

## mocap4r2_marker_viz_srvs

```
* Fix compilation
* Contributors: Francisco Martín Rico
```

## mocap4r2_robot_gt

- No changes

## mocap4r2_robot_gt_msgs

- No changes

## rqt_mocap4r2_control

- No changes
