### PR TITLE
ros2_control: 2.38.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6553,7 +6553,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.37.0-1
+      version: 2.38.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.38.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.37.0-1`

## controller_interface

- No changes

## controller_manager

```
* [CM] Fix controller parameter loading issue in different cases (#1293 <https://github.com/ros-controls/ros2_control/issues/1293>) (#1332 <https://github.com/ros-controls/ros2_control/issues/1332>)
* Enable setting of initial state in HW components (backport #1046 <https://github.com/ros-controls/ros2_control/issues/1046>) (#1064 <https://github.com/ros-controls/ros2_control/issues/1064>)
* Contributors: Sai Kishor Kothakota, mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* [CM] Fix controller parameter loading issue in different cases (#1293 <https://github.com/ros-controls/ros2_control/issues/1293>) (#1332 <https://github.com/ros-controls/ros2_control/issues/1332>)
* Enable setting of initial state in HW components (backport #1046 <https://github.com/ros-controls/ros2_control/issues/1046>) (#1064 <https://github.com/ros-controls/ros2_control/issues/1064>)
* Contributors: Sai Kishor Kothakota, mergify[bot]
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
