### PR TITLE
added apriltag_detector

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -464,6 +464,16 @@ repositories:
       url: https://github.com/AprilRobotics/apriltag.git
       version: master
     status: maintained
+  apriltag_detector:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/apriltag_detector.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/apriltag_detector.git
+      version: master
+    status: developed
   apriltag_msgs:
     release:
       tags:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -358,6 +358,16 @@ repositories:
       url: https://github.com/AprilRobotics/apriltag.git
       version: master
     status: maintained
+  apriltag_detector:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/apriltag_detector.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/apriltag_detector.git
+      version: master
+    status: developed
   apriltag_msgs:
     release:
       tags:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -358,6 +358,16 @@ repositories:
       url: https://github.com/AprilRobotics/apriltag.git
       version: master
     status: maintained
+  apriltag_detector:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/apriltag_detector.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/apriltag_detector.git
+      version: master
+    status: developed
   apriltag_msgs:
     release:
       tags:


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please add apriltag_detector to be indexed in the rosdistro.
ROS distros: humble, iron, rolling

Note: there is already a [apriltag_ros](https://github.com/christianrauch/apriltag_ros) package, so why add another one?
The existing apriltag_ros package not only detects apriltags, but also uses them to compute the pose of the tags (transforms). For that reason it subscribes to calibration (camera_info) messages which are *not available* until the camera has been calibrated. However, this makes the existing  package difficult to use for camera calibration.
The new package proposed here focuses only on the elementary task of perception: detect the tag's ID and corners in the image. Note that it uses the same message format as the apriltag_ros package, except that it does not utilize the homography field.

NAME of package: apriltag_detector

# The source is here:
https://github.com/ros-misc-utilities/apriltag_detector

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
