### PR TITLE
mp2p_icp: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3112,7 +3112,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `1.1.0-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-1`

## mp2p_icp

```
* FilterDecimateVoxels: Replace 3 bool parameters with an enum
* Fix clang warnings
* Save and visualize ICP step partial solutions
* QualityEvaluator_PairedRatio: now does not require parameters
* Add filter: Bonxai VoxelMap -> 2D gridmap. Bayesian filtering of voxel columns
* Generator: allow defining custom metric maps directly in the YAML configuration
* Contributors: Jose Luis Blanco-Claraco
```
