### PR TITLE
cras_laser_geometry: 1.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1676,7 +1676,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/cras_laser_geometry.git
-      version: 1.2.0-1
+      version: 1.2.1-1
     source:
       type: git
       url: https://github.com/ctu-vras/cras_laser_geometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_laser_geometry` to `1.2.1-1`:

- upstream repository: https://github.com/ctu-vras/cras_laser_geometry.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/cras_laser_geometry.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.0-1`

## cras_laser_geometry

```
* Fixed waiting for transforms in case fixed frame is specified and target frame is not.
* Contributors: Martin Pecka
```
