### PR TITLE
plotjuggler: 3.8.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7638,7 +7638,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.8.9-1
+      version: 3.8.10-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.8.10-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.8.9-1`

## plotjuggler

```
* Fix issue #924: crash when loading rosbag with std_msgs/Empty
* Allow ZMQ plugin to work as server
* Link against Abseil for macOS builds & improve macOS compile docs #845 <https://github.com/facontidavide/PlotJuggler/issues/845> (#905 <https://github.com/facontidavide/PlotJuggler/issues/905>)
* PlotJuggler with Fast-CDR-2.x.x (#920 <https://github.com/facontidavide/PlotJuggler/issues/920>)
* fix issue in CSV #926 <https://github.com/facontidavide/PlotJuggler/issues/926>
* attempt to match ambiguous ros msg within package before using external known type (#922 <https://github.com/facontidavide/PlotJuggler/issues/922>)
* Contributors: Davide Faconti, Manuel Valch, Will MacCormack, rugged-robotics
```
