### PR TITLE
plotjuggler: 3.8.10-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5073,7 +5073,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.8.8-3
+      version: 3.8.10-2
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.8.10-2`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/ros2-gbp/plotjuggler-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.8.8-3`

## plotjuggler

```
* Fix issue #924: crash when loading rosbag with std_msgs/Empty
* Allow ZMQ plugin to work as server
* Link against Abseil for macOS builds & improve macOS compile docs #845 <https://github.com/facontidavide/PlotJuggler/issues/845> (#905 <https://github.com/facontidavide/PlotJuggler/issues/905>)
* fix issue in CSV #926 <https://github.com/facontidavide/PlotJuggler/issues/926>
* attempt to match ambiguous ros msg within package before using external known type (#922 <https://github.com/facontidavide/PlotJuggler/issues/922>)
* Contributors: Davide Faconti, Manuel Valch, Will MacCormack, rugged-robotics
```
