### PR TITLE
sync_parameter_server: 1.0.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8311,7 +8311,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/sync_parameter_server-release.git
-      version: 1.0.0-1
+      version: 1.0.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sync_parameter_server` to `1.0.1-2`:

- upstream repository: https://github.com/Tacha-S/sync_parameter_server.git
- release repository: https://github.com/ros2-gbp/sync_parameter_server-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-1`

## sync_parameter_server

```
* Fix buildtool_depend
* Fix secret name
* Add release CI
* Contributors: Tatsuro Sakaguchi
```
