### PR TITLE
motion_capture_tracking: 1.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2987,7 +2987,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/motion_capture_tracking-release.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/IMRCLab/motion_capture_tracking.git


### PR DESCRIPTION
Increasing version of package(s) in repository `motion_capture_tracking` to `1.0.3-1`:

- upstream repository: https://github.com/IMRCLab/motion_capture_tracking.git
- release repository: https://github.com/ros2-gbp/motion_capture_tracking-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.2-1`

## motion_capture_tracking

- No changes

## motion_capture_tracking_interfaces

```
* add ament_lint_common test dependency
* Contributors: Wolfgang Hoenig
```
