### PR TITLE
Add python3-svg.path to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9013,6 +9013,13 @@ python3-suas-interop-clients-pip:
   ubuntu:
     pip:
       packages: [suas-interop-clients]
+python3-svg.path:
+  alpine: [py3-svgpath]
+  debian: [python3-svg.path]
+  fedora: [python3-svg-path]
+  gentoo: [dev-python/svg-path]
+  nixos: [python311Packages.svg-path]
+  ubuntu: [python3-svg.path]
 python3-sympy:
   debian: [python3-sympy]
   fedora: [python3-sympy]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`python3-svg.path`

## Package Upstream Source:

[svg.path](https://github.com/regebro/svg.path)

## Purpose of using this:

This dependency is being used for parsing SVG paths. This can be used for importing maps and relevant information from SVG files.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/python3-svg.path
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/jammy/python3-svg.path
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-svg-path/python3-svg-path/
- Arch: https://www.archlinux.org/packages/
  - NOT AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/svg-path
- macOS: https://formulae.brew.sh/
  - NOT AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/packages?name=py3-svgpath&branch=edge&repo=&arch=&maintainer=
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=23.11&show=python311Packages.svg-path
- openSUSE: https://software.opensuse.org/package/
  - NOT AVAILABLE
- rhel: https://rhel.pkgs.org/
  - NOT AVAILABLE