### PR TITLE
Bump ros2_conopen to 0.2.8-1

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5185,7 +5185,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_canopen-release.git
-      version: 0.2.7-1
+      version: 0.2.8-1
     source:
       type: git
       url: https://github.com/ros-industrial/ros2_canopen.git


### PR DESCRIPTION
Manually opening this PR since bloom failed to open one as reported here https://github.com/ros-industrial/ros2_canopen/issues/248#issuecomment-1900528051
As far as I can tell, the other steps in `bloom` succeeded.

This is to unblock the regression on Rolling.
