### PR TITLE
linux_isolate_process: 0.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2662,6 +2662,11 @@ repositories:
       type: git
       url: https://github.com/adityapande-1995/linux_isolate_process.git
       version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/linux_isolate_process-release.git
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/adityapande-1995/linux_isolate_process.git


### PR DESCRIPTION
Increasing version of package(s) in repository `linux_isolate_process` to `0.0.2-1`:

- upstream repository: https://github.com/adityapande-1995/linux_isolate_process.git
- release repository: https://github.com/ros2-gbp/linux_isolate_process-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## linux_isolate_process

```
* 0.0.1
* Removed entry points
* Added main
* Updated readme
* Update README.md
* Updated package.xml
* Changed to a ROS package
* Updated name
* Updated project name
* Updated toml
* Update pyproject.toml
* Update setup.py
* Update README.md
* Update README.md
* Update README.md
* Added toml file
* Create LICENSE
* Changed name of the tool to linux_isolate_process
* Update README.md
* Update README.md
* Update README.md
* Can use as a module
* Check os before execution
* Update isolate.py
* Update README.md
* Update README.md
* Added the basic script
* Initial commit
* Contributors: Aditya Pande
```
