### PR TITLE
psdk_ros2: 0.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5323,6 +5323,14 @@ repositories:
       type: git
       url: https://github.com/umdlife/psdk_ros2.git
       version: main
+    release:
+      packages:
+      - psdk_interfaces
+      - psdk_wrapper
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/psdk_ros2-release.git
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/umdlife/psdk_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `psdk_ros2` to `0.0.4-1`:

- upstream repository: https://github.com/umdlife/psdk_ros2.git
- release repository: https://github.com/ros2-gbp/psdk_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## psdk_interfaces

```
* Update maintainers
* Contributors: vicmassy
```

## psdk_wrapper

```
* Merge pull request #45 <https://github.com/umdlife/psdk_ros2/issues/45> from umdlife/feat/prepare-ros-index
  Prepare for ROS Index
* Reorder method call in lifecycle to avoid node crashes + increase nr. of retries for psdk init
* Update maintainers
* Contributors: Victor Massagué Respall, biancabnd, vicmassy
```
