### PR TITLE
Add python3-moteus-pip and python3-moteus-pi3hat-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6927,6 +6927,26 @@ python3-more-itertools:
     '*': [python3-more-itertools]
     '7': null
   ubuntu: [python3-more-itertools]
+python3-moteus-pi3hat-pip:
+  debian:
+    pip:
+      packages: [moteus-pi3hat]
+  ubuntu:
+    pip:
+      packages: [moteus-pi3hat]
+python3-moteus-pip:
+  debian:
+    pip:
+      packages: [moteus]
+  fedora:
+    pip:
+      packages: [moteus]
+  osx:
+    pip:
+      packages: [moteus]
+  ubuntu:
+    pip:
+      packages: [moteus]
 python3-msgpack:
   debian:
     '*': [python3-msgpack]


### PR DESCRIPTION
Please add the following dependencies to the rosdep database.

## Package name:

`moteus` and `moteus-pi3hat`

## Package Upstream Source:

* https://github.com/mjbots/moteus
* https://github.com/mjbots/pi3hat

## Purpose of using this:

moteus is a line of brushless motor controllers for 3 phase brushless motors.  These packages allow controlling and monitoring those motor controllers from python.  The pi3hat is a CAN-FD Raspberry Pi 3/4 hat used for communicating with them and the moteus-pi3hat allows using it from python.

Distro packaging links:

## Links to Distribution Packages

- pip: 
  - https://pypi.org/project/moteus
  - https://pypi.org/project/moteus-pi3hat
- Debian: https://packages.debian.org/
  - Use `pip` packages linked above.  Not available in the Debian repositories.
- Ubuntu: https://packages.ubuntu.com/
  - Use `pip` packages linked above.  Not available in the Ubuntu repositories.
- Fedora: https://packages.fedoraproject.org/
  - NOT AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - NOT AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - NOT AVAILABLE
- macOS: https://formulae.brew.sh/
  - NOT AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - NOT AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - NOT AVAILABLE
- openSUSE: https://software.opensuse.org/package/
  - NOT AVAILABLE
- rhel: https://rhel.pkgs.org/
  - NOT AVAILABLE