### PR TITLE
data_tamer: 0.9.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1303,6 +1303,14 @@ repositories:
       type: git
       url: https://github.com/PickNikRobotics/data_tamer.git
       version: main
+    release:
+      packages:
+      - data_tamer_cpp
+      - data_tamer_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/data_tamer-release.git
+      version: 0.9.2-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/data_tamer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `data_tamer` to `0.9.2-1`:

- upstream repository: https://github.com/PickNikRobotics/data_tamer.git
- release repository: https://github.com/ros2-gbp/data_tamer-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## data_tamer_cpp

```
* fix compilation in ament
* Update CMakeLists.txt. Fix #11 <https://github.com/facontidavide/data_tamer/issues/11>
* Contributors: Davide Faconti
```

## data_tamer_msgs

- No changes
