### PR TITLE
caret_analyze_cpp_impl: 0.5.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -824,6 +824,11 @@ repositories:
       type: git
       url: https://github.com/tier4/caret_analyze_cpp_impl.git
       version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/caret_analyze_cpp_impl-release.git
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/tier4/caret_analyze_cpp_impl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `caret_analyze_cpp_impl` to `0.5.0-1`:

- upstream repository: https://github.com/tier4/caret_analyze_cpp_impl.git
- release repository: https://github.com/ros2-gbp/caret_analyze_cpp_impl-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## caret_analyze_cpp_impl

```
* chore: update package.xml version to 0.4.24 (#192 <https://github.com/tier4/caret_analyze_cpp_impl/issues/192>)
* Contributors: h-suzuki-isp
```
