### PR TITLE
caret_trace: 0.5.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -834,6 +834,14 @@ repositories:
       type: git
       url: https://github.com/tier4/caret_trace.git
       version: main
+    release:
+      packages:
+      - caret_msgs
+      - caret_trace
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/caret_trace-release.git
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/tier4/caret_trace.git


### PR DESCRIPTION
Increasing version of package(s) in repository `caret_trace` to `0.5.0-1`:

- upstream repository: https://github.com/tier4/caret_trace.git
- release repository: https://github.com/ros2-gbp/caret_trace-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## caret_msgs

```
* chore: update package.xml version to 0.4.24 (#266 <https://github.com/tier4/caret_trace/issues/266>)
* Contributors: h-suzuki-isp
```

## caret_trace

```
* chore: update package.xml version to 0.4.24 (#266 <https://github.com/tier4/caret_trace/issues/266>)
* Contributors: h-suzuki-isp
```
