### PR TITLE
hri_msgs: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2623,6 +2623,21 @@ repositories:
       url: https://github.com/humanoid-path-planner/hpp-fcl.git
       version: devel
     status: developed
+  hri_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/hri_msgs.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros4hri/hri_msgs-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros4hri/hri_msgs.git
+      version: humble-devel
+    status: developed
   iceoryx:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `hri_msgs` to `2.0.0-1`:

- upstream repository: https://github.com/ros4hri/hri_msgs.git
- release repository: https://github.com/ros4hri/hri_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## hri_msgs

```
* porting to humble
* remove unused travis configuration
* improve messages documentation
* remove unused FAU field
* add IETF language code to LiveSpeech
* [doc] anonymous person are not supposed to be created via semi-defined match
* Contributors: Luka Juricic, Séverin Lemaignan
```
