### PR TITLE
ros2_controllers: 4.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5263,7 +5263,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 4.4.0-1
+      version: 4.5.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `4.5.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.4.0-1`

## ackermann_steering_controller

```
* Add tests for interface_configuration_type consistently (#899 <https://github.com/ros-controls/ros2_controllers/issues/899>)
* Contributors: Christoph Fröhlich
```

## admittance_controller

```
* Add tests for interface_configuration_type consistently (#899 <https://github.com/ros-controls/ros2_controllers/issues/899>)
* Let sphinx add parameter description with nested structures to documentation (#652 <https://github.com/ros-controls/ros2_controllers/issues/652>)
* Contributors: Christoph Fröhlich
```

## bicycle_steering_controller

```
* Add tests for interface_configuration_type consistently (#899 <https://github.com/ros-controls/ros2_controllers/issues/899>)
* Contributors: Christoph Fröhlich
```

## diff_drive_controller

```
* [diff_drive] Remove unused parameter and add simple validation #abi-breaking (#958 <https://github.com/ros-controls/ros2_controllers/issues/958>)
* Add tests for interface_configuration_type consistently (#899 <https://github.com/ros-controls/ros2_controllers/issues/899>)
* Let sphinx add parameter description with nested structures to documentation (#652 <https://github.com/ros-controls/ros2_controllers/issues/652>)
* Contributors: Christoph Fröhlich
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

```
* Add tests for interface_configuration_type consistently (#899 <https://github.com/ros-controls/ros2_controllers/issues/899>)
* Let sphinx add parameter description with nested structures to documentation (#652 <https://github.com/ros-controls/ros2_controllers/issues/652>)
* Revert "[ForceTorqueSensorBroadcaster] Create ParamListener and get parameters on configure (#698 <https://github.com/ros-controls/ros2_controllers/issues/698>)" (#988 <https://github.com/ros-controls/ros2_controllers/issues/988>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## forward_command_controller

```
* Add tests for interface_configuration_type consistently (#899 <https://github.com/ros-controls/ros2_controllers/issues/899>)
* Contributors: Christoph Fröhlich
```

## gripper_controllers

```
* Let sphinx add parameter description with nested structures to documentation (#652 <https://github.com/ros-controls/ros2_controllers/issues/652>)
* Contributors: Christoph Fröhlich
```

## imu_sensor_broadcaster

```
* Add tests for interface_configuration_type consistently (#899 <https://github.com/ros-controls/ros2_controllers/issues/899>)
* Let sphinx add parameter description with nested structures to documentation (#652 <https://github.com/ros-controls/ros2_controllers/issues/652>)
* Contributors: Christoph Fröhlich
```

## joint_state_broadcaster

```
* Add tests for interface_configuration_type consistently (#899 <https://github.com/ros-controls/ros2_controllers/issues/899>)
* Let sphinx add parameter description with nested structures to documentation (#652 <https://github.com/ros-controls/ros2_controllers/issues/652>)
* Contributors: Christoph Fröhlich
```

## joint_trajectory_controller

```
* [JTC] Fill action error_strings (#887 <https://github.com/ros-controls/ros2_controllers/issues/887>)
* Add tests for interface_configuration_type consistently (#899 <https://github.com/ros-controls/ros2_controllers/issues/899>)
* Let sphinx add parameter description with nested structures to documentation (#652 <https://github.com/ros-controls/ros2_controllers/issues/652>)
* [JTC] Invalidate empty trajectory messages (#902 <https://github.com/ros-controls/ros2_controllers/issues/902>)
* Revert "[JTC] Remove read_only from 'joints', 'state_interfaces' and 'command_interfaces' parameters (#967 <https://github.com/ros-controls/ros2_controllers/issues/967>)" (#978 <https://github.com/ros-controls/ros2_controllers/issues/978>)
* [JTC] Convert lambda to class functions (#945 <https://github.com/ros-controls/ros2_controllers/issues/945>)
* Contributors: Christoph Fröhlich, Noel Jiménez García
```

## pid_controller

```
* Add tests for interface_configuration_type consistently (#899 <https://github.com/ros-controls/ros2_controllers/issues/899>)
* [PID] Remove joint_jog include (#975 <https://github.com/ros-controls/ros2_controllers/issues/975>)
* Contributors: Christoph Fröhlich
```

## position_controllers

- No changes

## range_sensor_broadcaster

```
* Add tests for interface_configuration_type consistently (#899 <https://github.com/ros-controls/ros2_controllers/issues/899>)
* Let sphinx add parameter description with nested structures to documentation (#652 <https://github.com/ros-controls/ros2_controllers/issues/652>)
* Contributors: Christoph Fröhlich
```

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Add tests for interface_configuration_type consistently (#899 <https://github.com/ros-controls/ros2_controllers/issues/899>)
* Contributors: Christoph Fröhlich
```

## tricycle_controller

```
* [tricycle_controller] Use generate_parameter_library (#957 <https://github.com/ros-controls/ros2_controllers/issues/957>)
* Contributors: Christoph Fröhlich
```

## tricycle_steering_controller

```
* Add tests for interface_configuration_type consistently (#899 <https://github.com/ros-controls/ros2_controllers/issues/899>)
* Contributors: Christoph Fröhlich
```

## velocity_controllers

- No changes
