### PR TITLE
ros2_control: 4.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5217,6 +5217,7 @@ repositories:
       - controller_manager
       - controller_manager_msgs
       - hardware_interface
+      - hardware_interface_testing
       - joint_limits
       - ros2_control
       - ros2_control_test_assets
@@ -5226,7 +5227,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.3.0-1
+      version: 4.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.4.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.3.0-1`

## controller_interface

- No changes

## controller_manager

```
* Move test_components to own package (#1325 <https://github.com/ros-controls/ros2_control/issues/1325>)
* Fix controller parameter loading issue in different cases (#1293 <https://github.com/ros-controls/ros2_control/issues/1293>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Move test_components to own package (#1325 <https://github.com/ros-controls/ros2_control/issues/1325>)
* Fix controller parameter loading issue in different cases (#1293 <https://github.com/ros-controls/ros2_control/issues/1293>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## hardware_interface_testing

```
* Fix version
* Move test_components to own package (#1325 <https://github.com/ros-controls/ros2_control/issues/1325>)
* Contributors: Bence Magyar, Christoph Fröhlich
```

## joint_limits

```
* [Format] Correct formatting of JointLimits URDF file. (#1339 <https://github.com/ros-controls/ros2_control/issues/1339>)
* Add header to import limits from standard URDF definition (#1298 <https://github.com/ros-controls/ros2_control/issues/1298>)
* Contributors: Dr. Denis, Sai Kishor Kothakota
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
