### PR TITLE
camera_aravis: 4.0.5-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -670,7 +670,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/FraunhoferIOSB/camera_aravis-release.git
-      version: 4.0.4-1
+      version: 4.0.5-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_aravis` to `4.0.5-3`:

- upstream repository: https://github.com/FraunhoferIOSB/camera_aravis.git
- release repository: https://github.com/FraunhoferIOSB/camera_aravis-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.4-1`

## camera_aravis

```
* Added launch parameters allowing to manually set white balance
* Launch configuration, scripts and adjustments to allow raspawning
* Moved execution of set latch command for ptp
* Added parameter init_params_from_dyn_reconfigure and minor bugfix
* Read and publish camera diagnostics
* Improved support for Precision Time Protocol (PTP)
* Minor bugfixes
  * Opened device output
  * Resetting ptp timestamp
* Updated documentation in README.md
* Contributors: Boitumelo Ruf
```
