### PR TITLE
ros2_control: 3.23.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5521,6 +5521,7 @@ repositories:
       - controller_manager
       - controller_manager_msgs
       - hardware_interface
+      - hardware_interface_testing
       - joint_limits
       - ros2_control
       - ros2_control_test_assets
@@ -5530,7 +5531,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.22.1-1
+      version: 3.23.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.23.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.22.1-1`

## controller_interface

- No changes

## controller_manager

```
* Move test_components to own package (backport #1325 <https://github.com/ros-controls/ros2_control/issues/1325>) (#1341 <https://github.com/ros-controls/ros2_control/issues/1341>)
* Contributors: Christoph Fröhlich
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Move test_components to own package (backport #1325 <https://github.com/ros-controls/ros2_control/issues/1325>) (#1341 <https://github.com/ros-controls/ros2_control/issues/1341>)
* Contributors: Christoph Fröhlich
```

## hardware_interface_testing

```
* Move test_components to own package (backport #1325 <https://github.com/ros-controls/ros2_control/issues/1325>) (#1341 <https://github.com/ros-controls/ros2_control/issues/1341>)
* Contributors: Christoph Fröhlich, Bence Magyar
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
