### PR TITLE
data_tamer: 0.9.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1310,7 +1310,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/data_tamer-release.git
-      version: 0.9.2-1
+      version: 0.9.3-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/data_tamer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `data_tamer` to `0.9.3-1`:

- upstream repository: https://github.com/PickNikRobotics/data_tamer.git
- release repository: https://github.com/ros2-gbp/data_tamer-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.9.2-1`

## data_tamer_cpp

```
* add std::hash<DataTamer::RegistrationID>
* fix dead-lock
* Contributors: Davide Faconti
```

## data_tamer_msgs

- No changes
