### PR TITLE
Add python3-wand to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9479,6 +9479,14 @@ python3-waitress:
   opensuse: [python3-waitress]
   rhel: [python3-waitress]
   ubuntu: [python3-waitress]
+python3-wand:
+  alpine: [py3-wand]
+  arch: [python-wand]
+  brew: [imagemagick]
+  debian: [python3-wand]
+  gentoo: [dev-python/wand]
+  nixos: [python311Packages.wand]
+  ubuntu: [python3-wand]
 python3-watchdog:
   debian: [python3-watchdog]
   fedora: [python3-watchdog]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`python3-wand`

## Package Upstream Source:

[python3-wand](https://github.com/emcconville/wand)

## Purpose of using this:

This dependency is being used for generating images. This can be used for generating map images for robot navigation.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/python3-wand
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/jammy/python3-wand
- Fedora: https://packages.fedoraproject.org/
  - not available
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/any/python-wand/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/wand
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/imagemagick
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/packages?name=py3-wand&branch=edge
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=23.11&show=python311Packages.wand
- openSUSE: https://software.opensuse.org/package/
  - not available
- rhel: https://rhel.pkgs.org/
  - not available
