### PR TITLE
odri_master_board: 1.0.6-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3585,6 +3585,15 @@ repositories:
       url: https://github.com/gstavrinos/odom_to_tf_ros2.git
       version: master
     status: maintained
+  odri_master_board:
+    release:
+      packages:
+      - odri_master_board_sdk
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/odri_master_board_sdk-release.git
+      version: 1.0.6-3
+    status: maintained
   odri_master_board_sdk:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `odri_master_board` to `1.0.6-3`:

- upstream repository: https://github.com/stack-of-tasks/odri_master_board_sdk_release.git
- release repository: https://github.com/ros2-gbp/odri_master_board_sdk-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## odri_master_board_sdk

```
* Makes cmake-format happy !
* [CMakeList.txt] Fix CMakeLists.txt to install the header.
* Add cmake-format.
* Change name of the package to make it release in ROS-2.
* CMake: update submodule use
* CMake: bump catch2
* Partial support of the new Power-Board hardware
* Fix two bugs (FLOAT_TO_D8QN and compiling issue) + remove warnings on the core library.
* [master_board_sdk] Fix compilation error on master_board_interface.cpp l.263
  Introduced by commit 782c348 it fails because %s is expecting char * and not std::string.
  This fails on clang.
* [master_board_sdk] Fix warnings.
  There are still some warnings wih Catch2 and clang.
  But Catch2 is a dependency and should be fixed upstream.
* [protocol] FLOAT_TO_D8QN has a wrong bracket. This commit fix this.
* [cmake] Synchronize to remove error during install process.
* Add error, thrown by sdk, for protocol version mismatch (during init)
* Add ament_cmake build_type export in package.xml and install package.xml file
* Update sdk/master_board_sdk/CMakeLists.txt
* [master_board_sdk/CMakeLists.txt] Remove useless CMAKE_PREFIX_INSTALL specification.
* [master_board_sdk/package.xml] Remove ament_cmake dependency and buildtool dependency.
* [CMakeLists.txt] Remove dependency to ament_cmake and generates files for Colcon underlays.
* [package.xml] Add dependence to ament_cmake if ROS-2 is detected.
* [CMakeLists.txt] Uses ROS-2 if the environment is compatible.
* [package.xml] Add ament_cmake export for colcon support.
* [cmake] Add install procedure for file package.xml
* Adding ROS-2 rolling CI to the repository and some changes to have it working.
* [sdk/master_board_sdk/tests/test_protocol.cpp] Commented the test on NaN which is failing.
* [sdk/master_board_sdk/package.xml] Fix package dependency.
  Update version to 3.
  Add dependencies to libboost-python.
  Add git for dependencies.
* [cmake/sdk_master_board/CMakeLists.txt] Improve CMakeLists.txt.
* [cmake/master_board_sdk/CMakeLists.txt] Removing components
* [cmake] Change again python detection place.
* [cmake] Change place for python detection
* [sdk/master_board_sdk/CMakeLists.txt] Update Find Python detection.
  Update message when detection is failing.
* [Cmake] remove python components.
* [master_board_sdk/CMakeLists.txt] Provides better Python detection
* [cmake] Synchronize
* [package.xml] XML version 1.0
* [package.xml] Remove Boost depend.
* Cmake
* pre-commit run -a
* sync submodule
* (Small) Fix for sdk examples with python >=3.8
* Apple support for wired connection.
* [Link_manager] Fix message when the priority is not set correctly and fails using assert.
* [cmake] Switch back the default to ON if this is not an APPLE platform
* Add Python bindings for SetKp/Kd/SaturationCurrent and fix example.py
* Zero-initialise all members of Motor
* Change macro name for platform from UNIX to linux.
  Include net/if_arp.h only for APPLE.
* Fix missing header.
* Fix wrong elif condition and missing brackets.
* Apple support for wired connection.
* example.py: Initialise all reference values and gains to zero
  This should not really be needed anymore since values are already
  zero-initialised in Motor but better be safe than sorry.
* fix example.py: time.clock() has been removed
  time.clock() has been deprecated in Python 3.3 and does not exist
  anymore in newer versions.  Use perf_counter instead.
* Add Python bindings for Motor::SetKp/Kd/SaturationCurrent
  At least by now they are implemented in motor.cpp, so there's no reason
  to not add bindings for them.
* Zero-initialise all members of Motor
  This should fix an issue that was likely caused by kp being set to
  some random non-zero value, resulting in the motor unintentionally being
  held at some position.
* Missing include
* plateform and distro modules optionnal for sdk example com_analyser.py
* Swap process_time and clock for better intelligibility
* Protocol version added in init_ack packet & version mismatch throw runtime error in sdk
* Fix sdk examples for python version >=3.8
* CMake: add unit tests
* Fix minor build error and update cmake submodule
* CMake: add unit tests
* Handle out-of-range motor params without wraparound (#117 <https://github.com/olivier-stasse/master-board/issues/117>)
  Avoid fixed-point overflow
* Minor CMakelist change and cmake update
* SDK: fix a few warnings
* [CMake] set RPATH for executables
* SDK: fix warnings
* Add Python bindings for powerboard data
* add pyton bindings for power baord
* [SDK][Firmware] Add partial support for power-board, Update protocol version and sdk accordingly
* Contributors: EtienneAr, Felix Kloss, Guilhem Saurel, Naveau, Olivier Stasse, Thomas Flayols, Trevor Blackwell, odri, thomasfla
```
