### PR TITLE
update iron branch for openni2_camera

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3940,7 +3940,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git
-      version: ros2
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -3949,7 +3949,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git
-      version: ros2
+      version: iron
     status: maintained
   opensw:
     doc:


### PR DESCRIPTION
We had to fork off humble/iron from rolling/jazzy since we're going to leverage some API changes to support lazy subscribers