### PR TITLE
update humble branch for openni2_camera

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4657,7 +4657,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git
-      version: ros2
+      version: iron
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -4666,7 +4666,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git
-      version: ros2
+      version: iron
     status: maintained
   orocos_kdl_vendor:
     release:


### PR DESCRIPTION
We had to fork off humble/iron from rolling/jazzy since we're going to leverage some API changes to support lazy subscribers