### PR TITLE
data_tamer: 0.9.4-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -907,6 +907,25 @@ repositories:
       url: https://github.com/eclipse-cyclonedds/cyclonedds.git
       version: releases/0.10.x
     status: maintained
+  data_tamer:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/data_tamer.git
+      version: main
+    release:
+      packages:
+      - data_tamer_cpp
+      - data_tamer_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/data_tamer-release.git
+      version: 0.9.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/PickNikRobotics/data_tamer.git
+      version: main
+    status: developed
   demos:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `data_tamer` to `0.9.4-1`:

- upstream repository: https://github.com/PickNikRobotics/data_tamer.git
- release repository: https://github.com/ros2-gbp/data_tamer-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## data_tamer_cpp

```
* changed the way registerValue throws if you try registering the same address again
* add unit tests to verify that vectors with changing size are OK
* change name of the library/target to data_tamer_cpp
* Contributors: Davide Faconti
```

## data_tamer_msgs

- No changes
