### PR TITLE
Add rosdep keys for lsb-release

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6467,6 +6467,7 @@ log4cxx:
   ubuntu:
     '*': [liblog4cxx-dev]
 lsb-release:
+  alpine: [lsb-release-minimal]
   arch: [lsb-release]
   debian: [lsb-release]
   fedora: [lsb_release]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6474,7 +6474,7 @@ lsb-release:
   nixos: [lsb-release]
   openembedded: [lsb-release@openembedded-core]
   opensuse: [lsb-release]
-  rhel: [lsb-release]
+  rhel: [/usr/bin/lsb_release]
   slackware: [lsb-release]
   ubuntu: [lsb-release]
 lttng-modules:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6466,6 +6466,17 @@ log4cxx:
   slackware: [apache-log4cxx]
   ubuntu:
     '*': [liblog4cxx-dev]
+lsb-release:
+  arch: [lsb-release]
+  debian: [lsb-release]
+  fedora: [lsb_release]
+  gentoo: [sys-apps/lsb-release]
+  nixos: [lsb-release]
+  openembedded: [lsb-release@openembedded-core]
+  opensuse: [lsb-release]
+  rhel: [lsb-release]
+  slackware: [lsb-release]
+  ubuntu: [lsb-release]
 lttng-modules:
   arch: [lttng-modules]
   debian: [lttng-modules-dkms]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6475,7 +6475,9 @@ lsb-release:
   nixos: [lsb-release]
   openembedded: [lsb-release@openembedded-core]
   opensuse: [lsb-release]
-  rhel: [/usr/bin/lsb_release]
+  rhel:
+    '*': [lsb-release]
+    '8': [redhat-lsb-core]
   slackware: [lsb-release]
   ubuntu: [lsb-release]
 lttng-modules:


### PR DESCRIPTION
## Package name:

lsb-release

## Package Upstream Source:

https://salsa.debian.org/gioele/lsb-release-minimal

## Purpose of using this:

lsb-release is a ancient script used to parse os-release files in the Linux system. Some build systems are using it to discover what platform is the one used when building the software to adjust part of their build tooling.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/sid/lsb-release
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/jammy/lsb-release
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/lsb_release/lsb_release/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/lsb-release/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/sys-apps/lsb-release
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/lsb-release
- openSUSE: https://software.opensuse.org/package/
  - https://build.opensuse.org/package/show/openSUSE:Leap:42.3:Update/lsb-release
- rhel: https://rhel.pkgs.org/
  - https://rhel.pkgs.org/9/epel-aarch64/lsb_release-3.2-2.el9.noarch.rpm.html