### PR TITLE
Add Gazebo Harmonic Keys for Ubuntu Focal and Jammy

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1776,6 +1776,10 @@ gz-cmake2:
   ubuntu:
     focal: [libgz-cmake2-dev]
     jammy: [libgz-cmake2-dev]
+gz-cmake3:
+  ubuntu:
+    focal: [libgz-cmake3-dev]
+    jammy: [libgz-cmake3-dev]
 gz-common3:
   ubuntu:
     focal: [libgz-common3-dev]
@@ -1783,6 +1787,10 @@ gz-common4:
   ubuntu:
     focal: [libgz-common4-dev]
     jammy: [libgz-common4-dev]
+gz-common5:
+  ubuntu:
+    focal: [libgz-common5-dev]
+    jammy: [libgz-common5-dev]
 gz-fortress:
   ubuntu:
     focal: [gz-fortress]
@@ -1794,6 +1802,10 @@ gz-fuel-tools7:
   ubuntu:
     focal: [libgz-fuel-tools7-dev]
     jammy: [libgz-fuel-tools7-dev]
+gz-fuel-tools9:
+  ubuntu:
+    focal: [libgz-fuel-tools9-dev]
+    jammy: [libgz-fuel-tools9-dev]
 gz-gui3:
   ubuntu:
     focal: [libgz-gui3-dev]
@@ -1801,6 +1813,10 @@ gz-gui6:
   ubuntu:
     focal: [libgz-gui6-dev]
     jammy: [libgz-gui6-dev]
+gz-gui8:
+  ubuntu:
+    focal: [libgz-gui8-dev]
+    jammy: [libgz-gui8-dev]
 gz-launch2:
   ubuntu:
     focal: [libgz-launch2-dev]
@@ -1808,10 +1824,18 @@ gz-launch5:
   ubuntu:
     focal: [libgz-launch5-dev]
     jammy: [libgz-launch5-dev]
+gz-launch7:
+  ubuntu:
+    focal: [libgz-launch7-dev]
+    jammy: [libgz-launch7-dev]
 gz-math6:
   ubuntu:
     focal: [libgz-math6-dev]
     jammy: [libgz-math6-dev]
+gz-math7:
+  ubuntu:
+    focal: [libgz-math7-dev]
+    jammy: [libgz-math7-dev]
 gz-math6-eigen3:
   ubuntu:
     focal: [libgz-math6-eigen3-dev]
@@ -1823,6 +1847,10 @@ gz-msgs8:
   ubuntu:
     focal: [libgz-msgs8-dev]
     jammy: [libgz-msgs8-dev]
+gz-msgs10:
+  ubuntu:
+    focal: [libgz-msgs10-dev]
+    jammy: [libgz-msgs10-dev]
 gz-physics2:
   ubuntu:
     focal: [libgz-physics2-dev]
@@ -1830,10 +1858,18 @@ gz-physics5:
   ubuntu:
     focal: [libgz-physics5-dev]
     jammy: [libgz-physics5-dev]
+gz-physics7:
+  ubuntu:
+    focal: [libgz-physics7-dev]
+    jammy: [libgz-physics7-dev]
 gz-plugin:
   ubuntu:
     focal: [libgz-plugin-dev]
     jammy: [libgz-plugin-dev]
+gz-plugin2:
+  ubuntu:
+    focal: [libgz-plugin2-dev]
+    jammy: [libgz-plugin2-dev]
 gz-rendering3:
   ubuntu:
     focal: [libgz-rendering3-dev]
@@ -1841,6 +1877,10 @@ gz-rendering6:
   ubuntu:
     focal: [libgz-rendering6-dev]
     jammy: [libgz-rendering6-dev]
+gz-rendering8:
+  ubuntu:
+    focal: [libgz-rendering8-dev]
+    jammy: [libgz-rendering8-dev]
 gz-sensors3:
   ubuntu:
     focal: [libgz-sensors3-dev]
@@ -1848,6 +1888,10 @@ gz-sensors6:
   ubuntu:
     focal: [libgz-sensors6-dev]
     jammy: [libgz-sensors6-dev]
+gz-sensors8:
+  ubuntu:
+    focal: [libgz-sensors8-dev]
+    jammy: [libgz-sensors8-dev]
 gz-sim3:
   ubuntu:
     focal: [libgz-sim3-dev]
@@ -1855,6 +1899,10 @@ gz-sim6:
   ubuntu:
     focal: [libgz-sim6-dev]
     jammy: [libgz-sim6-dev]
+gz-sim8:
+  ubuntu:
+    focal: [libgz-sim8-dev]
+    jammy: [libgz-sim8-dev]
 gz-sim6-plugins:
   ubuntu:
     focal: [libgz-sim6-plugins]
@@ -1863,10 +1911,18 @@ gz-tools:
   ubuntu:
     focal: [libgz-tools-dev]
     jammy: [libgz-tools-dev]
+gz-tools2:
+  ubuntu:
+    focal: [libgz-tools2-dev]
+    jammy: [libgz-tools2-dev]
 gz-transport11:
   ubuntu:
     focal: [libgz-transport11-dev]
     jammy: [libgz-transport11-dev]
+gz-transport13:
+  ubuntu:
+    focal: [libgz-transport13-dev]
+    jammy: [libgz-transport13-dev]
 gz-transport8:
   ubuntu:
     focal: [libgz-transport8-dev]
@@ -1874,6 +1930,10 @@ gz-utils1:
   ubuntu:
     focal: [libgz-utils1-dev]
     jammy: [libgz-utils1-dev]
+gz-utils2:
+  ubuntu:
+    focal: [libgz-utils2-dev]
+    jammy: [libgz-utils2-dev]
 gz-utils1-cli:
   ubuntu:
     focal: [libgz-utils1-cli-dev]
@@ -7633,6 +7693,10 @@ sdformat12:
   ubuntu:
     focal: [libsdformat12-dev]
     jammy: [libsdformat12-dev]
+sdformat14:
+  ubuntu:
+    focal: [libsdformat14-dev]
+    jammy: [libsdformat14-dev]
 sdl:
   arch: [sdl]
   debian: [libsdl1.2-dev]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

Gazebo Harmonic 


## Package Upstream Source:

[collection-harmonic](https://github.com/gazebo-tooling/gazebodistro/blob/master/collection-harmonic.yaml) - Everything used in the official gazebo harmonic list.

Also seen here: https://gazebosim.org/docs/harmonic/install#harmonic-libraries

## Purpose of using this:

Solve build errors in https://github.com/ArduPilot/ardupilot_ros/pull/22 by relying on rosdep to install only the required gazebo harmonic dependencies.

## Links to Distribution Packages

See README for each respective repo. The README only claims to build jammy, but the CI instance shows undocumented focal jobs are also being built. According to the docs here, Harmonic is not supported on focal: https://gazebosim.org/docs/harmonic/install#supported-platforms

## Testing

I was unable to run `pytest` instructions locally, it was failing on packages that exist. For now, I'll just try to iterate using CI.

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
