### PR TITLE
aerostack2: 1.0.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -111,15 +111,15 @@ repositories:
       - as2_behaviors_trajectory_generation
       - as2_cli
       - as2_core
+      - as2_gazebo_assets
       - as2_gazebo_classic_assets
-      - as2_ign_gazebo_assets
       - as2_keyboard_teleoperation
       - as2_motion_controller
       - as2_motion_reference_handlers
       - as2_msgs
       - as2_platform_crazyflie
       - as2_platform_dji_osdk
-      - as2_platform_ign_gazebo
+      - as2_platform_gazebo
       - as2_platform_tello
       - as2_python_api
       - as2_realsense_interface
@@ -128,7 +128,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/aerostack2-release.git
-      version: 1.0.6-1
+      version: 1.0.7-1
     source:
       test_pull_requests: true
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -98,7 +98,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/aerostack2/aerostack2.git
-      version: humble-devel
+      version: main
     release:
       packages:
       - aerostack2
@@ -133,7 +133,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/aerostack2/aerostack2.git
-      version: humble-devel
+      version: main
     status: developed
   affordance_primitives:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `aerostack2` to `1.0.7-1`:

- upstream repository: https://github.com/aerostack2/aerostack2.git
- release repository: https://github.com/ros2-gbp/aerostack2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.6-1`

## aerostack2

```
* [as2_platform_dji_osdk] Added libusb-dev dependency
* [as2_platform_gazebo] Remove ign from name
* [as2_cli] Clean old unused files
* [as2_core] Bug fixed, getPoseStamped function differs from timeout 0 and not 0
* [as2_core] Python as2_names bindings
* [as2_core] format tests according with ament_lint_common() packages
* [as2_python_api] Moving test files to test folder
* [as2_gazebo_assets] Gimbal model added
* [as2_gazebo_assets] Cleaning remaining ign, bridges use gz instead ign
* [as2_gazebo_assets] Renamed to as2_gazebo_assets
* [as2_gazebo_classic_assets] Fix pass drone namespace to run_sitl.sh
* Contributors: Miguel Fernandez-Cortizas, Javilinos, Rafael Pérez, pariaspe, pawanw17
```

## as2_alphanumeric_viewer

- No changes

## as2_behavior

- No changes

## as2_behavior_tree

```
* [refactor] format tests according with ament_lint_common() packages
* fix build warning
* Contributors: pariaspe
```

## as2_behaviors_motion

```
* [refactor] format tests according with ament_lint_common() packages
* [refactor] add std::string() to topic names in order to be able to add a char*
* Contributors: Miguel Fernandez-Cortizas, pariaspe
```

## as2_behaviors_perception

- No changes

## as2_behaviors_platform

- No changes

## as2_behaviors_trajectory_generation

- No changes

## as2_cli

```
* Clean old unused files
* Contributors: Rafael Pérez, pariaspe
```

## as2_core

```
* Bug fixed, getPoseStamped function differs from timeout 0 and not 0
* [as2_core] Python as2_names bindings
* [refactor] format tests according with ament_lint_common() packages
* [refactor] check rosdistro if galactic use tf2__.h in other cases use tf2__.hpp
* Contributors: Javilinos, Miguel Fernandez-Cortizas, pariaspe
```

## as2_gazebo_assets

```
* Gimbal model added
* Cleaning remaining ign, bridges use gz instead ign
* [as2_gazebo_assets] Renamed to as2_gazebo_assets
* Contributors: Javilinos, Rafael Pérez, pariaspe
```

## as2_gazebo_classic_assets

```
* Fix pass drone namespace to run_sitl.sh
* Contributors: pariaspe, pawanw17
```

## as2_keyboard_teleoperation

- No changes

## as2_motion_controller

- No changes

## as2_motion_reference_handlers

- No changes

## as2_msgs

```
* Gimbal model added
* Contributors: Javilinos, pariaspe
```

## as2_platform_crazyflie

- No changes

## as2_platform_dji_osdk

```
* Added libusb-dev dependency
* Contributors: Miguel Fernandez-Cortizas, pariaspe
```

## as2_platform_gazebo

```
* [as2_platform_ign_gazebo] Remove ign from name
* Contributors: Rafael Pérez, pariaspe
```

## as2_platform_tello

- No changes

## as2_python_api

```
* Moving test files to test folder
* Contributors: Javilinos, Miguel Fernandez-Cortizas, pariaspe
```

## as2_realsense_interface

- No changes

## as2_state_estimator

- No changes

## as2_usb_camera_interface

- No changes
