### PR TITLE
plotjuggler: 3.9.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7638,7 +7638,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.8.10-2
+      version: 3.9.0-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.9.0-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.8.10-2`

## plotjuggler

```
* new status bar with messages from the internet
* Merge branch 'ulog_improvement'
* new memes
* quick file reload!
* transforms have now default values from previous
* add icons to dialog Delete Series
* cleanup and fix ULOG
* add ULOG parameters as 1 sample timeseries
* fix issue #929 <https://github.com/facontidavide/PlotJuggler/issues/929> : numerical truncation
* bypass truncation check
* Fixed parsing JointState messages (#927 <https://github.com/facontidavide/PlotJuggler/issues/927>)
* Contributors: Davide Faconti, Martin Pecka
```
