### PR TITLE
plotjuggler_ros: 2.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5155,7 +5155,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-ros-plugins-release.git
-      version: 2.0.0-3
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler_ros` to `2.1.0-1`:

- upstream repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
- release repository: https://github.com/ros2-gbp/plotjuggler-ros-plugins-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-3`

## plotjuggler_ros

```
* preparing for release 3.9
* Update ros1.yaml
* Add support for compressed rosbags (#77 <https://github.com/PlotJuggler/plotjuggler-ros-plugins/issues/77>)
* Contributors: Anthony Welte, Davide Faconti
```
