### PR TITLE
plotjuggler: 3.9.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3940,7 +3940,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.8.4-1
+      version: 3.9.0-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.9.0-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/ros2-gbp/plotjuggler-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.8.4-1`

## plotjuggler

```
* new status bar with messages from the internet
* Merge branch 'ulog_improvement'
* new memes
* quick file reload!
* transforms have now default values from previous
* add icons to dialog Delete Series
* cleanup and fix ULOG
* add ULOG parameters as 1 sample timeseries
* fix issue #929 <https://github.com/facontidavide/PlotJuggler/issues/929> : numerical truncation
* bypass truncation check
* Fixed parsing JointState messages (#927 <https://github.com/facontidavide/PlotJuggler/issues/927>)
* Contributors: Davide Faconti, Martin Pecka
```
