### PR TITLE
ur_robot_driver: 2.4.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7350,7 +7350,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.4.2-1
+      version: 2.4.3-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.4.3-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.4.2-1`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers

- No changes

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* fix move_group_node crash during initialization (#906 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/906>)
* Add UR30 support (#899 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/899>)
* Contributors: Chen Chen, Felix Exner (fexner)
```

## ur_robot_driver

```
* Add UR30 support (#899 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/899>)
* Add control description and ros2_control tag to driver. (#877 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/877>)
* Contributors: Felix Exner (fexner)
```
