### PR TITLE
psdk_ros2: 0.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5382,7 +5382,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/psdk_ros2-release.git
-      version: 0.0.4-1
+      version: 0.0.5-1
     source:
       type: git
       url: https://github.com/umdlife/psdk_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `psdk_ros2` to `0.0.5-1`:

- upstream repository: https://github.com/umdlife/psdk_ros2.git
- release repository: https://github.com/ros2-gbp/psdk_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.4-1`

## psdk_interfaces

```
* Merge pull request #48 <https://github.com/umdlife/psdk_ros2/issues/48> from umdlife/hotfix/update_documentation
  Unify build and deploy documentation workflow
* Contributors: biancabnd
```

## psdk_wrapper

```
* Move lifecycle interfaces to be public, also add rclcpp::shutdown() to finish cleanly the node when shutting down
* Contributors: Victor Massagué Respall, biancabnd, sergigraum
```
