### PR TITLE
Drop old stable debian release from Humble.

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3,8 +3,6 @@
 # see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
-  debian:
-  - bullseye
   rhel:
   - '8'
   ubuntu:


### PR DESCRIPTION
This will stop bloom from attempting to generate Debian Bullseye release metadata when running releases for these distributions.

This will not prevent past releases from being available in the ros2-gbp future releases will not include metadata for these platforms.

I am opening one PR for the initial review but I think it would be best to merge this change distribution-by-distribution after each one has completed a sync so that there is a tag which represents the last set of of releases where Debian metadata was attempted. I'll use this PR to coordinate those changes.

Last sync with Debian metadata:
- [ ] Humble
- [x] Iron https://github.com/ros/rosdistro/pull/39799
- [x] Rolling https://github.com/ros/rosdistro/pull/39802