### PR TITLE
Drop debian bullseye from Iron distribution.

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3,8 +3,6 @@
 # see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
-  debian:
-  - bullseye
   rhel:
   - '9'
   ubuntu:


### PR DESCRIPTION
Bullseye is no longer the current Debian Stable release and so we will stop generating release metadata for it after the next Iron sync.
This PR should be merged just after tagging this repository for the [next Iron sync](https://discourse.ros.org/t/preparing-for-iron-patch-and-sync-2024-02-09/35920).