### PR TITLE
Update distribution.yaml for serl_franka_controllers binary release [manual bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11082,6 +11082,11 @@ repositories:
       type: git
       url: https://github.com/rail-berkeley/serl_franka_controllers.git
       version: main
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/rail-berkeley/serl_franka_controllers.git
+      version: 0.1.1-2
     source:
       type: git
       url: https://github.com/rail-berkeley/serl_franka_controllers.git


### PR DESCRIPTION
This is a followup from https://github.com/ros/rosdistro/pull/39513

To release the code as binary release, I tried to use `bloom` to release the code. It ran perfectly and managed to update my repo, until it failed at the very last step of opening a PR to `rosdistro`. After attempting multiple times, I'm still unsure why. Hence I manually open a Bloom release PR.

I provided the printout for reference.
```bash
youliang@zenbook:~/catkin_ws/src/serl_franka_controllers$ bloom-release --rosdistro noetic --track noetic serl_franka_controllers

.....
   b8c1f11..e7e37af  patches/debian/noetic/serl_franka_controllers -> patches/debian/noetic/serl_franka_controllers
   16e06db..fc56fb6  patches/release/noetic/serl_franka_controllers -> patches/release/noetic/serl_franka_controllers
   85dfbb1..d68df73  release/noetic/serl_franka_controllers -> release/noetic/serl_franka_controllers
<== Pushed changes successfully
==> Pushing tags to release repository for 'serl_franka_controllers'
==> git push --tags
Username for 'https://github.com': youliangtan
Password for 'https://youliangtan@github.com': 
Total 0 (delta 0), reused 0 (delta 0)
To https://github.com/rail-berkeley/serl_franka_controllers.git
 * [new tag]         debian/ros-noetic-serl-franka-controllers_0.1.1-2_focal -> debian/ros-noetic-serl-franka-controllers_0.1.1-2_focal
 * [new tag]         release/noetic/serl_franka_controllers/0.1.1-2 -> release/noetic/serl_franka_controllers/0.1.1-2
<== Pushed tags successfully
==> Generating pull request to distro file located at 'https://raw.githubusercontent.com/ros/rosdistro/2ef6bc4afae106926d16cc2c89a1c714d9bff9d1/noetic/distribution.yaml'
Unified diff for the ROS distro file located at '/tmp/tmpeohaz1sb/serl_franka_controllers-0.1.1-2.patch':
--- 2ef6bc4afae106926d16cc2c89a1c714d9bff9d1/noetic/distribution.yaml
+++ 2ef6bc4afae106926d16cc2c89a1c714d9bff9d1/noetic/distribution.yaml
@@ -11082,6 +11082,11 @@
       type: git
       url: https://github.com/rail-berkeley/serl_franka_controllers.git
       version: main
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/rail-berkeley/serl_franka_controllers.git
+      version: 0.1.1-2
     source:
       type: git
       url: https://github.com/rail-berkeley/serl_franka_controllers.git
==> Checking on GitHub for a fork to make the pull request from...
Could not find a fork of ros/rosdistro on the MY_PRIVATE_TOKEN GitHub account.
Would you like to create one now?
Continue [Y/n]? Y
==> Using this fork to make a pull request from: MY_PRIVATE_TOKEN/rosdistro
==> Cloning MY_PRIVATE_TOKEN/rosdistro...
==> mkdir -p rosdistro
==> git init
Initialized empty Git repository in /tmp/u3mgwnyp/rosdistro/.git/
Failed to open pull request: GithubException - HTTP Error 404: Not Found (https://api.github.com/repos/MY_PRIVATE_TOKEN/rosdistro/branches?page=1&per_page=2): None
```

Also, I noticed that the bloom release command will create a lot of stray branches and tags, so I removed most of them and kept [these tags](https://github.com/rail-berkeley/serl_franka_controllers/tags). Those stray branches and tags were polluting the repo, but I believe removing them might create some issues, would need some clarification on this.

In summary, the `bloom-release` command is not working seamlessly as intended. Sorry for this as I'm unfamiliar with the binary release process. :man_shrugging: 
