### PR TITLE
novatel_oem7_driver: 4.3.0-5 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6806,7 +6806,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
-      version: 4.2.0-1
+      version: 4.3.0-5
     source:
       type: git
       url: https://github.com/novatel/novatel_oem7_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_oem7_driver` to `4.3.0-5`:

- upstream repository: https://github.com/novatel/novatel_oem7_driver.git
- release repository: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.2.0-1`

## novatel_oem7_driver

```
* ISA 100C data changed in src/novatel_oem7_driver/config/oem7_supported_imus.yaml
* CMake error fix in docker/Dockerfile.build
* CONNECTIMU command and CORRIMUSB comment added in src/novatel_oem7_driver/config/std_init_commands.yaml
```
