### PR TITLE
Drop debian bullseye from Rolling distribution.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3,8 +3,6 @@
 # see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
-  debian:
-  - bullseye
   rhel:
   - '9'
   ubuntu:


### PR DESCRIPTION
Bullseye is no longer the current Debian Stable release and so we will stop generating release metadata for it after the next Rolling sync.