### PR TITLE
image_common: 4.2.3-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2224,7 +2224,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 4.2.2-1
+      version: 4.2.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `4.2.3-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.2.2-1`

## camera_calibration_parsers

- No changes

## camera_info_manager

- No changes

## image_common

- No changes

## image_transport

```
* Implement CameraSubscriber::getNumPublishers (#299 <https://github.com/ros-perception/image_common/issues/299>)
* Add missing definition for CameraPublisher::publish overload (#295 <https://github.com/ros-perception/image_common/issues/295>)
* Contributors: Alejandro Hernández Cordero, Michael Ferguson, s-hall
```
