### PR TITLE
cyclonedds: 0.10.4-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -897,11 +897,15 @@ repositories:
       version: main
     status: maintained
   cyclonedds:
+    doc:
+      type: git
+      url: https://github.com/eclipse-cyclonedds/cyclonedds.git
+      version: releases/0.10.x
     release:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/cyclonedds-release.git
-      version: 0.10.3-2
+      version: 0.10.4-1
     source:
       type: git
       url: https://github.com/eclipse-cyclonedds/cyclonedds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cyclonedds` to `0.10.4-1`:

- upstream repository: https://github.com/eclipse-cyclonedds/cyclonedds.git
- release repository: https://github.com/ros2-gbp/cyclonedds-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.10.3-2`
