### PR TITLE
mp2p_icp: 1.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3135,7 +3135,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `1.1.1-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-1`

## mp2p_icp

```
* MergeFilter: now also handles CVoxelMap as inputs
* more memory efficient defaults
* FilterCurvature: now based on ring_id channel
* Use hash map min_factor to speed up clear()s
* add missing hash reserve
* PointCloudToVoxelGridSingle: Fix wrong initialization of point count
* Contributors: Jose Luis Blanco-Claraco
```
