### PR TITLE
launch_ros: 0.24.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2635,7 +2635,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.24.0-2
+      version: 0.24.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.24.1-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.24.0-2`

## launch_ros

- No changes

## launch_testing_ros

```
* WaitForTopics: get content of messages for each topic (#388 <https://github.com/ros2/launch_ros/issues/388>)
* Contributors: Giorgio Pintaudi
```

## ros2launch

- No changes
