### PR TITLE
rviz: 12.4.6-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6728,7 +6728,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 12.4.5-2
+      version: 12.4.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `12.4.6-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `12.4.5-2`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Append measured subscription frequency to topic status (#1130 <https://github.com/ros2/rviz/issues/1130>)
* Rolling namespace in title (#1100 <https://github.com/ros2/rviz/issues/1100>)
* Contributors: Alejandro Hernández Cordero, Yadunund
```

## rviz_default_plugins

```
* Append measured subscription frequency to topic status (#1130 <https://github.com/ros2/rviz/issues/1130>)
* Fix time-syncing message (#1124 <https://github.com/ros2/rviz/issues/1124>)
* Fix typo (#1106 <https://github.com/ros2/rviz/issues/1106>)
* Fixed screw display (#1095 <https://github.com/ros2/rviz/issues/1095>)
* Contributors: Alejandro Hernández Cordero, Christoph Fröhlich, Yadunund
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

```
* Remove the loading_ascii_stl_files_fail (#1127 <https://github.com/ros2/rviz/issues/1127>)
* Contributors: Chris Lalancette
```

## rviz_visual_testing_framework

- No changes
