### PR TITLE
sros2: 0.13.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6725,7 +6725,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.12.1-1
+      version: 0.13.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.13.0-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.12.1-1`

## sros2

```
* Use modern PKCS7 to sign the certificate bytes. (#290 <https://github.com/ros2/sros2/issues/290>)
* Fix a number of warnings on Ubuntu 24.04. (#289 <https://github.com/ros2/sros2/issues/289>)
* Contributors: Chris Lalancette
```

## sros2_cmake

- No changes
