### PR TITLE
rosidl_dds: 0.11.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5738,7 +5738,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_dds-release.git
-      version: 0.11.0-1
+      version: 0.11.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_dds` to `0.11.1-1`:

- upstream repository: https://github.com/ros2/rosidl_dds.git
- release repository: https://github.com/ros2-gbp/rosidl_dds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.11.0-1`

## rosidl_generator_dds_idl

```
* Remove unnecessary parentheses. (#61 <https://github.com/ros2/rosidl_dds/issues/61>)
* Contributors: Chris Lalancette
```
