### PR TITLE
rosidl: 4.5.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5701,7 +5701,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 4.5.0-1
+      version: 4.5.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `4.5.1-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.5.0-1`

## rosidl_adapter

- No changes

## rosidl_cli

- No changes

## rosidl_cmake

- No changes

## rosidl_generator_c

- No changes

## rosidl_generator_cpp

- No changes

## rosidl_generator_type_description

```
* Remove unnecessary parentheses. (#783 <https://github.com/ros2/rosidl/issues/783>)
* Contributors: Chris Lalancette
```

## rosidl_parser

```
* Remove unnecessary parentheses. (#783 <https://github.com/ros2/rosidl/issues/783>)
* Contributors: Chris Lalancette
```

## rosidl_pycommon

```
* Remove unnecessary parentheses. (#783 <https://github.com/ros2/rosidl/issues/783>)
* Contributors: Chris Lalancette
```

## rosidl_runtime_c

- No changes

## rosidl_runtime_cpp

- No changes

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

- No changes

## rosidl_typesupport_introspection_cpp

- No changes
