### PR TITLE
launch: 3.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2462,7 +2462,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.3.0-1
+      version: 3.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.4.0-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.3.0-1`

## launch

```
* Rework task exceptions loop. (#755 <https://github.com/ros2/launch/issues/755>)
* add format overriding by environment variables (#722 <https://github.com/ros2/launch/issues/722>)
* Add exception type to error output (#753 <https://github.com/ros2/launch/issues/753>)
* Contributors: Chris Lalancette, David Yackzan, Marc Bestmann
```

## launch_pytest

- No changes

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

```
* Fix flake8 warnings in launch_yaml. (#756 <https://github.com/ros2/launch/issues/756>)
* Contributors: Chris Lalancette
```
