### PR TITLE
geometry2: 0.36.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1757,7 +1757,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.35.1-1
+      version: 0.36.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.36.0-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.35.1-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

```
* Removed obsolete headers (#645 <https://github.com/ros2/geometry2/issues/645>)
* Contributors: Alejandro Hernández Cordero
```

## tf2_eigen

```
* Removed obsolete headers (#645 <https://github.com/ros2/geometry2/issues/645>)
* normalize quaternions on tf2_eigen (#644 <https://github.com/ros2/geometry2/issues/644>)
* Contributors: Alejandro Hernández Cordero, Paul Gesel
```

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

```
* Removed obsolete headers (#645 <https://github.com/ros2/geometry2/issues/645>)
* Contributors: Alejandro Hernández Cordero
```

## tf2_kdl

```
* Removed obsolete headers (#645 <https://github.com/ros2/geometry2/issues/645>)
* Contributors: Alejandro Hernández Cordero
```

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Enable intra-process (#649 <https://github.com/ros2/geometry2/issues/649>) (#642 <https://github.com/ros2/geometry2/issues/642>)
* Contributors: Patrick Roncagliolo
```

## tf2_ros_py

- No changes

## tf2_sensor_msgs

```
* Removed obsolete headers (#645 <https://github.com/ros2/geometry2/issues/645>)
* Contributors: Alejandro Hernández Cordero
```

## tf2_tools

```
* Add in tests for tf2_tools. (#647 <https://github.com/ros2/geometry2/issues/647>)
* Contributors: Chris Lalancette
```
