### PR TITLE
rqt_reconfigure: 1.6.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6163,7 +6163,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_reconfigure-release.git
-      version: 1.6.1-1
+      version: 1.6.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_reconfigure` to `1.6.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_reconfigure.git
- release repository: https://github.com/ros2-gbp/rqt_reconfigure-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.6.1-1`

## rqt_reconfigure

```
* Explicitly add a pytest test dependency. (#141 <https://github.com/ros-visualization/rqt_reconfigure/issues/141>)
* Remove unnecessary parentheses around if statements. (#140 <https://github.com/ros-visualization/rqt_reconfigure/issues/140>)
* Contributors: Chris Lalancette
```
