### PR TITLE
rqt_bag: 1.5.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5978,7 +5978,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
-      version: 1.5.0-1
+      version: 1.5.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `1.5.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros2-gbp/rqt_bag-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.5.0-1`

## rqt_bag

```
* Add a dependency on pytest to rqt_bag and rqt_bag_plugins. (#148 <https://github.com/ros-visualization/rqt_bag/issues/148>)
* Contributors: Chris Lalancette
```

## rqt_bag_plugins

```
* Add a dependency on pytest to rqt_bag and rqt_bag_plugins. (#148 <https://github.com/ros-visualization/rqt_bag/issues/148>)
* Contributors: Chris Lalancette
```
