### PR TITLE
qt_gui_core: 2.7.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4292,7 +4292,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 2.7.1-2
+      version: 2.7.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `2.7.2-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.7.1-2`

## qt_dotgraph

- No changes

## qt_gui

```
* Remove unnecessary parentheses for assert. (#286 <https://github.com/ros-visualization/qt_gui_core/issues/286>)
* Contributors: Chris Lalancette
```

## qt_gui_app

- No changes

## qt_gui_core

- No changes

## qt_gui_cpp

- No changes

## qt_gui_py_common

- No changes
