### PR TITLE
vrpn_mocap: 1.1.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -8159,7 +8159,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/vrpn_mocap-release.git
-      version: 1.0.3-3
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/alvinsunyixiao/vrpn_mocap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn_mocap` to `1.1.0-1`:

- upstream repository: https://github.com/alvinsunyixiao/vrpn_mocap.git
- release repository: https://github.com/ros2-gbp/vrpn_mocap-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.3-3`

## vrpn_mocap

```
* fix readme (#9 <https://github.com/alvinsunyixiao/vrpn_mocap/issues/9>)
* Add option to use VRPN timestamps rather than generating them again (#7 <https://github.com/alvinsunyixiao/vrpn_mocap/issues/7>)
* fix duplicate topic name for twist (#6 <https://github.com/alvinsunyixiao/vrpn_mocap/issues/6>)
  Co-authored-by: stuebema <mailto:stueben@isse.de>
  Co-authored-by: Alvin Sun <mailto:alvinsunyixiao@gmail.com>
* rename different CIs to different job names (#8 <https://github.com/alvinsunyixiao/vrpn_mocap/issues/8>)
* default to use sensor data qos (#4 <https://github.com/alvinsunyixiao/vrpn_mocap/issues/4>)
* Contributors: Alvin Sun, mstueben, njacquemin1993
```
