### PR TITLE
rosbag2: 0.22.6-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5935,7 +5935,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.22.5-1
+      version: 0.22.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.22.6-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.22.5-1`

## mcap_vendor

- No changes

## ros2bag

- No changes

## rosbag2

- No changes

## rosbag2_compression

```
* Add default initialization for CompressionOptions (#1545 <https://github.com/ros2/rosbag2/issues/1545>)
* Contributors: Arne Böckmann, Michael Orlov, Tomoya Fujita
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Call cv.wait_until only if necessary. (#1522 <https://github.com/ros2/rosbag2/issues/1522>)
* Contributors: Tomoya Fujita
```

## rosbag2_examples_cpp

- No changes

## rosbag2_examples_py

- No changes

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_performance_benchmarking_msgs

- No changes

## rosbag2_py

```
* Install signal handlers in recorder only inside record method (#1525 <https://github.com/ros2/rosbag2/issues/1525>)
* Contributors: Michael Orlov
```

## rosbag2_storage

```
* Remove rcpputils::fs dependencies from rosbag2_storages (#1564 <https://github.com/ros2/rosbag2/issues/1564>)
* Contributors: Chris Lalancette, Kenta Yonekura, Michael Orlov, Roman
```

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

```
* Use rw_lock to protect mcap metadata lists. (#1566 <https://github.com/ros2/rosbag2/issues/1566>)
* Remove rcpputils::fs dependencies from rosbag2_storages (#1564 <https://github.com/ros2/rosbag2/issues/1564>)
* Link and compile against rosbag2_storage_mcap: Fixed issue 1492 (#1497 <https://github.com/ros2/rosbag2/issues/1497>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Kenta Yonekura, Michael Orlov, Roman, Tomoya Fujita
```

## rosbag2_storage_sqlite3

```
* Use rw_lock to protect mcap metadata lists. (#1566 <https://github.com/ros2/rosbag2/issues/1566>)
* Remove rcpputils::fs dependencies from rosbag2_storages (#1564 <https://github.com/ros2/rosbag2/issues/1564>)
* Contributors: Chris Lalancette, Kenta Yonekura, Michael Orlov, Roman, Tomoya Fujita
```

## rosbag2_test_common

- No changes

## rosbag2_test_msgdefs

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

```
* Workaround for flaky test_play_services running with fastrtps (#1562 <https://github.com/ros2/rosbag2/issues/1562>)
* Add proper message for --start-paused (#1540 <https://github.com/ros2/rosbag2/issues/1540>)
* Recording stopped prints only once. (#1534 <https://github.com/ros2/rosbag2/issues/1534>)
* Bugfix for incorrect playback rate changes when pressing buttons (#1514 <https://github.com/ros2/rosbag2/issues/1514>)
* Contributors: Christoph Fröhlich, Michael Orlov, Tomoya Fujita
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
