### PR TITLE
sick_visionary_ros: 1.1.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11200,7 +11200,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/SICKAG/sick_visionary_ros-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_visionary_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_visionary_ros` to `1.1.2-1`:

- upstream repository: https://github.com/SICKAG/sick_visionary_ros.git
- release repository: https://github.com/SICKAG/sick_visionary_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.1-1`

## sick_visionary_ros

```
* update sick_visionary_cpp_shread to fix CoLa2 session timeout
* bump package.xml version
* fix CMakeLists.txt used wrong PCL LIBRARY variable, fix project version
```
