### PR TITLE
phidgets_drivers: Use dedicated source branches

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5051,7 +5051,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-drivers/phidgets_drivers.git
-      version: rolling
+      version: humble
     status: maintained
   pick_ik:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4195,7 +4195,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-drivers/phidgets_drivers.git
-      version: rolling
+      version: iron
     status: maintained
   pick_ik:
     doc:


### PR DESCRIPTION
In 19e2b012d7, I already switched the doc section to the new branches,
but I forgot the source section. This commit fixes that.