### PR TITLE
 Add a new package, unitree_ros, to rosdep database #39767 

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -7399,11 +7399,6 @@ repositories:
       url: https://github.com/ros2/unique_identifier_msgs.git
       version: foxy
     status: maintained
-  unitree_ros:
-    source:
-      type: git
-      url: https://github.com/snt-arg/unitree_ros.git
-      version: main
   ur_client_library:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -7399,6 +7399,11 @@ repositories:
       url: https://github.com/ros2/unique_identifier_msgs.git
       version: foxy
     status: maintained
+  unitree_ros:
+    source:
+      type: git
+      url: https://github.com/snt-arg/unitree_ros.git
+      version: main
   ur_client_library:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9172,6 +9172,11 @@ repositories:
       url: https://github.com/ros2/unique_identifier_msgs.git
       version: humble
     status: maintained
+  unitree_ros:
+    source:
+      type: git
+      url: https://github.com/snt-arg/unitree_ros.git
+      version: main
   ur_client_library:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7725,6 +7725,11 @@ repositories:
       url: https://github.com/ros2/unique_identifier_msgs.git
       version: iron
     status: maintained
+  unitree_ros:
+    source:
+      type: git
+      url: https://github.com/snt-arg/unitree_ros.git
+      version: main
   ur_client_library:
     doc:
       type: git


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

unitree_ros

## Package Upstream Source:

https://github.com/snt-arg/unitree_ros

## Purpose of using this:

This is a ROS package that is used to control the Unitree Go1 robot via ROS topics, as well as receiving data from the robot. This package can be useful for people who want to use the robot without needing to develop a driver/wrapper to use their robot. It can be especially useful for researchers, that want to test their development on the real hardware.

Distro packaging links:

## Links to Distribution Packages

I did not really understand what I should be doing here. Is this required? Sorry for this, it is my first time.

ROSDISTRO NAME: Foxy
<!--
# The source is here:

http://sourcecode_url-->

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro

(PS: Apologies if there is something missing.)