### PR TITLE
caret_trace: 0.5.0-3 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -845,7 +845,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/caret_trace-release.git
-      version: 0.5.0-2
+      version: 0.5.0-3
     source:
       type: git
       url: https://github.com/tier4/caret_trace.git


### PR DESCRIPTION
Increasing version of package(s) in repository `caret_trace` to `0.5.0-3`:

- upstream repository: https://github.com/tier4/caret_trace.git
- release repository: https://github.com/ros2-gbp/caret_trace-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.5.0-2`

## caret_msgs

```
* chore: update package.xml version to 0.4.24 (#266 <https://github.com/tier4/caret_trace/issues/266>)
* Contributors: h-suzuki-isp
```
