### PR TITLE
Add off_highway_sensor_drivers

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4684,6 +4684,16 @@ repositories:
       url: https://github.com/gstavrinos/odom_to_tf_ros2.git
       version: master
     status: maintained
+  off_highway_sensor_drivers:
+    doc:
+      type: git
+      url: https://github.com/bosch-engineering/off_highway_sensor_drivers.git
+      version: humble-devel
+    source:
+      type: git
+      url: https://github.com/bosch-engineering/off_highway_sensor_drivers.git
+      version: humble-devel
+    status: maintained
   ompl:
     release:
       tags:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

meta package: off_highway_sensor_drivers
with packages:

- off_highway_can
- off_highway_general_purpose_radar
- off_highway_general_purpose_radar_msgs
- off_highway_premium_radar
- off_highway_premium_radar_msgs
- off_highway_radar
- off_highway_radar_msgs
- off_highway_uss
- off_highway_uss_msgs

## Package Upstream Source:


## Purpose of using this:

This project provides ROS drivers for Bosch Off-Highway sensor systems. The drivers are used by various users in the off-highway domain, they request availability of prebuilt packages.

Distro packaging links:

## Links to Distribution Packages

Should be built by ROS buildfarm (ros2-gbp), links not available yet

# Please Add This Package to be indexed in the rosdistro.

humble

# The source is here:
https://github.com/bosch-engineering/off_highway_sensor_drivers

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
