### PR TITLE
qb_softhand_industry: 1.2.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8394,7 +8394,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbshin-ros-release.git
-      version: 1.0.9-1
+      version: 1.2.5-1
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbshin-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_softhand_industry` to `1.2.5-1`:

- upstream repository: https://bitbucket.org/qbrobotics/qbshin-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbshin-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.9-1`

## qb_softhand_industry

- No changes

## qb_softhand_industry_bringup

- No changes

## qb_softhand_industry_control

- No changes

## qb_softhand_industry_description

- No changes

## qb_softhand_industry_driver

- No changes

## qb_softhand_industry_hardware_interface

- No changes

## qb_softhand_industry_msgs

- No changes

## qb_softhand_industry_srvs

- No changes

## qb_softhand_industry_utils

- No changes
