### PR TITLE
apriltag_detector: 1.2.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -361,6 +361,11 @@ repositories:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_detector.git
       version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/apriltag_detector-release.git
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_detector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_detector` to `1.2.0-1`:

- upstream repository: https://github.com/ros-misc-utilities/apriltag_detector.git
- release repository: https://github.com/ros2-gbp/apriltag_detector-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## apriltag_detector

```
* initial release
* Contributors: Bernd Pfrommer
```
