### PR TITLE
multidim_rrt_planner: 0.0.8-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3421,7 +3421,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/multidim_rrt_planner-release.git
-      version: 0.0.7-3
+      version: 0.0.8-1
     source:
       type: git
       url: https://github.com/daviddorf2023/multidim_rrt_planner.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multidim_rrt_planner` to `0.0.8-1`:

- upstream repository: https://github.com/ros2-gbp/multidim_rrt_planner-release.git
- release repository: https://github.com/ros2-gbp/multidim_rrt_planner-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.7-3`

## multidim_rrt_planner

```
* 2D launch example argument bugfix
* Add service call to run RRT and updated documentation with optional examples.
* Contributors: daviddorf2023
```
