### PR TITLE
Add rosdep key for playsound alpine

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7518,6 +7518,9 @@ python3-playsound-pip:
   ubuntu:
     pip:
       packages: [playsound]
+  alpine:
+    pip:
+      packages: [playsound]
 python3-ply:
   arch: [python-ply]
   debian: [python3-ply]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7509,6 +7509,9 @@ python3-pkg-resources:
   rhel: ['python%{python3_pkgversion}-setuptools']
   ubuntu: [python3-pkg-resources]
 python3-playsound-pip:
+  alpine:
+    pip:
+      packages: [playsound]
   debian:
     pip:
       packages: [playsound]
@@ -7516,9 +7519,6 @@ python3-playsound-pip:
     pip:
       packages: [playsound]
   ubuntu:
-    pip:
-      packages: [playsound]
-  alpine:
     pip:
       packages: [playsound]
 python3-ply:


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-playsound-pip

## Package Upstream Source:

https://pypi.org/project/playsound/

## Purpose of using this:

The package is already in the database but I want to use it with Alpine.

## Links to Distribution Packages

N/A