### PR TITLE
libdbus-dev on RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3115,6 +3115,7 @@ libdbus-dev:
   fedora: [dbus-devel]
   gentoo: [sys-apps/dbus]
   nixos: [dbus]
+  rhel: [dbus-devel]
   ubuntu: [libdbus-1-dev]
 libdc1394-dev:
   arch:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

libdbus-dev

Distro packaging links:

## Links to Distribution Packages

- rhel: https://rhel.pkgs.org/
  - https://rhel.pkgs.org/8/okey-x86_64/dbus-devel-1.12.8-7.el8.x86_64.rpm.html
