### PR TITLE
aerostack2: 1.0.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -128,7 +128,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/aerostack2-release.git
-      version: 1.0.7-1
+      version: 1.0.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aerostack2` to `1.0.8-1`:

- upstream repository: https://github.com/aerostack2/aerostack2.git
- release repository: https://github.com/ros2-gbp/aerostack2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.7-1`

## aerostack2

```
* [as2_core] added pybind11 dependency
* [as2_python_api] Jenkins test fail: searching for module first at modules folder and hook as2_modules_path fix
* Contributors: pariaspe, Rafael Pérez
```

## as2_alphanumeric_viewer

- No changes

## as2_behavior

- No changes

## as2_behavior_tree

- No changes

## as2_behaviors_motion

- No changes

## as2_behaviors_perception

- No changes

## as2_behaviors_platform

- No changes

## as2_behaviors_trajectory_generation

- No changes

## as2_cli

- No changes

## as2_core

```
* [as2_core] added pybind11 dep
* Contributors: Rafael Pérez, pariaspe
```

## as2_gazebo_assets

- No changes

## as2_gazebo_classic_assets

- No changes

## as2_keyboard_teleoperation

- No changes

## as2_motion_controller

- No changes

## as2_motion_reference_handlers

- No changes

## as2_msgs

- No changes

## as2_platform_crazyflie

- No changes

## as2_platform_dji_osdk

- No changes

## as2_platform_gazebo

- No changes

## as2_platform_tello

- No changes

## as2_python_api

```
* [as2_python_api] Jenkins test fail: searching for module first at modules folder and hook as2_modules_path fix
* Contributors: pariaspe
```

## as2_realsense_interface

- No changes

## as2_state_estimator

- No changes

## as2_usb_camera_interface

- No changes
