### PR TITLE
ros2_control: 4.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5244,7 +5244,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.4.0-1
+      version: 4.5.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.5.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.4.0-1`

## controller_interface

```
* A method to get node options to setup the controller node #api-breaking (#1169 <https://github.com/ros-controls/ros2_control/issues/1169>)
* Contributors: Sai Kishor Kothakota
```

## controller_manager

```
* check for state of the controller node before cleanup (#1363 <https://github.com/ros-controls/ros2_control/issues/1363>)
* [CM] Use explicit constants in controller tests. (#1356 <https://github.com/ros-controls/ros2_control/issues/1356>)
* [CM] Optimized debug output about interfaces when switching controllers. (#1355 <https://github.com/ros-controls/ros2_control/issues/1355>)
* A method to get node options to setup the controller node #api-breaking (#1169 <https://github.com/ros-controls/ros2_control/issues/1169>)
* Contributors: Dr. Denis, Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Add missing export macros in lexical_casts.hpp (#1382 <https://github.com/ros-controls/ros2_control/issues/1382>)
* Move hardware interface README content to sphinx documentation (#1342 <https://github.com/ros-controls/ros2_control/issues/1342>)
* [Doc] Add documentation about initial_value regarding mock_hw (#1352 <https://github.com/ros-controls/ros2_control/issues/1352>)
* Contributors: Felix Exner (fexner), Mateus Menezes, Silvio Traversaro
```

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
