### PR TITLE
ros2_controllers: 4.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5281,7 +5281,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 4.5.0-1
+      version: 4.6.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `4.6.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.5.0-1`

## ackermann_steering_controller

```
* Add test_depend on hardware_interface_testing (#1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>)
* Fix tests for using new get_node_options API (#840 <https://github.com/ros-controls/ros2_controllers/issues/840>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## admittance_controller

```
* Add test_depend on hardware_interface_testing (#1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>)
* Contributors: Christoph Fröhlich
```

## bicycle_steering_controller

```
* Add test_depend on hardware_interface_testing (#1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>)
* Fix tests for using new get_node_options API (#840 <https://github.com/ros-controls/ros2_controllers/issues/840>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## diff_drive_controller

```
* Add test_depend on hardware_interface_testing also for diff_drive (#1021 <https://github.com/ros-controls/ros2_controllers/issues/1021>)
* Add test_depend on hardware_interface_testing (#1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>)
* Fix tests for using new get_node_options API (#840 <https://github.com/ros-controls/ros2_controllers/issues/840>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## effort_controllers

```
* Add test_depend on hardware_interface_testing (#1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>)
* Fix tests for using new get_node_options API (#840 <https://github.com/ros-controls/ros2_controllers/issues/840>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## force_torque_sensor_broadcaster

```
* Add test_depend on hardware_interface_testing (#1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>)
* Fix tests for using new get_node_options API (#840 <https://github.com/ros-controls/ros2_controllers/issues/840>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## forward_command_controller

```
* Add test_depend on hardware_interface_testing (#1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>)
* Fix tests for using new get_node_options API (#840 <https://github.com/ros-controls/ros2_controllers/issues/840>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## gripper_controllers

```
* Add test_depend on hardware_interface_testing (#1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>)
* Fix tests for using new get_node_options API (#840 <https://github.com/ros-controls/ros2_controllers/issues/840>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## imu_sensor_broadcaster

```
* Add test_depend on hardware_interface_testing (#1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>)
* Fix tests for using new get_node_options API (#840 <https://github.com/ros-controls/ros2_controllers/issues/840>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## joint_state_broadcaster

```
* Add test_depend on hardware_interface_testing (#1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>)
* Fix tests for using new get_node_options API (#840 <https://github.com/ros-controls/ros2_controllers/issues/840>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## joint_trajectory_controller

```
* Fix usage of M_PI on Windows (#1036 <https://github.com/ros-controls/ros2_controllers/issues/1036>)
* [JTC] Angle wraparound for first segment of trajectory (#796 <https://github.com/ros-controls/ros2_controllers/issues/796>)
* Add test_depend on hardware_interface_testing (#1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>)
* Fix tests for using new get_node_options API (#840 <https://github.com/ros-controls/ros2_controllers/issues/840>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota, Silvio Traversaro
```

## pid_controller

```
* Add test_depend on hardware_interface_testing (#1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>)
* Fix tests for using new get_node_options API (#840 <https://github.com/ros-controls/ros2_controllers/issues/840>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## position_controllers

```
* Add test_depend on hardware_interface_testing (#1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>)
* Fix tests for using new get_node_options API (#840 <https://github.com/ros-controls/ros2_controllers/issues/840>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## range_sensor_broadcaster

```
* Add test_depend on hardware_interface_testing (#1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>)
* Fix tests for using new get_node_options API (#840 <https://github.com/ros-controls/ros2_controllers/issues/840>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Fix usage of M_PI on Windows (#1036 <https://github.com/ros-controls/ros2_controllers/issues/1036>)
* Fix tests for using new get_node_options API (#840 <https://github.com/ros-controls/ros2_controllers/issues/840>)
* Contributors: Sai Kishor Kothakota, Silvio Traversaro
```

## tricycle_controller

```
* Fix usage of M_PI on Windows (#1036 <https://github.com/ros-controls/ros2_controllers/issues/1036>)
* Add test_depend on hardware_interface_testing (#1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>)
* Fix tests for using new get_node_options API (#840 <https://github.com/ros-controls/ros2_controllers/issues/840>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota, Silvio Traversaro
```

## tricycle_steering_controller

```
* Add test_depend on hardware_interface_testing (#1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>)
* Fix tests for using new get_node_options API (#840 <https://github.com/ros-controls/ros2_controllers/issues/840>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## velocity_controllers

```
* Add test_depend on hardware_interface_testing (#1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>)
* Fix tests for using new get_node_options API (#840 <https://github.com/ros-controls/ros2_controllers/issues/840>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```
