### PR TITLE
ros2_control: 2.39.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6646,6 +6646,7 @@ repositories:
       - controller_manager
       - controller_manager_msgs
       - hardware_interface
+      - hardware_interface_testing
       - joint_limits
       - ros2_control
       - ros2_control_test_assets
@@ -6655,7 +6656,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.38.0-1
+      version: 2.39.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.39.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.38.0-1`

## controller_interface

- No changes

## controller_manager

```
* [Spawners] Remove walrus operator (#1366 <https://github.com/ros-controls/ros2_control/issues/1366>)
* [CM] Use explicit constants in controller tests. (#1356 <https://github.com/ros-controls/ros2_control/issues/1356>) (#1359 <https://github.com/ros-controls/ros2_control/issues/1359>)
* Move test_components to own package (backport #1325 <https://github.com/ros-controls/ros2_control/issues/1325>) (#1340 <https://github.com/ros-controls/ros2_control/issues/1340>)
* Contributors: Christoph Fröhlich, Dr Denis
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Move test_components to own package (backport #1325 <https://github.com/ros-controls/ros2_control/issues/1325>) (#1340 <https://github.com/ros-controls/ros2_control/issues/1340>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

```
* Move test_components to own package (backport #1325 <https://github.com/ros-controls/ros2_control/issues/1325>) (#1340 <https://github.com/ros-controls/ros2_control/issues/1340>)
* Contributors: mergify[bot]
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
