### PR TITLE
ros2_controllers: 3.22.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5584,7 +5584,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 3.21.0-1
+      version: 3.22.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `3.22.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.21.0-1`

## ackermann_steering_controller

```
* Add test_depend on hardware_interface_testing (backport #1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>) (#1020 <https://github.com/ros-controls/ros2_controllers/issues/1020>)
* Add tests for interface_configuration_type consistently (backport #899 <https://github.com/ros-controls/ros2_controllers/issues/899>) (#1007 <https://github.com/ros-controls/ros2_controllers/issues/1007>)
* Contributors: mergify[bot]
```

## admittance_controller

```
* Add test_depend on hardware_interface_testing (backport #1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>) (#1020 <https://github.com/ros-controls/ros2_controllers/issues/1020>)
* Add tests for interface_configuration_type consistently (backport #899 <https://github.com/ros-controls/ros2_controllers/issues/899>) (#1007 <https://github.com/ros-controls/ros2_controllers/issues/1007>)
* Let sphinx add parameter description with nested structures to documentation (#652 <https://github.com/ros-controls/ros2_controllers/issues/652>) (#1006 <https://github.com/ros-controls/ros2_controllers/issues/1006>)
* Contributors: mergify[bot]
```

## bicycle_steering_controller

```
* Add test_depend on hardware_interface_testing (backport #1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>) (#1020 <https://github.com/ros-controls/ros2_controllers/issues/1020>)
* Add tests for interface_configuration_type consistently (backport #899 <https://github.com/ros-controls/ros2_controllers/issues/899>) (#1007 <https://github.com/ros-controls/ros2_controllers/issues/1007>)
* Contributors: mergify[bot]
```

## diff_drive_controller

```
* Add test_depend on hardware_interface_testing (backport #1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>) (#1020 <https://github.com/ros-controls/ros2_controllers/issues/1020>)
* Add tests for interface_configuration_type consistently (backport #899 <https://github.com/ros-controls/ros2_controllers/issues/899>) (#1007 <https://github.com/ros-controls/ros2_controllers/issues/1007>)
* Let sphinx add parameter description with nested structures to documentation (#652 <https://github.com/ros-controls/ros2_controllers/issues/652>) (#1006 <https://github.com/ros-controls/ros2_controllers/issues/1006>)
* Contributors: mergify[bot]
```

## effort_controllers

```
* Add test_depend on hardware_interface_testing (backport #1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>) (#1020 <https://github.com/ros-controls/ros2_controllers/issues/1020>)
* Contributors: mergify[bot]
```

## force_torque_sensor_broadcaster

```
* Add test_depend on hardware_interface_testing (backport #1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>) (#1020 <https://github.com/ros-controls/ros2_controllers/issues/1020>)
* Add tests for interface_configuration_type consistently (backport #899 <https://github.com/ros-controls/ros2_controllers/issues/899>) (#1007 <https://github.com/ros-controls/ros2_controllers/issues/1007>)
* Let sphinx add parameter description with nested structures to documentation (#652 <https://github.com/ros-controls/ros2_controllers/issues/652>) (#1006 <https://github.com/ros-controls/ros2_controllers/issues/1006>)
* Revert "[ForceTorqueSensorBroadcaster] Create ParamListener and get parameters on configure (#698 <https://github.com/ros-controls/ros2_controllers/issues/698>)" (#988 <https://github.com/ros-controls/ros2_controllers/issues/988>) (#1004 <https://github.com/ros-controls/ros2_controllers/issues/1004>)
* Contributors: mergify[bot]
```

## forward_command_controller

```
* Add test_depend on hardware_interface_testing (backport #1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>) (#1020 <https://github.com/ros-controls/ros2_controllers/issues/1020>)
* Add tests for interface_configuration_type consistently (backport #899 <https://github.com/ros-controls/ros2_controllers/issues/899>) (#1007 <https://github.com/ros-controls/ros2_controllers/issues/1007>)
* Contributors: mergify[bot]
```

## gripper_controllers

```
* Add test_depend on hardware_interface_testing (backport #1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>) (#1020 <https://github.com/ros-controls/ros2_controllers/issues/1020>)
* Let sphinx add parameter description with nested structures to documentation (#652 <https://github.com/ros-controls/ros2_controllers/issues/652>) (#1006 <https://github.com/ros-controls/ros2_controllers/issues/1006>)
* Contributors: mergify[bot]
```

## imu_sensor_broadcaster

```
* Add test_depend on hardware_interface_testing (backport #1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>) (#1020 <https://github.com/ros-controls/ros2_controllers/issues/1020>)
* Add tests for interface_configuration_type consistently (backport #899 <https://github.com/ros-controls/ros2_controllers/issues/899>) (#1007 <https://github.com/ros-controls/ros2_controllers/issues/1007>)
* Let sphinx add parameter description with nested structures to documentation (#652 <https://github.com/ros-controls/ros2_controllers/issues/652>) (#1006 <https://github.com/ros-controls/ros2_controllers/issues/1006>)
* Contributors: mergify[bot]
```

## joint_state_broadcaster

```
* Add test_depend on hardware_interface_testing (backport #1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>) (#1020 <https://github.com/ros-controls/ros2_controllers/issues/1020>)
* Add tests for interface_configuration_type consistently (backport #899 <https://github.com/ros-controls/ros2_controllers/issues/899>) (#1007 <https://github.com/ros-controls/ros2_controllers/issues/1007>)
* Let sphinx add parameter description with nested structures to documentation (#652 <https://github.com/ros-controls/ros2_controllers/issues/652>) (#1006 <https://github.com/ros-controls/ros2_controllers/issues/1006>)
* Contributors: mergify[bot]
```

## joint_trajectory_controller

```
* Fix usage of M_PI on Windows (#1036 <https://github.com/ros-controls/ros2_controllers/issues/1036>) (#1038 <https://github.com/ros-controls/ros2_controllers/issues/1038>)
* Add test_depend on hardware_interface_testing (backport #1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>) (#1020 <https://github.com/ros-controls/ros2_controllers/issues/1020>)
* Add tests for interface_configuration_type consistently (backport #899 <https://github.com/ros-controls/ros2_controllers/issues/899>) (#1007 <https://github.com/ros-controls/ros2_controllers/issues/1007>)
* Let sphinx add parameter description with nested structures to documentation (#652 <https://github.com/ros-controls/ros2_controllers/issues/652>) (#1006 <https://github.com/ros-controls/ros2_controllers/issues/1006>)
* [JTC] Fill action error_strings (#887 <https://github.com/ros-controls/ros2_controllers/issues/887>) (#1010 <https://github.com/ros-controls/ros2_controllers/issues/1010>)
* [JTC] Invalidate empty trajectory messages (#902 <https://github.com/ros-controls/ros2_controllers/issues/902>) (#1001 <https://github.com/ros-controls/ros2_controllers/issues/1001>)
* Revert "[JTC] Remove read_only from 'joints', 'state_interfaces' and 'command_interfaces' parameters (#967 <https://github.com/ros-controls/ros2_controllers/issues/967>)" (#978 <https://github.com/ros-controls/ros2_controllers/issues/978>) (#987 <https://github.com/ros-controls/ros2_controllers/issues/987>)
* Contributors: mergify[bot]
```

## position_controllers

```
* Add test_depend on hardware_interface_testing (backport #1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>) (#1020 <https://github.com/ros-controls/ros2_controllers/issues/1020>)
* Contributors: mergify[bot]
```

## range_sensor_broadcaster

```
* Add test_depend on hardware_interface_testing (backport #1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>) (#1020 <https://github.com/ros-controls/ros2_controllers/issues/1020>)
* Add tests for interface_configuration_type consistently (backport #899 <https://github.com/ros-controls/ros2_controllers/issues/899>) (#1007 <https://github.com/ros-controls/ros2_controllers/issues/1007>)
* Let sphinx add parameter description with nested structures to documentation (#652 <https://github.com/ros-controls/ros2_controllers/issues/652>) (#1006 <https://github.com/ros-controls/ros2_controllers/issues/1006>)
* Contributors: mergify[bot]
```

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Fix usage of M_PI on Windows (#1036 <https://github.com/ros-controls/ros2_controllers/issues/1036>) (#1038 <https://github.com/ros-controls/ros2_controllers/issues/1038>)
* Add tests for interface_configuration_type consistently (backport #899 <https://github.com/ros-controls/ros2_controllers/issues/899>) (#1007 <https://github.com/ros-controls/ros2_controllers/issues/1007>)
* Contributors: mergify[bot]
```

## tricycle_controller

```
* Fix usage of M_PI on Windows (#1036 <https://github.com/ros-controls/ros2_controllers/issues/1036>) (#1038 <https://github.com/ros-controls/ros2_controllers/issues/1038>)
* Add test_depend on hardware_interface_testing (backport #1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>) (#1020 <https://github.com/ros-controls/ros2_controllers/issues/1020>)
* Contributors: mergify[bot]
```

## tricycle_steering_controller

```
* Add test_depend on hardware_interface_testing (backport #1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>) (#1020 <https://github.com/ros-controls/ros2_controllers/issues/1020>)
* Add tests for interface_configuration_type consistently (backport #899 <https://github.com/ros-controls/ros2_controllers/issues/899>) (#1007 <https://github.com/ros-controls/ros2_controllers/issues/1007>)
* Contributors: mergify[bot]
```

## velocity_controllers

```
* Add test_depend on hardware_interface_testing (backport #1018 <https://github.com/ros-controls/ros2_controllers/issues/1018>) (#1020 <https://github.com/ros-controls/ros2_controllers/issues/1020>)
* Contributors: mergify[bot]
```
