### PR TITLE
Add opende rule for RHEL 8

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6928,6 +6928,8 @@ opende:
   fedora: [ode-devel]
   gentoo: [dev-games/ode]
   nixos: [ode]
+  rhel:
+    '8': [ode-devel]
   ubuntu: [libode-dev]
 opengl:
   alpine: [mesa-dev]


### PR DESCRIPTION
This package is available for RHEL 8 via EPEL, but is not currently available for RHEL 9.

https://src.fedoraproject.org/rpms/ode#bodhi_updates