### PR TITLE
Fix ffmpeg rules for Fedora, add RHEL 9 rules

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1021,13 +1021,16 @@ ffmpeg:
   arch: [ffmpeg]
   debian:
     '*': [ffmpeg, libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev]
-  fedora: [ffmpeg-devel]
+  fedora: [ffmpeg-free-devel]
   freebsd: [ffmpeg]
   gentoo: [virtual/ffmpeg]
   macports: [ffmpeg]
   nixos: [ffmpeg]
   openembedded: [ffmpeg@openembedded-core]
   opensuse: [ffmpeg-4-libavcodec-devel, ffmpeg-4-libavdevice-devel, ffmpeg-4-libavfilter-devel, ffmpeg-4-libavformat-devel, ffmpeg-4-libavresample-devel, ffmpeg-4-libavutil-devel, ffmpeg-4-libpostproc-devel, ffmpeg-4-libswresample-devel, ffmpeg-4-libswscale-devel, ffmpeg-4-private-devel]
+  rhel:
+    '*': [ffmpeg-free-devel]
+    '8': null
   slackware: [ffmpeg]
   ubuntu:
     '*': [ffmpeg, libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev]
@@ -1035,14 +1038,16 @@ ffmpeg-dev:
   alpine: [ffmpeg-dev]
   arch: [ffmpeg]
   debian: [libavcodec-dev, libavdevice-dev, libavfilter-dev, libavformat-dev, libavutil-dev, libpostproc-dev, libswresample-dev, libswscale-dev]
-  fedora: [ffmpeg-devel]
+  fedora: [ffmpeg-free-devel]
   freebsd: [ffmpeg]
   gentoo: [virtual/ffmpeg]
   macports: [ffmpeg]
   nixos: [ffmpeg]
   openembedded: [ffmpeg@openembedded-core]
   opensuse: [ffmpeg-4-libavcodec-devel, ffmpeg-4-libavdevice-devel, ffmpeg-4-libavfilter-devel, ffmpeg-4-libavformat-devel, ffmpeg-4-libavresample-devel, ffmpeg-4-libavutil-devel, ffmpeg-4-libpostproc-devel, ffmpeg-4-libswresample-devel, ffmpeg-4-libswscale-devel, ffmpeg-4-private-devel]
-  rhel: [ffmpeg-devel]
+  rhel:
+    '*': [ffmpeg-free-devel]
+    '8': null
   slackware: [ffmpeg]
   ubuntu: [libavcodec-dev, libavdevice-dev, libavfilter-dev, libavformat-dev, libavutil-dev, libpostproc-dev, libswresample-dev, libswscale-dev]
 ffmpeg2theora:
@@ -5754,9 +5759,12 @@ libsvn-dev:
 libswscale-dev:
   arch: [ffmpeg]
   debian: [libswscale-dev]
-  fedora: [ffmpeg-devel]
+  fedora: [libswscale-free-devel]
   gentoo: [virtual/ffmpeg]
   nixos: [ffmpeg]
+  rhel:
+    '*': [libswscale-free-devel]
+    '8': null
   ubuntu: [libswscale-dev]
 libsystemd-dev:
   debian: [libsystemd-dev]


### PR DESCRIPTION
The ffmpeg family of packages has historically not been part of Fedora likely due to licensing problems with parts of the codebase.

In recent years, a stripped-down variant of ffmpeg was made available in Fedora and EPEL 9 which has only royalty-free codecs.

https://packages.fedoraproject.org/pkgs/ffmpeg/ffmpeg-free-devel/
https://packages.fedoraproject.org/pkgs/ffmpeg/libswscale-free-devel/