### PR TITLE
leo_common: 1.2.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3198,7 +3198,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/leo_common-release.git
-      version: 1.2.0-1
+      version: 1.2.1-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_common-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_common` to `1.2.1-1`:

- upstream repository: https://github.com/LeoRover/leo_common-ros2.git
- release repository: https://github.com/ros2-gbp/leo_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.0-1`

## leo

- No changes

## leo_description

```
* Change wheel ode friction params (#8 <https://github.com/LeoRover/leo_common-ros2/issues/8>)
* Remove redundant ros2_control controller configuration
* Contributors: Błażej Sowa, Jan Hernas
```

## leo_msgs

- No changes

## leo_teleop

- No changes
