### PR TITLE
Add ros2-easy-test pip key to rosdep.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8483,6 +8483,19 @@ python3-robodk-pip:
 python3-rocker:
   debian: [python3-rocker]
   ubuntu: [python3-rocker]
+python3-ros2-easy-test-pip:
+  debian:
+    pip:
+      packages: [ros2-easy-test]
+  fedora:
+    pip:
+      packages: [ros2-easy-test]
+  osx:
+    pip:
+      packages: [ros2-easy-test]
+  ubuntu:
+    pip:
+      packages: [ros2-easy-test]
 python3-rosbags-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name: 
ros2-easy-test

## Package Upstream Source:
https://github.com/felixdivo/ros2-easy-test

## Purpose of using this:

This dependency allows testing for ros2 packages without a lot of boiler plate. It make a very useful addition to the rosdep database.

Distro packaging links:

## Links to Distribution Packages

- pip:
  - https://pypi.org/project/ros2-easy-test/
- Debian: https://packages.debian.org/
  - not available
- Ubuntu: https://packages.ubuntu.com/
  - not available
- Fedora: https://packages.fedoraproject.org/
  - not available
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available
- openSUSE: https://software.opensuse.org/package/
  - not available
- rhel: https://rhel.pkgs.org/
  - not available