### PR TITLE
psdk_ros2: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5406,7 +5406,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/psdk_ros2-release.git
-      version: 0.0.5-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/umdlife/psdk_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `psdk_ros2` to `1.0.0-1`:

- upstream repository: https://github.com/umdlife/psdk_ros2.git
- release repository: https://github.com/ros2-gbp/psdk_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.5-1`

## psdk_interfaces

```
* Merge pull request #34 <https://github.com/umdlife/psdk_ros2/issues/34> from umdlife/feat/upgrade-to-psdk-v3.8
  Feat/upgrade to psdk v3.8
* Upgrade wrapper to be compatible with DJI PSDK v3.8
* Contributors: Victor Massagué Respall, biancabnd
```

## psdk_wrapper

```
* Merge pull request #34 <https://github.com/umdlife/psdk_ros2/issues/34> from umdlife/feat/upgrade-to-psdk-v3.8
  Feat/upgrade to psdk v3.8
* Merge pull request #44 <https://github.com/umdlife/psdk_ros2/issues/44> from RPS98/feat/upgrade-to-psdk-v3.8
  Add config files as launcher configs
* Set camera, gimbal and streaming modules as non mandatory
* Merge pull request #49 <https://github.com/umdlife/psdk_ros2/issues/49> from umdlife/feat/parametrise-retry-num
  Make the number of init retries as a ros param
* Upgrade wrapper to be compatible with DJI PSDK v3.8
* Contributors: Rafael Perez-Segui, Sergi Grau Moya, Victor Massagué Respall, biancabnd
```
