### PR TITLE
openni2_camera: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3633,7 +3633,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/openni2_camera-release.git
-      version: 2.0.2-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_camera` to `2.1.0-1`:

- upstream repository: https://github.com/ros-drivers/openni2_camera.git
- release repository: https://github.com/ros2-gbp/openni2_camera-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.2-1`

## openni2_camera

```
* implement proper lazy subscribers (#136 <https://github.com/ros-drivers/openni2_camera/issues/136>)
  Fixes #119 <https://github.com/ros-drivers/openni2_camera/issues/119>, works in Jazzy and later
* publish tfs and set matching frame names (#135 <https://github.com/ros-drivers/openni2_camera/issues/135>)
  This PR ports the TFs from original
  [kinect_frames.launch](https://github.com/ros-drivers/rgbd_launch/blob/noetic-devel/launch/kinect_frames.launch)
  to the ROS 2 launch files and sets the image frame names appropriately.
* Depth-only point cloud launch file for Non-RGB PrimeSense device. (#132 <https://github.com/ros-drivers/openni2_camera/issues/132>)
* Contributors: Christian Rauch, Michael Ferguson, TinLethax
```
