### PR TITLE
marine_msgs: 2.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5424,6 +5424,23 @@ repositories:
       url: https://github.com/swri-robotics/mapviz.git
       version: master
     status: developed
+  marine_msgs:
+    doc:
+      type: git
+      url: https://github.com/apl-ocean-engineering/marine_msgs.git
+      version: 2.0.1
+    release:
+      packages:
+      - marine_acoustic_msgs
+      - marine_sensor_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/CCOMJHC/marine_msgs-release.git
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://github.com/apl-ocean-engineering/marine_msgs.git
+      version: main
   marker_msgs:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5428,7 +5428,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/apl-ocean-engineering/marine_msgs.git
-      version: 2.0.1
+      version: main
     release:
       packages:
       - marine_acoustic_msgs


### PR DESCRIPTION
Increasing version of package(s) in repository `marine_msgs` to `2.0.1-1`:

- upstream repository: https://github.com/apl-ocean-engineering/marine_msgs.git
- release repository: https://github.com/CCOMJHC/marine_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## marine_acoustic_msgs

- No changes

## marine_sensor_msgs

```
* Add radar message and migration rules. (#40 <https://github.com/rolker/marine_msgs/issues/40>)
  Add radar messages and migration rules.
* Contributors: Roland Arsenault
```
