### PR TITLE
add libepoxy

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3223,6 +3223,14 @@ libedit-dev:
   nixos: [libedit]
   rhel: [libedit-devel]
   ubuntu: [libedit-dev]
+libepoxy-dev:
+  alpine: [libepoxy-dev]
+  arch: [libepoxy]
+  debian: [libepoxy-dev]
+  fedora: [libepoxy-devel]
+  opensuse: [libepoxy-devel]
+  rhel: [libepoxy-devel]
+  ubuntu: [libepoxy-dev]
 libesd0-dev:
   debian: [libesd0-dev]
   fedora: [esound-devel]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package Upstream Source:

https://github.com/anholt/libepoxy

## Purpose of using this:

"Epoxy is a library for handling OpenGL function pointer management for you."

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/libepoxy-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/jammy/libepoxy-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/libepoxy/libepoxy-devel/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/libepoxy/
- rhel: https://rhel.pkgs.org/
  - https://rhel.pkgs.org/8/okey-x86_64/libepoxy-devel-1.5.2-1.el8.x86_64.rpm.html
