### PR TITLE
Use 1.0.x branch of Fast-CDR for source builds

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1872,7 +1872,7 @@ repositories:
       test_pull_requests: false
       type: git
       url: https://github.com/eProsima/Fast-CDR.git
-      version: master
+      version: 1.0.x
     status: maintained
   fastrtps:
     release:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1437,7 +1437,7 @@ repositories:
       test_pull_requests: false
       type: git
       url: https://github.com/eProsima/Fast-CDR.git
-      version: master
+      version: 1.0.x
     status: maintained
   fastrtps:
     doc:


### PR DESCRIPTION
This branch configuration is used by source builds when using `rosinstall_generator` with the `--upstream-development` flag as an alternative to using the curated `ros2.repos` file. Right now, we get the `master` branch of Fast-CDR which causes rosidl build failures in downstream packages on Humble.

Rolling targets the `1.1.x` branch, so it makes sense to target the `1.0.x` branch in Humble and Iron. Using this branch, my source builds were able to progress normally.

@MiguelCompany FYI