### PR TITLE
Add `overrides` to python rosdeps

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7327,7 +7327,7 @@ python3-openhsi-pip:
   ubuntu:
     pip:
       packages: [openhsi]
-python3-overrides-pip:
+python3-overrides:
   arch: [python-overrides]
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7317,6 +7317,16 @@ python3-opengl:
   nixos: [python3Packages.pyopengl]
   opensuse: [python3-opengl]
   ubuntu: [python3-opengl]
+python3-openhsi-pip:
+  debian:
+    pip:
+      packages: [openhsi]
+  fedora:
+    pip:
+      packages: [openhsi]
+  ubuntu:
+    pip:
+      packages: [openhsi]
 python3-overrides:
   arch: [python-overrides]
   debian:
@@ -7331,16 +7341,6 @@ python3-overrides:
   ubuntu:
     pip:
       packages: [overrides]
-python3-openhsi-pip:
-  debian:
-    pip:
-      packages: [openhsi]
-  fedora:
-    pip:
-      packages: [openhsi]
-  ubuntu:
-    pip:
-      packages: [openhsi]
 python3-owlready2-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7317,7 +7317,8 @@ python3-opengl:
   nixos: [python3Packages.pyopengl]
   opensuse: [python3-opengl]
   ubuntu: [python3-opengl]
-python3-overrides-pip:
+python3-overrides:
+  arch: [python-overrides]
   debian:
     pip:
       packages: [overrides]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7327,7 +7327,7 @@ python3-openhsi-pip:
   ubuntu:
     pip:
       packages: [openhsi]
-python3-overrides:
+python3-overrides-pip:
   arch: [python-overrides]
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7317,6 +7317,19 @@ python3-opengl:
   nixos: [python3Packages.pyopengl]
   opensuse: [python3-opengl]
   ubuntu: [python3-opengl]
+python3-overrides-pip:
+  debian:
+    pip:
+      packages: [overrides]
+  fedora:
+    pip:
+      packages: [overrides]
+  osx:
+    pip:
+      packages: [overrides]
+  ubuntu:
+    pip:
+      packages: [overrides]
 python3-openhsi-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`overrides`

## Package Upstream Source:

https://github.com/mkorpela/overrides

## Purpose of using this:

This dependency makes it easier and cleaner to manage docstrings when using class inheritance in Python3.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- pip: https://pypi.org
    - https://pypi.org/project/overrides
- Debian: https://packages.debian.org/
  - Use `pip` package linked above. Not available in the Debian repositories.
- Ubuntu: https://packages.ubuntu.com/
  - Use `pip` package linked above. Not available in the Ubuntu repositories.
- Fedora: https://packages.fedoraproject.org/
  - Use `pip` package linked above. Not available in the Fedora repositories.
- Arch: https://www.archlinux.org/packages/
  -https://archlinux.org/packages/extra/any/python-overrides/
- Gentoo: https://packages.gentoo.org/
  - Not available
- macOS: https://formulae.brew.sh/
  - Use `pip` package linked above. Not available in the Homebrew repositories.
- Alpine: https://pkgs.alpinelinux.org/packages
  - Not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - Not available
- openSUSE: https://software.opensuse.org/package/
  - Not available
- rhel: https://rhel.pkgs.org/
  - Not available
