### PR TITLE
Add `scikit-spatial` to python rosdeps

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8587,6 +8587,19 @@ python3-schema:
       packages: [schema]
   rhel: [python3-schema]
   ubuntu: [python3-schema]
+python3-scikit-spatial-pip:
+  debian:
+    pip:
+      packages: [scikit-spatial]
+  fedora:
+    pip:
+      packages: [scikit-spatial]
+  osx:
+    pip:
+      packages: [scikit-spatial]
+  ubuntu:
+    pip:
+      packages: [scikit-spatial]
 python3-scipy:
   arch: [python-scipy]
   debian: [python3-scipy]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`scikit-spatial`

## Package Upstream Source:

https://github.com/ajhynes7/scikit-spatial

## Purpose of using this:

This package provides a convenient way to reason about spatial objects (e.g., plane, sphere, etc.) and computations (e.g., projection, intersection, etc.) based on numpy arrays.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- pip: https://pypi.org
    - https://pypi.org/project/scikit-spatial/
- Debian: https://packages.debian.org/
  - Use `pip` package linked above. Not available in the Debian repositories.
- Ubuntu: https://packages.ubuntu.com/
  - Use `pip` package linked above. Not available in the Ubuntu repositories.
- Fedora: https://packages.fedoraproject.org/
  - Use `pip` package linked above. Not available in the Fedora repositories.
- Arch: https://www.archlinux.org/packages/
  -Not available
- Gentoo: https://packages.gentoo.org/
  - Not available
- macOS: https://formulae.brew.sh/
  - Use `pip` package linked above. Not available in the Homebrew repositories.
- Alpine: https://pkgs.alpinelinux.org/packages
  - Not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - Not available
- openSUSE: https://software.opensuse.org/package/
  - Not available
- rhel: https://rhel.pkgs.org/
  - Not available
