### PR TITLE
Add several missing RHEL and Fedora rules for ROS 2

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -856,6 +856,7 @@ dpkg:
   gentoo: [app-arch/dpkg]
   nixos: [dpkg]
   openembedded: [dpkg@openembedded-core]
+  rhel: [dpkg]
   ubuntu: [dpkg]
 dpkg-dev:
   debian: [dpkg-dev]
@@ -1914,8 +1915,10 @@ hdf5:
   ubuntu: [libhdf5-dev]
 hdf5-tools:
   debian: [hdf5-tools]
+  fedora: [hdf5]
   gentoo: [sci-libs/hdf5]
   nixos: [hdf5]
+  rhel: [hdf5]
   ubuntu: [hdf5-tools]
 hostapd:
   arch: [hostapd]
@@ -2372,6 +2375,7 @@ leveldb:
   gentoo: [dev-libs/leveldb]
   nixos: [leveldb]
   openembedded: [leveldb@meta-oe]
+  rhel: [leveldb-devel]
   ubuntu: [libleveldb-dev]
 lib32asound2:
   debian: [lib32asound2]
@@ -3800,6 +3804,7 @@ libhdf5-dev:
   gentoo: [sci-libs/hdf5]
   nixos: [hdf5]
   openembedded: [hdf5@meta-oe]
+  rhel: [hdf5-devel]
   ubuntu: [libhdf5-dev]
 libhidapi-dev:
   debian: [libhidapi-dev]
@@ -4527,6 +4532,9 @@ libopenscenegraph:
   gentoo: [dev-games/openscenegraph]
   nixos: [openscenegraph]
   opensuse: [OpenSceneGraph, libOpenSceneGraph-devel, libOpenThreads-devel]
+  rhel:
+    '*': [OpenSceneGraph, OpenSceneGraph-devel, OpenThreads, OpenThreads-devel]
+    '8': null
   ubuntu: [openscenegraph, libopenscenegraph-dev]
 libopensplice67:
   gentoo: [=sci-libs/opensplice-6.7.*]
@@ -7355,7 +7363,9 @@ qml-module-qtquick-dialogs:
   ubuntu: [qml-module-qtquick-dialogs]
 qml-module-qtquick-extras:
   debian: [qml-module-qtquick-extras]
+  fedora: [qt5-qtquickcontrols]
   gentoo: [dev-qt/qtquickcontrols]
+  rhel: [qt5-qtquickcontrols]
   ubuntu: [qml-module-qtquick-extras]
 qml-module-qtquick-layouts:
   debian: [qml-module-qtquick-layouts]
@@ -8594,6 +8604,7 @@ xterm:
   gentoo: [x11-terms/xterm]
   nixos: [xterm]
   openembedded: [xterm@meta-oe]
+  rhel: [xterm]
   ubuntu: [xterm]
 xulrunner-1.9.2:
   arch: [xulrunner]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5519,6 +5519,7 @@ python3-distro:
   fedora: [python3-distro]
   gentoo: [dev-python/distro]
   nixos: [python3Packages.distro]
+  rhel: [python3-distro]
   ubuntu: [python3-distro]
 python3-distutils:
   debian:
@@ -6334,6 +6335,7 @@ python3-graphviz:
   gentoo: [dev-python/graphviz]
   nixos: [python3Packages.graphviz]
   opensuse: [python3-graphviz]
+  rhel: [python3-pygraphviz]
   ubuntu: [python3-graphviz]
 python3-grip:
   debian:
@@ -7293,6 +7295,9 @@ python3-openai-pip:
     pip:
       packages: [openai]
   fedora:
+    pip:
+      packages: [openai]
+  rhel:
     pip:
       packages: [openai]
   ubuntu:
@@ -9093,6 +9098,7 @@ python3-tabulate:
   fedora: [python3-tabulate]
   gentoo: [dev-python/tabulate]
   nixos: [python3Packages.tabulate]
+  rhel: [python3-tabulate]
   ubuntu: [python3-tabulate]
 python3-tensorboardX-pip:
   debian:
@@ -9228,6 +9234,7 @@ python3-tqdm:
   osx:
     pip:
       packages: [tqdm]
+  rhel: [python3-tqdm]
   ubuntu:
     '*': [python3-tqdm]
 python3-transformers-pip:


### PR DESCRIPTION
These rules satisfy keys which are used in ROS 2 Humble.

* `dpkg`: https://packages.fedoraproject.org/pkgs/dpkg/dpkg/
* `hdf5`: https://packages.fedoraproject.org/pkgs/hdf5/hdf5-devel/
* `leveldb-devel`: https://packages.fedoraproject.org/pkgs/leveldb/leveldb-devel/
* `hdf5-devel`: https://packages.fedoraproject.org/pkgs/hdf5/hdf5-devel/
* `OpenSceneGraph`: https://packages.fedoraproject.org/pkgs/OpenSceneGraph/OpenSceneGraph/
* `OpenSceneGraph-devel`: https://packages.fedoraproject.org/pkgs/OpenSceneGraph/OpenSceneGraph-devel/
* `OpenThreads`: https://packages.fedoraproject.org/pkgs/OpenSceneGraph/OpenThreads/
* `OpenThreads-devel`: https://packages.fedoraproject.org/pkgs/OpenSceneGraph/OpenThreads-devel/
* `qt5-qtquickcontrols`:
  - Fedora: https://packages.fedoraproject.org/pkgs/qt5-qtquickcontrols/qt5-qtquickcontrols/
  - RHEL: https://almalinux.pkgs.org/9/almalinux-appstream-x86_64/qt5-qtquickcontrols-5.15.9-1.el9.x86_64.rpm.html
 * `xterm`: https://almalinux.pkgs.org/9/almalinux-appstream-x86_64/xterm-366-9.el9.x86_64.rpm.html
 * `python3-distro`: https://almalinux.pkgs.org/9/almalinux-appstream-x86_64/python3-distro-1.5.0-7.el9.noarch.rpm.html
 * `python3-pygraphviz`: https://packages.fedoraproject.org/pkgs/python-pygraphviz/python3-pygraphviz/
 * `python3-tabulate`: https://packages.fedoraproject.org/pkgs/python-tabulate/python3-tabulate/
 * `python3-tqdm`: https://packages.fedoraproject.org/pkgs/python-tqdm/python3-tqdm/