### PR TITLE
rosdep: nixos: Add python3-lttng package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6738,6 +6738,7 @@ python3-lttng:
   arch: [python-lttngust]
   debian: [python3-lttng]
   fedora: [python3-lttng]
+  nixos: [python3Packages.lttng]
   openembedded: [lttng-tools@openembedded-core]
   rhel:
     '*': [python3-lttng]


### PR DESCRIPTION
This add the NixOS entry for `python3-lttng`, as it was [recently added to Nixpkgs](https://github.com/NixOS/nixpkgs/pull/285390).

https://nixpkgs.dev/python311Packages.lttng