### PR TITLE
[rolling] Upgrade fastrtps to 2.13.x

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1402,7 +1402,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/eProsima/Fast-RTPS.git
-      version: 2.11.x
+      version: 2.13.x
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1413,7 +1413,7 @@ repositories:
       test_pull_requests: false
       type: git
       url: https://github.com/eProsima/Fast-DDS.git
-      version: 2.11.x
+      version: 2.13.x
     status: maintained
   ffmpeg_image_transport:
     doc:


### PR DESCRIPTION
This is to make rosdistro consistent with https://github.com/ros2/ros2/pull/1510

Related to #39911, where `2.13.2-1` was released with bloom