### PR TITLE
mp2p_icp: 1.2.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3313,7 +3313,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 1.1.1-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `1.2.0-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.1-1`

## mp2p_icp

```
* Add new apps: sm-cli, mm-info, txt2mm, mm2txt, mm-filter
* Improved documentation.
* new filter FilterByIntensity
* FilterNormalizeIntensity: add option for intensity range memory
* FilterByRange: renamed params to simplify them (removed param 'keep_between')
* FIX: missing intensity channel in decimate voxel when using some decimation methods
* sm-cli: new subcommand 'level' to maximize the 'horizontality' of built maps
* add optional profiler to filter pipelines
* Contributors: Jose Luis Blanco-Claraco
```
