### PR TITLE
geometry2: 0.25.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2357,7 +2357,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.25.5-1
+      version: 0.25.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.25.6-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.25.5-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* Fix constantly increasing memory in std::list (#648 <https://github.com/ros2/geometry2/issues/648>)
* Contributors: Ignacio Vizzo
```

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

```
* When finding Python3, use python3 executable as a hint (#650 <https://github.com/ros2/geometry2/issues/650>)
* Contributors: Scott K Logan
```

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

```
* When finding Python3, use python3 executable as a hint (#650 <https://github.com/ros2/geometry2/issues/650>)
* Contributors: Scott K Logan
```

## tf2_ros

- No changes

## tf2_ros_py

- No changes

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
