### PR TITLE
data_tamer: 0.9.4-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -935,7 +935,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/data_tamer-release.git
-      version: 0.9.1-1
+      version: 0.9.4-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `data_tamer` to `0.9.4-2`:

- upstream repository: https://github.com/PickNikRobotics/data_tamer.git
- release repository: https://github.com/ros2-gbp/data_tamer-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.9.1-1`

## data_tamer_cpp

```
* changed the way registerValue throws if you try registering the same address again
* add unit tests to verify that vectors with changing size are OK
* Contributors: Davide Faconti
```

## data_tamer_msgs

- No changes
