### PR TITLE
pointcloud_to_laserscan: 2.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4086,7 +4086,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pointcloud_to_laserscan-release.git
-      version: 2.0.1-3
+      version: 2.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pointcloud_to_laserscan` to `2.0.2-1`:

- upstream repository: https://github.com/ros-perception/pointcloud_to_laserscan.git
- release repository: https://github.com/ros2-gbp/pointcloud_to_laserscan-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.1-3`

## pointcloud_to_laserscan

```
* feat: use exported targets (#69 <https://github.com/ros-perception/pointcloud_to_laserscan/issues/69>)
* Stop using the deprecated tf2_sensor_msgs.h header. (#73 <https://github.com/ros-perception/pointcloud_to_laserscan/issues/73>)
* Fix default parameters in README (#65 <https://github.com/ros-perception/pointcloud_to_laserscan/issues/65>)
* fix: update static transfrom publisher arguments (#70 <https://github.com/ros-perception/pointcloud_to_laserscan/issues/70>)
* Cleanup CMakeLists.txt with ament_cmake_auto (#57 <https://github.com/ros-perception/pointcloud_to_laserscan/issues/57>)
* Add BSD-3 clause LICENSE
* Contributors: Carlos Andrés Álvarez Restrepo, Chris Lalancette, Daisuke Nishimatsu, Michel Hidalgo
```
