### PR TITLE
launch: 1.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3127,7 +3127,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `1.0.5-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.4-1`

## launch

```
* Backport error message improvements (#754 <https://github.com/ros2/launch/issues/754>)
* Contributors: David Yackzan
```

## launch_pytest

- No changes

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* Backport error message improvements (#754 <https://github.com/ros2/launch/issues/754>)
* Contributors: David Yackzan
```

## launch_yaml

```
* Backport error message improvements (#754 <https://github.com/ros2/launch/issues/754>)
* Contributors: David Yackzan
```
