### PR TITLE
rclpy: 3.3.12-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5950,7 +5950,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 3.3.11-1
+      version: 3.3.12-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `3.3.12-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.3.11-1`

## rclpy

```
* Don't crash the action server if the client goes away. (#1114 <https://github.com/ros2/rclpy/issues/1114>) (#1218 <https://github.com/ros2/rclpy/issues/1218>)
* Contributors: mergify[bot]
```
