### PR TITLE
rcpputils: 2.4.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5966,7 +5966,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 2.4.1-1
+      version: 2.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `2.4.2-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.4.1-1`

## rcpputils

```
* Included tl_expected (backport #185 <https://github.com/ros2/rcpputils/issues/185>) (#186 <https://github.com/ros2/rcpputils/issues/186>)
* humble: fix <cstdint> error (#184 <https://github.com/ros2/rcpputils/issues/184>)
* Contributors: Bernd Müller, mergify[bot]
```
