### PR TITLE
rviz: 11.2.11-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7838,7 +7838,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 11.2.10-1
+      version: 11.2.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `11.2.11-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `11.2.10-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Append measured subscription frequency to topic status (#1113 <https://github.com/ros2/rviz/issues/1113>) (#1129 <https://github.com/ros2/rviz/issues/1129>)
* Contributors: mergify[bot]
```

## rviz_default_plugins

```
* Fixed transport name in DepthCloud plugin (#1134 <https://github.com/ros2/rviz/issues/1134>) (#1135 <https://github.com/ros2/rviz/issues/1135>)
* Append measured subscription frequency to topic status (#1113 <https://github.com/ros2/rviz/issues/1113>) (#1129 <https://github.com/ros2/rviz/issues/1129>)
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
