### PR TITLE
bno055: 0.5.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -603,7 +603,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/bno055-release.git
-      version: 0.4.1-4
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/flynneva/bno055.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bno055` to `0.5.0-1`:

- upstream repository: https://github.com/flynneva/bno055.git
- release repository: https://github.com/ros2-gbp/bno055-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.1-4`

## bno055

```
* Bump to 0.5.0 to prep for release
* Added Gravity publisher (#64 <https://github.com/flynneva/bno055/issues/64>)
  * Added Gravity publisher
  * Updated Readme to introduce Gravity publisher
* Spelling/Grammar (#62 <https://github.com/flynneva/bno055/issues/62>)
* Fix uart write answer reading (#57 <https://github.com/flynneva/bno055/issues/57>)
* Update package.xml to include smbus dependency (#58 <https://github.com/flynneva/bno055/issues/58>)
* fix build error on foxy that caused by typo (#59 <https://github.com/flynneva/bno055/issues/59>)
* Contributors: Andrew Symington, Burak Guler, Combinatrix, Evan Flynn, Vintheruler1, emilnovak
```
