### PR TITLE
cob_command_tools: 0.6.34-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1048,7 +1048,7 @@ repositories:
   cob_command_tools:
     doc:
       type: git
-      url: https://github.com/ipa320/cob_command_tools.git
+      url: https://github.com/4am-robotics/cob_command_tools.git
       version: indigo_release_candidate
     release:
       packages:
@@ -1068,7 +1068,7 @@ repositories:
       version: 0.6.34-1
     source:
       type: git
-      url: https://github.com/ipa320/cob_command_tools.git
+      url: https://github.com/4am-robotics/cob_command_tools.git
       version: indigo_dev
     status: maintained
   cob_common:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1056,7 +1056,6 @@ repositories:
       - cob_command_tools
       - cob_dashboard
       - cob_helper_tools
-      - cob_interactive_teleop
       - cob_monitoring
       - cob_script_server
       - cob_teleop
@@ -1065,8 +1064,8 @@ repositories:
       - service_tools
       tags:
         release: release/noetic/{package}/{version}
-      url: https://github.com/ipa320/cob_command_tools-release.git
-      version: 0.6.33-1
+      url: https://github.com/4am-robotics/cob_command_tools-release.git
+      version: 0.6.34-1
     source:
       type: git
       url: https://github.com/ipa320/cob_command_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.34-1`:

- upstream repository: https://github.com/4am-robotics/cob_command_tools.git
- release repository: https://github.com/4am-robotics/cob_command_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.33-1`

## cob_command_gui

- No changes

## cob_command_tools

```
* Merge pull request #341 <https://github.com/4am-robotics/cob_command_tools/issues/341> from fmessmer/feature/optimize_workspace
  [WIP] optimize workspace
* remove cob_interactive_teleop
* Contributors: Felix Messmer, fmessmer
```

## cob_dashboard

- No changes

## cob_helper_tools

```
* Merge pull request #336 <https://github.com/4am-robotics/cob_command_tools/issues/336> from HannesBachter/feature/delay_retry
  make delay for retry configurable
* make delay for retry configurable
* Contributors: Felix Messmer, HannesBachter
```

## cob_monitoring

```
* Merge pull request #340 <https://github.com/4am-robotics/cob_command_tools/issues/340> from fmessmer/migrate_ipa320
  migrate ipa320
* properly specify dependency
* Merge pull request #338 <https://github.com/4am-robotics/cob_command_tools/issues/338> from Deleh/fix/netdata_swap_chart
  Support New Netdata Swap Chart Name
* add netdata version to cpu info
* support new netdata swap chart name
* Contributors: Denis Lehmann, Felix Messmer, fmessmer
```

## cob_script_server

- No changes

## cob_teleop

```
* Merge pull request #340 <https://github.com/4am-robotics/cob_command_tools/issues/340> from fmessmer/migrate_ipa320
  migrate ipa320
* remove outdated readme
* Contributors: Felix Messmer, fmessmer
```

## generic_throttle

- No changes

## scenario_test_tools

- No changes

## service_tools

- No changes
