### PR TITLE
caret_analyze_cpp_impl: 0.5.0-4 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -833,7 +833,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/caret_analyze_cpp_impl-release.git
-      version: 0.5.0-2
+      version: 0.5.0-4
     source:
       type: git
       url: https://github.com/tier4/caret_analyze_cpp_impl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `caret_analyze_cpp_impl` to `0.5.0-4`:

- upstream repository: https://github.com/tier4/caret_analyze_cpp_impl.git
- release repository: https://github.com/ros2-gbp/caret_analyze_cpp_impl-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.5.0-2`

## caret_analyze_cpp_impl

```
* chore: update package.xml version to 0.4.24 (#192 <https://github.com/tier4/caret_analyze_cpp_impl/issues/192>)
* Contributors: h-suzuki-isp
```
