### PR TITLE
point_cloud_transport: 3.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4032,7 +4032,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 3.0.3-1
+      version: 3.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `3.0.4-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.3-1`

## point_cloud_transport

```
* Cleanup republisher (#58 <https://github.com/ros-perception/point_cloud_transport/issues/58>)
* Fixed clang issues (#55 <https://github.com/ros-perception/point_cloud_transport/issues/55>)
* Fixed MacOS M1 build (#57 <https://github.com/ros-perception/point_cloud_transport/issues/57>)
* Contributors: Alejandro Hernández Cordero
```

## point_cloud_transport_py

- No changes
