### PR TITLE
cob_supported_robots: 0.6.18-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1385,7 +1385,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_supported_robots-release.git
-      version: 0.6.17-1
+      version: 0.6.18-1
     source:
       type: git
       url: https://github.com/ipa320/cob_supported_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_supported_robots` to `0.6.18-1`:

- upstream repository: https://github.com/ipa320/cob_supported_robots.git
- release repository: https://github.com/ipa320/cob_supported_robots-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.17-1`

## cob_supported_robots

```
* Merge pull request #32 <https://github.com/ipa320/cob_supported_robots/issues/32> from fmessmer/ci/gha
  migrate ci to gha
* migrate ci to gha
* remove kinetic jobs
* Contributors: Felix Messmer, fmessmer
```
