### PR TITLE
cob_simulation: 0.7.7-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1349,7 +1349,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_simulation-release.git
-      version: 0.7.7-1
+      version: 0.7.7-2
     source:
       type: git
       url: https://github.com/ipa320/cob_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_simulation` to `0.7.7-2`:

- upstream repository: https://github.com/ipa320/cob_simulation.git
- release repository: https://github.com/ipa320/cob_simulation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.7-1`

## cob_bringup_sim

- No changes

## cob_gazebo

- No changes

## cob_gazebo_objects

- No changes

## cob_gazebo_tools

- No changes

## cob_gazebo_worlds

- No changes

## cob_simulation

- No changes
