### PR TITLE
moveit_resources: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3110,7 +3110,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_resources-release.git
-      version: 2.1.1-1
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_resources.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `3.0.0-1`:

- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros2-gbp/moveit_resources-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.1-1`

## dual_arm_panda_moveit_config

```
* Update ros2 control usage (#192 <https://github.com/ros-planning/moveit_resources/issues/192>)
  * Update ros2_control usage
  * Update dual_arm_panda_moveit_config/config/panda_hand.ros2_control.xacro
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  ---------
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
* Update planner configs (#191 <https://github.com/ros-planning/moveit_resources/issues/191>)
* Update planning pipeline configs (#189 <https://github.com/ros-planning/moveit_resources/issues/189>)
* fix warnings about deprecated load_yaml (#188 <https://github.com/ros-planning/moveit_resources/issues/188>)
* Contributors: Christian Rauch, Sebastian Jahr
```

## moveit_resources

- No changes

## moveit_resources_fanuc_description

- No changes

## moveit_resources_fanuc_moveit_config

```
* Update ros2 control usage (#192 <https://github.com/ros-planning/moveit_resources/issues/192>)
  * Update ros2_control usage
  * Update dual_arm_panda_moveit_config/config/panda_hand.ros2_control.xacro
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  ---------
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
* Update planner configs (#191 <https://github.com/ros-planning/moveit_resources/issues/191>)
* Update planning pipeline configs (#189 <https://github.com/ros-planning/moveit_resources/issues/189>)
* fix warnings about deprecated load_yaml (#188 <https://github.com/ros-planning/moveit_resources/issues/188>)
* Contributors: Christian Rauch, Sebastian Jahr
```

## moveit_resources_panda_description

```
* Create Panda URDF Xacro, restore URDF for RobotModelTestUtils (#178 <https://github.com/ros-planning/moveit_resources/issues/178>)
* Apply inertial,dynamics and fix mesh locations (#176 <https://github.com/ros-planning/moveit_resources/issues/176>)
* Contributors: Henning Kayser
```

## moveit_resources_panda_moveit_config

```
* Update acceleration limits for robot configs (#195 <https://github.com/ros-planning/moveit_resources/issues/195>)
  * update panda
  * rename file to joint_limits_jerk_limited.yaml
  * rename to hard_joint_limits.yaml
  ---------
* Update ros2 control usage (#192 <https://github.com/ros-planning/moveit_resources/issues/192>)
  * Update ros2_control usage
  * Update dual_arm_panda_moveit_config/config/panda_hand.ros2_control.xacro
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  ---------
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
* Update planner configs (#191 <https://github.com/ros-planning/moveit_resources/issues/191>)
* Update planning pipeline configs (#189 <https://github.com/ros-planning/moveit_resources/issues/189>)
* Fix Panda demo launch for MoveIt 2 tutorials (#190 <https://github.com/ros-planning/moveit_resources/issues/190>)
* Add bio_ik and TRAC-IK kinematics configs (#187 <https://github.com/ros-planning/moveit_resources/issues/187>)
* Remove unsupported planner configs (#182 <https://github.com/ros-planning/moveit_resources/issues/182>)
* Create Panda URDF Xacro, restore URDF for RobotModelTestUtils (#178 <https://github.com/ros-planning/moveit_resources/issues/178>)
* Contributors: Henning Kayser, Paul Gesel, Sebastian Castro, Sebastian Jahr
```

## moveit_resources_pr2_description

- No changes
