### PR TITLE
cob_manipulation: 0.7.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1256,7 +1256,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_manipulation-release.git
-      version: 0.7.8-1
+      version: 0.7.9-1
     source:
       type: git
       url: https://github.com/ipa320/cob_manipulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_manipulation` to `0.7.9-1`:

- upstream repository: https://github.com/ipa320/cob_manipulation.git
- release repository: https://github.com/ipa320/cob_manipulation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.8-1`

## cob_collision_monitor

- No changes

## cob_grasp_generation

- No changes

## cob_lookat_action

- No changes

## cob_manipulation

- No changes

## cob_manipulation_msgs

- No changes

## cob_moveit_bringup

- No changes

## cob_moveit_interface

- No changes
