### PR TITLE
cob_calibration_data: 0.6.19-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1039,7 +1039,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_calibration_data-release.git
-      version: 0.6.18-1
+      version: 0.6.19-1
     source:
       type: git
       url: https://github.com/ipa320/cob_calibration_data.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_calibration_data` to `0.6.19-1`:

- upstream repository: https://github.com/ipa320/cob_calibration_data.git
- release repository: https://github.com/ipa320/cob_calibration_data-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.18-1`

## cob_calibration_data

```
* remove travis file
* Merge pull request #170 <https://github.com/ipa320/cob_calibration_data/issues/170> from fmessmer/ci/gha
  migrate ci to gha
* migrate ci to gha
* remove kinetic jobs
* Contributors: Felix Messmer, fmessmer
```
