### PR TITLE
care-o-bot: 0.7.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -707,7 +707,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/care-o-bot-release.git
-      version: 0.7.10-1
+      version: 0.7.11-1
     source:
       type: git
       url: https://github.com/ipa320/care-o-bot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `care-o-bot` to `0.7.11-1`:

- upstream repository: https://github.com/ipa320/care-o-bot.git
- release repository: https://github.com/ipa320/care-o-bot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.10-1`

## care_o_bot

- No changes

## care_o_bot_desktop

- No changes

## care_o_bot_robot

- No changes

## care_o_bot_simulation

- No changes
