### PR TITLE
kinematics_interface: 0.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2997,7 +2997,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
-      version: 0.2.0-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematics_interface` to `0.3.0-1`:

- upstream repository: https://github.com/ros-controls/kinematics_interface.git
- release repository: https://github.com/ros2-gbp/kinematics_interface-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.0-1`

## kinematics_interface

```
* Move definition logger to cpp to avoid "multiple definition" linker error (backport #21 <https://github.com/ros-controls/kinematics_interface/issues/21>) (#32 <https://github.com/ros-controls/kinematics_interface/issues/32>)
* Contributors: mergify[bot]
```

## kinematics_interface_kdl

- No changes
