### PR TITLE
cob_common: 0.7.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1087,8 +1087,8 @@ repositories:
       - raw_description
       tags:
         release: release/noetic/{package}/{version}
-      url: https://github.com/ipa320/cob_common-release.git
-      version: 0.7.9-1
+      url: https://github.com/4am-robotics/cob_common-release.git
+      version: 0.7.10-1
     source:
       type: git
       url: https://github.com/ipa320/cob_common.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1075,7 +1075,7 @@ repositories:
   cob_common:
     doc:
       type: git
-      url: https://github.com/ipa320/cob_common.git
+      url: https://github.com/4am-robotics/cob_common.git
       version: kinetic_release_candidate
     release:
       packages:
@@ -1091,7 +1091,7 @@ repositories:
       version: 0.7.10-1
     source:
       type: git
-      url: https://github.com/ipa320/cob_common.git
+      url: https://github.com/4am-robotics/cob_common.git
       version: kinetic_dev
     status: maintained
   cob_control:


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `0.7.10-1`:

- upstream repository: https://github.com/4am-robotics/cob_common.git
- release repository: https://github.com/4am-robotics/cob_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.9-1`

## cob_actions

- No changes

## cob_common

- No changes

## cob_description

- No changes

## cob_msgs

- No changes

## cob_srvs

- No changes

## raw_description

- No changes
