### PR TITLE
cob_control: 0.8.23-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1097,7 +1097,7 @@ repositories:
   cob_control:
     doc:
       type: git
-      url: https://github.com/ipa320/cob_control.git
+      url: https://github.com/4am-robotics/cob_control.git
       version: melodic_release_candidate
     release:
       packages:
@@ -1124,7 +1124,7 @@ repositories:
       version: 0.8.23-1
     source:
       type: git
-      url: https://github.com/ipa320/cob_control.git
+      url: https://github.com/4am-robotics/cob_control.git
       version: melodic_dev
     status: maintained
   cob_driver:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1120,8 +1120,8 @@ repositories:
       - cob_twist_controller
       tags:
         release: release/noetic/{package}/{version}
-      url: https://github.com/ipa320/cob_control-release.git
-      version: 0.8.22-1
+      url: https://github.com/4am-robotics/cob_control-release.git
+      version: 0.8.23-1
     source:
       type: git
       url: https://github.com/ipa320/cob_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.8.23-1`:

- upstream repository: https://github.com/4am-robotics/cob_control.git
- release repository: https://github.com/4am-robotics/cob_control-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.8.22-1`

## cob_base_controller_utils

- No changes

## cob_base_velocity_smoother

- No changes

## cob_cartesian_controller

```
* Merge pull request #281 <https://github.com/4am-robotics/cob_control/issues/281> from fmessmer/feature/optimize_workspace
  optimize workspace
* remove --inorder args
* Contributors: Felix Messmer, fmessmer
```

## cob_collision_velocity_filter

- No changes

## cob_control

- No changes

## cob_control_mode_adapter

- No changes

## cob_control_msgs

- No changes

## cob_footprint_observer

- No changes

## cob_frame_tracker

- No changes

## cob_hardware_emulation

```
* Merge pull request #279 <https://github.com/4am-robotics/cob_control/issues/279> from fmessmer/fix/emulation
  reliable start
* reliable start
* Contributors: Felix Messmer, fmessmer
```

## cob_mecanum_controller

- No changes

## cob_model_identifier

- No changes

## cob_obstacle_distance

```
* Merge pull request #281 <https://github.com/4am-robotics/cob_control/issues/281> from fmessmer/feature/optimize_workspace
  optimize workspace
* use mojin_gazebo_objects
* remove --inorder args
* Contributors: Felix Messmer, fmessmer
```

## cob_omni_drive_controller

- No changes

## cob_trajectory_controller

- No changes

## cob_tricycle_controller

- No changes

## cob_twist_controller

```
* Merge pull request #281 <https://github.com/4am-robotics/cob_control/issues/281> from fmessmer/feature/optimize_workspace
  optimize workspace
* remove --inorder args
* Contributors: Felix Messmer, fmessmer
```
