### PR TITLE
cob_driver: 0.7.16-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1130,7 +1130,7 @@ repositories:
   cob_driver:
     doc:
       type: git
-      url: https://github.com/ipa320/cob_driver.git
+      url: https://github.com/4am-robotics/cob_driver.git
       version: kinetic_release_candidate
     release:
       packages:
@@ -1160,7 +1160,7 @@ repositories:
       version: 0.7.16-2
     source:
       type: git
-      url: https://github.com/ipa320/cob_driver.git
+      url: https://github.com/4am-robotics/cob_driver.git
       version: kinetic_dev
     status: maintained
   cob_environments:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1156,8 +1156,8 @@ repositories:
       - laser_scan_densifier
       tags:
         release: release/noetic/{package}/{version}
-      url: https://github.com/ipa320/cob_driver-release.git
-      version: 0.7.15-1
+      url: https://github.com/4am-robotics/cob_driver-release.git
+      version: 0.7.16-2
     source:
       type: git
       url: https://github.com/ipa320/cob_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_driver` to `0.7.16-2`:

- upstream repository: https://github.com/4am-robotics/cob_driver.git
- release repository: https://github.com/4am-robotics/cob_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.15-1`

## cob_base_drive_chain

- No changes

## cob_bms_driver

- No changes

## cob_canopen_motor

- No changes

## cob_driver

- No changes

## cob_elmo_homing

- No changes

## cob_generic_can

- No changes

## cob_light

- No changes

## cob_mimic

- No changes

## cob_phidget_em_state

- No changes

## cob_phidget_power_state

- No changes

## cob_phidgets

- No changes

## cob_relayboard

- No changes

## cob_scan_unifier

```
* Merge pull request #443 <https://github.com/4am-robotics/cob_driver/issues/443> from mbeutelspacher/fix/scan_unifier_negative_angle_increment
  fix(cob_scan_unifier): fix handeling of negative angle_increments
* fix(cob_scan_unifier): fix handeling of negative angle_increments
  laser scanners that are upside down often have negative
  angle_increments (and also angle_max < angle_min).
  Since we use angle_max=M_PI angle_min=-M_PI in the unified scan here, we
  can't just copy the angle increment but need to use the absolute value
  of angle_increments
* Contributors: Felix Messmer, Max Beutelspacher
```

## cob_sick_lms1xx

- No changes

## cob_sick_s300

- No changes

## cob_sound

- No changes

## cob_undercarriage_ctrl

- No changes

## cob_utilities

- No changes

## cob_voltage_control

- No changes

## laser_scan_densifier

- No changes
