### PR TITLE
rqt_gauges: 0.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7419,7 +7419,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_gauges-release.git
-      version: 0.0.1-1
+      version: 0.0.2-1
     source:
       test_pull_requests: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_gauges` to `0.0.2-1`:

- upstream repository: https://github.com/ToyotaResearchInstitute/gauges2
- release repository: https://github.com/ros2-gbp/rqt_gauges-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.1-1`

## rqt_gauges

```
* Included build status (#34 <https://github.com/ToyotaResearchInstitute/gauges2/issues/34>)
* Raname speedometer and steering wheel widgets (#33 <https://github.com/ToyotaResearchInstitute/gauges2/issues/33>)
* Bar gauge (#32 <https://github.com/ToyotaResearchInstitute/gauges2/issues/32>)
* Show raw values. (#31 <https://github.com/ToyotaResearchInstitute/gauges2/issues/31>)
* Allow drag and drop from rqt_topic_monitor (#29 <https://github.com/ToyotaResearchInstitute/gauges2/issues/29>)
  Co-authored-by: Carlos Agüero <mailto:caguero@openrobotics.org>
* Fixed crashes (#30 <https://github.com/ToyotaResearchInstitute/gauges2/issues/30>)
* Steerirng Wheel widget truncated value (#28 <https://github.com/ToyotaResearchInstitute/gauges2/issues/28>)
* Contributors: Alejandro Hernández Cordero, Carlos Agüero
```
