### PR TITLE
cob_common: 2.7.10-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1078,8 +1078,8 @@ repositories:
       - cob_srvs
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/ipa320/cob_common-release.git
-      version: 2.7.9-1
+      url: https://github.com/4am-robotics/cob_common-release.git
+      version: 2.7.10-1
     source:
       type: git
       url: https://github.com/ipa320/cob_common.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1069,7 +1069,7 @@ repositories:
   cob_common:
     doc:
       type: git
-      url: https://github.com/ipa320/cob_common.git
+      url: https://github.com/4am-robotics/cob_common.git
       version: foxy
     release:
       packages:
@@ -1082,7 +1082,7 @@ repositories:
       version: 2.7.10-1
     source:
       type: git
-      url: https://github.com/ipa320/cob_common.git
+      url: https://github.com/4am-robotics/cob_common.git
       version: foxy
     status: maintained
   color_names:


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `2.7.10-1`:

- upstream repository: https://github.com/4am-robotics/cob_common.git
- release repository: https://github.com/4am-robotics/cob_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.7.9-1`

## cob_actions

- No changes

## cob_msgs

- No changes

## cob_srvs

- No changes
