### PR TITLE
psdk_ros2: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5406,7 +5406,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/psdk_ros2-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/umdlife/psdk_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `psdk_ros2` to `1.1.0-1`:

- upstream repository: https://github.com/umdlife/psdk_ros2.git
- release repository: https://github.com/ros2-gbp/psdk_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.0-1`

## psdk_interfaces

```
* Merge pull request #51 <https://github.com/umdlife/psdk_ros2/issues/51> from umdlife/feat/hms-support
  Integration of Health Monitoring System (HMS) as a module
* Merge pull request #59 <https://github.com/umdlife/psdk_ros2/issues/59> from umdlife/extend_single_battery_info
  Extend single battery info
* Merge pull request #57 <https://github.com/umdlife/psdk_ros2/issues/57> from umdlife/feat/single_battery_info
  Add new message types HmsInfoMsg, HmsInfoTable
* Contributors: Stevedan, Victor Massagué Respall, amoramar, biancabnd, marta
```

## psdk_wrapper

```
* Merge pull request #51 <https://github.com/umdlife/psdk_ros2/issues/51> from umdlife/feat/hms-support
  Integration of Health Monitoring System (HMS) as a module
* Merge pull request #59 <https://github.com/umdlife/psdk_ros2/issues/59> from umdlife/extend_single_battery_info
  Extend single battery info
* Merge pull request #57 <https://github.com/umdlife/psdk_ros2/issues/57> from umdlife/feat/single_battery_info
  Adding topic for reading battery info
* Contributors: Stevedan, Victor Massagué Respall, amoramar, biancabnd, marta
```
