### PR TITLE
simple_launch: 1.9.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6537,7 +6537,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/simple_launch-release.git
-      version: 1.8.0-1
+      version: 1.9.1-1
     source:
       type: git
       url: https://github.com/oKermorgant/simple_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_launch` to `1.9.1-1`:

- upstream repository: https://github.com/oKermorgant/simple_launch.git
- release repository: https://github.com/ros2-gbp/simple_launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.8.0-1`

## simple_launch

```
* simplify + debug logic of SimpleSubstitution divisions
* image instead of /image to be detected as an image topic
* remove auto_sim_time function
* more robust to various combinations of ROS and Gazebo
* default Gazebo is still ignition Fortress, better error message about GZ_VERSION
* add new bridges for Gazebo
* Contributors: Olivier Kermorgant
```
