### PR TITLE
plotjuggler: 3.9.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7637,7 +7637,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.9.0-1
+      version: 3.9.1-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.9.1-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.9.0-1`

## plotjuggler

```
* embed zstd 1.5.5
* updated lz4 1.9.4
* PlotJuggler with Fast-CDR-2.x.x (#932 <https://github.com/facontidavide/PlotJuggler/issues/932>)
* fix ROS2 parser bug
* fix #935 <https://github.com/facontidavide/PlotJuggler/issues/935> and #934 <https://github.com/facontidavide/PlotJuggler/issues/934>
* Add Sample Count to transforms
* fix compilation in Windows
* Contributors: Davide Faconti, Manuel Valch
```
