### PR TITLE
dbw_ros: 2.1.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1360,8 +1360,6 @@ repositories:
     release:
       packages:
       - dataspeed_dbw_common
-      - dataspeed_dbw_gateway
-      - dataspeed_dbw_msgs
       - dataspeed_ulc
       - dataspeed_ulc_can
       - dataspeed_ulc_msgs
@@ -1380,10 +1378,14 @@ repositories:
       - dbw_polaris_description
       - dbw_polaris_joystick_demo
       - dbw_polaris_msgs
+      - ds_dbw
+      - ds_dbw_can
+      - ds_dbw_joystick_demo
+      - ds_dbw_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_ros-release.git
-      version: 2.1.3-1
+      version: 2.1.8-1
     source:
       type: git
       url: https://bitbucket.org/dataspeedinc/dbw_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_ros` to `2.1.8-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/dbw_ros.git
- release repository: https://github.com/DataspeedInc-release/dbw_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.3-1`

## dataspeed_dbw_common

- No changes

## dataspeed_ulc

- No changes

## dataspeed_ulc_can

- No changes

## dataspeed_ulc_msgs

- No changes

## dbw_fca

- No changes

## dbw_fca_can

- No changes

## dbw_fca_description

- No changes

## dbw_fca_joystick_demo

- No changes

## dbw_fca_msgs

- No changes

## dbw_ford

- No changes

## dbw_ford_can

- No changes

## dbw_ford_description

- No changes

## dbw_ford_joystick_demo

- No changes

## dbw_ford_msgs

- No changes

## dbw_polaris

- No changes

## dbw_polaris_can

- No changes

## dbw_polaris_description

- No changes

## dbw_polaris_joystick_demo

- No changes

## dbw_polaris_msgs

- No changes

## ds_dbw

- No changes

## ds_dbw_can

```
* Bump firmware versions to match 2024/02/21 release package
* PlatformMap as sparse std::map instead of dense std::array
* Platform/Module from EcuInfo
* Rename LimitHash to ParamHash
* Fix ULC config message transmit rate
* Add warnings for ULC preemption and lack of CRC/RC validation
* ULC demo scripts converted to DBW 2
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```

## ds_dbw_joystick_demo

- No changes

## ds_dbw_msgs

- No changes
