### PR TITLE
rtabmap_ros: 0.21.4-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6695,7 +6695,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.21.3-1
+      version: 0.21.4-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap_ros` to `0.21.4-1`:

- upstream repository: https://github.com/introlab/rtabmap_ros.git
- release repository: https://github.com/introlab/rtabmap_ros-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.21.3-1`
