### PR TITLE
added spinnaker_synchronized_camera_driver package

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2003,12 +2003,13 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git
-      version: humble-devel
+      version: humble-release
     release:
       packages:
       - flir_camera_description
       - flir_camera_msgs
       - spinnaker_camera_driver
+      - spinnaker_synchronized_camera_driver
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1553,12 +1553,13 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git
-      version: humble-devel
+      version: iron-release
     release:
       packages:
       - flir_camera_description
       - flir_camera_msgs
       - spinnaker_camera_driver
+      - spinnaker_synchronized_camera_driver
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git


### PR DESCRIPTION
# Please add spinnaker_synchronized_camera_driver package to be indexed in the rosdistro.
This package is part of the flir_camera_driver family. It supports synchronized cameras by associating frames from multiple cameras with each other, and forcing identical time stamps for frames that have been triggered by the same sync pulse.

Note: I also updated which branches should be used for the documentation.

rosdistros: Humble and Iron

# The source is here:
https://github.com/ros-drivers/flir_camera_driver.git


# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
