### PR TITLE
atf: 0.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -308,6 +308,22 @@ repositories:
       url: https://github.com/fkie/async_web_server_cpp.git
       version: ros1-develop
     status: maintained
+  atf:
+    release:
+      packages:
+      - atf
+      - atf_core
+      - atf_metrics
+      - atf_msgs
+      - atf_plotter
+      - atf_recorder_plugins
+      - atf_test
+      - atf_test_tools
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/floweisshardt/atf-release.git
+      version: 0.1.1-1
+    status: maintained
   audibot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `atf` to `0.1.1-1`:

- upstream repository: https://github.com/floweisshardt/atf.git
- release repository: https://github.com/floweisshardt/atf-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`