### PR TITLE
add trac_ik to rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7048,7 +7048,7 @@ repositories:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git
       version: rolling-devel
-    status: developed  
+    status: developed
   tracetools_acceleration:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7039,6 +7039,16 @@ repositories:
       url: https://github.com/ros-tooling/topic_tools.git
       version: rolling
     status: developed
+  trac_ik:
+    doc:
+      type: git
+      url: https://bitbucket.org/traclabs/trac_ik.git
+      version: rolling-devel
+    source:
+      type: git
+      url: https://bitbucket.org/traclabs/trac_ik.git
+      version: rolling-devel
+    status: developed  
   tracetools_acceleration:
     doc:
       type: git


### PR DESCRIPTION

# Please Add This Package to be indexed in the rosdistro.

rolling 

# The source is here:

https://bitbucket.org/traclabs/trac_ik.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
