### PR TITLE
gazebo_no_physics_plugin: 0.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2172,6 +2172,11 @@ repositories:
       type: git
       url: https://github.com/Boeing/gazebo_no_physics_plugin.git
       version: humble
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/gazebo_no_physics_plugin-release.git
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/Boeing/gazebo_no_physics_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_no_physics_plugin` to `0.1.1-1`:

- upstream repository: https://github.com/Boeing/gazebo_no_physics_plugin.git
- release repository: https://github.com/ros2-gbp/gazebo_no_physics_plugin-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## gazebo_no_physics_plugin

```
* OSS release
* Contributors: Beau Colley-Allerton, Iñigo Moreno, Jason Cochrane, Leandro Ruiz, Leandro Ruiz-Lozano, Nathan Hui, RoBeau, leandroruiz
```
