### PR TITLE
ntrip_client: 1.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4574,7 +4574,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ntrip_client-release.git
-      version: 1.2.0-1
+      version: 1.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ntrip_client` to `1.3.0-1`:

- upstream repository: https://github.com/LORD-MicroStrain/ntrip_client.git
- release repository: https://github.com/ros2-gbp/ntrip_client-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.0-1`

## ntrip_client

```
* Updates README to mention new launch parameters (#27 <https://github.com/LORD-MicroStrain/ntrip_client/issues/27>)
* Change codec to ISO-8859-1 (#46 <https://github.com/LORD-MicroStrain/ntrip_client/issues/46>)
* Prefer rtcm_msgs instead of mavros_msgs (#37 <https://github.com/LORD-MicroStrain/ntrip_client/issues/37>)
* ROS NMEA sentence min/max length (#19 <https://github.com/LORD-MicroStrain/ntrip_client/issues/19>)
  * ROS NMEA sentence variable length
  * Removes unnecesarry imports
* ROS Adds ability to publish an rtcm_msgs Message instead of a mavros_msgs RTCM (#22 <https://github.com/LORD-MicroStrain/ntrip_client/issues/22>)
  * Adds ability to publish an rtcm_msgs Message instead of a mavros_msgs RTCM
  * Renames variables to differentiate between rtcm_msgs package and the conept of an rtcm_message
* Contributors: Rob
```
