### PR TITLE
flir_camera_driver: 2.0.8-2 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1562,7 +1562,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git
-      version: 2.0.8-1
+      version: 2.0.8-2
     source:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_camera_driver` to `2.0.8-2`:

- upstream repository: https://github.com/ros-drivers/flir_camera_driver.git
- release repository: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.8-1`

## flir_camera_description

```
* fix python formatting to satisfy linter
* Contributors: Bernd Pfrommer
```

## flir_camera_msgs

- No changes

## spinnaker_camera_driver

```
* Added linux_setup_flir script instructions to Readme
* Add newline echo before Done
* Rename script to remove extension
* Ask permission for usb change and don't limit detection to 1000
* Ask about usergroup and give feedback
* Added linux pc setup script
* fix python formatting to satisfy linter
* fix formatting of BSD license to satisfy linter
* Contributors: Bernd Pfrommer, Hilary Luo
```
