### PR TITLE
octomap_mapping: 2.0.0-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3532,7 +3532,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/octomap_mapping-release.git
-      version: 2.0.0-3
+      version: 2.0.0-4
     source:
       type: git
       url: https://github.com/OctoMap/octomap_mapping.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_mapping` to `2.0.0-4`:

- upstream repository: https://github.com/OctoMap/octomap_mapping.git
- release repository: https://github.com/ros2-gbp/octomap_mapping-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-3`

## octomap_mapping

```
* ROS2 Migration (#95 <https://github.com/octomap/octomap_mapping/issues/95>)
* Contributors: Daisuke Nishimatsu
```

## octomap_server

```
* ROS2 Migration (#95 <https://github.com/octomap/octomap_mapping/issues/95>)
* Contributors: Daisuke Nishimatsu, Wolfgang Merkt
```
