### PR TITLE
octomap_mapping: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3532,7 +3532,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/octomap_mapping-release.git
-      version: 2.0.0-3
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/OctoMap/octomap_mapping.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_mapping` to `2.1.0-1`:

- upstream repository: https://github.com/OctoMap/octomap_mapping.git
- release repository: https://github.com/ros2-gbp/octomap_mapping-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-3`

## octomap_mapping

- No changes

## octomap_server

```
* Fix header include order error (#125 <https://github.com/octomap/octomap_mapping/issues/125>)
* Removed geometry2 deprecated headers (#125 <https://github.com/octomap/octomap_mapping/issues/125>)
* Fix errors when path name is invalid (#108 <https://github.com/octomap/octomap_mapping/issues/108>)
* Fix header include order (#102 <https://github.com/octomap/octomap_mapping/issues/102>)
* Contributors: Alejandro Hernández Cordero, Daisuke Nishimatsu, Wolfgang Merkt
```
