### PR TITLE
ur_client_library: 1.3.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12220,7 +12220,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
-      version: 1.3.4-1
+      version: 1.3.5-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `1.3.5-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.4-1`

## ur_client_library

```
* Add support for UR30 in start_ursim.sh (#193 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/193>)
* Add header guard to datatypes.h (#189 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/pull/189>)
* Remove duplicated entry in clang-format file (#188 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/pull/188>)
* Wait after docker kill to prevent name conflicts (#187 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/187>)
* Contributors: Felix Exner, Robert Wilbrandt
```
