### PR TITLE
gnss-info: 1.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3523,7 +3523,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/gnss-info.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ctu-vras/gnss-info.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gnss-info` to `1.0.2-1`:

- upstream repository: https://github.com/ctu-vras/gnss-info.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/gnss-info.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.1-1`

## gnss_info

```
* Removed catkin_lint buildfarm hacks.
* Do not overwrite test data.
* Fixed CMake compatibility.
* Contributors: Martin Pecka
```

## gnss_info_msgs

```
* Removed catkin_lint buildfarm hacks.
* Contributors: Martin Pecka
```

## gnsstk_ros

```
* Removed catkin_lint buildfarm hacks.
* Contributors: Martin Pecka
```
