### PR TITLE
cras_ros_utils: 2.3.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1726,7 +1726,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
-      version: 2.3.8-1
+      version: 2.3.9-1
     source:
       type: git
       url: https://github.com/ctu-vras/ros-utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_ros_utils` to `2.3.9-1`:

- upstream repository: https://github.com/ctu-vras/ros-utils
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.8-1`

## cras_cpp_common

```
* Removed catkin_lint buildfarm hacks.
* Updated to fast_float 6.1.0 .
* Contributors: Martin Pecka
```

## cras_docs_common

```
* Removed catkin_lint buildfarm hacks.
* Contributors: Martin Pecka
```

## cras_py_common

```
* Removed catkin_lint buildfarm hacks.
* Contributors: Martin Pecka
```

## cras_topic_tools

```
* Removed catkin_lint buildfarm hacks.
* Contributors: Martin Pecka
```

## image_transport_codecs

```
* Removed catkin_lint buildfarm hacks.
* Contributors: Martin Pecka
```
