### PR TITLE
Fedora 37 is EOL, long live Fedora 39

### DIFF
--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -63,8 +63,8 @@ supported_versions:
   debian:
   - bookworm
   fedora:
-  - '37'
   - '38'
+  - '39'
   opensuse:
   - '15.2'
   rhel:


### PR DESCRIPTION
https://docs.fedoraproject.org/en-US/releases/eol/