### PR TITLE
Add repository checking for OpenEmbedded rosdep rules

### DIFF
--- a/test/rosdep_repo_check/config.py
+++ b/test/rosdep_repo_check/config.py
@@ -31,6 +31,7 @@ import yaml
 
 from .apk import apk_base_url
 from .deb import deb_base_url
+from .layer_index import layer_index_url
 from .pacman import pacman_base_url
 from .rpm import rpm_base_url
 from .rpm import rpm_mirrorlist_url
@@ -48,6 +49,10 @@ def load_apk_base_url(loader, node):
 def load_deb_base_url(loader, node):
     base_url, comp = node.value.rsplit(' ', 1)
     return deb_base_url(base_url, comp)
+
+
+def load_layer_index_url(loader, node):
+    return layer_index_url(node.value)
 
 
 def load_pacman_base_url(loader, node):
@@ -71,6 +76,8 @@ yaml.add_constructor(
     u'!apk_base_url', load_apk_base_url, Loader=yaml.SafeLoader)
 yaml.add_constructor(
     u'!deb_base_url', load_deb_base_url, Loader=yaml.SafeLoader)
+yaml.add_constructor(
+    u'!layer_index_url', load_layer_index_url, Loader=yaml.SafeLoader)
 yaml.add_constructor(
     u'!pacman_base_url', load_pacman_base_url, Loader=yaml.SafeLoader)
 yaml.add_constructor(

--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -17,6 +17,8 @@ package_sources:
   - !rpm_mirrorlist_url https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
   - !rpm_mirrorlist_url https://mirrors.fedoraproject.org/mirrorlist?repo=updates-released-f$releasever&arch=$basearch
   - !rpm_mirrorlist_url https://mirrors.rpmfusion.org/mirrorlist?repo=free-fedora-$releasever&arch=$basearch
+  openembedded:
+  - !layer_index_url http://layers.openembedded.org/layerindex/api/
   opensuse:
   - !rpm_base_url http://download.opensuse.org/distribution/leap/$releasever/repo/oss/
   - !rpm_base_url http://download.opensuse.org/distribution/leap/$releasever/repo/non-oss/
@@ -48,6 +50,8 @@ package_dashboards:
   url: https://packages.debian.org/{os_code_name}/{binary_name}
 - pattern: !regular_expression .*//dl.fedoraproject.org/pub/.*
   url: https://packages.fedoraproject.org/pkgs/{source_name}/{binary_name}/
+- pattern: !regular_expression .*://layers.openembedded.org/layerindex/api/recipes/([^/]+)
+  url: https://layers.openembedded.org/layerindex/recipe/\1/
 - pattern: !regular_expression .*//download.opensuse.org/.*
   url: https://software.opensuse.org/package/{source_name}
 - pattern: !regular_expression .*//archive.ubuntu.com/ubuntu/.*
@@ -67,6 +71,8 @@ supported_versions:
   - '38'
   opensuse:
   - '15.2'
+  openembedded:
+  - master
   rhel:
   - '8'
   - '9'
@@ -86,6 +92,8 @@ supported_arches:
   - x86_64
   opensuse:
   - x86_64
+  openembedded:
+  - ''
   rhel:
   - x86_64
   ubuntu:
@@ -97,6 +105,9 @@ name_replacements:
       '%{__isa_name}': 'x86'
     '38':
       '%{__isa_name}': 'x86'
+  openembedded:
+    master:
+      '${PYTHON_PN}': 'python3'
   rhel:
     '8':
       '%{__isa_name}': 'x86'

--- a/test/rosdep_repo_check/layer_index.py
+++ b/test/rosdep_repo_check/layer_index.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2024, Open Source Robotics Foundation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Willow Garage, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import json
+import os
+
+from . import open_gz_url
+from . import PackageEntry
+from . import RepositoryCacheCollection
+
+
+def enumerate_recipes(base_url, branch_name):
+    recipes_url = os.path.join(base_url, 'recipes')
+    recipes_url += f'?filter=layerbranch__branch__name:{branch_name}'
+    print('Reading OpenEmbedded recipe metadata from ' + recipes_url)
+    with open_gz_url(recipes_url) as f:
+        yield from json.load(f)
+
+
+def enumerate_layers_by_layer_branch_id(base_url, branch_name):
+    layers = dict(enumerate_layers(base_url))
+    layer_branches_url = os.path.join(base_url, 'layerBranches')
+    layer_branches_url += f'?filter=branch__name:{branch_name}'
+    print('Reading OpenEmbedded layer branches from ' + layer_branches_url)
+    with open_gz_url(layer_branches_url) as f:
+        for layer_branch in json.load(f):
+            layer_branch_id = str(layer_branch.get('id', ''))
+            layer_id = str(layer_branch.get('layer', ''))
+            if not layer_branch_id or not layer_id:
+                continue
+
+            layer_name = layers.get(layer_id)
+            if not layer_name:
+                continue
+
+            yield (layer_branch_id, layer_name)
+
+
+def enumerate_layers(base_url):
+    layers_url = os.path.join(base_url, 'layerItems')
+    print('Reading OpenEmbedded layers from ' + layers_url)
+    with open_gz_url(layers_url) as f:
+        for layer in json.load(f):
+            layer_id = str(layer.get('id', ''))
+            layer_name = layer.get('name')
+            if not layer_id or not layer_name:
+                continue
+            yield (layer_id, layer_name)
+
+
+def enumerate_layer_index_packages(base_url, branch_name):
+    """
+    Enumerate OpenEmbedded recipes in a layer index.
+
+    :param base_url: the OpenEmbedded layer index URL.
+    :param branch_name: the OpenEmbedded branch name.
+
+    :returns: an enumeration of package entries.
+    """
+    layer_branches = dict(
+        enumerate_layers_by_layer_branch_id(base_url, branch_name))
+    for recipe in enumerate_recipes(base_url, branch_name):
+        recipe_id = str(recipe.get('id', ''))
+        layer_branch_id = str(recipe.get('layerbranch', ''))
+        pn = recipe.get('pn')
+        if not recipe_id or not layer_branch_id or not pn:
+            continue
+
+        layer = layer_branches.get(layer_branch_id)
+        if not layer:
+            continue
+
+        recipe_url = os.path.join(base_url, 'recipes', recipe_id)
+        pv = recipe.get('pv')
+        yield PackageEntry(f'{pn}@{layer}', pv, recipe_url, pn, pn)
+
+        provides = recipe.get('provides', '')
+
+        for prov in provides.split():
+            if not prov:
+                continue
+            yield PackageEntry(f'{prov}@{layer}', pv, recipe_url, pn, pn)
+
+
+def layer_index_url(base_url):
+    """
+    Create an enumerable cache for an OpenEmbedded layer index.
+
+    :param base_url: the URL of the layer index.
+
+    :returns: an enumerable repository cache instance.
+    """
+    return RepositoryCacheCollection(
+        lambda os_name, os_code_name, os_arch:
+            enumerate_layer_index_packages(base_url, os_code_name))


### PR DESCRIPTION
This change adds repository checking capabilities to OpenEmbedded rules. Though many other platforms target a specific release, it was easy to simply point this check at the `master` branch.

If any OpenEmbedded users have feedback on which branch to target or any other part of this checking logic, please feel free to comment here.

Inspired by: https://github.com/ros/rosdistro/pull/40012#issuecomment-1969010513

At present, the checker found 56 invalid rules in rosdep: <details>

```
$ PYTHONPATH=$PWD python3 -m rosdep_repo_check
Verify all rosdep keys in 'rosdep/base.yaml'
Reading OpenEmbedded layers from http://layers.openembedded.org/layerindex/api/layerItems
Reading OpenEmbedded layer branches from http://layers.openembedded.org/layerindex/api/layerBranches?filter=branch__name:master
Reading OpenEmbedded recipe metadata from http://layers.openembedded.org/layerindex/api/recipes?filter=layerbranch__branch__name:master
Verify all rosdep keys in 'rosdep/python.yaml'
* The following 56 packages were not found for openembedded master on :
- Package alsa-oss@meta-oe for rosdep key alsa-oss
- Package assimp@openembedded-core for rosdep key assimp
- Package assimp@openembedded-core for rosdep key assimp-dev
- Package clang-native@meta-clang for rosdep key clang
- Package glfw@meta-intel-realsense for rosdep key libglfw3-dev
- Package graphviz@meta-ros-common for rosdep key graphviz
- Package grpc@meta-networking for rosdep key libgrpc
- Package gtk+@openembedded-core for rosdep key gtk2
- Package joystick@meta-ros-common for rosdep key joystick
- Package libmicrohttpd@meta-oe for rosdep key libmicrohttpd
- Package libsdl@openembedded-core for rosdep key sdl
- Package lua@meta-oe for rosdep key lua5.2-dev
- Package openblas@meta-ros-common for rosdep key libblas-dev
- Package openblas@meta-ros-common for rosdep key libopenblas-dev
- Package python-pyassimp@meta-ros-python2 for rosdep key python-pyassimp
- Package python-tornado45@meta-ros-python2 for rosdep key python-tornado
- Package python3-backports-ssl@meta-python for rosdep key python-backports.ssl-match-hostname
- Package python3-click@meta-python for rosdep key python-click
- Package python3-click@meta-python for rosdep key python3-click
- Package python3-cryptography@meta-python for rosdep key python3-cryptography
- Package python3-enum34@meta-python for rosdep key python-enum34
- Package python3-gnupg@meta-ros-common for rosdep key python-gnupg
- Package python3-lxml@meta-python for rosdep key python-lxml
- Package python3-lxml@meta-python for rosdep key python3-lxml
- Package python3-msgpack@meta-python2 for rosdep key python-msgpack
- Package python3-mypy@meta-ros-common for rosdep key python3-mypy
- Package python3-nose@openembedded-core for rosdep key python-nose
- Package python3-nose@openembedded-core for rosdep key python3-nose
- Package python3-paramiko@meta-ros-common for rosdep key paramiko
- Package python3-paramiko@meta-ros-common for rosdep key python-paramiko
- Package python3-paramiko@meta-ros-common for rosdep key python3-paramiko
- Package python3-pip@meta-python for rosdep key python-pip
- Package python3-psutil@meta-python for rosdep key python-psutil
- Package python3-psutil@meta-python for rosdep key python3-psutil
- Package python3-pycrypto@meta-python for rosdep key python-crypto
- Package python3-pycryptodomex@meta-python for rosdep key python3-pycryptodome
- Package python3-pyparsing@meta-python for rosdep key python3-pyparsing
- Package python3-pyproj@meta-ros-common for rosdep key python-pyproj
- Package python3-pyproj@meta-ros-common for rosdep key python3-pyproj
- Package python3-pytest@meta-python for rosdep key python3-pytest
- Package python3-pyyaml@meta-python for rosdep key python-yaml
- Package python3-pyyaml@meta-python for rosdep key python3-yaml
- Package python3-requests@meta-python for rosdep key python3-requests
- Package python3-ruamel-yaml@meta-python for rosdep key python3-ruamel.yaml
- Package python3-simplejson@openembedded-core for rosdep key python-simplejson
- Package python3-termcolor@openembedded-core for rosdep key python-termcolor
- Package python3-tkinter@openembedded-core for rosdep key python-tk
- Package python3-tkinter@openembedded-core for rosdep key python3-tk
- Package python3-twisted-core@meta-python for rosdep key python-twisted-core
- Package python3-whichcraft@meta-ros-common for rosdep key python3-whichcraft
- Package uncrustify@meta-ros-common for rosdep key uncrustify
- Package wxpython@meta-ros-python2 for rosdep key python-wxtools
- Package wxpython@meta-ros-python2 for rosdep key wxpython
- Package wxwidgets@meta-ros-common for rosdep key wx-common
- Package wxwidgets@meta-ros-common for rosdep key wxwidgets
- Package zstd@meta-oe for rosdep key libzstd-dev
```

</details>

This is not a remotely alarming number - we carry far more invalid rules on other platforms. There is no particular urgency to address the invalid rules as only new rules will be run through the checker automatically during pull requests.

RFC: @ros/meta-ros-maintainers