### PR TITLE
Update release url for color-util.

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1108,7 +1108,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/MetroRobots-release/color_util-release.git
+      url: https://github.com/ros2-gbp/color_util-release.git
       version: 1.0.0-1
     source:
       test_pull_requests: true

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -783,7 +783,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/MetroRobots-release/color_util-release.git
+      url: https://github.com/ros2-gbp/color_util-release.git
       version: 1.0.0-2
     source:
       test_pull_requests: true


### PR DESCRIPTION
The ros2-gbp release repository is already created and up-to-date from the creation of ROS 2 Iron.

No changes in the Rolling or Humble release artifacts have been made in either repository since. Which I verified via the following

```
git ls-remote -t origin > /tmp/origin.tags
git ls-remote -t ros2-gbp > /tmp/ros2-gbp.tags
diff -u /tmp/origin.tags /tmp/ros2-gbp.tags
```

That resulted in this diff
```diff
--- /tmp/origin.tags	2024-02-28 09:48:45.024768549 -0800
+++ /tmp/ros2-gbp.tags	2024-02-28 09:48:53.131686210 -0800
@@ -1,15 +1,19 @@
 3de5d5383751c49cb19a6a10cb76b8f10b594344	refs/tags/debian/ros-foxy-color-util_1.0.0-1_focal
 545f87fd511905938987b8f82438ebb3e06f8dd7	refs/tags/debian/ros-humble-color-util_1.0.0-1_bullseye
 14a541c17e82ffb125afa0628484db4af378b187	refs/tags/debian/ros-humble-color-util_1.0.0-1_jammy
+22d9dfc621042d61dea7fbdfa1f9100fc5f5356d	refs/tags/debian/ros-iron-color-util_1.0.0-3_bullseye
+3b63882c372a3f3c055113e673028e744eee2470	refs/tags/debian/ros-iron-color-util_1.0.0-3_jammy
 1ce28a72e73813e6481cfd796eeefae8765bd930	refs/tags/debian/ros-rolling-color-util_1.0.0-1_bullseye
 caff7d1eb24eaf7e142e755a2f89f502b4a1a85b	refs/tags/debian/ros-rolling-color-util_1.0.0-1_jammy
 73b4c6105a58bf95a9fc96059466b3765f8ae618	refs/tags/debian/ros-rolling-color-util_1.0.0-2_bullseye
 567ed35464793babeda2d3b03085adf59678cb09	refs/tags/debian/ros-rolling-color-util_1.0.0-2_jammy
 bec29130eb72aebbb75a4f135f051e7073b35882	refs/tags/release/foxy/color_util/1.0.0-1
 163eed6ac69bf51547ffc26a7c83201a69772601	refs/tags/release/humble/color_util/1.0.0-1
+e95230b6125246a7d311b9b0e6f8d9f996ecfd65	refs/tags/release/iron/color_util/1.0.0-3
 ee3a3ad97f2a59455d83fbe9f288333d28264d27	refs/tags/release/rolling/color_util/1.0.0-1
 07a7d9c0a680877ef04c2e35d31eea24a79e4d71	refs/tags/release/rolling/color_util/1.0.0-2
 8b9d0e581f68d5510bc5df0407fc87cbfb56edc8	refs/tags/rpm/ros-humble-color-util-1.0.0-1_8
+401ca408044776b2f4a262affcbc0408bcc0cf46	refs/tags/rpm/ros-iron-color-util-1.0.0-3_9
 2ce242976ef8956735d96258cce17f2944406ab1	refs/tags/rpm/ros-rolling-color-util-1.0.0-1_8
 9a9ca461ed2219f6961a17e6d33511dd825e65cd	refs/tags/rpm/ros-rolling-color-util-1.0.0-2_9
-6a51a9a1017b647c19c2274862d25051cc7dc513	refs/tags/upstream/1.0.0
+ed59e62c71fd4616e0c5e5726b7befa5f7ff577a	refs/tags/upstream/1.0.0
```

Which shows the additional Iron release artifacts and a spurious change to the upstream 1.0.0 tag which is a result of bloom's internal workings.
You could verify that these commits have the same contents with `git cat-file commit ${COMMIT_ID}` and see that the tree each commit points to is identical.