### PR TITLE
Use ros2-gbp release repository for polygon_ros.

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5348,7 +5348,7 @@ repositories:
       - polygon_utils
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/MetroRobots-release/polygon_ros-release.git
+      url: https://github.com/ros2-gbp/polygon_ros-release.git
       version: 1.0.2-1
     source:
       test_pull_requests: true

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4106,7 +4106,7 @@ repositories:
       - polygon_utils
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/MetroRobots-release/polygon_ros-release.git
+      url: https://github.com/ros2-gbp/polygon_ros-release.git
       version: 1.0.2-1
     source:
       test_pull_requests: true


### PR DESCRIPTION
The ros2-gbp release repository is already created and up-to-date from the creation of ROS 2 Iron.

No changes in the Rolling or Humble release artifacts have been made in either repository since. Which I verified via the following:

```
git ls-remote -t origin > /tmp/origin.tags
git ls-remote -t ros2-gbp > /tmp/ros2-gbp.tags
diff -u /tmp/origin.tags /tmp/ros2-gbp.tags
```

```diff
--- /tmp/origin.tags    2024-02-28 15:40:57.220318251 -0800
+++ /tmp/ros2-gbp.tags  2024-02-28 15:41:02.133584765 -0800
@@ -26,6 +26,14 @@
 d0a5deae14f0c0934f1ad68b729558c279e047d8       refs/tags/debian/ros-humble-polygon-utils_1.0.1-1_jammy
 baeac2003f2e6db393e6ab074fbd1d93daac25e6       refs/tags/debian/ros-humble-polygon-utils_1.0.2-1_bullseye
 ffab0d0c68d202a4b7ef460698c2341ee5c8317b       refs/tags/debian/ros-humble-polygon-utils_1.0.2-1_jammy
+2e9630780a740560290bf1bba530981168de3260       refs/tags/debian/ros-iron-polygon-demos_1.0.2-2_bullseye
+b54bdab70d82a3d16f6812e8964de26871f0d0c2       refs/tags/debian/ros-iron-polygon-demos_1.0.2-2_jammy
+0d15c9ce055480b124bc1df1bb283511ef8d2afa       refs/tags/debian/ros-iron-polygon-msgs_1.0.2-2_bullseye
+6ab02860530fbb24b47500c2e21df8d180233bf5       refs/tags/debian/ros-iron-polygon-msgs_1.0.2-2_jammy
+a3c97fbe60bd07b8c6e21191efbd531d2426efa6       refs/tags/debian/ros-iron-polygon-rviz-plugins_1.0.2-2_bullseye
+c7da87fc57df0747eb62f4644aa55525e345ef25       refs/tags/debian/ros-iron-polygon-rviz-plugins_1.0.2-2_jammy
+682304490c294659bcee3101aa76328fdeeb5899       refs/tags/debian/ros-iron-polygon-utils_1.0.2-2_bullseye
+3fbfa3b8a467c3e428a6444cf1b1046b28109ba2       refs/tags/debian/ros-iron-polygon-utils_1.0.2-2_jammy
 9dbb5bf53519cfff5b6335edcd5b01ea07295aa2       refs/tags/debian/ros-rolling-polygon-demos_1.0.2-1_bullseye
 b67d7c8b427caa3cdd811d96c9c84038e63dad9d       refs/tags/debian/ros-rolling-polygon-demos_1.0.2-1_jammy
 666f4952a147abe3814144f902671d9a9182b9de       refs/tags/debian/ros-rolling-polygon-msgs_1.0.2-1_bullseye
@@ -54,6 +62,10 @@
 fb4224084a5ddb226c20faf7b2da64f9a40ada13       refs/tags/release/humble/polygon_rviz_plugins/1.0.2-1
 fa69c3413ca0785af5030faa776bf24d02d90369       refs/tags/release/humble/polygon_utils/1.0.1-1
 9f13c71a3abad7c294bbdb474d07b537f2086c0f       refs/tags/release/humble/polygon_utils/1.0.2-1
+c06b644592bccd9178c5afa930fceebb7af33e68       refs/tags/release/iron/polygon_demos/1.0.2-2
+91e98585dd02a972f097e68c53a932e471d76a54       refs/tags/release/iron/polygon_msgs/1.0.2-2
+af7f47bce576e68823948e58921b8358033e1dad       refs/tags/release/iron/polygon_rviz_plugins/1.0.2-2
+433fed3f334e884f4f75433998bc885f505149f6       refs/tags/release/iron/polygon_utils/1.0.2-2
 982210556cf94f86987a6e6f88d831bf3e2c032b       refs/tags/release/rolling/polygon_demos/1.0.2-1
 9bd5e4c211ad71bf801aefbf6b6bd0a390fdce9d       refs/tags/release/rolling/polygon_msgs/1.0.2-1
 60ece43333603fb22025f0946883c4c5cb6f64f1       refs/tags/release/rolling/polygon_rviz_plugins/1.0.2-1
@@ -66,10 +78,14 @@
 ff945b92d789c76cc83c9b4092e06e22158694ec       refs/tags/rpm/ros-humble-polygon-rviz-plugins-1.0.2-1_8
 acde46b93dbeff5c86bbac3e3e7fd0b8ad73bfbc       refs/tags/rpm/ros-humble-polygon-utils-1.0.1-1_8
 7f60808a6d5dc1865a4d2e6a4a4a267c7713903e       refs/tags/rpm/ros-humble-polygon-utils-1.0.2-1_8
+5e99b9694b9cc455609548aa80255a10f364bdce       refs/tags/rpm/ros-iron-polygon-demos-1.0.2-2_9
+c824c54e786775f90309bee0be8d160ae5a4b04c       refs/tags/rpm/ros-iron-polygon-msgs-1.0.2-2_9
+0d7373e7f3e4db5186f28f1f0aec5f89ec5893f5       refs/tags/rpm/ros-iron-polygon-rviz-plugins-1.0.2-2_9
+cbd77aec92afa5165ce603d30bc123f955a789a7       refs/tags/rpm/ros-iron-polygon-utils-1.0.2-2_9
 dabaa3ee8a5980b608788af8e567ffbf281d9681       refs/tags/rpm/ros-rolling-polygon-demos-1.0.2-1_9
 70e74ae3d4b0a35c3a4445f3d11d457ca58697bc       refs/tags/rpm/ros-rolling-polygon-msgs-1.0.2-1_9
 0a462aed398734969385487efc366bb61863b735       refs/tags/rpm/ros-rolling-polygon-rviz-plugins-1.0.2-1_9
 a41a178c1753b2c09504230e8cee5a1495c026f5       refs/tags/rpm/ros-rolling-polygon-utils-1.0.2-1_9
 12cf8e15f0dea50f3ba9930d059b35f77661ba69       refs/tags/upstream/1.0.0
 61955b1afc9fffb26f364db10967d7eb92220d03       refs/tags/upstream/1.0.1
-27031f0d5a4ccc9bf0264ad450bb5b306f299afe       refs/tags/upstream/1.0.2
+7530963841cba7d5ba6189d902184b0cfa4d8952       refs/tags/upstream/1.0.2
```

Which shows the additional Iron release artifacts and a spurious change to the upstream 1.0.2 tag which is a result of bloom's internal workings. You could verify that these commits have the same contents with git cat-file commit ${COMMIT_ID} and see that the tree each commit points to is identical.
