### PR TITLE
Use ros2-gbp release repository for topic_based_ros2_control.

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8729,7 +8729,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/PickNikRobotics/topic_based_ros2_control-release.git
+      url: https://github.com/ros2-gbp/topic_based_ros2_control-release.git
       version: 0.2.0-1
   topic_tools:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7455,7 +7455,7 @@ repositories:
     release:
       tags:
         release: release/iron/{package}/{version}
-      url: https://github.com/PickNikRobotics/topic_based_ros2_control-release.git
+      url: https://github.com/ros2-gbp/topic_based_ros2_control-release.git
       version: 0.2.0-1
   topic_tools:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7019,7 +7019,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/PickNikRobotics/topic_based_ros2_control-release.git
+      url: https://github.com/ros2-gbp/topic_based_ros2_control-release.git
       version: 0.2.0-1
   topic_tools:
     doc:


### PR DESCRIPTION
The repository has been mirrored into ros2-gbp here: ros2-gbp/ros2-gbp-github-org#459.

I did not change the release repository for noetic at this time since it is not required for ROS 1 distributions, but if the maintainer prefers to use a single release repository for all distributions that is perfectly acceptable.