### PR TITLE
Use ros2-gbp release repository for pal_statistics.

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4923,7 +4923,7 @@ repositories:
       - pal_statistics_msgs
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/pal_statistics-release.git
+      url: https://github.com/ros2-gbp/pal_statistics-release.git
       version: 2.2.3-1
     source:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3768,7 +3768,7 @@ repositories:
       - pal_statistics_msgs
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/pal-gbp/pal_statistics-release.git
+      url: https://github.com/ros2-gbp/pal_statistics-release.git
       version: 2.1.5-1
     source:
       type: git


### PR DESCRIPTION
The repository has been mirrored into ros2-gbp here: ros2-gbp/ros2-gbp-github-org#460.

I did not change the release repository for noetic at this time since it is not required for ROS 1 distributions, but if the maintainer prefers to use a single release repository for all distributions that is perfectly acceptable.