### PR TITLE
Use ros2-gbp repository for magic_enum release.

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3483,7 +3483,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/nobleo/magic_enum-release.git
+      url: https://github.com/ros2-gbp/magic_enum-release.git
       version: 0.9.5-1
     source:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2875,7 +2875,7 @@ repositories:
     release:
       tags:
         release: release/iron/{package}/{version}
-      url: https://github.com/nobleo/magic_enum-release.git
+      url: https://github.com/ros2-gbp/magic_enum-release.git
       version: 0.9.5-1
     source:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2703,7 +2703,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/nobleo/magic_enum-release.git
+      url: https://github.com/ros2-gbp/magic_enum-release.git
       version: 0.9.5-1
     source:
       type: git


### PR DESCRIPTION
The repository has been mirrored into ros2-gbp here: ros2-gbp/ros2-gbp-github-org#456.

I did not change the release repository for noetic at this time since it is not required for ROS 1 distributions, but if the maintainer prefers to use a single release repository for all distributions that is perfectly acceptable.