### PR TITLE
add flir_camera_driver to rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1493,6 +1493,16 @@ repositories:
       url: https://github.com/flexbe/flexbe_behavior_engine.git
       version: rolling
     status: developed
+  flir_camera_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/flir_camera_driver.git
+      version: rolling-release
+    source:
+      type: git
+      url: https://github.com/ros-drivers/flir_camera_driver.git
+      version: rolling-release
+    status: maintained
   fluent_rviz:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please add flir_camera_driver to be indexed in the rosdistro for rolling

This repository is already in humble and iron.
This repository now also has a *new package* with the name ``spinnaker_synchronized_camera_driver``. This new package supports hardware-synchronized operation of multiple cameras.

# The source is here: https://github.com/ros-drivers/flir_camera_driver

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
