### PR TITLE
play_motion2: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5141,7 +5141,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/play_motion2-release.git
-      version: 0.0.13-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/play_motion2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `play_motion2` to `1.0.0-1`:

- upstream repository: https://github.com/pal-robotics/play_motion2.git
- release repository: https://github.com/pal-gbp/play_motion2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.13-1`

## play_motion2

```
* Rename planner launch argument and update its config
* Fix condition for checking planning groups parameter
* Enhance loop condition
* Enhance way of getting parameters
* Store parameter names in constants
* Remove unused method
* Complete comment
* Remove unnecessary variable all_joints_included
* Fix condition when checking valid move groups
* Update non-planned motion tests
* Remove line jump from log
* Add planning capability
* Add logic for planning parameters
* Create a MoveGroupInterfacePtr for each planning group
* Parse planning related parameters
* Include key in MotionInfo
* Handle INVALID Result State
* Remove unused function
* Rename motion_info to info
* Remove unused boolean variable
* Delete commented code
* Fix Result State type
* Enable motion canceling
* Use auto
* Move all the execution logic to MotionPlanner
  Now the MotionPlanner is the responsible of sending the goals for
  performing the motions. As well the motion has been splitted in two
  parts: Approach and Motion
  The Approach part is the movement from the initial point to the first
  position, and the rest of the positions form the Motion
* Get motion_planner parameters on constructor
* Rename ApproachPlanner to MotionPlanner
* Use play_motion2 node for ApproachPlanner
* Update types
* Contributors: Jordan Palacios, Noel Jimenez
```

## play_motion2_msgs

- No changes
