### PR TITLE
pmb2_robot: 5.0.16-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5242,7 +5242,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_robot-gbp.git
-      version: 5.0.15-1
+      version: 5.0.16-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_robot` to `5.0.16-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_robot.git
- release repository: https://github.com/pal-gbp/pmb2_robot-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `5.0.15-1`

## pmb2_bringup

```
* Merge branch 'feat/register-components' into 'humble-devel'
  remove need for remapping cmd_vel topic
  See merge request robots/pmb2_robot!121
* remove need for remapping cmd_vel topic
* Contributors: antoniobrandi
```

## pmb2_controller_configuration

- No changes

## pmb2_description

- No changes

## pmb2_robot

- No changes
