### PR TITLE
tiago_navigation: 4.0.12-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8622,7 +8622,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_navigation-release.git
-      version: 4.0.9-1
+      version: 4.0.12-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_navigation` to `4.0.12-1`:

- upstream repository: https://github.com/pal-robotics/tiago_navigation.git
- release repository: https://github.com/pal-gbp/tiago_navigation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.9-1`

## tiago_2dnav

```
* Merge branch 'abr/fix/world-name' into 'humble-devel'
  set default world_name for standalone navigation
  See merge request robots/tiago_navigation!97
* set default world_name for standalone navigation
* Contributors: antoniobrandi
```

## tiago_laser_sensors

- No changes

## tiago_navigation

- No changes
