### PR TITLE
tiago_robot: 4.2.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8642,7 +8642,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_robot-release.git
-      version: 4.1.2-1
+      version: 4.2.3-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_robot` to `4.2.3-1`:

- upstream repository: https://github.com/pal-robotics/tiago_robot
- release repository: https://github.com/pal-gbp/tiago_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.1.2-1`

## tiago_bringup

```
* Rename approach_planner config to motion_planner
* Update approach_planner configuration
* Contributors: Noel Jimenez
```

## tiago_controller_configuration

- No changes

## tiago_description

```
* Fix no-ee suffix for no-end-effector value
* Contributors: Noel Jimenez
```

## tiago_robot

- No changes
