### PR TITLE
Adding homing_local_planner to documentation index for humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2632,6 +2632,16 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
       version: rolling-devel
     status: developed
+  homing_local_planner:
+    doc:
+      type: git
+      url: https://github.com/zengxiaolei/homing_local_planner.git
+      version: humble-devel
+    source:
+      type: git
+      url: https://github.com/zengxiaolei/homing_local_planner.git
+      version: humble-devel
+    status: developed
   hpp-fcl:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

## Package name:

homing_local_planner

## Package Upstream Source:

[link to source repository](https://github.com/zengxiaolei/homing_local_planner)

## Purpose of using this:

The homing_local_planner package implements a plug-in to the nav2_core::Controller of the Nav2 in ROS2. 


# Please Add homing_local_planner to be indexed in the rosdistro for humble

humble

# The source is here:

https://github.com/zengxiaolei/homing_local_planner

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
