### PR TITLE
flir_camera_driver: 2.0.11-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1498,6 +1498,16 @@ repositories:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git
       version: rolling-release
+    release:
+      packages:
+      - flir_camera_description
+      - flir_camera_msgs
+      - spinnaker_camera_driver
+      - spinnaker_synchronized_camera_driver
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git
+      version: 2.0.11-1
     source:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_camera_driver` to `2.0.11-1`:

- upstream repository: https://github.com/ros-drivers/flir_camera_driver.git
- release repository: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## flir_camera_description

```
* removed changelogs
* Contributors: Bernd Pfrommer
```

## flir_camera_msgs

```
* removed changelogs
* Contributors: Bernd Pfrommer
```

## spinnaker_camera_driver

```
* provision camera driver for exposure control
* fixed bugs discovered when running on GigE cams
* avoid searching ROS path for library
* added connect_while_subscribed feature
* Added binning parameter
* install spinnaker library in same place as driver library
* remove junk directories from search path
* added first implementation of synchronized driver
* prepare single-camera driver for use with sync'ed driver
* fixed stereo launch file serial nb bug
* removed changelogs
* Contributors: Bernd Pfrommer, Luis Camero, buckleytoby
```

## spinnaker_synchronized_camera_driver

```
* first release as a ROS package on rolling
* Contributors: Bernd Pfrommer
```
