### PR TITLE
Added python3-scikit-sparse-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8607,6 +8607,40 @@ python3-schema:
       packages: [schema]
   rhel: [python3-schema]
   ubuntu: [python3-schema]
+python3-scikit-sparse-pip:
+  arch:
+    pip:
+      depends: [suitesparse]
+      packages: [scikit-sparse]
+  debian:
+    pip:
+      depends: [suitesparse]
+      packages: [scikit-sparse]
+  fedora:
+    pip:
+      depends: [suitesparse]
+      packages: [scikit-sparse]
+  gentoo:
+    pip:
+      depends: [suitesparse]
+      packages: [scikit-sparse]
+  nixos:
+    pip:
+      depends: [suitesparse]
+      packages: [scikit-sparse]
+  opensuse: [python-scikit-sparse]
+  osx:
+    pip:
+      depends: [suitesparse]
+      packages: [scikit-sparse]
+  rhel:
+    pip:
+      depends: [suitesparse]
+      packages: [scikit-sparse]
+  ubuntu:
+    pip:
+      depends: [suitesparse]
+      packages: [scikit-sparse]
 python3-scikit-spatial-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name: 

python3-scikit-sparse-pip

## Package Upstream Source:

https://github.com/scikit-sparse/scikit-sparse

## Purpose of using this:

Handy and efficient solvers for sparse matrix operations.

## Links to Distribution Packages

Only OpenSuse has binary packages. Other systems need to install a system dependency suitesparse first, and then they can install scikit-sparse using pip. suitesparse already was in rosdep.

- Debian: https://pypi.org/project/scikit-sparse
- Ubuntu: https://pypi.org/project/scikit-sparse
- Fedora: https://pypi.org/project/scikit-sparse
- Arch: https://pypi.org/project/scikit-sparse
- Gentoo: https://pypi.org/project/scikit-sparse
- macOS: https://pypi.org/project/scikit-sparse
- NixOS/nixpkgs: https://pypi.org/project/scikit-sparse
- openSUSE: https://software.opensuse.org/package/python-scikit-sparse
- rhel: https://pypi.org/project/scikit-sparse
