### PR TITLE
mvsim: 0.9.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4164,7 +4164,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mvsim-release.git
-      version: 0.8.3-1
+      version: 0.9.0-1
     source:
       type: git
       url: https://github.com/MRPT/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.9.0-1`:

- upstream repository: https://github.com/MRPT/mvsim.git
- release repository: https://github.com/ros2-gbp/mvsim-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.8.3-1`

## mvsim

```
* Do not publish tf world->map
* Expose do_fake_localization as ROS 2 launch file argument
* fix build with older mrpt
* 3D Lidar: also generate "ring" ID per point
* Contributors: Jose Luis Blanco-Claraco
```
