### PR TITLE
ros2_control: 3.24.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5553,7 +5553,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.23.0-1
+      version: 3.24.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.24.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.23.0-1`

## controller_interface

- No changes

## controller_manager

```
* Fix multiple chainable controller activation bug (backport #1401 <https://github.com/ros-controls/ros2_control/issues/1401>) (#1412 <https://github.com/ros-controls/ros2_control/issues/1412>)
* [CI] Code coverage + pre-commit (backport #1413 <https://github.com/ros-controls/ros2_control/issues/1413>) (#1415 <https://github.com/ros-controls/ros2_control/issues/1415>)
* [CM] Use explicit constants in controller tests. (#1356 <https://github.com/ros-controls/ros2_control/issues/1356>) (#1360 <https://github.com/ros-controls/ros2_control/issues/1360>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* [CI] Code coverage + pre-commit (backport #1413 <https://github.com/ros-controls/ros2_control/issues/1413>) (#1415 <https://github.com/ros-controls/ros2_control/issues/1415>)
* Move hardware interface README content to sphinx documentation (#1342 <https://github.com/ros-controls/ros2_control/issues/1342>) (#1381 <https://github.com/ros-controls/ros2_control/issues/1381>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

- No changes

## joint_limits

```
* [CI] Code coverage + pre-commit (backport #1413 <https://github.com/ros-controls/ros2_control/issues/1413>) (#1415 <https://github.com/ros-controls/ros2_control/issues/1415>)
* Add header to import limits from standard URDF definition (#1298 <https://github.com/ros-controls/ros2_control/issues/1298>) (#1418 <https://github.com/ros-controls/ros2_control/issues/1418>)
* Contributors: mergify[bot]
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Added spawner colours to list_controllers depending upon active or inactive (#1409 <https://github.com/ros-controls/ros2_control/issues/1409>) (#1425 <https://github.com/ros-controls/ros2_control/issues/1425>)
* Contributors: mergify[bot]
```

## rqt_controller_manager

```
* [CI] Code coverage + pre-commit (backport #1413 <https://github.com/ros-controls/ros2_control/issues/1413>) (#1415 <https://github.com/ros-controls/ros2_control/issues/1415>)
* Contributors: mergify[bot]
```

## transmission_interface

- No changes
