### PR TITLE
ros2_control: 2.40.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6663,7 +6663,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.39.1-1
+      version: 2.40.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.40.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.39.1-1`

## controller_interface

- No changes

## controller_manager

```
* Fix multiple chainable controller activation bug (backport #1401 <https://github.com/ros-controls/ros2_control/issues/1401>) (#1411 <https://github.com/ros-controls/ros2_control/issues/1411>)
* [CI] Code coverage + pre-commit (backport #1413 <https://github.com/ros-controls/ros2_control/issues/1413>) (#1414 <https://github.com/ros-controls/ros2_control/issues/1414>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* [CI] Code coverage + pre-commit (backport #1413 <https://github.com/ros-controls/ros2_control/issues/1413>) (#1414 <https://github.com/ros-controls/ros2_control/issues/1414>)
* Move hardware interface README content to sphinx documentation (#1342 <https://github.com/ros-controls/ros2_control/issues/1342>) (#1380 <https://github.com/ros-controls/ros2_control/issues/1380>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

- No changes

## joint_limits

```
* [CI] Code coverage + pre-commit (backport #1413 <https://github.com/ros-controls/ros2_control/issues/1413>) (#1414 <https://github.com/ros-controls/ros2_control/issues/1414>)
* Contributors: mergify[bot]
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* [CI] Code coverage + pre-commit (backport #1413 <https://github.com/ros-controls/ros2_control/issues/1413>) (#1414 <https://github.com/ros-controls/ros2_control/issues/1414>)
* Added spawner colours to list_controllers depending upon active or inactive (backport #1409 <https://github.com/ros-controls/ros2_control/issues/1409>) (#1424 <https://github.com/ros-controls/ros2_control/issues/1424>)
* Contributors: mergify[bot]
```

## rqt_controller_manager

```
* [CI] Code coverage + pre-commit (backport #1413 <https://github.com/ros-controls/ros2_control/issues/1413>) (#1414 <https://github.com/ros-controls/ros2_control/issues/1414>)
* Contributors: mergify[bot]
```

## transmission_interface

- No changes
