### PR TITLE
mavros: 1.18.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5557,7 +5557,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 1.17.0-1
+      version: 1.18.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `1.18.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.17.0-1`

## libmavconn

- No changes

## mavros

```
* sys_status.cpp: improve timeout code
* sys_status.cpp: Add a SYS_STATUS message publisher
* Contributors: Dr.-Ing. Amilcar do Carmo Lucas
```

## mavros_extras

```
* [camera plugin] Fix image_index and capture_result not properly filled
* Fix missing semi-colon
* GPS_STATUS Plugin: Fill in available messages for ROS1 legacy
  Filled in available fields in GPS_RAW_INT & GPS2_RAW messages
  p.s. seems GPS2_RAW more complete than original GPS_RAW_INT
* Contributors: Beniamino Pozzan, Seunghwan Jo
```

## mavros_msgs

```
* sys_status.cpp: Add a SYS_STATUS message publisher
* Contributors: Dr.-Ing. Amilcar do Carmo Lucas
```

## test_mavros

- No changes
