### PR TITLE
mavros: 2.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2826,7 +2826,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mavros-release.git
-      version: 2.6.0-1
+      version: 2.7.0-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `2.7.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/ros2-gbp/mavros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.6.0-1`

## libmavconn

```
* Merge branch 'master' into ros2
  * master:
  1.18.0
  update changelog
  sys_status.cpp: improve timeout code
  sys_status.cpp: Add a SYS_STATUS message publisher
  [camera plugin] Fix image_index and capture_result not properly filled
  Fix missing semi-colon
  GPS_STATUS Plugin: Fill in available messages for ROS1 legacy
* 1.18.0
* update changelog
* Contributors: Vladimir Ermakov
```

## mavros

```
* Merge branch 'master' into ros2
  * master:
  1.18.0
  update changelog
  sys_status.cpp: improve timeout code
  sys_status.cpp: Add a SYS_STATUS message publisher
  [camera plugin] Fix image_index and capture_result not properly filled
  Fix missing semi-colon
  GPS_STATUS Plugin: Fill in available messages for ROS1 legacy
* 1.18.0
* update changelog
* move /conn parameters to /sys and /time
* sys_status.cpp: improve timeout code
  # Conflicts:
  #     mavros/src/plugins/sys_status.cpp
* sys_status.cpp: Add a SYS_STATUS message publisher
* Removed warning from geometry2 header
* Fix PR 1922 regarding EVENT message
* use synchronise_stamp to create stamp
* new checksum for event enum
* remove event_time_boot_ms, fill stamp instead
* handle events
* fix mav service  call and wp load
* Remove hardcoded namespace from px4_pluginlists
* Remove hardcoded namespace from px4_config
* Define _frd frames in odom plugin based on parent/child frame parametrs
* Define parameters for base_link, odom, map frames
* Contributors: Alejandro Hernández Cordero, Dr.-Ing. Amilcar do Carmo Lucas, Mattia Giurato, Mohamed Abdelkader, Vladimir Ermakov, elgarbe, sathak93, victor
```

## mavros_extras

```
* re-generate with cogall.sh
* Merge branch 'master' into ros2
  * master:
  1.18.0
  update changelog
  sys_status.cpp: improve timeout code
  sys_status.cpp: Add a SYS_STATUS message publisher
  [camera plugin] Fix image_index and capture_result not properly filled
  Fix missing semi-colon
  GPS_STATUS Plugin: Fill in available messages for ROS1 legacy
* 1.18.0
* update changelog
* [camera plugin] Fix image_index and capture_result not properly filled
* [camera plugin] Fix image_index and capture_result not properly filled
* Update mavros_plugins.xml
* Update wheel_odometry.cpp
  fix typo
* Fix typo
  fix typo in odometry frame child id
* Removed unused variable
* Use SensorDataQoS for gp_origin subscriber
* Fix missing semi-colon
* GPS_STATUS Plugin: Fill in available messages for ROS1 legacy
  Filled in available fields in GPS_RAW_INT & GPS2_RAW messages
  p.s. seems GPS2_RAW more complete than original GPS_RAW_INT
* Define _frd frames in odom plugin based on parent/child frame parametrs
* Contributors: Beniamino Pozzan, Kristoffer Bergman, Matteo Molinari, Mattia Giurato, Mohamed Abdelkader, Seunghwan Jo, Vladimir Ermakov, hpbrandal
```

## mavros_msgs

```
* re-generate with cogall.sh
* Merge branch 'master' into ros2
  * master:
  1.18.0
  update changelog
  sys_status.cpp: improve timeout code
  sys_status.cpp: Add a SYS_STATUS message publisher
  [camera plugin] Fix image_index and capture_result not properly filled
  Fix missing semi-colon
  GPS_STATUS Plugin: Fill in available messages for ROS1 legacy
* 1.18.0
* update changelog
* sys_status.cpp: Add a SYS_STATUS message publisher
* cog checksum
* remove event_time_boot_ms, fill stamp instead
* handle events
* Fix errata in GPSRAW.msg
* Contributors: Dr.-Ing. Amilcar do Carmo Lucas, Seunghwan Jo, Vladimir Ermakov, victor
```
