### PR TITLE
Index mrpt_sensors in humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4140,6 +4140,16 @@ repositories:
       url: https://github.com/MRPT/mrpt_path_planning.git
       version: develop
     status: developed
+  mrpt_sensors:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
+      version: ros2
+    status: developed
   mrt_cmake_modules:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble

# The source is here:

https://github.com/mrpt-ros-pkg/mrpt_sensors/

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
