### PR TITLE
py_binding_tools: 1.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8214,6 +8214,17 @@ repositories:
       url: https://github.com/PilzDE/psen_scan_v2.git
       version: main
     status: developed
+  py_binding_tools:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/py_binding_tools-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/py_binding_tools.git
+      version: main
+    status: maintained
   py_trees:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_binding_tools` to `1.0.0-1`:

- upstream repository: https://github.com/ros-planning/py_binding_tools.git
- release repository: https://github.com/ros-gbp/py_binding_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## py_binding_tools

```
* Initial release factored out from https://github.com/ros-planning/moveit/pull/2910
```
