### PR TITLE
motion_capture_tracking: 1.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3948,7 +3948,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/motion_capture_tracking-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/IMRCLab/motion_capture_tracking.git


### PR DESCRIPTION
Increasing version of package(s) in repository `motion_capture_tracking` to `1.0.4-1`:

- upstream repository: https://github.com/IMRCLab/motion_capture_tracking.git
- release repository: https://github.com/ros2-gbp/motion_capture_tracking-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.3-1`

## motion_capture_tracking

```
* install libNatNet.so as part of package
  Fixes #14 <https://github.com/IMRCLab/motion_capture_tracking/issues/14>
* Add support for the "mock" motion capture type
  In "mock" mode, the rigid bodies defined in the cfg.yaml will be published at a fixed rate. This is useful for testing without access to a motion capture system.
* cfg: remove unused "mode"
  Mode is not being used in the code, and is therefore removed from the config.
* Contributors: Wolfgang Hoenig
```

## motion_capture_tracking_interfaces

- No changes
