### PR TITLE
raspimouse_ros2_examples: 2.2.0-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5715,7 +5715,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/raspimouse_ros2_examples-release.git
-      version: 2.1.0-1
+      version: 2.2.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspimouse_ros2_examples` to `2.2.0-2`:

- upstream repository: https://github.com/rt-net/raspimouse_ros2_examples.git
- release repository: https://github.com/ros2-gbp/raspimouse_ros2_examples-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.0-1`

## raspimouse_ros2_examples

```
* READMEにSLAM&Navigationパッケージの案内を追加 (#53 <https://github.com/rt-net/raspimouse_ros2_examples/issues/53>)
* Camera_FollowerクラスをCameraFollowerに変更 (#52 <https://github.com/rt-net/raspimouse_ros2_examples/issues/52>)
* Update camera line follower: Set motor power with switch input. Add area_threthold param. (#51 <https://github.com/rt-net/raspimouse_ros2_examples/issues/51>)
* Add velocity parameters for camera_line_follower (#50 <https://github.com/rt-net/raspimouse_ros2_examples/issues/50>)
* カメラライントレースを修正 (#49 <https://github.com/rt-net/raspimouse_ros2_examples/issues/49>)
* Change threthold of line detection
* Add usb_cam dependency (#48 <https://github.com/rt-net/raspimouse_ros2_examples/issues/48>)
* RGBカメラによるライントレースの実装 (#47 <https://github.com/rt-net/raspimouse_ros2_examples/issues/47>)
* リリースのためにCHANGELOG.rstとpackage.xmlを更新 (#45 <https://github.com/rt-net/raspimouse_ros2_examples/issues/45>)
* Contributors: Shota Aoki, ShotaAk, YusukeKato
```
