### PR TITLE
raspimouse_description: 1.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5700,7 +5700,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/raspimouse_description-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/rt-net/raspimouse_description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspimouse_description` to `1.2.0-1`:

- upstream repository: https://github.com/rt-net/raspimouse_description.git
- release repository: https://github.com/ros2-gbp/raspimouse_description-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-1`

## raspimouse_description

```
* シミュレータ環境でscanトピックをpublish (#52 <https://github.com/rt-net/raspimouse_description/issues/52>)
* camera_downwardがtrueのときRGBカメラが斜め下を向くように変更 (#50 <https://github.com/rt-net/raspimouse_description/issues/50>)
  Co-authored-by: Shota Aoki <mailto:s.aoki@rt-net.jp>
* READMEにRGBカメラを表示するコマンドを追記 (#47 <https://github.com/rt-net/raspimouse_description/issues/47>)
* Gazebo上で画像トピックを配信できるように変更 (#46 <https://github.com/rt-net/raspimouse_description/issues/46>)
* RGBカメラのモデルを表示できるように変更 (#45 <https://github.com/rt-net/raspimouse_description/issues/45>)
  Co-authored-by: Shota Aoki <mailto:s.aoki@rt-net.jp>
* cmd_velとodomのトピック名をremapping (#44 <https://github.com/rt-net/raspimouse_description/issues/44>)
* controller managerが起動するように変更 (#43 <https://github.com/rt-net/raspimouse_description/issues/43>)
  Co-authored-by: Shota Aoki <mailto:s.aoki@rt-net.jp>
* robot_description_loaderを実装 (#42 <https://github.com/rt-net/raspimouse_description/issues/42>)
  Co-authored-by: Daisuke Sato <mailto:daisuke.sato@rt-net.jp>
* Contributors: YusukeKato
```
