### PR TITLE
raspimouse_slam_navigation_ros2: 2.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5754,7 +5754,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspimouse_slam_navigation_ros2` to `2.1.0-1`:

- upstream repository: https://github.com/rt-net/raspimouse_slam_navigation_ros2.git
- release repository: https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-1`

## raspimouse_navigation

```
* Use rplidar_a1_launch.py because rplidar.launch.py does not exist. (#8 <https://github.com/rt-net/raspimouse_slam_navigation_ros2/issues/8>)
* Contributors: Shota Aoki
```

## raspimouse_slam

```
* Use rplidar_a1_launch.py because rplidar.launch.py does not exist. (#8 <https://github.com/rt-net/raspimouse_slam_navigation_ros2/issues/8>)
* Contributors: Shota Aoki
```

## raspimouse_slam_navigation

- No changes
