### PR TITLE
raspimouse_sim: 2.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5735,7 +5735,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/raspimouse_sim-release.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/rt-net/raspimouse_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspimouse_sim` to `2.1.0-1`:

- upstream repository: https://github.com/rt-net/raspimouse_sim.git
- release repository: https://github.com/ros2-gbp/raspimouse_sim-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-1`

## raspimouse_fake

- No changes

## raspimouse_gazebo

```
* シミュレータ環境でSLAMとNavigationを実行 (#77 <https://github.com/rt-net/raspimouse_sim/issues/77>)
  Co-authored-by: Shota Aoki <mailto:s.aoki@rt-net.jp>
* コントローラのパラメータを調整してオドメトリのズレを修正 (#76 <https://github.com/rt-net/raspimouse_sim/issues/76>)
* camera_downwardがtrueのときRGBカメラが斜め下を向くように変更 (#75 <https://github.com/rt-net/raspimouse_sim/issues/75>)
  Co-authored-by: Shota Aoki <mailto:s.aoki@rt-net.jp>
* ライントレース用のコースを作成 (#74 <https://github.com/rt-net/raspimouse_sim/issues/74>)
  Co-authored-by: Shota Aoki <mailto:s.aoki@rt-net.jp>
* Contributors: YusukeKato
```

## raspimouse_sim

- No changes
