### PR TITLE
Add in rosdep key for noble for libboost-filesystem.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2700,6 +2700,7 @@ libboost-filesystem:
     bionic: [libboost-filesystem1.65.1]
     focal: [libboost-filesystem1.71.0]
     jammy: [libboost-filesystem1.74.0]
+    noble: [libboost-filesystem1.83.0]
 libboost-filesystem-dev:
   debian: [libboost-filesystem-dev]
   fedora: [boost-devel]


### PR DESCRIPTION
Please update the following dependency in the rosdep database.

## Package name:

libboost-filesystem

## Package Upstream Source:

https://www.boost.org

## Purpose of using this:

Update libboost-filesystem to have a `noble` key.  This is needed to release geometric_shapes into Rolling on Noble.

## Links to Distribution Packages

- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/libboost-filesystem1.83.0

@marcoag @nuclearsandwich FYI