### PR TITLE
Add in libboost-python rosdep key for noble.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2802,6 +2802,7 @@ libboost-python:
     bionic: [libboost-python1.65.1]
     focal: [libboost-python1.71.0]
     jammy: [libboost-python1.74.0]
+    noble: [libboost-python1.83.0]
 libboost-python-dev:
   alpine: [boost-python2]
   debian: [libboost-python-dev]


### PR DESCRIPTION
Please update the following dependency in the rosdep database.

## Package name:

libboost-python

## Package Upstream Source:

https://www.boost.org

## Purpose of using this:

Update libboost-python to have a `noble` key.  This is needed to release vision_opencv into Rolling on Noble.

## Links to Distribution Packages

- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/libboost-python1.83.0

@marcoag @nuclearsandwich FYI