### PR TITLE
Make the ros1_bridge and rosbag2_bag_v2 source-only in Rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5184,20 +5184,13 @@ repositories:
       url: https://github.com/robotont/robotont_msgs.git
       version: ros2-rolling-devel
   ros1_bridge:
-    doc:
-      type: git
-      url: https://github.com/ros2/ros1_bridge.git
-      version: master
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/ros1_bridge-release.git
     source:
       test_commits: false
       type: git
       url: https://github.com/ros2/ros1_bridge.git
       version: master
-    status: maintained
+    status_description: Maintained in source form only since no ROS 1 packages available
+      in Rolling
   ros2_canopen:
     doc:
       type: git
@@ -5641,23 +5634,13 @@ repositories:
       version: rolling
     status: developed
   rosbag2_bag_v2:
-    doc:
-      type: git
-      url: https://github.com/ros2/rosbag2_bag_v2.git
-      version: master
-    release:
-      packages:
-      - ros1_rosbag_storage_vendor
-      - rosbag2_bag_v2_plugins
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/rosbag2_bag_v2-release.git
     source:
       test_commits: false
       type: git
       url: https://github.com/ros2/rosbag2_bag_v2.git
       version: master
-    status: maintained
+    status_description: Maintained in source form only since no ROS 1 packages available
+      in Rolling
   rosbridge_suite:
     doc:
       type: git


### PR DESCRIPTION
Both of these require ROS 1 packages, which are not available in Ubuntu Noble, so we cannot build binary packages for them.  They are both still available to build from source.

@marcoag @nuclearsandwich FYI