### PR TITLE
control_box_rst: 0.0.7-5 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -844,6 +844,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/control_box_rst-release.git
+      version: 0.0.7-5
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_box_rst` to `0.0.7-5`:

- upstream repository: https://github.com/rst-tu-dortmund/control_box_rst.git
- release repository: https://github.com/ros2-gbp/control_box_rst-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## control_box_rst

```
* Fixed issue: Wrong sparse Jacobian pattern in solver LM
* Stage functions: added dedicated method for state and time dependency
* Lsq form added to hybrid cost functions
* Added missing header for eigenvalue computation
* Contributors: Christoph Rösmann
```
