### PR TITLE
Add in rosdep key for nlohmann-json-dev for noble.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6917,6 +6917,7 @@ nlohmann-json-dev:
     bionic: [nlohmann-json-dev]
     focal: [nlohmann-json3-dev]
     jammy: [nlohmann-json3-dev]
+    noble: [nlohmann-json3-dev]
 nmap:
   archlinux: [nmap]
   debian: [nmap]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6904,9 +6904,7 @@ nkf:
   ubuntu: [nkf]
 nlohmann-json-dev:
   debian:
-    bullseye: [nlohmann-json3-dev]
-    buster: [nlohmann-json3-dev]
-    sid: [nlohmann-json3-dev]
+    '*': [nlohmann-json3-dev]
     stretch: [nlohmann-json-dev]
   fedora: [json-devel]
   gentoo: [dev-cpp/nlohmann_json]
@@ -6914,10 +6912,8 @@ nlohmann-json-dev:
   openembedded: [nlohmann-json@meta-oe]
   rhel: [json-devel]
   ubuntu:
+    '*': [nlohmann-json3-dev]
     bionic: [nlohmann-json-dev]
-    focal: [nlohmann-json3-dev]
-    jammy: [nlohmann-json3-dev]
-    noble: [nlohmann-json3-dev]
 nmap:
   archlinux: [nmap]
   debian: [nmap]


### PR DESCRIPTION
Please update the following dependency in the rosdep database.

## Package name:

nlohmann-json-dev

## Package Upstream Source:

https://nlohmann.github.io/json/

## Purpose of using this:

Update nlohmann-json-dev to have a noble key. This is needed to release `foxglove_bridge` into Rolling on Noble.

## Links to Distribution Packages

- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/nlohmann-json3-dev