### PR TITLE
Add libpaho-mqttpp-dev key for Debian bookworm and later.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4698,6 +4698,9 @@ libpaho-mqtt-dev:
     bionic: null
     focal: null
 libpaho-mqttpp:
+  debian:
+    '*': [libpaho-mqttpp3-1]
+    bullseye: null
   nixos: [paho-mqtt-cpp]
   openembedded: [paho-mqtt-cpp@meta-oe]
   ubuntu:
@@ -4705,6 +4708,9 @@ libpaho-mqttpp:
     bionic: null
     focal: null
 libpaho-mqttpp-dev:
+  debian:
+    '*': [libpaho-mqttpp-dev]
+    bullseye: null
   nixos: [paho-mqtt-cpp]
   openembedded: [paho-mqtt-cpp@meta-oe]
   ubuntu:


### PR DESCRIPTION
Please update the following dependency in the rosdep database.

## Package name:

libpaho-mqtt, libpaho-mqtt-dev

## Package Upstream Source:

https://github.com/eclipse/paho.mqtt.cpp/

## Purpose of using this:

Update libpaho-mqtt and libpaho-mqtt-dev to have a Debian bookworm key. This is needed to release mqtt_client into Rolling.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=libpaho-mqttpp&searchon=names&suite=all&section=all
  - https://packages.debian.org/search?keywords=libpaho-mqttpp-dev&searchon=names&suite=all&section=all