### PR TITLE
py_trees_js: 0.6.4-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4163,6 +4163,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_js-release.git
+      version: 0.6.4-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_js` to `0.6.4-3`:

- upstream repository: https://github.com/splintered-reality/py_trees_js.git
- release repository: https://github.com/ros2-gbp/py_trees_js-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## py_trees_js

```
* [actions] pre-merge and update-cache, #146 <https://github.com/splintered-reality/py_trees_js/pull/146>
* [actions] push containers, #144 <https://github.com/splintered-reality/py_trees_js/pull/144>
* [poetry] update project to use poetry, #143 <https://github.com/splintered-reality/py_trees_js/pull/143>
* [vscode] devcontainer workflows, #143 <https://github.com/splintered-reality/py_trees_js/pull/143>
* [tests] basic tests, formatting, linting, #143 <https://github.com/splintered-reality/py_trees_js/pull/143>
```
