### PR TITLE
Add python3-smbus rule for RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8923,6 +8923,9 @@ python3-smbus:
   debian: [python3-smbus]
   fedora: [python3-i2c-tools]
   opensuse: [python3-smbus]
+  rhel:
+    '*': [python3-i2c-tools]
+    '8': null
   ubuntu: [python3-smbus]
 python3-smbus2-pip:
   debian:


### PR DESCRIPTION
```
$ dnf provides -q 'python3dist(smbus)'
python3-i2c-tools-4.3-3.el9.x86_64 : Python 3 bindings for Linux SMBus access through i2c-dev
Repo        : rhel-9-for-x86_64-appstream-rpms
Matched from:
Provide    : python3dist(smbus) = 1.1
```

https://pkgs.org/search/?q=python3-i2c-tools