### PR TITLE
perception_open3d: 0.1.2-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3800,6 +3800,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/perception_open3d-release.git
+      version: 0.1.2-3
     source:
       type: git
       url: https://github.com/ros-perception/perception_open3d.git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_open3d` to `0.1.2-3`:

- upstream repository: https://github.com/ros-perception/perception_open3d.git
- release repository: https://github.com/ros2-gbp/perception_open3d-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
