### PR TITLE
event_camera_py: 1.2.5-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1350,7 +1350,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_py-release.git
-      version: 1.2.4-1
+      version: 1.2.5-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_py.git


### PR DESCRIPTION
Increasing version of package(s) in repository `event_camera_py` to `1.2.5-1`:

- upstream repository: https://github.com/ros-event-camera/event_camera_py.git
- release repository: https://github.com/ros2-gbp/event_camera_py-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.4-1`

## event_camera_py

```
* added current work dir to the path in conf.py
* updated README for better viewing on rosindex
* removed unused imports
* Contributors: Bernd Pfrommer
```
