### PR TITLE
updated source and doc for ros-event-camera and ros-misc-utilities

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -468,7 +468,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_detector.git
-      version: master
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -477,7 +477,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_detector.git
-      version: master
+      version: humble
     status: developed
   apriltag_msgs:
     release:
@@ -1734,7 +1734,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_codecs.git
-      version: master
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -1743,13 +1743,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_codecs.git
-      version: master
+      version: humble
     status: developed
   event_camera_msgs:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_msgs.git
-      version: master
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -1758,13 +1758,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_msgs.git
-      version: master
+      version: humble
     status: developed
   event_camera_py:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_py.git
-      version: master
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -1773,13 +1773,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_py.git
-      version: master
+      version: humble
     status: developed
   event_camera_renderer:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_renderer.git
-      version: master
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -1788,7 +1788,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_renderer.git
-      version: master
+      version: humble
     status: developed
   example_interfaces:
     doc:
@@ -1893,7 +1893,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git
-      version: master
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -1902,13 +1902,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git
-      version: master
+      version: humble
     status: developed
   ffmpeg_image_transport_msgs:
     doc:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git
-      version: master
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -1917,7 +1917,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git
-      version: master
+      version: humble
     status: developed
   fields2cover:
     doc:
@@ -3307,7 +3307,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/libcaer_driver.git
-      version: master
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -3316,7 +3316,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer_driver.git
-      version: master
+      version: humble
     status: developed
   libcamera:
     release:
@@ -3695,7 +3695,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/metavision_driver.git
-      version: master
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -3704,7 +3704,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/metavision_driver.git
-      version: master
+      version: humble
     status: developed
   metrics_msgs:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -360,7 +360,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_detector.git
-      version: master
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -369,7 +369,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_detector.git
-      version: master
+      version: iron
     status: developed
   apriltag_msgs:
     release:
@@ -1315,7 +1315,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_codecs.git
-      version: master
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -1324,13 +1324,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_codecs.git
-      version: master
+      version: iron
     status: developed
   event_camera_msgs:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_msgs.git
-      version: master
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -1339,13 +1339,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_msgs.git
-      version: master
+      version: iron
     status: developed
   event_camera_py:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_py.git
-      version: master
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -1354,13 +1354,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_py.git
-      version: master
+      version: iron
     status: developed
   event_camera_renderer:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_renderer.git
-      version: master
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -1369,7 +1369,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_renderer.git
-      version: master
+      version: iron
     status: developed
   example_interfaces:
     doc:
@@ -1460,7 +1460,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git
-      version: master
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -1469,13 +1469,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git
-      version: master
+      version: iron
     status: developed
   ffmpeg_image_transport_msgs:
     doc:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git
-      version: master
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -1484,7 +1484,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git
-      version: master
+      version: iron
     status: developed
   fields2cover:
     release:
@@ -2735,7 +2735,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/libcaer_driver.git
-      version: master
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -2744,7 +2744,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer_driver.git
-      version: master
+      version: iron
     status: developed
   libcreate:
     doc:
@@ -3044,7 +3044,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/metavision_driver.git
-      version: master
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -3053,7 +3053,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/metavision_driver.git
-      version: master
+      version: iron
     status: developed
   micro_ros_diagnostics:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -361,7 +361,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_detector.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -370,7 +370,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_detector.git
-      version: master
+      version: rolling
     status: developed
   apriltag_msgs:
     release:
@@ -1272,7 +1272,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_codecs.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1281,13 +1281,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_codecs.git
-      version: master
+      version: rolling
     status: developed
   event_camera_msgs:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_msgs.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1296,13 +1296,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_msgs.git
-      version: master
+      version: rolling
     status: developed
   event_camera_py:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_py.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1311,13 +1311,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_py.git
-      version: master
+      version: rolling
     status: developed
   event_camera_renderer:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_renderer.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1326,7 +1326,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_renderer.git
-      version: master
+      version: rolling
     status: developed
   example_interfaces:
     doc:
@@ -1417,7 +1417,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1425,13 +1425,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git
-      version: master
+      version: rolling
     status: developed
   ffmpeg_image_transport_msgs:
     doc:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1440,7 +1440,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git
-      version: master
+      version: rolling
     status: developed
   fields2cover:
     release:
@@ -2596,7 +2596,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/libcaer_driver.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2605,7 +2605,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer_driver.git
-      version: master
+      version: rolling
     status: developed
   libg2o:
     release:
@@ -2872,7 +2872,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/metavision_driver.git
-      version: master
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2881,7 +2881,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/metavision_driver.git
-      version: master
+      version: rolling
     status: developed
   micro_ros_diagnostics:
     doc:


### PR DESCRIPTION
This PR corrects the source and doc entries for all repos belonging to release teams ros-misc-utilities and ros-event-camera. All affected repositories are maintained by me.
I understand humble is in sync hold and rolling is transitioning to Noble. This PR can wait until that's complete.