### PR TITLE
vision_opencv: 3.4.0-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7651,6 +7651,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
+      version: 3.4.0-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `3.4.0-3`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros2-gbp/vision_opencv-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## cv_bridge

- No changes

## image_geometry

```
* Add fovX and fovY functions in python, cpp (#493 <https://github.com/ros-perception/vision_opencv/issues/493>)
* Contributors: Chris Thierauf, Kenji Brameld
```

## vision_opencv

- No changes
