### PR TITLE
ecal: 5.12.0-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1131,6 +1131,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ecal-release.git
+      version: 5.12.0-4
     source:
       type: git
       url: https://github.com/eclipse-ecal/ecal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecal` to `5.12.0-4`:

- upstream repository: https://github.com/eclipse-ecal/ecal.git
- release repository: https://github.com/ros2-gbp/ecal-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
