### PR TITLE
Add in libavdevice-dev key for Fedora and RHEL.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2529,6 +2529,8 @@ libavahi-core-dev:
   ubuntu: [libavahi-core-dev]
 libavdevice-dev:
   debian: [libavdevice-dev]
+  fedora: [libavdevice-free-devel]
+  rhel: [libavdevice-free-devel]
   ubuntu: [libavdevice-dev]
 libb64-dev:
   arch: [libb64]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2530,7 +2530,9 @@ libavahi-core-dev:
 libavdevice-dev:
   debian: [libavdevice-dev]
   fedora: [libavdevice-free-devel]
-  rhel: [libavdevice-free-devel]
+  rhel:
+    '*': [libavdevice-free-devel]
+    '8': null
   ubuntu: [libavdevice-dev]
 libb64-dev:
   arch: [libb64]


### PR DESCRIPTION
Please update the following dependency in the rosdep database.

## Package name:

libavdevice-dev

## Package Upstream Source:

https://ffmpeg.org/

## Purpose of using this:

Update libavdevice-dev to have keys for both RHEL and Fedora.  This is needed to release ffmpeg_image_transport on those distributions.

## Links to Distribution Packages

- Fedora
  - https://pkgs.org/search/?q=libavdevice-free-devel
- RHEL
  - https://pkgs.org/search/?q=libavdevice-free-devel

@marcoag @nuclearsandwich FYI