### PR TITLE
Update rti-connext-dds-6.0.1 keys.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7670,8 +7670,8 @@ rti-connext-dds-5.3.1:
 rti-connext-dds-6.0.1:
   nixos: []
   ubuntu:
-    focal: [rti-connext-dds-6.0.1]
-    jammy: [rti-connext-dds-6.0.1]
+    '*': [rti-connext-dds-6.0.1]
+    bionic: null
 rtmidi:
   debian: [librtmidi-dev]
   fedora: [rtmidi-devel]


### PR DESCRIPTION
This package is now also in the ROS repositories for noble. While here, I consolidated the definitions since there's only one active ubuntu distribution which lacks this package.

Please add the following dependency to the rosdep database.

## Package name: rti-connext-dds-6.0.1

## Package Upstream Source:

Sources aren't available for this proprietary package distributed in the ROS repositories.
https://community.rti.com/documentation/rti-connext-dds-601

## Purpose of using this:

DDS vendor package for the rmw_connextdds rmw provider.

Distro packaging links:

The package is available for Ubuntu on amd64. Empty packages are provided on arm64 and armhf as a backfill for rosdep. The packages depending on this will gracefully detect the dummy packages and become empty shims themselves.