### PR TITLE
ffmpeg_image_transport: 1.0.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1424,6 +1424,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ffmpeg_image_transport-release.git
+      version: 1.0.0-2
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ffmpeg_image_transport` to `1.0.0-2`:

- upstream repository: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git
- release repository: https://github.com/ros2-gbp/ffmpeg_image_transport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## ffmpeg_image_transport

```
* initial release of ROS2 package
* Contributors: Akshay Srinivasan, Bernd Pfrommer, Francesco Ferroni, Michal Sojka, akssri
```
