### PR TITLE
foxglove_bridge: 0.7.6-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1578,6 +1578,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
+      version: 0.7.6-2
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_bridge` to `0.7.6-2`:

- upstream repository: https://github.com/foxglove/ros-foxglove-bridge.git
- release repository: https://github.com/ros2-gbp/foxglove_bridge-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## foxglove_bridge

```
* Fix rolling builds (#289 <https://github.com/foxglove/ros-foxglove-bridge/issues/289>)
* Remove dual ROS 1+2 devcontainer, remove ROS Galactic from the support matrix (#285 <https://github.com/foxglove/ros-foxglove-bridge/issues/285>)
* Contributors: Hans-Joachim Krauch, John Hurliman
```
