### PR TITLE
moveit: 2.9.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3074,6 +3074,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
+      version: 2.9.0-2
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.9.0-2`:

- upstream repository: https://github.com/ros-planning/moveit2.git
- release repository: https://github.com/ros2-gbp/moveit2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## chomp_motion_planner

```
* Node logging for the rest of MoveIt (#2599 <https://github.com/ros-planning/moveit2/issues/2599>)
* [Planning Pipeline Refactoring] #1 <https://github.com/ros-planning/moveit2/issues/1> Simplify Adapter - Planner chain (#2429 <https://github.com/ros-planning/moveit2/issues/2429>)
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Sebastian Jahr, Tyler Weaver
```

## moveit

```
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Sebastian Jahr
```

## moveit_common

```
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Sebastian Jahr
```

## moveit_configs_utils

```
* Update ros2_control usage (#2620 <https://github.com/ros-planning/moveit2/issues/2620>)
  * Update ros2_control usage
  * Update xacro file
* [Planning Pipeline Refactoring] #2 <https://github.com/ros-planning/moveit2/issues/2> Enable chaining planners (#2457 <https://github.com/ros-planning/moveit2/issues/2457>)
  * Enable chaining multiple planners
* [Planning Pipeline Refactoring] #1 <https://github.com/ros-planning/moveit2/issues/1> Simplify Adapter - Planner chain (#2429 <https://github.com/ros-planning/moveit2/issues/2429>)
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Sebastian Jahr
```

## moveit_core

```
* (core) Remove all references to python wrapper from the core pkg (#2623 <https://github.com/ros-planning/moveit2/issues/2623>)
  * (core) remove commented python wrapper code
  * (core) remove dep on pybind11_vendor
* Add missing pluginlib dependency (#2641 <https://github.com/ros-planning/moveit2/issues/2641>)
* make time_optimal_trajectory_generation harder to misuse (#2624 <https://github.com/ros-planning/moveit2/issues/2624>)
  * make time_optimal_trajectory_generation harder to misuse
  * style fixes
  * more style fixes
  * more style fixes
  * address PR comments
* Add collision_detection dependency on pluginlib (#2638 <https://github.com/ros-planning/moveit2/issues/2638>)
  It is included by src/collision_plugin_cache.cpp, so it should be set as a dependency.
* reset accelerations on setToDefaultValues (#2618 <https://github.com/ros-planning/moveit2/issues/2618>)
* fix out-of-bounds memory access with zero-variable joints (#2617 <https://github.com/ros-planning/moveit2/issues/2617>)
* Node logging for the rest of MoveIt (#2599 <https://github.com/ros-planning/moveit2/issues/2599>)
* Sync Ruckig with MoveIt1 (#2596 <https://github.com/ros-planning/moveit2/issues/2596>)
  * Debug Ruckig tests (MoveIt1 3300)
  * Add a test, termination condition bugfix (MoveIt1 3348)
  * Mitigate Ruckig overshoot (MoveIt1 3376)
  * Small variable fixup
* Add missing header (#2592 <https://github.com/ros-planning/moveit2/issues/2592>)
* Depend on rsl::rsl as a non-Ament dependency (#2578 <https://github.com/ros-planning/moveit2/issues/2578>)
* [Planning Pipeline Refactoring] #2 <https://github.com/ros-planning/moveit2/issues/2> Enable chaining planners (#2457 <https://github.com/ros-planning/moveit2/issues/2457>)
  * Enable chaining multiple planners
* Pass more distance information out from FCL collision check (#2572 <https://github.com/ros-planning/moveit2/issues/2572>)
  * Pass more distance information out from FCL collision check
  * Update moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@tuta.io>
  * Update moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
  ---------
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Node logging in moveit_core (#2503 <https://github.com/ros-planning/moveit2/issues/2503>)
* Benchmark robot state (#2546 <https://github.com/ros-planning/moveit2/issues/2546>)
  * simplify memory management in RobotState
  * further changes
  * avoid pointer arithmetic where possible
  * fix memory access issue on root joint with 0 variables
  * fix vector size
  * remove unused header
* Remember original color of objects in planning scene (#2549 <https://github.com/ros-planning/moveit2/issues/2549>)
* Allow editing allowed collision matrix in python + fix get_entry function (#2551 <https://github.com/ros-planning/moveit2/issues/2551>)
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* [Planning Pipeline Refactoring] #1 <https://github.com/ros-planning/moveit2/issues/1> Simplify Adapter - Planner chain (#2429 <https://github.com/ros-planning/moveit2/issues/2429>)
* Fix angular distance calculation in floating joint model (#2538 <https://github.com/ros-planning/moveit2/issues/2538>)
* Add a benchmark for RobotTrajectory creation and timing. (#2530 <https://github.com/ros-planning/moveit2/issues/2530>)
* Consolidate RobotState benchmarks in single file (#2528 <https://github.com/ros-planning/moveit2/issues/2528>)
  * Consolidate RobotState benchmarks in single file
  * some cosmetics
  * style fixes
  * additional comments
* add rsl depend to moveit_core (#2532 <https://github.com/ros-planning/moveit2/issues/2532>)
  - This should fix #2516 <https://github.com/ros-planning/moveit2/issues/2516>
  - Several moveit2 packages already depend on rsl
  - PR #2482 <https://github.com/ros-planning/moveit2/issues/2482> added a depend in moveit_core
  This is only broken when building all of moveit2 deps in one colcon workspace
  And not using rosdep because colcon uses the package.xml and rsl might not have been built
* Avoid calling static node's destructor. (#2513 <https://github.com/ros-planning/moveit2/issues/2513>)
* Factor out path joint-space jump check (#2506 <https://github.com/ros-planning/moveit2/issues/2506>)
* Use node logging in moveit_ros (#2482 <https://github.com/ros-planning/moveit2/issues/2482>)
* Add new clang-tidy style rules (#2177 <https://github.com/ros-planning/moveit2/issues/2177>)
* Use default initializers in collision_common.h (#2475 <https://github.com/ros-planning/moveit2/issues/2475>)
* Node logger through singleton (warehouse) (#2445 <https://github.com/ros-planning/moveit2/issues/2445>)
  Co-authored-by: Abishalini Sivaraman <mailto:abi.gpuram@gmail.com>
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Smoothing plugin API update and bug fix (#2470 <https://github.com/ros-planning/moveit2/issues/2470>)
  * Use Eigen::vector in smoothing plugin
  * Fix dependencies
  * Make args to reset const
  * Make KinematicState use Eigen::Vector
  * Mark params as unused
  * Fix type issues
  * Variable optimization
  Co-authored-by: AndyZe <andyz@utexas.edu>
  * Link against Eigen, not tf2_eigen
  * Don't resize every time
  * Don't reset the smoother_ every time
  * Initialize the kinematic state of the smoother
  * Cleanup
  ---------
  Co-authored-by: ibrahiminfinite <ibrahimjkd@gmail.com>
  Co-authored-by: V Mohammed Ibrahim <12377945+ibrahiminfinite@users.noreply.github.com>
* Do not pass and return simple types by const ref (#2453 <https://github.com/ros-planning/moveit2/issues/2453>)
  Co-authored-by: Nils <mailto:nilsmailiseke@gmail.com>
* Fix typo in bullet function name (#2472 <https://github.com/ros-planning/moveit2/issues/2472>)
* Update pre-commit and add to .codespell_words (#2465 <https://github.com/ros-planning/moveit2/issues/2465>)
* Port #3464 <https://github.com/ros-planning/moveit2/issues/3464> from MoveIt1 (#2456 <https://github.com/ros-planning/moveit2/issues/2456>)
  * Port unit test
  cherry-pick of https://github.com/ros-planning/moveit/pull/3464
  * Increment added_path_index in callAdapter
  Doesn't work because previous=0 for all recursively called functions.
  * Pass individual add_path_index vectors to callAdapter
  ---------
  Co-authored-by: Hugal31 <mailto:hla@lescompanions.com>
* [Python] Add RetimeTrajectory to RobotTrajectory (#2411 <https://github.com/ros-planning/moveit2/issues/2411>)
  * [Python] Add RetimeTrajectory to RobotTrajectory
  * Split retime trajecotry in multiple functions
  Moved logic to trajectory_tools
  Added Docstrings
  * Removed retime function from python binding
  ---------
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Use find_package for fcl (#2399 <https://github.com/ros-planning/moveit2/issues/2399>)
* Remove old deprecated functions (#2384 <https://github.com/ros-planning/moveit2/issues/2384>)
* Make getJacobian simpler and faster (#2389 <https://github.com/ros-planning/moveit2/issues/2389>)
  * Make getJacobian simpler and faster
  * readability and const-correctness
  * fix issue when joint group is not at URDF origin
  * Update moveit_core/robot_state/src/robot_state.cpp
* Add RobotState::getJacobian() tests (#2375 <https://github.com/ros-planning/moveit2/issues/2375>)
* Compare MoveIt! Jacobian against KDL (#2377 <https://github.com/ros-planning/moveit2/issues/2377>)
* Update clang-format-14 with QualifierAlignment (#2362 <https://github.com/ros-planning/moveit2/issues/2362>)
  * Set qualifier order in .clang-format
  * Ran pre-commit to update according to new style guide
* Converts float to double (#2343 <https://github.com/ros-planning/moveit2/issues/2343>)
  * Limiting the scope of variables #874 <https://github.com/ros-planning/moveit2/issues/874>
  Limited the scope of variables in moveit_core/collision_detection
  * Update moveit_core/collision_detection/src/collision_octomap_filter.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * Update moveit_core/collision_detection/src/collision_octomap_filter.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * Update moveit_core/collision_detection/src/collision_octomap_filter.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * convert float to double
  * change double to float
  * Feedback fixes
  * Introduced variables removed from previous merge commit
  * Updated GL_Renderer function definitions with double instead of float
  * Changed update() function arguments to float since it is a derived virtual function and needs to be overriden
  * Fixed all override errors in visualization
  * *Fixed override errors in perception
  *Changed reinterpret_cast to double* from float*
  * change variable types to fit function definition
  * Fixed clang-tidy warnings
  * Fixed scope of reusable variables
  ---------
  Co-authored-by: Salah Soliman <mailto:salahsoliman96@gmail.com>
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Alex Moriarty, AndyZe, Chris Lalancette, Chris Thrasher, Jens Vanhooydonck, Mario Prats, Marq Rasmussen, Matthijs van der Burgh, Nacho Mellado, Rayene Messaoud, Robert Haschke, Sebastian Castro, Sebastian Jahr, Shobuj Paul, Stephanie Eng, Tyler Weaver
```

## moveit_hybrid_planning

```
* Update ros2_control usage (#2620 <https://github.com/ros-planning/moveit2/issues/2620>)
  * Update ros2_control usage
  * Update xacro file
* Node logging for the rest of MoveIt (#2599 <https://github.com/ros-planning/moveit2/issues/2599>)
* [Planning Pipeline Refactoring] #2 <https://github.com/ros-planning/moveit2/issues/2> Enable chaining planners (#2457 <https://github.com/ros-planning/moveit2/issues/2457>)
  * Enable chaining multiple planners
* [Planning Pipeline Refactoring] #1 <https://github.com/ros-planning/moveit2/issues/1> Simplify Adapter - Planner chain (#2429 <https://github.com/ros-planning/moveit2/issues/2429>)
* Use node logging in moveit_ros (#2482 <https://github.com/ros-planning/moveit2/issues/2482>)
* Add new clang-tidy style rules (#2177 <https://github.com/ros-planning/moveit2/issues/2177>)
* Update pre-commit and add to .codespell_words (#2465 <https://github.com/ros-planning/moveit2/issues/2465>)
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Remove old deprecated functions (#2384 <https://github.com/ros-planning/moveit2/issues/2384>)
* Converts float to double (#2343 <https://github.com/ros-planning/moveit2/issues/2343>)
  * Limiting the scope of variables #874 <https://github.com/ros-planning/moveit2/issues/874>
  Limited the scope of variables in moveit_core/collision_detection
  * Update moveit_core/collision_detection/src/collision_octomap_filter.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * Update moveit_core/collision_detection/src/collision_octomap_filter.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * Update moveit_core/collision_detection/src/collision_octomap_filter.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * convert float to double
  * change double to float
  * Feedback fixes
  * Introduced variables removed from previous merge commit
  * Updated GL_Renderer function definitions with double instead of float
  * Changed update() function arguments to float since it is a derived virtual function and needs to be overriden
  * Fixed all override errors in visualization
  * *Fixed override errors in perception
  *Changed reinterpret_cast to double* from float*
  * change variable types to fit function definition
  * Fixed clang-tidy warnings
  * Fixed scope of reusable variables
  ---------
  Co-authored-by: Salah Soliman <mailto:salahsoliman96@gmail.com>
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Marq Rasmussen, Rayene Messaoud, Sebastian Jahr, Shobuj Paul, Tyler Weaver
```

## moveit_kinematics

```
* Node logging for the rest of MoveIt (#2599 <https://github.com/ros-planning/moveit2/issues/2599>)
* Remove LMA kinematics plugin (#2595 <https://github.com/ros-planning/moveit2/issues/2595>)
* Update ROS Snapshots GPG key (#2547 <https://github.com/ros-planning/moveit2/issues/2547>)
  * Update GPG key for ROS snapshot
  * Add link
* Do not pass and return simple types by const ref (#2453 <https://github.com/ros-planning/moveit2/issues/2453>)
  Co-authored-by: Nils <mailto:nilsmailiseke@gmail.com>
* Update pre-commit and add to .codespell_words (#2465 <https://github.com/ros-planning/moveit2/issues/2465>)
* Fix CMake error when building cached_ik_kinematics_plugin with trac_ik present (#2421 <https://github.com/ros-planning/moveit2/issues/2421>)
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Update clang-format-14 with QualifierAlignment (#2362 <https://github.com/ros-planning/moveit2/issues/2362>)
  * Set qualifier order in .clang-format
  * Ran pre-commit to update according to new style guide
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Marq Rasmussen, Sebastian Castro, Sebastian Jahr, Shobuj Paul, Stephanie Eng, Tyler Weaver
```

## moveit_planners

```
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Sebastian Jahr
```

## moveit_planners_chomp

```
* Node logging for the rest of MoveIt (#2599 <https://github.com/ros-planning/moveit2/issues/2599>)
* [Planning Pipeline Refactoring] #1 <https://github.com/ros-planning/moveit2/issues/1> Simplify Adapter - Planner chain (#2429 <https://github.com/ros-planning/moveit2/issues/2429>)
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Sebastian Jahr, Tyler Weaver
```

## moveit_planners_ompl

```
* Handle unsupported position constraints in OMPL (#2417 <https://github.com/ros-planning/moveit2/issues/2417>)
  * Handle unsupported position constraints in OMPL
  OMPL constrained planning assumes that all position constraints have three
  dimensions, meaning that they are represented by a BOX bounding volume.
  If another shape is used (like a SPHERE from moveit_core/kinematic_constraints/utils.hpp),
  the constraint adapter implementation will produce a segfault because of
  the lack of dimensions. This fix prevents this by checking for the
  required BOX type.
  * Add warning if more than one position primitive is used
  ---------
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Invoke OMPL debug print only when debug logging is enabled (#2608 <https://github.com/ros-planning/moveit2/issues/2608>)
* Node logging for the rest of MoveIt (#2599 <https://github.com/ros-planning/moveit2/issues/2599>)
* [Planning Pipeline Refactoring] #1 <https://github.com/ros-planning/moveit2/issues/1> Simplify Adapter - Planner chain (#2429 <https://github.com/ros-planning/moveit2/issues/2429>)
* Add new clang-tidy style rules (#2177 <https://github.com/ros-planning/moveit2/issues/2177>)
* Do not pass and return simple types by const ref (#2453 <https://github.com/ros-planning/moveit2/issues/2453>)
  Co-authored-by: Nils <mailto:nilsmailiseke@gmail.com>
* Update pre-commit and add to .codespell_words (#2465 <https://github.com/ros-planning/moveit2/issues/2465>)
* Map ompl's APPROXIMATE_SOLUTION -> TIMED_OUT / PLANNING_FAILED (#2455 <https://github.com/ros-planning/moveit2/issues/2455>)
  ompl's APPROXIMATE_SOLUTION is not suitable for actual execution. It just states that we got closer to the goal...
  The most prominent reason for an approximate solution is a timeout. Thus, return TIMED_OUT and print the used timeouts for convenience.
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Update clang-format-14 with QualifierAlignment (#2362 <https://github.com/ros-planning/moveit2/issues/2362>)
  * Set qualifier order in .clang-format
  * Ran pre-commit to update according to new style guide
* Converts float to double (#2343 <https://github.com/ros-planning/moveit2/issues/2343>)
  * Limiting the scope of variables #874 <https://github.com/ros-planning/moveit2/issues/874>
  Limited the scope of variables in moveit_core/collision_detection
  * Update moveit_core/collision_detection/src/collision_octomap_filter.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * Update moveit_core/collision_detection/src/collision_octomap_filter.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * Update moveit_core/collision_detection/src/collision_octomap_filter.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * convert float to double
  * change double to float
  * Feedback fixes
  * Introduced variables removed from previous merge commit
  * Updated GL_Renderer function definitions with double instead of float
  * Changed update() function arguments to float since it is a derived virtual function and needs to be overriden
  * Fixed all override errors in visualization
  * *Fixed override errors in perception
  *Changed reinterpret_cast to double* from float*
  * change variable types to fit function definition
  * Fixed clang-tidy warnings
  * Fixed scope of reusable variables
  ---------
  Co-authored-by: Salah Soliman <mailto:salahsoliman96@gmail.com>
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Henning Kayser, Igor Medvedev, Marq Rasmussen, Robert Haschke, Sebastian Jahr, Shobuj Paul, Tyler Weaver
```

## moveit_planners_stomp

```
* Node logging for the rest of MoveIt (#2599 <https://github.com/ros-planning/moveit2/issues/2599>)
* [Planning Pipeline Refactoring] #2 <https://github.com/ros-planning/moveit2/issues/2> Enable chaining planners (#2457 <https://github.com/ros-planning/moveit2/issues/2457>)
  * Enable chaining multiple planners
* [Planning Pipeline Refactoring] #1 <https://github.com/ros-planning/moveit2/issues/1> Simplify Adapter - Planner chain (#2429 <https://github.com/ros-planning/moveit2/issues/2429>)
* Add new clang-tidy style rules (#2177 <https://github.com/ros-planning/moveit2/issues/2177>)
* Do not pass and return simple types by const ref (#2453 <https://github.com/ros-planning/moveit2/issues/2453>)
  Co-authored-by: Nils <mailto:nilsmailiseke@gmail.com>
* Use constraint distance instead of bool validity in STOMP cost function (#2418 <https://github.com/ros-planning/moveit2/issues/2418>)
  * Use constraint distance instead of bool validity in STOMP cost function
  * Fix comment
* Using std types instead of boost for Gaussian sampling (#2351 <https://github.com/ros-planning/moveit2/issues/2351>)
  * *Changed boost namespace to std
  *Need to compare function implementations
  *Find an equivalent implementation for variate_generator
  * calling Distribution(Engine) directly
  * cleanup
  * Seed mersenne twister variable with random device
  * Updated with rsl random library
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Update clang-format-14 with QualifierAlignment (#2362 <https://github.com/ros-planning/moveit2/issues/2362>)
  * Set qualifier order in .clang-format
  * Ran pre-commit to update according to new style guide
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Henning Kayser, Marq Rasmussen, Sebastian Jahr, Shobuj Paul, Tyler Weaver
```

## moveit_plugins

```
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Sebastian Jahr
```

## moveit_py

```
* [PSM] Process collision object color when adding object trough the planning scene monitor (#2567 <https://github.com/ros-planning/moveit2/issues/2567>)
  * Added an optional Collision Object color object to set the coller of the collision object when adding the collision object trough the PSM.
  * Fixes for clang-tidy warnings
  * fix pre-commit
  * Pass by reference
* Node logging for the rest of MoveIt (#2599 <https://github.com/ros-planning/moveit2/issues/2599>)
* Fix moveit_py Policy docs build (#2584 <https://github.com/ros-planning/moveit2/issues/2584>)
* init policy class (#2494 <https://github.com/ros-planning/moveit2/issues/2494>)
  update command interfaces
  Update moveit_py/moveit/policies/policy.py
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  Update moveit_py/moveit/policies/policy.py
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  Update moveit_py/moveit/policies/policy.py
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  Update moveit_py/moveit/policies/policy.py
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  Update moveit_py/moveit/policies/policy.py
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  Update moveit_py/moveit/policies/policy.py
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  update script description
* (moveit_py) Extend Trajectory Execution Manager (#2569 <https://github.com/ros-planning/moveit2/issues/2569>)
  * (moveit_py) Extend Trajectory Execution Manager
  Added part of the functions from #2442 <https://github.com/ros-planning/moveit2/issues/2442>
  * PR-remarks
  * Update moveit_py/src/moveit/moveit_ros/trajectory_execution_manager/trajectory_execution_manager.cpp
  Co-authored-by: Matthijs van der Burgh <mailto:matthijs.vander.burgh@live.nl>
  * Update moveit_py/src/moveit/moveit_ros/trajectory_execution_manager/trajectory_execution_manager.cpp
  Co-authored-by: Matthijs van der Burgh <mailto:matthijs.vander.burgh@live.nl>
  * Update planning.pyi - Removed unused import
  * Fixes whitespace issues
  ---------
  Co-authored-by: Matthijs van der Burgh <mailto:matthijs.vander.burgh@live.nl>
* (moveit_py) execute needs a gil_scoped_release (#2573 <https://github.com/ros-planning/moveit2/issues/2573>)
* Fix trajectory execution manager comments for docs builds (#2563 <https://github.com/ros-planning/moveit2/issues/2563>)
* [PSM] Add proccess Collision Object to PSM and request planning scene to moveit py to allow syncing of mutliple PSM (#2536 <https://github.com/ros-planning/moveit2/issues/2536>)
  * PlanningSceneMonitor and request planning scene to moveit py to allow syncing of multiple planning scene monitors
  * pre-commit fixes
  * Update moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
  First catch empty scene to not have a unneeded indents.
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@tuta.io>
  * Removed unneeded callback functions
  ---------
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Allow editing allowed collision matrix in python + fix get_entry function (#2551 <https://github.com/ros-planning/moveit2/issues/2551>)
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Update README.md (#2552 <https://github.com/ros-planning/moveit2/issues/2552>)
  replace moveit wiht moveit_py
* (moveit_py) fix pyi files (#2526 <https://github.com/ros-planning/moveit2/issues/2526>)
  * (moveit_py) fix planning.pyi
  * (moveit_py) add missing functions to robot_trajectory.pyi
  * (moveit_py) fix command to generate stubs
* (moveit_py) Add Trajectory Execution Manager (#2406 <https://github.com/ros-planning/moveit2/issues/2406>)
  * (moveit_py) add trajectory execution manager
  * (moveit_py) add __bool__ to ExecutionStatus
  * (moveit_py) Update copyright header of changed files
  * (moveit_py) add comment referencing issue
  * Rename init_trajectory_execution_manager -> initTrajectoryExecutionManager
  * (moveit_py) python functions snake_case
  * (moveit_py) fix styling
  ---------
* (moveit_py) add update_frame_transforms to planning_scene_monitor (#2521 <https://github.com/ros-planning/moveit2/issues/2521>)
* (moveit_py) remove unused applyPlanningScene (#2505 <https://github.com/ros-planning/moveit2/issues/2505>)
* [moveit_py] add missing constructor of CollisionResult (#2500 <https://github.com/ros-planning/moveit2/issues/2500>)
  Co-authored-by: Dongya Jiang <mailto:jiangdongya@xiaoyubot.com>
* Fix wrong rename of set_start_state in 63e0c3a (#2497 <https://github.com/ros-planning/moveit2/issues/2497>)
* Add new clang-tidy style rules (#2177 <https://github.com/ros-planning/moveit2/issues/2177>)
* Finally fix errors building new RobotTrajectory Python bindings docs (#2481 <https://github.com/ros-planning/moveit2/issues/2481>)
  * Add missing parenthesis in Python bindings docstring
  * Fix more docstrings
* [Python] Add Allowed Collision Matrix to planning scene and optional planning scene during planning (#2387 <https://github.com/ros-planning/moveit2/issues/2387>)
* More fixes to Python bindings docstrings (#2474 <https://github.com/ros-planning/moveit2/issues/2474>)
* Fix docstring spacing in newly added trajectory Python bindings (#2471 <https://github.com/ros-planning/moveit2/issues/2471>)
* (moveit_py) node can have multiple param files (#2393 <https://github.com/ros-planning/moveit2/issues/2393>)
  A node is often started with multiple param files. Using list.index only returns the first occurrence. The new code searches for all occurrences.
* [Python] Add RetimeTrajectory to RobotTrajectory (#2411 <https://github.com/ros-planning/moveit2/issues/2411>)
  * [Python] Add RetimeTrajectory to RobotTrajectory
  * Split retime trajecotry in multiple functions
  Moved logic to trajectory_tools
  Added Docstrings
  * Removed retime function from python binding
  ---------
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Dongya Jiang, Jens Vanhooydonck, Matthijs van der Burgh, Nils-Christian Iseke, Peter David Fagan, Sebastian Castro, Sebastian Jahr, Tyler Weaver
```

## moveit_resources_prbt_ikfast_manipulator_plugin

```
* Do not pass and return simple types by const ref (#2453 <https://github.com/ros-planning/moveit2/issues/2453>)
  Co-authored-by: Nils <mailto:nilsmailiseke@gmail.com>
* Update pre-commit and add to .codespell_words (#2465 <https://github.com/ros-planning/moveit2/issues/2465>)
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* PRBT IkFast patch from robostack (#2395 <https://github.com/ros-planning/moveit2/issues/2395>)
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Marq Rasmussen, Sebastian Jahr, Shobuj Paul, Tyler Weaver
```

## moveit_resources_prbt_moveit_config

```
* Update ros2_control usage (#2620 <https://github.com/ros-planning/moveit2/issues/2620>)
  * Update ros2_control usage
  * Update xacro file
* [Planning Pipeline Refactoring] #2 <https://github.com/ros-planning/moveit2/issues/2> Enable chaining planners (#2457 <https://github.com/ros-planning/moveit2/issues/2457>)
  * Enable chaining multiple planners
* [Planning Pipeline Refactoring] #1 <https://github.com/ros-planning/moveit2/issues/1> Simplify Adapter - Planner chain (#2429 <https://github.com/ros-planning/moveit2/issues/2429>)
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Sebastian Jahr
```

## moveit_resources_prbt_pg70_support

```
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Sebastian Jahr
```

## moveit_resources_prbt_support

```
* Update ros2_control usage (#2620 <https://github.com/ros-planning/moveit2/issues/2620>)
  * Update ros2_control usage
  * Update xacro file
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Sebastian Jahr
```

## moveit_ros

```
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Sebastian Jahr
```

## moveit_ros_benchmarks

```
* [Planning Pipeline Refactoring] #2 <https://github.com/ros-planning/moveit2/issues/2> Enable chaining planners (#2457 <https://github.com/ros-planning/moveit2/issues/2457>)
  * Enable chaining multiple planners
* Node logging in moveit_core (#2503 <https://github.com/ros-planning/moveit2/issues/2503>)
* Use node logging in moveit_ros (#2482 <https://github.com/ros-planning/moveit2/issues/2482>)
* Add new clang-tidy style rules (#2177 <https://github.com/ros-planning/moveit2/issues/2177>)
* Use generate parameters library in PlanningPipelineClass + general cleanups (#2288 <https://github.com/ros-planning/moveit2/issues/2288>)
  * Don't discard stuff
  * Move constants into source file
  * Move static consts into header
  * Don't ignore pipeline result
  * Use generate parameter library for planning pipeline parameters
  * Fix CI
  * More CI fixes
  * Remove more state from planning pipeline
  * Small cleanups
  * Assert planner_instance_ is not a nullptr
  * Remove valid variable
  * Simplify logic for trajectory printing
  * More helpful comments
  * Small logic simplification by using break
  * Fix clang-tidy
  * Pre-commit + Deprecate functions instead of removing them
  * Fix CI
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Enable running parallel or single pipeline benchmarks (#2385 <https://github.com/ros-planning/moveit2/issues/2385>)
  * Enable running single or parallel planning pipeline benchmarks
  * Decrease log severity
* Update clang-format-14 with QualifierAlignment (#2362 <https://github.com/ros-planning/moveit2/issues/2362>)
  * Set qualifier order in .clang-format
  * Ran pre-commit to update according to new style guide
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Marq Rasmussen, Sebastian Jahr, Shobuj Paul, Tyler Weaver
```

## moveit_ros_control_interface

```
* Fix warning and cleanup unneeded placeholders (#2566 <https://github.com/ros-planning/moveit2/issues/2566>)
  * Fix warning and cleanup unneeded placeholders
  * Make clang-tidy happy
  * Remove print statement
* Node logging for the rest of MoveIt (#2599 <https://github.com/ros-planning/moveit2/issues/2599>)
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Sebastian Jahr, Tyler Weaver
```

## moveit_ros_move_group

```
* Fix warning and cleanup unneeded placeholders (#2566 <https://github.com/ros-planning/moveit2/issues/2566>)
  * Fix warning and cleanup unneeded placeholders
  * Make clang-tidy happy
  * Remove print statement
* [Planning Pipeline Refactoring] #2 <https://github.com/ros-planning/moveit2/issues/2> Enable chaining planners (#2457 <https://github.com/ros-planning/moveit2/issues/2457>)
  * Enable chaining multiple planners
* Node logging in moveit_core (#2503 <https://github.com/ros-planning/moveit2/issues/2503>)
* [Planning Pipeline Refactoring] #1 <https://github.com/ros-planning/moveit2/issues/1> Simplify Adapter - Planner chain (#2429 <https://github.com/ros-planning/moveit2/issues/2429>)
* Factor out path joint-space jump check (#2506 <https://github.com/ros-planning/moveit2/issues/2506>)
* Use node logging in moveit_ros (#2482 <https://github.com/ros-planning/moveit2/issues/2482>)
* Add new clang-tidy style rules (#2177 <https://github.com/ros-planning/moveit2/issues/2177>)
* Use generate parameters library in PlanningPipelineClass + general cleanups (#2288 <https://github.com/ros-planning/moveit2/issues/2288>)
  * Don't discard stuff
  * Move constants into source file
  * Move static consts into header
  * Don't ignore pipeline result
  * Use generate parameter library for planning pipeline parameters
  * Fix CI
  * More CI fixes
  * Remove more state from planning pipeline
  * Small cleanups
  * Assert planner_instance_ is not a nullptr
  * Remove valid variable
  * Simplify logic for trajectory printing
  * More helpful comments
  * Small logic simplification by using break
  * Fix clang-tidy
  * Pre-commit + Deprecate functions instead of removing them
  * Fix CI
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Remove old deprecated functions (#2384 <https://github.com/ros-planning/moveit2/issues/2384>)
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Mario Prats, Marq Rasmussen, Rayene Messaoud, Sebastian Jahr, Tyler Weaver
```

## moveit_ros_occupancy_map_monitor

```
* Node logging in moveit_core (#2503 <https://github.com/ros-planning/moveit2/issues/2503>)
* Use node logging in moveit_ros (#2482 <https://github.com/ros-planning/moveit2/issues/2482>)
* Add new clang-tidy style rules (#2177 <https://github.com/ros-planning/moveit2/issues/2177>)
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Sebastian Jahr, Tyler Weaver
```

## moveit_ros_perception

```
* (moveit_ros) add missing CYLINDER check (#2640 <https://github.com/ros-planning/moveit2/issues/2640>)
  As this check was missing, the CYLINDER check later on was unreachable
* Node logging in moveit_core (#2503 <https://github.com/ros-planning/moveit2/issues/2503>)
* Use node logging in moveit_ros (#2482 <https://github.com/ros-planning/moveit2/issues/2482>)
* Add new clang-tidy style rules (#2177 <https://github.com/ros-planning/moveit2/issues/2177>)
* Update pre-commit and add to .codespell_words (#2465 <https://github.com/ros-planning/moveit2/issues/2465>)
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Update clang-format-14 with QualifierAlignment (#2362 <https://github.com/ros-planning/moveit2/issues/2362>)
  * Set qualifier order in .clang-format
  * Ran pre-commit to update according to new style guide
* Converts float to double (#2343 <https://github.com/ros-planning/moveit2/issues/2343>)
  * Limiting the scope of variables #874 <https://github.com/ros-planning/moveit2/issues/874>
  Limited the scope of variables in moveit_core/collision_detection
  * Update moveit_core/collision_detection/src/collision_octomap_filter.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * Update moveit_core/collision_detection/src/collision_octomap_filter.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * Update moveit_core/collision_detection/src/collision_octomap_filter.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * convert float to double
  * change double to float
  * Feedback fixes
  * Introduced variables removed from previous merge commit
  * Updated GL_Renderer function definitions with double instead of float
  * Changed update() function arguments to float since it is a derived virtual function and needs to be overriden
  * Fixed all override errors in visualization
  * *Fixed override errors in perception
  *Changed reinterpret_cast to double* from float*
  * change variable types to fit function definition
  * Fixed clang-tidy warnings
  * Fixed scope of reusable variables
  ---------
  Co-authored-by: Salah Soliman <mailto:salahsoliman96@gmail.com>
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Marq Rasmussen, Matthijs van der Burgh, Sebastian Jahr, Shobuj Paul, Tyler Weaver
```

## moveit_ros_planning

```
* [PSM] Process collision object color when adding object trough the planning scene monitor (#2567 <https://github.com/ros-planning/moveit2/issues/2567>)
  * Added an optional Collision Object color object to set the coller of the collision object when adding the collision object trough the PSM.
  * Fixes for clang-tidy warnings
  * fix pre-commit
  * Pass by reference
* [Servo] Make listening to octomap updates optional (#2627 <https://github.com/ros-planning/moveit2/issues/2627>)
  * [Servo] Make listening to octomap updates optional
  * Update moveit_ros/moveit_servo/config/panda_simulated_config.yaml
* Node logging for the rest of MoveIt (#2599 <https://github.com/ros-planning/moveit2/issues/2599>)
* [Planning Pipeline Refactoring] #2 <https://github.com/ros-planning/moveit2/issues/2> Enable chaining planners (#2457 <https://github.com/ros-planning/moveit2/issues/2457>)
  * Enable chaining multiple planners
* Node logging in moveit_core (#2503 <https://github.com/ros-planning/moveit2/issues/2503>)
* Fix trajectory execution manager comments for docs builds (#2563 <https://github.com/ros-planning/moveit2/issues/2563>)
* Change default topic name for display contacts (#2561 <https://github.com/ros-planning/moveit2/issues/2561>)
* [PSM] Add proccess Collision Object to PSM and request planning scene to moveit py to allow syncing of mutliple PSM (#2536 <https://github.com/ros-planning/moveit2/issues/2536>)
  * PlanningSceneMonitor and request planning scene to moveit py to allow syncing of multiple planning scene monitors
  * pre-commit fixes
  * Update moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
  First catch empty scene to not have a unneeded indents.
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@tuta.io>
  * Removed unneeded callback functions
  ---------
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* [Planning Pipeline Refactoring] #1 <https://github.com/ros-planning/moveit2/issues/1> Simplify Adapter - Planner chain (#2429 <https://github.com/ros-planning/moveit2/issues/2429>)
* Use node logging in moveit_ros (#2482 <https://github.com/ros-planning/moveit2/issues/2482>)
* Add new clang-tidy style rules (#2177 <https://github.com/ros-planning/moveit2/issues/2177>)
* Re-enable waiting for current state in MoveItCpp (#2419 <https://github.com/ros-planning/moveit2/issues/2419>)
* Protect against zero frequency in TrajectoryMonitorMiddlewareHandler (#2423 <https://github.com/ros-planning/moveit2/issues/2423>)
* Small planning pipeline class fixes (#2416 <https://github.com/ros-planning/moveit2/issues/2416>)
* Use generate parameters library in PlanningPipelineClass + general cleanups (#2288 <https://github.com/ros-planning/moveit2/issues/2288>)
  * Don't discard stuff
  * Move constants into source file
  * Move static consts into header
  * Don't ignore pipeline result
  * Use generate parameter library for planning pipeline parameters
  * Fix CI
  * More CI fixes
  * Remove more state from planning pipeline
  * Small cleanups
  * Assert planner_instance_ is not a nullptr
  * Remove valid variable
  * Simplify logic for trajectory printing
  * More helpful comments
  * Small logic simplification by using break
  * Fix clang-tidy
  * Pre-commit + Deprecate functions instead of removing them
  * Fix CI
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Remove old deprecated functions (#2384 <https://github.com/ros-planning/moveit2/issues/2384>)
* [PSM] Get the parameter values of the main node when declaring them in the private node. (#2392 <https://github.com/ros-planning/moveit2/issues/2392>)
  * Get the values of the main node when declaring them in the private node.
  * [chore] linting
  * Removed logging
  * Update formatting
  * Removed whitespace
  ---------
* Update clang-format-14 with QualifierAlignment (#2362 <https://github.com/ros-planning/moveit2/issues/2362>)
  * Set qualifier order in .clang-format
  * Ran pre-commit to update according to new style guide
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Abishalini Sivaraman, Henning Kayser, Jens Vanhooydonck, Marq Rasmussen, Rayene Messaoud, Sebastian Castro, Sebastian Jahr, Shobuj Paul, Tyler Weaver
```

## moveit_ros_planning_interface

```
* Update ros2_control usage (#2620 <https://github.com/ros-planning/moveit2/issues/2620>)
  * Update ros2_control usage
  * Update xacro file
* Node logging in moveit_core (#2503 <https://github.com/ros-planning/moveit2/issues/2503>)
* Use node logging in moveit_ros (#2482 <https://github.com/ros-planning/moveit2/issues/2482>)
* Add new clang-tidy style rules (#2177 <https://github.com/ros-planning/moveit2/issues/2177>)
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Remove old deprecated functions (#2384 <https://github.com/ros-planning/moveit2/issues/2384>)
* Update clang-format-14 with QualifierAlignment (#2362 <https://github.com/ros-planning/moveit2/issues/2362>)
  * Set qualifier order in .clang-format
  * Ran pre-commit to update according to new style guide
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Marq Rasmussen, Rayene Messaoud, Sebastian Jahr, Shobuj Paul, Tyler Weaver
```

## moveit_ros_robot_interaction

```
* Node logging in moveit_core (#2503 <https://github.com/ros-planning/moveit2/issues/2503>)
* Use node logging in moveit_ros (#2482 <https://github.com/ros-planning/moveit2/issues/2482>)
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Converts float to double (#2343 <https://github.com/ros-planning/moveit2/issues/2343>)
  * Limiting the scope of variables #874 <https://github.com/ros-planning/moveit2/issues/874>
  Limited the scope of variables in moveit_core/collision_detection
  * Update moveit_core/collision_detection/src/collision_octomap_filter.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * Update moveit_core/collision_detection/src/collision_octomap_filter.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * Update moveit_core/collision_detection/src/collision_octomap_filter.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * convert float to double
  * change double to float
  * Feedback fixes
  * Introduced variables removed from previous merge commit
  * Updated GL_Renderer function definitions with double instead of float
  * Changed update() function arguments to float since it is a derived virtual function and needs to be overriden
  * Fixed all override errors in visualization
  * *Fixed override errors in perception
  *Changed reinterpret_cast to double* from float*
  * change variable types to fit function definition
  * Fixed clang-tidy warnings
  * Fixed scope of reusable variables
  ---------
  Co-authored-by: Salah Soliman <mailto:salahsoliman96@gmail.com>
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Marq Rasmussen, Sebastian Jahr, Shobuj Paul, Tyler Weaver
```

## moveit_ros_visualization

```
* Node logging for the rest of MoveIt (#2599 <https://github.com/ros-planning/moveit2/issues/2599>)
* Node logging in moveit_core (#2503 <https://github.com/ros-planning/moveit2/issues/2503>)
* Use node logging in moveit_ros (#2482 <https://github.com/ros-planning/moveit2/issues/2482>)
* Add new clang-tidy style rules (#2177 <https://github.com/ros-planning/moveit2/issues/2177>)
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Converts float to double (#2343 <https://github.com/ros-planning/moveit2/issues/2343>)
  * Limiting the scope of variables #874 <https://github.com/ros-planning/moveit2/issues/874>
  Limited the scope of variables in moveit_core/collision_detection
  * Update moveit_core/collision_detection/src/collision_octomap_filter.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * Update moveit_core/collision_detection/src/collision_octomap_filter.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * Update moveit_core/collision_detection/src/collision_octomap_filter.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * convert float to double
  * change double to float
  * Feedback fixes
  * Introduced variables removed from previous merge commit
  * Updated GL_Renderer function definitions with double instead of float
  * Changed update() function arguments to float since it is a derived virtual function and needs to be overriden
  * Fixed all override errors in visualization
  * *Fixed override errors in perception
  *Changed reinterpret_cast to double* from float*
  * change variable types to fit function definition
  * Fixed clang-tidy warnings
  * Fixed scope of reusable variables
  ---------
  Co-authored-by: Salah Soliman <mailto:salahsoliman96@gmail.com>
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Marq Rasmussen, Sebastian Jahr, Shobuj Paul, Tyler Weaver
```

## moveit_ros_warehouse

```
* Node logging in moveit_core (#2503 <https://github.com/ros-planning/moveit2/issues/2503>)
* Use node logging in moveit_ros (#2482 <https://github.com/ros-planning/moveit2/issues/2482>)
* Add new clang-tidy style rules (#2177 <https://github.com/ros-planning/moveit2/issues/2177>)
* Node logger through singleton (warehouse) (#2445 <https://github.com/ros-planning/moveit2/issues/2445>)
  Co-authored-by: Abishalini Sivaraman <mailto:abi.gpuram@gmail.com>
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Use node logging in warehouse broadcast (#2432 <https://github.com/ros-planning/moveit2/issues/2432>)
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Sebastian Jahr, Tyler Weaver
```

## moveit_runtime

```
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Sebastian Jahr
```

## moveit_servo

```
* Add command queue to servo to account for latency (#2594 <https://github.com/ros-planning/moveit2/issues/2594>)
  * add command queue to servo to account for latency
  * run pre-commit
  * fix unsigned compare
  * Update moveit_ros/moveit_servo/config/servo_parameters.yaml
  Fix wording
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  * Update moveit_ros/moveit_servo/src/servo.cpp
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  * Update moveit_ros/moveit_servo/src/servo.cpp
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  * add comments and change variable names
  * add checks to determine what state information should be published
  * change latency parameter name
  * factor command queue out of servo instance
  * update demos
  * needs clean up but working well
  * deal with duplicate timestamps for sim
  * add acceleration limiting smoothing
  * add timeout check in filter
  * factor out robot state from servo call
  * update comments in smoothing pluin
  * fix tests
  * change velocity calculation to make interpolation not overshoot
  * Update moveit_ros/moveit_servo/config/panda_simulated_config.yaml
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  * Update moveit_ros/moveit_servo/config/servo_parameters.yaml
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  * Update moveit_ros/moveit_servo/demos/cpp_interface/demo_joint_jog.cpp
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  * fix time calculation
  * add check to ensure time interval is positive
  * simplify demos
  * wait for first robot state before starting servo loop
  * add comments to acceleration filter
  * fix wait time units
  * fix logic bug in smoothHalt and remove stopping point from trajectory message. Still some overshoot.
  * add acceleration limit to servo
  * remove acceleration filter
  * remove other filter files from moveit_core
  * add doc string and basic clean up
  * refactor getRobotState to utils and add a test
  * make some things const and fix comments
  * use joint_limts params to get robot acceleration limits
  * update demo config and set velocities in demos
  * fix acceleration calculation
  * apply collision_velocity_scale_ in smooth hault, add comments, and rename variables
  * use bounds on scaling factors in [0... 1]
  * remove joint_acceleration parameter
  * add test for jointLimitAccelerationScaling
  * refactor velocity and acceleration scaling into common function
  * general clean up, add comments, fix parameters, set timestamp in updateSlidingWindow, etc.
  * Update moveit_ros/moveit_servo/config/panda_simulated_config.yaml
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * Update moveit_ros/moveit_servo/src/servo.cpp
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * remove override_acceleration_scaling_factor
  * fix variable name
  * enable use_smoothing in demos
  * Update moveit_ros/moveit_servo/config/panda_simulated_config.yaml
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * add current state to command queue if it is empty. This is needed since the time stamp is set in the updateSlidingWindow function now.
  * remove acceleration smoothing
  * revert jointLimitVelocityScalingFactor refactor
  * 1) fix spelling 2) add comments 3) make sure rolling_window always has current state if no command generated 4) fix smooth hault: stop command was not generated if smoothing disabled 5) call resetSmoothing when there are no commands
  ---------
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
* MoveIt Servo should respect the AllowedCollisionMatrix (#2605 <https://github.com/ros-planning/moveit2/issues/2605>)
  * MoveIt Servo should respect the AllowedCollisionMatrix
  * Formatting
* [Servo] Make listening to octomap updates optional (#2627 <https://github.com/ros-planning/moveit2/issues/2627>)
  * [Servo] Make listening to octomap updates optional
  * Update moveit_ros/moveit_servo/config/panda_simulated_config.yaml
* Update ros2_control usage (#2620 <https://github.com/ros-planning/moveit2/issues/2620>)
  * Update ros2_control usage
  * Update xacro file
* Making the error messages of moveit_servo::validateParams more expressive. (#2602 <https://github.com/ros-planning/moveit2/issues/2602>)
* Make moveit_servo listen to Octomap updates (#2601 <https://github.com/ros-planning/moveit2/issues/2601>)
  * Start servo's world geometry monitor
  * Typo fix
  ---------
  Co-authored-by: Amal Nanavati <mailto:amaln@cs.washington.edu>
* Replaced single value joint_limit_margin with list of joint_limit_margin (#2576 <https://github.com/ros-planning/moveit2/issues/2576>)
  * Replaced joint_limit_margin with list of margins: joint_limit_margin. Enabling setting individual margins for each joint.
  * Dimension comment update
  * Adding a dimension check within the validateParams() function of servo.cpp to give a clear error message if the size of joint_limit_margis does not match the number of joints of the move_group
  * Formatting fix
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  * Fix panda_simulated_config.yaml
  ---------
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
* Node logging in moveit_core (#2503 <https://github.com/ros-planning/moveit2/issues/2503>)
* Fix velocity scaling factor calculations and support multi-DOF joints in Servo (#2540 <https://github.com/ros-planning/moveit2/issues/2540>)
* Ensure to reset the smoothing plugin when resuming Servo (#2537 <https://github.com/ros-planning/moveit2/issues/2537>)
* [Servo] Change planning frame to base frame of active joint subgroup (#2515 <https://github.com/ros-planning/moveit2/issues/2515>)
* Fix threading issue for collision velocity scaling in MoveIt Servo (#2517 <https://github.com/ros-planning/moveit2/issues/2517>)
* Add distance to servo collision checker requests (#2511 <https://github.com/ros-planning/moveit2/issues/2511>)
* Use node logging in moveit_ros (#2482 <https://github.com/ros-planning/moveit2/issues/2482>)
* Smoothing plugin API update and bug fix (#2470 <https://github.com/ros-planning/moveit2/issues/2470>)
  * Use Eigen::vector in smoothing plugin
  * Fix dependencies
  * Make args to reset const
  * Make KinematicState use Eigen::Vector
  * Mark params as unused
  * Fix type issues
  * Variable optimization
  Co-authored-by: AndyZe <andyz@utexas.edu>
  * Link against Eigen, not tf2_eigen
  * Don't resize every time
  * Don't reset the smoother_ every time
  * Initialize the kinematic state of the smoother
  * Cleanup
  ---------
  Co-authored-by: ibrahiminfinite <ibrahimjkd@gmail.com>
  Co-authored-by: V Mohammed Ibrahim <12377945+ibrahiminfinite@users.noreply.github.com>
* Fix levels in servo logs (#2440 <https://github.com/ros-planning/moveit2/issues/2440>)
* Enable using a subgroup of the move group in servo (#2396 <https://github.com/ros-planning/moveit2/issues/2396>)
  * Enable using a subgroup of the move group in servo
  * Remove unnecessary validations since the param is const
  * Apply suggestions from code review
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  * Don't copy joints if subgroup == move group
  * Re-add params_valid in validateParams
  * Generalize active subgroup delta calculation
  * Add more efficient move group joint position lookup
  * Create subgroup map in the constructor
  * Apply suggestions from code review
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  * Update moveit_ros/moveit_servo/src/servo.cpp
  ---------
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
* Fix Servo singularity scaling unit tests (#2414 <https://github.com/ros-planning/moveit2/issues/2414>)
  * Fix Servo singularity scaling unit tests
  * Fix Servo singularity scaling unit tests
  * Simplify tests
  * updateLinkTransforms is not needed after all
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* [Servo] Set static parameters as read-only (#2381 <https://github.com/ros-planning/moveit2/issues/2381>)
  * Make some params read-only + grouping
  * Apply suggestions from code review
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * Allow dynamic initialization of velocity scales
  ---------
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* [Servo] Fix bugs when halting for collision + transforming commands to planning frame (#2350 <https://github.com/ros-planning/moveit2/issues/2350>)
* Contributors: Amal Nanavati, AndyZe, Erik Holum, Marq Rasmussen, Nils-Christian Iseke, Paul Gesel, Sebastian Castro, Sebastian Jahr, Tyler Weaver, V Mohammed Ibrahim
```

## moveit_setup_app_plugins

```
* Node logging for the rest of MoveIt (#2599 <https://github.com/ros-planning/moveit2/issues/2599>)
* Update pre-commit and add to .codespell_words (#2465 <https://github.com/ros-planning/moveit2/issues/2465>)
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Sebastian Jahr, Shobuj Paul, Tyler Weaver
```

## moveit_setup_assistant

```
* Node logging for the rest of MoveIt (#2599 <https://github.com/ros-planning/moveit2/issues/2599>)
* Do not pass and return simple types by const ref (#2453 <https://github.com/ros-planning/moveit2/issues/2453>)
  Co-authored-by: Nils <mailto:nilsmailiseke@gmail.com>
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Sebastian Jahr, Shobuj Paul, Tyler Weaver
```

## moveit_setup_controllers

```
* Node logging for the rest of MoveIt (#2599 <https://github.com/ros-planning/moveit2/issues/2599>)
* Don't assume gripper controller for single joint control in MoveIt Setup Assistant (#2555 <https://github.com/ros-planning/moveit2/issues/2555>)
  * For single joint controllers which are not gripper controllers, still output joints list
  * Use OR
  * Only check for GripperActionController
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
  ---------
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Forrest Rogers-Marcovitz, Sebastian Jahr, Tyler Weaver
```

## moveit_setup_core_plugins

```
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Sebastian Jahr
```

## moveit_setup_framework

```
* Node logging for the rest of MoveIt (#2599 <https://github.com/ros-planning/moveit2/issues/2599>)
* Update pre-commit and add to .codespell_words (#2465 <https://github.com/ros-planning/moveit2/issues/2465>)
* Fix #1971 <https://github.com/ros-planning/moveit2/issues/1971> (#2428 <https://github.com/ros-planning/moveit2/issues/2428>)
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Fix collisions_updater CLI if no package is used (#2344 <https://github.com/ros-planning/moveit2/issues/2344>)
  * Fix collisions_updater CLI if no package is used
  The exceptions introduced with https://github.com/ros-planning/moveit2/pull/2032
  prevented from running the collisions updater CLI without a ROS package.
  This fix makes ROS packages optional again, allowing to use the CLI with absolute
  paths only.
  * Improve warn message wording
* Contributors: David V. Lu!!, Henning Kayser, Sebastian Jahr, Shobuj Paul, Tyler Weaver
```

## moveit_setup_srdf_plugins

```
* Node logging for the rest of MoveIt (#2599 <https://github.com/ros-planning/moveit2/issues/2599>)
* fix typos in compute_default_collisions.cpp (#2461 <https://github.com/ros-planning/moveit2/issues/2461>)
  * fix typos in compute_default_collisions.cpp
  * Fix typo
  ---------
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@tuta.io>
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Sebastian Jahr, Surav Shrestha, Tyler Weaver
```

## moveit_simple_controller_manager

```
* Node logging for the rest of MoveIt (#2599 <https://github.com/ros-planning/moveit2/issues/2599>)
* Add new clang-tidy style rules (#2177 <https://github.com/ros-planning/moveit2/issues/2177>)
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Sebastian Jahr, Tyler Weaver
```

## pilz_industrial_motion_planner

```
* Node logging for the rest of MoveIt (#2599 <https://github.com/ros-planning/moveit2/issues/2599>)
* [Planning Pipeline Refactoring] #2 <https://github.com/ros-planning/moveit2/issues/2> Enable chaining planners (#2457 <https://github.com/ros-planning/moveit2/issues/2457>)
  * Enable chaining multiple planners
* [Planning Pipeline Refactoring] #1 <https://github.com/ros-planning/moveit2/issues/1> Simplify Adapter - Planner chain (#2429 <https://github.com/ros-planning/moveit2/issues/2429>)
* Add new clang-tidy style rules (#2177 <https://github.com/ros-planning/moveit2/issues/2177>)
* Do not pass and return simple types by const ref (#2453 <https://github.com/ros-planning/moveit2/issues/2453>)
  Co-authored-by: Nils <mailto:nilsmailiseke@gmail.com>
* Update pre-commit and add to .codespell_words (#2465 <https://github.com/ros-planning/moveit2/issues/2465>)
* Use generate parameters library in PlanningPipelineClass + general cleanups (#2288 <https://github.com/ros-planning/moveit2/issues/2288>)
  * Don't discard stuff
  * Move constants into source file
  * Move static consts into header
  * Don't ignore pipeline result
  * Use generate parameter library for planning pipeline parameters
  * Fix CI
  * More CI fixes
  * Remove more state from planning pipeline
  * Small cleanups
  * Assert planner_instance_ is not a nullptr
  * Remove valid variable
  * Simplify logic for trajectory printing
  * More helpful comments
  * Small logic simplification by using break
  * Fix clang-tidy
  * Pre-commit + Deprecate functions instead of removing them
  * Fix CI
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Fix for already declared deceleration parameters when using Pilz (#2388 <https://github.com/ros-planning/moveit2/issues/2388>)
  * Fix for already declare deceleration parameters when using Pilz
  * Updated formatting
  * Updated formatting
  ---------
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Update clang-format-14 with QualifierAlignment (#2362 <https://github.com/ros-planning/moveit2/issues/2362>)
  * Set qualifier order in .clang-format
  * Ran pre-commit to update according to new style guide
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Jens Vanhooydonck, Marq Rasmussen, Sebastian Jahr, Shobuj Paul, Tyler Weaver
```

## pilz_industrial_motion_planner_testutils

```
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Update clang-format-14 with QualifierAlignment (#2362 <https://github.com/ros-planning/moveit2/issues/2362>)
  * Set qualifier order in .clang-format
  * Ran pre-commit to update according to new style guide
* Merge branch 'main' into dependabot/github_actions/SonarSource/sonarcloud-github-c-cpp-2
* Contributors: Marq Rasmussen, Sebastian Jahr, Shobuj Paul
```
