### PR TITLE
Add in libpcl-all keys for Debian bookworm.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4741,6 +4741,7 @@ libpcap:
 libpcl-all:
   arch: [pcl]
   debian:
+    bookworm: [libpcl-apps1.13, libpcl-common1.13, libpcl-features1.13, libpcl-filters1.13, libpcl-io1.13, libpcl-kdtree1.13, libpcl-keypoints1.13, libpcl-ml1.13, libpcl-octree1.13, libpcl-outofcore1.13, libpcl-people1.13, libpcl-recognition1.13, libpcl-registration1.13, libpcl-sample-consensus1.13, libpcl-search1.13, libpcl-segmentation1.13, libpcl-stereo1.13, libpcl-surface1.13, libpcl-tracking1.13, libpcl-visualization1.13]
     bullseye: [libpcl-apps1.11, libpcl-common1.11, libpcl-features1.11, libpcl-filters1.11, libpcl-io1.11, libpcl-kdtree1.11, libpcl-keypoints1.11, libpcl-ml1.11, libpcl-octree1.11, libpcl-outofcore1.11, libpcl-people1.11, libpcl-recognition1.11, libpcl-registration1.11, libpcl-sample-consensus1.11, libpcl-search1.11, libpcl-segmentation1.11, libpcl-stereo1.11, libpcl-surface1.11, libpcl-tracking1.11, libpcl-visualization1.11]
     buster: [libpcl-apps1.9, libpcl-common1.9, libpcl-features1.9, libpcl-filters1.9, libpcl-io1.9, libpcl-kdtree1.9, libpcl-keypoints1.9, libpcl-ml1.9, libpcl-octree1.9, libpcl-outofcore1.9, libpcl-people1.9, libpcl-recognition1.9, libpcl-registration1.9, libpcl-sample-consensus1.9, libpcl-search1.9, libpcl-segmentation1.9, libpcl-stereo1.9, libpcl-surface1.9, libpcl-tracking1.9, libpcl-visualization1.9]
   fedora: [pcl, pcl-tools]


### PR DESCRIPTION
Please update the following dependency in the rosdep database.

## Package name:

libpcl-all

## Package Upstream Source:

https://pointclouds.org/

## Purpose of using this:

Update libpcl-all to have a `noble` key.  This is needed to release `ros2_ouster_drivers` into Rolling on Noble.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/libpcl-apps1.13
  - https://packages.debian.org/bookworm/libpcl-common1.13
  - https://packages.debian.org/bookworm/libpcl-features1.13
  - https://packages.debian.org/bookworm/libpcl-filters1.13
  - https://packages.debian.org/bookworm/libpcl-io1.13
  - https://packages.debian.org/bookworm/libpcl-kdtree1.13
  - https://packages.debian.org/bookworm/libpcl-keypoints1.13
  - https://packages.debian.org/bookworm/libpcl-ml1.13
  - https://packages.debian.org/bookworm/libpcl-octree1.13
  - https://packages.debian.org/bookworm/libpcl-outofcore1.13
  - https://packages.debian.org/bookworm/libpcl-people1.13
  - https://packages.debian.org/bookworm/libpcl-recognition1.13
  - https://packages.debian.org/bookworm/libpcl-registration1.13
  - https://packages.debian.org/bookworm/libpcl-sample-consensus1.13
  - https://packages.debian.org/bookworm/libpcl-search1.13
  - https://packages.debian.org/bookworm/libpcl-segmentation1.13
  - https://packages.debian.org/bookworm/libpcl-stereo1.13
  - https://packages.debian.org/bookworm/libpcl-surface1.13
  - https://packages.debian.org/bookworm/libpcl-tracking1.13
  - https://packages.debian.org/bookworm/libpcl-visualization1.13

@marcoag @nuclearsandwich FYI