### PR TITLE
ros_workspace: 1.0.3-5 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5590,7 +5590,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_workspace-release.git
-      version: 1.0.3-4
+      version: 1.0.3-5
     source:
       type: git
       url: https://github.com/ros2/ros_workspace.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_workspace` to `1.0.3-5`:

- upstream repository: https://github.com/ros2/ros_workspace.git
- release repository: https://github.com/ros2-gbp/ros_workspace-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.3-4`

## ros_workspace

```
* Remove path hook generation from ament_environment (#28 <https://github.com/ros2/ros_workspace/issues/28>)
* [latest] Update maintainers - 2022-11-07 (#26 <https://github.com/ros2/ros_workspace/issues/26>)
* Contributors: Audrow Nash, Michael Carroll
```
