### PR TITLE
ignition_cmake2_vendor: 0.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2061,6 +2061,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ignition_cmake2_vendor-release.git
+      version: 0.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ignition_cmake2_vendor` to `0.3.0-1`:

- upstream repository: https://github.com/ignition-release/ignition_cmake2_vendor.git
- release repository: https://github.com/ros2-gbp/ignition_cmake2_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## ignition_cmake2_vendor

```
* Vendor gz_cmake2 unconditionally. (#7 <https://github.com/gazebo-release/gz_cmake2_vendor/issues/7>)
* Contributors: Steven! Ragnarök
```
