### PR TITLE
teleop_twist_keyboard: 2.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6881,7 +6881,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_twist_keyboard-release.git
-      version: 2.3.2-5
+      version: 2.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_keyboard` to `2.4.0-1`:

- upstream repository: https://github.com/ros2/teleop_twist_keyboard.git
- release repository: https://github.com/ros2-gbp/teleop_twist_keyboard-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.2-5`

## teleop_twist_keyboard

```
* Fixes for flake8. (#29 <https://github.com/ros2/teleop_twist_keyboard/issues/29>)
* Show command to change topic name on readme (#27 <https://github.com/ros2/teleop_twist_keyboard/issues/27>)
* Remove url for ros1 on package.xml (#28 <https://github.com/ros2/teleop_twist_keyboard/issues/28>)
* Added TwistStamped option (#26 <https://github.com/ros2/teleop_twist_keyboard/issues/26>)
* Switch to underscores for setup.cfg. (#25 <https://github.com/ros2/teleop_twist_keyboard/issues/25>)
* Contributors: Asuki Kono, Chris Lalancette, agyoungs
```
