### PR TITLE
generate_parameter_library: 0.3.8-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1786,13 +1786,16 @@ repositories:
       version: main
     release:
       packages:
+      - cmake_generate_parameter_module_example
       - generate_parameter_library
+      - generate_parameter_library_example
       - generate_parameter_library_py
+      - generate_parameter_module_example
       - parameter_traits
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 0.3.7-1
+      version: 0.3.8-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `generate_parameter_library` to `0.3.8-1`:

- upstream repository: https://github.com/PickNikRobotics/generate_parameter_library.git
- release repository: https://github.com/ros2-gbp/generate_parameter_library-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.7-1`

## cmake_generate_parameter_module_example

- No changes

## generate_parameter_library

```
* uss python_install_dir (#178 <https://github.com/PickNikRobotics/generate_parameter_library/issues/178>)
* Update CMakeLists.txt (#173 <https://github.com/PickNikRobotics/generate_parameter_library/issues/173>)
* Contributors: Christoph Fröhlich, Paul Gesel
```

## generate_parameter_library_example

```
* Fix newline issue (#176 <https://github.com/PickNikRobotics/generate_parameter_library/issues/176>)
  * fix new line rendering for Python
* Support nested mapped parameters (#166 <https://github.com/PickNikRobotics/generate_parameter_library/issues/166>)
* Contributors: Paul Gesel
```

## generate_parameter_library_py

```
* add # flake8: noqa to template (#177 <https://github.com/PickNikRobotics/generate_parameter_library/issues/177>)
* Fix newline issue (#176 <https://github.com/PickNikRobotics/generate_parameter_library/issues/176>)
  * fix new line rendering for Python
* Support nested mapped parameters (#166 <https://github.com/PickNikRobotics/generate_parameter_library/issues/166>)
* Contributors: Paul Gesel
```

## generate_parameter_module_example

```
* Fix newline issue (#176 <https://github.com/PickNikRobotics/generate_parameter_library/issues/176>)
  * fix new line rendering for Python
* Support nested mapped parameters (#166 <https://github.com/PickNikRobotics/generate_parameter_library/issues/166>)
* Contributors: Paul Gesel
```

## parameter_traits

- No changes
