### PR TITLE
rmf_api_msgs: 0.2.1-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4763,6 +4763,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_api_msgs-release.git
+      version: 0.2.1-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_api_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_api_msgs` to `0.2.1-2`:

- upstream repository: https://github.com/open-rmf/rmf_api_msgs
- release repository: https://github.com/ros2-gbp/rmf_api_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## rmf_api_msgs

```
* Added ``unix_millis_request_time`` and ``requester`` fields to ``task_request.json`` and ``task_state.json`` (#35 <https://github.com/open-rmf/rmf_api_msgs/pull/35>)
* Contributors: Aaron Chong, César Rolón
```
