### PR TITLE
rmf_ros2: 2.5.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4867,6 +4867,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
+      version: 2.5.0-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_ros2` to `2.5.0-2`:

- upstream repository: https://github.com/open-rmf/rmf_ros2.git
- release repository: https://github.com/ros2-gbp/rmf_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## rmf_charging_schedule

- No changes

## rmf_fleet_adapter

```
* Fix edge case when starting on a lane (#312 <https://github.com/open-rmf/rmf_ros2/pull/312>)
* Update GoToPlace to allow finding nearest spot (#308 <https://github.com/open-rmf/rmf_ros2/pull/308>)
* Contributors: Arjo Chakravarty, Grey
```

## rmf_fleet_adapter_python

- No changes

## rmf_task_ros2

- No changes

## rmf_traffic_ros2

- No changes

## rmf_websocket

- No changes
