### PR TITLE
rmf_task: 2.4.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4905,6 +4905,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
+      version: 2.4.0-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_task.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_task` to `2.4.0-2`:

- upstream repository: https://github.com/open-rmf/rmf_task.git
- release repository: https://github.com/ros2-gbp/rmf_task-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## rmf_task

- No changes

## rmf_task_sequence

```
* Add support for multiple destinations to choose from. (#101 <https://github.com/open-rmf/rmf_task/pull/101>)
* Contributors: Arjo Chakravartyi, Grey
```
