### PR TITLE
Correct the freetype runtime key for Fedora.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3461,7 +3461,7 @@ libfreetype6:
   alpine: [freetype]
   arch: [freetype2]
   debian: [libfreetype6]
-  fedora: [freetype-devel]
+  fedora: [freetype]
   gentoo: [media-libs/freetype]
   nixos: [freetype]
   openembedded: [freetype@openembedded-core]


### PR DESCRIPTION
It should *not* install the devel package, and should just install the runtime libraries.  That makes it compatible with what all of the other platforms do for this key.