### PR TITLE
Update the ncurses key on Ubuntu and Debian.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4341,24 +4341,24 @@ libnanopb-dev:
     bionic: null
 libncurses:
   arch: [ncurses]
-  debian: [libncurses5]
+  debian: [libncurses6]
   fedora: [ncurses]
   gentoo: [sys-libs/ncurses]
   osx:
     homebrew:
       packages: [ncurses]
   rhel: [ncurses]
-  ubuntu: [libncurses5]
+  ubuntu: [libncurses6]
 libncurses-dev:
   arch: [ncurses]
-  debian: [libncurses5-dev]
+  debian: [libncurses-dev]
   fedora: [ncurses-devel]
   gentoo: [sys-libs/ncurses]
   macports: [ncurses]
   nixos: [ncurses]
   openembedded: [ncurses@openembedded-core]
   rhel: [ncurses-devel]
-  ubuntu: [libncurses5-dev]
+  ubuntu: [libncurses-dev]
 libneon27-gnutls-dev:
   debian: [libneon27-gnutls-dev]
   gentoo: [net-libs/neon]


### PR DESCRIPTION
The situation with these packages is complicated, but to whit:

1. There are packages named libncurses-dev, libncurses5-dev, and libncursesw5-dev.  However, they all package exactly the same software, namely version 6(!) of the development libraries of ncurses.

2. There are packages named libncurses5, libncurses6 and libncursesw6. However, they all package exactly the same software, version 6(1) of the runtime libraries of ncurses.

We change both Ubuntu and Debian to use the canonical names of these libraries, namely libncurses-dev (for development) and libncurses6 (for runtime).