### PR TITLE
rviz: 13.4.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6398,7 +6398,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 13.4.0-1
+      version: 13.4.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `13.4.0-2`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `13.4.0-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Fix camera display overlay (#1151 <https://github.com/ros2/rviz/issues/1151>)
* Fixes for uncrustify 0.78. (#1155 <https://github.com/ros2/rviz/issues/1155>)
  Mostly what we do here is to disable the indentation on
  certain constructs that are different between 0.72 and
  0.78.  It isn't my preferred solution, but since it only
  affects a small amount of code (and most of that in macros),
  this seems acceptable to me.
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```

## rviz_default_plugins

```
* Select QoS reliability policy in DepthCloud Plugin (#1159 <https://github.com/ros2/rviz/issues/1159>)
* Fixed crash on DepthCloud plugin (#1161 <https://github.com/ros2/rviz/issues/1161>)
* Fixes for uncrustify 0.78. (#1155 <https://github.com/ros2/rviz/issues/1155>)
  Mostly what we do here is to disable the indentation on
  certain constructs that are different between 0.72 and
  0.78.  It isn't my preferred solution, but since it only
  affects a small amount of code (and most of that in macros),
  this seems acceptable to me.
* Fixed crash on DepthCloudPlugin (#1133 <https://github.com/ros2/rviz/issues/1133>)
* Wrench accepth nan values fix (#1141 <https://github.com/ros2/rviz/issues/1141>)
* DepthCloud plugin: Append measured subscription frequency to topic status (#1137 <https://github.com/ros2/rviz/issues/1137>)
* Added Cache to camera display for TimeExact (#1138 <https://github.com/ros2/rviz/issues/1138>)
* Fixed transport name in DepthCloud plugin (#1134 <https://github.com/ros2/rviz/issues/1134>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```

## rviz_ogre_vendor

```
* Change an rviz_ogre_vendor dependency to libfreetype-dev. (#1167 <https://github.com/ros2/rviz/issues/1167>)
  The situation is complicated, but in versions of Ubuntu
  prior to Focal and versions of Debian prior to Bookworm,
  the name of the library was 'libfreetype6-dev'.  Since
  Focal and Bookworm, the name of the library is 'libfreetype-dev'.
  While 'libfreetype-dev' provides a "virtual package"
  for 'libfreetype6-dev', we should really use the new canonical
  name.
  Further, there is currently a bug on ros_buildfarm where
  it doesn't properly deal with "virtual packages" like this.
  This is currently preventing this package from building on
  Ubuntu Noble.  That bug is being worked on separately.
  Finally, I'll note that we already have a libfreetype-dev
  key in rosdep, so we just switch to using that here which
  should work around the bug on the buildfarm, and also use
  the correct canonical name going forward.
* fix: modify typo in cmake args for mac (#1160 <https://github.com/ros2/rviz/issues/1160>)
* feat: support macos (#1156 <https://github.com/ros2/rviz/issues/1156>)
* Contributors: Chris Lalancette, Daisuke Nishimatsu
```

## rviz_rendering

```
* Fix camera display overlay (#1151 <https://github.com/ros2/rviz/issues/1151>)
* Fixes for uncrustify 0.78. (#1155 <https://github.com/ros2/rviz/issues/1155>)
  Mostly what we do here is to disable the indentation on
  certain constructs that are different between 0.72 and
  0.78.  It isn't my preferred solution, but since it only
  affects a small amount of code (and most of that in macros),
  this seems acceptable to me.
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
