### PR TITLE
added ffmpeg_image_transport_tools to humble and iron

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1919,6 +1919,16 @@ repositories:
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git
       version: master
     status: developed
+  ffmpeg_image_transport_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_tools.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_tools.git
+      version: humble
+    status: developed
   fields2cover:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1486,6 +1486,16 @@ repositories:
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git
       version: master
     status: developed
+  ffmpeg_image_transport_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_tools.git
+      version: iron
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_tools.git
+      version: iron
+    status: developed
   fields2cover:
     release:
       tags:


### PR DESCRIPTION
# Please add ffmpeg_image_transport_tools package to be indexed in the rosdistro.

This is a new package with tools to process ffmpeg_image_transport_msgs that are generated by the ffmpeg_image_transport plugin: convert a rosbag with messages into an mp4 file or a sequence of images.

ROSDISTRO NAME: humble and iron

The source is [here](http://github.com/ros-misc-utilities/ffmpeg_image_transport_tools)

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
