### PR TITLE
filters: 2.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1461,7 +1461,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/filters-release.git
-      version: 2.1.0-5
+      version: 2.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `filters` to `2.1.1-1`:

- upstream repository: https://github.com/ros/filters.git
- release repository: https://github.com/ros2-gbp/filters-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.0-5`

## filters

```
* Provide target based dependencies in cmake for filter_base and libraries.
* Support Boost 1.71 (Ubuntu 20.04 Humble)
* Allow to iterate over RealtimeCircularBuffer.
* Change function signature to use pointer instead of array.
  This really has no downstream consequence, but makes it so that
  rosdoc2 can successfully generate documentation.
* Contributors: Chris Lalancette, Daisuke Nishimatsu, Jonathan Binney,
  Patrick Roncagliolo, Ryan Friedman, wep21
```
