### PR TITLE
feat: add rasterio to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8417,6 +8417,14 @@ python3-rapidfuzz-pip:
   ubuntu:
     pip:
       packages: [rapidfuzz]
+python3-rasterio:
+  debian: [python3-rasterio]
+  fedora: [python3-rasterio]
+  opensuse: [python3-rasterio]
+  osx:
+    pip:
+      packages: [rasterio]
+  ubuntu: [python3-rasterio]
 python3-rdflib:
   arch: [python-rdflib]
   debian: [python3-rdflib]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8420,7 +8420,6 @@ python3-rapidfuzz-pip:
 python3-rasterio:
   debian: [python3-rasterio]
   fedora: [python3-rasterio]
-  opensuse: [python3-rasterio]
   osx:
     pip:
       packages: [rasterio]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`rasterio`

## Package Upstream Source:

https://github.com/rasterio/rasterio

## Purpose of using this:

Rasterio reads and writes geospatial raster data. It can be used to create a occupancy grid map. 

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/python3-rasterio
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/jammy/python3-rasterio
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-rasterio/python3-rasterio/
- Arch: https://www.archlinux.org/packages/
  - Not available
- Gentoo: https://packages.gentoo.org/
  - Not available
- macOS: https://formulae.brew.sh/
  - Not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - Not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - Not available
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python3-rasterio
- rhel: https://rhel.pkgs.org/
  - Not available
- pip
  -  https://pypi.org/project/rasterio/

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

humble

# The source is here:

https://github.com/rasterio/rasterio

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
