### PR TITLE
rc_genicam_api: 2.6.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4417,7 +4417,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rc_genicam_api-release.git
-      version: 2.6.1-3
+      version: 2.6.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_api` to `2.6.5-1`:

- upstream repository: https://github.com/roboception/rc_genicam_api.git
- release repository: https://github.com/ros2-gbp/rc_genicam_api-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.6.1-3`

## rc_genicam_api

```
* Added method to get remote port of device to directly read and write register
* Added functions to read and write GenICam register parameters
* Fixed write error message of gc_file tool
* fix for gcc 13: use global stdint
```
