### PR TITLE
motion_capture_tracking: 1.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3961,7 +3961,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/motion_capture_tracking-release.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/IMRCLab/motion_capture_tracking.git


### PR DESCRIPTION
Increasing version of package(s) in repository `motion_capture_tracking` to `1.0.5-1`:

- upstream repository: https://github.com/IMRCLab/motion_capture_tracking.git
- release repository: https://github.com/ros2-gbp/motion_capture_tracking-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.4-1`

## motion_capture_tracking

```
* Install libNatNet.so only on x64 Linux
  * Should fix ROS 2 build farm errors.
* Contributors: Wolfgang Hoenig
```

## motion_capture_tracking_interfaces

- No changes
