### PR TITLE
Remove mqtt_client from Rolling.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3164,23 +3164,6 @@ repositories:
       url: https://github.com/MOLAorg/mp2p_icp.git
       version: master
     status: developed
-  mqtt_client:
-    doc:
-      type: git
-      url: https://github.com/ika-rwth-aachen/mqtt_client.git
-      version: main
-    release:
-      packages:
-      - mqtt_client
-      - mqtt_client_interfaces
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/mqtt_client-release.git
-    source:
-      type: git
-      url: https://github.com/ika-rwth-aachen/mqtt_client.git
-      version: main
-    status: maintained
   mrpt2:
     doc:
       type: git


### PR DESCRIPTION
As far as I can tell, it has never successfully even attempted to be built on Rolling: https://build.ros2.org/search/?q=mqtt_client

It probably needs a new source release, along with a new bloom release, using the correct release repository. For now, just remove it from Rolling completely; we can always add it back later.

@lreiher FYI.