### PR TITLE
Remove rc_dynamics_api from Rolling.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4393,21 +4393,6 @@ repositories:
       url: https://github.com/roboception/rc_common_msgs_ros2.git
       version: master
     status: developed
-  rc_dynamics_api:
-    doc:
-      type: git
-      url: https://github.com/roboception/rc_dynamics_api.git
-      version: master
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/rc_dynamics_api-release.git
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/roboception/rc_dynamics_api.git
-      version: master
-    status: developed
   rc_genicam_api:
     doc:
       type: git


### PR DESCRIPTION
As far as I can tell, it has never successfully built on Rolling: https://build.ros2.org/search/?q=rc_dynamics_api

Just remove it for now.

FYI @flixr 