### PR TITLE
Remove warehouse_ros_mongo.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7744,20 +7744,6 @@ repositories:
       url: https://github.com/ros-planning/warehouse_ros.git
       version: ros2
     status: maintained
-  warehouse_ros_mongo:
-    doc:
-      type: git
-      url: https://github.com/ros-planning/warehouse_ros_mongo.git
-      version: ros2
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/warehouse_ros_mongo-release.git
-    source:
-      type: git
-      url: https://github.com/ros-planning/warehouse_ros_mongo.git
-      version: ros2
-    status: maintained
   warehouse_ros_sqlite:
     doc:
       type: git


### PR DESCRIPTION
As far as I can tell, it has not had a successful build on the buildfarm in a long time: https://build.ros2.org/search/?q=warehouse_ros_mongo

Just remove it for now.

@henningkayser FYI