### PR TITLE
rmf_ros2: 2.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4868,7 +4868,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 2.5.0-2
+      version: 2.6.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_ros2` to `2.6.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_ros2.git
- release repository: https://github.com/ros2-gbp/rmf_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.5.0-2`

## rmf_charging_schedule

- No changes

## rmf_fleet_adapter

```
* Removes a line of dead code (#322 <https://github.com/open-rmf/rmf_ros2/pull/322>)
* include cstdint header (#331 <https://github.com/open-rmf/rmf_ros2/pull/331>)
* Add Backward-ROS for improved logging in event of segfaults (#327 <https://github.com/open-rmf/rmf_ros2/pull/327>)
* Explicitly specify all qos depth (#323 <https://github.com/open-rmf/rmf_ros2/pull/323>)
* Add support of fleet-level task (#317 <https://github.com/open-rmf/rmf_ros2/pull/317>)
* Fix minor logging error (#318 <https://github.com/open-rmf/rmf_ros2/pull/318>)
* Contributors: Arjo Chakravarty, Teo Koon Peng, Yadunund, cwrx777
```

## rmf_fleet_adapter_python

```
* add in_lift readonly property in Graph::Waypoint binding. (#326 <https://github.com/open-rmf/rmf_ros2/pull/326>)
* Contributors: cwrx777
```

## rmf_task_ros2

```
* Add Backward-ROS for improved logging in event of segfaults (#327 <https://github.com/open-rmf/rmf_ros2/pull/327>)
* Explicitly specify all qos depth (#323 <https://github.com/open-rmf/rmf_ros2/pull/323>)
* Adds an option to generate unique hex strings for new task ids, fix time stamp logic (#319 <https://github.com/open-rmf/rmf_ros2/pull/319>)
* Contributors: Aaron Chong, Arjo Chakravarty, Teo Koon Peng
```

## rmf_traffic_ros2

```
* Add Backward-ROS for improved logging in event of segfaults (#327 <https://github.com/open-rmf/rmf_ros2/pull/327>)
* Explicitly specify all qos depth (#323 <https://github.com/open-rmf/rmf_ros2/pull/323>)
* Contributors: Arjo Chakravarty, Teo Koon Peng, Yadunund
```

## rmf_websocket

- No changes
