### PR TITLE
phidgets_drivers: 1.0.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7513,6 +7513,7 @@ repositories:
       - phidgets_drivers
       - phidgets_gyroscope
       - phidgets_high_speed_encoder
+      - phidgets_humidity
       - phidgets_ik
       - phidgets_magnetometer
       - phidgets_motors
@@ -7522,7 +7523,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
-      version: 1.0.8-2
+      version: 1.0.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `1.0.9-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.8-2`

## libphidget22

```
* Update to libphidget22 1.19 (#175 <https://github.com/ros-drivers/phidgets_drivers/issues/175>)
* Contributors: Martin Günther
```

## phidgets_accelerometer

- No changes

## phidgets_analog_inputs

- No changes

## phidgets_analog_outputs

- No changes

## phidgets_api

```
* Add support for Phidgets Humidity sensors (#173 <https://github.com/ros-drivers/phidgets_drivers/issues/173>)
* Contributors: Gary Edwards
```

## phidgets_digital_inputs

- No changes

## phidgets_digital_outputs

- No changes

## phidgets_drivers

- No changes

## phidgets_gyroscope

- No changes

## phidgets_high_speed_encoder

- No changes

## phidgets_humidity

```
* Add support for Phidgets Humidity sensors (#173 <https://github.com/ros-drivers/phidgets_drivers/issues/173>)
  I have done a find and replace on the phidgets_temperature package to get the Phidgets Humidity sensor working. Tested with a HUM1001_0.
* Contributors: Gary Edwards
```

## phidgets_ik

- No changes

## phidgets_magnetometer

- No changes

## phidgets_motors

- No changes

## phidgets_msgs

- No changes

## phidgets_spatial

- No changes

## phidgets_temperature

- No changes
