### PR TITLE
flir_camera_driver: 2.2.13-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1569,10 +1569,11 @@ repositories:
       - flir_camera_description
       - flir_camera_msgs
       - spinnaker_camera_driver
+      - spinnaker_synchronized_camera_driver
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git
-      version: 2.0.8-3
+      version: 2.2.13-1
     source:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_camera_driver` to `2.2.13-1`:

- upstream repository: https://github.com/ros-drivers/flir_camera_driver.git
- release repository: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.8-3`

## flir_camera_description

- No changes

## flir_camera_msgs

- No changes

## spinnaker_camera_driver

```
* added blackfly GigE configuration file
* Contributors: Bernd Pfrommer
```

## spinnaker_synchronized_camera_driver

- No changes
