### PR TITLE
flir_camera_driver: 2.1.13-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2021,10 +2021,11 @@ repositories:
       - flir_camera_description
       - flir_camera_msgs
       - spinnaker_camera_driver
+      - spinnaker_synchronized_camera_driver
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git
-      version: 2.0.8-3
+      version: 2.1.13-1
     source:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_camera_driver` to `2.1.13-1`:

- upstream repository: https://github.com/ros-drivers/flir_camera_driver.git
- release repository: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.8-3`

## flir_camera_description

- No changes

## flir_camera_msgs

- No changes

## spinnaker_camera_driver

```
* added blackfly GigE configuration file
* track incomplete frames
* fixed licensing documentation
* provision camera driver for exposure control
* fixed bugs discovered when running on GigE cams
* avoid searching ROS path for library
* Contributors: Bernd Pfrommer
```

## spinnaker_synchronized_camera_driver

```
* track incomplete frames
* fixed licensing documentation
* implement individual exposure controller
* fixed bugs discovered when running on GigE cams
* Contributors: Bernd Pfrommer
```
