### PR TITLE
phidgets_drivers: 2.3.3-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4216,7 +4216,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/phidgets_drivers-release.git
-      version: 2.3.2-1
+      version: 2.3.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `2.3.3-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros2-gbp/phidgets_drivers-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.2-1`

## libphidget22

```
* Update to libphidget22 1.19 (#176 <https://github.com/ros-drivers/phidgets_drivers/issues/176>)
* Contributors: Martin Günther
```

## phidgets_accelerometer

```
* Add support for VINT networkhub (#172 <https://github.com/ros-drivers/phidgets_drivers/issues/172>)
  This is a port of #127 <https://github.com/ros-drivers/phidgets_drivers/issues/127> to ROS2.
  Closes #135 <https://github.com/ros-drivers/phidgets_drivers/issues/135>.
* Contributors: Martin Günther
```

## phidgets_analog_inputs

```
* Add support for VINT networkhub (#172 <https://github.com/ros-drivers/phidgets_drivers/issues/172>)
  This is a port of #127 <https://github.com/ros-drivers/phidgets_drivers/issues/127> to ROS2.
  Closes #135 <https://github.com/ros-drivers/phidgets_drivers/issues/135>.
* Contributors: Martin Günther
```

## phidgets_analog_outputs

```
* Add support for VINT networkhub (#172 <https://github.com/ros-drivers/phidgets_drivers/issues/172>)
  This is a port of #127 <https://github.com/ros-drivers/phidgets_drivers/issues/127> to ROS2.
  Closes #135 <https://github.com/ros-drivers/phidgets_drivers/issues/135>.
* Contributors: Martin Günther
```

## phidgets_api

- No changes

## phidgets_digital_inputs

```
* Add support for VINT networkhub (#172 <https://github.com/ros-drivers/phidgets_drivers/issues/172>)
  This is a port of #127 <https://github.com/ros-drivers/phidgets_drivers/issues/127> to ROS2.
  Closes #135 <https://github.com/ros-drivers/phidgets_drivers/issues/135>.
* Contributors: Martin Günther
```

## phidgets_digital_outputs

```
* Add support for VINT networkhub (#172 <https://github.com/ros-drivers/phidgets_drivers/issues/172>)
  This is a port of #127 <https://github.com/ros-drivers/phidgets_drivers/issues/127> to ROS2.
  Closes #135 <https://github.com/ros-drivers/phidgets_drivers/issues/135>.
* Contributors: Martin Günther
```

## phidgets_drivers

- No changes

## phidgets_gyroscope

```
* Add support for VINT networkhub (#172 <https://github.com/ros-drivers/phidgets_drivers/issues/172>)
  This is a port of #127 <https://github.com/ros-drivers/phidgets_drivers/issues/127> to ROS2.
  Closes #135 <https://github.com/ros-drivers/phidgets_drivers/issues/135>.
* Contributors: Martin Günther
```

## phidgets_high_speed_encoder

```
* Add support for VINT networkhub (#172 <https://github.com/ros-drivers/phidgets_drivers/issues/172>)
  This is a port of #127 <https://github.com/ros-drivers/phidgets_drivers/issues/127> to ROS2.
  Closes #135 <https://github.com/ros-drivers/phidgets_drivers/issues/135>.
* Contributors: Martin Günther
```

## phidgets_ik

- No changes

## phidgets_magnetometer

```
* Add support for VINT networkhub (#172 <https://github.com/ros-drivers/phidgets_drivers/issues/172>)
  This is a port of #127 <https://github.com/ros-drivers/phidgets_drivers/issues/127> to ROS2.
  Closes #135 <https://github.com/ros-drivers/phidgets_drivers/issues/135>.
* Contributors: Martin Günther
```

## phidgets_motors

```
* Add support for VINT networkhub (#172 <https://github.com/ros-drivers/phidgets_drivers/issues/172>)
  This is a port of #127 <https://github.com/ros-drivers/phidgets_drivers/issues/127> to ROS2.
  Closes #135 <https://github.com/ros-drivers/phidgets_drivers/issues/135>.
* Contributors: Martin Günther
```

## phidgets_msgs

- No changes

## phidgets_spatial

```
* Add support for VINT networkhub (#172 <https://github.com/ros-drivers/phidgets_drivers/issues/172>)
  This is a port of #127 <https://github.com/ros-drivers/phidgets_drivers/issues/127> to ROS2.
  Closes #135 <https://github.com/ros-drivers/phidgets_drivers/issues/135>.
* Contributors: Martin Günther
```

## phidgets_temperature

```
* Add support for VINT networkhub (#172 <https://github.com/ros-drivers/phidgets_drivers/issues/172>)
  This is a port of #127 <https://github.com/ros-drivers/phidgets_drivers/issues/127> to ROS2.
  Closes #135 <https://github.com/ros-drivers/phidgets_drivers/issues/135>.
* Contributors: Martin Günther
```
