### PR TITLE
rosdep: add protobuf for ubuntu noble

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7350,6 +7350,7 @@ protobuf:
     bionic: [libprotobuf10]
     focal: [libprotobuf17]
     jammy: [libprotobuf23]
+    noble: [libprotobuf32]
 protobuf-compiler-grpc:
   debian: [protobuf-compiler-grpc]
   fedora: [grpc-plugins]


### PR DESCRIPTION
Add rosdep entry for `protobuf` on Ubuntu noble.

Should fix e.g. https://build.ros2.org/job/Rdev__rc_dynamics_api__ubuntu_noble_amd64/2/console and also relates to https://github.com/ros/rosdistro/pull/40184