### PR TITLE
rqt_gauges: 0.0.3-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6355,7 +6355,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_gauges-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/ToyotaResearchInstitute/gauges2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_gauges` to `0.0.3-1`:

- upstream repository: https://github.com/ToyotaResearchInstitute/gauges2
- release repository: https://github.com/ros2-gbp/rqt_gauges-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.2-1`

## rqt_gauges

```
* Refactor using a base widget class (#35 <https://github.com/ekumenlabs/gauges2//issues/35>)
* Contributors: Carlos Agüero
```
