### PR TITLE
add python3-orjson key to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7352,6 +7352,8 @@ python3-openhsi-pip:
     pip:
       packages: [openhsi]
 python3-orjson:
+  # Replace pip packages with native packages when this bug is resolved:
+  # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1002996
   arch: [python-orjson]
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7359,7 +7359,13 @@ python3-orjson:
   fedora: [python3-orjson]
   gentoo: [dev-python/orjson]
   nixos: ['python%{python3_pkgversion}Packages.orjson']
+  openembedded:
+    pip:
+      packages: [orjson]
   opensuse:
+    pip:
+      packages: [orjson]
+  rhel:
     pip:
       packages: [orjson]
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7351,6 +7351,20 @@ python3-openhsi-pip:
   ubuntu:
     pip:
       packages: [openhsi]
+python3-orjson:
+  arch: [python-orjson]
+  debian:
+    pip:
+      packages: [orjson]
+  fedora: [python3-orjson]
+  gentoo: [dev-python/orjson]
+  nixos: ['python%{python3_pkgversion}Packages.orjson']
+  opensuse:
+    pip:
+      packages: [orjson]
+  ubuntu:
+    pip:
+      packages: [orjson]
 python3-overrides:
   arch: [python-overrides]
   debian:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-orjson

## Package Upstream Source:

Source: https://github.com/ijl/orjson

## Purpose of using this:

orjson is a fast, correct JSON library for Python. This dependency is being used for this reason. This is why I think it's valuable to be added to the rosdep database.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://pypi.org/project/orjson/
- Ubuntu: https://pypi.org/project/orjson/
- Fedora: https://packages.fedoraproject.org/pkgs/python-orjson/python3-orjson/
- Arch: https://archlinux.org/packages/extra/x86_64/python-orjson/
- Gentoo: https://packages.gentoo.org/packages/dev-python/orjson
- macOS: not available
- Alpine: not available
- NixOS/nixpkgs: [link](https://search.nixos.org/packages?channel=23.11&show=python310Packages.orjson&from=0&size=50&sort=relevance&type=packages&query=orjson)
- openSUSE: not available for python 3.8
- rhel: not available
