### PR TITLE
rosdep: add protobuf for debian bookworm

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7335,6 +7335,7 @@ proj:
 protobuf:
   arch: [protobuf]
   debian:
+    bookworm: [libprotobuf32]
     bullseye: [libprotobuf23]
     buster: [libprotobuf17]
   fedora: [protobuf]


### PR DESCRIPTION
Add rosdep entry for `protobuf` on debian bookworm.

Relates to https://github.com/ros/rosdistro/pull/40184