### PR TITLE
Add python3-singleton-pattern-decorator-pip to rosdep/base.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8873,6 +8873,16 @@ python3-simplification-pip:
   ubuntu:
     pip:
       packages: [simplification]
+python3-singleton-pattern-decorator-pip:
+  debian:
+    pip:
+      packages: [singleton-pattern-decorator]
+  fedora:
+    pip:
+      packages: [singleton-pattern-decorator]
+  ubuntu:
+    pip:
+      packages: [singleton-pattern-decorator]
 python3-sip:
   debian: [python3-sip-dev]
   fedora: [python3-sip-devel]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-singleton-pattern-decorator-pip

## Package Upstream Source:

Source: https://github.com/jbw/singleton-pattern-decorator

## Purpose of using this:

This is a singleton pattern decorator for Python ant it is helpful to create singleton classes. I think it's valuable to be added to the rosdep database.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

This package is only available via PyPI: https://pypi.org/project/singleton-pattern-decorator/

