### PR TITLE
rc_dynamics_api: 0.10.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4404,7 +4404,8 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/rc_dynamics_api-release.git
+      url: git@github.com:ros2-gbp/rc_dynamics_api-release.git
+      version: 0.10.5-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4404,7 +4404,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: git@github.com:ros2-gbp/rc_dynamics_api-release.git
+      url: https://github.com/ros2-gbp/rc_dynamics_api-release.git
       version: 0.10.5-1
     source:
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_dynamics_api` to `0.10.5-1`:

- upstream repository: https://github.com/roboception/rc_dynamics_api.git
- release repository: git@github.com:ros2-gbp/rc_dynamics_api-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## rc_dynamics_api

```
* [ci]: remove bionic and xenial, add focal arm64 and jammy
* update cmake files for better version handling
```
