### PR TITLE
robotraconteur: 1.1.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5525,7 +5525,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/robotraconteur-packaging/robotraconteur-ros2-release.git
-      version: 1.0.0-2
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/robotraconteur/robotraconteur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotraconteur` to `1.1.0-1`:

- upstream repository: https://github.com/robotraconteur/robotraconteur.git
- release repository: https://github.com/robotraconteur-packaging/robotraconteur-ros2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-2`
