### PR TITLE
Update individual libpcl-* keys.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4791,6 +4791,7 @@ libpcl-apps:
 libpcl-common:
   alpine: [pcl-libs]
   debian:
+    bookworm: [libpcl-common1.13]
     bullseye: [libpcl-common1.11]
     buster: [libpcl-common1.9]
   fedora: [pcl]
@@ -4805,9 +4806,11 @@ libpcl-common:
     bionic: [libpcl-common1.8]
     focal: [libpcl-common1.10]
     jammy: [libpcl-common1.12]
+    noble: [libpcl-common1.13]
 libpcl-features:
   alpine: [pcl-libs]
   debian:
+    bookworm: [libpcl-features1.13]
     bullseye: [libpcl-features1.11]
     buster: [libpcl-features1.9]
   fedora: [pcl]
@@ -4822,9 +4825,11 @@ libpcl-features:
     bionic: [libpcl-features1.8]
     focal: [libpcl-features1.10]
     jammy: [libpcl-features1.12]
+    noble: [libpcl-features1.13]
 libpcl-filters:
   alpine: [pcl-libs]
   debian:
+    bookworm: [libpcl-filters1.13]
     bullseye: [libpcl-filters1.11]
     buster: [libpcl-filters1.9]
   fedora: [pcl]
@@ -4839,9 +4844,11 @@ libpcl-filters:
     bionic: [libpcl-filters1.8]
     focal: [libpcl-filters1.10]
     jammy: [libpcl-filters1.12]
+    noble: [libpcl-filters1.13]
 libpcl-io:
   alpine: [pcl-libs]
   debian:
+    bookworm: [libpcl-io1.13]
     bullseye: [libpcl-io1.11]
     buster: [libpcl-io1.9]
   fedora: [pcl]
@@ -4856,6 +4863,7 @@ libpcl-io:
     bionic: [libpcl-io1.8]
     focal: [libpcl-io1.10]
     jammy: [libpcl-io1.12]
+    noble: [libpcl-io1.13]
 libpcl-kdtree:
   alpine: [pcl-libs]
   debian:
@@ -5029,6 +5037,7 @@ libpcl-search:
 libpcl-segmentation:
   alpine: [pcl-libs]
   debian:
+    bookworm: [libpcl-segmentation1.13]
     bullseye: [libpcl-segmentation1.11]
     buster: [libpcl-segmentation1.9]
   fedora: [pcl]
@@ -5043,6 +5052,7 @@ libpcl-segmentation:
     bionic: [libpcl-segmentation1.8]
     focal: [libpcl-segmentation1.10]
     jammy: [libpcl-segmentation1.12]
+    noble: [libpcl-segmentation1.13]
 libpcl-stereo:
   alpine: [pcl-libs]
   debian:
@@ -5063,6 +5073,7 @@ libpcl-stereo:
 libpcl-surface:
   alpine: [pcl-libs]
   debian:
+    bookworm: [libpcl-surface1.13]
     bullseye: [libpcl-surface1.11]
     buster: [libpcl-surface1.9]
   fedora: [pcl]
@@ -5077,6 +5088,7 @@ libpcl-surface:
     bionic: [libpcl-surface1.8]
     focal: [libpcl-surface1.10]
     jammy: [libpcl-surface1.12]
+    noble: [libpcl-surface1.13]
 libpcl-tracking:
   alpine: [pcl-libs]
   debian:


### PR DESCRIPTION
Some downstream packages (like pcl_ros and pcl_conversions) rely on these individual keys, rather than the omnibus libpcl-all.  Update them here for noble and bookworm.

This is a follow-up to #40127 and #40096