### PR TITLE
mp2p_icp: 1.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3161,7 +3161,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 1.2.0-2
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `1.3.0-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.0-2`

## mp2p_icp

```
* mm-viewer: new options to visualize georeferenced maps
* New sm-cli commands: --cut, --export-keyframes, --export-rawlog
* propagate cmake deps downstream
* metric_map_t: add georeferencing optional field
* mm-filter: add --rename operation
* GetOrCreatePointLayer() moved to its own header and uses shared ptrs
* FilterMerge: add param input_layer_in_local_coordinates
* Contributors: Jose Luis Blanco-Claraco
```
