### PR TITLE
fix: typo on yoctopuce python package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9760,7 +9760,7 @@ python3-yappi:
   ubuntu:
     '*': [python3-yappi]
     bionic: null
-python3-yocotopuce-pip:
+python3-yoctopuce-pip:
   ubuntu:
     pip:
       packages: [yoctopuce]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

## Package name:

`python3-yoctopuce-pip`

## Package Upstream Source:

[yoctolib_api](https://github.com/yoctopuce/yoctolib_python)

## Purpose of using this:

This dependency is being used for controlling the [Yoctopuce](https://www.yoctopuce.com/) devices using their Python API. This makes easier to use and control actuators and sensors.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - [https://pypi.org/project/yoctopuce/](https://pypi.org/project/yoctopuce/)
- Ubuntu: https://packages.ubuntu.com/
  - [https://pypi.org/project/yoctopuce/](https://pypi.org/project/yoctopuce/)
- Fedora: https://packages.fedoraproject.org/
  - Not available
- Arch: https://www.archlinux.org/packages/
  - Not available
- Gentoo: https://packages.gentoo.org/
  - Not available
- macOS: https://formulae.brew.sh/
  - Not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - Not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - Not available
- openSUSE: https://software.opensuse.org/package/
  - Not available
- rhel: https://rhel.pkgs.org/
  - Not available

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
