### PR TITLE
cartographer_ros: 2.0.9002-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -885,7 +885,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/cartographer_ros-release.git
-      version: 2.0.9000-2
+      version: 2.0.9002-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cartographer_ros` to `2.0.9002-1`:

- upstream repository: https://github.com/ros2/cartographer_ros.git
- release repository: https://github.com/ros2-gbp/cartographer_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.9000-2`

## cartographer_ros

```
* Fix for newer Google logging.
* Fix warnings when building against recent ROS 2 releases.
* Contributors: Chris Lalancette
```

## cartographer_ros_msgs

- No changes

## cartographer_rviz

```
* Fix a warning when building against newer Ogre.
* Fix warnings when building against recent ROS 2 releases.
* Contributors: Chris Lalancette
```
