### PR TITLE
Fork the sophus repositories.

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8335,7 +8335,7 @@ repositories:
   sophus:
     doc:
       type: git
-      url: https://github.com/stonier/sophus.git
+      url: https://github.com/clalancette/sophus.git
       version: release/1.3.x
     release:
       tags:
@@ -8344,7 +8344,7 @@ repositories:
       version: 1.3.1-1
     source:
       type: git
-      url: https://github.com/stonier/sophus.git
+      url: https://github.com/clalancette/sophus.git
       version: release/1.3.x
     status: maintained
   spdlog_vendor:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7129,8 +7129,8 @@ repositories:
   sophus:
     doc:
       type: git
-      url: https://github.com/stonier/sophus.git
-      version: release/1.2.x
+      url: https://github.com/clalancette/sophus.git
+      version: release/1.3.x
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -7138,8 +7138,8 @@ repositories:
       version: 1.3.1-3
     source:
       type: git
-      url: https://github.com/stonier/sophus.git
-      version: release/1.2.x
+      url: https://github.com/clalancette/sophus.git
+      version: release/1.3.x
     status: maintained
   spdlog_vendor:
     release:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6676,8 +6676,8 @@ repositories:
   sophus:
     doc:
       type: git
-      url: https://github.com/stonier/sophus.git
-      version: release/1.2.x
+      url: https://github.com/clalancette/sophus.git
+      version: release/1.3.x
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -6685,8 +6685,8 @@ repositories:
       version: 1.3.1-3
     source:
       type: git
-      url: https://github.com/stonier/sophus.git
-      version: release/1.2.x
+      url: https://github.com/clalancette/sophus.git
+      version: release/1.3.x
     status: maintained
   spdlog_vendor:
     release:


### PR DESCRIPTION
We've been waiting for almost a year to get some fixes to sophus merged so that we can get turtlebot2 released into Humble and Iron: https://github.com/stonier/sophus/pull/23

For now, use a fork under my username to do the release. I still haven't merged that fix in, but once we switch this over I will have the power to do so.

While we are in here, switch the source and doc branches to be correct (we are releasing from the 1.3.x branch nowadays).