### PR TITLE
marine_msgs: 2.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5451,7 +5451,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/CCOMJHC/marine_msgs-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/apl-ocean-engineering/marine_msgs.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5456,7 +5456,7 @@ repositories:
       type: git
       url: https://github.com/apl-ocean-engineering/marine_msgs.git
       version: main
-    status: maintained
+    status: developed
   marker_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marine_msgs` to `2.0.2-1`:

- upstream repository: https://github.com/apl-ocean-engineering/marine_msgs.git
- release repository: https://github.com/CCOMJHC/marine_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.1-1`

## marine_acoustic_msgs

```
* Add Roland Arsenault as maintainer (#55 <https://github.com/rolker/marine_msgs/issues/55>)
* Contributors: Roland Arsenault
```

## marine_sensor_msgs

```
* Add Roland Arsenault as maintainer (#55 <https://github.com/rolker/marine_msgs/issues/55>)
* Contributors: Roland Arsenault
```
