### PR TITLE
Add new keys for pybind11-json-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7421,6 +7421,15 @@ pybind11-dev:
     '*': [pybind11-devel]
     '7': null
   ubuntu: [pybind11-dev]
+pybind11-json-dev:
+  debian: [pybind11-json-dev]
+  fedora:
+    '*': [pybind11-json-devel]
+    '38': null
+  rhel: [pybind11-json-devel]
+  ubuntu:
+    '*': [pybind11-json-dev]
+    focal: null
 python-dev:
   debian: [python-dev]
   fedora: [python2-devel]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

pybind11_json

## Package Upstream Source:

https://github.com/pybind/pybind11_json

## Purpose of using this:

`pybind11_json` is an `nlohmann::json` to `pybind11` bridge, it allows you to automatically convert `nlohmann::json` to `py::object` and the other way around.

This package is currently vendored in Open-RMF

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=pybind11-json-dev&searchon=names&suite=all&section=all
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=pybind11-json-dev&searchon=names&suite=all&section=all
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/pybind11-json/pybind11-json-devel/
- Arch: https://www.archlinux.org/packages/
  - NOT AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - NOT AVAILABLE
- macOS: https://formulae.brew.sh/
  - NOT AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - NOT AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - NOT AVAILABLE
- openSUSE: https://software.opensuse.org/package/
  - NOT AVAILABLE
- rhel: https://rhel.pkgs.org/
  - https://packages.fedoraproject.org/pkgs/pybind11-json/pybind11-json-devel/