### PR TITLE
marine_msgs: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2747,6 +2747,14 @@ repositories:
       type: git
       url: https://github.com/apl-ocean-engineering/marine_msgs.git
       version: ros2
+    release:
+      packages:
+      - marine_acoustic_msgs
+      - marine_sensor_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/marine_msgs-release.git
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/apl-ocean-engineering/marine_msgs.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2759,7 +2759,7 @@ repositories:
       type: git
       url: https://github.com/apl-ocean-engineering/marine_msgs.git
       version: ros2
-    status: maintained
+    status: developed
   marti_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marine_msgs` to `2.1.0-1`:

- upstream repository: https://github.com/apl-ocean-engineering/marine_msgs.git
- release repository: https://github.com/ros2-gbp/marine_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## marine_acoustic_msgs

```
* Update CMake files to follow established standards
* Add Roland Arsenault as maintainer
* Update ros2 CI to use current ROS2 distributions (#56 <https://github.com/apl-ocean-engineering/marine_msgs/issues/56>)
* Updated ros2 branch to be in line with revisions in main (#44 <https://github.com/apl-ocean-engineering/marine_msgs/issues/44>)
* Contributors: Roland Arsenault, Sean Fish, Laura Lindzey
```

## marine_sensor_msgs

```
* Update CMake files to follow established standards
* Add Roland Arsenault as maintainer
* Update ros2 CI to use current ROS2 distributions (#56 <https://github.com/apl-ocean-engineering/marine_msgs/issues/56>)
* Updated ros2 branch to be in line with revisions in main (#44 <https://github.com/apl-ocean-engineering/marine_msgs/issues/44>)
* Add radar message and migration rules. (#40 <https://github.com/apl-ocean-engineering/marine_msgs/issues/40>)
* Contributors: Roland Arsenault, Sean Fish, Laura Lindzey
```
