### PR TITLE
marine_msgs: 2.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3535,6 +3535,24 @@ repositories:
       url: https://github.com/swri-robotics/mapviz.git
       version: ros2-devel
     status: developed
+  marine_msgs:
+    doc:
+      type: git
+      url: https://github.com/apl-ocean-engineering/marine_msgs.git
+      version: ros2
+    release:
+      packages:
+      - marine_acoustic_msgs
+      - marine_sensor_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/marine_msgs-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/apl-ocean-engineering/marine_msgs.git
+      version: ros2
+    status: developed
   marker_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marine_msgs` to `2.1.0-1`:

- upstream repository: https://github.com/apl-ocean-engineering/marine_msgs.git
- release repository: https://github.com/ros2-gbp/marine_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## marine_acoustic_msgs

```
* Update CMake files to follow established standards
* Add Roland Arsenault as maintainer
* Update ros2 CI to use current ROS2 distributions (#56 <https://github.com/apl-ocean-engineering/marine_msgs/issues/56>)
* Updated ros2 branch to be in line with revisions in main (#44 <https://github.com/apl-ocean-engineering/marine_msgs/issues/44>)
* Contributors: Roland Arsenault, Sean Fish, Laura Lindzey
```

## marine_sensor_msgs

```
* Update CMake files to follow established standards
* Add Roland Arsenault as maintainer
* Update ros2 CI to use current ROS2 distributions (#56 <https://github.com/apl-ocean-engineering/marine_msgs/issues/56>)
* Updated ros2 branch to be in line with revisions in main (#44 <https://github.com/apl-ocean-engineering/marine_msgs/issues/44>)
* Add radar message and migration rules. (#40 <https://github.com/apl-ocean-engineering/marine_msgs/issues/40>)
* Contributors: Roland Arsenault, Sean Fish, Laura Lindzey
```
