### PR TITLE
Fix rosdep keys for wxwidgets in modern Ubuntu/Debian

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8601,9 +8601,9 @@ wxwidgets:
     '7': [wxGTK-devel]
   ubuntu:
     '*': [libwxgtk3.2-dev]
+    bionic: [libwxgtk3.0-dev]
     focal: [libwxgtk3.0-gtk3-dev]
     jammy: [libwxgtk3.0-gtk3-dev]
-    bionic: [libwxgtk3.0-dev]
 x11proto-dri2-dev:
   arch: [dri2proto]
   debian: [x11proto-dri2-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8586,7 +8586,8 @@ wx-common:
 wxwidgets:
   arch: [wxgtk]
   debian:
-    '*': [libwxgtk3.0-gtk3-dev]
+    '*': [libwxgtk3.2-dev]
+    bullseye: [libwxgtk3.0-gtk3-dev]
     buster: [libwxgtk3.0-dev]
   fedora: [wxGTK3-devel]
   freebsd: [wxgtk2]
@@ -8599,7 +8600,9 @@ wxwidgets:
     '*': [wxGTK3-devel]
     '7': [wxGTK-devel]
   ubuntu:
-    '*': [libwxgtk3.0-gtk3-dev]
+    '*': [libwxgtk3.2-dev]
+    focal: [libwxgtk3.0-gtk3-dev]
+    jammy: [libwxgtk3.0-gtk3-dev]
     bionic: [libwxgtk3.0-dev]
 x11proto-dri2-dev:
   arch: [dri2proto]


### PR DESCRIPTION
Updated the package names for Debian and Ubuntu for wxWidgets. 

References:
- https://packages.ubuntu.com/search?keywords=wxwidgets&searchon=sourcenames
- https://tracker.debian.org/pkg/wxwidgets3.0
- https://tracker.debian.org/pkg/wxwidgets3.2


I have the doubt on the preferred way to do this: either use the wildcard '*' for the new current distros (with the idea of it will be working in the future), or for the older ones. I picked the first. 
Please, let me know if it's desired to do it the other way around.