### PR TITLE
sophus: 1.3.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8359,7 +8359,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/sophus-release.git
-      version: 1.3.1-1
+      version: 1.3.2-1
     source:
       type: git
       url: https://github.com/clalancette/sophus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sophus` to `1.3.2-1`:

- upstream repository: https://github.com/clalancette/sophus.git
- release repository: https://github.com/ros2-gbp/sophus-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.1-1`
