### PR TITLE
hri: 2.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2671,6 +2671,24 @@ repositories:
       url: https://github.com/humanoid-path-planner/hpp-fcl.git
       version: devel
     status: developed
+  hri:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/libhri.git
+      version: humble-devel
+    release:
+      packages:
+      - hri
+      - pyhri
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros4hri/libhri-release.git
+      version: 2.3.0-1
+    source:
+      type: git
+      url: https://github.com/ros4hri/libhri.git
+      version: humble-devel
+    status: developed
   hri_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hri` to `2.3.0-1`:

- upstream repository: https://github.com/ros4hri/libhri.git
- release repository: https://github.com/ros4hri/libhri-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## hri

```
2.2.0 (2024-01-18)
------------------
* add clear functions; lower missing tf log level
* add bitwise operators to FeatureType
* revert feature constness for getters
* add remaining interfaces to NodeInterfaces
* Contributors: Luka Juricic

2.1.0 (2024-01-18)
------------------
* add tf listener to the callback group
* add pyhri tests and align hri ones with the former
* add pybind11 based python bindings to pyhri
* add pyhri python bindings package
* Contributors: Luka Juricic

2.0.0 (2023-12-19)
------------------

Port the ROS 2.This release is *not* backward compatible with series libhri-0.x!

* fix version; use safer cmake variables
* add author; rename example node
* getters return pointers to const objects
* change example folder location
* add example instructions
* invalidate non-tracked/known features
* do not use const feature trackers
  they do not allow the registration of feature tracker callbacks (e.g. hri::Voice::onSpeech), while the members are already private and thus protected
* naming consistency
* review fixes
  - pass const objects to callbacks
  - emplace new tracked features
  - fix documentation
* review polish
  - add support for LifecycleNode
  - feature getters return const objects
  - avoid trivial typedefs
  - remove legacy docgen files
* fixez in cmake install, QoS, tests
* pass safer weak pointer of HRIListener to Person
* move FeatureTracker::init() to constructor
  avoid accidental re-initialization using public init() function
* bump version ahead of release 2.0.0
* remove unnecessary compile local files
* replace returned ROS messages with cpp types
* big cleanup
  - collect types in types.hpp
  - comply to coding guidelines (headers reordering, renaming, ...)
  - make all subscribed info optional
* cleanup tests
* group common functionalities into FeatureTracker
* simplify the execution architecture
  - HRIListener uses an external node for subscribing to topics
  - FeatureTracker collects additional common members
* do not use const pointers
  they are deceptive, actually the callbacks are modifying the 'const' objects
* switch license to apache 2.0
* use shared pointers instead of weak ones
* switch to std::optional
* building cleanup
  - target-based CMake
  - add back the copyright in the license
  - fix file naming
  - reorder depencencies alphabetically
* Merge main 0.6.4 into humble-devel 0.5.3
  3ff30aa3263abe2c6e7d2500165889e3bf0a5c36 into f50816fa0f65cc71e8057c25a8edba1ccee676bc
* Merge pull request #2 from juandpenan/humble-devel
  Code migrated to ROS2 Humble
* all tests passed
* changed buffer to buffercore
* test added
* voice sub fixed
* body sub fixed
* change bodies from weak to shared
* face callbacks fixed
* face listener working
* tf_listener fashon added
* ros1 fashon
* using namespace removed
* header guards changed
* testing
* revert to weak
* test added
* ID error fixed
* Merge pull request #1 from Juancams/humble-devel
  Migrated to ROS2 Humble
* Migrated to ROS2 Humble
* first_commit
* first_commit
* Contributors: Francisco Martín Rico, Juan Diego, Juancams, Luka Juricic, Séverin Lemaignan
```

## pyhri

```
2.3.0 (2024-03-18)
------------------
* change python module name to hri
* Contributors: Luka Juricic

2.2.0 (2024-01-18)
------------------

2.1.0 (2024-01-18)
------------------

Major new release, moved from ROS 1 to ROS 2, based on libhri + pybind11.

While the overall pyhri API should not have changed in significant ways, this
release *only works with ROS 2*!

Detailed changelog:

* convert IntensityConfidence and PointOfInterest to tuple
* add documentation
* fix version, documentation, example install
* add pyhri example
* move rivate headers to src
* cleanup CMakeLists.txt
* add test dependencies
* add tf listener to the callback group
* fix external code acknowledgement
* minor adaptations to ndarray_converter
* add external code ndarray_converter for image cast
* add pyhri tests and align hri ones with the former
* add pybind11 based python bindings to pyhri
* add pyhri python bindings package
* Contributors: Luka Juricic
```
