### PR TITLE
human_description: 2.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2686,6 +2686,21 @@ repositories:
       url: https://github.com/ros4hri/hri_msgs.git
       version: humble-devel
     status: developed
+  human_description:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/human_description.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros4hri/human_description-release.git
+      version: 2.0.2-1
+    source:
+      type: git
+      url: https://github.com/ros4hri/human_description.git
+      version: humble-devel
+    status: developed
   iceoryx:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `human_description` to `2.0.2-1`:

- upstream repository: https://github.com/ros4hri/human_description.git
- release repository: https://github.com/ros4hri/human_description-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## human_description

```
2.0.2 (2024-02-05)
------------------
* fix joint limits for the arms
  the joint limits for the arms were wrong, as they did not really
  reflect the range of movements a human is able to perform. This
  commit introduces realistic joint limits for human arms.
* Contributors: lorenzoferrini

2.0.1 (2023-11-13)
------------------
* port to ROS2 humble
* Contributors: Séverin Lemaignan
```
