### PR TITLE
libsoup2.4-dev in 'rosdep/base.yml'

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5753,6 +5753,16 @@ libsoundio-dev:
   macports: [libsoundio]
   nixos: [libsoundio]
   ubuntu: [libsoundio-dev]
+libsoup2.4-dev:
+  alpine: [libsoup-dev]
+  arch: [libsoup]
+  debian: [libsoup2.4-dev]
+  fedora: [libsoup-devel]
+  gentoo: [net-libs/libsoup-2.4]
+  macports: [libsoup@2]
+  nixos: [libsoup]
+  opensuse: [libsoup-2_4-1]
+  ubuntu: [libsoup2.4-dev]
 libspatialindex-dev:
   debian: [libspatialindex-dev]
   fedora: [spatialindex-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5753,7 +5753,7 @@ libsoundio-dev:
   macports: [libsoundio]
   nixos: [libsoundio]
   ubuntu: [libsoundio-dev]
-libsoup-dev:
+libsoup2-dev:
   alpine: [libsoup-dev]
   arch: [libsoup]
   debian: [libsoup2.4-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5753,7 +5753,7 @@ libsoundio-dev:
   macports: [libsoundio]
   nixos: [libsoundio]
   ubuntu: [libsoundio-dev]
-libsoup2.4-dev:
+libsoup-dev:
   alpine: [libsoup-dev]
   arch: [libsoup]
   debian: [libsoup2.4-dev]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

libsoup2.4-dev

## Package Upstream Source:

https://gitlab.gnome.org/GNOME/libsoup

## Purpose of using this:

Needed as a system dependency for the [ros-gst-bridge](https://github.com/BrettRD/ros-gst-bridge) package 

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/libsoup2.4-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/mantic/libsoup2.4-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/libsoup/libsoup-devel/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/libsoup/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/net-libs/libsoup
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/libsoup@2#default
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/community/x86_64/libsoup-dev
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=23.11&show=libsoup&from=0&size=50&sort=relevance&type=packages&query=libsoup
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/libsoup-2_4-1
- rhel: https://rhel.pkgs.org/
  - NOT AVAILABLE