### PR TITLE
robotont_driver: 0.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6653,6 +6653,11 @@ repositories:
       type: git
       url: https://github.com/robotont/robotont_driver.git
       version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/robotont_driver-release.git
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/robotont/robotont_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotont_driver` to `0.1.2-1`:

- upstream repository: https://github.com/robotont/robotont_driver.git
- release repository: https://github.com/ros2-gbp/robotont_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
