### PR TITLE
Update geographiclib key for modern Debian/Ubuntu.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1328,13 +1328,18 @@ gdal-bin:
   nixos: [gdal]
   ubuntu: [gdal-bin]
 geographiclib:
-  debian: [libgeographic-dev]
+  debian:
+    '*': [libgeographiclib-dev]
+    bullseye: [libgeographic-dev]
   fedora: [GeographicLib-devel]
   gentoo: [sci-geosciences/GeographicLib]
   nixos: [geographiclib]
   openembedded: [geographiclib@meta-ros-common]
   rhel: [GeographicLib-devel]
-  ubuntu: [libgeographic-dev]
+  ubuntu:
+    '*': [libgeographiclib-dev]
+    focal: [libgeographic-dev]
+    jammy: [libgeographic-dev]
 geographiclib-tools:
   debian: [geographiclib-tools]
   fedora: [GeographicLib]


### PR DESCRIPTION
Since Debian bookworm and Ubuntu Lunar, the libgeographic-dev package has been renamed to libgeographiclib-dev:

Ubuntu:
https://packages.ubuntu.com/search?keywords=libgeographic-dev&searchon=names&suite=all&section=all https://packages.ubuntu.com/search?keywords=libgeographiclib-dev&searchon=names&suite=all&section=all

Debian:
https://packages.debian.org/search?keywords=libgeographic-dev&searchon=names&suite=all&section=all https://packages.debian.org/search?keywords=libgeographiclib-dev&searchon=names&suite=all&section=all

Update the key here to handle these differences.