### PR TITLE
novatel_gps_driver: 4.1.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3821,7 +3821,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/novatel_gps_driver-release.git
-      version: 4.1.1-1
+      version: 4.1.2-1
     source:
       type: git
       url: https://github.com/swri-robotics/novatel_gps_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `4.1.2-1`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/ros2-gbp/novatel_gps_driver-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.1.1-1`

## novatel_gps_driver

```
* Merge pull request #117 <https://github.com/danthony06/novatel_gps_driver/issues/117> from JWhitleyWork/add-time-reference
  Add the ability to publish TimeReference messages.
* Fix month.
* Try to fix nanoseconds in time reference.
* Add the ability to publish TimeReference messages.
* Contributors: David Anthony, Joshua Whitley
```

## novatel_gps_msgs

- No changes
