### PR TITLE
novatel_gps_driver: 4.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4584,7 +4584,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/novatel_gps_driver-release.git
-      version: 4.1.1-2
+      version: 4.1.2-1
     source:
       type: git
       url: https://github.com/swri-robotics/novatel_gps_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `4.1.2-1`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/ros2-gbp/novatel_gps_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.1.1-2`

## novatel_gps_driver

```
* Merge pull request #117 <https://github.com/danthony06/novatel_gps_driver/issues/117> from JWhitleyWork/add-time-reference
  Add the ability to publish TimeReference messages.
* Fix month.
* Try to fix nanoseconds in time reference.
* Add the ability to publish TimeReference messages.
* Contributors: David Anthony, Joshua Whitley
```

## novatel_gps_msgs

- No changes
