### PR TITLE
message_tf_frame_transformer: 1.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2891,7 +2891,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/message_tf_frame_transformer-release.git
-      version: 1.1.0-2
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/ika-rwth-aachen/message_tf_frame_transformer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_tf_frame_transformer` to `1.1.1-1`:

- upstream repository: https://github.com/ika-rwth-aachen/message_tf_frame_transformer.git
- release repository: https://github.com/ros2-gbp/message_tf_frame_transformer-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-2`

## message_tf_frame_transformer

```
* Merge pull request #3 from clalancette/clalancette/fix-compile-error
  Fix a compile error with modern rclcpp.
* Contributors: Lennart Reiher
```
