### PR TITLE
message_tf_frame_transformer: 1.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5714,7 +5714,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ika-rwth-aachen/message_tf_frame_transformer-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/ika-rwth-aachen/message_tf_frame_transformer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_tf_frame_transformer` to `1.1.1-1`:

- upstream repository: https://github.com/ika-rwth-aachen/message_tf_frame_transformer.git
- release repository: https://github.com/ika-rwth-aachen/message_tf_frame_transformer-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-1`

## message_tf_frame_transformer

```
* Merge pull request #3 from clalancette/clalancette/fix-compile-error
  Fix a compile error with modern rclcpp.
* Contributors: Lennart Reiher
```
