### PR TITLE
rosbag_fancy: 1.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9699,7 +9699,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/xqms/rosbag_fancy-release.git
-      version: 1.0.1-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/xqms/rosbag_fancy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag_fancy` to `1.1.0-1`:

- upstream repository: https://github.com/xqms/rosbag_fancy
- release repository: https://github.com/xqms/rosbag_fancy-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.1-1`

## rosbag_fancy

```
* play: refuse to play non-monotonic bags
* Add --no-ui for play with status info and start/stop/pause services (PR #19)
* cmd_play: basic topic information in status message
* rosbag_fancy: link executable for devel space
  Fixes rosbag_fancy usage in catkin devel spaces (which is the default
  with catkin_make and catkin_tools). I mainly test & develop with colcon,
  so I did not notice so far that the command was not available properly.
* Contributors: Jan Quenzel, Max Schwarz
```

## rosbag_fancy_msgs

```
* Add --no-ui for play with status info and start/stop/pause services (PR #19)
* Contributors: Jan Quenzel, Max Schwarz
```

## rqt_rosbag_fancy

- No changes
