### PR TITLE
Add in liblz4 and liblz4-dev keys.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4204,6 +4204,22 @@ liblttng-ust-dev:
   openembedded: [lttng-ust@openembedded-core]
   rhel: [lttng-ust-devel]
   ubuntu: [liblttng-ust-dev]
+liblz4:
+  debian: [liblz4-1]
+  fedora: [lz4-libs]
+  opensuse:
+    '*': [liblz4]
+    '15.2': null
+  rhel: [lz4-libs]
+  ubuntu: [liblz4-1]
+liblz4-dev:
+  debian: [liblz4-dev]
+  fedora: [lz4-devel]
+  opensuse:
+    '*': [liblz4-devel]
+    '15.2': null
+  rhel: [lz4-devel]
+  ubuntu: [liblz4-dev]
 liblzma-dev:
   debian: [liblzma-dev]
   fedora: [xz-devel]


### PR DESCRIPTION
This is so we can split the runtime and buildtime
dependencies.

Please add the following dependency to the rosdep database.

## Package name:

liblz4

Note that we already have an `lz4` key, but it is implicitly the "development" packages.  The addition of these keys are more keeping with our current practices, and are explicit about the split between the library package and the development package.

## Package Upstream Source:

https://github.com/lz4/lz4/

## Purpose of using this:

This will be used to finish up https://github.com/ros2/rosbag2/pull/1583

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=liblz4-1
  - https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=liblz4-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=liblz4-1&searchon=names
  - https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=liblz4-dev&searchon=names
- Fedora: https://packages.fedoraproject.org/
  - https://pkgs.org/search/?q=lz4-libs
  - https://pkgs.org/search/?q=lz4-devel
- openSUSE: https://software.opensuse.org/package/
  - https://pkgs.org/search/?q=liblz4
  - https://pkgs.org/search/?q=liblz4-devel
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=lz4-libs
  - https://pkgs.org/search/?q=lz4-devel