### PR TITLE
libgstreamer-plugins-bad1.0-dev in 'rosdep/base.yml'

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3788,6 +3788,12 @@ libgsl:
   openembedded: [gsl@meta-oe]
   ubuntu:
     '*': [libgsl-dev]
+libgstreamer-plugins-bad1.0-dev:
+  debian: [libgstreamer-plugins-bad1.0-dev]
+  fedora: [gstreamer1-plugins-bad-free-devel]
+  gentoo: ['media-libs/gst-plugins-bad:1.0']
+  nixos: [gst_all_1.gst-plugins-bad]
+  ubuntu: [libgstreamer-plugins-bad1.0-dev]
 libgstreamer-plugins-base0.10-0:
   arch: [gstreamer0.10-base-plugins]
   debian:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

libgstreamer-plugins-bad1.0-dev

## Package Upstream Source:

https://gitlab.freedesktop.org/gstreamer/gstreamer/-/tree/main/subprojects/gst-plugins-bad

## Purpose of using this:

This is needed for the [ros-gst-bridge](https://github.com/BrettRD/ros-gst-bridge) package

Distro packaging links:

## Links to Distribution Packages
- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/libgstreamer-plugins-bad1.0-dev 
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/jammy/libgstreamer-plugins-bad1.0-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/gstreamer1-plugins-bad-free/gstreamer1-plugins-bad-free-devel/
- Arch: https://www.archlinux.org/packages/
  - UNAVAILABLE
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/media-libs/gst-plugins-bad
- macOS: https://formulae.brew.sh/
  - UNAVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - UNAVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=23.11&show=gst_all_1.gst-plugins-bad&from=0&size=50&sort=relevance&type=packages&query=gst_all_1.gst-plugins-bad
- openSUSE: https://software.opensuse.org/package/
  - UNAVAILABLE
- rhel: https://rhel.pkgs.org/
  - UNAVAILABLE