### PR TITLE
point_cloud_transport_tutorial: 0.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4099,7 +4099,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport_tutorial-release.git
-      version: 0.0.1-2
+      version: 0.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport_tutorial` to `0.0.2-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport_tutorial
- release repository: https://github.com/ros2-gbp/point_cloud_transport_tutorial-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.1-2`

## point_cloud_transport_tutorial

```
* point_cloud_Transport_plugins is not a build dependency of this package (#9 <https://github.com/ros-perception/point_cloud_transport_tutorial/issues/9>)
* Added humble CI (#8 <https://github.com/ros-perception/point_cloud_transport_tutorial/issues/8>)
* Contributors: Alejandro Hernández Cordero, john-maidbot
```
