### PR TITLE
mrpt_navigation: 1.0.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6302,7 +6302,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `1.0.5-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.4-1`

## mrpt_local_obstacles

```
* fix missing mola-common submodule
* Ported PointCloud to PointCloud2
* allow subscribing to pointcloud sensor msgs too
* Add optional pointcloud filtering (via mp2p_icp library)
* Contributors: Jose Luis Blanco Claraco, Jose Luis Blanco-Claraco
```

## mrpt_localization

```
* Merge branch 'mrpt-ros-pkg:ros1' into ros1
* Add new parameters to control initial uncertainty: initial_pose_std_xy,initial_pose_std_phi
* Contributors: Jose Luis Blanco Claraco, Shravan S Rai
```

## mrpt_map

- No changes

## mrpt_msgs_bridge

```
* Merge branch 'newtip' into ros1
* dependency changes
* Contributors: Jose Luis Blanco-Claraco, SRai22
```

## mrpt_navigation

- No changes

## mrpt_rawlog

```
* fix mrpt2 API
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_reactivenav2d

```
* fix mrpt2 API
* Optional plugin files for ptgs
* observe the waypoint ignore_heading field
* waypoint navigation enabled
* Contributors: Jose Luis Blanco-Claraco, SRai22
```

## mrpt_tutorials

- No changes
