### PR TITLE
mola: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3948,6 +3948,32 @@ repositories:
       type: git
       url: https://github.com/MOLAorg/mola.git
       version: develop
+    release:
+      packages:
+      - kitti_metrics_eval
+      - mola
+      - mola_bridge_ros2
+      - mola_demos
+      - mola_imu_preintegration
+      - mola_input_euroc_dataset
+      - mola_input_kitti360_dataset
+      - mola_input_kitti_dataset
+      - mola_input_mulran_dataset
+      - mola_input_paris_luco_dataset
+      - mola_input_rawlog
+      - mola_input_rosbag2
+      - mola_kernel
+      - mola_launcher
+      - mola_metric_maps
+      - mola_navstate_fuse
+      - mola_pose_list
+      - mola_traj_tools
+      - mola_viz
+      - mola_yaml
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/mola-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `1.0.0-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## kitti_metrics_eval

```
* Add option to use several groundtruth/result file pairs
* copyright update
* kitti eval cli moves to its own package
* Contributors: Jose Luis Blanco-Claraco
```

## mola

```
* add metapackage mola
* Contributors: Jose Luis Blanco-Claraco
```

## mola_bridge_ros2

```
* Comply with ROS2 REP-2003
* Merge ROS2 input and output in one module
* Contributors: Jose Luis Blanco-Claraco
```

## mola_demos

```
* Add use_fixed_sensor_pose flag
* Publish ground truth to ROS2 too
* ROS 2 launch demos
* mola-cli now does not need the -c cli flag
* More generic demo launch
* reorganize as monorepo
* Contributors: Jose Luis Blanco-Claraco
```

## mola_imu_preintegration

```
* API changes for new package mola_navstate_fuse
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_euroc_dataset

```
* New option to shutdown automatically mola-cli after dataset ends
* Show dataset replay progress percent
* Correct usage of mola:: namespace in cmake targets
* copyright update
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_kitti360_dataset

```
* Refactor initialize()
* Kitti360: add point timestamps, add ground truth
* Add Kitti360 dataset source
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_kitti_dataset

```
* Refactor initialize()
* implement UI dataset
* New option to shutdown automatically mola-cli after dataset ends
* save useless memory in offline dataset access mode
* Correct usage of mola:: namespace in cmake targets
* copyright update
* kitti eval cli moves to its own package
* mola-kitti-eval-error: allow comparing against other custom GT files
* reorganize for monorepo
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_mulran_dataset

```
* use new mrpt GPS covariance field
* Refactor initialize()
* implement UI dataset
* New option to shutdown automatically mola-cli after dataset ends
* Mulran: fix synchronization of GPS observations
* Mulran dataset: publish GPS too
* Free probably-never-to-be-used-again memory
* mulran dataset: generate per-point RING id
* Correct usage of mola:: namespace in cmake targets
* copyright update
* Fix 1-to-1 correspondence of GT to lidar scans
* reorganize as monorepo
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_paris_luco_dataset

```
* Refactor initialize()
* Implement UI Dataset in the rest of dataset sources
* fix bug in published point timestamps
* New option to shutdown automatically mola-cli after dataset ends
* ParisLuco dataset: reconstruct ringId field
* Free probably-never-to-be-used-again memory
* Add Paris Luco dataset input package
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_rawlog

```
* Refactor initialize()
* Implement UI Dataset in the rest of dataset sources
* New option to shutdown automatically mola-cli after dataset ends
* Fix boundless memory usage growth in rawlog inputs
* Show dataset replay progress percent
* Correct usage of mola:: namespace in cmake targets
* copyright update
* reorganize as monorepo
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_rosbag2

```
* tolerate missing tf data temporarily
* Merge ROS2 input and output in one module
* Add use_fixed_sensor_pose flag
* Fix ROS2 sensorPose from /tf data
* Fix jump forward in time in rosbags
* Implement UI Dataset in the rest of dataset sources
* New option to shutdown automatically mola-cli after dataset ends
* Automatic determination of storage id from file extension
* Show dataset replay progress percent
* Correct usage of mola:: namespace in cmake targets
* copyright update
* Hide ros2 dependencies from public .h
* Contributors: Jose Luis Blanco-Claraco
```

## mola_kernel

```
* add methods to query for subscribers
* New interfaces
* Refactor initialize()
* mola_kernel: new UI interface for datasets
* New option to shutdown automatically mola-cli after dataset ends
* viz API: add enqueue_custom_nanogui_code()
* mola_viz: show console messages
* Correct usage of mola:: namespace in cmake targets
* copyright update
* mola_viz: support visualizing velodyne observations
* Add look_at() viz interface
* Fewer mutex locking()
* dont force by default load() lazy-load observations
* FrontEndBase: attach to VizInterface too
* Fix loss of yaml key/values when using import-from-file feature
* kitti eval cli moves to its own package
* port to mrpt::lockHelper()
* reorganize as monorepo
* Contributors: Jose Luis Blanco-Claraco
```

## mola_launcher

```
* ROS2 launch demos
* reorganize as monorepo
* Contributors: Jose Luis Blanco-Claraco
```

## mola_metric_maps

```
* implement cached conversion to pointcloud
* make cfg file section optional
* FIX: error on rendering empty voxel maps
* HashedVoxelPointCloud: add missing reserve()
* copyright update
* Contributors: Jose Luis Blanco-Claraco
```

## mola_navstate_fuse

```
* use odometry
* add new package mola_navstate_fuse
* Contributors: Jose Luis Blanco-Claraco
```

## mola_pose_list

```
* Refactor SearchablePoseList into its own package
* Contributors: Jose Luis Blanco-Claraco
```

## mola_traj_tools

```
* Add tool to rebase TUM trajectory
* new package with small TUM trajectory cli tools
* Contributors: Jose Luis Blanco-Claraco
```

## mola_viz

```
* ROS2 launch demos
* use new mrpt GPS covariance field
* visualize sensor pose
* mola_kernel: new UI interface for datasets
* mola-viz: show image channel of RGBD observations
* Fix sensorPose on lidar preview
* Viz: show GPS data
* mola_viz: add custom icon
* viz: more options to visualize RGBD camera observations
* viz API: add enqueue_custom_nanogui_code()
* viz console: add fading effect
* mola_viz: show console messages
* Correct usage of mola:: namespace in cmake targets
* copyright update
* mola_viz: support visualizing velodyne observations
* Add look_at() viz interface
* Fewer mutex locking()
* reorganize as monorepo
* Contributors: Jose Luis Blanco-Claraco
```

## mola_yaml

```
* copyright update
* reorganize as monorepo
* Contributors: Jose Luis Blanco-Claraco
```
