### PR TITLE
octomap: 1.10.0-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3543,7 +3543,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/octomap-release.git
-      version: 1.9.8-3
+      version: 1.10.0-3
     source:
       type: git
       url: https://github.com/octomap/octomap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap` to `1.10.0-3`:

- upstream repository: https://github.com/OctoMap/octomap.git
- release repository: https://github.com/ros2-gbp/octomap-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.9.8-3`
