### PR TITLE
Remove stubborn_buddies from Iron and Rolling.

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7220,24 +7220,6 @@ repositories:
       url: https://github.com/ros-industrial/stomp.git
       version: main
     status: maintained
-  stubborn_buddies:
-    doc:
-      type: git
-      url: https://github.com/open-rmf/stubborn_buddies.git
-      version: main
-    release:
-      packages:
-      - stubborn_buddies
-      - stubborn_buddies_msgs
-      tags:
-        release: release/iron/{package}/{version}
-      url: https://github.com/ros2-gbp/stubborn_buddies-release.git
-      version: 1.0.0-6
-    source:
-      type: git
-      url: https://github.com/open-rmf/stubborn_buddies.git
-      version: main
-    status: developed
   swri_console:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6758,24 +6758,6 @@ repositories:
       url: https://github.com/ros-industrial/stomp.git
       version: main
     status: maintained
-  stubborn_buddies:
-    doc:
-      type: git
-      url: https://github.com/open-rmf/stubborn_buddies.git
-      version: main
-    release:
-      packages:
-      - stubborn_buddies
-      - stubborn_buddies_msgs
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/stubborn_buddies-release.git
-      version: 1.0.0-6
-    source:
-      type: git
-      url: https://github.com/open-rmf/stubborn_buddies.git
-      version: main
-    status: developed
   swri_console:
     doc:
       type: git


### PR DESCRIPTION
It has never built on either of those platforms, so just remove it for now.

https://build.ros2.org/job/Rbin_uN64__stubborn_buddies__ubuntu_noble_amd64__binary/
https://build.ros2.org/job/Ibin_uJ64__stubborn_buddies__ubuntu_jammy_amd64__binary/

@Yadunund @marcoag FYI