### PR TITLE
Update the wxwidgets key for Ubuntu Noble.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8600,7 +8600,8 @@ wx-common:
 wxwidgets:
   arch: [wxgtk]
   debian:
-    '*': [libwxgtk3.0-gtk3-dev]
+    '*': [libwxgtk3.2-dev]
+    bullseye: [libwxgtk3.0-gtk3-dev]
     buster: [libwxgtk3.0-dev]
   fedora: [wxGTK3-devel]
   freebsd: [wxgtk2]
@@ -8613,8 +8614,10 @@ wxwidgets:
     '*': [wxGTK3-devel]
     '7': [wxGTK-devel]
   ubuntu:
-    '*': [libwxgtk3.0-gtk3-dev]
+    '*': [libwxgtk3.2-dev]
     bionic: [libwxgtk3.0-dev]
+    focal: [libwxgtk3.0-gtk3-dev]
+    jammy: [libwxgtk3.0-gtk3-dev]
 x11proto-dri2-dev:
   arch: [dri2proto]
   debian: [x11proto-dri2-dev]


### PR DESCRIPTION
The package name has changed to libwxgtk3.2-dev in Ubuntu Noble, as well as in newer versions of Debian.

Please update the following dependency in the rosdep database.

## Package name:

libwxgtk3.2-dev

## Package Upstream Source:

https://www.wxwidgets.org/

## Purpose of using this:

The `wxwidgets` key is needed by mrpt2: https://github.com/MRPT/mrpt/blob/6f1ac5b7e91e1bc49f78363c6dda933f9f6d885a/package.xml#L58

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=libwxgtk3&searchon=names&suite=all&section=all
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=libwxgtk3&searchon=names&suite=all&section=all