### PR TITLE
Add in the gazebo vendor packages.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1926,6 +1926,114 @@ repositories:
       url: https://github.com/borglab/gtsam.git
       version: develop
     status: developed
+  gz_cmake_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_cmake_vendor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/gazebo-release/gz_cmake_vendor.git
+      version: main
+  gz_common_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_common_vendor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/gazebo-release/gz_common_vendor.git
+      version: main
+  gz_dartsim_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_dartsim_vendor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/gazebo-release/gz_dartsim_vendor.git
+      version: main
+  gz_fuel_tools_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_fuel_tools_vendor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/gazebo-release/gz_fuel_tools_vendor.git
+      version: main
+  gz_gui_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_gui_vendor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/gazebo-release/gz_gui_vendor.git
+      version: main
+  gz_launch_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_launch_vendor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/gazebo-release/gz_launch_vendor.git
+      version: main
+  gz_math_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_math_vendor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/gazebo-release/gz_math_vendor.git
+      version: main
+  gz_msgs_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_msgs_vendor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/gazebo-release/gz_msgs_vendor.git
+      version: main
+  gz_ogre_next_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_ogre_next_vendor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/gazebo-release/gz_ogre_next_vendor.git
+      version: main
+  gz_physics_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_physics_vendor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/gazebo-release/gz_physics_vendor.git
+      version: main
+  gz_plugin_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_plugin_vendor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/gazebo-release/gz_plugin_vendor.git
+      version: main
+  gz_rendering_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_rendering_vendor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/gazebo-release/gz_rendering_vendor.git
+      version: main
   gz_ros2_control:
     doc:
       type: git
@@ -1943,6 +2051,51 @@ repositories:
       url: https://github.com/ros-controls/gz_ros2_control.git
       version: master
     status: maintained
+  gz_sensors_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_sensors_vendor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/gazebo-release/gz_sensors_vendor.git
+      version: main
+  gz_sim_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_sim_vendor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/gazebo-release/gz_sim_vendor.git
+      version: main
+  gz_tools_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_tools_vendor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/gazebo-release/gz_tools_vendor.git
+      version: main
+  gz_transport_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_transport_vendor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/gazebo-release/gz_transport_vendor.git
+      version: main
+  gz_utils_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_utils_vendor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/gazebo-release/gz_utils_vendor.git
+      version: main
   hash_library_vendor:
     doc:
       type: git
@@ -6469,6 +6622,15 @@ repositories:
       url: https://github.com/ros/sdformat_urdf.git
       version: ros2
     status: maintained
+  sdformat_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/sdformat_vendor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/gazebo-release/sdformat_vendor.git
+      version: main
   septentrio_gnss_driver:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1930,110 +1930,110 @@ repositories:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_cmake_vendor.git
-      version: main
+      version: rolling
     source:
       type: git
       url: https://github.com/gazebo-release/gz_cmake_vendor.git
-      version: main
+      version: rolling
   gz_common_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_common_vendor.git
-      version: main
+      version: rolling
     source:
       type: git
       url: https://github.com/gazebo-release/gz_common_vendor.git
-      version: main
+      version: rolling
   gz_dartsim_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_dartsim_vendor.git
-      version: main
+      version: rolling
     source:
       type: git
       url: https://github.com/gazebo-release/gz_dartsim_vendor.git
-      version: main
+      version: rolling
   gz_fuel_tools_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_fuel_tools_vendor.git
-      version: main
+      version: rolling
     source:
       type: git
       url: https://github.com/gazebo-release/gz_fuel_tools_vendor.git
-      version: main
+      version: rolling
   gz_gui_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_gui_vendor.git
-      version: main
+      version: rolling
     source:
       type: git
       url: https://github.com/gazebo-release/gz_gui_vendor.git
-      version: main
+      version: rolling
   gz_launch_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_launch_vendor.git
-      version: main
+      version: rolling
     source:
       type: git
       url: https://github.com/gazebo-release/gz_launch_vendor.git
-      version: main
+      version: rolling
   gz_math_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_math_vendor.git
-      version: main
+      version: rolling
     source:
       type: git
       url: https://github.com/gazebo-release/gz_math_vendor.git
-      version: main
+      version: rolling
   gz_msgs_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_msgs_vendor.git
-      version: main
+      version: rolling
     source:
       type: git
       url: https://github.com/gazebo-release/gz_msgs_vendor.git
-      version: main
+      version: rolling
   gz_ogre_next_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_ogre_next_vendor.git
-      version: main
+      version: rolling
     source:
       type: git
       url: https://github.com/gazebo-release/gz_ogre_next_vendor.git
-      version: main
+      version: rolling
   gz_physics_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_physics_vendor.git
-      version: main
+      version: rolling
     source:
       type: git
       url: https://github.com/gazebo-release/gz_physics_vendor.git
-      version: main
+      version: rolling
   gz_plugin_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_plugin_vendor.git
-      version: main
+      version: rolling
     source:
       type: git
       url: https://github.com/gazebo-release/gz_plugin_vendor.git
-      version: main
+      version: rolling
   gz_rendering_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_rendering_vendor.git
-      version: main
+      version: rolling
     source:
       type: git
       url: https://github.com/gazebo-release/gz_rendering_vendor.git
-      version: main
+      version: rolling
   gz_ros2_control:
     doc:
       type: git
@@ -2055,47 +2055,47 @@ repositories:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_sensors_vendor.git
-      version: main
+      version: rolling
     source:
       type: git
       url: https://github.com/gazebo-release/gz_sensors_vendor.git
-      version: main
+      version: rolling
   gz_sim_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_sim_vendor.git
-      version: main
+      version: rolling
     source:
       type: git
       url: https://github.com/gazebo-release/gz_sim_vendor.git
-      version: main
+      version: rolling
   gz_tools_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_tools_vendor.git
-      version: main
+      version: rolling
     source:
       type: git
       url: https://github.com/gazebo-release/gz_tools_vendor.git
-      version: main
+      version: rolling
   gz_transport_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_transport_vendor.git
-      version: main
+      version: rolling
     source:
       type: git
       url: https://github.com/gazebo-release/gz_transport_vendor.git
-      version: main
+      version: rolling
   gz_utils_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_utils_vendor.git
-      version: main
+      version: rolling
     source:
       type: git
       url: https://github.com/gazebo-release/gz_utils_vendor.git
-      version: main
+      version: rolling
   hash_library_vendor:
     doc:
       type: git
@@ -6626,11 +6626,11 @@ repositories:
     doc:
       type: git
       url: https://github.com/gazebo-release/sdformat_vendor.git
-      version: main
+      version: rolling
     source:
       type: git
       url: https://github.com/gazebo-release/sdformat_vendor.git
-      version: main
+      version: rolling
   septentrio_gnss_driver:
     doc:
       type: git


### PR DESCRIPTION
We are switching to a model where we vendor Gazebo within ROS itself, rather than having it separate.  This will make it very clear which version of Gazebo is supported with which version of ROS.  This PR adds in the necessary packages to do this vendoring.

There are a number of steps to follow to get this completely integrated:
1.  Get this PR reviewed for REP-144 naming, and merged.
2.  Add in ros2-gbp repositories for these new packages (https://github.com/ros2-gbp/ros2-gbp-github-org/pull/474)
3.  Addition of a number of rosdep keys (there is a list in https://github.com/gazebo-tooling/release-tools/issues/1117#issuecomment-2005407791)
4.  Update of https://github.com/ros2/ros2/blob/rolling/ros2.repos to use these new vendor packages.