### PR TITLE
tinyspline_vendor: 0.6.0-5 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6979,7 +6979,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tinyspline_vendor-release.git
-      version: 0.6.0-4
+      version: 0.6.0-5
     source:
       type: git
       url: https://github.com/wep21/tinyspline_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tinyspline_vendor` to `0.6.0-5`:

- upstream repository: https://github.com/wep21/tinyspline_vendor.git
- release repository: https://github.com/ros2-gbp/tinyspline_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.0-4`

## tinyspline_vendor

```
* fix: use install directory
* docs: add readme
* feat: initial commit
* Contributors: Daisuke Nishimatsu
```
