### PR TITLE
Remove gazebo_ros_pkgs and dependencies from Rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1018,27 +1018,6 @@ repositories:
       url: https://github.com/ros/diagnostics.git
       version: ros2
     status: maintained
-  dolly:
-    doc:
-      type: git
-      url: https://github.com/chapulina/dolly.git
-      version: galactic
-    release:
-      packages:
-      - dolly
-      - dolly_follow
-      - dolly_gazebo
-      - dolly_ignition
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/dolly-release.git
-      version: 0.4.0-5
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/chapulina/dolly.git
-      version: galactic
-    status: developed
   domain_bridge:
     doc:
       type: git
@@ -1628,45 +1607,6 @@ repositories:
       type: git
       url: https://github.com/locusrobotics/fuse.git
       version: rolling
-    status: maintained
-  gazebo_ros2_control:
-    doc:
-      type: git
-      url: https://github.com/ros-simulation/gazebo_ros2_control.git
-      version: master
-    release:
-      packages:
-      - gazebo_ros2_control
-      - gazebo_ros2_control_demos
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.7.1-2
-    source:
-      type: git
-      url: https://github.com/ros-simulation/gazebo_ros2_control.git
-      version: master
-    status: developed
-  gazebo_ros_pkgs:
-    doc:
-      type: git
-      url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
-      version: ros2
-    release:
-      packages:
-      - gazebo_dev
-      - gazebo_msgs
-      - gazebo_plugins
-      - gazebo_ros
-      - gazebo_ros_pkgs
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
-      version: ros2
     status: maintained
   gc_spl:
     doc:
@@ -7129,7 +7069,6 @@ repositories:
     release:
       packages:
       - turtlebot3_fake_node
-      - turtlebot3_gazebo
       - turtlebot3_simulations
       tags:
         release: release/rolling/{package}/{version}
@@ -7588,25 +7527,6 @@ repositories:
       url: https://github.com/ros-drivers/velodyne.git
       version: ros2
     status: developed
-  velodyne_simulator:
-    doc:
-      type: git
-      url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
-      version: foxy-devel
-    release:
-      packages:
-      - velodyne_description
-      - velodyne_gazebo_plugins
-      - velodyne_simulator
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/velodyne_simulator-release.git
-      version: 2.0.3-3
-    source:
-      type: git
-      url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
-      version: foxy-devel
-    status: maintained
   vision_msgs:
     doc:
       type: git


### PR DESCRIPTION
Gazebo classic aka gazebo11 package is not present in Ubuntu Noble nor is the plan of the Gazebo simulation team to package it anymore since the recommended path is to migrate to the new Gazebo, see https://gazebosim.org/docs/latest/migrating_gazebo_classic_ros2_packages. 

I'm completely removing in this PR the entries from the rolling `distribution.yaml`, not sure if there is any better way of dealing with this kind of "retirement".