### PR TITLE
Add libx11-xcb-dev key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6246,6 +6246,14 @@ libx11-dev:
   opensuse: [libX11-devel]
   rhel: [libX11-devel]
   ubuntu: [libx11-dev]
+libx11-xcb-dev:
+  alpine: [libx11-dev]
+  arch: [libx11]
+  debian: [libx11-xcb-dev]
+  fedora: [libX11-devel]
+  gentoo: [x11-libs/libX11]
+  nixos: [xorg.libX11]
+  ubuntu: [libx11-xcb-dev]
 libx264-dev:
   debian: [libx264-dev]
   fedora: [x264-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6253,6 +6253,8 @@ libx11-xcb-dev:
   fedora: [libX11-devel]
   gentoo: [x11-libs/libX11]
   nixos: [xorg.libX11]
+  opensuse: [libX11-devel]
+  rhel: [libX11-devel]
   ubuntu: [libx11-xcb-dev]
 libx264-dev:
   debian: [libx264-dev]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`libx11-xcb-dev`

## Package Upstream Source:

https://gitlab.freedesktop.org/xorg/lib/libx11

## Purpose of using this:

Needed by [`gz_ogre_next_vendor`](https://github.com/gazebo-release/gz_ogre_next_vendor)

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/libx11-xcb-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/libx11-xcb-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/libX11/libX11-devel/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/libx11
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/x11-libs/libX11
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/main/x86_64/libx11
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://github.com/NixOS/nixpkgs/blob/nixos-23.11/pkgs/servers/x11/xorg/default.nix#L1121
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - skipped

