### PR TITLE
Add libxcb-randr0-dev key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6270,6 +6270,14 @@ libxcursor-dev:
   fedora: [libXcursor-devel]
   nixos: [xorg.libXcursor]
   ubuntu: [libxcursor-dev]
+libxcb-randr0-dev:
+  arch: [libxcb]
+  alpine: [libxcb-dev]
+  debian: [libxcb-randr0-dev]
+  fedora: [libxcb-devel]
+  gentoo: [x11-libs/libxcb]
+  nixos: [xorg.libxcb]
+  ubuntu: [libxcb-randr0-dev]
 libxenomai-dev:
   debian:
     wheezy: [libxenomai-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6266,8 +6266,8 @@ libxaw:
   rhel: [libXaw-devel]
   ubuntu: [libxaw7-dev]
 libxcb-randr0-dev:
-  arch: [libxcb]
   alpine: [libxcb-dev]
+  arch: [libxcb]
   debian: [libxcb-randr0-dev]
   fedora: [libxcb-devel]
   gentoo: [x11-libs/libxcb]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6265,11 +6265,6 @@ libxaw:
   opensuse: [xorg-x11-devel]
   rhel: [libXaw-devel]
   ubuntu: [libxaw7-dev]
-libxcursor-dev:
-  debian: [libxcursor-dev]
-  fedora: [libXcursor-devel]
-  nixos: [xorg.libXcursor]
-  ubuntu: [libxcursor-dev]
 libxcb-randr0-dev:
   arch: [libxcb]
   alpine: [libxcb-dev]
@@ -6278,6 +6273,11 @@ libxcb-randr0-dev:
   gentoo: [x11-libs/libxcb]
   nixos: [xorg.libxcb]
   ubuntu: [libxcb-randr0-dev]
+libxcursor-dev:
+  debian: [libxcursor-dev]
+  fedora: [libXcursor-devel]
+  nixos: [xorg.libXcursor]
+  ubuntu: [libxcursor-dev]
 libxenomai-dev:
   debian:
     wheezy: [libxenomai-dev]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`libxcb-randr0-dev`

## Package Upstream Source:

https://gitlab.freedesktop.org/xorg/lib/libxcb

## Purpose of using this:

Needed by [`gz_ogre_next_vendor`](https://github.com/gazebo-release/gz_ogre_next_vendor)

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/libxcb-randr0-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/libxcb-randr0-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/libxcb/libxcb-devel/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/libxcb
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/x11-libs/libxcb
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/main/x86_64/libxcb-dev
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://github.com/NixOS/nixpkgs/blob/nixos-23.11/pkgs/servers/x11/xorg/default.nix#L1802
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - skipped

