### PR TITLE
Add `libshaderc-dev` key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5727,7 +5727,9 @@ libshaderc-dev:
   debian: [libshaderc-dev]
   fedora: [libshaderc-devel]
   gentoo: [media-libs/shaderc]
-  ubuntu: [libshaderc-dev]
+  ubuntu:
+    '*': null
+    noble: [libshaderc-dev]
 libsimage-dev:
   arch: [simage]
   debian: [libsimage-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5723,13 +5723,19 @@ libserial-dev:
   debian: [libserial-dev]
   ubuntu: [libserial-dev]
 libshaderc-dev:
+  alpine: [shaderc-dev]
   arch: [shaderc]
   debian: [libshaderc-dev]
   fedora: [libshaderc-devel]
   gentoo: [media-libs/shaderc]
+  opensuse: [shaderc-devel]
+  rhel:
+    '*': [libshaderc-devel]
+    '8': null
   ubuntu:
-    '*': null
-    noble: [libshaderc-dev]
+    '*': [libshaderc-dev]
+    'focal': null
+    'jammy': null
 libsimage-dev:
   arch: [simage]
   debian: [libsimage-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5722,6 +5722,12 @@ libsensors4-dev:
 libserial-dev:
   debian: [libserial-dev]
   ubuntu: [libserial-dev]
+libshaderc-dev:
+  arch: [shaderc]
+  debian: [libshaderc-dev]
+  fedora: [libshaderc-devel]
+  gentoo: [media-libs/shaderc]
+  ubuntu: [libshaderc-dev]
 libsimage-dev:
   arch: [simage]
   debian: [libsimage-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5725,7 +5725,9 @@ libserial-dev:
 libshaderc-dev:
   alpine: [shaderc-dev]
   arch: [shaderc]
-  debian: [libshaderc-dev]
+  debian:
+    '*': [libshaderc-dev]
+    bullseye: null
   fedora: [libshaderc-devel]
   gentoo: [media-libs/shaderc]
   opensuse: [shaderc-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5736,8 +5736,8 @@ libshaderc-dev:
     '8': null
   ubuntu:
     '*': [libshaderc-dev]
-    'focal': null
-    'jammy': null
+    focal: null
+    jammy: null
 libsimage-dev:
   arch: [simage]
   debian: [libsimage-dev]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`libshaderc-dev`

## Package Upstream Source:

https://github.com/google/shaderc/

## Purpose of using this:

Needed by [`gz_ogre_next_vendor`](https://github.com/gazebo-release/gz_ogre_next_vendor)

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/libshaderc-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/libshaderc-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/shaderc/libshaderc-devel/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/shaderc/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/media-libs/shaderc
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - skipped
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - skipped



