### PR TITLE
Add glslc key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1456,9 +1456,13 @@ glslc:
   debian: [glslc]
   fedora: [glslc]
   gentoo: [media-libs/shaderc]
+  rhel:
+    '*': [glslc]
+    '8': null
   ubuntu:
-    '*': null
-    noble: [glslc]
+    '*': [glslc]
+    focal: null
+    jammy: null
 glut:
   arch: [freeglut]
   debian: [freeglut3-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1451,6 +1451,12 @@ glpk:
   gentoo: [sci-mathematics/glpk]
   rhel: [glpk-devel]
   ubuntu: [libglpk-dev]
+glslc:
+  arch: [shaderc]
+  debian: [glslc]
+  fedora: [glslc]
+  gentoo: [media-libs/shaderc]
+  ubuntu: [glslc]
 glut:
   arch: [freeglut]
   debian: [freeglut3-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1456,7 +1456,9 @@ glslc:
   debian: [glslc]
   fedora: [glslc]
   gentoo: [media-libs/shaderc]
-  ubuntu: [glslc]
+  ubuntu:
+    '*': null
+    noble: [glslc]
 glut:
   arch: [freeglut]
   debian: [freeglut3-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1464,7 +1464,9 @@ glslang-dev:
   ubuntu: [glslang-dev]
 glslc:
   arch: [shaderc]
-  debian: [glslc]
+  debian:
+    '*': [glslc]
+    bullseye: null
   fedora: [glslc]
   gentoo: [media-libs/shaderc]
   rhel:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`glslc`

## Package Upstream Source:

https://github.com/google/shaderc

## Purpose of using this:

Needed by [`gz_ogre_next_vendor`](https://github.com/gazebo-release/gz_ogre_next_vendor)

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - debian: https://packages.debian.org/bookworm/glslc
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/glslc
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/shaderc/glslc
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/shaderc/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/media-libs/shaderc
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - skipped
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - skipped

