### PR TITLE
Add `glslang-dev` key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1451,6 +1451,12 @@ glpk:
   gentoo: [sci-mathematics/glpk]
   rhel: [glpk-devel]
   ubuntu: [libglpk-dev]
+glslang-dev:
+  arch: [glslang]
+  debian: [glslang-dev]
+  fedora: [glslang-devel]
+  gentoo: [dev-util/glslang]
+  ubuntu: [glslang-dev]
 glut:
   arch: [freeglut]
   debian: [freeglut3-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1452,10 +1452,15 @@ glpk:
   rhel: [glpk-devel]
   ubuntu: [libglpk-dev]
 glslang-dev:
+  alpine: [glslang-dev]
   arch: [glslang]
   debian: [glslang-dev]
   fedora: [glslang-devel]
   gentoo: [dev-util/glslang]
+  opensuse: [glslang-devel]
+  rhel:
+    '*': [glslang-devel]
+    '8': null
   ubuntu: [glslang-dev]
 glut:
   arch: [freeglut]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`glslang-dev`

## Package Upstream Source:

https://github.com/KhronosGroup/glslang

## Purpose of using this:

Needed by [`gz_ogre_next_vendor`](https://github.com/gazebo-release/gz_ogre_next_vendor)

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/glslang-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/glslang-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/glslang/glslang-devel/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/glslang/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-util/glslang
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - skipped
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - skipped

