### PR TITLE
Add `qml-module-qtpositioning` key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7469,7 +7469,9 @@ qml-module-qtmultimedia:
   debian: [qml-module-qtmultimedia]
   ubuntu: [qml-module-qtmultimedia]
 qml-module-qtpositioning:
+  arch: [qt5-location]
   debian: [qml-module-qtpositioning]
+  fedora: [qt5-qtlocation]
   gentoo: [dev-qt/qtpositioning]
   ubuntu: [qml-module-qtpositioning]
 qml-module-qtquick-controls:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7468,6 +7468,10 @@ qml-module-qtgraphicaleffects:
 qml-module-qtmultimedia:
   debian: [qml-module-qtmultimedia]
   ubuntu: [qml-module-qtmultimedia]
+qml-module-qtpositioning:
+  debian: [qml-module-qtpositioning]
+  gentoo: [dev-qt/qtpositioning]
+  ubuntu: [qml-module-qtpositioning]
 qml-module-qtquick-controls:
   debian: [qml-module-qtquick-controls]
   gentoo: [dev-qt/qtquickcontrols]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`qml-module-qtpositioning`

## Package Upstream Source:

https://github.com/qt/qtpositioning

## Purpose of using this:

Needed by [`gz_gui_vendor`](https://github.com/gazebo-release/gz_gui_vendor)

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/qml-module-qtpositioning
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/qml-module-qtpositioning
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/qt5-qtlocation/qt5-qtlocation/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/qt5-location/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-qt/qtpositioning
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - skipped
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - skipped
