### PR TITLE
Add `qml-module-qt-labs-platform` key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7459,6 +7459,12 @@ qhull-bin:
 qml-module-qt-labs-folderlistmodel:
   debian: [qml-module-qt-labs-folderlistmodel]
   ubuntu: [qml-module-qt-labs-folderlistmodel]
+qml-module-qt-labs-platform:
+  arch: [qt5-quickcontrols2]
+  debian: [qml-module-qt-labs-platform]
+  fedora: [qt5-qtquickcontrols2]
+  gentoo: [dev-qt/qtquickcontrols2]
+  ubuntu: [qml-module-qt-labs-platform]
 qml-module-qt-labs-settings:
   debian: [qml-module-qt-labs-settings]
   ubuntu: [qml-module-qt-labs-settings]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`qml-module-qt-labs-platform`

## Package Upstream Source:

https://github.com/qt/qtdeclarative


## Purpose of using this:

Needed by [`gz_gui_vendor`](https://github.com/gazebo-release/gz_gui_vendor)

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/qml-module-qt-labs-platform
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/qml-module-qt-labs-platform
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/qt5-qtquickcontrols2/qt5-qtquickcontrols2/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/qt5-quickcontrols2/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-qt/qtquickcontrols2
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - skipped
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - skipped
