### PR TITLE
Add `rubocop` key

### DIFF
--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -63,6 +63,10 @@ rdoc:
   fedora: [rubygem-rdoc]
   gentoo: [dev-ruby/rdoc]
   ubuntu: [ruby]
+rubocop:
+  arch: [rubocop]
+  debian: [rubocop]
+  ubuntu: [rubocop]
 ruby:
   arch: [ruby]
   debian:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`rubocop`

## Package Upstream Source:

https://github.com/rubocop/rubocop


## Purpose of using this:

Needed by [`gz_tools_vendor`](https://github.com/gazebo-release/gz_tools_vendor)

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/rubocop
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/rubocop
- Fedora: https://packages.fedoraproject.org/
  - not available
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/any/rubocop/
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - skipped
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - skipped
