### PR TITLE
ign_ros2_control: 0.7.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2731,12 +2731,13 @@ repositories:
       version: humble
     release:
       packages:
+      - gz_ros2_control_tests
       - ign_ros2_control
       - ign_ros2_control_demos
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 0.7.5-1
+      version: 0.7.6-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2731,7 +2731,6 @@ repositories:
       version: humble
     release:
       packages:
-      - gz_ros2_control_tests
       - ign_ros2_control
       - ign_ros2_control_demos
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ign_ros2_control` to `0.7.6-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.5-1`

## ign_ros2_control

```
* Fix typo (#253 <https://github.com/ros-controls/gz_ros2_control/issues/253>) (#254 <https://github.com/ros-controls/gz_ros2_control/issues/254>)
  (cherry picked from commit a98cb2a8b72827b7c1669987d6a12d3f0b30a41e)
  Co-authored-by: Stephanie Eng <mailto:stephanie-eng@users.noreply.github.com>
* Fix #247 <https://github.com/ros-controls/gz_ros2_control/issues/247> (#248 <https://github.com/ros-controls/gz_ros2_control/issues/248>) (#250 <https://github.com/ros-controls/gz_ros2_control/issues/250>)
  (cherry picked from commit 94745e6f5f051214ac9862051f9a918685f2c6b9)
  Co-authored-by: Graziato Davide <mailto:85335579+Fixit-Davide@users.noreply.github.com>
* Fix initial_value not working (backport #241 <https://github.com/ros-controls/gz_ros2_control/issues/241>) (#243 <https://github.com/ros-controls/gz_ros2_control/issues/243>)
  * Reset Gazebo with initial joint positions and velocities (#241 <https://github.com/ros-controls/gz_ros2_control/issues/241>)
  (cherry picked from commit c5b0b9049ce75410e75d1828242c1dfd5b19bb80)
  Co-authored-by: Ruddick Lawrence <mailto:679360+mrjogo@users.noreply.github.com>
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Use portable versio for usleep (backport #237 <https://github.com/ros-controls/gz_ros2_control/issues/237>) (#238 <https://github.com/ros-controls/gz_ros2_control/issues/238>)
  * Use portable versio for usleep (#237 <https://github.com/ros-controls/gz_ros2_control/issues/237>)
  (cherry picked from commit 0bdf13e6986c613c99a595889a587da1db6d7f69)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Fix crashing due to an invalid parameter in the initial value (backport #233 <https://github.com/ros-controls/gz_ros2_control/issues/233>) (#234 <https://github.com/ros-controls/gz_ros2_control/issues/234>)
  * Fix crashing due to an invalid parameter in the initial value (#233 <https://github.com/ros-controls/gz_ros2_control/issues/233>)
  (cherry picked from commit a3beadb014f62e0808033de2c5ad84e2428c36e9)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: Alejandro Hernández Cordero, Ruddick Lawrence, Stephanie Eng, Graziato Davide, mergify[bot]
```

## ign_ros2_control_demos

```
* Add ros_gz_bridge as dependency to demos (backport #256 <https://github.com/ros-controls/gz_ros2_control/issues/256>) (#257 <https://github.com/ros-controls/gz_ros2_control/issues/257>)
  * Add dep (#256 <https://github.com/ros-controls/gz_ros2_control/issues/256>)
  (cherry picked from commit b35100db16e80ffb574c0266321800e2197136c3)
  # Conflicts:
  #     ign_ros2_control_demos/package.xml
  * fixed merge
  ---------
  Co-authored-by: Christoph Fröhlich <mailto:christophfroehlich@users.noreply.github.com>
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```
