### PR TITLE
gz_ros2_control: 1.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1935,9 +1935,11 @@ repositories:
       packages:
       - gz_ros2_control
       - gz_ros2_control_demos
+      - gz_ros2_control_tests
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
+      version: 1.2.2-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1935,7 +1935,6 @@ repositories:
       packages:
       - gz_ros2_control
       - gz_ros2_control_demos
-      - gz_ros2_control_tests
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `1.2.2-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## gz_ros2_control

```
* Fix typo (#253 <https://github.com/ros-controls/gz_ros2_control/issues/253>)
* Fix #247 <https://github.com/ros-controls/gz_ros2_control/issues/247> (#248 <https://github.com/ros-controls/gz_ros2_control/issues/248>)
* Reset Gazebo with initial joint positions and velocities (#241 <https://github.com/ros-controls/gz_ros2_control/issues/241>)
* Use portable versio for usleep (#237 <https://github.com/ros-controls/gz_ros2_control/issues/237>)
* Fix crashing due to an invalid parameter in the initial value (#233 <https://github.com/ros-controls/gz_ros2_control/issues/233>)
* Contributors: Alejandro Hernández Cordero, Graziato Davide, Ruddick Lawrence, Stephanie Eng
```

## gz_ros2_control_demos

```
* Add dep (#256 <https://github.com/ros-controls/gz_ros2_control/issues/256>)
* Contributors: Christoph Fröhlich
```

## gz_ros2_control_tests

- No changes
