### PR TITLE
mvsim: 0.9.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6447,7 +6447,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
-      version: 0.9.1-2
+      version: 0.9.2-1
     source:
       type: git
       url: https://github.com/ual-arm-ros-pkg/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.9.2-1`:

- upstream repository: https://github.com/ual-arm-ros-pkg/mvsim.git
- release repository: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.9.1-2`

## mvsim

```
* BUG FIX: 3D lidars should not 'see' XYZ corners of wheels
* BUG FIX: gridmaps were published at a too high rate in the ROS 2 node
* remove dead code
* update header version
* Contributors: Jose Luis Blanco-Claraco
```
