### PR TITLE
mvsim: 0.9.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3473,7 +3473,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/mvsim-release.git
-      version: 0.9.1-1
+      version: 0.9.2-1
     source:
       type: git
       url: https://github.com/MRPT/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.9.2-1`:

- upstream repository: https://github.com/MRPT/mvsim.git
- release repository: https://github.com/ros2-gbp/mvsim-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.9.1-1`

## mvsim

```
* BUG FIX: 3D lidars should not 'see' XYZ corners of wheels
* BUG FIX: gridmaps were published at a too high rate in the ROS 2 node
* remove dead code
* update header version
* Contributors: Jose Luis Blanco-Claraco
```
