### PR TITLE
mrpt_path_planning: 0.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3268,7 +3268,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_path_planning-release.git
-      version: 0.1.0-2
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_path_planning.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_path_planning` to `0.1.1-1`:

- upstream repository: https://github.com/MRPT/mrpt_path_planning.git
- release repository: https://github.com/ros2-gbp/mrpt_path_planning-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.0-2`

## mrpt_path_planning

```
* Fix usage of obsolete mrpt methods
* update ros badges
* Contributors: Jose Luis Blanco-Claraco
```
