### PR TITLE
Update `zziplib` key for Ubuntu Noble

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8966,7 +8966,4 @@ zziplib:
   nixos: [zziplib]
   opensuse: [zziplib-devel]
   rhel: [zziplib-devel]
-  ubuntu:
-    '*': [libzzip-0-13t64, libzzip-dev]
-    focal: [libzzip-0-13, libzzip-dev]
-    jammy: [libzzip-0-13, libzzip-dev]
+  ubuntu: [libzzip-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8958,7 +8958,7 @@ zsh:
   ubuntu: [zsh]
 zziplib:
   arch: [zziplib]
-  debian: [libzzip-0-13, libzzip-dev]
+  debian: [libzzip-dev]
   fedora: [zziplib-devel]
   freebsd: [zziplib]
   gentoo: [dev-libs/zziplib]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8966,4 +8966,7 @@ zziplib:
   nixos: [zziplib]
   opensuse: [zziplib-devel]
   rhel: [zziplib-devel]
-  ubuntu: [libzzip-0-13, libzzip-dev]
+  ubuntu:
+    '*' : [libzzip-0-13t64, libzzip-dev]
+    focal : [libzzip-0-13, libzzip-dev]
+    jammy : [libzzip-0-13, libzzip-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8967,6 +8967,6 @@ zziplib:
   opensuse: [zziplib-devel]
   rhel: [zziplib-devel]
   ubuntu:
-    '*' : [libzzip-0-13t64, libzzip-dev]
-    focal : [libzzip-0-13, libzzip-dev]
-    jammy : [libzzip-0-13, libzzip-dev]
+    '*': [libzzip-0-13t64, libzzip-dev]
+    focal: [libzzip-0-13, libzzip-dev]
+    jammy: [libzzip-0-13, libzzip-dev]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`zziplib`

## Purpose of using this:

On Ubuntu Noble, the package `libzzip-dev` now depends on `libzzip-0-13t64` which breaks `libzzip-0-13`. We believe this name change is due to the 64bit time  transition (see https://wiki.debian.org/ReleaseGoals/64bit-time)

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/libzzip-dev
  - https://packages.ubuntu.com/noble/libzzip-0-13t64


