### PR TITLE
Revert "generate_parameter_library: 0.3.8-1 in 'iron/distribution.yaml' [bloom]"

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1797,16 +1797,13 @@ repositories:
       version: main
     release:
       packages:
-      - cmake_generate_parameter_module_example
       - generate_parameter_library
-      - generate_parameter_library_example
       - generate_parameter_library_py
-      - generate_parameter_module_example
       - parameter_traits
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 0.3.8-1
+      version: 0.3.7-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git


### PR DESCRIPTION
Reverts ros/rosdistro#40149

The changes here result in regressions in moveit2 which block the upcoming Iron sync.
See https://github.com/ros-planning/moveit2/issues/2758#issuecomment-2013696411