### PR TITLE
ublox_dgnss: 0.5.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7441,7 +7441,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ublox_dgnss-release.git
-      version: 0.5.2-2
+      version: 0.5.3-1
     source:
       type: git
       url: https://github.com/aussierobots/ublox_dgnss.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ublox_dgnss` to `0.5.3-1`:

- upstream repository: https://github.com/aussierobots/ublox_dgnss
- release repository: https://github.com/ros2-gbp/ublox_dgnss-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.5.2-2`

## ntrip_client_node

```
* Merge pull request #18 <https://github.com/aussierobots/ublox_dgnss/issues/18> from tfoldi/user_agent
  chore: set user-agent for caster http requests
* chore: set user-agent for caster http requests
  Some public caster servers (like caster.centipede.fr) requires
  specific user agents for streaming requests (NTRIP as first
  string in the agent).
* Contributors: Nick Hortovanyi, Tamas Foldi
```

## ublox_dgnss

```
* hp sv tracking and jamming/interference launch file
* Contributors: Nick Hortovanyi
```

## ublox_dgnss_node

```
* Jamming and interference monitor configuration
* Contributors: Nick Hortovanyi
```

## ublox_nav_sat_fix_hp_node

- No changes

## ublox_ubx_interfaces

- No changes

## ublox_ubx_msgs

- No changes
